### PR TITLE
feat(license): add a generator for synchronising license files and source code headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.1.0",
     "exponential-backoff": "^3.1.1",
+    "fast-glob": "^3.3.3",
     "fs-extra": "^11.2.0",
     "husky": "^9.1.7",
     "jsdom": "~22.1.0",

--- a/packages/nx-plugin/LICENSE-THIRD-PARTY
+++ b/packages/nx-plugin/LICENSE-THIRD-PARTY
@@ -10744,7 +10744,7 @@ THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: fast-glob (3.3.2)
+The following software may be included in this product: fast-glob (3.3.3)
 This software contains the following license and notice below:
 
 The MIT License (MIT)
@@ -38935,6 +38935,27 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ---
 
 The following software may be included in this product: minimatch (9.0.5)
+This software contains the following license and notice below:
+
+The ISC License
+
+Copyright (c) 2011-2023 Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following software may be included in this product: minimatch (10.0.1)
 This software contains the following license and notice below:
 
 The ISC License

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -38,6 +38,17 @@
       "factory": "./src/trpc/react/generator",
       "schema": "./src/trpc/react/schema.json",
       "description": "provides React integration to a React website"
+    },
+    "license": {
+      "factory": "./src/license/generator",
+      "schema": "./src/license/schema.json",
+      "description": "Add LICENSE files and configure source code licence headers"
+    },
+    "license#sync": {
+      "factory": "./src/license/sync/generator",
+      "schema": "./src/license/sync/schema.json",
+      "description": "Sync generator for writing licence headers and subproject LICENSE files",
+      "hidden": true
     }
   }
 }

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -11,7 +11,8 @@
   },
   "generators": "./generators.json",
   "peerDependencies": {
-    "prettier": "^3.4.2"
+    "prettier": "^3.4.2",
+    "nx": "20.4.0"
   },
   "dependencies": {
     "@nx/devkit": "^20.4.0",
@@ -20,7 +21,9 @@
     "@nx/react": "^20.4.0",
     "@nx/vite": "^20.4.0",
     "@phenomnomnominal/tsquery": "6.1.3",
+    "fast-glob": "^3.3.3",
     "lodash.kebabcase": "4.1.1",
+    "minimatch": "^10.0.1",
     "typescript": "~5.5.4",
     "vite": "^5.4.0",
     "vitest": "^1.6.0"

--- a/packages/nx-plugin/src/index.ts
+++ b/packages/nx-plugin/src/index.ts
@@ -2,3 +2,4 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+export * from './utils/config';

--- a/packages/nx-plugin/src/license/README.md
+++ b/packages/nx-plugin/src/license/README.md
@@ -1,0 +1,255 @@
+# License Generator
+
+## Overview
+
+This generator configures `LICENSE` files and source file headers for your project. After you run this generator, a [sync generator](https://nx.dev/concepts/sync-generators) is registered to execute as part of your `lint` targets which will ensure that your source files conform to the desired license content and format, as well as ensuring that all projects in your workspace contain a copy of the root `LICENSE` file.
+
+## Usage
+
+You can run the generator in two ways:
+
+### 1. Using VSCode IDE
+
+First, install the NX Console extension for VSCode:
+
+1. Open VSCode
+2. Go to Extensions (Ctrl+Shift+X / Cmd+Shift+X)
+3. Search for "Nx Console"
+4. Install [Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)
+
+Then generate your API:
+
+1. Open the NX Console in VSCode
+2. Click on "Generate"
+3. Search for "license"
+4. Fill in the required parameters in the form
+5. Click "Run"
+
+### 2. Using CLI
+
+Generate the API:
+
+```bash
+nx g @aws/nx-plugin:license my-api --copyrightHolder="My Company, Inc." --license=MIT
+```
+
+You can also perform a dry-run to see what files would be generated or updated without actually creating them:
+
+```bash
+nx g @aws/nx-plugin:license my-api --copyrightHolder="My Company, Inc." --license=MIT --dry-run
+```
+
+Both methods will create a root `LICENSE` file based on your selected license and copyright holder, as well as configuring the sync generator to ensure that source files specify the correct license header.
+
+## Input Parameters
+
+| Parameter       | Type   | Default                              | Description                                                                            |
+| --------------- | ------ | ------------------------------------ | -------------------------------------------------------------------------------------- |
+| license         | string | "Apache-2.0"                         | The SPDX license identifier for your chosen license.                                   |
+| copyrightHolder | string | "Amazon.com, Inc. or its affiliates" | The copyright holder, included in the LICENSE file and source file headers by default. |
+
+## Expected Output
+
+The generator will create or update the following files:
+
+```
+└── LICENSE                    # The content is written based on the selected license
+└── package.json               # The "license" field is updated with the selected license
+└── nx.json                    # The "lint" target is configured to sync LICENSE files and source file headers
+└── aws-nx-plugin.config.mts   # Configuration for the license sync, such as customising the license header content and format for different languages
+```
+
+Some default configuration for license header content and format is added to `aws-nx-plugin.config.mts` to write appropriate headers for a handful of file types. You may wish to customise this further; please see the [configuration section](#configuration) below.
+
+## License Sync Behaviour
+
+The license sync generator performs two main tasks:
+
+### 1. Synchronise Source File License Headers
+
+When the sync generator is run, it will ensure that all source code files in your workspace (based on your configuration) contain the appropriate license header. The header is written as the first block comment or consecutive series of line comments in the file (besides the shebang/hashbang if present in a file).
+
+You can update the configuration at any time to change which files should be included or excluded, as well as the content or format of license headers for different file types. For more details, please see the [configuration section](#configuration) below.
+
+### 2. Synchronise LICENSE Files
+
+When the sync generator is run, it will ensure that all projects in your workspace contain the same `LICENSE` file as the `LICENSE` file in the root of your workspace. If your workspace does not have a root LICENSE file, this is skipped.
+
+You can exclude projects in the configuration if required. For more details, please see the [configuration section](#configuration) below.
+
+## Configuration
+
+Configuration is defined in the `aws-nx-plugin.config.mts` file in the root of your workspace.
+
+### License header content
+
+The license header content can be configured in two ways:
+
+1. Using inline content:
+
+```typescript
+{
+  license: {
+    header: {
+      content: {
+        lines: ['Copyright My Company, Inc.', 'Licensed under MIT License', 'All rights reserved'];
+      }
+      // ... format configuration
+    }
+  }
+}
+```
+
+2. Loading from a file:
+
+```typescript
+{
+  license: {
+    header: {
+      content: {
+        filePath: 'license-header.txt'; // relative to workspace root
+      }
+      // ... format configuration
+    }
+  }
+}
+```
+
+### Including files and specifying a format
+
+You can specify how license headers should be formatted for different file types using glob patterns. The format configuration supports line comments, block comments, or a combination of both:
+
+```typescript
+{
+  license: {
+    header: {
+      content: {
+        lines: ['Copyright notice here']
+      },
+      format: {
+        // Line comments
+        '**/*.ts': {
+          lineStart: '// '
+        },
+
+        // Block comments
+        '**/*.css': {
+          blockStart: '/*',
+          blockEnd: '*/'
+        },
+
+        // Block comments with line prefixes
+        '**/*.java': {
+          blockStart: '/*',
+          lineStart: ' * ',
+          blockEnd: ' */'
+        },
+
+        // Line comments with header/footer
+        '**/*.py': {
+          blockStart: '# ------------',
+          lineStart: '# ',
+          blockEnd: '# ------------'
+        }
+      }
+    }
+  }
+}
+```
+
+The format configuration supports:
+
+- `blockStart`: Text written before the license content (e.g., to start a block comment)
+- `lineStart`: Text prepended to each line of the license content
+- `lineEnd`: Text appended to each line of the license content
+- `blockEnd`: Text written after the license content (e.g., to end a block comment)
+
+### Custom comment syntax
+
+For file types that aren't natively supported, you can specify custom comment syntax:
+
+```typescript
+{
+  license: {
+    header: {
+      content: {
+        lines: ['My license header']
+      },
+      format: {
+        '**/*.xyz': {
+          lineStart: '## '
+        }
+      },
+      commentSyntax: {
+        xyz: {
+          line: '##'  // Define line comment syntax
+        },
+        abc: {
+          block: {    // Define block comment syntax
+            start: '<!--',
+            end: '-->'
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This tells the sync generator how to identify existing license headers in these file types. The `commentSyntax` configuration supports:
+
+- `line`: Characters that start a line comment
+- `block`: Characters that start and end a block comment
+
+### Excluding files
+
+By default, in a git repository, all `.gitignore` files are honored to ensure that only files managed by version control are synchronized. In non-git repositories, all files are considered unless explicitly excluded in configuration.
+
+You can exclude additional files from license header synchronization using glob patterns:
+
+```typescript
+{
+  license: {
+    header: {
+      content: {
+        lines: ['My license header']
+      },
+      format: {
+        '**/*.ts': {
+          lineStart: '// '
+        }
+      },
+      exclude: [
+        '**/generated/**',
+        '**/dist/**',
+        'some-specific-file.ts'
+      ]
+    }
+  }
+}
+```
+
+### Excluding projects from LICENSE file sync
+
+You can exclude specific projects from LICENSE file synchronization using glob patterns:
+
+```typescript
+{
+  license: {
+    files: {
+      exclude: ['packages/excluded-project', 'apps/internal-*'];
+    }
+  }
+}
+```
+
+When excluded, these projects will not receive a copy of the root LICENSE file during synchronization.
+
+## Disabling license sync
+
+To disable the license sync generator:
+
+1. Remove the `license` section from your configuration in `aws-nx-plugin.config.mts` (or remove the `aws-nx-plugin.config.mts` file)
+2. Remove the `@aws/nx-plugin:license#sync` generator from `targetDefaults.lint.syncGenerators`
+
+To re-enable license sync, simply run the `license` generator again.

--- a/packages/nx-plugin/src/license/__snapshots__/config.spec.ts.snap
+++ b/packages/nx-plugin/src/license/__snapshots__/config.spec.ts.snap
@@ -1,0 +1,89 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`license config > defaultLicenseConfig > should generate default license config for ASL 1`] = `
+{
+  "header": {
+    "content": {
+      "lines": [
+        "Copyright Test Inc. or its affiliates. All Rights Reserved.                                                      ",
+        "                                                                                                                 ",
+        "Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance       ",
+        "with the License. A copy of the License is located at                                                            ",
+        "                                                                                                                 ",
+        "   https://aws.amazon.com/asl/                                                                                   ",
+        "                                                                                                                 ",
+        "or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES",
+        "OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions   ",
+        "and limitations under the License.                                                                               ",
+      ],
+    },
+    "exclude": [],
+    "format": {
+      "**/*.{js,ts}": {
+        "blockEnd": " **********************************************************************************************************************/",
+        "blockStart": "/**********************************************************************************************************************",
+        "lineEnd": " *",
+        "lineStart": " *  ",
+      },
+      "**/*.{py,sh}": {
+        "blockEnd": "######################################################################################################################",
+        "blockStart": "######################################################################################################################",
+        "lineEnd": " #",
+        "lineStart": "#  ",
+      },
+    },
+  },
+}
+`;
+
+exports[`license config > defaultLicenseConfig > should generate default license config for Apache-2.0 1`] = `
+{
+  "header": {
+    "content": {
+      "lines": [
+        "Copyright Test Inc. or its affiliates. All Rights Reserved.",
+        "SPDX-License-Identifier: Apache-2.0",
+      ],
+    },
+    "exclude": [],
+    "format": {
+      "**/*.{js,ts}": {
+        "blockEnd": " */",
+        "blockStart": "/**",
+        "lineStart": " * ",
+      },
+      "**/*.{py,sh}": {
+        "blockEnd": "# ",
+        "blockStart": "# ",
+        "lineStart": "# ",
+      },
+    },
+  },
+}
+`;
+
+exports[`license config > defaultLicenseConfig > should generate default license config for MIT 1`] = `
+{
+  "header": {
+    "content": {
+      "lines": [
+        "Copyright Test Inc. or its affiliates. All Rights Reserved.",
+        "SPDX-License-Identifier: MIT",
+      ],
+    },
+    "exclude": [],
+    "format": {
+      "**/*.{js,ts}": {
+        "blockEnd": " */",
+        "blockStart": "/**",
+        "lineStart": " * ",
+      },
+      "**/*.{py,sh}": {
+        "blockEnd": "# ",
+        "blockStart": "# ",
+        "lineStart": "# ",
+      },
+    },
+  },
+}
+`;

--- a/packages/nx-plugin/src/license/config-types.ts
+++ b/packages/nx-plugin/src/license/config-types.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export interface LicenseConfig {
+  /**
+   * Configuration for source code license headers
+   * Omit if you do not want any source code license headers to be synced
+   */
+  header?: LicenseHeaderConfig;
+  /**
+   * Configuration for LICENSE files
+   */
+  files?: LicenseFileConfig;
+}
+
+/**
+ * Configuration for the LICENSE file sync
+ */
+export interface LicenseFileConfig {
+  /**
+   * Exclude LICENSE file sync checks for the given glob patterns
+   */
+  exclude?: string[];
+}
+
+/**
+ * Specifies license content as a path to a file
+ */
+export interface LicenseFilePathContent {
+  /**
+   * Load the license text from the specified file (relative to the workspace root)
+   */
+  filePath: string;
+}
+
+/**
+ * Specifies license content inline
+ */
+export interface LicenseLinesContent {
+  /**
+   * Inline license text
+   */
+  lines: string[];
+}
+
+/**
+ * Configuration for source code license header sync
+ */
+export interface LicenseHeaderConfig {
+  /**
+   * Content of the license header
+   */
+  content: LicenseFilePathContent | LicenseLinesContent;
+  /**
+   * Specifies the license header format for given glob patterns
+   */
+  format: {
+    [filePattern: string]: LicenseHeaderFormat;
+  };
+  /**
+   * Exclude out of sync source code license header checks for the given glob patterns
+   */
+  exclude?: string[];
+  /**
+   * User-specified comment syntax for file types we don't have config for
+   */
+  commentSyntax?: {
+    [ext: string]: CommentSyntax;
+  };
+}
+
+/**
+ * Format settings for source code license headers
+ */
+export interface LicenseHeaderFormat {
+  /**
+   * Text written to the line prior to the license lines
+   * Use this to start a block comment if desired
+   */
+  blockStart?: string;
+  /**
+   * Text written to the start of each line of the license
+   */
+  lineStart?: string;
+  /**
+   * Text written to the end of each line of the license
+   */
+  lineEnd?: string;
+  /**
+   * Text written to the line after the license lines
+   * Use this to end a block comment if desired
+   */
+  blockEnd?: string;
+}
+
+/**
+ * Defines comment syntax for a particular language
+ * Used to instruct the license sync generator to find the first comment in a file
+ */
+export interface CommentSyntax {
+  /**
+   * If the language supports line comments, specify the character(s) used to start a line comment
+   */
+  line?: string;
+  /**
+   * If the language supports block comments, specify the character(s) used to start and end the block comment
+   */
+  block?: {
+    start: string;
+    end: string;
+  };
+}

--- a/packages/nx-plugin/src/license/config.spec.ts
+++ b/packages/nx-plugin/src/license/config.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import {
+  defaultLicenseConfig,
+  readLicenseConfig,
+  writeLicenseConfig,
+} from './config';
+import { SPDXLicenseIdentifier } from './schema';
+import { createTreeUsingTsSolutionSetup } from '../utils/test';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../utils/config/utils';
+import { LicenseConfig } from './config-types';
+
+const LICENSES: SPDXLicenseIdentifier[] = ['Apache-2.0', 'MIT', 'ASL'];
+
+describe('license config', () => {
+  let tree: Tree;
+
+  const sampleConfig: LicenseConfig = {
+    header: {
+      content: {
+        lines: ['this is a test license header'],
+      },
+      format: {
+        '**/*.js': {
+          lineStart: '// ',
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  describe('defaultLicenseConfig', () => {
+    it.each(LICENSES)(
+      'should generate default license config for %s',
+      (spdx) => {
+        expect(
+          defaultLicenseConfig(spdx, 'Test Inc. or its affiliates'),
+        ).toMatchSnapshot();
+      },
+    );
+  });
+
+  describe('readLicenseConfig', () => {
+    it('should read license configuration', async () => {
+      tree.write(
+        AWS_NX_PLUGIN_CONFIG_FILE_NAME,
+        `
+        export default {
+          license: ${JSON.stringify(sampleConfig)}
+        };
+      `,
+      );
+
+      expect(await readLicenseConfig(tree)).toEqual(sampleConfig);
+    });
+  });
+
+  describe('writeLicenseConfig', () => {
+    it('should write license configuration and update package.json spdx', async () => {
+      tree.write('package.json', `{ "name": "test-package" }`);
+      tree.write(AWS_NX_PLUGIN_CONFIG_FILE_NAME, `export default {}`);
+
+      await writeLicenseConfig(tree, 'Apache-2.0', sampleConfig);
+
+      expect(JSON.parse(tree.read('package.json', 'utf-8')).license).toBe(
+        'Apache-2.0',
+      );
+      expect(tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')).toContain(
+        'this is a test license header',
+      );
+    });
+  });
+});

--- a/packages/nx-plugin/src/license/config.ts
+++ b/packages/nx-plugin/src/license/config.ts
@@ -1,0 +1,204 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree, updateJson } from '@nx/devkit';
+import { SPDXLicenseIdentifier } from './schema';
+import {
+  readAwsNxPluginConfig,
+  updateAwsNxPluginConfig,
+} from '../utils/config/utils';
+import { CommentSyntax, LicenseConfig } from './config-types';
+
+/**
+ * Defines the comment syntax for popular programming languages
+ */
+export const LANGUAGE_COMMENT_SYNTAX: { [ext: string]: CommentSyntax } = {
+  // C++ style comments
+  ...Object.fromEntries(
+    [
+      // Node
+      'js',
+      'ts',
+      'cjs',
+      'mjs',
+      'cts',
+      'mts',
+      // React
+      'jsx',
+      'tsx',
+      // Web
+      'sass',
+      'scss',
+      'php',
+      // Java
+      'java',
+      // Smithy
+      'smithy',
+      // TypeSpec
+      'tsp',
+      // Golang
+      'go',
+      // Rust
+      'rs',
+      // C and C++
+      'c',
+      'cpp',
+      'cxx',
+      'cc',
+      'h',
+      'hpp',
+      // C#
+      'cs',
+      // Scala
+      'scala',
+      'sc',
+      'sbt',
+      // Kotlin
+      'kt',
+      // Swift
+      'swift',
+    ].map((ext) => [ext, { line: '//', block: { start: '/*', end: '*/' } }]),
+  ),
+  // Bash style comments
+  ...Object.fromEntries(
+    [
+      // Bash
+      'sh',
+      // Perl
+      'pl',
+      // YAML
+      'yaml',
+      'yml',
+      // R
+      'r',
+    ].map((ext) => [ext, { line: '#' }]),
+  ),
+  // Docker
+  Dockerfile: { line: '#' },
+  // Python
+  py: { line: '#', block: { start: '"""', end: '"""' } },
+  // Web
+  html: { block: { start: '<!--', end: '-->' } },
+  css: { block: { start: '/*', end: '*/' } },
+  // Ruby
+  rb: { line: '#', block: { start: '=begin', end: '=end' } },
+  // F#
+  ...Object.fromEntries(
+    ['fs', 'fsx'].map((ext) => [
+      ext,
+      { line: '//', block: { start: '(*', end: '*)' } },
+    ]),
+  ),
+  // Visual Basic
+  vb: { line: "' " },
+  // Lua
+  lua: { line: '--', block: { start: '--[[', end: ']]' } },
+  // PowerShell
+  ps1: { line: '#', block: { start: '<#', end: '#>' } },
+  psm1: { line: '#', block: { start: '<#', end: '#>' } },
+  // Markdown
+  md: { block: { start: '<!--', end: '-->' } },
+};
+
+/**
+ * Build the default license config for a given license
+ */
+export const defaultLicenseConfig = (
+  spdx: SPDXLicenseIdentifier,
+  copyrightHolder: string,
+): LicenseConfig => {
+  switch (spdx) {
+    case 'ASL': {
+      // For ASL, we use a "box" style license header
+      const rawContent = [
+        `Copyright ${copyrightHolder}. All Rights Reserved.`,
+        '',
+        'Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance',
+        'with the License. A copy of the License is located at',
+        '',
+        '   https://aws.amazon.com/asl/',
+        '',
+        'or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES',
+        'OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions',
+        'and limitations under the License.',
+      ];
+      const maxLen = Math.max(...rawContent.map((line) => line.length));
+      const lines = rawContent.map(
+        (line) => `${line}${' '.repeat(maxLen - line.length)}`,
+      );
+      return {
+        header: {
+          content: { lines },
+          format: {
+            '**/*.{js,ts}': {
+              blockStart: `/***${'*'.repeat(maxLen)}**`,
+              lineStart: ' *  ',
+              lineEnd: ' *',
+              blockEnd: ` ***${'*'.repeat(maxLen)}**/`,
+            },
+            '**/*.{py,sh}': {
+              blockStart: `###${'#'.repeat(maxLen)}##`,
+              lineStart: '#  ',
+              lineEnd: ' #',
+              blockEnd: `###${'#'.repeat(maxLen)}##`,
+            },
+          },
+          exclude: [],
+        },
+      };
+    }
+    default: {
+      return {
+        header: {
+          content: {
+            lines: [
+              `Copyright ${copyrightHolder}. All Rights Reserved.`,
+              `SPDX-License-Identifier: ${spdx}`,
+            ],
+          },
+          format: {
+            '**/*.{js,ts}': {
+              blockStart: '/**',
+              lineStart: ' * ',
+              blockEnd: ' */',
+            },
+            '**/*.{py,sh}': {
+              blockStart: '# ',
+              lineStart: '# ',
+              blockEnd: '# ',
+            },
+          },
+          exclude: [],
+        },
+      };
+    }
+  }
+};
+
+/**
+ * Write license configuration to the aws nx plugin config
+ */
+export const writeLicenseConfig = async (
+  tree: Tree,
+  spdx: SPDXLicenseIdentifier,
+  config: LicenseConfig,
+) => {
+  updateJson(tree, 'package.json', (packageJson) => ({
+    ...packageJson,
+    license: spdx,
+  }));
+
+  await updateAwsNxPluginConfig(tree, {
+    license: config,
+  });
+};
+
+/**
+ * Read license configuration
+ */
+export const readLicenseConfig = async (
+  tree: Tree,
+): Promise<LicenseConfig | undefined> => {
+  return (await readAwsNxPluginConfig(tree))?.license;
+};

--- a/packages/nx-plugin/src/license/files/licenses/ASL/LICENSE.template
+++ b/packages/nx-plugin/src/license/files/licenses/ASL/LICENSE.template
@@ -1,0 +1,96 @@
+Amazon Software License 1.0
+
+This Amazon Software License ("License") governs your use, reproduction, and
+distribution of the accompanying software as specified below.
+
+1. Definitions
+
+  "Licensor" means any person or entity that distributes its Work.
+
+  "Software" means the original work of authorship made available under this
+  License.
+
+  "Work" means the Software and any additions to or derivative works of the
+  Software that are made available under this License.
+
+  The terms "reproduce," "reproduction," "derivative works," and
+  "distribution" have the meaning as provided under U.S. copyright law;
+  provided, however, that for the purposes of this License, derivative works
+  shall not include works that remain separable from, or merely link (or bind
+  by name) to the interfaces of, the Work.
+
+  Works, including the Software, are "made available" under this License by
+  including in or with the Work either (a) a copyright notice referencing the
+  applicability of this License to the Work, or (b) a copy of this License.
+
+2. License Grants
+
+  2.1 Copyright Grant. Subject to the terms and conditions of this License,
+  each Licensor grants to you a perpetual, worldwide, non-exclusive,
+  royalty-free, copyright license to reproduce, prepare derivative works of,
+  publicly display, publicly perform, sublicense and distribute its Work and
+  any resulting derivative works in any form.
+
+  2.2 Patent Grant. Subject to the terms and conditions of this License, each
+  Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free
+  patent license to make, have made, use, sell, offer for sale, import, and
+  otherwise transfer its Work, in whole or in part. The foregoing license
+  applies only to the patent claims licensable by Licensor that would be
+  infringed by Licensor's Work (or portion thereof) individually and
+  excluding any combinations with any other materials or technology.
+
+3. Limitations
+
+  3.1 Redistribution. You may reproduce or distribute the Work only if
+  (a) you do so under this License, (b) you include a complete copy of this
+  License with your distribution, and (c) you retain without modification
+  any copyright, patent, trademark, or attribution notices that are present
+  in the Work.
+
+  3.2 Derivative Works. You may specify that additional or different terms
+  apply to the use, reproduction, and distribution of your derivative works
+  of the Work ("Your Terms") only if (a) Your Terms provide that the use
+  limitation in Section 3.3 applies to your derivative works, and (b) you
+  identify the specific derivative works that are subject to Your Terms.
+  Notwithstanding Your Terms, this License (including the redistribution
+  requirements in Section 3.1) will continue to apply to the Work itself.
+
+  3.3 Use Limitation. The Work and any derivative works thereof only may be
+  used or intended for use with the web services, computing platforms or
+  applications provided by Amazon.com, Inc. or its affiliates, including
+  Amazon Web Services, Inc.
+
+  3.4 Patent Claims. If you bring or threaten to bring a patent claim against
+  any Licensor (including any claim, cross-claim or counterclaim in a
+  lawsuit) to enforce any patents that you allege are infringed by any Work,
+  then your rights under this License from such Licensor (including the
+  grants in Sections 2.1 and 2.2) will terminate immediately.
+
+  3.5 Trademarks. This License does not grant any rights to use any
+  Licensor's or its affiliates' names, logos, or trademarks, except as
+  necessary to reproduce the notices described in this License.
+
+  3.6 Termination. If you violate any term of this License, then your rights
+  under this License (including the grants in Sections 2.1 and 2.2) will
+  terminate immediately.
+
+4. Disclaimer of Warranty.
+
+  THE WORK IS PROVIDED "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR
+  NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER
+  THIS LICENSE. SOME STATES' CONSUMER LAWS DO NOT ALLOW EXCLUSION OF AN
+  IMPLIED WARRANTY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+5. Limitation of Liability.
+
+  EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL
+  THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE
+  SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT,
+  INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR
+  RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK (INCLUDING
+  BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS
+  OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER COMM ERCIAL DAMAGES
+  OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGES.

--- a/packages/nx-plugin/src/license/files/licenses/Apache-2.0/LICENSE.template
+++ b/packages/nx-plugin/src/license/files/licenses/Apache-2.0/LICENSE.template
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/nx-plugin/src/license/files/licenses/MIT/LICENSE.template
+++ b/packages/nx-plugin/src/license/files/licenses/MIT/LICENSE.template
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <%- year %> <%- copyrightHolder %>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/nx-plugin/src/license/generator.spec.ts
+++ b/packages/nx-plugin/src/license/generator.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { readJson, readNxJson, Tree } from '@nx/devkit';
+
+import { licenseGenerator } from './generator';
+import { LicenseGeneratorSchema } from './schema';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../utils/config/utils';
+import { SYNC_GENERATOR_NAME } from './sync/generator';
+
+describe('license generator', () => {
+  let tree: Tree;
+  const options: LicenseGeneratorSchema = {
+    license: 'Apache-2.0',
+    copyrightHolder: 'Test Inc. or its affiliates',
+  };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add a top level license file', async () => {
+    await licenseGenerator(tree, options);
+
+    expect(tree.exists('LICENSE')).toBeTruthy();
+  });
+
+  it('should write default license config', async () => {
+    await licenseGenerator(tree, options);
+
+    expect(tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)).toBeTruthy();
+    expect(tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')).toContain(
+      'Copyright Test Inc. or its affiliates.',
+    );
+  });
+
+  it('should register the sync generator', async () => {
+    await licenseGenerator(tree, options);
+
+    expect(readNxJson(tree).targetDefaults.lint.syncGenerators).toContain(
+      SYNC_GENERATOR_NAME,
+    );
+  });
+
+  it('should allow successive runs to change the license', async () => {
+    await licenseGenerator(tree, {
+      license: 'MIT',
+      copyrightHolder: 'Foo',
+    });
+
+    expect(tree.read('LICENSE', 'utf-8')).toContain('Foo');
+    expect(readJson(tree, 'package.json').license).toBe('MIT');
+
+    await licenseGenerator(tree, {
+      license: 'MIT',
+      copyrightHolder: 'Bar',
+    });
+
+    expect(tree.read('LICENSE', 'utf-8')).toContain('Bar');
+    expect(readJson(tree, 'package.json').license).toBe('MIT');
+
+    await licenseGenerator(tree, {
+      license: 'ASL',
+      copyrightHolder: 'Baz',
+    });
+
+    expect(tree.read('LICENSE', 'utf-8')).toContain('Amazon Software License');
+    expect(readJson(tree, 'package.json').license).toBe('ASL');
+  });
+});

--- a/packages/nx-plugin/src/license/generator.ts
+++ b/packages/nx-plugin/src/license/generator.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { generateFiles, readNxJson, Tree, updateNxJson } from '@nx/devkit';
+import { join } from 'path';
+import { LicenseGeneratorSchema } from './schema';
+import { defaultLicenseConfig, writeLicenseConfig } from './config';
+import { ensureAwsNxPluginConfig } from '../utils/config/utils';
+import { SYNC_GENERATOR_NAME } from './sync/generator';
+
+export async function licenseGenerator(
+  tree: Tree,
+  options: LicenseGeneratorSchema,
+) {
+  const { license, copyrightHolder } = options;
+
+  // Add LICENSE file
+  generateFiles(tree, join(__dirname, 'files', 'licenses', license), '.', {
+    ...options,
+    year: new Date().getFullYear(),
+  });
+
+  // Write default config for the license headers
+  await ensureAwsNxPluginConfig(tree);
+  await writeLicenseConfig(
+    tree,
+    license,
+    defaultLicenseConfig(license, copyrightHolder),
+  );
+
+  // Configure sync generator to run as part of all projects' lint target
+  const nxJson = readNxJson(tree);
+  updateNxJson(tree, {
+    ...nxJson,
+    targetDefaults: {
+      ...nxJson.targetDefaults,
+      lint: {
+        ...nxJson.targetDefaults?.lint,
+        syncGenerators: [
+          ...(nxJson.targetDefaults?.lint?.syncGenerators ?? []).filter(
+            (g) => g !== SYNC_GENERATOR_NAME,
+          ),
+          SYNC_GENERATOR_NAME,
+        ],
+      },
+    },
+  });
+}
+
+export default licenseGenerator;

--- a/packages/nx-plugin/src/license/schema.d.ts
+++ b/packages/nx-plugin/src/license/schema.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export type SPDXLicenseIdentifier = 'Apache-2.0' | 'MIT' | 'ASL';
+
+export interface LicenseGeneratorSchema {
+  /**
+   * SPDX License Identifier
+   */
+  license: SPDXLicenseIdentifier;
+
+  /**
+   * Copyright holder name
+   */
+  copyrightHolder: string;
+}

--- a/packages/nx-plugin/src/license/schema.json
+++ b/packages/nx-plugin/src/license/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "License",
+  "title": "Add LICENSE files, and configure source code license headers",
+  "type": "object",
+  "properties": {
+    "license": {
+      "type": "string",
+      "description": "SPDX License Identifier",
+      "enum": ["Apache-2.0", "MIT", "ASL"],
+      "default": "Apache-2.0",
+      "x-priority": "important"
+    },
+    "copyrightHolder": {
+      "type": "string",
+      "description": "Copyright holder name",
+      "default": "Amazon.com, Inc. or its affiliates",
+      "x-priority": "important"
+    }
+  },
+  "required": []
+}

--- a/packages/nx-plugin/src/license/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/license/sync/generator.spec.ts
@@ -1,0 +1,847 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { licenseSyncGenerator } from './generator';
+import {
+  ensureAwsNxPluginConfig,
+  updateAwsNxPluginConfig,
+} from '../../utils/config/utils';
+import { LicenseConfig } from '../config-types';
+import { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
+import { mkdtempSync, rmSync } from 'fs';
+import { flushChanges, FsTree } from 'nx/src/generators/tree';
+import { execSync } from 'child_process';
+
+describe('licenseSyncGenerator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const addLicenseConfig = async (
+    licenseConfig?: LicenseConfig,
+    _tree: Tree = tree,
+  ) => {
+    await ensureAwsNxPluginConfig(_tree);
+    await updateAwsNxPluginConfig(_tree, {
+      license: licenseConfig ?? {
+        header: {
+          content: {
+            lines: ['Test Header'],
+          },
+          format: {
+            '**/*.ts': {
+              lineStart: '// ',
+            },
+            '**/*.sh': {
+              lineStart: '# ',
+            },
+          },
+        },
+      },
+    });
+  };
+
+  const getOutOfSyncMessage = (
+    res: SyncGeneratorResult,
+  ): string | undefined => {
+    if (typeof res === 'object') {
+      return res.outOfSyncMessage;
+    }
+    return undefined;
+  };
+
+  it('should do nothing when there is no license config', async () => {
+    const numChangesPrior = tree.listChanges().length;
+    await licenseSyncGenerator(tree);
+    expect(tree.listChanges()).toHaveLength(numChangesPrior);
+  });
+
+  it('should add headers', async () => {
+    await addLicenseConfig();
+
+    tree.write('foo.ts', `const foo = 'bar';`);
+
+    const res = await licenseSyncGenerator(tree);
+
+    expect(tree.read('foo.ts', 'utf-8')).toBe(
+      `// Test Header\nconst foo = 'bar';`,
+    );
+
+    expect(getOutOfSyncMessage(res)).toContain(
+      `License headers are out of sync in the following source files:\n- foo.ts`,
+    );
+  });
+
+  it('should add multi-line headers', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: [
+            'Copyright Test Inc.',
+            'Licensed under MIT',
+            'All rights reserved',
+          ],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    tree.write('foo.ts', `const foo = 'bar';`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('foo.ts', 'utf-8')).toBe(
+      `// Copyright Test Inc.\n// Licensed under MIT\n// All rights reserved\nconst foo = 'bar';`,
+    );
+  });
+
+  it('should add multi-line block comment headers', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: [
+            'Copyright Test Inc.',
+            'Licensed under MIT',
+            'All rights reserved',
+          ],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/*',
+            blockEnd: '*/',
+          },
+        },
+      },
+    });
+
+    tree.write('foo.ts', `const foo = 'bar';`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('foo.ts', 'utf-8')).toBe(
+      `/*\nCopyright Test Inc.\nLicensed under MIT\nAll rights reserved\n*/\nconst foo = 'bar';`,
+    );
+  });
+
+  it("should allow custom comment syntax for files which aren't natively supported", async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.xyz': {
+            lineStart: '## ',
+          },
+        },
+        commentSyntax: {
+          xyz: {
+            line: '##',
+          },
+        },
+      },
+    });
+
+    tree.write('test.xyz', `some content`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.xyz', 'utf-8')).toBe(`## Test Header\nsome content`);
+  });
+
+  it('should preserve bash hashbangs', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.sh': {
+            lineStart: '# ',
+          },
+        },
+      },
+    });
+
+    tree.write('script.sh', `#!/bin/bash\necho "hello"`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('script.sh', 'utf-8')).toBe(
+      `#!/bin/bash\n# Test Header\necho "hello"`,
+    );
+  });
+
+  it('should update an existing header', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['New Header'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `// Old Header\nconst x = 1;`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(`// New Header\nconst x = 1;`);
+  });
+
+  it('should only update the first block comment', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['New Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/***',
+            lineStart: ' * ',
+            blockEnd: ' ***/',
+          },
+        },
+      },
+    });
+
+    tree.write(
+      'test.ts',
+      `/* Old Header */\n/* Another comment */\nconst x = 1;`,
+    );
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(
+      `/***\n * New Header\n ***/\n/* Another comment */\nconst x = 1;`,
+    );
+  });
+
+  it('should only update the first series of line comments', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['New Header'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    tree.write(
+      'test.ts',
+      `// Old Header\n// More old header\n/* some block comment */\nconst x = 1;\n// Another comment`,
+    );
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(
+      `// New Header\n/* some block comment */\nconst x = 1;\n// Another comment`,
+    );
+  });
+
+  it('should read header content from a file', async () => {
+    tree.write('header.txt', 'File Header Content');
+
+    await addLicenseConfig({
+      header: {
+        content: {
+          filePath: 'header.txt',
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(
+      `// File Header Content\nconst x = 1;`,
+    );
+  });
+
+  it('should error if the header content file does not exist', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          filePath: 'non-existent.txt',
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Could not find license header content file non-existent.txt',
+    );
+  });
+
+  it('should error for a file with unknown line comment syntax', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.xyz': {
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    tree.write('test.xyz', `content`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Unknown file extension xyz',
+    );
+  });
+
+  it('should error for a file with unknown block comment syntax', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.xyz': {
+            blockStart: '/*',
+            blockEnd: '*/',
+          },
+        },
+      },
+    });
+
+    tree.write('test.xyz', `content`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Unknown file extension xyz',
+    );
+  });
+
+  it('should error when a configured format would result in an invalid line comment', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '-- ',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided format for ts file would generate invalid comment syntax',
+    );
+  });
+
+  it('should error when a configured format would result in an invalid block comment', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '-- ',
+            blockEnd: ' --',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided format for ts file would generate invalid comment syntax',
+    );
+  });
+
+  it('should error when a confgured license header would cause a syntax error by closing a block comment early', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test */ Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/*',
+            blockEnd: '*/',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided license content would close a block comment early and cause a syntax error! Please remove "*/" from your license text.',
+    );
+  });
+
+  it('should error when blockEnd does not close a block comment opened by blockStart', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/*',
+            blockEnd: '// does not close',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided format for ts file opens a block comment with "/*" in blockStart but does not close it with "*/" in blockEnd',
+    );
+  });
+
+  it('should allow a format which uses line comments in block start and end', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '// header',
+            lineStart: '// ',
+            blockEnd: '// footer',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(
+      `// header\n// Test Header\n// footer\nconst x = 1;`,
+    );
+  });
+
+  it('should allow a format which uses line comments in block start and omits block end', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '// header',
+            lineStart: '// ',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(
+      `// header\n// Test Header\nconst x = 1;`,
+    );
+  });
+
+  it('should allow a format which uses line comments in block end and omits block start', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+            blockEnd: '// footer',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(
+      `// Test Header\n// footer\nconst x = 1;`,
+    );
+  });
+
+  it("should error when multiple block comments would be rendered and we couldn't therefore replace the header again", async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header Line 1', 'Test Header Line 2'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/* ',
+            lineStart: '/* ',
+            lineEnd: ' */',
+            blockEnd: ' */',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'The license header content, or format for ts files would produce a header that cannot be safely replaced',
+    );
+  });
+
+  it('should error when multiple block comments would be rendered from just block start and end', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header Line 1', 'Test Header Line 2'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/* something */',
+            blockEnd: '/* something else */',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided format for ts file may cause syntax errors since it closes the block comment with "*/" in blockStart',
+    );
+  });
+
+  it('should error when a block comment is terminated early by lineEnd', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header Line 1', 'Test Header Line 2'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/* something',
+            lineStart: '//',
+            lineEnd: ' */',
+            blockEnd: ' */',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'The license header content, or format for ts files would produce a header that cannot be safely replaced',
+    );
+  });
+
+  it('should error when a line comment spills over and tries to add non-comment code', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '//\nconsole.log("hack!"); //',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'The license header content, or format for ts files would produce a header that cannot be safely replaced',
+    );
+  });
+
+  it("should error when content lines contain extra newlines that wouldn't render as comments", async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header\nconsole.log("hack!");'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '//',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'The license header content, or format for ts files would produce a header that cannot be safely replaced',
+    );
+  });
+
+  it('should error when a blockEnd format double-ends a comment', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/*',
+            blockEnd: '*/ console.log("hack!"); /* */',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided format for ts file may cause syntax errors due to closing a block comment multiple times with "*/" in blockEnd',
+    );
+  });
+
+  it('should error when a blockStart format ends a block comment', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header Line 1', 'Test Header Line 2'],
+        },
+        format: {
+          '**/*.ts': {
+            blockStart: '/* something */console.log("hack!");/*',
+            blockEnd: ' */',
+          },
+        },
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+
+    await expect(licenseSyncGenerator(tree)).rejects.toThrow(
+      'Provided format for ts file may cause syntax errors since it closes the block comment with "*/" in blockStart',
+    );
+  });
+
+  it('should allow files to be excluded from license header updates', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header'],
+        },
+        format: {
+          '**/*.ts': {
+            lineStart: '// ',
+          },
+        },
+        exclude: ['**/excluded.ts'],
+      },
+    });
+
+    tree.write('test.ts', `const x = 1;`);
+    tree.write('excluded.ts', `const y = 2;`);
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(`// Test Header\nconst x = 1;`);
+    expect(tree.read('excluded.ts', 'utf-8')).toBe(`const y = 2;`);
+  });
+
+  it('should synchronise subproject LICENSE files when a root LICENSE file is present', async () => {
+    await addLicenseConfig();
+    tree.write('LICENSE', 'my test license');
+
+    addProjectConfiguration(tree, 'without-license', {
+      root: 'packages/without-license',
+    });
+
+    addProjectConfiguration(tree, 'with-bad-license', {
+      root: 'packages/with-bad-license',
+    });
+    tree.write('packages/with-bad-license/LICENSE', 'bad license');
+
+    const res = await licenseSyncGenerator(tree);
+
+    expect(tree.exists('packages/without-license/LICENSE')).toBeTruthy();
+    expect(tree.read('packages/without-license/LICENSE', 'utf-8')).toBe(
+      'my test license',
+    );
+
+    expect(tree.exists('packages/with-bad-license/LICENSE')).toBeTruthy();
+    expect(tree.read('packages/with-bad-license/LICENSE', 'utf-8')).toBe(
+      'my test license',
+    );
+
+    expect(getOutOfSyncMessage(res)).toContain(
+      'Project license files are missing:\n- packages/without-license/LICENSE',
+    );
+    expect(getOutOfSyncMessage(res)).toContain(
+      'Project license files are out of sync:\n- packages/with-bad-license/LICENSE',
+    );
+  });
+
+  it('should not write subproject LICENSE files when no root LICENSE file is found', async () => {
+    await addLicenseConfig();
+
+    addProjectConfiguration(tree, 'test-project', {
+      root: 'packages/test-project',
+    });
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.exists('packages/test-project/LICENSE')).toBeFalsy();
+  });
+
+  it('should allow subprojects to be excluded from LICENSE file sync', async () => {
+    await addLicenseConfig({
+      files: {
+        exclude: ['packages/excluded-project'],
+      },
+    });
+
+    tree.write('LICENSE', 'test license');
+
+    addProjectConfiguration(tree, 'excluded-project', {
+      root: 'packages/excluded-project',
+    });
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.exists('packages/excluded-project/LICENSE')).toBeFalsy();
+  });
+
+  it('should not update ignored files in git projects', async () => {
+    const tmpDir = mkdtempSync('tmp-dir');
+
+    try {
+      const fsTree = new FsTree(tmpDir, false);
+      execSync('git init', { cwd: tmpDir });
+      execSync('git config user.email test@example.com', { cwd: tmpDir });
+      execSync('git config user.name test', { cwd: tmpDir });
+
+      // Add default config
+      await addLicenseConfig(undefined, fsTree);
+
+      fsTree.write('.gitignore', '*.js');
+      fsTree.write('test.ts', "const x = 'foo';");
+      fsTree.write('ignored.js', "const y = 'bar';");
+
+      // Flush to ensure git is aware of the files
+      flushChanges(fsTree.root, fsTree.listChanges());
+
+      await licenseSyncGenerator(fsTree);
+
+      expect(fsTree.read('test.ts', 'utf-8')).toBe(
+        `// Test Header\nconst x = 'foo';`,
+      );
+      expect(fsTree.read('ignored.js', 'utf-8')).toBe(`const y = 'bar';`);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      ext: 'ts',
+      content: 'const x = 1;',
+      format: {
+        blockStart: '/*',
+        blockEnd: '*/',
+      },
+      expected: '/*\nTest Header\n*/\nconst x = 1;',
+      description: 'block comments (C-style)',
+    },
+    {
+      ext: 'py',
+      content: 'x = 1',
+      format: {
+        lineStart: '# ',
+      },
+      expected: '# Test Header\nx = 1',
+      description: 'line comments (Python-style)',
+    },
+    {
+      ext: 'html',
+      content: '<div>test</div>',
+      format: {
+        blockStart: '<!--',
+        blockEnd: '-->',
+      },
+      expected: '<!--\nTest Header\n-->\n<div>test</div>',
+      description: 'block-only comments (HTML)',
+    },
+    {
+      ext: 'sh',
+      content: 'echo "hello"',
+      format: {
+        lineStart: '# ',
+      },
+      expected: '# Test Header\necho "hello"',
+      description: 'line-only comments (shell)',
+    },
+    {
+      ext: 'rb',
+      content: 'puts "hello"',
+      format: {
+        blockStart: '=begin',
+        blockEnd: '=end',
+      },
+      expected: '=begin\nTest Header\n=end\nputs "hello"',
+      description: 'alternative block syntax (Ruby)',
+    },
+  ])(
+    'should support popular languages: $description',
+    async ({ ext, content, format, expected }) => {
+      await addLicenseConfig({
+        header: {
+          content: {
+            lines: ['Test Header'],
+          },
+          format: {
+            [`**/*.${ext}`]: format,
+          },
+        },
+      });
+
+      tree.write(`test.${ext}`, content);
+      await licenseSyncGenerator(tree);
+      expect(tree.read(`test.${ext}`, 'utf-8')).toBe(expected);
+    },
+  );
+});

--- a/packages/nx-plugin/src/license/sync/generator.ts
+++ b/packages/nx-plugin/src/license/sync/generator.ts
@@ -1,0 +1,418 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { getProjects, globAsync, joinPathFragments, Tree } from '@nx/devkit';
+import { LANGUAGE_COMMENT_SYNTAX, readLicenseConfig } from '../config';
+import {
+  CommentSyntax,
+  LicenseHeaderConfig,
+  LicenseHeaderFormat,
+} from '../config-types';
+import { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
+import { basename } from 'path';
+import { glob as fastGlob } from 'fast-glob';
+import { minimatch } from 'minimatch';
+import { getGitIncludedFiles } from '../../utils/git';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils';
+
+export const SYNC_GENERATOR_NAME = '@aws/nx-plugin:license#sync';
+
+export async function licenseSyncGenerator(
+  tree: Tree,
+): Promise<SyncGeneratorResult> {
+  const config = await readLicenseConfig(tree);
+
+  if (!config) {
+    // Nothing to do when not configured
+    return {};
+  }
+
+  const licenseHeadersUpdated: string[] = [];
+
+  if (config.header) {
+    // Get all candidate project files for header
+    const candidateProjectFiles = await getCandidateProjectFilesForHeader(
+      tree,
+      config.header,
+    );
+
+    const headerContentLines = loadHeaderContentLines(tree, config.header);
+
+    // Add headers to project files which match the include pattern
+    for (const [includePattern, format] of Object.entries(
+      config.header.format,
+    )) {
+      const files = minimatch.match(candidateProjectFiles, includePattern);
+
+      files.forEach((file) => {
+        const didAdd = addHeader(
+          tree,
+          file,
+          headerContentLines,
+          config.header,
+          format,
+        );
+        if (didAdd) {
+          licenseHeadersUpdated.push(file);
+        }
+      });
+    }
+  }
+
+  const licenseFilesAdded: string[] = [];
+  const licenseFilesUpdated: string[] = [];
+
+  if (tree.exists('LICENSE')) {
+    const rootLicense = tree.read('LICENSE', 'utf-8');
+
+    // Sync subproject license files
+    for (const project of getProjects(tree).values()) {
+      const projectLicensePath = joinPathFragments(project.root, 'LICENSE');
+
+      // Check that this project is not excluded in config
+      if (
+        !(config?.files?.exclude ?? []).some(
+          (excludePattern) =>
+            minimatch(projectLicensePath, excludePattern) ||
+            minimatch(project.root, excludePattern),
+        )
+      ) {
+        // Write the license if it doesn't exist, or if it doesn't match the root license
+        let shouldWrite = false;
+        if (!tree.exists(projectLicensePath)) {
+          licenseFilesAdded.push(projectLicensePath);
+          shouldWrite = true;
+        } else if (tree.read(projectLicensePath, 'utf-8') !== rootLicense) {
+          licenseFilesUpdated.push(projectLicensePath);
+          shouldWrite = true;
+        }
+
+        if (shouldWrite) {
+          tree.write(projectLicensePath, rootLicense);
+        }
+      }
+    }
+  }
+
+  return {
+    outOfSyncMessage: buildOutOfSyncMessage({
+      licenseHeadersUpdated,
+      licenseFilesAdded,
+      licenseFilesUpdated,
+    }),
+  };
+}
+
+/**
+ * Build the message to display when the sync generator would make changes to the tree
+ */
+const buildOutOfSyncMessage = (updates: {
+  licenseFilesAdded: string[];
+  licenseFilesUpdated: string[];
+  licenseHeadersUpdated: string[];
+}): string => {
+  let outOfSyncMessage = '';
+
+  if (updates.licenseFilesAdded.length > 0) {
+    outOfSyncMessage += `Project license files are missing:\n${updates.licenseFilesAdded.map((p) => `- ${p}`).join('\n')}\n\n`;
+  }
+  if (updates.licenseFilesUpdated.length > 0) {
+    outOfSyncMessage += `Project license files are out of sync:\n${updates.licenseFilesUpdated.map((p) => `- ${p}`).join('\n')}\n\n`;
+  }
+  if (updates.licenseHeadersUpdated.length > 0) {
+    outOfSyncMessage += `License headers are out of sync in the following source files:\n${updates.licenseHeadersUpdated.map((p) => `- ${p}`).join('\n')}\n\n`;
+  }
+
+  return outOfSyncMessage.trim();
+};
+
+/**
+ * Load the license header content lines
+ */
+const loadHeaderContentLines = (
+  tree: Tree,
+  config: LicenseHeaderConfig,
+): string[] => {
+  // Load the license header content
+  let headerContentLines = [];
+  if ('lines' in config.content) {
+    headerContentLines = config.content.lines;
+  } else {
+    if (!tree.exists(config.content.filePath)) {
+      throw new Error(
+        `Could not find license header content file ${config.content.filePath}`,
+      );
+    }
+    headerContentLines = tree
+      .read(config.content.filePath, 'utf-8')
+      .split('\n');
+  }
+  return headerContentLines;
+};
+
+/**
+ * Returns all files in the given tree - both in-memory only and in the filesystem under the tree root
+ */
+const getAllFilesInTree = async (tree: Tree): Promise<string[]> => {
+  return [
+    ...new Set([
+      // Get all files in memory in the tree
+      ...(await globAsync(tree, ['*'])),
+      // Find all files on the filesystem that may not be in memory in the tree
+      ...(await fastGlob(['*'], { cwd: tree.root, dot: true })),
+    ]),
+  ].filter((f) => tree.exists(f));
+};
+
+/**
+ * Returns the list of project files
+ */
+const getCandidateProjectFilesForHeader = async (
+  tree: Tree,
+  config: LicenseHeaderConfig,
+): Promise<string[]> => {
+  // Prefer, if possible, to treat all non gitignored files as our candidate set such that we honour users .gitignore files
+  // If we're not in a git repo, fall back to everything and rely on the user configuring exclusions below
+  const projectFiles = tree.exists('.git')
+    ? getGitIncludedFiles(tree)
+    : await getAllFilesInTree(tree);
+
+  // Remove any files that were excluded in the config
+  const ignoredProjectFiles = new Set(
+    (config.exclude ?? []).flatMap((pattern) =>
+      minimatch.match(projectFiles, pattern),
+    ),
+  );
+  return projectFiles.filter((file) => !ignoredProjectFiles.has(file));
+};
+
+/**
+ * Renders a header with the given format
+ */
+const renderHeader = (
+  contentLines: string[],
+  format: LicenseHeaderFormat,
+): string => {
+  return `${format.blockStart ? `${format.blockStart}\n` : ''}${contentLines.map((line) => `${format.lineStart ?? ''}${line}${format.lineEnd ?? ''}`).join('\n')}${format.blockEnd ? `\n${format.blockEnd}` : ''}`;
+};
+
+/**
+ * Validates header format to ensure it produces a valid comment
+ */
+const validateFormat = (
+  fileExtension: string,
+  syntax: CommentSyntax,
+  format: LicenseHeaderFormat,
+  contentLines: string[],
+): void => {
+  const blockStartOpensBlockComment =
+    format.blockStart &&
+    syntax.block &&
+    format.blockStart.startsWith(syntax.block.start);
+  const blockEndClosesBlockComment =
+    format.blockEnd &&
+    syntax.block &&
+    format.blockEnd.endsWith(syntax.block.end);
+
+  // Block start must start with the block start or line comment
+  const validBlockStart =
+    !format.blockStart ||
+    blockStartOpensBlockComment ||
+    (syntax.line && format.blockStart.startsWith(syntax.line));
+  // Block end must end with the block end, or begin with the line comment
+  const validBlockEnd =
+    !format.blockEnd ||
+    blockEndClosesBlockComment ||
+    (syntax.line && format.blockEnd.startsWith(syntax.line));
+
+  // Lines must start with the line comment syntax, unless within a block comment
+  const validLineStart =
+    !format.lineStart ||
+    (syntax.line && format.lineStart.startsWith(syntax.line)) ||
+    (blockStartOpensBlockComment && blockEndClosesBlockComment);
+
+  if (!validLineStart || !validBlockStart || !validBlockEnd) {
+    throw new Error(
+      `Provided format for ${fileExtension} file would generate invalid comment syntax. Configured syntax for ${fileExtension} is ${JSON.stringify(syntax, null, 2)}.`,
+    );
+  }
+
+  if (blockStartOpensBlockComment && !blockEndClosesBlockComment) {
+    throw new Error(
+      `Provided format for ${fileExtension} file opens a block comment with "${syntax.block.start}" in blockStart but does not close it with "${syntax.block.end}" in blockEnd`,
+    );
+  }
+
+  if (
+    blockStartOpensBlockComment &&
+    contentLines.some((line) => line.includes(syntax.block.end))
+  ) {
+    throw new Error(
+      `Provided license content would close a block comment early and cause a syntax error! Please remove "${syntax.block.end}" from your license text.`,
+    );
+  }
+
+  if (blockStartOpensBlockComment && blockEndClosesBlockComment) {
+    if (
+      format.blockEnd.lastIndexOf(syntax.block.end) !==
+      format.blockEnd.indexOf(syntax.block.end)
+    ) {
+      throw new Error(
+        `Provided format for ${fileExtension} file may cause syntax errors due to closing a block comment multiple times with "${syntax.block.end}" in blockEnd`,
+      );
+    }
+    if (format.blockStart.includes(syntax.block.end)) {
+      throw new Error(
+        `Provided format for ${fileExtension} file may cause syntax errors since it closes the block comment with "${syntax.block.end}" in blockStart`,
+      );
+    }
+  }
+};
+
+/**
+ * Parse the hashbang, header and body from a file.
+ * The header is the first block comment, or consecutive series of line comments found in the file, after the hashbang
+ */
+const parseFile = (
+  content: string,
+  syntax: CommentSyntax,
+): { hashbang: string; header: string; body: string } => {
+  const lines = content.split('\n');
+  let i = 0;
+
+  // Hashbangs must always go first, so extract this if it exists
+  const hashbangLines = [];
+  for (; i < lines.length; i++) {
+    if (hashbangLines.length === 0) {
+      if (lines[i].startsWith('#!')) {
+        hashbangLines.push(lines[i]);
+      } else {
+        break;
+      }
+    } else {
+      if (lines[i].trim().length === 0) {
+        // Preserve any empty lines following the hashbang
+        hashbangLines.push(lines[i]);
+      } else {
+        break;
+      }
+    }
+  }
+
+  // After the hashbang, consume the next comment which follows.
+  // This could either be all lines of a block comment, or all consecutive line comments until a non line-comment is seen
+  const headerLines = [];
+  let withinBlockComment = false;
+  let withinLineCommentSeries = false;
+  for (; i < lines.length; i++) {
+    const trimmedLine = lines[i].trim();
+    if (
+      syntax.block &&
+      trimmedLine.endsWith(syntax.block.end) &&
+      !withinLineCommentSeries
+    ) {
+      // Comment ends with the block end, so we've completed the header and therefore break out of the loop
+      headerLines.push(lines[i]);
+      i++; // Increment here to ensure we point to the next line for the body
+      break;
+    } else if (
+      syntax.block &&
+      trimmedLine.startsWith(syntax.block.start) &&
+      !withinLineCommentSeries
+    ) {
+      // Line begins a comment block (without also ending it on the same line), so start consuming the block
+      withinBlockComment = true;
+      headerLines.push(lines[i]);
+    } else if (withinBlockComment) {
+      // We haven't yet closed the block comment, so consume this line
+      headerLines.push(lines[i]);
+    } else if (syntax.line && trimmedLine.startsWith(syntax.line)) {
+      // Line starts with the line comment syntax, so consume it
+      withinLineCommentSeries = true;
+      headerLines.push(lines[i]);
+    } else {
+      break;
+    }
+  }
+
+  // Body of the file is the rest
+  const bodyLines = lines.slice(i);
+
+  return {
+    hashbang: hashbangLines.join('\n'),
+    header: headerLines.join('\n'),
+    body: bodyLines.join('\n'),
+  };
+};
+
+/**
+ * Add a header to the given file according to the header content and license config
+ * Returns true if the header was added/updated, and false otherwise.
+ */
+const addHeader = (
+  tree: Tree,
+  file: string,
+  contentLines: string[],
+  config: LicenseHeaderConfig,
+  format: LicenseHeaderFormat,
+): boolean => {
+  const fileName = basename(file);
+  const fileNameParts = fileName.split('.');
+  const fileExtension = fileNameParts[fileNameParts.length - 1];
+
+  const syntax =
+    (config.commentSyntax ?? {})[fileExtension] ??
+    LANGUAGE_COMMENT_SYNTAX[fileExtension];
+  if (!syntax) {
+    throw new Error(`Unknown file extension ${fileExtension}. Please configure commentSyntax in ${AWS_NX_PLUGIN_CONFIG_FILE_NAME}, eg:
+
+export default {
+  license: {
+    header: {
+      ...
+      commentSyntax: {
+        ${fileExtension}: {
+          line: "//",
+          block: { start: "/*", end: "*/" }
+        }
+      }
+    }
+  }
+} satisfies AwsNxPluginConfig;
+`);
+  }
+
+  // Check that we would render a valid comment
+  validateFormat(fileExtension, syntax, format, contentLines);
+
+  const existingContent = tree.read(file, 'utf-8');
+
+  const { hashbang, body } = parseFile(existingContent, syntax);
+
+  const newContent = [
+    ...(hashbang ? [hashbang] : []),
+    renderHeader(contentLines, format),
+    body,
+  ].join('\n');
+
+  // Sanity check that we wouldn't edit the hashbang or body, only the header
+  const { hashbang: newHashbang, body: newBody } = parseFile(
+    newContent,
+    syntax,
+  );
+  if (hashbang !== newHashbang || body !== newBody) {
+    throw new Error(
+      `The license header content, or format for ${fileExtension} files would produce a header that cannot be safely replaced. Please revise license content and format in ${AWS_NX_PLUGIN_CONFIG_FILE_NAME}`,
+    );
+  }
+
+  if (newContent !== existingContent) {
+    tree.write(file, newContent);
+    return true;
+  }
+
+  return false;
+};
+
+export default licenseSyncGenerator;

--- a/packages/nx-plugin/src/license/sync/schema.json
+++ b/packages/nx-plugin/src/license/sync/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "license-headers",
+  "title": "Sync generator for adding license headers to source code",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/packages/nx-plugin/src/ts/lib/eslint.ts
+++ b/packages/nx-plugin/src/ts/lib/eslint.ts
@@ -36,7 +36,7 @@ export const configureEslint = async (tree: Tree) => {
   addDependenciesToPackageJson(
     tree,
     {},
-    withVersions(['prettier', 'eslint-plugin-prettier'])
+    withVersions(['prettier', 'eslint-plugin-prettier']),
   );
   // Update or create eslint.config.mjs
   const eslintConfigPath = 'eslint.config.mjs';
@@ -46,7 +46,7 @@ export const configureEslint = async (tree: Tree) => {
     // Check if import exists
     const existingImport = tsquery.query(
       sourceFile,
-      'VariableDeclaration[name.text="eslintPluginPrettierRecommended"]'
+      'VariableDeclaration[name.text="eslintPluginPrettierRecommended"]',
     );
     let updatedContent = sourceFile;
     // Add import if it doesn't exist
@@ -56,14 +56,14 @@ export const configureEslint = async (tree: Tree) => {
           tree,
           eslintConfigPath,
           'eslintPluginPrettierRecommended',
-          'eslint-plugin-prettier/recommended'
-        )
+          'eslint-plugin-prettier/recommended',
+        ),
       );
     }
     // Check if eslintPluginPrettierRecommended exists in exports array
     const existingPlugin = tsquery.query(
       updatedContent,
-      'ExportAssignment > ArrayLiteralExpression Identifier[name="eslintPluginPrettierRecommended"]'
+      'ExportAssignment > ArrayLiteralExpression Identifier[name="eslintPluginPrettierRecommended"]',
     );
     // Add eslintPluginPrettierRecommended to array if it doesn't exist
     if (existingPlugin.length === 0) {
@@ -76,9 +76,9 @@ export const configureEslint = async (tree: Tree) => {
               factory.createIdentifier('eslintPluginPrettierRecommended'),
               ...node.elements,
             ],
-            true
+            true,
           );
-        }
+        },
       );
     }
     // Only write if changes were made
@@ -92,6 +92,7 @@ export const configureEslint = async (tree: Tree) => {
       targetDefaults: {
         ...(nxJson.targetDefaults ?? {}),
         lint: {
+          ...nxJson.targetDefaults?.lint,
           cache: true,
           configurations: {
             fix: {

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -11,6 +11,8 @@ import {
   JsxChild,
   JsxClosingElement,
   JsxOpeningElement,
+  Node,
+  Expression,
   SourceFile,
 } from 'typescript';
 const assertFilePath = (tree: Tree, filePath: string) => {
@@ -22,7 +24,7 @@ export const destructuredImport = (
   tree: Tree,
   filePath: string,
   variableNames: string[],
-  from: string
+  from: string,
 ): string => {
   assertFilePath(tree, filePath);
   const contents = tree.read(filePath).toString();
@@ -30,20 +32,20 @@ export const destructuredImport = (
   // Check if any of the variables are already imported from the same module
   const existingImports: ImportSpecifier[] = tsquery.query(
     sourceAst,
-    `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause ImportSpecifier`
+    `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause ImportSpecifier`,
   );
   const existingVariables = new Set(
     existingImports.map((node) => {
       const importSpecifier = node as ImportSpecifier;
       return importSpecifier.name.escapedText.toString();
-    })
+    }),
   );
   // Filter out variables that are already imported
   const newVariables = variableNames.filter(
     (name) =>
       !existingVariables.has(
-        name.includes(' as ') ? name.split(' as ')[1] : name
-      )
+        name.includes(' as ') ? name.split(' as ')[1] : name,
+      ),
   );
   if (newVariables.length === 0) {
     return contents;
@@ -60,12 +62,12 @@ export const destructuredImport = (
           return factory.createImportSpecifier(
             false,
             alias ? factory.createIdentifier(name) : undefined,
-            factory.createIdentifier(alias || name)
+            factory.createIdentifier(alias || name),
           );
         }),
-      ])
+      ]),
     ) as ImportClause,
-    factory.createStringLiteral(from, true)
+    factory.createStringLiteral(from, true),
   );
   const updatedContents = tsquery
     .map(ast(contents), 'SourceFile', (node: SourceFile) => {
@@ -84,7 +86,7 @@ export const singleImport = (
   tree: Tree,
   filePath: string,
   variableName: string,
-  from: string
+  from: string,
 ): string => {
   assertFilePath(tree, filePath);
   const contents = tree.read(filePath).toString();
@@ -92,7 +94,7 @@ export const singleImport = (
   // Check if the import already exists
   const existingImports = tsquery.query(
     sourceAst,
-    `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause > Identifier[text="${variableName}"]`
+    `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause > Identifier[text="${variableName}"]`,
   );
   if (existingImports.length > 0) {
     return contents;
@@ -102,9 +104,9 @@ export const singleImport = (
     factory.createImportClause(
       false,
       factory.createIdentifier(variableName),
-      undefined
+      undefined,
     ) as ImportClause,
-    factory.createStringLiteral(from)
+    factory.createStringLiteral(from),
   );
   const updatedContents = tsquery
     .map(ast(contents), 'SourceFile', (node: SourceFile) => {
@@ -126,14 +128,14 @@ export const addStarExport = (tree: Tree, filePath: string, from: string) => {
   const hasExport =
     tsquery.query(
       ast(indexContents),
-      `ExportDeclaration StringLiteral[text="${from}"]`
+      `ExportDeclaration StringLiteral[text="${from}"]`,
     ).length > 0;
   if (!hasExport) {
     const exportDeclaration = factory.createExportDeclaration(
       undefined,
       undefined,
       undefined,
-      factory.createStringLiteral(from)
+      factory.createStringLiteral(from),
     );
     const updatedIndexContents = tsquery
       .map(ast(indexContents), 'SourceFile', (node: SourceFile) => ({
@@ -146,12 +148,13 @@ export const addStarExport = (tree: Tree, filePath: string, from: string) => {
     }
   }
 };
+
 export const replace = (
   tree: Tree,
   filePath: string,
   selector: string,
   transformer: NodeTransformer,
-  errorIfNoMatches = true
+  errorIfNoMatches = true,
 ) => {
   assertFilePath(tree, filePath);
   const source = tree.read(filePath).toString();
@@ -159,7 +162,7 @@ export const replace = (
     const queryNodes = tsquery.query(ast(source), selector);
     if (queryNodes.length === 0) {
       throw new Error(
-        `Could not locate a element im ${filePath} matching ${selector}`
+        `Could not locate a element im ${filePath} matching ${selector}`,
       );
     }
   }
@@ -172,19 +175,67 @@ export const replace = (
 };
 export const createJsxElementFromIdentifier = (
   identifier: string,
-  children: readonly JsxChild[]
+  children: readonly JsxChild[],
 ) =>
   factory.createJsxElement(
     factory.createJsxOpeningElement(
       factory.createIdentifier(identifier),
       undefined,
-      factory.createJsxAttributes([])
+      factory.createJsxAttributes([]),
     ),
     children,
-    factory.createJsxClosingElement(factory.createIdentifier(identifier))
+    factory.createJsxClosingElement(factory.createIdentifier(identifier)),
   );
 export const createJsxElement = (
   openingElement: JsxOpeningElement,
   children: readonly JsxChild[],
-  closingElement: JsxClosingElement
+  closingElement: JsxClosingElement,
 ) => factory.createJsxElement(openingElement, children, closingElement);
+
+/**
+ * Convert a given json object to its AST representation
+ */
+export const jsonToAst = (obj: unknown): Node => {
+  if (obj === null) {
+    return factory.createNull();
+  }
+
+  if (obj === undefined) {
+    return factory.createIdentifier('undefined');
+  }
+
+  if (typeof obj === 'string') {
+    return factory.createStringLiteral(obj);
+  }
+
+  if (typeof obj === 'number') {
+    return factory.createNumericLiteral(obj);
+  }
+
+  if (typeof obj === 'boolean') {
+    return obj ? factory.createTrue() : factory.createFalse();
+  }
+
+  if (Array.isArray(obj)) {
+    return factory.createArrayLiteralExpression(
+      obj.map((item) => jsonToAst(item) as Expression),
+    );
+  }
+
+  if (typeof obj === 'object') {
+    return factory.createObjectLiteralExpression(
+      Object.entries(obj).map(([key, value]) => {
+        // Check if the key is a valid identifier
+        const isValidIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key);
+        return factory.createPropertyAssignment(
+          isValidIdentifier
+            ? factory.createIdentifier(key)
+            : factory.createStringLiteral(key),
+          jsonToAst(value) as Expression,
+        );
+      }),
+    );
+  }
+
+  throw new Error(`Unsupported type: ${typeof obj}`);
+};

--- a/packages/nx-plugin/src/utils/config/__snapshots__/utils.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/config/__snapshots__/utils.spec.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`config utils > should update user config 1`] = `
+"import { AwsNxPluginConfig } from '@aws/nx-plugin';
+export default {
+  license: {
+    header: {
+      content: { lines: ['Test Copyright Header'] },
+      format: {
+        '**/*.ts': { blockStart: '/**', lineStart: ' * ', blockEnd: ' */' },
+      },
+    },
+  },
+} satisfies AwsNxPluginConfig;
+"
+`;

--- a/packages/nx-plugin/src/utils/config/files/aws-nx-plugin.config.mts.template
+++ b/packages/nx-plugin/src/utils/config/files/aws-nx-plugin.config.mts.template
@@ -1,0 +1,5 @@
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+
+} satisfies AwsNxPluginConfig;

--- a/packages/nx-plugin/src/utils/config/index.ts
+++ b/packages/nx-plugin/src/utils/config/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { LicenseConfig } from '../../license/config-types';
+export * from '../../license/config-types';
+
+/**
+ * Configuration for the nx plugin
+ */
+export interface AwsNxPluginConfig {
+  /**
+   * Configuration for the license sync generator
+   */
+  license?: LicenseConfig;
+}

--- a/packages/nx-plugin/src/utils/config/utils.spec.ts
+++ b/packages/nx-plugin/src/utils/config/utils.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree } from '@nx/devkit';
+import {
+  ensureAwsNxPluginConfig,
+  readAwsNxPluginConfig,
+  updateAwsNxPluginConfig,
+  AWS_NX_PLUGIN_CONFIG_FILE_NAME,
+} from './utils';
+import { LicenseLinesContent } from '../../license/config-types';
+
+describe('config utils', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+    await ensureAwsNxPluginConfig(tree);
+  });
+
+  it('should ensure config exists', async () => {
+    expect(tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)).toBe(true);
+  });
+
+  it('should update user config', async () => {
+    await updateAwsNxPluginConfig(tree, {
+      license: {
+        header: {
+          content: { lines: ['Test Copyright Header'] },
+          format: {
+            '**/*.ts': {
+              blockStart: '/**',
+              lineStart: ' * ',
+              blockEnd: ' */',
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8'),
+    ).toMatchSnapshot();
+
+    expect(
+      (
+        (await readAwsNxPluginConfig(tree)).license.header
+          .content as LicenseLinesContent
+      ).lines[0],
+    ).toBe('Test Copyright Header');
+
+    await updateAwsNxPluginConfig(tree, {
+      license: {
+        header: {
+          content: { lines: ['Test Copyright Header 2'] },
+          format: {
+            '**/*.ts': {
+              blockStart: '/**',
+              lineStart: ' * ',
+              blockEnd: ' */',
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      (
+        (await readAwsNxPluginConfig(tree)).license.header
+          .content as LicenseLinesContent
+      ).lines[0],
+    ).toBe('Test Copyright Header 2');
+  });
+
+  it('should not delete other user config', async () => {
+    await updateAwsNxPluginConfig(tree, {
+      license: {
+        header: {
+          content: { lines: ['Test Copyright Header'] },
+          format: {
+            '**/*.ts': {
+              blockStart: '/**',
+              lineStart: ' * ',
+              blockEnd: ' */',
+            },
+          },
+        },
+      },
+    });
+
+    await updateAwsNxPluginConfig(tree, {});
+
+    expect(
+      (
+        (await readAwsNxPluginConfig(tree)).license.header
+          .content as LicenseLinesContent
+      ).lines[0],
+    ).toBe('Test Copyright Header');
+  });
+});

--- a/packages/nx-plugin/src/utils/config/utils.ts
+++ b/packages/nx-plugin/src/utils/config/utils.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { generateFiles, joinPathFragments, Tree } from '@nx/devkit';
+import { AwsNxPluginConfig } from '.';
+import * as ts from 'typescript';
+import { jsonToAst, replace } from '../ast';
+import { factory } from 'typescript';
+import { formatFilesInSubtree } from '../format';
+import { importTypeScriptModule } from '../js';
+
+export const AWS_NX_PLUGIN_CONFIG_FILE_NAME = 'aws-nx-plugin.config.mts';
+
+/**
+ * Ensure that the config file exists
+ */
+export const ensureAwsNxPluginConfig = async (
+  tree: Tree,
+): Promise<AwsNxPluginConfig> => {
+  if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) {
+    // Create an empty config file if it doesn't already exist
+    generateFiles(tree, joinPathFragments(__dirname, 'files'), '.', {});
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return await readAwsNxPluginConfig(tree)!;
+};
+
+/**
+ * Read config from the aws nx plugin configuration file
+ */
+export const readAwsNxPluginConfig = async (
+  tree: Tree,
+): Promise<AwsNxPluginConfig | undefined> => {
+  if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) {
+    return undefined;
+  }
+  const configTs = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8');
+  return await importTypeScriptModule(configTs);
+};
+
+/**
+ * Update the aws nx plugin config file.
+ * Undefined top level keys in the config update will be untouched, otherwise config is replaced
+ */
+export const updateAwsNxPluginConfig = async (
+  tree: Tree,
+  configUpdate: Partial<AwsNxPluginConfig>,
+): Promise<void> => {
+  // Replace the default export
+  replace(
+    tree,
+    AWS_NX_PLUGIN_CONFIG_FILE_NAME,
+    'ExportAssignment ObjectLiteralExpression',
+    (node) => {
+      const existingObj = node as ts.ObjectLiteralExpression;
+
+      const existingProps = new Map<string, ts.PropertyAssignment>();
+      existingObj.properties.forEach((prop) => {
+        if (ts.isPropertyAssignment(prop)) {
+          existingProps.set(prop.name.getText(), prop);
+        }
+      });
+
+      const properties: ts.PropertyAssignment[] = [];
+
+      for (const [key, value] of Object.entries(configUpdate)) {
+        properties.push(
+          factory.createPropertyAssignment(
+            key,
+            jsonToAst(value) as ts.Expression,
+          ),
+        );
+      }
+
+      existingObj.properties.forEach((prop) => {
+        if (ts.isPropertyAssignment(prop)) {
+          const name = prop.name.getText();
+          if (configUpdate[name] === undefined) {
+            properties.push(prop);
+          }
+        }
+      });
+
+      return factory.createObjectLiteralExpression(properties, true);
+    },
+  );
+
+  // Format the config nicely after an update
+  await formatFilesInSubtree(tree, AWS_NX_PLUGIN_CONFIG_FILE_NAME);
+};

--- a/packages/nx-plugin/src/utils/git.spec.ts
+++ b/packages/nx-plugin/src/utils/git.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { flushChanges, FsTree } from 'nx/src/generators/tree';
+import { getGitIncludedFiles } from './git';
+import { mkdtempSync, rmSync } from 'fs';
+import { execSync } from 'child_process';
+
+describe('git utils', () => {
+  describe('getGitIncludedFiles', () => {
+    let tmpDir: string;
+    let tree: FsTree;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync('test-dir');
+      tree = new FsTree(tmpDir, false);
+      execSync('git init', { cwd: tmpDir });
+      execSync('git config user.email test@example.com', { cwd: tmpDir });
+      execSync('git config user.name test', { cwd: tmpDir });
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should get all git included files', () => {
+      tree.write('.gitignore', `*.txt`);
+      tree.write('committed.ts', "const foo = 'bar';");
+
+      flushChanges(tree.root, tree.listChanges());
+
+      execSync('git add .', { cwd: tmpDir });
+      execSync("git commit -m 'test' --no-verify", { cwd: tmpDir });
+
+      tree.write('new-and-not-committed.ts', "const bar = 'baz';");
+      tree.write('ignored.txt', 'should not be included');
+
+      flushChanges(tree.root, tree.listChanges());
+
+      const includedFiles = getGitIncludedFiles(tree);
+
+      expect(includedFiles).toContain('committed.ts');
+      expect(includedFiles).toContain('new-and-not-committed.ts');
+      expect(includedFiles).not.toContain('ignored.txt');
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/git.ts
+++ b/packages/nx-plugin/src/utils/git.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { execSync } from 'child_process';
+
+/**
+ * Returns all files from the tree root that are not gitignored (both tracked and untracked)
+ */
+export const getGitIncludedFiles = (tree: Tree): string[] => {
+  return [
+    // Git tracked files
+    ...execSync('git ls-files --exclude-standard', {
+      encoding: 'utf-8',
+      cwd: tree.root,
+    })
+      .split('\n')
+      .filter((x) => x),
+    // Untracked files that aren't ignored
+    ...execSync('git ls-files --others --exclude-standard', {
+      encoding: 'utf-8',
+      cwd: tree.root,
+    })
+      .split('\n')
+      .filter((x) => x),
+  ];
+};

--- a/packages/nx-plugin/src/utils/js.spec.ts
+++ b/packages/nx-plugin/src/utils/js.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { importJavaScriptModule } from './js';
+
+describe('js utils', () => {
+  describe('importJavaScriptModule', () => {
+    it('should import the default javascript module export', async () => {
+      expect(
+        await importJavaScriptModule(`export default { foo: 'bar' }`),
+      ).toEqual({ foo: 'bar' });
+    });
+
+    it('should import the full module without a default export', async () => {
+      const module = await importJavaScriptModule<{
+        baz: number;
+        bat: string;
+      }>(`
+        export const baz = 42;
+        export const bat = 'string';
+      `);
+      expect(module.baz).toBe(42);
+      expect(module.bat).toBe('string');
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/js.ts
+++ b/packages/nx-plugin/src/utils/js.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import ts from 'typescript';
+import { dynamicImport } from '@nx/devkit/src/utils/config-utils';
+
+/**
+ * Imports a javascript module from a string of js code
+ */
+export const importJavaScriptModule = async <T>(jsCode: string): Promise<T> => {
+  // Use nx's dynamic import to ensure that transpilers (namely @swc-node/register) don't process the import and it's
+  // instead processed by node at runtime, which allows for data urls
+  const module = await dynamicImport(
+    `data:text/javascript,${encodeURIComponent(jsCode)}`,
+  );
+
+  // Return the default export if available, otherwise the full module
+  return (module.default ?? module) as T;
+};
+
+/**
+ * Imports a typescript module from a string of typescript code
+ */
+export const importTypeScriptModule = async <T>(tsCode: string): Promise<T> => {
+  // Transpile to js and then import as a js module
+  const jsCode = ts.transpileModule(tsCode, {
+    compilerOptions: { module: ts.ModuleKind.ESNext },
+  }).outputText;
+  return await importJavaScriptModule<T>(jsCode);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       exponential-backoff:
         specifier: ^3.1.1
         version: 3.1.1
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -205,9 +208,18 @@ importers:
       '@phenomnomnominal/tsquery':
         specifier: 6.1.3
         version: 6.1.3(typescript@5.5.4)
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       lodash.kebabcase:
         specifier: 4.1.1
         version: 4.1.1
+      minimatch:
+        specifier: ^10.0.1
+        version: 10.0.1
+      nx:
+        specifier: 20.4.0
+        version: 20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -4856,8 +4868,8 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
-  fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
@@ -8930,7 +8942,6 @@ packages:
   verdaccio@5.33.0:
     resolution: {integrity: sha512-mZWTt/k3KyprhS9IriUEHfKSV4lqB9P1aTVhw5GcNgu4533GSsJRwlBwrFijnoBbWDVarjZoIf+t8wq0iv+5jg==}
     engines: {node: '>=14'}
-    deprecated: this version is deprecated, please migrate to 6.x versions
     hasBin: true
 
   verdaccio@6.0.3:
@@ -13415,7 +13426,7 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
       debug: 4.4.0
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
@@ -13788,7 +13799,7 @@ snapshots:
   '@vitest/ui@1.6.0(vitest@1.6.0)':
     dependencies:
       '@vitest/utils': 1.6.0
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       fflate: 0.8.2
       flatted: 3.3.1
       pathe: 1.1.2
@@ -14722,7 +14733,7 @@ snapshots:
 
   copy-webpack-plugin@10.2.4(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       glob-parent: 6.0.2
       globby: 12.2.0
       normalize-path: 3.0.0
@@ -14732,7 +14743,7 @@ snapshots:
 
   copy-webpack-plugin@11.0.0(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       glob-parent: 6.0.2
       globby: 13.2.2
       normalize-path: 3.0.0
@@ -15894,7 +15905,7 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-glob@3.3.2:
+  fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
@@ -16294,7 +16305,7 @@ snapshots:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
@@ -16303,7 +16314,7 @@ snapshots:
     dependencies:
       array-union: 3.0.1
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
@@ -16311,7 +16322,7 @@ snapshots:
   globby@13.2.2:
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
@@ -20233,7 +20244,7 @@ snapshots:
 
   stylus-loader@7.1.3(stylus@0.64.0)(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
       webpack: 5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)


### PR DESCRIPTION
### Reason for this change

Add a polyglot license header generator to reduce the manual effort for configuring language-specific linters to write license headers, and copy/pasting LICENSE files.

### Description of changes

This change adds a two new generators:

`license` allows users to specify their desired SPDX and Copyright Holder and:

 - generates the root LICENSE file
 - updates the root package.json with the SPDX
 - configures the `license#sync` generator to run as part of the `lint` target for all projects
 - creates a default `aws-nx-plugin.config.mts` file (more details below)

`license#sync` is a hidden sync generator which ensures:

 - source code license headers are kept in sync with the configured license content and format
 - all projects within the workspace also have the same `LICENSE` file as the root workspace

We introduce a new configuration file `aws-nx-plugin.config.mts`, which can be used to configure runtime aspects of `@aws/nx-plugin` - right now it's only for the `license#sync` generator but it's written generically in case there are other places where similar configuration is desired.

Source code license header sync is language agnostic - comment syntax for common languages is built in but additional languages can also be configured. Users can customise the content and format of license headers at any time via the config file, and the generator will ensure these are synced.

### Description of how you validated changes

Unit tests, manual testing on example project.

### Issue # (if applicable)

Fixes #21

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*