### PR TITLE
fix(infra): ensure synth output is not overwritten by compile

### DIFF
--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -147,6 +147,7 @@ exports[`infra generator > should configure project.json with correct targets > 
       "cache": true,
       "dependsOn": [
         "^build",
+        "compile",
       ],
       "executor": "nx:run-commands",
       "options": {
@@ -484,7 +485,7 @@ exports[`infra generator > should generate files with correct content > project-
       "cache": true,
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/dist/packages/test/cdk.out"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "compile"],
       "options": {
         "cwd": "packages/test",
         "command": "cdk synth"
@@ -792,6 +793,7 @@ exports[`infra generator > should handle custom project names correctly > custom
       "cache": true,
       "dependsOn": [
         "^build",
+        "compile",
       ],
       "executor": "nx:run-commands",
       "options": {

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -64,7 +64,7 @@ describe('infra generator', () => {
       cache: true,
       executor: 'nx:run-commands',
       outputs: ['{workspaceRoot}/dist/packages/test/cdk.out'],
-      dependsOn: ['^build'],
+      dependsOn: ['^build', 'compile'],
       options: {
         cwd: 'packages/test',
         command: 'cdk synth',

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -94,7 +94,7 @@ export async function infraGenerator(
         cache: true,
         executor: 'nx:run-commands',
         outputs: [`{workspaceRoot}${synthDirFromRoot}`],
-        dependsOn: ['^build'],
+        dependsOn: ['^build', 'compile'], // compile clobbers dist directory, so ensure synth runs afterwards
         options: {
           cwd: libraryRoot,
           command: 'cdk synth',


### PR DESCRIPTION
### Reason for this change

Fix intermittent cdk deploy issue

### Description of changes

A race condition existed where the synth and compile tasks can run in parallel, and if synth completed first, compile would overwrite the `dist/packages/infra` directory and a subsequent cdk deploy would fail. Address this by ensuring compile is executed before synth.

### Description of how you validated changes

Manual testing

### Issue # (if applicable)

Fixes #55

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*