### PR TITLE
fix: resolve issues with trpc router not being bundled correctly

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -80,7 +80,7 @@ export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
       description: `Load runtime config from your deployed stack for dev purposes. You must set the AWS_REGION and CDK_APP_DIR env variables whilst calling i.e: AWS_REGION=ap-southeast-2 CDK_APP_DIR=./dist/packages/infra/cdk.out pnpm exec nx run ${fullyQualifiedName}:load:runtime-config`,
     },
     options: {
-      command: `curl https://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='infra-sandbox'][].Outputs[?contains(OutputKey, 'WebsiteDistributionDomainName')].OutputValue" --output text\`/runtime-config.json > './${websiteContentPath}/public/runtime-config.json'`,
+      command: `curl https://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='infra-sandbox'][].Outputs[?contains(OutputKey, 'DistributionDomainName')].OutputValue" --output text\`/runtime-config.json > './${websiteContentPath}/public/runtime-config.json'`,
     },
   };
   const buildTarget = targets['build'];

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -40,13 +40,11 @@ export const fastApiProjectGenerator = async (
 ): Promise<GeneratorCallback> => {
   await sharedConstructsGenerator(tree);
 
-  const { dir, normalizedName, normalizedModuleName, fullyQualifiedName } = getPyProjectDetails(
-    tree,
-    {
+  const { dir, normalizedName, normalizedModuleName, fullyQualifiedName } =
+    getPyProjectDetails(tree, {
       name: schema.name,
       directory: schema.directory,
-    },
-  );
+    });
   const apiNameSnakeCase = toSnakeCase(schema.name);
   const apiNameKebabCase = toKebabCase(schema.name);
   const apiNameClassName = toClassName(schema.name);
@@ -74,7 +72,7 @@ export const fastApiProjectGenerator = async (
     options: {
       commands: [
         `uv export --frozen --no-dev --no-editable --project ${normalizedName} -o dist/${dir}/bundle/requirements.txt`,
-        `uv pip install --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python \`uv python pin\` --target dist/${dir}/bundle -r dist/${dir}/bundle/requirements.txt`
+        `uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python \`uv python pin\` --target dist/${dir}/bundle -r dist/${dir}/bundle/requirements.txt`,
       ],
       parallel: false,
     },
@@ -173,22 +171,22 @@ export const fastApiProjectGenerator = async (
   addHttpApi(tree, apiNameClassName);
 
   updateJson(
-      tree,
-      joinPathFragments(PACKAGES_DIR, SHARED_CONSTRUCTS_DIR, 'project.json'),
-      (config: ProjectConfiguration) => {
-        if (!config.targets) {
-          config.targets = {};
-        }
-        if (!config.targets.build) {
-          config.targets.build = {};
-        }
-        config.targets.build.dependsOn = [
-          ...(config.targets.build.dependsOn ?? []),
-          `${fullyQualifiedName}:build`,
-        ];
-        return config;
-      },
-    );
+    tree,
+    joinPathFragments(PACKAGES_DIR, SHARED_CONSTRUCTS_DIR, 'project.json'),
+    (config: ProjectConfiguration) => {
+      if (!config.targets) {
+        config.targets = {};
+      }
+      if (!config.targets.build) {
+        config.targets.build = {};
+      }
+      config.targets.build.dependsOn = [
+        ...(config.targets.build.dependsOn ?? []),
+        `${fullyQualifiedName}:build`,
+      ];
+      return config;
+    },
+  );
 
   const projectToml = parse(
     tree.read(joinPathFragments(dir, 'pyproject.toml'), 'utf8'),

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -145,8 +145,8 @@ export async function trpcBackendGenerator(
         executor: 'nx:run-commands',
         outputs: [`{workspaceRoot}/dist/${backendRoot}/bundle`],
         options: {
-          command: `esbuild ${backendRoot}/src/index.ts --bundle --outfile=dist/${backendRoot}/bundle/index.js --platform=node --format=cjs`
-        }
+          command: `esbuild ${backendRoot}/src/router.ts --bundle --outfile=dist/${backendRoot}/bundle/index.js --platform=node --format=cjs`,
+        },
       };
       config.targets.build.dependsOn = [
         ...(config.targets.build.dependsOn ?? []),
@@ -154,6 +154,24 @@ export async function trpcBackendGenerator(
       ];
 
       config.targets = sortProjectTargets(config.targets);
+      return config;
+    },
+  );
+
+  updateJson(
+    tree,
+    joinPathFragments(PACKAGES_DIR, SHARED_CONSTRUCTS_DIR, 'project.json'),
+    (config: ProjectConfiguration) => {
+      if (!config.targets) {
+        config.targets = {};
+      }
+      if (!config.targets.build) {
+        config.targets.build = {};
+      }
+      config.targets.build.dependsOn = [
+        ...(config.targets.build.dependsOn ?? []),
+        `${backendProjectName}:build`,
+      ];
       return config;
     },
   );


### PR DESCRIPTION
### Reason for this change

- trpc router was not being deployed correctly.

### Description of changes

- change bundle entrypoint to router.ts given Jack's recent commit which no longer exports it from `index.ts`
- add explicit dependency on the trpc backend from shared constructs in order to to fix caching issues where changes to the backend do not resolve in a resynth.
- disable `uv pip install` cache when bundling to prevent stale deps

### Description of how you validated changes

- unit tests
- e2e tests
- deployment to sandbox

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*