### PR TITLE
fix(trpc): share a single tanstack query client for all trpc apis

### DIFF
--- a/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
@@ -1,7 +1,35 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`trpc react generator > should generate trpc react files > TrpcClients-IsolatedTrpcProvider.tsx 1`] = `
-"import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+exports[`trpc react generator > should generate trpc react files > TrpcClients-TrpcApis.tsx 1`] = `
+"import {
+  AppRouter as TestApiAppRouter,
+  Context as TestApiContext,
+} from 'backend';
+import { createTrpcClientProvider } from './TrpcProvider';
+export default {
+  TestApi: createTrpcClientProvider<TestApiAppRouter, TestApiContext>(),
+};
+"
+`;
+
+exports[`trpc react generator > should generate trpc react files > TrpcClients-TrpcClientProviders.tsx 1`] = `
+"import TrpcApis from './TrpcApis';
+import { useRuntimeConfig } from '../../hooks/useRuntimeConfig';
+import { FC, PropsWithChildren } from 'react';
+const TrpcClientProviders: FC<PropsWithChildren> = ({ children }) => {
+  const runtimeConfig = useRuntimeConfig();
+  return (
+    <TrpcApis.TestApi.Provider apiUrl={runtimeConfig.httpApis.TestApi}>
+      {children}
+    </TrpcApis.TestApi.Provider>
+  );
+};
+export default TrpcClientProviders;
+"
+`;
+
+exports[`trpc react generator > should generate trpc react files > TrpcClients-TrpcProvider.tsx 1`] = `
+"import { useQueryClient } from '@tanstack/react-query';
 import { createTRPCContext } from '@trpc/tanstack-react-query';
 import {
   httpBatchLink,
@@ -11,25 +39,25 @@ import {
   splitLink,
   createTRPCClient,
 } from '@trpc/client';
-import { useState, FC, useMemo, PropsWithChildren } from 'react';
+import { FC, useMemo, PropsWithChildren } from 'react';
 
 import { AnyTRPCRouter } from '@trpc/server';
 
-export interface IsolatedTrpcClientProviderProps extends PropsWithChildren {
+export interface TrpcClientProviderProps extends PropsWithChildren {
   readonly apiUrl: string;
 }
 
-export const createIsolatedTrpcClientProvider = <
+export const createTrpcClientProvider = <
   TAppRouter extends AnyTRPCRouter,
   TContext,
 >() => {
   const { TRPCProvider, useTRPC } = createTRPCContext<TAppRouter>();
 
-  const IsolatedTrpcClientProvider: FC<IsolatedTrpcClientProviderProps> = ({
+  const TrpcClientProvider: FC<TrpcClientProviderProps> = ({
     apiUrl,
     children,
   }) => {
-    const [queryClient] = useState(() => new QueryClient());
+    const queryClient = useQueryClient();
 
     const trpcClient = useMemo(() => {
       const linkOptions: HTTPLinkOptions<any> & HTTPBatchLinkOptions<any> = {
@@ -51,9 +79,7 @@ export const createIsolatedTrpcClientProvider = <
 
     return (
       <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-        <QueryClientProvider client={queryClient}>
-          {children}
-        </QueryClientProvider>
+        {children}
       </TRPCProvider>
     );
   };
@@ -63,34 +89,6 @@ export const createIsolatedTrpcClientProvider = <
     Provider: IsolatedTrpcClientProvider,
   };
 };
-"
-`;
-
-exports[`trpc react generator > should generate trpc react files > TrpcClients-TrpcApis.tsx 1`] = `
-"import {
-  AppRouter as TestApiAppRouter,
-  Context as TestApiContext,
-} from 'backend';
-import { createIsolatedTrpcClientProvider } from './IsolatedTrpcProvider';
-export default {
-  TestApi: createIsolatedTrpcClientProvider<TestApiAppRouter, TestApiContext>(),
-};
-"
-`;
-
-exports[`trpc react generator > should generate trpc react files > TrpcClients-TrpcClientProviders.tsx 1`] = `
-"import TrpcApis from './TrpcApis';
-import { useRuntimeConfig } from '../../hooks/useRuntimeConfig';
-import { FC, PropsWithChildren } from 'react';
-const TrpcClientProviders: FC<PropsWithChildren> = ({ children }) => {
-  const runtimeConfig = useRuntimeConfig();
-  return (
-    <TrpcApis.TestApi.Provider apiUrl={runtimeConfig.httpApis.TestApi}>
-      {children}
-    </TrpcApis.TestApi.Provider>
-  );
-};
-export default TrpcClientProviders;
 "
 `;
 
@@ -114,15 +112,18 @@ exports[`trpc react generator > should handle IAM auth option > TRPCClientProvid
 
 exports[`trpc react generator > should modify main.tsx correctly > main.tsx 1`] = `
 "import TrpcClientProviders from './components/TrpcClients';
+import QueryClientProvider from './components/QueryClientProvider';
 import RuntimeConfigProvider from './components/RuntimeConfig';
 import { App } from './app';
 import { RouterProvider } from '@tanstack/react-router';
 export function Main() {
   return (
     <RuntimeConfigProvider>
-      <TrpcClientProviders>
-        <RouterProvider router={router} />
-      </TrpcClientProviders>
+      <QueryClientProvider>
+        <TrpcClientProviders>
+          <RouterProvider router={router} />
+        </TrpcClientProviders>
+      </QueryClientProvider>
     </RuntimeConfigProvider>
   );
 }

--- a/packages/nx-plugin/src/trpc/react/files/src/components/TrpcClients/TrpcProvider.tsx.template
+++ b/packages/nx-plugin/src/trpc/react/files/src/components/TrpcClients/TrpcProvider.tsx.template
@@ -1,15 +1,14 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { createTRPCContext } from '@trpc/tanstack-react-query';
 import {
-    httpBatchLink,
-    httpLink,
-    HTTPBatchLinkOptions,
-    HTTPLinkOptions,
-    splitLink,
-    createTRPCClient,
-  } from '@trpc/client';
+  httpBatchLink,
+  httpLink,
+  HTTPBatchLinkOptions,
+  HTTPLinkOptions,
+  splitLink,
+  createTRPCClient,
+} from '@trpc/client';
 import {
-  useState,
   FC,
   useMemo,
   PropsWithChildren,
@@ -17,21 +16,21 @@ import {
 <% if(auth === 'IAM') { %> import { useSigV4 } from '../../hooks/useSigV4'; <% } %>
 import { AnyTRPCRouter } from '@trpc/server';
 
-export interface IsolatedTrpcClientProviderProps extends PropsWithChildren {
+export interface TrpcClientProviderProps extends PropsWithChildren {
   readonly apiUrl: string;
 }
 
-export const createIsolatedTrpcClientProvider = <
+export const createTrpcClientProvider = <
   TAppRouter extends AnyTRPCRouter,
   TContext
 >() => {
   const { TRPCProvider, useTRPC } = createTRPCContext<TAppRouter>();
 
-  const IsolatedTrpcClientProvider: FC<IsolatedTrpcClientProviderProps> = ({
+  const TrpcClientProvider: FC<TrpcClientProviderProps> = ({
     apiUrl,
     children,
   }) => {
-    const [queryClient] = useState(() => new QueryClient());
+    const queryClient = useQueryClient();
     <% if(auth === 'IAM') { %> const sigv4Client = useSigV4(); <% } %>
 
     const trpcClient = useMemo(() => {
@@ -55,9 +54,7 @@ export const createIsolatedTrpcClientProvider = <
 
     return (
       <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-        <QueryClientProvider client={queryClient}>
-          {children}
-        </QueryClientProvider>
+        {children}
       </TRPCProvider>
     );
   };

--- a/packages/nx-plugin/src/trpc/react/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.spec.ts
@@ -63,10 +63,10 @@ export function Main() {
     ).toMatchSnapshot('TrpcClients-index.tsx');
     expect(
       tree.read(
-        'apps/frontend/src/components/TrpcClients/IsolatedTrpcProvider.tsx',
+        'apps/frontend/src/components/TrpcClients/TrpcProvider.tsx',
         'utf-8',
       ),
-    ).toMatchSnapshot('TrpcClients-IsolatedTrpcProvider.tsx');
+    ).toMatchSnapshot('TrpcClients-TrpcProvider.tsx');
     expect(
       tree.read(
         'apps/frontend/src/components/TrpcClients/TrpcApis.tsx',

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -162,7 +162,7 @@ export const replace = (
     const queryNodes = tsquery.query(ast(source), selector);
     if (queryNodes.length === 0) {
       throw new Error(
-        `Could not locate a element im ${filePath} matching ${selector}`,
+        `Could not locate an element in ${filePath} matching ${selector}`,
       );
     }
   }

--- a/packages/nx-plugin/src/utils/files/website/components/tanstack-query/QueryClientProvider.tsx.template
+++ b/packages/nx-plugin/src/utils/files/website/components/tanstack-query/QueryClientProvider.tsx.template
@@ -1,0 +1,18 @@
+import { FC, PropsWithChildren, useState } from 'react';
+import {
+  QueryClient,
+  QueryClientProvider as QueryClientProviderInner,
+} from '@tanstack/react-query';
+
+export const QueryClientProvider: FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const [queryClient] = useState(new QueryClient());
+  return (
+    <QueryClientProviderInner client={queryClient}>
+      {children}
+    </QueryClientProviderInner>
+  );
+};
+
+export default QueryClientProvider;


### PR DESCRIPTION
### Reason for this change

Ensure users can access the query client for multiple tRPC APIs, now that the query client is not wrapped by tRPC.

### Description of changes

In the new client, the recommended approach for cache invalidations, prefetching, etc, is to use the tanstack query client directly.

The `useQueryClient` hook from `@tanstack/react-query` finds the query client from the closest parent provider. The IsolatedTrpcProvider created a new query client per-API, which meant that when integrating with multiple tRPC APIs, the `useQueryClient` hook would only find the query client for the API defined first.

This change shares a single query client between all tRPC APIs, so that the useQueryClient hook gives you the query client for any tRPC API.

Also added the README updates I forgot to add in #73 

### Description of how you validated changes

Unit tests, manual testing

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*