### PR TITLE
feat(open-api): support for type-safe streaming responses in generated typescript client

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`openApiTsClientGenerator > should allow duplicate operation ids discrim
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -19,8 +19,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -31,6 +49,9 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this._itemsStockList = this._itemsStockList.bind(this);
+    this._usersPeopleList = this._usersPeopleList.bind(this);
   }
 
   private $url = (
@@ -79,10 +100,10 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  private _itemsStockList = async (): Promise<Array<string>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _itemsStockList(): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -96,17 +117,17 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()) as Array<string>;
+      return await response.json();
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  private _usersPeopleList = async (): Promise<Array<string>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _usersPeopleList(): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -120,39 +141,39 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()) as Array<string>;
+      return await response.json();
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
   /**
    * items operations
    */
   public items = {
-    list: this._itemsStockList,
+    list: this._itemsStockList.bind(this),
   };
 
   /**
    * stock operations
    */
   public stock = {
-    list: this._itemsStockList,
+    list: this._itemsStockList.bind(this),
   };
 
   /**
    * users operations
    */
   public users = {
-    list: this._usersPeopleList,
+    list: this._usersPeopleList.bind(this),
   };
 
   /**
    * people operations
    */
   public people = {
-    list: this._usersPeopleList,
+    list: this._usersPeopleList.bind(this),
   };
 }
 "
@@ -169,7 +190,7 @@ exports[`openApiTsClientGenerator > should allow duplicate operation ids discrim
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -177,8 +198,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -189,6 +228,9 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this._itemsList = this._itemsList.bind(this);
+    this._usersList = this._usersList.bind(this);
   }
 
   private $url = (
@@ -237,10 +279,10 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  private _itemsList = async (): Promise<Array<string>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _itemsList(): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -254,17 +296,17 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()) as Array<string>;
+      return await response.json();
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  private _usersList = async (): Promise<Array<string>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _usersList(): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -278,25 +320,25 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()) as Array<string>;
+      return await response.json();
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
   /**
    * items operations
    */
   public items = {
-    list: this._itemsList,
+    list: this._itemsList.bind(this),
   };
 
   /**
    * users operations
    */
   public users = {
-    list: this._usersList,
+    list: this._usersList.bind(this),
   };
 }
 "
@@ -335,7 +377,7 @@ exports[`openApiTsClientGenerator > should generate valid TypeScript for arrays 
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200ResponseItem = {
@@ -395,7 +437,7 @@ class $IO {
         ...(model.complexDict === undefined
           ? {}
           : {
-              complexDict: $IO.mapValues(
+              complexDict: $IO.$mapValues(
                 model.complexDict,
                 $IO.PostTestRequestContentComplexDictValue.toJson,
               ),
@@ -425,7 +467,7 @@ class $IO {
         ...(json['complexDict'] === undefined
           ? {}
           : {
-              complexDict: $IO.mapValues(
+              complexDict: $IO.$mapValues(
                 json['complexDict'],
                 $IO.PostTestRequestContentComplexDictValue.fromJson,
               ),
@@ -468,8 +510,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -480,6 +540,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postTest = this.postTest.bind(this);
   }
 
   private $url = (
@@ -528,12 +590,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postTest = async (
+  public async postTest(
     input?: PostTestRequest,
-  ): Promise<Array<PostTest200ResponseItem>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<Array<PostTest200ResponseItem>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -551,12 +616,14 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()).map($IO.PostTest200ResponseItem.fromJson);
+      return ((await response.json()) as Array<any>).map(
+        $IO.PostTest200ResponseItem.fromJson,
+      );
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -610,7 +677,7 @@ exports[`openApiTsClientGenerator > should generate valid TypeScript for composi
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PutTest200Response = {
@@ -803,8 +870,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -815,6 +900,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.putTest = this.putTest.bind(this);
   }
 
   private $url = (
@@ -863,12 +950,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public putTest = async (
-    input?: PutTestRequest,
-  ): Promise<PutTest200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async putTest(input?: PutTestRequest): Promise<PutTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -891,7 +979,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -943,7 +1031,7 @@ exports[`openApiTsClientGenerator > should generate valid TypeScript for paramet
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -1088,8 +1176,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -1100,6 +1206,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.getTest = this.getTest.bind(this);
   }
 
   private $url = (
@@ -1148,12 +1256,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public getTest = async (
-    input: GetTestRequest,
-  ): Promise<GetTest200Response> => {
-    const pathParameters = $IO.GetTestRequestPathParameters.toJson(input);
-    const queryParameters = $IO.GetTestRequestQueryParameters.toJson(input);
-    const headerParameters = $IO.GetTestRequestHeaderParameters.toJson(input);
+  public async getTest(input: GetTestRequest): Promise<GetTest200Response> {
+    const pathParameters: { [key: string]: any } =
+      $IO.GetTestRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } =
+      $IO.GetTestRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } =
+      $IO.GetTestRequestHeaderParameters.toJson(input);
     const collectionFormats = {
       'x-api-key': 'csv',
       filter: 'multi',
@@ -1193,7 +1302,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -1218,7 +1327,7 @@ exports[`openApiTsClientGenerator > should generate valid TypeScript for primiti
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -1290,8 +1399,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -1302,6 +1429,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.getTest = this.getTest.bind(this);
   }
 
   private $url = (
@@ -1353,10 +1482,10 @@ export class TestApi {
   /**
    * Sends a test request!
    */
-  public getTest = async (): Promise<GetTest200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async getTest(): Promise<GetTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -1375,7 +1504,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -1418,7 +1547,7 @@ exports[`openApiTsClientGenerator > should handle composite primitive and array 
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static CompositeRequestContent = {
@@ -1453,7 +1582,7 @@ class $IO {
         ...(model === null ? null : model),
         ...(model === null
           ? null
-          : $IO.mapValues(
+          : $IO.$mapValues(
               model,
               $IO.CompositeRequestContentOneOf3Value.toJson,
             )),
@@ -1495,7 +1624,7 @@ class $IO {
         ...(json === null ? null : json),
         ...(json === null
           ? null
-          : $IO.mapValues(
+          : $IO.$mapValues(
               json,
               $IO.CompositeRequestContentOneOf3Value.fromJson,
             )),
@@ -1590,8 +1719,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -1602,6 +1749,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.composite = this.composite.bind(this);
   }
 
   private $url = (
@@ -1650,10 +1799,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public composite = async (input?: CompositeRequest): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async composite(input?: CompositeRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -1676,7 +1828,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -1713,7 +1865,7 @@ exports[`openApiTsClientGenerator > should handle date and date-time formats 2`]
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostDates200Response = {
@@ -1815,8 +1967,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -1827,6 +1997,9 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postDates = this.postDates.bind(this);
+    this.postSingleDate = this.postSingleDate.bind(this);
   }
 
   private $url = (
@@ -1875,12 +2048,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postDates = async (
+  public async postDates(
     input?: PostDatesRequest,
-  ): Promise<PostDates200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<PostDates200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -1903,14 +2079,15 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postSingleDate = async (
-    input: PostSingleDateRequest,
-  ): Promise<Date> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async postSingleDate(input: PostSingleDateRequest): Promise<Date> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input.toISOString().slice(0, 10);
 
     const response = await this.$fetch(
@@ -1928,7 +2105,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -1958,7 +2135,7 @@ exports[`openApiTsClientGenerator > should handle default responses 2`] = `
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -2012,8 +2189,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -2024,6 +2219,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.getTest = this.getTest.bind(this);
   }
 
   private $url = (
@@ -2072,10 +2269,10 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public getTest = async (): Promise<GetTest200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async getTest(): Promise<GetTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -2095,7 +2292,7 @@ export class TestApi {
       status: response.status,
       error: $IO.GetTestdefaultResponse.fromJson(await response.json()),
     };
-  };
+  }
 }
 "
 `;
@@ -2124,7 +2321,7 @@ exports[`openApiTsClientGenerator > should handle enum request and response bodi
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -2132,8 +2329,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -2144,6 +2359,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.updateStatus = this.updateStatus.bind(this);
   }
 
   private $url = (
@@ -2192,12 +2409,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public updateStatus = async (
+  public async updateStatus(
     input: UpdateStatusRequest,
-  ): Promise<UpdateStatus200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<UpdateStatus200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input;
 
     const response = await this.$fetch(
@@ -2215,7 +2435,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -2291,7 +2511,7 @@ exports[`openApiTsClientGenerator > should handle inline primitives and composit
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestArrays200Response = {
@@ -2505,8 +2725,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -2517,6 +2755,14 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.testArrays = this.testArrays.bind(this);
+    this.testArraysWithOtherParameters =
+      this.testArraysWithOtherParameters.bind(this);
+    this.testComposites = this.testComposites.bind(this);
+    this.testEnums = this.testEnums.bind(this);
+    this.testPrimitiveBinary = this.testPrimitiveBinary.bind(this);
+    this.testPrimitiveText = this.testPrimitiveText.bind(this);
   }
 
   private $url = (
@@ -2565,12 +2811,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public testArrays = async (
+  public async testArrays(
     input?: TestArraysRequest,
-  ): Promise<TestArrays200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<TestArrays200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -2593,15 +2842,18 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public testArraysWithOtherParameters = async (
+  public async testArraysWithOtherParameters(
     input: TestArraysWithOtherParametersRequest,
-  ): Promise<TestArraysWithOtherParameters200Response> => {
-    const pathParameters = {};
-    const queryParameters =
+  ): Promise<TestArraysWithOtherParameters200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
       $IO.TestArraysWithOtherParametersRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       someParameter: 'multi',
     } as const;
@@ -2642,14 +2894,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public testComposites = async (
+  public async testComposites(
     input?: TestCompositesRequest,
-  ): Promise<TestComposites200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<TestComposites200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -2672,12 +2927,12 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public testEnums = async (): Promise<TestEnums200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async testEnums(): Promise<TestEnums200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -2696,14 +2951,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public testPrimitiveBinary = async (
+  public async testPrimitiveBinary(
     input: TestPrimitiveBinaryRequest,
-  ): Promise<Blob> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<Blob> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/octet-stream';
+    }
     const body = input;
 
     const response = await this.$fetch(
@@ -2721,14 +2979,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public testPrimitiveText = async (
+  public async testPrimitiveText(
     input: TestPrimitiveTextRequest,
-  ): Promise<number> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<number> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = String(input);
 
     const response = await this.$fetch(
@@ -2746,7 +3007,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -2893,7 +3154,7 @@ exports[`openApiTsClientGenerator > should handle multiple response status codes
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestResponses2XXResponse = {
@@ -3019,8 +3280,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -3031,6 +3310,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.testResponses = this.testResponses.bind(this);
   }
 
   private $url = (
@@ -3079,12 +3360,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public testResponses = async (
+  public async testResponses(
     input?: TestResponsesRequest,
-  ): Promise<TestResponses2XXResponse> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<TestResponses2XXResponse> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -3119,7 +3403,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -3153,7 +3437,7 @@ exports[`openApiTsClientGenerator > should handle not schema type 2`] = `
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestNot200Response = {
@@ -3252,8 +3536,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -3264,6 +3566,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.testNot = this.testNot.bind(this);
   }
 
   private $url = (
@@ -3312,12 +3616,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public testNot = async (
-    input?: TestNotRequest,
-  ): Promise<TestNot200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async testNot(input?: TestNotRequest): Promise<TestNot200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -3340,7 +3645,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -3443,7 +3748,7 @@ exports[`openApiTsClientGenerator > should handle nullable schemas in various co
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostSingleNullableObjectRequestContent = {
@@ -3966,8 +4271,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -3978,6 +4301,13 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postSingleNullableArray = this.postSingleNullableArray.bind(this);
+    this.postSingleNullableBoolean = this.postSingleNullableBoolean.bind(this);
+    this.postSingleNullableNumber = this.postSingleNullableNumber.bind(this);
+    this.postSingleNullableObject = this.postSingleNullableObject.bind(this);
+    this.postSingleNullableString = this.postSingleNullableString.bind(this);
+    this.testNullable = this.testNullable.bind(this);
   }
 
   private $url = (
@@ -4026,12 +4356,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postSingleNullableArray = async (
+  public async postSingleNullableArray(
     input?: PostSingleNullableArrayRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -4054,14 +4387,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postSingleNullableBoolean = async (
+  public async postSingleNullableBoolean(
     input?: PostSingleNullableBooleanRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input === undefined ? undefined : String(input);
 
     const response = await this.$fetch(
@@ -4079,14 +4415,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postSingleNullableNumber = async (
+  public async postSingleNullableNumber(
     input?: PostSingleNullableNumberRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input === undefined ? undefined : String(input);
 
     const response = await this.$fetch(
@@ -4104,14 +4443,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postSingleNullableObject = async (
+  public async postSingleNullableObject(
     input?: PostSingleNullableObjectRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -4136,14 +4478,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postSingleNullableString = async (
+  public async postSingleNullableString(
     input?: PostSingleNullableStringRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input === undefined ? undefined : String(input);
 
     const response = await this.$fetch(
@@ -4161,15 +4506,19 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public testNullable = async (
+  public async testNullable(
     input: TestNullableRequest,
-  ): Promise<TestNullable200Response> => {
-    const pathParameters = $IO.TestNullableRequestPathParameters.toJson(input);
-    const queryParameters =
+  ): Promise<TestNullable200Response> {
+    const pathParameters: { [key: string]: any } =
+      $IO.TestNullableRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } =
       $IO.TestNullableRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       queryString: 'multi',
       queryNumber: 'multi',
@@ -4205,7 +4554,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -4239,7 +4588,7 @@ exports[`openApiTsClientGenerator > should handle number and string constraints 
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestConstraints200Response = {
@@ -4343,8 +4692,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -4355,6 +4722,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.testConstraints = this.testConstraints.bind(this);
   }
 
   private $url = (
@@ -4403,12 +4772,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public testConstraints = async (
+  public async testConstraints(
     input?: TestConstraintsRequest,
-  ): Promise<TestConstraints200Response> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<TestConstraints200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -4431,7 +4803,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -4451,7 +4823,7 @@ exports[`openApiTsClientGenerator > should handle only default response 2`] = `
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTestdefaultResponse = {
@@ -4482,8 +4854,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -4494,6 +4884,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.getTest = this.getTest.bind(this);
   }
 
   private $url = (
@@ -4542,10 +4934,10 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public getTest = async (): Promise<GetTestdefaultResponse> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async getTest(): Promise<GetTestdefaultResponse> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -4559,7 +4951,7 @@ export class TestApi {
     );
 
     return $IO.GetTestdefaultResponse.fromJson(await response.json());
-  };
+  }
 }
 "
 `;
@@ -4577,7 +4969,7 @@ exports[`openApiTsClientGenerator > should handle operation tags and multiple se
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -4585,8 +4977,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -4597,6 +5007,11 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this._createUser = this._createUser.bind(this);
+    this._getItems = this._getItems.bind(this);
+    this.getStatus = this.getStatus.bind(this);
+    this._getUsers = this._getUsers.bind(this);
   }
 
   private $url = (
@@ -4645,10 +5060,10 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  private _createUser = async (): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _createUser(): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -4667,15 +5082,15 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
   /**
    * Returns a list of all the items
    */
-  private _getItems = async (): Promise<Array<string>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _getItems(): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -4689,17 +5104,17 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()) as Array<string>;
+      return await response.json();
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public getStatus = async (): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async getStatus(): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -4718,12 +5133,12 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  private _getUsers = async (): Promise<Array<string>> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _getUsers(): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -4737,19 +5152,19 @@ export class TestApi {
     );
 
     if (response.status === 200) {
-      return (await response.json()) as Array<string>;
+      return await response.json();
     }
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
   /**
    * users operations
    */
   public users = {
-    createUser: this._createUser,
-    getUsers: this._getUsers,
+    createUser: this._createUser.bind(this),
+    getUsers: this._getUsers.bind(this),
   };
 
   /**
@@ -4759,7 +5174,7 @@ export class TestApi {
     /**
      * Returns a list of all the items
      */
-    getItems: this._getItems,
+    getItems: this._getItems.bind(this),
   };
 }
 "
@@ -4849,7 +5264,7 @@ exports[`openApiTsClientGenerator > should handle operations with complex map ty
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostMapOfArraysOfObjectsRequestContent = {
@@ -4858,7 +5273,7 @@ class $IO {
         return model;
       }
       return {
-        ...$IO.mapValues(model, (item0) =>
+        ...$IO.$mapValues(model, (item0) =>
           item0.map($IO.PostMapOfArraysOfObjectsRequestContentValueItem.toJson),
         ),
       };
@@ -4868,7 +5283,7 @@ class $IO {
         return json;
       }
       return {
-        ...$IO.mapValues(json, (item0) =>
+        ...$IO.$mapValues(json, (item0) =>
           item0.map(
             $IO.PostMapOfArraysOfObjectsRequestContentValueItem.fromJson,
           ),
@@ -4969,7 +5384,10 @@ class $IO {
         return model;
       }
       return {
-        ...$IO.mapValues(model, $IO.PostMapOfObjectsRequestContentValue.toJson),
+        ...$IO.$mapValues(
+          model,
+          $IO.PostMapOfObjectsRequestContentValue.toJson,
+        ),
       };
     },
     fromJson: (json: any): PostMapOfObjectsRequestContent => {
@@ -4977,7 +5395,7 @@ class $IO {
         return json;
       }
       return {
-        ...$IO.mapValues(
+        ...$IO.$mapValues(
           json,
           $IO.PostMapOfObjectsRequestContentValue.fromJson,
         ),
@@ -5019,8 +5437,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -5031,6 +5467,16 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postArrayOfMapsOfArraysOfNumbers =
+      this.postArrayOfMapsOfArraysOfNumbers.bind(this);
+    this.postArrayOfMapsOfNumbers = this.postArrayOfMapsOfNumbers.bind(this);
+    this.postMapOfArraysOfObjects = this.postMapOfArraysOfObjects.bind(this);
+    this.postMapOfMapsOfArraysOfNumbers =
+      this.postMapOfMapsOfArraysOfNumbers.bind(this);
+    this.postMapOfMapsOfNumbers = this.postMapOfMapsOfNumbers.bind(this);
+    this.postMapOfNumbers = this.postMapOfNumbers.bind(this);
+    this.postMapOfObjects = this.postMapOfObjects.bind(this);
   }
 
   private $url = (
@@ -5079,12 +5525,15 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postArrayOfMapsOfArraysOfNumbers = async (
+  public async postArrayOfMapsOfArraysOfNumbers(
     input?: PostArrayOfMapsOfArraysOfNumbersRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5111,14 +5560,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postArrayOfMapsOfNumbers = async (
+  public async postArrayOfMapsOfNumbers(
     input?: PostArrayOfMapsOfNumbersRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5141,14 +5593,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postMapOfArraysOfObjects = async (
+  public async postMapOfArraysOfObjects(
     input?: PostMapOfArraysOfObjectsRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5173,14 +5628,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postMapOfMapsOfArraysOfNumbers = async (
+  public async postMapOfMapsOfArraysOfNumbers(
     input?: PostMapOfMapsOfArraysOfNumbersRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5211,14 +5669,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postMapOfMapsOfNumbers = async (
+  public async postMapOfMapsOfNumbers(
     input?: PostMapOfMapsOfNumbersRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5243,14 +5704,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postMapOfNumbers = async (
+  public async postMapOfNumbers(
     input?: PostMapOfNumbersRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5273,14 +5737,17 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postMapOfObjects = async (
+  public async postMapOfObjects(
     input?: PostMapOfObjectsRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -5303,7 +5770,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -5319,7 +5786,7 @@ exports[`openApiTsClientGenerator > should handle operations with multiple tags 
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -5327,8 +5794,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -5339,6 +5824,9 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this._getMultiTagged = this._getMultiTagged.bind(this);
+    this._postMultiTagged = this._postMultiTagged.bind(this);
   }
 
   private $url = (
@@ -5387,10 +5875,10 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  private _getMultiTagged = async (): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _getMultiTagged(): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -5409,12 +5897,12 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  private _postMultiTagged = async (): Promise<number> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  private async _postMultiTagged(): Promise<number> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -5433,29 +5921,29 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
   /**
    * tag1 operations
    */
   public tag1 = {
-    getMultiTagged: this._getMultiTagged,
-    postMultiTagged: this._postMultiTagged,
+    getMultiTagged: this._getMultiTagged.bind(this),
+    postMultiTagged: this._postMultiTagged.bind(this),
   };
 
   /**
    * tag2 operations
    */
   public tag2 = {
-    getMultiTagged: this._getMultiTagged,
+    getMultiTagged: this._getMultiTagged.bind(this),
   };
 
   /**
    * tag3 operations
    */
   public tag3 = {
-    getMultiTagged: this._getMultiTagged,
-    postMultiTagged: this._postMultiTagged,
+    getMultiTagged: this._getMultiTagged.bind(this),
+    postMultiTagged: this._postMultiTagged.bind(this),
   };
 }
 "
@@ -5527,7 +6015,7 @@ exports[`openApiTsClientGenerator > should handle operations with simple request
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostBooleanWithQueryRequestBodyParameters = {
@@ -5697,8 +6185,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -5709,6 +6215,13 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postBoolean = this.postBoolean.bind(this);
+    this.postBooleanWithQuery = this.postBooleanWithQuery.bind(this);
+    this.postNumber = this.postNumber.bind(this);
+    this.postNumberWithQuery = this.postNumberWithQuery.bind(this);
+    this.postString = this.postString.bind(this);
+    this.postStringWithQuery = this.postStringWithQuery.bind(this);
   }
 
   private $url = (
@@ -5757,10 +6270,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postBoolean = async (input?: PostBooleanRequest): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async postBoolean(input?: PostBooleanRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input === undefined ? undefined : String(input);
 
     const response = await this.$fetch(
@@ -5778,15 +6294,18 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postBooleanWithQuery = async (
+  public async postBooleanWithQuery(
     input: PostBooleanWithQueryRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters =
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
       $IO.PostBooleanWithQueryRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       filter: 'multi',
     } as const;
@@ -5812,12 +6331,15 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postNumber = async (input?: PostNumberRequest): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async postNumber(input?: PostNumberRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input === undefined ? undefined : String(input);
 
     const response = await this.$fetch(
@@ -5835,15 +6357,18 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postNumberWithQuery = async (
+  public async postNumberWithQuery(
     input: PostNumberWithQueryRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters =
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
       $IO.PostNumberWithQueryRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       filter: 'multi',
     } as const;
@@ -5869,12 +6394,15 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postString = async (input?: PostStringRequest): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async postString(input?: PostStringRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body = input === undefined ? undefined : String(input);
 
     const response = await this.$fetch(
@@ -5892,15 +6420,18 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public postStringWithQuery = async (
+  public async postStringWithQuery(
     input: PostStringWithQueryRequest,
-  ): Promise<string> => {
-    const pathParameters = {};
-    const queryParameters =
+  ): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
       $IO.PostStringWithQueryRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       filter: 'multi',
     } as const;
@@ -5926,7 +6457,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -5951,7 +6482,7 @@ exports[`openApiTsClientGenerator > should handle recursive schema references 2`
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TreeNode = {
@@ -6000,8 +6531,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -6012,6 +6561,9 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.createTree = this.createTree.bind(this);
+    this.getTree = this.getTree.bind(this);
   }
 
   private $url = (
@@ -6060,10 +6612,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public createTree = async (input?: CreateTreeRequest): Promise<TreeNode> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async createTree(input?: CreateTreeRequest): Promise<TreeNode> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       input === undefined
         ? undefined
@@ -6086,12 +6641,12 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 
-  public getTree = async (): Promise<TreeNode> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async getTree(): Promise<TreeNode> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
 
     const body = undefined;
 
@@ -6110,7 +6665,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -6155,7 +6710,7 @@ exports[`openApiTsClientGenerator > should handle refs and hoisting of inline sc
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static Error = {
@@ -6307,8 +6862,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -6319,6 +6892,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postTest = this.postTest.bind(this);
   }
 
   private $url = (
@@ -6367,10 +6942,13 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postTest = async (input: PostTestRequest): Promise<void> => {
-    const pathParameters = {};
-    const queryParameters = {};
-    const headerParameters = {};
+  public async postTest(input: PostTestRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const body =
       typeof input === 'object'
         ? JSON.stringify($IO.PostTestRequestContent.toJson(input))
@@ -6397,7 +6975,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -6440,7 +7018,7 @@ exports[`openApiTsClientGenerator > should handle request body property matching
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200Response = {
@@ -6585,8 +7163,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -6597,6 +7193,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postTest = this.postTest.bind(this);
   }
 
   private $url = (
@@ -6645,12 +7243,14 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postTest = async (
-    input: PostTestRequest,
-  ): Promise<PostTest200Response> => {
-    const pathParameters = {};
-    const queryParameters = $IO.PostTestRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+  public async postTest(input: PostTestRequest): Promise<PostTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.PostTestRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       filter: 'multi',
     } as const;
@@ -6676,7 +7276,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;
@@ -6718,7 +7318,7 @@ exports[`openApiTsClientGenerator > should handle special formats and vendor ext
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200Response = {
@@ -6887,8 +7487,26 @@ class $IO {
  * Client configuration for TestApi
  */
 export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -6899,6 +7517,8 @@ export class TestApi {
 
   constructor(config: TestApiConfig) {
     this.$config = config;
+
+    this.postTest = this.postTest.bind(this);
   }
 
   private $url = (
@@ -6947,12 +7567,14 @@ export class TestApi {
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
-  public postTest = async (
-    input: PostTestRequest,
-  ): Promise<PostTest200Response> => {
-    const pathParameters = {};
-    const queryParameters = $IO.PostTestRequestQueryParameters.toJson(input);
-    const headerParameters = {};
+  public async postTest(input: PostTestRequest): Promise<PostTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.PostTestRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
     const collectionFormats = {
       date: 'multi',
       timestamp: 'multi',
@@ -6979,7 +7601,7 @@ export class TestApi {
     throw new Error(
       \`Unknown response status \${response.status} returned by API\`,
     );
-  };
+  }
 }
 "
 `;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -1,0 +1,1678 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - streaming > should handle error responses for streaming operations 1`] = `
+"export type GetStream400Response = {
+  code: string;
+  message: string;
+};
+export type GetStream500Response = {
+  error: string;
+  details?: string;
+};
+export type GetStream400Error = {
+  status: 400;
+  error: GetStream400Response;
+};
+export type GetStream500Error = {
+  status: 500;
+  error: GetStream500Response;
+};
+export type GetStreamError = GetStream400Error | GetStream500Error;
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should handle error responses for streaming operations 2`] = `
+"import type {
+  GetStream400Response,
+  GetStream500Response,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetStream400Response = {
+    toJson: (model: GetStream400Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.code === undefined
+          ? {}
+          : {
+              code: model.code,
+            }),
+        ...(model.message === undefined
+          ? {}
+          : {
+              message: model.message,
+            }),
+      };
+    },
+    fromJson: (json: any): GetStream400Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        code: json['code'],
+        message: json['message'],
+      };
+    },
+  };
+
+  public static GetStream500Response = {
+    toJson: (model: GetStream500Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.error === undefined
+          ? {}
+          : {
+              error: model.error,
+            }),
+        ...(model.details === undefined
+          ? {}
+          : {
+              details: model.details,
+            }),
+      };
+    },
+    fromJson: (json: any): GetStream500Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        error: json['error'],
+        ...(json['details'] === undefined
+          ? {}
+          : {
+              details: json['details'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getStream = this.getStream.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *getStream(): AsyncIterableIterator<number> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/stream', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield Number(value);
+      }
+      return;
+    }
+    if (response.status === 400) {
+      throw {
+        status: response.status,
+        error: $IO.GetStream400Response.fromJson(await response.json()),
+      };
+    }
+    if (response.status === 500) {
+      throw {
+        status: response.status,
+        error: $IO.GetStream500Response.fromJson(await response.json()),
+      };
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of arrays 1`] = `
+"export type GetObjectArrays200ResponseItem = {
+  id: number;
+  name: string;
+};
+export type GetBooleanArraysError = never;
+export type GetDateArraysError = never;
+export type GetNumberArraysError = never;
+export type GetObjectArraysError = never;
+export type GetStringArraysError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of arrays 2`] = `
+"import type { GetObjectArrays200ResponseItem } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetObjectArrays200ResponseItem = {
+    toJson: (model: GetObjectArrays200ResponseItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+      };
+    },
+    fromJson: (json: any): GetObjectArrays200ResponseItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        name: json['name'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getBooleanArrays = this.getBooleanArrays.bind(this);
+    this.getDateArrays = this.getDateArrays.bind(this);
+    this.getNumberArrays = this.getNumberArrays.bind(this);
+    this.getObjectArrays = this.getObjectArrays.bind(this);
+    this.getStringArrays = this.getStringArrays.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *getBooleanArrays(): AsyncIterableIterator<Array<boolean>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/boolean-arrays', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield JSON.parse(value);
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getDateArrays(): AsyncIterableIterator<Array<Date>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/date-arrays', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield (JSON.parse(value) as Array<any>).map((item0) => new Date(item0));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getNumberArrays(): AsyncIterableIterator<Array<number>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/number-arrays', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield JSON.parse(value);
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getObjectArrays(): AsyncIterableIterator<
+    Array<GetObjectArrays200ResponseItem>
+  > {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/object-arrays', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield (JSON.parse(value) as Array<any>).map(
+          $IO.GetObjectArrays200ResponseItem.fromJson,
+        );
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getStringArrays(): AsyncIterableIterator<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/string-arrays', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield JSON.parse(value);
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of dictionaries 1`] = `
+"export type GetArrayDict200Response = {
+  [key: string]: Array<number>;
+};
+export type GetBooleanDict200Response = {
+  [key: string]: boolean;
+};
+export type GetDateDict200Response = {
+  [key: string]: Date;
+};
+export type GetEnumDict200Response = {
+  [key: string]: string;
+};
+export type GetEnumDict200ResponseValue = 'RED' | 'GREEN' | 'BLUE';
+export type GetNestedDict200Response = {
+  [key: string]: { [key: string]: GetNestedDict200ResponseValueValue };
+};
+export type GetNestedDict200ResponseValueValue = {
+  value: number;
+  tags: Array<string>;
+};
+export type GetNumberDict200Response = {
+  [key: string]: number;
+};
+export type GetObjectArrayDict200Response = {
+  [key: string]: Array<GetObjectArrayDict200ResponseValueItem>;
+};
+export type GetObjectArrayDict200ResponseValueItem = {
+  id: number;
+  name: string;
+};
+export type GetStringDict200Response = {
+  [key: string]: string;
+};
+export type GetArrayDictError = never;
+export type GetBooleanDictError = never;
+export type GetDateDictError = never;
+export type GetEnumDictError = never;
+export type GetNestedDictError = never;
+export type GetNumberDictError = never;
+export type GetObjectArrayDictError = never;
+export type GetStringDictError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of dictionaries 2`] = `
+"import type {
+  GetArrayDict200Response,
+  GetBooleanDict200Response,
+  GetDateDict200Response,
+  GetEnumDict200Response,
+  GetEnumDict200ResponseValue,
+  GetNestedDict200Response,
+  GetNestedDict200ResponseValueValue,
+  GetNumberDict200Response,
+  GetObjectArrayDict200Response,
+  GetObjectArrayDict200ResponseValueItem,
+  GetStringDict200Response,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetArrayDict200Response = {
+    toJson: (model: GetArrayDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...model,
+      };
+    },
+    fromJson: (json: any): GetArrayDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...json,
+      };
+    },
+  };
+
+  public static GetBooleanDict200Response = {
+    toJson: (model: GetBooleanDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...model,
+      };
+    },
+    fromJson: (json: any): GetBooleanDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...json,
+      };
+    },
+  };
+
+  public static GetDateDict200Response = {
+    toJson: (model: GetDateDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(model, (item0) => item0.toISOString()),
+      };
+    },
+    fromJson: (json: any): GetDateDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(json, (item0) => new Date(item0)),
+      };
+    },
+  };
+
+  public static GetEnumDict200Response = {
+    toJson: (model: GetEnumDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...model,
+      };
+    },
+    fromJson: (json: any): GetEnumDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...json,
+      };
+    },
+  };
+
+  public static GetNestedDict200Response = {
+    toJson: (model: GetNestedDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(model, (item0) =>
+          $IO.$mapValues(item0, $IO.GetNestedDict200ResponseValueValue.toJson),
+        ),
+      };
+    },
+    fromJson: (json: any): GetNestedDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(json, (item0) =>
+          $IO.$mapValues(
+            item0,
+            $IO.GetNestedDict200ResponseValueValue.fromJson,
+          ),
+        ),
+      };
+    },
+  };
+
+  public static GetNestedDict200ResponseValueValue = {
+    toJson: (model: GetNestedDict200ResponseValueValue): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.value === undefined
+          ? {}
+          : {
+              value: model.value,
+            }),
+        ...(model.tags === undefined
+          ? {}
+          : {
+              tags: model.tags,
+            }),
+      };
+    },
+    fromJson: (json: any): GetNestedDict200ResponseValueValue => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        value: json['value'],
+        tags: json['tags'],
+      };
+    },
+  };
+
+  public static GetNumberDict200Response = {
+    toJson: (model: GetNumberDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...model,
+      };
+    },
+    fromJson: (json: any): GetNumberDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...json,
+      };
+    },
+  };
+
+  public static GetObjectArrayDict200Response = {
+    toJson: (model: GetObjectArrayDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(model, (item0) =>
+          item0.map($IO.GetObjectArrayDict200ResponseValueItem.toJson),
+        ),
+      };
+    },
+    fromJson: (json: any): GetObjectArrayDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(json, (item0) =>
+          item0.map($IO.GetObjectArrayDict200ResponseValueItem.fromJson),
+        ),
+      };
+    },
+  };
+
+  public static GetObjectArrayDict200ResponseValueItem = {
+    toJson: (model: GetObjectArrayDict200ResponseValueItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+      };
+    },
+    fromJson: (json: any): GetObjectArrayDict200ResponseValueItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        name: json['name'],
+      };
+    },
+  };
+
+  public static GetStringDict200Response = {
+    toJson: (model: GetStringDict200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...model,
+      };
+    },
+    fromJson: (json: any): GetStringDict200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...json,
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getArrayDict = this.getArrayDict.bind(this);
+    this.getBooleanDict = this.getBooleanDict.bind(this);
+    this.getDateDict = this.getDateDict.bind(this);
+    this.getEnumDict = this.getEnumDict.bind(this);
+    this.getNestedDict = this.getNestedDict.bind(this);
+    this.getNumberDict = this.getNumberDict.bind(this);
+    this.getObjectArrayDict = this.getObjectArrayDict.bind(this);
+    this.getStringDict = this.getStringDict.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *getArrayDict(): AsyncIterableIterator<GetArrayDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/array-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetArrayDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getBooleanDict(): AsyncIterableIterator<GetBooleanDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/boolean-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetBooleanDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getDateDict(): AsyncIterableIterator<GetDateDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/date-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetDateDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getEnumDict(): AsyncIterableIterator<GetEnumDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/enum-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetEnumDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getNestedDict(): AsyncIterableIterator<GetNestedDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/nested-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetNestedDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getNumberDict(): AsyncIterableIterator<GetNumberDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/number-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetNumberDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getObjectArrayDict(): AsyncIterableIterator<GetObjectArrayDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/object-array-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetObjectArrayDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getStringDict(): AsyncIterableIterator<GetStringDict200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/string-dict', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetStringDict200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of numbers, booleans and dates 1`] = `
+"export type GetBooleansError = never;
+export type GetDatesError = never;
+export type GetNumbersError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of numbers, booleans and dates 2`] = `
+"/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getBooleans = this.getBooleans.bind(this);
+    this.getDates = this.getDates.bind(this);
+    this.getNumbers = this.getNumbers.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *getBooleans(): AsyncIterableIterator<boolean> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/booleans', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield value === 'true' ? true : false;
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getDates(): AsyncIterableIterator<Date> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/dates', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield new Date(value);
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async *getNumbers(): AsyncIterableIterator<number> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test/numbers', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield Number(value);
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of objects 1`] = `
+"export type GetTest200Response = {
+  foo: string;
+  bar: number;
+};
+export type GetTestError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of objects 2`] = `
+"import type { GetTest200Response } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetTest200Response = {
+    toJson: (model: GetTest200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.foo === undefined
+          ? {}
+          : {
+              foo: model.foo,
+            }),
+        ...(model.bar === undefined
+          ? {}
+          : {
+              bar: model.bar,
+            }),
+      };
+    },
+    fromJson: (json: any): GetTest200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        foo: json['foo'],
+        bar: json['bar'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getTest = this.getTest.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *getTest(): AsyncIterableIterator<GetTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield $IO.GetTest200Response.fromJson(JSON.parse(value));
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of strings 1`] = `
+"export type GetTestError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - streaming > should return an iterator over a stream of strings 2`] = `
+"/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getTest = this.getTest.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *getTest(): AsyncIterableIterator<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/test', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      while (reader) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        yield value;
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -40,7 +40,7 @@ const canShortCircuitConversion = (property) => {
 const renderToJsonDateValue = (identifier, format) => {
   return `${identifier}.toISOString()${format === 'date' ? '.slice(0,10)' : ''}`;
 };
-// Renders the appropriate nested function for .map() or mapValues() for arrays and dictionaries for the given type
+// Renders the appropriate nested function for .map() or $mapValues() for arrays and dictionaries for the given type
 const renderNestedToJsonValue = (type, depth = 0) => {
   const itemIdentifier = `item${depth}`;
   if (type.isPrimitive || type.typescriptType === 'unknown' || type.export === 'enum' || type.isEnum) {
@@ -48,7 +48,7 @@ const renderNestedToJsonValue = (type, depth = 0) => {
   } else if (type.export === "array") {
     return `(${itemIdentifier}) => ${itemIdentifier}.map(${renderNestedToJsonValue(type.link, depth + 1)})`;
   } else if (type.export === "dictionary") {
-    return `(${itemIdentifier}) => $IO.mapValues(${itemIdentifier}, ${renderNestedToJsonValue(type.link, depth + 1)})`;
+    return `(${itemIdentifier}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedToJsonValue(type.link, depth + 1)})`;
   }
   return `$IO.${type.name || type.type}.toJson`;
 };
@@ -64,7 +64,7 @@ const renderToJsonValue = (property, value) => {
     const prefix = property.uniqueItems ? `Array.from(${value})` : `${value}`;
     rendered = `(${prefix}.map(${renderNestedToJsonValue(property.link)}))`;
   } else if (property.export === "dictionary") {
-    rendered = `($IO.mapValues(${value}, ${renderNestedToJsonValue(property.link)}))`;
+    rendered = `($IO.$mapValues(${value}, ${renderNestedToJsonValue(property.link)}))`;
   } else if (property.type !== "any") {
     rendered = `$IO.${property.type}.toJson(${value})`;
   } else {
@@ -76,7 +76,7 @@ const renderToJsonValue = (property, value) => {
   }
   return rendered;
 };
-// Renders the appropriate nested function for .map() or mapValues() for arrays and dictionaries for the given type
+// Renders the appropriate nested function for .map() or $mapValues() for arrays and dictionaries for the given type
 const renderNestedFromJsonValue = (type, depth = 0) => {
     const itemIdentifier = `item${depth}`;
     if (type.isPrimitive || type.typescriptType === 'unknown' || type.export === 'enum' || type.isEnum) {
@@ -84,7 +84,7 @@ const renderNestedFromJsonValue = (type, depth = 0) => {
     } else if (type.export === "array") {
         return `(${itemIdentifier}) => ${itemIdentifier}.map(${renderNestedFromJsonValue(type.link, depth + 1)})`;
     } else if (type.export === "dictionary") {
-        return `(${itemIdentifier}) => $IO.mapValues(${itemIdentifier}, ${renderNestedFromJsonValue(type.link, depth + 1)})`;
+        return `(${itemIdentifier}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedFromJsonValue(type.link, depth + 1)})`;
     }
     return `$IO.${type.name || type.type}.fromJson`;
 };
@@ -99,7 +99,7 @@ const renderFromJsonValue = (property, value) => {
         rendered = `((${value} as Array<any>).map(${renderNestedFromJsonValue(property.link)}))`;
         rendered = property.uniqueItems ? `new Set(${rendered})` : rendered;
     } else if (property.export === "dictionary") {
-        rendered = `($IO.mapValues(${value}, ${renderNestedFromJsonValue(property.link)}))`;
+        rendered = `($IO.$mapValues(${value}, ${renderNestedFromJsonValue(property.link)}))`;
     } else {
         rendered = `$IO.${property.type}.fromJson(${value})`;
     }
@@ -116,34 +116,36 @@ const renderResponseCondition = (code) => {
   return `response.status === ${code}`;
 };
 // Renders the code which handles deserialising the response from a fetch call
-const renderResponse = (response) => {
-  if (response.export === 'array') {
-    if (response.isPrimitive || (response.link && response.link.isPrimitive)) {
-      return `(await response.json()) as ${response.typescriptType}`;
-    }
-    return `(await response.json()).map($IO.${response.type}.fromJson)`;
+const renderResponse = (response, options) => {
+  let opts = options || {
+    asText: 'await response.text()',
+    asJson: 'await response.json()',
+    asBlob: 'await response.blob()',
+  };
+  if (response.type === 'binary') {
+    return opts.asBlob;
   }
-  if (response.isPrimitive && ['date', 'date-time'].includes(response.format)) {
-    return `new Date(await response.text())`;
-  }
-  if (response.isPrimitive || ['unknown', 'any'].includes(response.type)) {
+  if ((response.isPrimitive || ['unknown', 'any'].includes(response.type)) && !['array', 'dictionary'].includes(response.export)) {
     if (response.type === 'number') {
-      return `Number(await response.text())`;
+      return `Number(${opts.asText})`;
     } else if (response.type === 'boolean') {
-      return `Boolean(await response.text())`;
-    } else if (response.type === 'binary') {
-      return `await response.blob()`;
+      return `(${opts.asText}) === 'true' ? true : false`;
+    } else if (['date', 'date-time'].includes(response.format)) {
+      return `new Date(${opts.asText})`;
     }
-    return `await response.text()${['unknown', 'any'].includes(response.type) ? ' as any' : ''}`;
+    return `${opts.asText}${['unknown', 'any'].includes(response.type) ? ' as any' : ''}`;
   }
   if (response.isEnum || response.export === 'enum') {
-    return `(await response.text()) as ${response.typescriptType}`;
+    return `(${opts.asText}) as ${response.typescriptType}`;
   }
-  // Non primitive
-  if (response.export === 'array') {
-    return `(await response.json()).map($IO.${response.type}.fromJson)`;
-  }
-  return `$IO.${response.typescriptType}.fromJson(await response.json())`;
+  return renderFromJsonValue(response, `(${opts.asJson})`);
+};
+const renderStreamingResponseChunk = (response) => {
+  return renderResponse(response, {
+    asJson: 'JSON.parse(value)',
+    asText: 'value',
+    asBlob: 'new Blob([value])',
+  });
 };
 _%>
 
@@ -151,7 +153,7 @@ _%>
  * Utility for serialisation and deserialisation of API types.
  */
 class $IO {
-  private static mapValues = (data: any, fn: (item: any) => any) =>
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 <%_ models.filter(m => m.export !== 'enum').forEach((model) => { _%>
 <%_ const isComposite = model.export === "one-of" || model.export === "any-of" || model.export === "all-of"; _%>
@@ -258,8 +260,26 @@ class $IO {
  * Client configuration for <%- className %>
  */
 export interface <%- className %>Config {
+  /**
+   * Base URL for the API
+   */
   url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
   fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
 }
 
 /**
@@ -270,6 +290,11 @@ export class <%- className %> {
 
   constructor(config: <%- className %>Config) {
     this.$config = config;
+
+    <%_ allOperations.forEach((op) => { _%>
+    <%_ const hasTag = op.tags && op.tags.length > 0; _%>
+    this.<% if (hasTag) { %>_<% } %><%- op.uniqueName %> = this.<% if (hasTag) { %>_<% } %><%- op.uniqueName %>.bind(this);
+    <%_ }); _%>
   }
 
   private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' }): string => {
@@ -298,16 +323,22 @@ export class <%- className %> {
   private $fetch: typeof fetch = (...args) => (this.$config.fetch ?? fetch)(...args);
   <%_ allOperations.forEach((op) => { _%>
   <%_ const hasTag = op.tags && op.tags.length > 0; _%>
-
+  <%_ const isStreaming = (op.vendorExtensions ?? {})['x-streaming']; _%>
   <%_ const isInputOptional = (op.parameters.length === 1 && op.parametersBody && !op.parametersBody.isRequired) || op.parameters.length === 0; _%>
-<%- docString(op, '  ') %>  <%- hasTag ? 'private _' : 'public ' %><%- op.uniqueName %> = async (<% if (op.parameters.length > 0) { %>input<%- isInputOptional ? '?' : '' %>: <%- op.operationIdPascalCase %>Request<% } %>): Promise<<%- op.result ? op.result.typescriptType : 'void' %>> => {
+
+<%- docString(op, '  ') %>  <%- hasTag ? 'private' : 'public' %> async <% if (isStreaming) { %>*<% } %><%- hasTag ? '_' : '' %><%- op.uniqueName %>(<% if (op.parameters.length > 0) { %>input<%- isInputOptional ? '?' : '' %>: <%- op.operationIdPascalCase %>Request<% } %>): <%- isStreaming ? 'AsyncIterableIterator' : 'Promise' %><<%- op.result ? op.result.typescriptType : 'void' %>> {
     <%_ ['path', 'query', 'header'].forEach((position) => { _%>
     <%_ if (op.parameters.map(p => p.in).includes(position)) { _%>
-    const <%- position %>Parameters = $IO.<%- op.operationIdPascalCase %>Request<%- upperFirst(position) %>Parameters.toJson(input);
+    const <%- position %>Parameters: {[key: string]: any} = $IO.<%- op.operationIdPascalCase %>Request<%- upperFirst(position) %>Parameters.toJson(input);
     <%_ } else { _%>
-    const <%- position %>Parameters = {};
+    const <%- position %>Parameters: {[key: string]: any} = {};
     <%_ } _%>
     <%_ }); _%>
+    <%_ if (op.parametersBody && op.parametersBody.mediaTypes) { _%>
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = '<%- op.parametersBody.mediaTypes %>';
+    }
+    <%_ } _%>
     <%_ if (op.parameters.filter(p => p.collectionFormat).length > 0) { _%>
     const collectionFormats = {
       <%_ op.parameters.filter(p => p.collectionFormat).forEach((parameter) => { _%>
@@ -342,12 +373,28 @@ export class <%- className %> {
     <%_ if (response.code !== 'default') { _%>
     if (<%- renderResponseCondition(response.code) %>) {
     <%_ } _%>
-    <% if (response.code !== 'default') { %>  <% } %><% if (isResultResponse) { %>return <%- response.type === 'void' ? 'undefined' : renderResponse(response) %><% } else { %>throw {
-    <% if (response.code !== 'default') { %>  <% } %>  status: response.status,
+    <%_ if (isResultResponse) { _%>
+    <%_ if (isStreaming) { _%>
+    <%_ if (response.type === 'void') { _%>
+    return;
+    <%_ } else { _%>
+    const reader = response.body?<% if (response.type !== 'binary') { %>.pipeThrough(new TextDecoderStream())<% } %>.getReader();
+    while (reader) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      yield <%- renderStreamingResponseChunk(response) %>;
+    }
+    return;
+    <%_ } _%>
+    <%_ } else { _%>
+    return <%- response.type === 'void' ? 'undefined' : renderResponse(response) _%>
+    <%_ } _%>
+<% } else { %>throw {
+      status: response.status,
       <%_ if (response.type !== 'void') { _%>
-    <% if (response.code !== 'default') { %>  <% } %>  error: <%- renderResponse(response) %>,
+      error: <%- renderResponse(response) %>,
       <%_ } _%>
-    <% if (response.code !== 'default') { %>  <% } %>}<% } %>;
+    }<% } %>;
     <%_ if (response.code !== 'default') { _%>
     }
     <%_ } _%>
@@ -355,13 +402,13 @@ export class <%- className %> {
     <%_ if (!op.responses.find(response => response.code === 'default')) { _%>
     throw new Error(`Unknown response status ${response.status} returned by API`);
     <%_ } _%>
-  };
+  }
   <%_ }); _%>
   <%_ Object.entries(operationsByTag).forEach(([tag, operations]) => { _%>
 
 <%- docString({ description: `${tag} operations` }, '  ') %>  public <%- tag %> = {
     <%_ operations.forEach((op) => { _%>
-<%- docString(op, '    ') %>    <%- op.name %>: this._<%- op.uniqueName %>,
+<%- docString(op, '    ') %>    <%- op.name %>: this._<%- op.uniqueName %>.bind(this),
     <%_ }); _%>
   };
   <%_ }); _%>

--- a/packages/nx-plugin/src/open-api/ts-client/generator.streaming.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.streaming.spec.ts
@@ -1,0 +1,1092 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { expectTypeScriptToCompile } from './generator.utils.spec';
+import { Mock } from 'vitest';
+import { importTypeScriptModule } from '../../utils/js';
+import { Spec } from '../utils/types';
+import openApiTsClientGenerator from './generator';
+
+describe('openApiTsClientGenerator - streaming', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+  const baseUrl = 'https://example.com';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths);
+  };
+
+  const callGeneratedClientStreaming = async (
+    clientModule: string,
+    mockFetch: Mock<any, any>,
+    op: string,
+    parameters?: any,
+  ): Promise<AsyncIterableIterator<any>> => {
+    const { TestApi } = await importTypeScriptModule<any>(clientModule);
+    const client = new TestApi({ url: baseUrl, fetch: mockFetch });
+    const clientMethod = op.split('.').reduce((m, opPart) => m[opPart], client);
+    return clientMethod(parameters);
+  };
+
+  const mockStreamingFetch = (
+    status: number,
+    chunks: any[],
+  ): Mock<any, any> => {
+    const mockFetch = vi.fn();
+
+    let i = 0;
+
+    const mockReader = vi.fn();
+    mockReader.mockReturnValue({
+      read: vi.fn().mockImplementation(() => {
+        const value = chunks[i];
+        const done = i >= chunks.length;
+        i++;
+        return {
+          done,
+          value,
+        };
+      }),
+    });
+
+    mockFetch.mockResolvedValue({
+      status,
+      body: {
+        pipeThrough: () => ({
+          getReader: mockReader,
+        }),
+        getReader: () => mockReader,
+      },
+    });
+
+    return mockFetch;
+  };
+
+  it('should return an iterator over a stream of strings', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            // Mark as a streaming api
+            ...{ 'x-streaming': true },
+            operationId: 'getTest',
+            responses: {
+              '200': {
+                description: 'getTest',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = mockStreamingFetch(200, ['some', 'text', 'chunks']);
+
+    const receivedChunks: string[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetch,
+      'getTest',
+    )) {
+      receivedChunks.push(chunk);
+    }
+
+    expect(receivedChunks).toEqual(['some', 'text', 'chunks']);
+  });
+
+  it('should return an iterator over a stream of objects', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            // Mark as a streaming api
+            ...{ 'x-streaming': true },
+            operationId: 'getTest',
+            responses: {
+              '200': {
+                description: 'getTest',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        foo: {
+                          type: 'string',
+                        },
+                        bar: {
+                          type: 'number',
+                        },
+                      },
+                      required: ['foo', 'bar'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = mockStreamingFetch(200, [
+      '{ "foo": "foo1", "bar": 1 }',
+      '{ "foo": "foo2", "bar": 2 }',
+      '{ "foo": "foo3", "bar": 3 }',
+    ]);
+
+    const receivedChunks: { foo: string; bar: number }[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetch,
+      'getTest',
+    )) {
+      receivedChunks.push(chunk);
+    }
+
+    expect(receivedChunks).toEqual([
+      { foo: 'foo1', bar: 1 },
+      { foo: 'foo2', bar: 2 },
+      { foo: 'foo3', bar: 3 },
+    ]);
+  });
+
+  it('should return an iterator over a stream of numbers, booleans and dates', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/test/numbers': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getNumbers',
+            responses: {
+              '200': {
+                description: 'getNumbers',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'number',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/booleans': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getBooleans',
+            responses: {
+              '200': {
+                description: 'getBooleans',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'boolean',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/dates': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getDates',
+            responses: {
+              '200': {
+                description: 'getDates',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'string',
+                      format: 'date-time',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    // Test number stream
+    const mockFetchNumbers = mockStreamingFetch(200, ['42', '-123.45']);
+    const receivedNumbers: number[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchNumbers,
+      'getNumbers',
+    )) {
+      receivedNumbers.push(chunk);
+    }
+    expect(receivedNumbers).toEqual([42, -123.45]);
+
+    // Test boolean stream
+    const mockFetchBooleans = mockStreamingFetch(200, ['true', 'false']);
+    const receivedBooleans: boolean[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchBooleans,
+      'getBooleans',
+    )) {
+      receivedBooleans.push(chunk);
+    }
+    expect(receivedBooleans).toEqual([true, false]);
+
+    // Test date stream
+    const mockFetchDates = mockStreamingFetch(200, [
+      '2024-02-25T00:00:00.000Z',
+      '2025-12-31T23:59:59.999Z',
+    ]);
+    const receivedDates: Date[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchDates,
+      'getDates',
+    )) {
+      receivedDates.push(chunk);
+    }
+    expect(receivedDates).toEqual([
+      new Date('2024-02-25T00:00:00.000Z'),
+      new Date('2025-12-31T23:59:59.999Z'),
+    ]);
+  });
+
+  it('should return an iterator over a stream of arrays', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/test/number-arrays': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getNumberArrays',
+            responses: {
+              '200': {
+                description: 'getNumberArrays',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'number',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/string-arrays': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getStringArrays',
+            responses: {
+              '200': {
+                description: 'getStringArrays',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/boolean-arrays': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getBooleanArrays',
+            responses: {
+              '200': {
+                description: 'getBooleanArrays',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'boolean',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/date-arrays': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getDateArrays',
+            responses: {
+              '200': {
+                description: 'getDateArrays',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/object-arrays': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getObjectArrays',
+            responses: {
+              '200': {
+                description: 'getObjectArrays',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          id: {
+                            type: 'number',
+                          },
+                          name: {
+                            type: 'string',
+                          },
+                        },
+                        required: ['id', 'name'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    // Test number arrays
+    const mockFetchNumberArrays = mockStreamingFetch(200, [
+      '[1, 2, 3]',
+      '[-4.5, 0, 6.7]',
+    ]);
+    const receivedNumberArrays: number[][] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchNumberArrays,
+      'getNumberArrays',
+    )) {
+      receivedNumberArrays.push(chunk);
+    }
+    expect(receivedNumberArrays).toEqual([
+      [1, 2, 3],
+      [-4.5, 0, 6.7],
+    ]);
+
+    // Test string arrays
+    const mockFetchStringArrays = mockStreamingFetch(200, [
+      '["a", "b", "c"]',
+      '["x", "y", "z"]',
+    ]);
+    const receivedStringArrays: string[][] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchStringArrays,
+      'getStringArrays',
+    )) {
+      receivedStringArrays.push(chunk);
+    }
+    expect(receivedStringArrays).toEqual([
+      ['a', 'b', 'c'],
+      ['x', 'y', 'z'],
+    ]);
+
+    // Test boolean arrays
+    const mockFetchBooleanArrays = mockStreamingFetch(200, [
+      '[true, false, true]',
+      '[false, false, true]',
+    ]);
+    const receivedBooleanArrays: boolean[][] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchBooleanArrays,
+      'getBooleanArrays',
+    )) {
+      receivedBooleanArrays.push(chunk);
+    }
+    expect(receivedBooleanArrays).toEqual([
+      [true, false, true],
+      [false, false, true],
+    ]);
+
+    // Test date arrays
+    const mockFetchDateArrays = mockStreamingFetch(200, [
+      '["2024-02-25T00:00:00.000Z", "2024-02-26T00:00:00.000Z"]',
+      '["2025-12-31T23:59:59.999Z", "2026-01-01T00:00:00.000Z"]',
+    ]);
+    const receivedDateArrays: Date[][] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchDateArrays,
+      'getDateArrays',
+    )) {
+      receivedDateArrays.push(chunk);
+    }
+    expect(receivedDateArrays).toEqual([
+      [
+        new Date('2024-02-25T00:00:00.000Z'),
+        new Date('2024-02-26T00:00:00.000Z'),
+      ],
+      [
+        new Date('2025-12-31T23:59:59.999Z'),
+        new Date('2026-01-01T00:00:00.000Z'),
+      ],
+    ]);
+
+    // Test object arrays
+    const mockFetchObjectArrays = mockStreamingFetch(200, [
+      '[{"id": 1, "name": "first"}, {"id": 2, "name": "second"}]',
+      '[{"id": 3, "name": "third"}, {"id": 4, "name": "fourth"}]',
+    ]);
+    const receivedObjectArrays: Array<{ id: number; name: string }>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchObjectArrays,
+      'getObjectArrays',
+    )) {
+      receivedObjectArrays.push(chunk);
+    }
+    expect(receivedObjectArrays).toEqual([
+      [
+        { id: 1, name: 'first' },
+        { id: 2, name: 'second' },
+      ],
+      [
+        { id: 3, name: 'third' },
+        { id: 4, name: 'fourth' },
+      ],
+    ]);
+  });
+
+  it('should return an iterator over a stream of dictionaries', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/test/number-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getNumberDict',
+            responses: {
+              '200': {
+                description: 'getNumberDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'number',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/string-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getStringDict',
+            responses: {
+              '200': {
+                description: 'getStringDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/enum-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getEnumDict',
+            responses: {
+              '200': {
+                description: 'getEnumDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'string',
+                        enum: ['RED', 'GREEN', 'BLUE'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/boolean-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getBooleanDict',
+            responses: {
+              '200': {
+                description: 'getBooleanDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'boolean',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/date-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getDateDict',
+            responses: {
+              '200': {
+                description: 'getDateDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/array-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getArrayDict',
+            responses: {
+              '200': {
+                description: 'getArrayDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'array',
+                        items: {
+                          type: 'number',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/object-array-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getObjectArrayDict',
+            responses: {
+              '200': {
+                description: 'getObjectArrayDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            id: { type: 'number' },
+                            name: { type: 'string' },
+                          },
+                          required: ['id', 'name'],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/test/nested-dict': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getNestedDict',
+            responses: {
+              '200': {
+                description: 'getNestedDict',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'object',
+                        additionalProperties: {
+                          type: 'object',
+                          properties: {
+                            value: { type: 'number' },
+                            tags: {
+                              type: 'array',
+                              items: { type: 'string' },
+                            },
+                          },
+                          required: ['value', 'tags'],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    // Test number dictionary
+    const mockFetchNumberDict = mockStreamingFetch(200, [
+      '{"a": 1, "b": 2}',
+      '{"x": -3.14, "y": 0}',
+    ]);
+    const receivedNumberDicts: Record<string, number>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchNumberDict,
+      'getNumberDict',
+    )) {
+      receivedNumberDicts.push(chunk);
+    }
+    expect(receivedNumberDicts).toEqual([
+      { a: 1, b: 2 },
+      { x: -3.14, y: 0 },
+    ]);
+
+    // Test string dictionary
+    const mockFetchStringDict = mockStreamingFetch(200, [
+      '{"first": "hello", "second": "world"}',
+      '{"third": "test", "fourth": "data"}',
+    ]);
+    const receivedStringDicts: Record<string, string>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchStringDict,
+      'getStringDict',
+    )) {
+      receivedStringDicts.push(chunk);
+    }
+    expect(receivedStringDicts).toEqual([
+      { first: 'hello', second: 'world' },
+      { third: 'test', fourth: 'data' },
+    ]);
+
+    // Test enum dictionary
+    const mockFetchEnumDict = mockStreamingFetch(200, [
+      '{"primary": "RED", "secondary": "BLUE"}',
+      '{"accent": "GREEN"}',
+    ]);
+    const receivedEnumDicts: Record<string, 'RED' | 'GREEN' | 'BLUE'>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchEnumDict,
+      'getEnumDict',
+    )) {
+      receivedEnumDicts.push(chunk);
+    }
+    expect(receivedEnumDicts).toEqual([
+      { primary: 'RED', secondary: 'BLUE' },
+      { accent: 'GREEN' },
+    ]);
+
+    // Test boolean dictionary
+    const mockFetchBooleanDict = mockStreamingFetch(200, [
+      '{"isValid": true, "isEnabled": false}',
+      '{"isReady": true}',
+    ]);
+    const receivedBooleanDicts: Record<string, boolean>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchBooleanDict,
+      'getBooleanDict',
+    )) {
+      receivedBooleanDicts.push(chunk);
+    }
+    expect(receivedBooleanDicts).toEqual([
+      { isValid: true, isEnabled: false },
+      { isReady: true },
+    ]);
+
+    // Test date dictionary
+    const mockFetchDateDict = mockStreamingFetch(200, [
+      '{"start": "2024-02-25T00:00:00.000Z", "end": "2024-02-26T00:00:00.000Z"}',
+      '{"deadline": "2025-12-31T23:59:59.999Z"}',
+    ]);
+    const receivedDateDicts: Record<string, Date>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchDateDict,
+      'getDateDict',
+    )) {
+      receivedDateDicts.push(chunk);
+    }
+    expect(receivedDateDicts).toEqual([
+      {
+        start: new Date('2024-02-25T00:00:00.000Z'),
+        end: new Date('2024-02-26T00:00:00.000Z'),
+      },
+      {
+        deadline: new Date('2025-12-31T23:59:59.999Z'),
+      },
+    ]);
+
+    // Test array dictionary
+    const mockFetchArrayDict = mockStreamingFetch(200, [
+      '{"scores": [1, 2, 3], "values": [-1, 0, 1]}',
+      '{"grades": [85, 90, 95]}',
+    ]);
+    const receivedArrayDicts: Record<string, number[]>[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchArrayDict,
+      'getArrayDict',
+    )) {
+      receivedArrayDicts.push(chunk);
+    }
+    expect(receivedArrayDicts).toEqual([
+      { scores: [1, 2, 3], values: [-1, 0, 1] },
+      { grades: [85, 90, 95] },
+    ]);
+
+    // Test object array dictionary
+    const mockFetchObjectArrayDict = mockStreamingFetch(200, [
+      '{"users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}',
+      '{"admins": [{"id": 3, "name": "Charlie"}]}',
+    ]);
+    const receivedObjectArrayDicts: Record<
+      string,
+      Array<{ id: number; name: string }>
+    >[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchObjectArrayDict,
+      'getObjectArrayDict',
+    )) {
+      receivedObjectArrayDicts.push(chunk);
+    }
+    expect(receivedObjectArrayDicts).toEqual([
+      {
+        users: [
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ],
+      },
+      { admins: [{ id: 3, name: 'Charlie' }] },
+    ]);
+
+    // Test nested dictionary
+    const mockFetchNestedDict = mockStreamingFetch(200, [
+      '{"region1": {"zone1": {"value": 42, "tags": ["prod", "high"]}}}',
+      '{"region2": {"zone2": {"value": 21, "tags": ["dev"]}}}',
+    ]);
+    const receivedNestedDicts: Record<
+      string,
+      Record<string, { value: number; tags: string[] }>
+    >[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetchNestedDict,
+      'getNestedDict',
+    )) {
+      receivedNestedDicts.push(chunk);
+    }
+    expect(receivedNestedDicts).toEqual([
+      {
+        region1: {
+          zone1: { value: 42, tags: ['prod', 'high'] },
+        },
+      },
+      {
+        region2: {
+          zone2: { value: 21, tags: ['dev'] },
+        },
+      },
+    ]);
+  });
+
+  it('should handle error responses for streaming operations', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/stream': {
+          get: {
+            ...{ 'x-streaming': true },
+            operationId: 'getStream',
+            responses: {
+              '200': {
+                description: 'Success',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'number',
+                    },
+                  },
+                },
+              },
+              '400': {
+                description: 'Bad Request',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        code: { type: 'string' },
+                        message: { type: 'string' },
+                      },
+                      required: ['code', 'message'],
+                    },
+                  },
+                },
+              },
+              '500': {
+                description: 'Internal Server Error',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        error: { type: 'string' },
+                        details: { type: 'string' },
+                      },
+                      required: ['error'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    // Test 400 error
+    const mockFetch400 = vi.fn();
+    mockFetch400.mockResolvedValue({
+      status: 400,
+      json: vi.fn().mockResolvedValue({
+        code: 'INVALID_PARAMETER',
+        message: 'Invalid query parameter',
+      }),
+    });
+
+    await expect(async () => {
+      for await (const chunk of await callGeneratedClientStreaming(
+        client,
+        mockFetch400,
+        'getStream',
+      )) {
+        // noop
+      }
+    }).rejects.toThrow(
+      expect.objectContaining({
+        status: 400,
+        error: {
+          code: 'INVALID_PARAMETER',
+          message: 'Invalid query parameter',
+        },
+      }),
+    );
+
+    // Test 500 error
+    const mockFetch500 = vi.fn();
+    mockFetch500.mockResolvedValue({
+      status: 500,
+      json: vi.fn().mockResolvedValue({
+        error: 'Internal error occurred',
+        details: 'Stack trace...',
+      }),
+    });
+
+    await expect(async () => {
+      for await (const chunk of await callGeneratedClientStreaming(
+        client,
+        mockFetch500,
+        'getStream',
+      )) {
+        // noop
+      }
+    }).rejects.toThrow(
+      expect.objectContaining({
+        status: 500,
+        error: {
+          error: 'Internal error occurred',
+          details: 'Stack trace...',
+        },
+      }),
+    );
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-client/generator.utils.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.utils.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createProjectSync } from '@ts-morph/bootstrap';
+import ts from 'typescript';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+
+export const expectTypeScriptToCompile = (
+  tree: Tree,
+  paths: string[],
+  silent = false,
+) => {
+  const project = createProjectSync({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      skipLibCheck: true,
+      strict: true,
+    },
+  });
+  paths.forEach((p) => {
+    project.createSourceFile(p, tree.read(p, 'utf-8'));
+  });
+
+  const program = project.createProgram();
+
+  const diagnostics = [
+    ...program.getSemanticDiagnostics(),
+    ...program.getSyntacticDiagnostics(),
+  ];
+
+  if (diagnostics.length > 0 && !silent) {
+    console.log(project.formatDiagnosticsWithColorAndContext(diagnostics));
+  }
+  expect(diagnostics).toHaveLength(0);
+};
+
+// A couple of tests for the test utility as a sanity check
+describe('expectTypeScriptToCompile', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should not throw for valid TypeScript', () => {
+    tree.write('test.ts', 'const myNumber: number = 1;');
+    expectTypeScriptToCompile(tree, ['test.ts']);
+  });
+
+  it('should throw for invalid TypeScript', () => {
+    tree.write('test.ts', 'const myNumber: number = "string";');
+    expect(() => expectTypeScriptToCompile(tree, ['test.ts'], true)).toThrow();
+  });
+});


### PR DESCRIPTION
### Reason for this change

Type-Safe consumption of streaming APIs

### Description of changes

This change adds support for OpenAPI operations to declare that they will return a streaming response via setting the vendor extension `x-streaming` to true. When set, the generated client will provide an async iterator for consumers to iterate over each chunk as it becomes available, in a type-safe manner.

A few other additional changes:

* If a response body was typed as a boolean, we'd always return the response `true` as `Boolean('false') === true`! Fix by checking for the string `"true"`.
* When `$IO.mapValues` was unused, the typescript compiler complained, so we make it `protected`. Additionally rename to `$mapValues` to indicate it's an internal method and ensure no clashes with operation/schema names.
* Add a Content-Type header automatically based on the media type of the request to save users needing to override `fetch` just to add `Content-Type: application/json`. Provide a config option to turn this off and let users manage their own Content-Type header by overriding fetch.
* Operation methods on the client are no longer arrow functions so that they are closer in syntax to the streaming response async generators to keep the template simple. We therefore explicitly bind the client instance to each method (eg. `this.myOp = this.myOp.bind(this)`) so that they can still be passed around as functions if desired.

### Description of how you validated changes

Unit tests, manual testing

### Issue # (if applicable)

References #19 

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*