### PR TITLE
feat(fast-api): improve operation names in open api specification for better generated clients

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit
 from fastapi import FastAPI, Request, Response
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from mangum import Mangum
@@ -53,7 +54,7 @@ async def metrics_handler(request: Request, call_next):
     metrics.add_metric(name="RequestCount", unit=MetricUnit.Count, value=1)
 
     response = await call_next(request)
-    
+
     if response.status_code == 200:
         metrics.add_metric(name="Success", unit=MetricUnit.Count, value=1)
 
@@ -98,7 +99,26 @@ class LoggerRouteHandler(APIRoute):
 
         return route_handler
 
-app.router.route_class = LoggerRouteHandler",
+app.router.route_class = LoggerRouteHandler
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route.operation_id = route.name
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+app.openapi = custom_openapi
+",
   "apps/test_api/test_api/main.py": "from .init import app, lambda_handler, tracer
 
 handler = lambda_handler

--- a/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
+++ b/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit
 from fastapi import FastAPI, Request, Response
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from mangum import Mangum
@@ -47,7 +48,7 @@ async def metrics_handler(request: Request, call_next):
     metrics.add_metric(name="RequestCount", unit=MetricUnit.Count, value=1)
 
     response = await call_next(request)
-    
+
     if response.status_code == 200:
         metrics.add_metric(name="Success", unit=MetricUnit.Count, value=1)
 
@@ -93,3 +94,21 @@ class LoggerRouteHandler(APIRoute):
         return route_handler
 
 app.router.route_class = LoggerRouteHandler
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route.operation_id = route.name
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+app.openapi = custom_openapi

--- a/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
@@ -1,19 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`fastapi react generator > should generate OpenAPI spec script > generate_open_api.py 1`] = `
-"from fastapi.openapi.utils import get_openapi
-from src.main import app
+"from src.main import app
 import json, os, sys
 
 os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True)
 with open(sys.argv[1], 'w') as f:
-  json.dump(get_openapi(
-    title=app.title,
-    version=app.version,
-    openapi_version=app.openapi_version,
-    description=app.description,
-    routes=app.routes,
-  ), f)
+  json.dump(app.openapi(), f)
 "
 `;
 

--- a/packages/nx-plugin/src/py/fast-api/react/files/fast-api/scripts/generate_open_api.py.template
+++ b/packages/nx-plugin/src/py/fast-api/react/files/fast-api/scripts/generate_open_api.py.template
@@ -1,13 +1,6 @@
-from fastapi.openapi.utils import get_openapi
 from <%= moduleName %>.main import app
 import json, os, sys
 
 os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True)
 with open(sys.argv[1], 'w') as f:
-  json.dump(get_openapi(
-    title=app.title,
-    version=app.version,
-    openapi_version=app.openapi_version,
-    description=app.description,
-    routes=app.routes,
-  ), f)
+  json.dump(app.openapi(), f)


### PR DESCRIPTION
### Reason for this change

By default, FastAPI includes the function name, path and http method in the operationId which in turn is used to generate the names of the functions to call each operation. For example:

```python
@app.get('/items')
def list_items(...):
	...
```

By default gets the operationId `list_items_items_get`, which isn't very friendly in the generated client, which would end up having a method `client.listItemsItemsGet(...)`.

### Description of changes

We use just the function name as the operationId to address this. Which for this example would be `client.listItems(...)`

### Description of how you validated changes

Unit tests, integ tests

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*