### PR TITLE
fix: ensure typescript plugin is only defined once

### DIFF
--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { readNxJson, Tree } from '@nx/devkit';
 import { tsLibGenerator } from './generator';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 describe('ts lib generator', () => {
@@ -23,13 +23,13 @@ describe('ts lib generator', () => {
     expect(tree.exists('test-lib/project.json')).toBeTruthy();
     // Create snapshots of generated files
     expect(tree.read('test-lib/src/index.ts', 'utf-8')).toMatchSnapshot(
-      'index.ts'
+      'index.ts',
     );
     expect(tree.read('test-lib/tsconfig.json', 'utf-8')).toMatchSnapshot(
-      'tsconfig.json'
+      'tsconfig.json',
     );
     expect(tree.read('test-lib/project.json', 'utf-8')).toMatchSnapshot(
-      'project.json'
+      'project.json',
     );
   });
   it('should generate library with custom directory', async () => {
@@ -44,13 +44,13 @@ describe('ts lib generator', () => {
     expect(tree.exists('libs/test-lib/src/index.ts')).toBeTruthy();
     // Create snapshots of generated files
     expect(tree.read('libs/test-lib/src/index.ts', 'utf-8')).toMatchSnapshot(
-      'custom-dir-index.ts'
+      'custom-dir-index.ts',
     );
     expect(tree.read('libs/test-lib/tsconfig.json', 'utf-8')).toMatchSnapshot(
-      'custom-dir-tsconfig.json'
+      'custom-dir-tsconfig.json',
     );
     expect(tree.read('libs/test-lib/project.json', 'utf-8')).toMatchSnapshot(
-      'custom-dir-project.json'
+      'custom-dir-project.json',
     );
   });
   it('should generate library with subdirectory', async () => {
@@ -66,13 +66,29 @@ describe('ts lib generator', () => {
     expect(tree.exists('feature/test-lib/src/index.ts')).toBeTruthy();
     // Create snapshots of generated files
     expect(tree.read('feature/test-lib/src/index.ts', 'utf-8')).toMatchSnapshot(
-      'subdir-index.ts'
+      'subdir-index.ts',
     );
     expect(
-      tree.read('feature/test-lib/tsconfig.json', 'utf-8')
+      tree.read('feature/test-lib/tsconfig.json', 'utf-8'),
     ).toMatchSnapshot('subdir-tsconfig.json');
     expect(tree.read('feature/test-lib/project.json', 'utf-8')).toMatchSnapshot(
-      'subdir-project.json'
+      'subdir-project.json',
     );
+  });
+
+  it('should not configure duplicate @nx/js/typescript plugin entries', async () => {
+    await tsLibGenerator(tree, {
+      name: 'test-1',
+      skipInstall: true,
+    });
+    await tsLibGenerator(tree, {
+      name: 'test-2',
+      skipInstall: true,
+    });
+
+    const jsPlugins = readNxJson(tree).plugins.filter(
+      (p) => typeof p !== 'string' && p.plugin === '@nx/js/typescript',
+    );
+    expect(jsPlugins).toHaveLength(1);
   });
 });

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -126,16 +126,28 @@ export const tsLibGenerator = async (
         ...nxJson.targetDefaults?.compile,
       },
     };
-    nxJson.plugins = nxJson.plugins.map((p) => {
-      if (
-        typeof p !== 'string' &&
-        p.plugin === '@nx/js/typescript' &&
-        p.options?.['build']
-      ) {
-        p.options['build'].targetName = 'compile';
-      }
-      return p;
-    });
+
+    // Ensure we only declare a single typescript plugin with the correct settings
+    nxJson.plugins = [
+      {
+        plugin: '@nx/js/typescript',
+        options: {
+          typecheck: {
+            targetName: 'typecheck',
+          },
+          build: {
+            targetName: 'compile',
+            configName: 'tsconfig.lib.json',
+            buildDepsName: 'build-deps',
+            watchDepsName: 'watch-deps',
+          },
+        },
+      },
+      ...nxJson.plugins.filter(
+        (p) => typeof p === 'string' || p.plugin !== '@nx/js/typescript',
+      ),
+    ];
+
     return nxJson;
   });
 


### PR DESCRIPTION
### Reason for this change

1. It's confusing to have multiple entries with include/exclude patterns (the nx library generator creates a new entry for any new package when the build target name isn't build).
2. Integration tests were failing due to a race condition writing some cache file https://github.com/nrwl/nx/issues/30239

### Description of changes

Ensure the nx typescript plugin is only defined once

### Description of how you validated changes

End to end tests

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*