### PR TITLE
fix: preserve existing new lines in typescript files updated by generators

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
@@ -28,6 +28,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
 export default defineConfig({
   define: {
     global: {},

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -245,11 +245,190 @@ export class UserIdentity extends Construct {
 
 exports[`cognito-auth generator > should not be able to run the generator multiple times 1`] = `[Error: This generator has already been run on test-project.]`;
 
+exports[`cognito-auth generator > should update AppLayout > app-layout-with-auth 1`] = `
+"import { useAuth } from 'react-oidc-context';
+import * as React from 'react';
+import { createContext, useCallback, useEffect, useState } from 'react';
+import { NavItems } from './navitems';
+import Config from '../../config';
+
+import {
+  BreadcrumbGroup,
+  BreadcrumbGroupProps,
+  SideNavigation,
+  TopNavigation,
+} from '@cloudscape-design/components';
+
+import CloudscapeAppLayout, {
+  AppLayoutProps,
+} from '@cloudscape-design/components/app-layout';
+
+import { matchByPath, useLocation, useNavigate } from '@tanstack/react-router';
+import { Outlet } from '@tanstack/react-router';
+
+const getBreadcrumbs = (
+  pathName: string,
+  search: string,
+  defaultBreadcrumb: string,
+  availableRoutes?: string[],
+) => {
+  const segments = [
+    defaultBreadcrumb,
+    ...pathName.split('/').filter((segment) => segment !== ''),
+  ];
+
+  return segments.map((segment, i) => {
+    const href =
+      i === 0
+        ? '/'
+        : \`/\${segments
+            .slice(1, i + 1)
+            .join('/')
+            .replace('//', '/')}\`;
+
+    const matched =
+      !availableRoutes || availableRoutes.find((r) => matchByPath(r, href, {}));
+
+    return {
+      href: matched ? \`\${href}\${search}\` : '#',
+      text: segment,
+    };
+  });
+};
+
+export interface AppLayoutContext {
+  appLayoutProps: AppLayoutProps;
+  setAppLayoutProps: (props: AppLayoutProps) => void;
+  displayHelpPanel: (helpContent: React.ReactNode) => void;
+}
+
+/**
+ * Context for updating/retrieving the AppLayout.
+ */
+export const AppLayoutContext = createContext({
+  appLayoutProps: {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setAppLayoutProps: (_: AppLayoutProps) => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  displayHelpPanel: (_: React.ReactNode) => {},
+});
+
+/**
+ * Defines the App layout and contains logic for routing.
+ */
+const AppLayout: React.FC = () => {
+  const { user, removeUser, signoutRedirect, clearStaleState } = useAuth();
+  const navigate = useNavigate();
+  const appLayout = React.useRef<AppLayoutProps.Ref>(null);
+  const [activeBreadcrumbs, setActiveBreadcrumbs] = useState<
+    BreadcrumbGroupProps.Item[]
+  >([{ text: '/', href: '/' }]);
+  const [appLayoutProps, setAppLayoutProps] = useState<AppLayoutProps>({});
+  const { pathname, search } = useLocation();
+  const setAppLayoutPropsSafe = useCallback(
+    (props: AppLayoutProps) => {
+      JSON.stringify(appLayoutProps) !== JSON.stringify(props) &&
+        setAppLayoutProps(props);
+    },
+    [appLayoutProps],
+  );
+  useEffect(() => {
+    const breadcrumbs = getBreadcrumbs(
+      pathname,
+      Object.entries(search).reduce((p, [k, v]) => p + \`\${k}=\${v}\`, ''),
+      '/',
+    );
+    setActiveBreadcrumbs(breadcrumbs);
+  }, [pathname, search]);
+  const onNavigate = useCallback(
+    (
+      e: CustomEvent<{
+        href: string;
+        external?: boolean;
+      }>,
+    ) => {
+      if (!e.detail.external) {
+        e.preventDefault();
+        setAppLayoutPropsSafe({
+          contentType: undefined,
+        });
+        navigate({ to: e.detail.href });
+      }
+    },
+    [navigate, setAppLayoutPropsSafe],
+  );
+  return (
+    <AppLayoutContext.Provider
+      value={{
+        appLayoutProps,
+        setAppLayoutProps: setAppLayoutPropsSafe,
+        displayHelpPanel: (helpContent: React.ReactNode) => {
+          setAppLayoutPropsSafe({ tools: helpContent, toolsHide: false });
+          appLayout.current?.openTools();
+        },
+      }}
+    >
+      <TopNavigation
+        identity={{
+          href: '/',
+          title: Config.applicationName,
+          logo: {
+            src: Config.logo,
+          },
+        }}
+        utilities={[
+          {
+            type: 'menu-dropdown',
+            text: \`\${user?.profile?.['cognito:username']}\`,
+            iconName: 'user-profile-active',
+            onItemClick: (e) => {
+              if (e.detail.id === 'signout') {
+                removeUser();
+                signoutRedirect({
+                  post_logout_redirect_uri: window.location.origin,
+                  extraQueryParams: {
+                    redirect_uri: window.location.origin,
+                    response_type: 'code',
+                  },
+                });
+                clearStaleState();
+              }
+            },
+            items: [{ id: 'signout', text: 'Sign out' }],
+          },
+        ]}
+      />
+      <CloudscapeAppLayout
+        ref={appLayout}
+        breadcrumbs={
+          <BreadcrumbGroup onFollow={onNavigate} items={activeBreadcrumbs} />
+        }
+        toolsHide
+        navigation={
+          <SideNavigation
+            header={{ text: Config.applicationName, href: '/' }}
+            activeHref={pathname}
+            onFollow={onNavigate}
+            items={NavItems}
+          />
+        }
+        content={<Outlet />}
+        {...appLayoutProps}
+      />
+    </AppLayoutContext.Provider>
+  );
+};
+
+export default AppLayout;
+"
+`;
+
 exports[`cognito-auth generator > should update main.tsx when RuntimeConfigProvider exists > main-tsx-with-runtime-config 1`] = `
 "import CognitoAuth from './components/CognitoAuth';
 import RuntimeConfigProvider from './components/RuntimeConfig';
 import { RuntimeConfigProvider } from './components/RuntimeConfig';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
+
 export function App() {
   return (
     <RuntimeConfigProvider>

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.spec.ts
@@ -204,4 +204,215 @@ describe('cognito-auth generator', () => {
       async () => await cognitoAuthGenerator(tree, options),
     ).rejects.toThrowErrorMatchingSnapshot();
   });
+
+  it('should update AppLayout', async () => {
+    // Setup main.tsx with RuntimeConfigProvider
+    tree.write(
+      'packages/test-project/src/main.tsx',
+      `
+      import { RuntimeConfigProvider } from './components/RuntimeConfig';
+      import { RouterProvider, createRouter } from '@tanstack/react-router';
+
+      export function App() {
+        return (
+          <RuntimeConfigProvider>
+            <RouterProvider router={router} />
+          </RuntimeConfigProvider>
+        );
+      }
+    `,
+    );
+
+    // Setup AppLayout.tsx with a basic component
+    tree.write(
+      'packages/test-project/src/components/AppLayout/index.tsx',
+      `
+      import * as React from 'react';
+import { createContext, useCallback, useEffect, useState } from 'react';
+import { NavItems } from './navitems';
+import Config from '../../config';
+
+import {
+  BreadcrumbGroup,
+  BreadcrumbGroupProps,
+  SideNavigation,
+  TopNavigation,
+} from '@cloudscape-design/components';
+
+import CloudscapeAppLayout, {
+  AppLayoutProps,
+} from '@cloudscape-design/components/app-layout';
+
+import { matchByPath, useLocation, useNavigate } from '@tanstack/react-router';
+import { Outlet } from '@tanstack/react-router';
+
+const getBreadcrumbs = (
+  pathName: string,
+  search: string,
+  defaultBreadcrumb: string,
+  availableRoutes?: string[],
+) => {
+  const segments = [
+    defaultBreadcrumb,
+    ...pathName.split('/').filter((segment) => segment !== ''),
+  ];
+
+  return segments.map((segment, i) => {
+    const href =
+      i === 0
+        ? '/'
+        : \`/\${segments
+            .slice(1, i + 1)
+            .join('/')
+            .replace('//', '/')}\`;
+
+    const matched =
+      !availableRoutes || availableRoutes.find((r) => matchByPath(r, href, {}));
+
+    return {
+      href: matched ? \`\${href}\${search}\` : '#',
+      text: segment,
+    };
+  });
+};
+
+export interface AppLayoutContext {
+  appLayoutProps: AppLayoutProps;
+  setAppLayoutProps: (props: AppLayoutProps) => void;
+  displayHelpPanel: (helpContent: React.ReactNode) => void;
+}
+
+/**
+ * Context for updating/retrieving the AppLayout.
+ */
+export const AppLayoutContext = createContext({
+  appLayoutProps: {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setAppLayoutProps: (_: AppLayoutProps) => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  displayHelpPanel: (_: React.ReactNode) => {},
+});
+
+/**
+ * Defines the App layout and contains logic for routing.
+ */
+const AppLayout: React.FC = () => {
+  const navigate = useNavigate();
+  const appLayout = React.useRef<AppLayoutProps.Ref>(null);
+  const [activeBreadcrumbs, setActiveBreadcrumbs] = useState<
+    BreadcrumbGroupProps.Item[]
+  >([{ text: '/', href: '/' }]);
+  const [appLayoutProps, setAppLayoutProps] = useState<AppLayoutProps>({});
+  const { pathname, search } = useLocation();
+
+  const setAppLayoutPropsSafe = useCallback(
+    (props: AppLayoutProps) => {
+      JSON.stringify(appLayoutProps) !== JSON.stringify(props) &&
+        setAppLayoutProps(props);
+    },
+    [appLayoutProps],
+  );
+
+  useEffect(() => {
+    const breadcrumbs = getBreadcrumbs(
+      pathname,
+      Object.entries(search).reduce((p, [k, v]) => p + \`\${k}=\${v}\`, ''),
+      '/',
+    );
+    setActiveBreadcrumbs(breadcrumbs);
+  }, [pathname, search]);
+
+  const onNavigate = useCallback(
+    (e: CustomEvent<{ href: string; external?: boolean }>) => {
+      if (!e.detail.external) {
+        e.preventDefault();
+        setAppLayoutPropsSafe({
+          contentType: undefined,
+        });
+        navigate({ to: e.detail.href });
+      }
+    },
+    [navigate, setAppLayoutPropsSafe],
+  );
+
+  return (
+    <AppLayoutContext.Provider
+      value={{
+        appLayoutProps,
+        setAppLayoutProps: setAppLayoutPropsSafe,
+        displayHelpPanel: (helpContent: React.ReactNode) => {
+          setAppLayoutPropsSafe({ tools: helpContent, toolsHide: false });
+          appLayout.current?.openTools();
+        },
+      }}
+    >
+      <TopNavigation
+        identity={{
+          href: '/',
+          title: Config.applicationName,
+          logo: {
+            src: Config.logo,
+          },
+        }}
+      />
+      <CloudscapeAppLayout
+        ref={appLayout}
+        breadcrumbs={
+          <BreadcrumbGroup onFollow={onNavigate} items={activeBreadcrumbs} />
+        }
+        toolsHide
+        navigation={
+          <SideNavigation
+            header={{ text: Config.applicationName, href: '/' }}
+            activeHref={pathname}
+            onFollow={onNavigate}
+            items={NavItems}
+          />
+        }
+        content={<Outlet />}
+        {...appLayoutProps}
+      />
+    </AppLayoutContext.Provider>
+  );
+};
+
+export default AppLayout;
+
+    `,
+    );
+
+    await cognitoAuthGenerator(tree, options);
+
+    const appLayoutContent = tree
+      .read('packages/test-project/src/components/AppLayout/index.tsx')
+      .toString();
+
+    // Verify useAuth import is added
+    expect(appLayoutContent).toContain(
+      "import { useAuth } from 'react-oidc-context'",
+    );
+
+    // Verify useAuth hook is used in the component
+    expect(appLayoutContent).toContain(
+      'const { user, removeUser, signoutRedirect, clearStaleState } = useAuth()',
+    );
+
+    // Verify TopNavigation has utilities attribute
+    expect(appLayoutContent).toContain('utilities={[');
+    expect(appLayoutContent).toContain("type: 'menu-dropdown'");
+    expect(appLayoutContent).toContain(
+      "text: `${user?.profile?.['cognito:username']}`",
+    );
+    expect(appLayoutContent).toContain("iconName: 'user-profile-active'");
+
+    // Verify sign out functionality
+    expect(appLayoutContent).toContain("id: 'signout'");
+    expect(appLayoutContent).toContain("text: 'Sign out'");
+    expect(appLayoutContent).toContain('removeUser()');
+    expect(appLayoutContent).toContain('signoutRedirect(');
+    expect(appLayoutContent).toContain('clearStaleState()');
+
+    // Create snapshot of the modified AppLayout.tsx
+    expect(appLayoutContent).toMatchSnapshot('app-layout-with-auth');
+  });
 });

--- a/packages/nx-plugin/src/cloudscape-website/runtime-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/runtime-config/__snapshots__/generator.spec.ts.snap
@@ -101,6 +101,7 @@ export class RuntimeConfig extends Construct {
 exports[`runtime-config generator > should modify main.tsx correctly > modified-main.tsx 1`] = `
 "import RuntimeConfigProvider from './components/RuntimeConfig';
 import { RouterProvider } from '@tanstack/react-router';
+
 export function App() {
   return (
     <RuntimeConfigProvider>

--- a/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`trpc react generator > should generate trpc react files > TrpcClients-T
 "import TrpcApis from './TrpcApis';
 import { useRuntimeConfig } from '../../hooks/useRuntimeConfig';
 import { FC, PropsWithChildren } from 'react';
+
 const TrpcClientProviders: FC<PropsWithChildren> = ({ children }) => {
   const runtimeConfig = useRuntimeConfig();
   return (
@@ -24,6 +25,7 @@ const TrpcClientProviders: FC<PropsWithChildren> = ({ children }) => {
     </TrpcApis.TestApi.Provider>
   );
 };
+
 export default TrpcClientProviders;
 "
 `;
@@ -116,6 +118,7 @@ import QueryClientProvider from './components/QueryClientProvider';
 import RuntimeConfigProvider from './components/RuntimeConfig';
 import { App } from './app';
 import { RouterProvider } from '@tanstack/react-router';
+
 export function Main() {
   return (
     <RuntimeConfigProvider>

--- a/packages/nx-plugin/src/ts/lib/vitest.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.ts
@@ -3,98 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readNxJson, Tree, updateNxJson } from '@nx/devkit';
-import { tsquery } from '@phenomnomnominal/tsquery';
 import { join } from 'path';
-import ts from 'typescript';
+import ts, { factory, ObjectLiteralExpression } from 'typescript';
 import { ConfigureProjectOptions } from './types';
-const passWithNoTests = (sourceFile: ts.SourceFile): ts.SourceFile => {
-  const transformer =
-    <T extends ts.Node>(context: ts.TransformationContext) =>
-    (rootNode: T) => {
-      function visit(node: ts.Node): ts.Node {
-        if (
-          ts.isCallExpression(node) &&
-          ts.isIdentifier(node.expression) &&
-          node.expression.text === 'defineConfig' &&
-          node.arguments.length === 1
-        ) {
-          const configObject = node.arguments[0];
-          if (ts.isObjectLiteralExpression(configObject)) {
-            const testProperty = configObject.properties.find(
-              (p) =>
-                ts.isPropertyAssignment(p) &&
-                ts.isIdentifier(p.name) &&
-                p.name.text === 'test'
-            );
-            if (testProperty && ts.isPropertyAssignment(testProperty)) {
-              const testValue = testProperty.initializer;
-              if (ts.isObjectLiteralExpression(testValue)) {
-                // Check if passWithNoTests already exists
-                const hasPassWithNoTests = testValue.properties.some(
-                  (p) =>
-                    ts.isPropertyAssignment(p) &&
-                    ts.isIdentifier(p.name) &&
-                    p.name.text === 'passWithNoTests'
-                );
-                if (!hasPassWithNoTests) {
-                  // Add passWithNoTests: true to the test object
-                  const newTestValue =
-                    context.factory.updateObjectLiteralExpression(testValue, [
-                      ...testValue.properties,
-                      context.factory.createPropertyAssignment(
-                        'passWithNoTests',
-                        context.factory.createTrue()
-                      ),
-                    ]);
-                  // Update the test property with the new value
-                  const newTestProperty =
-                    context.factory.updatePropertyAssignment(
-                      testProperty,
-                      testProperty.name,
-                      newTestValue
-                    );
-                  // Update the config object with the new test property
-                  return context.factory.updateCallExpression(
-                    node,
-                    node.expression,
-                    node.typeArguments,
-                    [
-                      context.factory.updateObjectLiteralExpression(
-                        configObject,
-                        configObject.properties.map((p) =>
-                          p === testProperty ? newTestProperty : p
-                        )
-                      ),
-                    ]
-                  );
-                }
-              }
-            }
-          }
-        }
-        return ts.visitEachChild(node, visit, context);
-      }
-      return ts.visitNode(rootNode, visit);
-    };
-  const result = ts.transform(sourceFile, [transformer]);
-  return result.transformed[0] as ts.SourceFile;
-};
+import { replaceIfExists } from '../../utils/ast';
+
 export const configureVitest = (
   tree: Tree,
-  options: ConfigureProjectOptions
+  options: ConfigureProjectOptions,
 ) => {
   const configPath = join(options.dir, 'vite.config.ts');
+
   if (tree.exists(configPath)) {
-    const originalSourceFile = tsquery.ast(tree.read(configPath, 'utf-8'));
-    let sourceFile = originalSourceFile;
-    sourceFile = passWithNoTests(sourceFile);
-    const printer = ts.createPrinter({
-      removeComments: false,
-      newLine: ts.NewLineKind.LineFeed,
-    });
-    tree.write(
+    replaceIfExists(
+      tree,
       configPath,
-      printer.printNode(ts.EmitHint.Unspecified, sourceFile, originalSourceFile)
+      'CallExpression:has(Identifier[name="defineConfig"]) PropertyAssignment:has(Identifier[name="test"]) ObjectLiteralExpression',
+      (node: ObjectLiteralExpression) => {
+        // Check if passWithNoTests already exists
+        const hasPassWithNoTests = node.properties.some(
+          (p) =>
+            ts.isPropertyAssignment(p) &&
+            ts.isIdentifier(p.name) &&
+            p.name.text === 'passWithNoTests',
+        );
+        if (!hasPassWithNoTests) {
+          return factory.createObjectLiteralExpression([
+            ...node.properties,
+            factory.createPropertyAssignment(
+              'passWithNoTests',
+              factory.createTrue(),
+            ),
+          ]);
+        }
+        return node;
+      },
     );
 
     const nxJson = readNxJson(tree);

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Tree } from '@nx/devkit';
-import { ast, NodeTransformer, tsquery } from '@phenomnomnominal/tsquery';
-import {
+import { ast, tsquery } from '@phenomnomnominal/tsquery';
+import ts, {
   factory,
   ImportClause,
   ImportSpecifier,
@@ -13,151 +13,173 @@ import {
   JsxOpeningElement,
   Node,
   Expression,
-  SourceFile,
 } from 'typescript';
+
 const assertFilePath = (tree: Tree, filePath: string) => {
   if (!tree.exists(filePath)) {
     throw new Error(`No file located at ${filePath}`);
   }
 };
-export const destructuredImport = (
+
+const updateFile = (
+  tree: Tree,
+  filePath: string,
+  doUpdate: (prev: string) => string,
+) => {
+  assertFilePath(tree, filePath);
+  const contents = tree.read(filePath)?.toString() ?? '';
+  const updatedContents = doUpdate(contents);
+  if (updatedContents !== contents) {
+    tree.write(filePath, updatedContents);
+  }
+};
+
+const createOrUpdateFile = (
+  tree: Tree,
+  filePath: string,
+  doUpdate: (prev?: string) => string,
+) => {
+  const contents = tree.read(filePath)?.toString();
+  const updatedContents = doUpdate(contents);
+  if (updatedContents !== contents) {
+    tree.write(filePath, updatedContents);
+  }
+};
+
+export const addDestructuredImport = (
   tree: Tree,
   filePath: string,
   variableNames: string[],
   from: string,
-): string => {
-  assertFilePath(tree, filePath);
-  const contents = tree.read(filePath).toString();
-  const sourceAst = ast(contents);
-  // Check if any of the variables are already imported from the same module
-  const existingImports: ImportSpecifier[] = tsquery.query(
-    sourceAst,
-    `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause ImportSpecifier`,
-  );
-  const existingVariables = new Set(
-    existingImports.map((node) => {
-      const importSpecifier = node as ImportSpecifier;
-      return importSpecifier.name.escapedText.toString();
-    }),
-  );
-  // Filter out variables that are already imported
-  const newVariables = variableNames.filter(
-    (name) =>
-      !existingVariables.has(
-        name.includes(' as ') ? name.split(' as ')[1] : name,
-      ),
-  );
-  if (newVariables.length === 0) {
-    return contents;
-  }
-  const destructuredImport = factory.createImportDeclaration(
-    undefined,
-    factory.createImportClause(
-      false,
+) => {
+  updateFile(tree, filePath, (contents) => {
+    const sourceAst = ast(contents);
+
+    // Check if any of the variables are already imported from the same module
+    const existingImports: ImportSpecifier[] = tsquery.query(
+      sourceAst,
+      `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause ImportSpecifier`,
+    );
+
+    const existingVariables = new Set(
+      existingImports.map((node) => {
+        const importSpecifier = node as ImportSpecifier;
+        return importSpecifier.name.escapedText.toString();
+      }),
+    );
+
+    // Filter out variables that are already imported
+    const newVariables = variableNames.filter(
+      (name) =>
+        !existingVariables.has(
+          name.includes(' as ') ? name.split(' as ')[1] : name,
+        ),
+    );
+
+    if (newVariables.length === 0) {
+      return contents;
+    }
+
+    const destructuredImport = factory.createImportDeclaration(
       undefined,
-      factory.createNamedImports([
-        ...existingImports,
-        ...newVariables.map((variableName) => {
-          const [name, alias] = variableName.split(' as ');
-          return factory.createImportSpecifier(
-            false,
-            alias ? factory.createIdentifier(name) : undefined,
-            factory.createIdentifier(alias || name),
-          );
-        }),
-      ]),
-    ) as ImportClause,
-    factory.createStringLiteral(from, true),
-  );
-  const updatedContents = tsquery
-    .map(ast(contents), 'SourceFile', (node: SourceFile) => {
-      return {
-        ...node,
-        statements: [destructuredImport, ...node.statements],
-      };
-    })
-    .getFullText();
-  if (contents !== updatedContents) {
-    tree.write(filePath, updatedContents);
-  }
-  return updatedContents;
+      factory.createImportClause(
+        false,
+        undefined,
+        factory.createNamedImports([
+          ...existingImports,
+          ...newVariables.map((variableName) => {
+            const [name, alias] = variableName.split(' as ');
+            return factory.createImportSpecifier(
+              false,
+              alias ? factory.createIdentifier(name) : undefined,
+              factory.createIdentifier(alias || name),
+            );
+          }),
+        ]),
+      ),
+      factory.createStringLiteral(from, true),
+    );
+
+    return prependStatementsToCodeText(contents, [destructuredImport]);
+  });
 };
-export const singleImport = (
+
+/**
+ * Adds an `import <variableName> from '<from>'; statement to the beginning of the file,
+ * if it doesn't already exist
+ */
+export const addSingleImport = (
   tree: Tree,
   filePath: string,
   variableName: string,
   from: string,
-): string => {
-  assertFilePath(tree, filePath);
-  const contents = tree.read(filePath).toString();
-  const sourceAst = ast(contents);
-  // Check if the import already exists
-  const existingImports = tsquery.query(
-    sourceAst,
-    `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause > Identifier[text="${variableName}"]`,
-  );
-  if (existingImports.length > 0) {
-    return contents;
-  }
-  const importDeclaration = factory.createImportDeclaration(
-    undefined,
-    factory.createImportClause(
-      false,
-      factory.createIdentifier(variableName),
+) => {
+  updateFile(tree, filePath, (contents) => {
+    const sourceAst = ast(contents);
+
+    // Check if the import already exists
+    const existingImports = tsquery.query(
+      sourceAst,
+      `ImportDeclaration[moduleSpecifier.text="${from}"] ImportClause > Identifier[text="${variableName}"]`,
+    );
+
+    if (existingImports.length > 0) {
+      return contents;
+    }
+
+    const importDeclaration = factory.createImportDeclaration(
       undefined,
-    ) as ImportClause,
-    factory.createStringLiteral(from),
-  );
-  const updatedContents = tsquery
-    .map(ast(contents), 'SourceFile', (node: SourceFile) => {
-      return {
-        ...node,
-        statements: [importDeclaration, ...node.statements],
-      };
-    })
-    .getFullText();
-  if (contents !== updatedContents) {
-    tree.write(filePath, updatedContents);
-  }
-  return updatedContents;
-};
-export const addStarExport = (tree: Tree, filePath: string, from: string) => {
-  const indexContents = tree.exists(filePath)
-    ? tree.read(filePath).toString()
-    : '';
-  const hasExport =
-    tsquery.query(
-      ast(indexContents),
-      `ExportDeclaration StringLiteral[text="${from}"]`,
-    ).length > 0;
-  if (!hasExport) {
-    const exportDeclaration = factory.createExportDeclaration(
-      undefined,
-      undefined,
-      undefined,
+      factory.createImportClause(
+        false,
+        factory.createIdentifier(variableName),
+        undefined,
+      ) as ImportClause,
       factory.createStringLiteral(from),
     );
-    const updatedIndexContents = tsquery
-      .map(ast(indexContents), 'SourceFile', (node: SourceFile) => ({
-        ...node,
-        statements: [exportDeclaration, ...node.statements],
-      }))
-      .getFullText();
-    if (indexContents !== updatedIndexContents) {
-      tree.write(filePath, updatedIndexContents);
-    }
-  }
+
+    return prependStatementsToCodeText(contents, [importDeclaration]);
+  });
 };
 
+/**
+ * Adds an `export * from '<from>'; statement to the given TypeScript file.
+ * Note that this will create the file if it does not exist in the tree.
+ */
+export const addStarExport = (tree: Tree, filePath: string, from: string) => {
+  createOrUpdateFile(tree, filePath, (contents) => {
+    const hasExport =
+      tsquery.query(
+        ast(contents ?? ''),
+        `ExportDeclaration StringLiteral[text="${from}"]`,
+      ).length > 0;
+
+    if (!hasExport) {
+      const exportDeclaration = factory.createExportDeclaration(
+        undefined,
+        undefined,
+        undefined,
+        factory.createStringLiteral(from),
+      );
+
+      return prependStatementsToCodeText(contents ?? '', [exportDeclaration]);
+    }
+    return contents;
+  });
+};
+
+/**
+ * Replace nodes matching a given selector by applying the transformer on matches
+ */
 export const replace = (
   tree: Tree,
   filePath: string,
   selector: string,
-  transformer: NodeTransformer,
+  transformer: (node: Node) => Node,
   errorIfNoMatches = true,
 ) => {
   assertFilePath(tree, filePath);
   const source = tree.read(filePath).toString();
+
   if (errorIfNoMatches) {
     const queryNodes = tsquery.query(ast(source), selector);
     if (queryNodes.length === 0) {
@@ -166,13 +188,134 @@ export const replace = (
       );
     }
   }
-  const updatedSource = tsquery
-    .map(ast(source), selector, transformer)
-    .getFullText();
+
+  const updatedSource = applyTransform(source, selector, transformer);
+
   if (source !== updatedSource) {
     tree.write(filePath, updatedSource);
   }
 };
+
+/**
+ * Replace nodes matching a given selector if present, otherwise leaves the code unchanged
+ */
+export const replaceIfExists = (
+  tree: Tree,
+  filePath: string,
+  selector: string,
+  transformer: (node: Node) => Node,
+) => replace(tree, filePath, selector, transformer, false);
+
+/**
+ * Apply a transform to the given code using the transformer.
+ * Equivalent to tsquery.map, except that this preserves existing code formatting where possible
+ */
+const applyTransform = (
+  code: string,
+  selector: string,
+  transformer: (node: Node) => Node,
+): string => {
+  const sourceFile = ast(code);
+
+  const transforms: { start: number; end: number; newText: string }[] = [];
+
+  const printer = ts.createPrinter();
+
+  tsquery.map(sourceFile, selector, (node) => {
+    const newNode = transformer(node);
+
+    if (newNode !== node && newNode) {
+      transforms.push({
+        start: node.getStart(sourceFile, true),
+        end: node.getEnd(),
+        newText: printer.printNode(
+          ts.EmitHint.Unspecified,
+          newNode,
+          sourceFile,
+        ),
+      });
+    }
+
+    return newNode;
+  });
+
+  let newCode = code;
+  let offset = 0;
+
+  transforms.forEach((transform) => {
+    newCode =
+      newCode.substring(0, transform.start + offset) +
+      transform.newText +
+      newCode.substring(transform.end + offset);
+    offset = newCode.length - code.length;
+  });
+
+  return newCode;
+};
+
+const insertStatements = (
+  isPrepend: boolean,
+  code: string,
+  statements: ts.Statement[],
+): string => {
+  const sourceFile = ast(code);
+  const printer = ts.createPrinter();
+  const newText = statements
+    .map((s) => printer.printNode(ts.EmitHint.Unspecified, s, sourceFile))
+    .join('\n');
+  if (isPrepend) {
+    return newText + '\n' + code;
+  }
+  return code + '\n' + newText;
+};
+
+const appendStatementsToCodeText = (
+  code: string,
+  statements: ts.Statement[],
+): string => {
+  return insertStatements(false, code, statements);
+};
+
+const prependStatementsToCodeText = (
+  code: string,
+  statements: ts.Statement[],
+): string => {
+  return insertStatements(true, code, statements);
+};
+
+export const prependStatements = (
+  tree: Tree,
+  filePath: string,
+  statements: ts.Statement[],
+) => {
+  updateFile(tree, filePath, (contents) => {
+    return prependStatementsToCodeText(contents, statements);
+  });
+};
+
+export const appendStatements = (
+  tree: Tree,
+  filePath: string,
+  statements: ts.Statement[],
+) => {
+  updateFile(tree, filePath, (contents) => {
+    return appendStatementsToCodeText(contents, statements);
+  });
+};
+
+/**
+ * Query a typescript file in the tree using tsquery
+ */
+export const query = (
+  tree: Tree,
+  filePath: string,
+  selector: string,
+): Node[] => {
+  assertFilePath(tree, filePath);
+  const source = tree.read(filePath).toString();
+  return tsquery.query(ast(source), selector);
+};
+
 export const createJsxElementFromIdentifier = (
   identifier: string,
   children: readonly JsxChild[],
@@ -186,6 +329,7 @@ export const createJsxElementFromIdentifier = (
     children,
     factory.createJsxClosingElement(factory.createIdentifier(identifier)),
   );
+
 export const createJsxElement = (
   openingElement: JsxOpeningElement,
   children: readonly JsxChild[],

--- a/packages/nx-plugin/src/utils/config/__snapshots__/utils.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/config/__snapshots__/utils.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`config utils > should update user config 1`] = `
 "import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
 export default {
   license: {
     header: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,10 +50,10 @@ importers:
         version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))
       '@nx/playwright':
         specifier: 20.4.0
-        version: 20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)
+        version: 20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)
       '@nx/react':
         specifier: 20.4.0
-        version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
+        version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
       '@nx/vite':
         specifier: 20.4.0
         version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)
@@ -257,7 +257,7 @@ importers:
         version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/react':
         specifier: ^20.4.0
-        version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
+        version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
       '@nx/vite':
         specifier: ^20.4.0
         version: 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)
@@ -11330,13 +11330,13 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.4.0':
     optional: true
 
-  '@nx/playwright@20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)':
+  '@nx/playwright@20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)':
     dependencies:
       '@nx/devkit': 20.4.0(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))
       '@nx/eslint': 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite': 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))(vitest@1.6.0)
-      '@nx/webpack': 20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(esbuild@0.24.0)(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/webpack': 20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(esbuild@0.24.0)(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.4)
       minimatch: 9.0.3
       tslib: 2.7.0
@@ -11372,7 +11372,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@nx/react@20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))':
+  '@nx/react@20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))':
     dependencies:
       '@nx/devkit': 20.4.0(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))
       '@nx/eslint': 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))
@@ -11382,7 +11382,7 @@ snapshots:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.4)
       '@svgr/webpack': 8.1.0(typescript@5.5.4)
       express: 4.21.2
-      file-loader: 6.2.0(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
+      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
       http-proxy-middleware: 3.0.3
       minimatch: 9.0.3
       picocolors: 1.1.0
@@ -11413,7 +11413,7 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@nx/react@20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))':
+  '@nx/react@20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))':
     dependencies:
       '@nx/devkit': 20.4.0(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))
       '@nx/eslint': 20.4.0(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(eslint@9.17.0(jiti@2.4.2))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))
@@ -11423,7 +11423,7 @@ snapshots:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.4)
       '@svgr/webpack': 8.1.0(typescript@5.5.4)
       express: 4.21.2
-      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
+      file-loader: 6.2.0(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
       http-proxy-middleware: 3.0.3
       minimatch: 9.0.3
       picocolors: 1.1.0
@@ -11540,7 +11540,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/webpack@20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(esbuild@0.24.0)(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/webpack@20.4.0(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.13))(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@types/node@18.16.9)(esbuild@0.24.0)(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))(typescript@5.5.4)(verdaccio@6.0.3(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@nx/devkit': 20.4.0(nx@20.4.0(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.7.26(@swc/helpers@0.5.13)))
@@ -11578,7 +11578,7 @@ snapshots:
       webpack: 5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)
       webpack-dev-server: 5.2.0(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
       webpack-node-externals: 3.0.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -15556,7 +15556,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
+  html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15565,7 +15565,7 @@ snapshots:
       tapable: 2.2.1
     optionalDependencies:
       '@rspack/core': 1.1.8(@swc/helpers@0.5.13)
-      webpack: 5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)
+      webpack: 5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)
     optional: true
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
@@ -19784,12 +19784,12 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0)
     optionalDependencies:
-      html-webpack-plugin: 5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
+      html-webpack-plugin: 5.6.0(@rspack/core@1.1.8(@swc/helpers@0.5.13))(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0))
 
   webpack@5.88.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.24.0):
     dependencies:


### PR DESCRIPTION
### Reason for this change

When updating TypeScript files with AST manipulation, we would previously strip files of their new lines since these aren't tracked in the AST at all.

This means that we'd mess up user's formatting, and squish everything together, eg:

```ts
import { foo, bar, baz } from 'bat';

export const doThings = (x: number) => {
  foo();
 
  bar();

  baz();
};

export const somethingElse = () => {};
```

would become:

```ts
import { foo, bar, baz } from 'bat';
export const doThings = (x: number) => {
  foo();
  bar();
  baz();
};
export const somethingElse = () => {};
```

### Description of changes

This change preserves new lines by rendering any updated nodes in isolation and splicing them back in to the original TypeScript file.

Note that we treat adding statements to a source file as a separate case to also preserve new lines, since splicing the source file node would replace the entire file.

### Description of how you validated changes

Unit tests and integration tests

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*