### PR TITLE
fix: ensure targets are cached correctly

### DIFF
--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -145,6 +145,9 @@ exports[`infra generator > should configure project.json with correct targets > 
         "compile",
       ],
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+      ],
       "options": {
         "command": "cdk synth",
         "cwd": "packages/test",
@@ -474,6 +477,7 @@ exports[`infra generator > should generate files with correct content > project-
     "synth": {
       "cache": true,
       "executor": "nx:run-commands",
+      "inputs": ["default"],
       "outputs": ["{workspaceRoot}/dist/packages/test/cdk.out"],
       "dependsOn": ["^build", "compile"],
       "options": {
@@ -779,6 +783,9 @@ exports[`infra generator > should handle custom project names correctly > custom
         "compile",
       ],
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+      ],
       "options": {
         "command": "cdk synth",
         "cwd": "packages/custom-infra",

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -89,6 +89,7 @@ export async function infraGenerator(
       config.targets.synth = {
         cache: true,
         executor: 'nx:run-commands',
+        inputs: ['default'],
         outputs: [`{workspaceRoot}${synthDirFromRoot}`],
         dependsOn: ['^build', 'compile'], // compile clobbers dist directory, so ensure synth runs afterwards
         options: {

--- a/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
@@ -1,5 +1,88 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ts lib generator > should configure named inputs in nx.json 1`] = `
+"{
+  "affected": {
+    "defaultBase": "main"
+  },
+  "targetDefaults": {
+    "build": {
+      "cache": true,
+      "inputs": ["default"]
+    },
+    "lint": {
+      "cache": true,
+      "configurations": {
+        "fix": {
+          "fix": true
+        }
+      },
+      "inputs": [
+        "default",
+        "{workspaceRoot}/eslint.config.mjs",
+        "{projectRoot}/eslint.config.mjs"
+      ]
+    },
+    "@nx/eslint:lint": {
+      "cache": true,
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json",
+        "{workspaceRoot}/.eslintignore",
+        "{workspaceRoot}/eslint.config.mjs"
+      ]
+    },
+    "@nx/vite:test": {
+      "cache": true,
+      "inputs": ["default", "^default"],
+      "configurations": {
+        "update-snapshot": {
+          "args": "--update"
+        }
+      }
+    },
+    "compile": {
+      "cache": true,
+      "inputs": ["default"]
+    },
+    "test": {
+      "inputs": ["default"]
+    }
+  },
+  "plugins": [
+    {
+      "plugin": "@nx/js/typescript",
+      "options": {
+        "typecheck": {
+          "targetName": "typecheck"
+        },
+        "build": {
+          "targetName": "compile",
+          "configName": "tsconfig.lib.json",
+          "buildDepsName": "build-deps",
+          "watchDepsName": "watch-deps"
+        }
+      }
+    },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    }
+  ],
+  "namedInputs": {
+    "default": [
+      {
+        "dependentTasksOutputFiles": "**/*",
+        "transitive": true
+      }
+    ]
+  }
+}
+"
+`;
+
 exports[`ts lib generator > should generate library with custom directory > custom-dir-index.ts 1`] = `
 "export function hello() {
   return 'Hello!';

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -119,11 +119,52 @@ export const tsLibGenerator = async (
   updateProjectConfiguration(tree, fullyQualifiedName, projectConfiguration);
 
   updateJson(tree, 'nx.json', (nxJson: NxJsonConfiguration) => {
+    nxJson.namedInputs = {
+      ...nxJson.namedInputs,
+      default: [
+        ...(nxJson.namedInputs?.default ?? []).filter(
+          (input) =>
+            typeof input !== 'object' ||
+            !('dependentTasksOutputFiles' in input) ||
+            !(input.dependentTasksOutputFiles === '**/*' && input.transitive),
+        ),
+        {
+          dependentTasksOutputFiles: '**/*',
+          transitive: true,
+        },
+      ],
+    };
+
     nxJson.targetDefaults = {
       ...nxJson.targetDefaults,
       compile: {
         cache: true,
         ...nxJson.targetDefaults?.compile,
+        inputs: [
+          ...(nxJson.targetDefaults?.compile?.inputs ?? []).filter(
+            (i) => i !== 'default',
+          ),
+          'default',
+        ],
+      },
+      build: {
+        cache: true,
+        ...nxJson.targetDefaults?.build,
+        inputs: [
+          ...(nxJson.targetDefaults?.build?.inputs ?? []).filter(
+            (i) => i !== 'default',
+          ),
+          'default',
+        ],
+      },
+      test: {
+        ...nxJson.targetDefaults?.test,
+        inputs: [
+          ...(nxJson.targetDefaults?.test?.inputs ?? []).filter(
+            (i) => i !== 'default',
+          ),
+          'default',
+        ],
       },
     };
 


### PR DESCRIPTION
### Reason for this change

The cache was not being invalidated for some projects when dependencies changed, causing unexpected behaviour.

### Description of changes

We ensure that the compile and build tasks are cached correctly by including their transitive dependency outputs as inputs to invalidate the cache. Additionally ensure that the infra synth task also rebuilds if its transitive dependencies change.

### Description of how you validated changes

Tests

### Issue # (if applicable)

Fixes #61

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*