### PR TITLE
fix(license): do not attempt to add header to git tracked deleted files

### DIFF
--- a/packages/nx-plugin/src/utils/git.spec.ts
+++ b/packages/nx-plugin/src/utils/git.spec.ts
@@ -30,6 +30,7 @@ describe('git utils', () => {
     it('should get all git included files', () => {
       tree.write('.gitignore', `*.txt`);
       tree.write('committed.ts', "const foo = 'bar';");
+      tree.write('committed-but-will-be-deleted.ts', 'const x = 1;');
 
       flushChanges(tree.root, tree.listChanges());
 
@@ -38,6 +39,7 @@ describe('git utils', () => {
 
       tree.write('new-and-not-committed.ts', "const bar = 'baz';");
       tree.write('ignored.txt', 'should not be included');
+      tree.delete('committed-but-will-be-deleted.ts');
 
       flushChanges(tree.root, tree.listChanges());
 
@@ -46,6 +48,7 @@ describe('git utils', () => {
       expect(includedFiles).toContain('committed.ts');
       expect(includedFiles).toContain('new-and-not-committed.ts');
       expect(includedFiles).not.toContain('ignored.txt');
+      expect(includedFiles).not.toContain('committed-but-will-be-deleted.ts');
     });
   });
 

--- a/packages/nx-plugin/src/utils/git.ts
+++ b/packages/nx-plugin/src/utils/git.ts
@@ -25,7 +25,7 @@ export const getGitIncludedFiles = (tree: Tree): string[] => {
     })
       .split('\n')
       .filter((x) => x),
-  ];
+  ].filter((f) => tree.exists(f));
 };
 
 /**


### PR DESCRIPTION
### Reason for this change

Fix error observed when running license sync on workshop project:

```bash
 NX   The workspace is probably out of sync because a sync generator failed to run

[@aws/nx-plugin:license#sync]: Cannot read properties of null (reading 'split')
  TypeError: Cannot read properties of null (reading 'split')
    at parseFile (/Users/xxx/workshop-dryrun/dungeon-adventure/node_modules/.pnpm/@aws+nx-plugin@0.14.0_@babel+traverse@7.26.9_@swc-node+register@1.9.2_@swc+core@1.5.29__6b3b897a87b18ae33a9b163fc5799905/node_modules/@aws/nx-plugin/src/license/sync/generator.js:204:27)
    at addHeader (/Users/xxx/workshop-dryrun/dungeon-adventure/node_modules/.pnpm/@aws+nx-plugin@0.14.0_@babel+traverse@7.26.9_@swc-node+register@1.9.2_@swc+core@1.5.29__6b3b897a87b18ae33a9b163fc5799905/node_modules/@aws/nx-plugin/src/license/sync/generator.js:301:32)
    at /Users/xxx/workshop-dryrun/dungeon-adventure/node_modules/.pnpm/@aws+nx-plugin@0.14.0_@babel+traverse@7.26.9_@swc-node+register@1.9.2_@swc+core@1.5.29__6b3b897a87b18ae33a9b163fc5799905/node_modules/@aws/nx-plugin/src/license/sync/generator.js:39:36
    at Array.forEach (<anonymous>)
    at /Users/xxx/workshop-dryrun/dungeon-adventure/node_modules/.pnpm/@aws+nx-plugin@0.14.0_@babel+traverse@7.26.9_@swc-node+register@1.9.2_@swc+core@1.5.29__6b3b897a87b18ae33a9b163fc5799905/node_modules/@aws/nx-plugin/src/license/sync/generator.js:35:23
    at Generator.next (<anonymous>)
    at fulfilled (/Users/xxx/workshop-dryrun/dungeon-adventure/node_modules/.pnpm/tslib@2.8.1/node_modules/tslib/tslib.js:167:62)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Please check the error above and address the issue.
If needed, you can disable the failing sync generator by setting `sync.disabledTaskSyncGenerators: ["@aws/nx-plugin:license#sync"]` in your `nx.json`.
```

### Description of changes

The list of files we were reading from `git ls-files` included files which were tracked but have been deleted, so the license sync generator was attempting to add a header to any uncommitted deleted files!

Update to ensure only existing files are included in the header sync.

### Description of how you validated changes

Linked package into tutorial codebase where I had an uncommitted delete and ran `pnpm nx sync`.

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*