### PR TITLE
fix(api-connection): fix generated client compilation issues for optional fields

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.spec.ts.snap
@@ -1509,6 +1509,279 @@ export class TestApi {
 "
 `;
 
+exports[`openApiTsClientGenerator > should generate valid typescript for openapi v3.1 specifications with null types 1`] = `
+"export type PostTest200Response = {};
+export type PostTestRequestContent = {
+  requiredNull: null;
+  optionalNull?: null;
+  requiredCompositeNull: PostTestRequestContentRequiredCompositeNull;
+  optionalCompositeNull?: PostTestRequestContentOptionalCompositeNull;
+};
+export type PostTestRequestContentOptionalCompositeNull = string | null;
+export type PostTestRequestContentRequiredCompositeNull = string | null;
+
+export type PostTestRequest = PostTestRequestContent;
+export type PostTestError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator > should generate valid typescript for openapi v3.1 specifications with null types 2`] = `
+"import type {
+  PostTest200Response,
+  PostTestRequestContent,
+  PostTestRequestContentOptionalCompositeNull,
+  PostTestRequestContentRequiredCompositeNull,
+  PostTestRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static PostTest200Response = {
+    toJson: (model: PostTest200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...model,
+      };
+    },
+    fromJson: (json: any): PostTest200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...json,
+      };
+    },
+  };
+
+  public static PostTestRequestContent = {
+    toJson: (model: PostTestRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.requiredNull === undefined
+          ? {}
+          : {
+              requiredNull: model.requiredNull,
+            }),
+        ...(model.optionalNull === undefined
+          ? {}
+          : {
+              optionalNull: model.optionalNull,
+            }),
+        ...(model.requiredCompositeNull === undefined
+          ? {}
+          : {
+              requiredCompositeNull:
+                $IO.PostTestRequestContentRequiredCompositeNull.toJson(
+                  model.requiredCompositeNull,
+                ),
+            }),
+        ...(model.optionalCompositeNull === undefined
+          ? {}
+          : {
+              optionalCompositeNull:
+                $IO.PostTestRequestContentOptionalCompositeNull.toJson(
+                  model.optionalCompositeNull,
+                ),
+            }),
+      };
+    },
+    fromJson: (json: any): PostTestRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        requiredNull:
+          json['requiredNull'] === null ? null : json['requiredNull'],
+        ...(json['optionalNull'] === undefined
+          ? {}
+          : {
+              optionalNull:
+                json['optionalNull'] === null ? null : json['optionalNull'],
+            }),
+        requiredCompositeNull:
+          $IO.PostTestRequestContentRequiredCompositeNull.fromJson(
+            json['requiredCompositeNull'],
+          ),
+        ...(json['optionalCompositeNull'] === undefined
+          ? {}
+          : {
+              optionalCompositeNull:
+                $IO.PostTestRequestContentOptionalCompositeNull.fromJson(
+                  json['optionalCompositeNull'],
+                ),
+            }),
+      };
+    },
+  };
+
+  public static PostTestRequestContentOptionalCompositeNull = {
+    toJson: (model: PostTestRequestContentOptionalCompositeNull): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (typeof model === 'string') {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): PostTestRequestContentOptionalCompositeNull => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      if (typeof json === 'string') {
+        return json;
+      }
+      return json;
+    },
+  };
+
+  public static PostTestRequestContentRequiredCompositeNull = {
+    toJson: (model: PostTestRequestContentRequiredCompositeNull): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (typeof model === 'string') {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): PostTestRequestContentRequiredCompositeNull => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      if (typeof json === 'string') {
+        return json;
+      }
+      return json;
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postTest = this.postTest.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postTest(input: PostTestRequest): Promise<PostTest200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.PostTestRequestContent.toJson(input))
+        : String($IO.PostTestRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/test', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.PostTest200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
 exports[`openApiTsClientGenerator > should handle composite primitive and array request bodies 1`] = `
 "export type CompositeRequestContent =
   | string

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -32,7 +32,7 @@ import type {
 // eg. an array of arrays of strings doesn't need to be rendered as `value.map(item0 => item0.map(item1 => item1))`
 const canShortCircuitConversion = (property) => {
   if (["array", "dictionary"].includes(property.export)) {
-    return canShortCircuitConversion(property.link);
+    return !property.link || canShortCircuitConversion(property.link);
   }
   return property.isPrimitive && !["date", "date-time"].includes(property.format);
 };
@@ -164,7 +164,7 @@ export class $IO {
         return model;
       }
       <%_ if (isComposite) { _%>
-      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export)).forEach((primitive) => { _%>
+      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && p.type !== 'null').forEach((primitive) => { _%>
       if (typeof model === "<%- primitive.typescriptType %>") {
           return model;
       }
@@ -209,7 +209,7 @@ export class $IO {
         return json;
       }
       <%_ if (isComposite) { _%>
-      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export)).forEach((primitive) => { _%>
+      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && p.type !== 'null').forEach((primitive) => { _%>
       if (typeof json === "<%- primitive.typescriptType %>") {
           return json;
       }

--- a/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
@@ -27,12 +27,12 @@ _%>
 <%_ } else if (isComposite) { _%>
 <%- docString(model, '') %>export type <%- model.name %> =<% model.properties.forEach((composedType, i) => { %><% if (i > 0) { %><% if (model.export === "all-of") { %> &<% } else { %> |<% } %><% } %> <%- composedType.typescriptType %><% }); %>;
 <%_ } else { _%>
-<%- docString(model, '') %>export type <%= model.name %> = <% if (model.isNullable) { %>null | <% } %>{
+<%- docString(model, '') %>export type <%= model.name %> = <% if (model.isNullable && model.type !== 'null') { %>null | <% } %>{
 <%_ if (model.export === "dictionary" && model.link) { _%>
 <%- docString(model.link, '  ') %>  [key: string]: <%- model.link.typescriptType %>;
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>
-<%- docString(property, '  ') %>  <%= property.isReadOnly ? 'readonly ' : '' %><%= property.typescriptName %><%= property.isRequired ? '' : '?' %>: <%- property.typescriptType %><%= property.isNullable ? ' | null' : '' %>;
+<%- docString(property, '  ') %>  <%= property.isReadOnly ? 'readonly ' : '' %><%= property.typescriptName %><%= property.isRequired ? '' : '?' %>: <%- property.typescriptType %><%= (property.isNullable && property.type !== 'null') ? ' | null' : '' %>;
 <%_ }); _%>
 };
 <%_ } _%>


### PR DESCRIPTION
### Reason for this change

FastAPI generates an OpenAPI specification which uses the OpenAPI v3.1 "null" type when a property is typed as `Optional[xxx]`. Specifically it creates a composite `anyOf` schema for the actual type and `null`, eg:

`Optional[str]` becomes `"anyOf": [{ type: "string" }, { type: "null" }]`

The templates had a bug where we'd test `typeof property === 'null'` to discriminate between such composite types, which is invalid TypeScript.

### Description of changes

Fix the bug by ensuring we don't test `typeof property === 'null'` - we already test `property === null` above so we don't need to replace it with anything.

Additionally ensure we don't generate `null | null` as the type for properties which are just null (we were adding `| null` to the type if a field is nullable, but the type is already `null` so we ended up with `null | null`!)

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Fixes #108

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*