### PR TITLE
fix(open-api): handle object schemas with additional properties and pattern properties

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -1,0 +1,2236 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - complex types > should handle response objects with a mixture of properties and additionalProperties 1`] = `
+"export type GetDynamicPropertiesAny200Response = {
+  id: string;
+  timestamp?: Date;
+  [additionalProperties: string]: unknown;
+};
+export type GetDynamicPropertiesNested200Response = {
+  id: string;
+  version?: string;
+  [
+    additionalProperties: string
+  ]: unknown /* GetDynamicPropertiesNested200ResponseValue */;
+};
+export type GetDynamicPropertiesNested200ResponseValue = {
+  name: string;
+  config?: { [key: string]: number };
+};
+export type GetDynamicPropertiesNumbers200Response = {
+  id: string;
+  name: string;
+  [additionalProperties: string]: unknown /* number */;
+};
+export type GetDynamicPropertiesObjects200Response = {
+  id: string;
+  name: string;
+  lastModifiedTimestamp?: Date;
+  [
+    additionalProperties: string
+  ]: unknown /* GetDynamicPropertiesObjects200ResponseValue */;
+};
+export type GetDynamicPropertiesObjects200ResponseValue = {
+  title: string;
+  value: number;
+  active?: boolean;
+};
+export type GetDynamicPropertyValues200Response = {
+  [key: string]: GetDynamicPropertyValues200ResponseValue;
+};
+export type GetDynamicPropertyValues200ResponseValue = {
+  value: string;
+  metadata?: { [key: string]: unknown };
+};
+export type GetDynamicPropertiesAnyError = never;
+export type GetDynamicPropertiesNestedError = never;
+export type GetDynamicPropertiesNumbersError = never;
+export type GetDynamicPropertiesObjectsError = never;
+export type GetDynamicPropertyValuesError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - complex types > should handle response objects with a mixture of properties and additionalProperties 2`] = `
+"import type {
+  GetDynamicPropertiesAny200Response,
+  GetDynamicPropertiesNested200Response,
+  GetDynamicPropertiesNested200ResponseValue,
+  GetDynamicPropertiesNumbers200Response,
+  GetDynamicPropertiesObjects200Response,
+  GetDynamicPropertiesObjects200ResponseValue,
+  GetDynamicPropertyValues200Response,
+  GetDynamicPropertyValues200ResponseValue,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetDynamicPropertiesAny200Response = {
+    toJson: (model: GetDynamicPropertiesAny200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'timestamp'].includes(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.timestamp === undefined
+          ? {}
+          : {
+              timestamp: model.timestamp.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertiesAny200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'timestamp'].includes(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        id: json['id'],
+        ...(json['timestamp'] === undefined
+          ? {}
+          : {
+              timestamp: new Date(json['timestamp']),
+            }),
+      };
+    },
+  };
+
+  public static GetDynamicPropertiesNested200Response = {
+    toJson: (model: GetDynamicPropertiesNested200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'version'].includes(key),
+            ),
+          ),
+          (additionalProperty) =>
+            $IO.GetDynamicPropertiesNested200ResponseValue.toJson(
+              additionalProperty,
+            ),
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.version === undefined
+          ? {}
+          : {
+              version: model.version,
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertiesNested200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'version'].includes(key),
+            ),
+          ),
+          (additionalProperty) =>
+            $IO.GetDynamicPropertiesNested200ResponseValue.fromJson(
+              additionalProperty,
+            ),
+        ),
+        id: json['id'],
+        ...(json['version'] === undefined
+          ? {}
+          : {
+              version: json['version'],
+            }),
+      };
+    },
+  };
+
+  public static GetDynamicPropertiesNested200ResponseValue = {
+    toJson: (model: GetDynamicPropertiesNested200ResponseValue): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.config === undefined
+          ? {}
+          : {
+              config: model.config,
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertiesNested200ResponseValue => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        name: json['name'],
+        ...(json['config'] === undefined
+          ? {}
+          : {
+              config: json['config'],
+            }),
+      };
+    },
+  };
+
+  public static GetDynamicPropertiesNumbers200Response = {
+    toJson: (model: GetDynamicPropertiesNumbers200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name'].includes(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertiesNumbers200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'name'].includes(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        id: json['id'],
+        name: json['name'],
+      };
+    },
+  };
+
+  public static GetDynamicPropertiesObjects200Response = {
+    toJson: (model: GetDynamicPropertiesObjects200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name', 'lastModifiedTimestamp'].includes(key),
+            ),
+          ),
+          (additionalProperty) =>
+            $IO.GetDynamicPropertiesObjects200ResponseValue.toJson(
+              additionalProperty,
+            ),
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.lastModifiedTimestamp === undefined
+          ? {}
+          : {
+              last_modified_timestamp:
+                model.lastModifiedTimestamp.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertiesObjects200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'name', 'last_modified_timestamp'].includes(key),
+            ),
+          ),
+          (additionalProperty) =>
+            $IO.GetDynamicPropertiesObjects200ResponseValue.fromJson(
+              additionalProperty,
+            ),
+        ),
+        id: json['id'],
+        name: json['name'],
+        ...(json['last_modified_timestamp'] === undefined
+          ? {}
+          : {
+              lastModifiedTimestamp: new Date(json['last_modified_timestamp']),
+            }),
+      };
+    },
+  };
+
+  public static GetDynamicPropertiesObjects200ResponseValue = {
+    toJson: (model: GetDynamicPropertiesObjects200ResponseValue): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.title === undefined
+          ? {}
+          : {
+              title: model.title,
+            }),
+        ...(model.value === undefined
+          ? {}
+          : {
+              value: model.value,
+            }),
+        ...(model.active === undefined
+          ? {}
+          : {
+              active: model.active,
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertiesObjects200ResponseValue => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        title: json['title'],
+        value: json['value'],
+        ...(json['active'] === undefined
+          ? {}
+          : {
+              active: json['active'],
+            }),
+      };
+    },
+  };
+
+  public static GetDynamicPropertyValues200Response = {
+    toJson: (model: GetDynamicPropertyValues200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          model,
+          $IO.GetDynamicPropertyValues200ResponseValue.toJson,
+        ),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertyValues200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          json,
+          $IO.GetDynamicPropertyValues200ResponseValue.fromJson,
+        ),
+      };
+    },
+  };
+
+  public static GetDynamicPropertyValues200ResponseValue = {
+    toJson: (model: GetDynamicPropertyValues200ResponseValue): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.value === undefined
+          ? {}
+          : {
+              value: model.value,
+            }),
+        ...(model.metadata === undefined
+          ? {}
+          : {
+              metadata: $IO.$mapValues(model.metadata, (item0) => item0),
+            }),
+      };
+    },
+    fromJson: (json: any): GetDynamicPropertyValues200ResponseValue => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        value: json['value'],
+        ...(json['metadata'] === undefined
+          ? {}
+          : {
+              metadata: $IO.$mapValues(json['metadata'], (item0) => item0),
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getDynamicPropertiesAny = this.getDynamicPropertiesAny.bind(this);
+    this.getDynamicPropertiesNested =
+      this.getDynamicPropertiesNested.bind(this);
+    this.getDynamicPropertiesNumbers =
+      this.getDynamicPropertiesNumbers.bind(this);
+    this.getDynamicPropertiesObjects =
+      this.getDynamicPropertiesObjects.bind(this);
+    this.getDynamicPropertyValues = this.getDynamicPropertyValues.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getDynamicPropertiesAny(): Promise<GetDynamicPropertiesAny200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/dynamic-properties-any', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetDynamicPropertiesAny200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getDynamicPropertiesNested(): Promise<GetDynamicPropertiesNested200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/dynamic-properties-nested', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetDynamicPropertiesNested200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getDynamicPropertiesNumbers(): Promise<GetDynamicPropertiesNumbers200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/dynamic-properties-numbers', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetDynamicPropertiesNumbers200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getDynamicPropertiesObjects(): Promise<GetDynamicPropertiesObjects200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/dynamic-properties-objects', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetDynamicPropertiesObjects200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getDynamicPropertyValues(): Promise<GetDynamicPropertyValues200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/dynamic-property-values', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetDynamicPropertyValues200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - complex types > should handle response objects with patternProperties 1`] = `
+"export type GetPatternPropertiesArrayArrays200Response = {
+  id: string;
+  matrix?: Array<Array<number>>;
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesArrayObjectDicts200Response = {
+  id: string;
+  objectDicts?: Array<{
+    [
+      key: string
+    ]: GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue;
+  }>;
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue =
+  {
+    name?: string;
+    value?: number;
+  };
+export type GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue = {
+  id?: string;
+  count?: number;
+};
+export type GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue = {
+  label?: string;
+  enabled?: boolean;
+};
+export type GetPatternPropertiesArrayObjects200Response = {
+  id: string;
+  items?: Array<GetPatternPropertiesArrayObjects200ResponseItemsItem>;
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesArrayObjects200ResponseItemsItem = {
+  name?: string;
+  value?: number;
+};
+export type GetPatternPropertiesArrayObjects200ResponseValueItem = {
+  id?: string;
+  count?: number;
+};
+export type GetPatternPropertiesArrayObjects200ResponseX0Item = {
+  label?: string;
+  enabled?: boolean;
+};
+export type GetPatternPropertiesArrayPrimitives200Response = {
+  id: string;
+  stringArray?: Array<string>;
+  numberArray?: Array<number>;
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesArrayStringDicts200Response = {
+  id: string;
+  dictionaries?: Array<{ [key: string]: string }>;
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesMixed200Response = {
+  id: string;
+  name: string;
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesMultiple200Response = {
+  id: string;
+  name: string;
+  [patternProperties: string]: unknown;
+};
+export type GetPatternPropertiesNested200Response = {
+  id: string;
+  config?: GetPatternPropertiesNested200ResponseConfig;
+};
+export type GetPatternPropertiesNested200ResponseConfig = {
+  [patternProperties: string]: unknown;
+};
+export type GetPatternPropertiesNested200ResponseConfigSetting0 = {
+  isEnabled?: boolean;
+  [patternProperties: string]: unknown;
+};
+export type GetPatternPropertiesNoProps200Response = {
+  [additionalAndPatternProperties: string]: unknown;
+};
+export type GetPatternPropertiesOnly200Response = {
+  [patternProperties: string]: unknown;
+};
+export type GetPatternPropertiesSingle200Response = {
+  id: string;
+  name: string;
+  [patternProperties: string]: unknown;
+};
+export type GetPatternPropertiesArrayArraysError = never;
+export type GetPatternPropertiesArrayObjectDictsError = never;
+export type GetPatternPropertiesArrayObjectsError = never;
+export type GetPatternPropertiesArrayPrimitivesError = never;
+export type GetPatternPropertiesArrayStringDictsError = never;
+export type GetPatternPropertiesMixedError = never;
+export type GetPatternPropertiesMultipleError = never;
+export type GetPatternPropertiesNestedError = never;
+export type GetPatternPropertiesNoPropsError = never;
+export type GetPatternPropertiesOnlyError = never;
+export type GetPatternPropertiesSingleError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - complex types > should handle response objects with patternProperties 2`] = `
+"import type {
+  GetPatternPropertiesArrayArrays200Response,
+  GetPatternPropertiesArrayObjectDicts200Response,
+  GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue,
+  GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue,
+  GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue,
+  GetPatternPropertiesArrayObjects200Response,
+  GetPatternPropertiesArrayObjects200ResponseItemsItem,
+  GetPatternPropertiesArrayObjects200ResponseValueItem,
+  GetPatternPropertiesArrayObjects200ResponseX0Item,
+  GetPatternPropertiesArrayPrimitives200Response,
+  GetPatternPropertiesArrayStringDicts200Response,
+  GetPatternPropertiesMixed200Response,
+  GetPatternPropertiesMultiple200Response,
+  GetPatternPropertiesNested200Response,
+  GetPatternPropertiesNested200ResponseConfig,
+  GetPatternPropertiesNested200ResponseConfigSetting0,
+  GetPatternPropertiesNoProps200Response,
+  GetPatternPropertiesOnly200Response,
+  GetPatternPropertiesSingle200Response,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetPatternPropertiesArrayArrays200Response = {
+    toJson: (model: GetPatternPropertiesArrayArrays200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'matrix'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'matrix'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.matrix === undefined
+          ? {}
+          : {
+              matrix: model.matrix,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesArrayArrays200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'matrix'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'matrix'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        id: json['id'],
+        ...(json['matrix'] === undefined
+          ? {}
+          : {
+              matrix: json['matrix'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayObjectDicts200Response = {
+    toJson: (model: GetPatternPropertiesArrayObjectDicts200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'objectDicts'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) =>
+            patternProperty.map((item0: any) =>
+              $IO.$mapValues(
+                item0,
+                $IO.GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue
+                  .toJson,
+              ),
+            ),
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'objectDicts'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) =>
+            additionalProperty.map((item0: any) =>
+              $IO.$mapValues(
+                item0,
+                $IO
+                  .GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue
+                  .toJson,
+              ),
+            ),
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.objectDicts === undefined
+          ? {}
+          : {
+              objectDicts: model.objectDicts.map((item0) =>
+                $IO.$mapValues(
+                  item0,
+                  $IO
+                    .GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue
+                    .toJson,
+                ),
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesArrayObjectDicts200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'objectDicts'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) =>
+            (patternProperty as Array<any>).map((item0: any) =>
+              $IO.$mapValues(
+                item0,
+                $IO.GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue
+                  .fromJson,
+              ),
+            ),
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'objectDicts'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) =>
+            (additionalProperty as Array<any>).map((item0: any) =>
+              $IO.$mapValues(
+                item0,
+                $IO
+                  .GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue
+                  .fromJson,
+              ),
+            ),
+        ),
+        id: json['id'],
+        ...(json['objectDicts'] === undefined
+          ? {}
+          : {
+              objectDicts: (json['objectDicts'] as Array<any>).map((item0) =>
+                $IO.$mapValues(
+                  item0,
+                  $IO
+                    .GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue
+                    .fromJson,
+                ),
+              ),
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue =
+    {
+      toJson: (
+        model: GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue,
+      ): any => {
+        if (model === undefined || model === null) {
+          return model;
+        }
+        return {
+          ...(model.name === undefined
+            ? {}
+            : {
+                name: model.name,
+              }),
+          ...(model.value === undefined
+            ? {}
+            : {
+                value: model.value,
+              }),
+        };
+      },
+      fromJson: (
+        json: any,
+      ): GetPatternPropertiesArrayObjectDicts200ResponseObjectDictsItemValue => {
+        if (json === undefined || json === null) {
+          return json;
+        }
+        return {
+          ...(json['name'] === undefined
+            ? {}
+            : {
+                name: json['name'],
+              }),
+          ...(json['value'] === undefined
+            ? {}
+            : {
+                value: json['value'],
+              }),
+        };
+      },
+    };
+
+  public static GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue =
+    {
+      toJson: (
+        model: GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue,
+      ): any => {
+        if (model === undefined || model === null) {
+          return model;
+        }
+        return {
+          ...(model.id === undefined
+            ? {}
+            : {
+                id: model.id,
+              }),
+          ...(model.count === undefined
+            ? {}
+            : {
+                count: model.count,
+              }),
+        };
+      },
+      fromJson: (
+        json: any,
+      ): GetPatternPropertiesArrayObjectDicts200ResponseValueItemValue => {
+        if (json === undefined || json === null) {
+          return json;
+        }
+        return {
+          ...(json['id'] === undefined
+            ? {}
+            : {
+                id: json['id'],
+              }),
+          ...(json['count'] === undefined
+            ? {}
+            : {
+                count: json['count'],
+              }),
+        };
+      },
+    };
+
+  public static GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue = {
+    toJson: (
+      model: GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue,
+    ): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.label === undefined
+          ? {}
+          : {
+              label: model.label,
+            }),
+        ...(model.enabled === undefined
+          ? {}
+          : {
+              enabled: model.enabled,
+            }),
+      };
+    },
+    fromJson: (
+      json: any,
+    ): GetPatternPropertiesArrayObjectDicts200ResponseX0ItemValue => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['label'] === undefined
+          ? {}
+          : {
+              label: json['label'],
+            }),
+        ...(json['enabled'] === undefined
+          ? {}
+          : {
+              enabled: json['enabled'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayObjects200Response = {
+    toJson: (model: GetPatternPropertiesArrayObjects200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'items'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) =>
+            patternProperty.map(
+              $IO.GetPatternPropertiesArrayObjects200ResponseX0Item.toJson,
+            ),
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'items'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) =>
+            additionalProperty.map(
+              $IO.GetPatternPropertiesArrayObjects200ResponseValueItem.toJson,
+            ),
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.items === undefined
+          ? {}
+          : {
+              items: model.items.map(
+                $IO.GetPatternPropertiesArrayObjects200ResponseItemsItem.toJson,
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesArrayObjects200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'items'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) =>
+            (patternProperty as Array<any>).map(
+              $IO.GetPatternPropertiesArrayObjects200ResponseX0Item.fromJson,
+            ),
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'items'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) =>
+            (additionalProperty as Array<any>).map(
+              $IO.GetPatternPropertiesArrayObjects200ResponseValueItem.fromJson,
+            ),
+        ),
+        id: json['id'],
+        ...(json['items'] === undefined
+          ? {}
+          : {
+              items: (json['items'] as Array<any>).map(
+                $IO.GetPatternPropertiesArrayObjects200ResponseItemsItem
+                  .fromJson,
+              ),
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayObjects200ResponseItemsItem = {
+    toJson: (
+      model: GetPatternPropertiesArrayObjects200ResponseItemsItem,
+    ): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.value === undefined
+          ? {}
+          : {
+              value: model.value,
+            }),
+      };
+    },
+    fromJson: (
+      json: any,
+    ): GetPatternPropertiesArrayObjects200ResponseItemsItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['name'] === undefined
+          ? {}
+          : {
+              name: json['name'],
+            }),
+        ...(json['value'] === undefined
+          ? {}
+          : {
+              value: json['value'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayObjects200ResponseValueItem = {
+    toJson: (
+      model: GetPatternPropertiesArrayObjects200ResponseValueItem,
+    ): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.count === undefined
+          ? {}
+          : {
+              count: model.count,
+            }),
+      };
+    },
+    fromJson: (
+      json: any,
+    ): GetPatternPropertiesArrayObjects200ResponseValueItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['id'] === undefined
+          ? {}
+          : {
+              id: json['id'],
+            }),
+        ...(json['count'] === undefined
+          ? {}
+          : {
+              count: json['count'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayObjects200ResponseX0Item = {
+    toJson: (model: GetPatternPropertiesArrayObjects200ResponseX0Item): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.label === undefined
+          ? {}
+          : {
+              label: model.label,
+            }),
+        ...(model.enabled === undefined
+          ? {}
+          : {
+              enabled: model.enabled,
+            }),
+      };
+    },
+    fromJson: (
+      json: any,
+    ): GetPatternPropertiesArrayObjects200ResponseX0Item => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['label'] === undefined
+          ? {}
+          : {
+              label: json['label'],
+            }),
+        ...(json['enabled'] === undefined
+          ? {}
+          : {
+              enabled: json['enabled'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayPrimitives200Response = {
+    toJson: (model: GetPatternPropertiesArrayPrimitives200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'stringArray', 'numberArray'].includes(key) &&
+                /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'stringArray', 'numberArray'].includes(key) &&
+                /^y-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'stringArray', 'numberArray'].includes(key) &&
+                !(/^x-/.test(key) || /^y-/.test(key)),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.stringArray === undefined
+          ? {}
+          : {
+              stringArray: model.stringArray,
+            }),
+        ...(model.numberArray === undefined
+          ? {}
+          : {
+              numberArray: model.numberArray,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesArrayPrimitives200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'stringArray', 'numberArray'].includes(key) &&
+                /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'stringArray', 'numberArray'].includes(key) &&
+                /^y-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'stringArray', 'numberArray'].includes(key) &&
+                !(/^x-/.test(key) || /^y-/.test(key)),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        id: json['id'],
+        ...(json['stringArray'] === undefined
+          ? {}
+          : {
+              stringArray: json['stringArray'],
+            }),
+        ...(json['numberArray'] === undefined
+          ? {}
+          : {
+              numberArray: json['numberArray'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesArrayStringDicts200Response = {
+    toJson: (model: GetPatternPropertiesArrayStringDicts200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'dictionaries'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) =>
+                !['id', 'dictionaries'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.dictionaries === undefined
+          ? {}
+          : {
+              dictionaries: model.dictionaries,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesArrayStringDicts200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'dictionaries'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) =>
+                !['id', 'dictionaries'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        id: json['id'],
+        ...(json['dictionaries'] === undefined
+          ? {}
+          : {
+              dictionaries: json['dictionaries'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesMixed200Response = {
+    toJson: (model: GetPatternPropertiesMixed200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesMixed200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'name'].includes(key) && !/^x-/.test(key),
+            ),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+        id: json['id'],
+        name: json['name'],
+      };
+    },
+  };
+
+  public static GetPatternPropertiesMultiple200Response = {
+    toJson: (model: GetPatternPropertiesMultiple200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^y-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesMultiple200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^y-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        id: json['id'],
+        name: json['name'],
+      };
+    },
+  };
+
+  public static GetPatternPropertiesNested200Response = {
+    toJson: (model: GetPatternPropertiesNested200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.config === undefined
+          ? {}
+          : {
+              config: $IO.GetPatternPropertiesNested200ResponseConfig.toJson(
+                model.config,
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesNested200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        ...(json['config'] === undefined
+          ? {}
+          : {
+              config: $IO.GetPatternPropertiesNested200ResponseConfig.fromJson(
+                json['config'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesNested200ResponseConfig = {
+    toJson: (model: GetPatternPropertiesNested200ResponseConfig): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(([key]) => /^setting-/.test(key)),
+          ),
+          (patternProperty) =>
+            $IO.GetPatternPropertiesNested200ResponseConfigSetting0.toJson(
+              patternProperty,
+            ),
+        ),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesNested200ResponseConfig => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(([key]) => /^setting-/.test(key)),
+          ),
+          (patternProperty) =>
+            $IO.GetPatternPropertiesNested200ResponseConfigSetting0.fromJson(
+              patternProperty,
+            ),
+        ),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesNested200ResponseConfigSetting0 = {
+    toJson: (
+      model: GetPatternPropertiesNested200ResponseConfigSetting0,
+    ): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['isEnabled'].includes(key) && /^option-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...(model.isEnabled === undefined
+          ? {}
+          : {
+              is_enabled: model.isEnabled,
+            }),
+      };
+    },
+    fromJson: (
+      json: any,
+    ): GetPatternPropertiesNested200ResponseConfigSetting0 => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['is_enabled'].includes(key) && /^option-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...(json['is_enabled'] === undefined
+          ? {}
+          : {
+              isEnabled: json['is_enabled'],
+            }),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesNoProps200Response = {
+    toJson: (model: GetPatternPropertiesNoProps200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(([key]) => /^x-/.test(key)),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(([key]) => !/^x-/.test(key)),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesNoProps200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(([key]) => /^x-/.test(key)),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(([key]) => !/^x-/.test(key)),
+          ),
+          (additionalProperty) => additionalProperty,
+        ),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesOnly200Response = {
+    toJson: (model: GetPatternPropertiesOnly200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(([key]) => /^x-/.test(key)),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(([key]) => /^y-/.test(key)),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesOnly200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(([key]) => /^x-/.test(key)),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(([key]) => /^y-/.test(key)),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+      };
+    },
+  };
+
+  public static GetPatternPropertiesSingle200Response = {
+    toJson: (model: GetPatternPropertiesSingle200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(model).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPatternPropertiesSingle200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(
+          Object.fromEntries(
+            Object.entries(json).filter(
+              ([key]) => !['id', 'name'].includes(key) && /^x-/.test(key),
+            ),
+          ),
+          (patternProperty) => patternProperty,
+        ),
+        id: json['id'],
+        name: json['name'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getPatternPropertiesArrayArrays =
+      this.getPatternPropertiesArrayArrays.bind(this);
+    this.getPatternPropertiesArrayObjectDicts =
+      this.getPatternPropertiesArrayObjectDicts.bind(this);
+    this.getPatternPropertiesArrayObjects =
+      this.getPatternPropertiesArrayObjects.bind(this);
+    this.getPatternPropertiesArrayPrimitives =
+      this.getPatternPropertiesArrayPrimitives.bind(this);
+    this.getPatternPropertiesArrayStringDicts =
+      this.getPatternPropertiesArrayStringDicts.bind(this);
+    this.getPatternPropertiesMixed = this.getPatternPropertiesMixed.bind(this);
+    this.getPatternPropertiesMultiple =
+      this.getPatternPropertiesMultiple.bind(this);
+    this.getPatternPropertiesNested =
+      this.getPatternPropertiesNested.bind(this);
+    this.getPatternPropertiesNoProps =
+      this.getPatternPropertiesNoProps.bind(this);
+    this.getPatternPropertiesOnly = this.getPatternPropertiesOnly.bind(this);
+    this.getPatternPropertiesSingle =
+      this.getPatternPropertiesSingle.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getPatternPropertiesArrayArrays(): Promise<GetPatternPropertiesArrayArrays200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-array-arrays',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesArrayArrays200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesArrayObjectDicts(): Promise<GetPatternPropertiesArrayObjectDicts200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-array-object-dicts',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesArrayObjectDicts200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesArrayObjects(): Promise<GetPatternPropertiesArrayObjects200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-array-objects',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesArrayObjects200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesArrayPrimitives(): Promise<GetPatternPropertiesArrayPrimitives200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-array-primitives',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesArrayPrimitives200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesArrayStringDicts(): Promise<GetPatternPropertiesArrayStringDicts200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-array-string-dicts',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesArrayStringDicts200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesMixed(): Promise<GetPatternPropertiesMixed200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/pattern-properties-mixed', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesMixed200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesMultiple(): Promise<GetPatternPropertiesMultiple200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-multiple',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesMultiple200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesNested(): Promise<GetPatternPropertiesNested200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/pattern-properties-nested', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesNested200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesNoProps(): Promise<GetPatternPropertiesNoProps200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pattern-properties-no-props',
+        pathParameters,
+        queryParameters,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesNoProps200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesOnly(): Promise<GetPatternPropertiesOnly200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/pattern-properties-only', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesOnly200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getPatternPropertiesSingle(): Promise<GetPatternPropertiesSingle200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/pattern-properties-single', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetPatternPropertiesSingle200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -41,19 +41,22 @@ const renderToJsonDateValue = (identifier, format) => {
   return `${identifier}.toISOString()${format === 'date' ? '.slice(0,10)' : ''}`;
 };
 // Renders the appropriate nested function for .map() or $mapValues() for arrays and dictionaries for the given type
-const renderNestedToJsonValue = (type, depth = 0) => {
+const renderNestedToJsonValue = (type, argumentType = undefined, depth = 0) => {
   const itemIdentifier = `item${depth}`;
+  const argType = `${argumentType ? `: ${argumentType}` : ''}`;
   if (type.isPrimitive || type.typescriptType === 'unknown' || type.export === 'enum' || type.isEnum) {
-    return `(${itemIdentifier}) => ${["date", "date-time"].includes(type.format) ? renderToJsonDateValue(itemIdentifier, type.format) : itemIdentifier}`;
+    return `(${itemIdentifier}${argType}) => ${["date", "date-time"].includes(type.format) ? renderToJsonDateValue(itemIdentifier, type.format) : itemIdentifier}`;
   } else if (type.export === "array") {
-    return `(${itemIdentifier}) => ${itemIdentifier}.map(${renderNestedToJsonValue(type.link, depth + 1)})`;
+    return `(${itemIdentifier}${argType}) => ${itemIdentifier}.map(${renderNestedToJsonValue(type.link, argumentType, depth + 1)})`;
   } else if (type.export === "dictionary") {
-    return `(${itemIdentifier}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedToJsonValue(type.link, depth + 1)})`;
+    return `(${itemIdentifier}${argType}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedToJsonValue(type.link, argumentType, depth + 1)})`;
+  } else if (type.type === 'unknown') {
+    return `(${itemIdentifier}${argType}) => ${itemIdentifier}`;
   }
   return `$IO.${type.name || type.type}.toJson`;
 };
 // Renders the code to transform a property of the model to its json representation from the model types
-const renderToJsonValue = (property, value) => {
+const renderToJsonValue = (property, value, argumentType = undefined) => {
   let rendered = '';
 
   if (canShortCircuitConversion(property)) {
@@ -62,9 +65,9 @@ const renderToJsonValue = (property, value) => {
     rendered = ["date", "date-time"].includes(property.format) ? `(${renderToJsonDateValue(value, property.format)})` : value;
   } else if (property.export === "array") {
     const prefix = property.uniqueItems ? `Array.from(${value})` : `${value}`;
-    rendered = `(${prefix}.map(${renderNestedToJsonValue(property.link)}))`;
+    rendered = `(${prefix}.map(${renderNestedToJsonValue(property.link, argumentType)}))`;
   } else if (property.export === "dictionary") {
-    rendered = `($IO.$mapValues(${value}, ${renderNestedToJsonValue(property.link)}))`;
+    rendered = `($IO.$mapValues(${value}, ${renderNestedToJsonValue(property.link, argumentType)}))`;
   } else if (property.type !== "any") {
     rendered = `$IO.${property.type}.toJson(${value})`;
   } else {
@@ -77,29 +80,32 @@ const renderToJsonValue = (property, value) => {
   return rendered;
 };
 // Renders the appropriate nested function for .map() or $mapValues() for arrays and dictionaries for the given type
-const renderNestedFromJsonValue = (type, depth = 0) => {
+const renderNestedFromJsonValue = (type, argumentType = undefined, depth = 0) => {
     const itemIdentifier = `item${depth}`;
+    const argType = `${argumentType ? `: ${argumentType}` : ''}`;
     if (type.isPrimitive || type.typescriptType === 'unknown' || type.export === 'enum' || type.isEnum) {
-        return `(${itemIdentifier}) => ${["date", "date-time"].includes(type.format) ? `new Date(${itemIdentifier})` : itemIdentifier}`;
+        return `(${itemIdentifier}${argType}) => ${["date", "date-time"].includes(type.format) ? `new Date(${itemIdentifier})` : itemIdentifier}`;
     } else if (type.export === "array") {
-        return `(${itemIdentifier}) => ${itemIdentifier}.map(${renderNestedFromJsonValue(type.link, depth + 1)})`;
+        return `(${itemIdentifier}${argType}) => ${itemIdentifier}.map(${renderNestedFromJsonValue(type.link, argumentType, depth + 1)})`;
     } else if (type.export === "dictionary") {
-        return `(${itemIdentifier}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedFromJsonValue(type.link, depth + 1)})`;
+        return `(${itemIdentifier}${argType}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedFromJsonValue(type.link, argumentType, depth + 1)})`;
+    } else if (type.type === 'unknown') {
+      return `(${itemIdentifier}${argType}) => ${itemIdentifier}`;
     }
     return `$IO.${type.name || type.type}.fromJson`;
 };
 // Renders the code to transform a property of the model from its json representation into the model types
-const renderFromJsonValue = (property, value) => {
+const renderFromJsonValue = (property, value, argumentType = undefined) => {
     let rendered = '';
     if (canShortCircuitConversion(property)) {
         rendered = value;
     } else if (property.isPrimitive || property.typescriptType === 'unknown' || property.export === 'enum' || property.isEnum) {
         rendered = ["date", "date-time"].includes(property.format) ? `(new Date(${value}))` : value;
     } else if (property.export === "array") {
-        rendered = `((${value} as Array<any>).map(${renderNestedFromJsonValue(property.link)}))`;
+        rendered = `((${value} as Array<any>).map(${renderNestedFromJsonValue(property.link, argumentType)}))`;
         rendered = property.uniqueItems ? `new Set(${rendered})` : rendered;
     } else if (property.export === "dictionary") {
-        rendered = `($IO.$mapValues(${value}, ${renderNestedFromJsonValue(property.link)}))`;
+        rendered = `($IO.$mapValues(${value}, ${renderNestedFromJsonValue(property.link, argumentType)}))`;
     } else {
         rendered = `$IO.${property.type}.fromJson(${value})`;
     }
@@ -146,6 +152,9 @@ const renderStreamingResponseChunk = (response) => {
     asText: 'value',
     asBlob: 'new Blob([value])',
   });
+};
+const matchPattern = (pattern, value) => {
+  return `/${pattern}/.test(${value})`;
 };
 _%>
 
@@ -196,6 +205,20 @@ export class $IO {
         <%_ if (model.export === 'dictionary') { _%>
         ...<%- renderToJsonValue(model, 'model') %>,
         <%_ } _%>
+        <%_ if (model.hasPatternProperties && model.patternPropertiesModels.length > 0) { _%>
+        <%_ model.patternPropertiesModels.forEach(({ pattern, model: patternProperty }) => { _%>
+          ...$IO.$mapValues(Object.fromEntries(Object.entries(model).filter(([key]) => <% if (model.properties.length > 0) { %>![<%- model.properties.map(p => `'${p.typescriptName}'`).join(', ') %>].includes(key) && <% } %>
+          <%- matchPattern(pattern, 'key') %>
+          )), (patternProperty) => <%- renderToJsonValue(patternProperty, 'patternProperty', 'any') %>),
+        <%_ }); _%>
+        <%_ } _%>
+        <%_ if (model.hasAdditionalProperties) { _%>
+          ...$IO.$mapValues(Object.fromEntries(Object.entries(model).filter(([key]) => <% if (model.properties.length > 0) { %>![<%- model.properties.map(p => `'${p.typescriptName}'`).join(', ') %>].includes(key)<% } %>
+          <%_ if (model.hasPatternProperties && model.patternPropertiesModels.length > 0) { _%>
+          <% if (model.properties.length > 0) { %>&& <% } %>!(<%- model.patternPropertiesModels.map(({ pattern }) => matchPattern(pattern, 'key')).join(' || ') %>)
+          <%_ } _%>
+          )), (additionalProperty) => <%- renderToJsonValue(model.additionalPropertiesModel, 'additionalProperty', 'any') %>),
+        <%_ } _%>
         <%_ model.properties.forEach((property) => { _%>
         ...(model.<%- property.typescriptName %> === undefined ? {} : {
           '<%= property.name %>': <%- renderToJsonValue(property, `model.${property.typescriptName}`) %>,
@@ -239,6 +262,20 @@ export class $IO {
       return {
         <%_ if (model.export === 'dictionary') { _%>
         ...<%- renderFromJsonValue(model, 'json') %>,
+        <%_ } _%>
+        <%_ if (model.hasPatternProperties && model.patternPropertiesModels.length > 0) { _%>
+        <%_ model.patternPropertiesModels.forEach(({ pattern, model: patternProperty }) => { _%>
+          ...$IO.$mapValues(Object.fromEntries(Object.entries(json).filter(([key]) => <% if (model.properties.length > 0) { %>![<%- model.properties.map(p => `'${p.name}'`).join(', ') %>].includes(key) && <% } %>
+          <%- matchPattern(pattern, 'key') %>
+          )), (patternProperty) => <%- renderFromJsonValue(patternProperty, 'patternProperty', 'any') %>),
+        <%_ }); _%>
+        <%_ } _%>
+        <%_ if (model.hasAdditionalProperties) { _%>
+        ...$IO.$mapValues(Object.fromEntries(Object.entries(json).filter(([key]) => <% if (model.properties.length > 0) { %>![<%- model.properties.map(p => `'${p.name}'`).join(', ') %>].includes(key)<% } %>
+        <%_ if (model.hasPatternProperties && model.patternPropertiesModels.length > 0) { _%>
+        <% if (model.properties.length > 0) { %>&& <% } %>!(<%- model.patternPropertiesModels.map(({ pattern }) => matchPattern(pattern, 'key')).join(' || ') %>)
+        <%_ } _%>
+        )), (additionalProperty) => <%- renderFromJsonValue(model.additionalPropertiesModel, 'additionalProperty', 'any') %>),
         <%_ } _%>
         <%_ model.properties.forEach((property) => { _%>
         <%_ if (!property.isRequired) { _%>

--- a/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
@@ -34,6 +34,11 @@ _%>
 <%_ model.properties.forEach((property) => { _%>
 <%- docString(property, '  ') %>  <%= property.isReadOnly ? 'readonly ' : '' %><%= property.typescriptName %><%= property.isRequired ? '' : '?' %>: <%- property.typescriptType %><%= (property.isNullable && property.type !== 'null') ? ' | null' : '' %>;
 <%_ }); _%>
+<%_ if (model.hasAdditionalProperties || model.hasPatternProperties) { _%>
+<%_ const keyName = (model.hasAdditionalProperties && model.hasPatternProperties) ? 'additionalAndPatternProperties' : (model.hasAdditionalProperties ? 'additionalProperties' : 'patternProperties'); _%>
+<%_ const typeComment = (model.hasAdditionalProperties && !model.hasPatternProperties && model.additionalPropertiesModel.typescriptType !== 'unknown') ? ` /* ${model.additionalPropertiesModel.typescriptType} */` : '' _%>
+  [<%- keyName %>: string]: unknown<%- typeComment %>;
+<%_ } _%>
 };
 <%_ } _%>
 <%_ }); _%>

--- a/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
@@ -1,0 +1,1314 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { Spec } from '../utils/types';
+import {
+  baseUrl,
+  callGeneratedClient,
+  expectTypeScriptToCompile,
+} from './generator.utils.spec';
+import { Tree } from '@nx/devkit';
+
+describe('openApiTsClientGenerator - complex types', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths);
+  };
+
+  it('should handle response objects with a mixture of properties and additionalProperties', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/dynamic-properties-any': {
+          get: {
+            operationId: 'getDynamicPropertiesAny',
+            responses: {
+              '200': {
+                description: 'A response with dynamic properties of any type',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: true,
+                      properties: {
+                        id: { type: 'string' },
+                        timestamp: { type: 'string', format: 'date-time' },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/dynamic-properties-numbers': {
+          get: {
+            operationId: 'getDynamicPropertiesNumbers',
+            responses: {
+              '200': {
+                description:
+                  'A response with dynamic properties that must be numbers',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                      },
+                      additionalProperties: { type: 'number' },
+                      required: ['id', 'name'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/dynamic-properties-objects': {
+          get: {
+            operationId: 'getDynamicPropertiesObjects',
+            responses: {
+              '200': {
+                description:
+                  'A response with dynamic properties that are objects with properties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                        last_modified_timestamp: {
+                          type: 'string',
+                          format: 'date-time',
+                        },
+                      },
+                      additionalProperties: {
+                        type: 'object',
+                        properties: {
+                          title: { type: 'string' },
+                          value: { type: 'number' },
+                          active: { type: 'boolean' },
+                        },
+                        required: ['title', 'value'],
+                      },
+                      required: ['id', 'name'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/dynamic-properties-nested': {
+          get: {
+            operationId: 'getDynamicPropertiesNested',
+            responses: {
+              '200': {
+                description:
+                  'A response with dynamic properties that have nested dynamic properties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        version: { type: 'string' },
+                      },
+                      additionalProperties: {
+                        type: 'object',
+                        properties: {
+                          name: { type: 'string' },
+                          config: {
+                            type: 'object',
+                            additionalProperties: { type: 'number' },
+                          },
+                        },
+                        required: ['name'],
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/dynamic-property-values': {
+          get: {
+            operationId: 'getDynamicPropertyValues',
+            responses: {
+              '200': {
+                description: 'A response with a dictionary of values',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'object',
+                        properties: {
+                          value: { type: 'string' },
+                          metadata: {
+                            type: 'object',
+                            additionalProperties: true,
+                          },
+                        },
+                        required: ['value'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+
+    // Test dynamic properties with any type
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test123',
+        timestamp: '2023-01-01T12:00:00Z',
+        dynamicProp1: 'value1',
+        dynamicProp2: 42,
+        dynamicProp3: { nestedValue: true },
+      }),
+    });
+
+    const responseAny = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getDynamicPropertiesAny',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/dynamic-properties-any`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseAny).toEqual({
+      id: 'test123',
+      timestamp: new Date('2023-01-01T12:00:00Z'),
+      dynamicProp1: 'value1',
+      dynamicProp2: 42,
+      dynamicProp3: { nestedValue: true },
+    });
+
+    // Test dynamic properties with number type constraints
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test456',
+        name: 'Test Item',
+        count: 42,
+        price: 99.99,
+        rating: 4.5,
+      }),
+    });
+
+    const responseNumbers = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getDynamicPropertiesNumbers',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/dynamic-properties-numbers`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseNumbers).toEqual({
+      id: 'test456',
+      name: 'Test Item',
+      count: 42,
+      price: 99.99,
+      rating: 4.5,
+    });
+
+    // Test dynamic properties with object type constraints
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test789',
+        name: 'Complex Item',
+        last_modified_timestamp: '2025-01-01T00:00:00.000Z',
+        feature1: {
+          title: 'First Feature',
+          value: 100,
+          active: true,
+        },
+        feature2: {
+          title: 'Second Feature',
+          value: 200,
+          active: false,
+        },
+        feature3: {
+          title: 'Third Feature',
+          value: 300,
+        },
+      }),
+    });
+
+    const responseObjects = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getDynamicPropertiesObjects',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/dynamic-properties-objects`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseObjects).toEqual({
+      id: 'test789',
+      name: 'Complex Item',
+      lastModifiedTimestamp: new Date('2025-01-01T00:00:00.000Z'),
+      feature1: {
+        title: 'First Feature',
+        value: 100,
+        active: true,
+      },
+      feature2: {
+        title: 'Second Feature',
+        value: 200,
+        active: false,
+      },
+      feature3: {
+        title: 'Third Feature',
+        value: 300,
+      },
+    });
+
+    // Test dynamic properties with nested dynamic properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'nested123',
+        version: '1.0.0',
+        module1: {
+          name: 'First Module',
+          config: {
+            timeout: 5000,
+            retries: 3,
+            maxConnections: 10,
+          },
+        },
+        module2: {
+          name: 'Second Module',
+          config: {
+            timeout: 3000,
+            maxSize: 1024,
+          },
+        },
+      }),
+    });
+
+    const responseNested = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getDynamicPropertiesNested',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/dynamic-properties-nested`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseNested).toEqual({
+      id: 'nested123',
+      version: '1.0.0',
+      module1: {
+        name: 'First Module',
+        config: {
+          timeout: 5000,
+          retries: 3,
+          maxConnections: 10,
+        },
+      },
+      module2: {
+        name: 'Second Module',
+        config: {
+          timeout: 3000,
+          maxSize: 1024,
+        },
+      },
+    });
+
+    // Test nested dynamic properties response
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        prop1: {
+          value: 'value1',
+          metadata: { source: 'system', priority: 'high' },
+        },
+        prop2: {
+          value: 'value2',
+          metadata: { source: 'user', tags: ['important', 'verified'] },
+        },
+      }),
+    });
+
+    const nestedResponse = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getDynamicPropertyValues',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/dynamic-property-values`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(nestedResponse).toEqual({
+      prop1: {
+        value: 'value1',
+        metadata: { source: 'system', priority: 'high' },
+      },
+      prop2: {
+        value: 'value2',
+        metadata: { source: 'user', tags: ['important', 'verified'] },
+      },
+    });
+  });
+
+  it('should handle response objects with patternProperties', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/pattern-properties-single': {
+          get: {
+            operationId: 'getPatternPropertiesSingle',
+            responses: {
+              '200': {
+                description: 'A response with a single pattern property',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': { type: 'string' },
+                        },
+                      },
+                      required: ['id', 'name'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-multiple': {
+          get: {
+            operationId: 'getPatternPropertiesMultiple',
+            responses: {
+              '200': {
+                description: 'A response with multiple pattern properties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': { type: 'string' },
+                          '^y-': { type: 'number' },
+                        },
+                      },
+                      required: ['id', 'name'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-mixed': {
+          get: {
+            operationId: 'getPatternPropertiesMixed',
+            responses: {
+              '200': {
+                description:
+                  'A response with a mixture of patternProperties, properties, and additionalProperties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': { type: 'string' },
+                        },
+                      },
+                      additionalProperties: { type: 'number' },
+                      required: ['id', 'name'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-no-props': {
+          get: {
+            operationId: 'getPatternPropertiesNoProps',
+            responses: {
+              '200': {
+                description:
+                  'A response with patternProperties and additionalProperties but no properties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      ...{
+                        patternProperties: {
+                          '^x-': { type: 'string' },
+                        },
+                      },
+                      additionalProperties: { type: 'number' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-only': {
+          get: {
+            operationId: 'getPatternPropertiesOnly',
+            responses: {
+              '200': {
+                description: 'A response with only patternProperties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      ...{
+                        patternProperties: {
+                          '^x-': { type: 'string' },
+                          '^y-': { type: 'number' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-nested': {
+          get: {
+            operationId: 'getPatternPropertiesNested',
+            responses: {
+              '200': {
+                description: 'A response with nested patternProperties',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        config: {
+                          type: 'object',
+                          ...{
+                            patternProperties: {
+                              '^setting-': {
+                                type: 'object',
+                                properties: {
+                                  is_enabled: { type: 'boolean' },
+                                },
+                                patternProperties: {
+                                  '^option-': { type: 'string' },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-array-objects': {
+          get: {
+            operationId: 'getPatternPropertiesArrayObjects',
+            responses: {
+              '200': {
+                description:
+                  'A response with properties, patternProperties and additionalProperties that are all arrays of objects',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        items: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              name: { type: 'string' },
+                              value: { type: 'number' },
+                            },
+                          },
+                        },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              properties: {
+                                label: { type: 'string' },
+                                enabled: { type: 'boolean' },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      additionalProperties: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            id: { type: 'string' },
+                            count: { type: 'number' },
+                          },
+                        },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-array-primitives': {
+          get: {
+            operationId: 'getPatternPropertiesArrayPrimitives',
+            responses: {
+              '200': {
+                description:
+                  'A response with properties, patternProperties and additionalProperties that are all arrays of primitives',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        stringArray: {
+                          type: 'array',
+                          items: { type: 'string' },
+                        },
+                        numberArray: {
+                          type: 'array',
+                          items: { type: 'number' },
+                        },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': {
+                            type: 'array',
+                            items: { type: 'string' },
+                          },
+                          '^y-': {
+                            type: 'array',
+                            items: { type: 'number' },
+                          },
+                        },
+                      },
+                      additionalProperties: {
+                        type: 'array',
+                        items: { type: 'boolean' },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-array-arrays': {
+          get: {
+            operationId: 'getPatternPropertiesArrayArrays',
+            responses: {
+              '200': {
+                description:
+                  'A response with properties, patternProperties and additionalProperties that are all arrays of arrays of primitives',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        matrix: {
+                          type: 'array',
+                          items: {
+                            type: 'array',
+                            items: { type: 'number' },
+                          },
+                        },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': {
+                            type: 'array',
+                            items: {
+                              type: 'array',
+                              items: { type: 'string' },
+                            },
+                          },
+                        },
+                      },
+                      additionalProperties: {
+                        type: 'array',
+                        items: {
+                          type: 'array',
+                          items: { type: 'boolean' },
+                        },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-array-string-dicts': {
+          get: {
+            operationId: 'getPatternPropertiesArrayStringDicts',
+            responses: {
+              '200': {
+                description:
+                  'A response with properties, patternProperties and additionalProperties that are all arrays of string dictionaries',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        dictionaries: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            additionalProperties: { type: 'string' },
+                          },
+                        },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              additionalProperties: { type: 'string' },
+                            },
+                          },
+                        },
+                      },
+                      additionalProperties: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          additionalProperties: { type: 'string' },
+                        },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/pattern-properties-array-object-dicts': {
+          get: {
+            operationId: 'getPatternPropertiesArrayObjectDicts',
+            responses: {
+              '200': {
+                description:
+                  'A response with properties, patternProperties and additionalProperties that are all arrays of object dictionaries',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        objectDicts: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            additionalProperties: {
+                              type: 'object',
+                              properties: {
+                                name: { type: 'string' },
+                                value: { type: 'number' },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      ...{
+                        patternProperties: {
+                          '^x-': {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              additionalProperties: {
+                                type: 'object',
+                                properties: {
+                                  label: { type: 'string' },
+                                  enabled: { type: 'boolean' },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      additionalProperties: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          additionalProperties: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              count: { type: 'number' },
+                            },
+                          },
+                        },
+                      },
+                      required: ['id'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+
+    // Test single pattern property
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test123',
+        name: 'Test Item',
+        'x-custom': 'custom value',
+        'x-another': 'another value',
+      }),
+    });
+
+    const responseSingle = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesSingle',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-single`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseSingle).toEqual({
+      id: 'test123',
+      name: 'Test Item',
+      'x-custom': 'custom value',
+      'x-another': 'another value',
+    });
+
+    // Test multiple pattern properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test456',
+        name: 'Test Item 2',
+        'x-custom': 'custom value',
+        'y-count': 42,
+        'y-price': 99.99,
+      }),
+    });
+
+    const responseMultiple = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesMultiple',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-multiple`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseMultiple).toEqual({
+      id: 'test456',
+      name: 'Test Item 2',
+      'x-custom': 'custom value',
+      'y-count': 42,
+      'y-price': 99.99,
+    });
+
+    // Test mixed properties, patternProperties, and additionalProperties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test789',
+        name: 'Test Item 3',
+        'x-custom': 'custom value',
+        'other-prop': 123,
+        'another-prop': 456,
+      }),
+    });
+
+    const responseMixed = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesMixed',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-mixed`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseMixed).toEqual({
+      id: 'test789',
+      name: 'Test Item 3',
+      'x-custom': 'custom value',
+      'other-prop': 123,
+      'another-prop': 456,
+    });
+
+    // Test patternProperties and additionalProperties but no properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        'x-custom': 'custom value',
+        'x-another': 'another value',
+        'other-prop': 123,
+        'another-prop': 456,
+      }),
+    });
+
+    const responseNoProps = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesNoProps',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-no-props`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseNoProps).toEqual({
+      'x-custom': 'custom value',
+      'x-another': 'another value',
+      'other-prop': 123,
+      'another-prop': 456,
+    });
+
+    // Test only patternProperties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        'x-custom': 'custom value',
+        'y-count': 42,
+        'y-price': 99.99,
+      }),
+    });
+
+    const responseOnlyPatterns = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesOnly',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-only`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseOnlyPatterns).toEqual({
+      'x-custom': 'custom value',
+      'y-count': 42,
+      'y-price': 99.99,
+    });
+
+    // Test nested patternProperties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'test789',
+        config: {
+          'setting-theme': {
+            is_enabled: true,
+            'option-color': 'blue',
+            'option-size': 'large',
+          },
+          'setting-notifications': {
+            is_enabled: false,
+            'option-sound': 'chime',
+          },
+        },
+      }),
+    });
+
+    const responseNested = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesNested',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-nested`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseNested).toEqual({
+      id: 'test789',
+      config: {
+        'setting-theme': {
+          isEnabled: true,
+          'option-color': 'blue',
+          'option-size': 'large',
+        },
+        'setting-notifications': {
+          isEnabled: false,
+          'option-sound': 'chime',
+        },
+      },
+    });
+
+    // Test arrays of objects with pattern properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'array-objects',
+        items: [
+          { name: 'Item 1', value: 100 },
+          { name: 'Item 2', value: 200 },
+        ],
+        'x-metadata': [
+          { label: 'Meta 1', enabled: true },
+          { label: 'Meta 2', enabled: false },
+        ],
+        'custom-items': [
+          { id: 'c1', count: 5 },
+          { id: 'c2', count: 10 },
+        ],
+      }),
+    });
+
+    const responseArrayObjects = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesArrayObjects',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-array-objects`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseArrayObjects).toEqual({
+      id: 'array-objects',
+      items: [
+        { name: 'Item 1', value: 100 },
+        { name: 'Item 2', value: 200 },
+      ],
+      'x-metadata': [
+        { label: 'Meta 1', enabled: true },
+        { label: 'Meta 2', enabled: false },
+      ],
+      'custom-items': [
+        { id: 'c1', count: 5 },
+        { id: 'c2', count: 10 },
+      ],
+    });
+
+    // Test arrays of primitives with pattern properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'array-primitives',
+        stringArray: ['a', 'b', 'c'],
+        numberArray: [1, 2, 3],
+        'x-tags': ['tag1', 'tag2'],
+        'y-values': [10, 20, 30],
+        'custom-flags': [true, false, true],
+      }),
+    });
+
+    const responseArrayPrimitives = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesArrayPrimitives',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-array-primitives`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseArrayPrimitives).toEqual({
+      id: 'array-primitives',
+      stringArray: ['a', 'b', 'c'],
+      numberArray: [1, 2, 3],
+      'x-tags': ['tag1', 'tag2'],
+      'y-values': [10, 20, 30],
+      'custom-flags': [true, false, true],
+    });
+
+    // Test arrays of arrays with pattern properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'array-arrays',
+        matrix: [
+          [1, 2],
+          [3, 4],
+        ],
+        'x-grid': [
+          ['a', 'b'],
+          ['c', 'd'],
+        ],
+        'custom-matrix': [
+          [true, false],
+          [false, true],
+        ],
+      }),
+    });
+
+    const responseArrayArrays = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesArrayArrays',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-array-arrays`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseArrayArrays).toEqual({
+      id: 'array-arrays',
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+      'x-grid': [
+        ['a', 'b'],
+        ['c', 'd'],
+      ],
+      'custom-matrix': [
+        [true, false],
+        [false, true],
+      ],
+    });
+
+    // Test arrays of string dictionaries with pattern properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'array-string-dicts',
+        dictionaries: [
+          { key1: 'value1', key2: 'value2' },
+          { key3: 'value3', key4: 'value4' },
+        ],
+        'x-metadata': [
+          { tag1: 'meta1', tag2: 'meta2' },
+          { tag3: 'meta3', tag4: 'meta4' },
+        ],
+        'custom-dicts': [
+          { prop1: 'val1', prop2: 'val2' },
+          { prop3: 'val3', prop4: 'val4' },
+        ],
+      }),
+    });
+
+    const responseArrayStringDicts = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesArrayStringDicts',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-array-string-dicts`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseArrayStringDicts).toEqual({
+      id: 'array-string-dicts',
+      dictionaries: [
+        { key1: 'value1', key2: 'value2' },
+        { key3: 'value3', key4: 'value4' },
+      ],
+      'x-metadata': [
+        { tag1: 'meta1', tag2: 'meta2' },
+        { tag3: 'meta3', tag4: 'meta4' },
+      ],
+      'custom-dicts': [
+        { prop1: 'val1', prop2: 'val2' },
+        { prop3: 'val3', prop4: 'val4' },
+      ],
+    });
+
+    // Test arrays of object dictionaries with pattern properties
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: 'array-object-dicts',
+        objectDicts: [
+          {
+            obj1: { name: 'Object 1', value: 100 },
+            obj2: { name: 'Object 2', value: 200 },
+          },
+          {
+            obj3: { name: 'Object 3', value: 300 },
+            obj4: { name: 'Object 4', value: 400 },
+          },
+        ],
+        'x-metadata': [
+          {
+            meta1: { label: 'Meta 1', enabled: true },
+            meta2: { label: 'Meta 2', enabled: false },
+          },
+        ],
+        'custom-dicts': [
+          {
+            item1: { id: 'i1', count: 5 },
+            item2: { id: 'i2', count: 10 },
+          },
+        ],
+      }),
+    });
+
+    const responseArrayObjectDicts = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getPatternPropertiesArrayObjectDicts',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/pattern-properties-array-object-dicts`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(responseArrayObjectDicts).toEqual({
+      id: 'array-object-dicts',
+      objectDicts: [
+        {
+          obj1: { name: 'Object 1', value: 100 },
+          obj2: { name: 'Object 2', value: 200 },
+        },
+        {
+          obj3: { name: 'Object 3', value: 300 },
+          obj4: { name: 'Object 4', value: 400 },
+        },
+      ],
+      'x-metadata': [
+        {
+          meta1: { label: 'Meta 1', enabled: true },
+          meta2: { label: 'Meta 2', enabled: false },
+        },
+      ],
+      'custom-dicts': [
+        {
+          item1: { id: 'i1', count: 5 },
+          item2: { id: 'i2', count: 10 },
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
### Reason for this change

Schemas which mixed objects and additional properties were causing clients to be generated which did not compile.
    
We'd render invalid code like `$IO.unknown.toJson(xxxx)`.
    
Additionally, `patternProperties` are part of the JSON schema version used by OpenAPI v3.1, and so therefore should be handled too.
    
This change adds support for additional properties and pattern properties.

### Description of changes

Models for schemas with both explicit properties and additional properties were represented in multiple different ways, which were being treated differently in code generation (some had `export: "dictionary"`, others had `export: "interface"` but with a property named `[key: string]`).

As part of constructing the data structure for codegen, we now standardise on the following:

- `export: "dictionary"` means a proper dictionary type, with no explicit properties, only arbitrary ones.
- `export: "interface"` is a standard model, but it can have additional properties

Note that due to a limitation of the TypeScript type system, we must type additional properties and pattern properties as `unknown`, rather than the type defined in the schema. As unfortunately a type like this is invalid due to `name` not being of type `number`:

```ts
export type SomeType = {
  name: string;
  [key: string]: number;
};
```

It's also not possible to define the `key` type as "any string except name" in TypeScript, ie this type:

```ts
export type SomeType = {
  name: string;
} & Record<Exclude<string, 'name'>, number>
```

Still evaluates to `Record<string, number>` and so is also invalid due to `name` not being of type `number`.

While the generated types for additional properties and pattern properties have this limitation, we still ensure that these properties are marshalled correctly.

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*