### PR TITLE
feat(api-connection): tanstack query hooks for connecting react to fastapi

### DIFF
--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
@@ -529,9 +529,14 @@ Below is a list of all files which have been generated/updated by the `api-conne
     - src/
       - hooks/
         - useSigV4.tsx used by StoryApi to sign requests
-        - useStoryApi.tsx hooks to call the StoryApi
+        - useStoryApiClient.tsx hook to construct a StoryApi client
+        - useStoryApi.tsx hook for interacting with the StoryApi using TanStack Query
+      - components/
+        - QueryClientProvider.tsx TanStack Query client provider
+        - StoryApiProvider.tsx Provider for the StoryApi TanStack Query hook
+      - main.tsx Instrument the QueryClientProvider and StoryApiProvider
     - .gitignore ignore generated client files
-    - project.json updated to add targets for generating openapi client
+    - project.json updated to add targets for generating openapi hooks
     - ...
   - story_api/
     - scripts/
@@ -541,7 +546,7 @@ Below is a list of all files which have been generated/updated by the `api-conne
 </FileTree>
 
 ```tsx {1,12-15}
-// packages/game-ui/src/hooks/useStoryApi.tsx
+// packages/game-ui/src/hooks/useStoryApiClient.tsx
 import { StoryApi } from '../generated/story-api/client.gen';
 import { useSigV4 } from './useSigV4';
 import { useRuntimeConfig } from './useRuntimeConfig';
@@ -562,10 +567,39 @@ export const useStoryApi = (): StoryApi => {
 };
 ```
 
-This hook is what will be used to make authenticated API requests to the `StoryApi`. As you can see in the implementation, it uses the `StoryApi` which is generated at build time and as such you will see an error in your IDE until we build our code. For more details on how the client is generated or how to consume the API, refer to the [React to FastAPI guide](/nx-plugin-for-aws/guides/api-connection/react-fastapi).
+This hook can be used to make authenticated API requests to the `StoryApi`. As you can see in the implementation, it uses the `StoryApi` which is generated at build time and as such you will see an error in your IDE until we build our code. For more details on how the client is generated or how to consume the API, refer to the [React to FastAPI guide](/nx-plugin-for-aws/guides/api-connection/react-fastapi).
+
+```tsx
+// packages/game-ui/src/components/StoryApiProvider.tsx
+import { createContext, FC, PropsWithChildren, useMemo } from 'react';
+import { useStoryApiClient } from '../hooks/useStoryApiClient';
+import { StoryApiOptionsProxy } from '../generated/story-api/options-proxy.gen';
+
+export const StoryApiContext = createContext<StoryApiOptionsProxy | undefined>(
+  undefined,
+);
+
+export const StoryApiProvider: FC<PropsWithChildren> = ({ children }) => {
+  const client = useStoryApiClient();
+  const optionsProxy = useMemo(
+    () => new StoryApiOptionsProxy({ client }),
+    [client],
+  );
+
+  return (
+    <StoryApiContext.Provider value={optionsProxy}>
+      {children}
+    </StoryApiContext.Provider>
+  );
+};
+
+export default StoryApiProvider;
+```
+
+The above provider component uses the `useStoryApiClient` hook, and instantiates the `StoryApiOptionsProxy`, which is used to build options for TanStack Query hooks. We will use the corresponding hook `useStoryApi` to provide us with this options proxy so that we can let TanStack Query manage the state for our streaming API.
 
 <Aside type="caution">
-The `client.gen.ts` file that is generated should never be modified manually as this will be re-generated any time a change to the backend API is detected.
+The `src/generated/story-api/*.gen.ts` files should never be modified manually as they will be re-generated any time a change to the backend API is detected.
 </Aside>
 
 </Drawer>
@@ -590,7 +624,6 @@ Below is a list of all files which have been generated/updated by the `api-conne
           - TrpcApis.tsx all configured tRPC APIs
           - TrpcClientProviders.tsx creates a client provider per tRPC API
           - TrpcProvider.tsx
-        - QueryClientProvider.tsx sets up the query client
       - hooks/
         - **useGameApi.tsx** hooks to call the GameApi
       - **main.tsx** injects the trpc client providers

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
@@ -596,10 +596,12 @@ export const StoryApiProvider: FC<PropsWithChildren> = ({ children }) => {
 export default StoryApiProvider;
 ```
 
-The above provider component uses the `useStoryApiClient` hook, and instantiates the `StoryApiOptionsProxy`, which is used to build options for TanStack Query hooks. We will use the corresponding hook `useStoryApi` to provide us with this options proxy so that we can let TanStack Query manage the state for our streaming API.
+The above provider component uses the `useStoryApiClient` hook, and instantiates the `StoryApiOptionsProxy`, which is used to build options for TanStack Query hooks. You can use the corresponding hook `useStoryApi` to access this options proxy, which provides a way to interact with your FastAPI in a consistent manner to your tRPC API.
+
+Since `useStoryApiClient` provides us with an async iterator for our streaming API, we will just use the vanilla client directly in this tutorial.
 
 <Aside type="caution">
-The `src/generated/story-api/*.gen.ts` files should never be modified manually as they will be re-generated any time a change to the backend API is detected.
+The `src/generated/story-api/*.gen.ts` files should never be modified manually as they will be re-generated every time you build your API.
 </Aside>
 
 </Drawer>

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
@@ -97,7 +97,7 @@ async def bedrock_stream(request: StoryRequest):
                     yield "\n"
 
 @app.post("/story/generate",
-          openapi_extra={'x-streaming': True},
+          openapi_extra={'x-streaming': True, 'x-query': True},
           response_class=PlainTextResponse)
 def generate_story(request: StoryRequest) -> str:
     return StreamingResponse(bedrock_stream(request), media_type="text/plain")
@@ -106,6 +106,7 @@ def generate_story(request: StoryRequest) -> str:
 Analyzing the code above:
 
 - We use the `x-streaming` setting to indicate that this is a streaming API when we eventually generate our client SDK. This will allow us to consume this API in a streaming manner whilst maintaining type-safety!
+- We use the `x-query` setting to indicate that while this is a POST request, we will treat it as a `query` instead of a `mutation`, allowing us to take full advantage of TanStack Query managing our streaming state.
 - Our API simply returns a stream of text as defined by both the `media_type="text/plain"` and the `response_class=PlainTextResponse`
 
 ### Infrastructure

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
@@ -109,6 +109,12 @@ Analyzing the code above:
 - We use the `x-query` setting to indicate that while this is a POST request, we will treat it as a `query` instead of a `mutation`, allowing us to take full advantage of TanStack Query managing our streaming state.
 - Our API simply returns a stream of text as defined by both the `media_type="text/plain"` and the `response_class=PlainTextResponse`
 
+:::note
+Every time you make changes to your FastAPI, you will need to rebuild your project to see those changes reflected in the generated client in your website.
+
+We'll make a few more changes below before we rebuild.
+:::
+
 ### Infrastructure
 
 The [Infrastructure we set up previously](/nx-plugin-for-aws/get_started/tutorials/dungeon-game/1#game-ui-infrastructure) assumes that all APIs have an API Gateway integrating with a Lambda. For our `story_api` we actually don't want to use API Gateway as this does not support streaming repsonses. Instead, we will use a [Lambda Function URL configured with response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/4.mdx
@@ -578,10 +578,11 @@ function RouteComponent() {
 import { PromptInput, Spinner } from '@cloudscape-design/components';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useGameApi } from '../../hooks/useGameApi';
 import { useStoryApi } from '../../hooks/useStoryApi';
 import type { IAction, IGame } from ':dungeon-adventure/game-api-schema';
+import { GenerateStoryRequest } from '../../generated/story-api/types.gen';
 
 type IGameState = Omit<IGame, 'lastUpdated'> & { actions: IAction[] };
 
@@ -599,7 +600,9 @@ function RouteComponent() {
   const { genre } = Route.useSearch();
 
   const [currentInput, setCurrentInput] = useState('');
-  const [streamingContent, setStreamingContent] = useState('');
+  const [generateStoryInput, setGenerateStoryInput] = useState<
+    GenerateStoryRequest | undefined
+  >();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -612,6 +615,36 @@ function RouteComponent() {
     gameApi.actions.query.queryOptions({ playerName, limit: 100 }),
   );
 
+  // Query for managing the streaming state from the story api
+  const streamingContentQuery = useQuery(
+    storyApi.generateStory.queryOptions(generateStoryInput!, {
+      enabled: !!generateStoryInput,
+    }),
+  );
+
+  // We join each chunk from the generate story api together to form our streaming content
+  const streamingContent = useMemo(
+    () => (streamingContentQuery.data ?? []).join(''),
+    [streamingContentQuery.data],
+  );
+
+  // Track whether the current story generation has completed
+  const isCurrentStreamComplete = useMemo(
+    () =>
+      streamingContentQuery.fetchStatus === 'idle' && streamingContent !== '',
+    [streamingContentQuery.fetchStatus, streamingContent],
+  );
+
+  // Track whether we've saved the current story actions
+  const isStreamingContentSaved = useMemo(
+    () =>
+      gameActionsQuery.data &&
+      (gameActionsQuery.data.items.length > 0 &&
+        gameActionsQuery.data.items[gameActionsQuery.data.items.length - 1]
+          .content) === streamingContent,
+    [gameActionsQuery.data, streamingContent],
+  );
+
   // no actions - therefore must be a new game - generate initial story
   useEffect(() => {
     if (
@@ -619,30 +652,42 @@ function RouteComponent() {
       gameActionsQuery.data?.items &&
       gameActionsQuery.data?.items.length === 0
     ) {
-      generateStory({
+      setGenerateStoryInput({
         playerName,
         genre,
         actions: [],
       });
     }
-  }, [gameActionsQuery.data?.items, gameActionsQuery.isLoading]);
+  }, [
+    gameActionsQuery.data?.items,
+    gameActionsQuery.isLoading,
+    setGenerateStoryInput,
+  ]);
 
-  const generateStoryMutation = useMutation({
-    mutationFn: async ({ playerName, genre, actions }: IGameState) => {
-      let content = '';
-      for await (const chunk of storyApi.generateStory({
-        playerName,
-        genre,
-        actions,
-      })) {
-        content += chunk;
-        // make chunks available to render in a streaming fashion
-        setStreamingContent(content);
-      }
+  useEffect(() => {
+    if (
+      !gameActionsQuery.isLoading &&
+      isCurrentStreamComplete &&
+      !isStreamingContentSaved
+    ) {
+      void (async () => {
+        // Save assistant's response whenever streaming stops
+        await saveActionMutation.mutateAsync({
+          playerName,
+          role: 'assistant',
+          content: streamingContent,
+        });
 
-      return content;
-    },
-  });
+        await gameActionsQuery.refetch();
+      })();
+    }
+  }, [
+    gameActionsQuery.data?.items,
+    gameActionsQuery.isLoading,
+    isCurrentStreamComplete,
+    streamingContent,
+    isStreamingContentSaved,
+  ]);
 
   // scroll to the last message
   const scrollToBottom = () => {
@@ -653,30 +698,6 @@ function RouteComponent() {
   useEffect(() => {
     scrollToBottom();
   }, [streamingContent, gameActionsQuery]);
-
-  // progress the story
-  const generateStory = async ({ playerName, genre, actions }: IGameState) => {
-    try {
-      const content = await generateStoryMutation.mutateAsync({
-        playerName,
-        genre,
-        actions,
-      });
-
-      // Save assistant's response
-      await saveActionMutation.mutateAsync({
-        playerName,
-        role: 'assistant',
-        content,
-      });
-
-      await gameActionsQuery.refetch();
-
-      setStreamingContent('');
-    } catch (error) {
-      console.error('Failed to generate story:', error);
-    }
-  };
 
   // progress the story when the user submits input
   const handleSubmitAction = async () => {
@@ -696,7 +717,7 @@ function RouteComponent() {
     setCurrentInput('');
 
     // Generate response
-    await generateStory({
+    setGenerateStoryInput({
       genre,
       playerName,
       actions: [...(gameActionsQuery.data?.items ?? []), userAction],
@@ -707,9 +728,9 @@ function RouteComponent() {
     <div className="game-interface">
       <div className="messages-area">
         <div className="messages-container">
-          {gameActionsQuery.data?.items
+          {(gameActionsQuery.data?.items ?? [])
             .concat(
-              streamingContent.length > 0
+              !isStreamingContentSaved && streamingContentQuery.isSuccess
                 ? [
                     {
                       playerName,
@@ -730,7 +751,7 @@ function RouteComponent() {
                 {action.content}
               </div>
             ))}
-          {generateStoryMutation.isPending && streamingContent.length === 0 && (
+          {(streamingContentQuery.isLoading || gameActionsQuery.isLoading) && (
             <Spinner data-style="generating" size="big" />
           )}
           <div ref={messagesEndRef} />
@@ -739,6 +760,7 @@ function RouteComponent() {
       <div className="input-area">
         <PromptInput
           onChange={({ detail }) => setCurrentInput(detail.value)}
+          disabled={saveActionMutation.isPending || gameActionsQuery.isLoading || streamingContentQuery.isFetching}
           value={currentInput}
           actionButtonAriaLabel="Send message"
           actionButtonIconName="send"
@@ -750,6 +772,7 @@ function RouteComponent() {
     </div>
   );
 }
+
 ```
 
 <Aside type="tip">

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/4.mdx
@@ -578,11 +578,10 @@ function RouteComponent() {
 import { PromptInput, Spinner } from '@cloudscape-design/components';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useGameApi } from '../../hooks/useGameApi';
-import { useStoryApi } from '../../hooks/useStoryApi';
+import { useStoryApiClient } from '../../hooks/useStoryApiClient';
 import type { IAction, IGame } from ':dungeon-adventure/game-api-schema';
-import { GenerateStoryRequest } from '../../generated/story-api/types.gen';
 
 type IGameState = Omit<IGame, 'lastUpdated'> & { actions: IAction[] };
 
@@ -600,49 +599,17 @@ function RouteComponent() {
   const { genre } = Route.useSearch();
 
   const [currentInput, setCurrentInput] = useState('');
-  const [generateStoryInput, setGenerateStoryInput] = useState<
-    GenerateStoryRequest | undefined
-  >();
+  const [streamingContent, setStreamingContent] = useState('');
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const gameApi = useGameApi();
-  const storyApi = useStoryApi();
+  const storyApi = useStoryApiClient();
   const saveActionMutation = useMutation(
     gameApi.actions.save.mutationOptions(),
   );
   const gameActionsQuery = useQuery(
     gameApi.actions.query.queryOptions({ playerName, limit: 100 }),
-  );
-
-  // Query for managing the streaming state from the story api
-  const streamingContentQuery = useQuery(
-    storyApi.generateStory.queryOptions(generateStoryInput!, {
-      enabled: !!generateStoryInput,
-    }),
-  );
-
-  // We join each chunk from the generate story api together to form our streaming content
-  const streamingContent = useMemo(
-    () => (streamingContentQuery.data ?? []).join(''),
-    [streamingContentQuery.data],
-  );
-
-  // Track whether the current story generation has completed
-  const isCurrentStreamComplete = useMemo(
-    () =>
-      streamingContentQuery.fetchStatus === 'idle' && streamingContent !== '',
-    [streamingContentQuery.fetchStatus, streamingContent],
-  );
-
-  // Track whether we've saved the current story actions
-  const isStreamingContentSaved = useMemo(
-    () =>
-      gameActionsQuery.data &&
-      (gameActionsQuery.data.items.length > 0 &&
-        gameActionsQuery.data.items[gameActionsQuery.data.items.length - 1]
-          .content) === streamingContent,
-    [gameActionsQuery.data, streamingContent],
   );
 
   // no actions - therefore must be a new game - generate initial story
@@ -652,42 +619,30 @@ function RouteComponent() {
       gameActionsQuery.data?.items &&
       gameActionsQuery.data?.items.length === 0
     ) {
-      setGenerateStoryInput({
+      generateStory({
         playerName,
         genre,
         actions: [],
       });
     }
-  }, [
-    gameActionsQuery.data?.items,
-    gameActionsQuery.isLoading,
-    setGenerateStoryInput,
-  ]);
+  }, [gameActionsQuery.data?.items, gameActionsQuery.isLoading]);
 
-  useEffect(() => {
-    if (
-      !gameActionsQuery.isLoading &&
-      isCurrentStreamComplete &&
-      !isStreamingContentSaved
-    ) {
-      void (async () => {
-        // Save assistant's response whenever streaming stops
-        await saveActionMutation.mutateAsync({
-          playerName,
-          role: 'assistant',
-          content: streamingContent,
-        });
+  const generateStoryMutation = useMutation({
+    mutationFn: async ({ playerName, genre, actions }: IGameState) => {
+      let content = '';
+      for await (const chunk of storyApi.generateStory({
+        playerName,
+        genre,
+        actions,
+      })) {
+        content += chunk;
+        // make chunks available to render in a streaming fashion
+        setStreamingContent(content);
+      }
 
-        await gameActionsQuery.refetch();
-      })();
-    }
-  }, [
-    gameActionsQuery.data?.items,
-    gameActionsQuery.isLoading,
-    isCurrentStreamComplete,
-    streamingContent,
-    isStreamingContentSaved,
-  ]);
+      return content;
+    },
+  });
 
   // scroll to the last message
   const scrollToBottom = () => {
@@ -698,6 +653,30 @@ function RouteComponent() {
   useEffect(() => {
     scrollToBottom();
   }, [streamingContent, gameActionsQuery]);
+
+  // progress the story
+  const generateStory = async ({ playerName, genre, actions }: IGameState) => {
+    try {
+      const content = await generateStoryMutation.mutateAsync({
+        playerName,
+        genre,
+        actions,
+      });
+
+      // Save assistant's response
+      await saveActionMutation.mutateAsync({
+        playerName,
+        role: 'assistant',
+        content,
+      });
+
+      await gameActionsQuery.refetch();
+
+      setStreamingContent('');
+    } catch (error) {
+      console.error('Failed to generate story:', error);
+    }
+  };
 
   // progress the story when the user submits input
   const handleSubmitAction = async () => {
@@ -717,7 +696,7 @@ function RouteComponent() {
     setCurrentInput('');
 
     // Generate response
-    setGenerateStoryInput({
+    await generateStory({
       genre,
       playerName,
       actions: [...(gameActionsQuery.data?.items ?? []), userAction],
@@ -728,9 +707,9 @@ function RouteComponent() {
     <div className="game-interface">
       <div className="messages-area">
         <div className="messages-container">
-          {(gameActionsQuery.data?.items ?? [])
+          {gameActionsQuery.data?.items
             .concat(
-              !isStreamingContentSaved && streamingContentQuery.isSuccess
+              streamingContent.length > 0
                 ? [
                     {
                       playerName,
@@ -751,7 +730,7 @@ function RouteComponent() {
                 {action.content}
               </div>
             ))}
-          {(streamingContentQuery.isLoading || gameActionsQuery.isLoading) && (
+          {generateStoryMutation.isPending && streamingContent.length === 0 && (
             <Spinner data-style="generating" size="big" />
           )}
           <div ref={messagesEndRef} />
@@ -760,7 +739,6 @@ function RouteComponent() {
       <div className="input-area">
         <PromptInput
           onChange={({ detail }) => setCurrentInput(detail.value)}
-          disabled={saveActionMutation.isPending || gameActionsQuery.isLoading || streamingContentQuery.isFetching}
           value={currentInput}
           actionButtonAriaLabel="Send message"
           actionButtonIconName="send"
@@ -772,7 +750,6 @@ function RouteComponent() {
     </div>
   );
 }
-
 ```
 
 <Aside type="tip">

--- a/docs/src/content/docs/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/guides/api-connection/react-fastapi.mdx
@@ -3,13 +3,14 @@ title: React to FastAPI
 description: Connect a React website to a Python FastAPI
 ---
 
-import { FileTree } from '@astrojs/starlight/components';
+import { FileTree, Steps } from '@astrojs/starlight/components';
 import RunGenerator from '../../../../components/run-generator.astro';
 import NxCommands from '../../../../components/nx-commands.astro';
+import Drawer from '../../../../components/drawer.astro';
 import GeneratorParameters from '../../../../components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-The `api-connection` generator provides a way to quickly integrate your React website with your FastAPI backend. It sets up all necessary configuration for connecting to your FastAPI backends in a type-safe manner, including client generation, AWS IAM authentication support and proper error handling.
+The `api-connection` generator provides a way to quickly integrate your React website with your FastAPI backend. It sets up all necessary configuration for connecting to your FastAPI backends in a type-safe manner, including client and [TanStack Query](https://tanstack.com/query/v5) hooks generation, AWS IAM authentication support and proper error handling.
 
 ## Prerequisites
 
@@ -65,9 +66,13 @@ The generator will make changes to the following files in your React application
 <FileTree>
 
 - src
+  - components
+    - \<ApiName>Provider.tsx Provider for your API client
+    - QueryClientProvider.tsx TanStack React Query client provider
   - hooks
+    - use\<ApiName>.tsx Add a hook for calling your API with state managed by TanStack Query
+    - use\<ApiName>Client.tsx Add a hook for instantiating the vanilla API client which can call your API.
     - useSigV4.tsx Add a hook for signing HTTP requests with SigV4 (if you selected IAM authentication)
-    - use\<ApiName>.tsx Add a hook for instantiating an API client which can call your API.
 - project.json A new target is added to the build which generates a type-safe client
 - .gitignore The generated client files are ignored by default
 
@@ -77,7 +82,7 @@ The generator will also add Runtime Config to your website infrastructure if not
 
 ### Code Generation
 
-At build time, a type-safe client is generated from your FastAPI's OpenAPI specification. This will add two new files to your React application:
+At build time, a type-safe client is generated from your FastAPI's OpenAPI specification. This will add three new files to your React application:
 
 <FileTree>
 
@@ -86,6 +91,7 @@ At build time, a type-safe client is generated from your FastAPI's OpenAPI speci
     - \<ApiName>
       - types.gen.ts Generated types from the pydantic models defined in your FastAPI
       - client.gen.ts Type-safe client for calling your API
+      - options-proxy.gen.ts Provides methods to create TanStack Query hooks options for interacting with your API using TanStack Query
 
 </FileTree>
 
@@ -95,7 +101,7 @@ By default, the generated client is ignored from version control. If you would p
 
 ## Using the Generated Code
 
-The generated type-safe client can be used to call your FastAPI from your React application.
+The generated type-safe client can be used to call your FastAPI from your React application. It's recommended to make use of the client via the TanStack Query hooks, but you can use the vanilla client if you prefer.
 
 :::note
 Whenever you make changes to your FastAPI, you need to rebuild your project in order for those changes to be reflected in the generated client. For example:
@@ -116,14 +122,35 @@ If you're actively working on both your React application and FastAPI together, 
 
 ### Using the API Hook
 
-The generator provides a `use<ApiName>` hook that gives you access to the type-safe API client:
+The generator provides a `use<ApiName>` hook which you can use to call your API with TanStack Query.
 
-```tsx {5,13}
+### Queries
+
+You can use the `queryOptions` method to retrieve the options required for calling your API using TanStack Query's `useQuery` hook:
+
+```tsx {7}
+import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { useMyApi } from './hooks/useMyApi';
 
 function MyComponent() {
   const api = useMyApi();
+  const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
+
+  if (item.isLoading) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {item.error.message}</div>;
+
+  return <div>Item: {item.data.name}</div>;
+}
+```
+
+<Drawer title="Using the API client directly" trigger="Click here for an example using the vanilla client directly.">
+```tsx {5,13}
+import { useState, useEffect } from 'react';
+import { useMyApiClient } from './hooks/useMyApiClient';
+
+function MyComponent() {
+  const api = useMyApiClient();
   const [item, setItem] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -148,14 +175,338 @@ function MyComponent() {
   return <div>Item: {item.name}</div>;
 }
 ```
+</Drawer>
+
+### Mutations
+
+The generated hooks include support for mutations using TanStack Query's `useMutation` hook. This provides a clean way to handle create, update, and delete operations with loading states, error handling, and optimistic updates.
+
+```tsx {5-7,11}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function CreateItemForm() {
+  const api = useMyApi();
+  // Create a mutation using the generated mutation options
+  const createItem = useMutation(api.createItem.mutationOptions());
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    createItem.mutate({ name: 'New Item', description: 'A new item' });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* Form fields */}
+      <button
+        type="submit"
+        disabled={createItem.isPending}
+      >
+        {createItem.isPending ? 'Creating...' : 'Create Item'}
+      </button>
+
+      {createItem.isSuccess && (
+        <div className="success">
+          Item created with ID: {createItem.data.id}
+        </div>
+      )}
+
+      {createItem.isError && (
+        <div className="error">
+          Error: {createItem.error.message}
+        </div>
+      )}
+    </form>
+  );
+}
+```
+
+You can also add callbacks for different mutation states:
+
+```tsx
+const createItem = useMutation({
+  ...api.createItem.mutationOptions(),
+  onSuccess: (data) => {
+    // This will run when the mutation succeeds
+    console.log('Item created:', data);
+    // You can navigate to the new item
+    navigate(`/items/${data.id}`);
+  },
+  onError: (error) => {
+    // This will run when the mutation fails
+    console.error('Failed to create item:', error);
+  },
+  onSettled: () => {
+    // This will run when the mutation completes (success or error)
+    // Good place to invalidate queries that might be affected
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+  }
+});
+```
+
+<Drawer title="Mutations using the API client directly" trigger="Click here for an example using the client directly.">
+```tsx
+import { useState } from 'react';
+import { useMyApiClient } from './hooks/useMyApiClient';
+
+function CreateItemForm() {
+  const api = useMyApiClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [createdItem, setCreatedItem] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const newItem = await api.createItem({
+        name: 'New Item',
+        description: 'A new item'
+      });
+      setCreatedItem(newItem);
+      // You can navigate to the new item
+      // navigate(`/items/${newItem.id}`);
+    } catch (err) {
+      setError(err);
+      console.error('Failed to create item:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* Form fields */}
+      <button
+        type="submit"
+        disabled={isLoading}
+      >
+        {isLoading ? 'Creating...' : 'Create Item'}
+      </button>
+
+      {createdItem && (
+        <div className="success">
+          Item created with ID: {createdItem.id}
+        </div>
+      )}
+
+      {error && (
+        <div className="error">
+          Error: {error.message}
+        </div>
+      )}
+    </form>
+  );
+}
+```
+</Drawer>
+
+### Pagination with Infinite Queries
+
+For endpoints that accept a `cursor` parameter as input, the generated hooks provide support for infinite queries using TanStack Query's `useInfiniteQuery` hook. This makes it easy to implement "load more" or infinite scrolling functionality.
+
+```tsx {5-14,24-26}
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function ItemList() {
+  const api = useMyApi();
+  const items = useInfiniteQuery({
+    ...api.listItems.infiniteQueryOptions({
+      limit: 10, // Number of items per page
+    }, {
+      // Make sure you define a getNextPageParam function to return
+      // the parameter that should be passed as the 'cursor' for the
+      // next page
+      getNextPageParam: (lastPage) =>
+        lastPage.nextCursor || undefined
+      }),
+  });
+
+  if (items.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (items.isError) {
+    return <ErrorMessage message={items.error.message} />;
+  }
+
+  return (
+    <div>
+      {/* Flatten the pages array to render all items */}
+      <ul>
+        {items.data.pages.flatMap(page =>
+          page.items.map(item => (
+            <li key={item.id}>{item.name}</li>
+          ))
+        )}
+      </ul>
+
+      <button
+        onClick={() => items.fetchNextPage()}
+        disabled={!items.hasNextPage || items.isFetchingNextPage}
+      >
+        {items.isFetchingNextPage
+          ? 'Loading more...'
+          : items.hasNextPage
+          ? 'Load More'
+          : 'No more items'}
+      </button>
+    </div>
+  );
+}
+```
+
+The generated hooks automatically handle cursor-based pagination if your API supports it. The `nextCursor` value is extracted from the response and used to fetch the next page.
+
+:::tip
+If you have a paginated API which has its pagination parameter named something other than `cursor`, you can [customise it using the `x-cursor` OpenAPI vendor extension](#custom-pagination-cursor).
+:::
+
+<Drawer title="Pagination using the API client directly" trigger="Click here for an example using the client directly.">
+```tsx
+import { useState, useEffect } from 'react';
+import { useMyApiClient } from './hooks/useMyApiClient';
+
+function ItemList() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [nextCursor, setNextCursor] = useState(null);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+
+  // Fetch initial data
+  useEffect(() => {
+    const fetchItems = async () => {
+      try {
+        setIsLoading(true);
+        const response = await api.listItems({ limit: 10 });
+        setItems(response.items);
+        setNextCursor(response.nextCursor);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchItems();
+  }, [api]);
+
+  // Function to load more items
+  const loadMore = async () => {
+    if (!nextCursor) return;
+
+    try {
+      setIsFetchingMore(true);
+      const response = await api.listItems({
+        limit: 10,
+        cursor: nextCursor
+      });
+
+      setItems(prevItems => [...prevItems, ...response.items]);
+      setNextCursor(response.nextCursor);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setIsFetchingMore(false);
+    }
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error.message} />;
+  }
+
+  return (
+    <div>
+      <ul>
+        {items.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+
+      <button
+        onClick={loadMore}
+        disabled={!nextCursor || isFetchingMore}
+      >
+        {isFetchingMore
+          ? 'Loading more...'
+          : nextCursor
+          ? 'Load More'
+          : 'No more items'}
+      </button>
+    </div>
+  );
+}
+```
+</Drawer>
 
 ### Error Handling
 
 The integration includes built-in error handling with typed error responses. An `<operation-name>Error` type is generated which encapsulates the possible error responses defined in the OpenAPI specification. Each error has a `status` and `error` property, and by checking the value of `status` you can narrow to a specific type of error.
 
-```tsx {9,15}
+```tsx {12}
+import { useMutation } from '@tanstack/react-query';
+
 function MyComponent() {
   const api = useMyApi();
+  const createItem = useMutation(api.createItem.mutationOptions());
+
+  const handleClick = () => {
+    createItem.mutate({ name: 'New Item' });
+  };
+
+  if (createItem.error) {
+    switch (createItem.error.status) {
+      case 400:
+        // error.error is typed as CreateItem400Response
+        return (
+          <div>
+            <h2>Invalid input:</h2>
+            <p>{createItem.error.error.message}</p>
+            <ul>
+              {createItem.error.error.validationErrors.map((err) => (
+                <li key={err.field}>{err.message}</li>
+              ))}
+            </ul>
+          </div>
+        );
+      case 403:
+        // error.error is typed as CreateItem403Response
+        return (
+          <div>
+            <h2>Not authorized:</h2>
+            <p>{createItem.error.error.reason}</p>
+          </div>
+        );
+      case 500:
+      case 502:
+        // error.error is typed as CreateItem5XXResponse
+        return (
+          <div>
+            <h2>Server error:</h2>
+            <p>{createItem.error.error.message}</p>
+            <p>Trace ID: {createItem.error.error.traceId}</p>
+          </div>
+        );
+    }
+  }
+
+  return <button onClick={handleClick}>Create Item</button>;
+}
+```
+
+<Drawer title="Error handling using the API client directly" trigger="Click here for an example using the vanilla client directly.">
+```tsx {9,15}
+function MyComponent() {
+  const api = useMyApiClient();
   const [error, setError] = useState<CreateItemError | null>(null);
 
   const handleClick = async () => {
@@ -206,8 +557,60 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+</Drawer>
 
 ### Consuming a Stream
+
+If you have [configured your FastAPI to stream responses](/nx-plugin-for-aws/guides/fastapi#streaming), your `useQuery` hook will automatically update its data as new chunks of the stream arrive.
+
+For example:
+
+```tsx {3}
+function MyStreamingComponent() {
+  const api = useMyApi();
+  const stream = useQuery(api.myStream.queryOptions());
+
+  return (
+    <ul>
+      {(stream.data ?? []).map((chunk) => (
+        <li>
+          {chunk.timestamp.toISOString()}: {chunk.message}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+You can use the `isLoading` and `fetchStatus` properties to determine the current state of the stream if necessary. A stream follows this lifecycle:
+
+<Steps>
+  1. The HTTP request to start streaming is sent
+
+      - `isLoading` is `true`
+      - `fetchStatus` is `'fetching'`
+      - `data` is `undefined`
+
+  2. The first chunk of the stream is received
+
+      - `isLoading` becomes `false`
+      - `fetchStatus` remains `'fetching'`
+      - `data` becomes an array containing the first chunk
+
+  3. Subsequent chunks are received
+
+      - `isLoading` remains `false`
+      - `fetchStatus` remains `'fetching'`
+      - `data` is updated with each subsequent chunk as soon as it is received
+
+  4. The stream completes
+
+      - `isLoading` remains `false`
+      - `fetchStatus` becomes `'idle'`
+      - `data` is an array of all received chunks
+</Steps>
+
+<Drawer title="Streaming using the API client directly" trigger="Click here for an example using the vanilla client directly.">
 
 If you have [configured your FastAPI to stream responses](/nx-plugin-for-aws/guides/fastapi#streaming), the generated client will include type-safe methods for asynchronously iterating over chunks in your stream using `for await` syntax.
 
@@ -215,7 +618,7 @@ For example:
 
 ```tsx {8}
 function MyStreamingComponent() {
-  const api = useMyApi();
+  const api = useMyApiClient();
 
   const [chunks, setChunks] = useState<Chunk[]>([]);
 
@@ -239,6 +642,489 @@ function MyStreamingComponent() {
   );
 }
 ```
+</Drawer>
+
+:::note
+If you have a streaming API which accepts a `cursor` parameter, when using the `useInfiniteQuery` hook, each page will wait for the stream to finish before it has been loaded.
+:::
+
+## Customising the Generated Code
+
+### Queries and Mutations
+
+By default, operations in your FastAPI which use the HTTP methods `PUT`, `POST`, `PATCH` and `DELETE` are considered mutations, and all others are considered queries.
+
+You can change this behaviour using `x-query` and `x-mutation`.
+
+#### x-query
+
+```python
+@app.post(
+    "/items",
+    openapi_extra={
+        "x-query": True
+    }
+)
+def list_items():
+    # ...
+```
+
+The generated hook will provide `queryOptions` even though it uses the `POST` HTTP method:
+
+```tsx
+const items = useQuery(api.listItems.queryOptions());
+```
+
+#### x-mutation
+
+```python
+@app.get(
+    "/start-processing",
+    openapi_extra={
+        "x-mutation": True
+    }
+)
+def start_processing():
+    # ...
+```
+
+The generated hook will provide `mutationOptions` even though it uses the `GET` HTTP method:
+
+```tsx
+// Generated hook will include the custom options
+const startProcessing = useMutation(api.startProcessing.mutationOptions());
+```
+
+### Custom Pagination Cursor
+
+By default, the generated hooks assume cursor-based pagination with a parameter named `cursor`. You can customize this behavior using the `x-cursor` extension:
+
+```python
+@app.get(
+    "/items",
+    openapi_extra={
+        # Specify a different parameter name for the cursor
+        "x-cursor": "page_token"
+    }
+)
+def list_items(page_token: str = None, limit: int = 10):
+    # ...
+    return {
+        "items": items,
+        "page_token": next_page_token  # The response must include the cursor with the same name
+    }
+```
+
+If you would not like to generate `infiniteQueryOptions` for an operation, you can set `x-cursor` to `False`:
+
+```python
+@app.get(
+    "/items",
+    openapi_extra={
+        # Disable cursor-based pagination for this endpoint
+        "x-cursor": False
+    }
+)
+def list_items(page: int = 1, limit: int = 10):
+    # ...
+    return {
+        "items": items,
+        "total": total_count,
+        "page": page,
+        "pages": total_pages
+    }
+```
+
+### Grouping Operations
+
+The generated hooks and client methods are automatically organized based on the OpenAPI tags in your FastAPI endpoints. This helps keep your API calls organized and makes it easier to find related operations.
+
+For example:
+
+```python title="items.py"
+@app.get(
+    "/items",
+    tags=["items"],
+)
+def list():
+    # ...
+
+@app.post(
+    "/items",
+    tags=["items"],
+)
+def create(item: Item):
+    # ...
+```
+
+```python title="users.py"
+@app.get(
+    "/users",
+    tags=["users"],
+)
+def list():
+    # ...
+```
+
+The generated hooks will be grouped by these tags:
+
+```tsx
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function ItemsAndUsers() {
+  const api = useMyApi();
+
+  // Items operations are grouped under api.items
+  const items = useQuery(api.items.list.queryOptions());
+  const createItem = useMutation(api.items.create.mutationOptions());
+
+  // Users operations are grouped under api.users
+  const users = useQuery(api.users.list.queryOptions());
+
+  // Usage example
+  const handleCreateItem = () => {
+    createItem.mutate({ name: 'New Item' });
+  };
+
+  return (
+    <div>
+      <h2>Items</h2>
+      <ul>
+        {items.data?.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+      <button onClick={handleCreateItem}>Add Item</button>
+
+      <h2>Users</h2>
+      <ul>
+        {users.data?.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+This grouping makes it easier to organize your API calls and provides better code completion in your IDE.
+
+<Drawer title="Grouped operations using the API client directly" trigger="Click here for an example using the client directly.">
+```tsx
+import { useState, useEffect } from 'react';
+import { useMyApiClient } from './hooks/useMyApiClient';
+
+function ItemsAndUsers() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load data
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+
+        // Items operations are grouped under api.items
+        const itemsData = await api.items.list();
+        setItems(itemsData);
+
+        // Users operations are grouped under api.users
+        const usersData = await api.users.list();
+        setUsers(usersData);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [api]);
+
+  const handleCreateItem = async () => {
+    try {
+      // Create item using the grouped method
+      const newItem = await api.items.create({ name: 'New Item' });
+      setItems(prevItems => [...prevItems, newItem]);
+    } catch (error) {
+      console.error('Error creating item:', error);
+    }
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Items</h2>
+      <ul>
+        {items.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+      <button onClick={handleCreateItem}>Add Item</button>
+
+      <h2>Users</h2>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+</Drawer>
+
+### Errors
+
+You can customize error responses in your FastAPI by defining custom exception classes, exception handlers, and specifying response models for different error status codes. The generated client will automatically handle these custom error types.
+
+#### Defining Custom Error Models
+
+First, define your error models using Pydantic:
+
+```python title="models.py"
+from pydantic import BaseModel
+
+class ErrorDetails(BaseModel):
+    message: str
+
+class ValidationError(BaseModel):
+    message: str
+    field_errors: list[str]
+```
+
+#### Creating Custom Exceptions
+
+Then create custom exception classes for different error scenarios:
+
+```python title="exceptions.py"
+class NotFoundException(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+class ValidationException(Exception):
+    def __init__(self, details: ValidationError):
+        self.details = details
+```
+
+#### Adding Exception Handlers
+
+Register exception handlers to convert your exceptions to HTTP responses:
+
+```python title="main.py"
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+@app.exception_handler(NotFoundException)
+async def not_found_handler(request: Request, exc: NotFoundException):
+    return JSONResponse(
+        status_code=404,
+        content=exc.message,
+    )
+
+@app.exception_handler(ValidationException)
+async def validation_error_handler(request: Request, exc: ValidationException):
+    return JSONResponse(
+        status_code=400,
+        content=exc.details.model_dump(),
+    )
+```
+
+:::tip
+The `JSONResponse` accepts a dictionary, so we use our Pydantic model's `model_dump` method.
+:::
+
+#### Specifying Response Models
+
+Finally, specify the response models for different error status codes in your endpoint definitions:
+
+```python title="main.py"
+@app.get(
+    "/items/{item_id}",
+    responses={
+        404: {"model": str}
+        500: {"model": ErrorDetails}
+    }
+)
+def get_item(item_id: str) -> Item:
+    item = find_item(item_id)
+    if not item:
+        raise NotFoundException(message=f"Item with ID {item_id} not found")
+    return item
+
+@app.post(
+    "/items",
+    responses={
+        400: {"model": ValidationError},
+        403: {"model": str}
+    }
+)
+def create_item(item: Item) -> Item:
+    if not is_valid(item):
+        raise ValidationException(
+            ValidationError(
+                message="Invalid item data",
+                field_errors=["name is required"]
+            )
+        )
+    return save_item(item)
+```
+
+#### Using Custom Error Types in React
+
+The generated client will automatically handle these custom error types, allowing you to type-check and handle different error responses:
+
+```tsx
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+function ItemComponent() {
+  const api = useMyApi();
+
+  // Query with typed error handling
+  const getItem = useQuery({
+    ...api.getItem.queryOptions({ itemId: '123' }),
+    onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
+      switch (error.status) {
+        case 404:
+          // error.error is a string as specified in the responses
+          console.error('Not found:', error.error);
+          break;
+        case 500:
+          // error.error is typed as ErrorDetails
+          console.error('Server error:', error.error.message);
+          break;
+      }
+    }
+  });
+
+  // Mutation with typed error handling
+  const createItem = useMutation({
+    ...api.createItem.mutationOptions(),
+    onError: (error) => {
+      switch (error.status) {
+        case 400:
+          // error.error is typed as ValidationError
+          console.error('Validation error:', error.error.message);
+          console.error('Field errors:', error.error.field_errors);
+          break;
+        case 403:
+          // error.error is a string as specified in the responses
+          console.error('Forbidden:', error.error);
+          break;
+      }
+    }
+  });
+
+  // Component rendering with error handling
+  if (getItem.isError) {
+    if (getItem.error.status === 404) {
+      return <NotFoundMessage message={getItem.error.error} />;
+    } else {
+      return <ErrorMessage message={getItem.error.error.message} />;
+    }
+  }
+
+  return (
+    <div>
+      {/* Component content */}
+    </div>
+  );
+}
+```
+
+<Drawer title="Handling custom errors with the client directly" trigger="Click here for an example using the client directly.">
+```tsx
+import { useState, useEffect } from 'react';
+
+function ItemComponent() {
+  const api = useMyApiClient();
+  const [item, setItem] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch item with error handling
+  useEffect(() => {
+    const fetchItem = async () => {
+      try {
+        setLoading(true);
+        const data = await api.getItem({ itemId: '123' });
+        setItem(data);
+      } catch (e) {
+        // Error is typed based on the responses in your FastAPI
+        const err = e as GetItemError;
+        setError(err);
+
+        switch (err.status) {
+          case 404:
+            // err.error is a string as specified in the responses
+            console.error('Not found:', err.error);
+            break;
+          case 500:
+            // err.error is typed as ErrorDetails
+            console.error('Server error:', err.error.message);
+            break;
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItem();
+  }, [api]);
+
+  // Create item with error handling
+  const handleCreateItem = async (data) => {
+    try {
+      await api.createItem(data);
+    } catch (e) {
+      const err = e as CreateItemError;
+
+      switch (err.status) {
+        case 400:
+          // err.error is typed as ValidationError
+          console.error('Validation error:', err.error.message);
+          console.error('Field errors:', err.error.field_errors);
+          break;
+        case 403:
+          // err.error is a string as specified in the responses
+          console.error('Forbidden:', err.error);
+          break;
+      }
+    }
+  };
+
+  // Component rendering with error handling
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    if (error.status === 404) {
+      return <NotFoundMessage message={error.error} />;
+    } else if (error.status === 500) {
+      return <ErrorMessage message={error.error.message} />;
+    }
+  }
+
+  return (
+    <div>
+      {/* Component content */}
+    </div>
+  );
+}
+```
+</Drawer>
+
+:::tip
+When defining error responses in FastAPI, always use the `responses` parameter to specify the model for each status code. This ensures that the generated client will have proper type information for error handling.
+:::
 
 ## Best Practices
 
@@ -247,8 +1133,50 @@ function MyStreamingComponent() {
 Always handle loading and error states for a better user experience:
 
 ```tsx
+import { useQuery } from '@tanstack/react-query';
+
 function ItemList() {
   const api = useMyApi();
+  const items = useQuery(api.listItems.queryOptions());
+
+  if (items.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (items.isError) {
+    const err = items.error;
+    switch (err.status) {
+      case 403:
+        // err.error is typed as ListItems403Response
+        return <ErrorMessage message={err.error.reason} />;
+      case 500:
+      case 502:
+        // err.error is typed as ListItems5XXResponse
+        return (
+          <ErrorMessage
+            message={err.error.message}
+            details={`Trace ID: ${err.error.traceId}`}
+          />
+        );
+      default:
+        return <ErrorMessage message="An unknown error occurred" />;
+    }
+  }
+
+  return (
+    <ul>
+      {items.data.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+<Drawer title="Handle loading states using the API client directly" trigger="Click here for an example using the vanilla client directly.">
+```tsx
+function ItemList() {
+  const api = useMyApiClient();
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -300,14 +1228,82 @@ function ItemList() {
   );
 }
 ```
+</Drawer>
 
 ### Optimistic Updates
 
 Implement optimistic updates for a better user experience:
 
 ```tsx
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
 function ItemList() {
   const api = useMyApi();
+  const queryClient = useQueryClient();
+
+  // Query to fetch items
+  const itemsQuery = useQuery(api.listItems.queryOptions());
+
+  // Mutation for deleting items with optimistic updates
+  const deleteMutation = useMutation({
+    ...api.deleteItem.mutationOptions(),
+    onMutate: async (itemId) => {
+      // Cancel any outgoing refetches
+      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+
+      // Snapshot the previous value
+      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+
+      // Optimistically update to the new value
+      queryClient.setQueryData(
+        api.listItems.queryKey(),
+        (old) => old.filter((item) => item.id !== itemId)
+      );
+
+      // Return a context object with the snapshot
+      return { previousItems };
+    },
+    onError: (err, itemId, context) => {
+      // If the mutation fails, use the context returned from onMutate to roll back
+      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      console.error('Failed to delete item:', err);
+    },
+    onSettled: () => {
+      // Always refetch after error or success to ensure data is in sync with server
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    },
+  });
+
+  if (itemsQuery.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (itemsQuery.isError) {
+    return <ErrorMessage message="Failed to load items" />;
+  }
+
+  return (
+    <ul>
+      {itemsQuery.data.map((item) => (
+        <li key={item.id}>
+          {item.name}
+          <button
+            onClick={() => deleteMutation.mutate(item.id)}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+<Drawer title="Optimistic updates using the API client directly" trigger="Click here for an example using the vanilla client directly.">
+```tsx
+function ItemList() {
+  const api = useMyApiClient();
   const [items, setItems] = useState([]);
 
   const handleDelete = async (itemId) => {
@@ -336,14 +1332,75 @@ function ItemList() {
   );
 }
 ```
+</Drawer>
 
 ## Type Safety
 
 The integration provides complete end-to-end type safety. Your IDE will provide full autocompletion and type checking for all your API calls:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function ItemForm() {
   const api = useMyApi();
+
+  // Type-safe mutation for creating items
+  const createItem = useMutation({
+    ...api.createItem.mutationOptions(),
+    // ✅ Type error if onSuccess callback doesn't handle the correct response type
+    onSuccess: (data) => {
+      // data is fully typed based on your API's response schema
+      console.log(`Item created with ID: ${data.id}`);
+    },
+  });
+
+  const handleSubmit = (data: CreateItemInput) => {
+    // ✅ Type error if input doesn't match schema
+    createItem.mutate(data);
+  };
+
+  // Error UI can use type narrowing to handle different error types
+  if (createItem.error) {
+    const error = createItem.error;
+    switch (error.status) {
+      case 400:
+        // error.error is typed as CreateItem400Response
+        return (
+          <FormError
+            message="Invalid input"
+            errors={error.error.validationErrors}
+          />
+        );
+      case 403:
+        // error.error is typed as CreateItem403Response
+        return <AuthError reason={error.error.reason} />;
+      default:
+        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        return <ServerError message={error.error.message} />;
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault();
+      handleSubmit({ name: 'New Item' });
+    }}>
+      {/* Form fields */}
+      <button
+        type="submit"
+        disabled={createItem.isPending}
+      >
+        {createItem.isPending ? 'Creating...' : 'Create Item'}
+      </button>
+    </form>
+  );
+}
+```
+
+<Drawer title="Type safety using the API client directly" trigger="Click here for an example using the vanilla client directly.">
+```tsx
+function ItemForm() {
+  const api = useMyApiClient();
   const [error, setError] = useState<CreateItemError | null>(null);
 
   const handleSubmit = async (data: CreateItemInput) => {
@@ -397,5 +1454,6 @@ function ItemForm() {
   return <form onSubmit={handleSubmit}>{/* ... */}</form>;
 }
 ```
+</Drawer>
 
 The types are automatically generated from your FastAPI's OpenAPI schema, ensuring that any changes to your API are reflected in your frontend code after a build.

--- a/docs/src/content/docs/guides/fastapi.mdx
+++ b/docs/src/content/docs/guides/fastapi.mdx
@@ -150,6 +150,10 @@ Unhandled exceptions are caught by the middleware and:
 3. Return a safe 500 response to the client
 4. Preserve the correlation ID
 
+:::tip
+It's recommended to specify response models for your API operations for better code generation if using the `api-connection` generator. [See here for more details](/nx-plugin-for-aws/guides/api-connection/react-fastapi#errors).
+:::
+
 ### Streaming
 
 With FastAPI, you can stream a response to the caller with the [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) response type.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@phenomnomnominal/tsquery": "6.1.3",
     "@quantco/pnpm-licenses": "^2.1.0",
     "@tailwindcss/vite": "^4.0.9",
+    "@tanstack/react-query": "^5.59.20",
+    "@testing-library/react": "^16.2.0",
     "@ts-morph/bootstrap": "^0.26.1",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash.camelcase": "^4.3.9",

--- a/packages/nx-plugin/.eslintrc.json
+++ b/packages/nx-plugin/.eslintrc.json
@@ -26,7 +26,7 @@
         "@nx/dependency-checks": [
           "error",
           {
-            "ignoredFiles": ["**/*.spec.ts"]
+            "ignoredFiles": ["**/*.spec.ts", "**/*.spec.tsx"]
           }
         ]
       }

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -360,7 +360,7 @@ export class <%- className %> {
   private $fetch: typeof fetch = (...args) => (this.$config.fetch ?? fetch)(...args);
   <%_ allOperations.forEach((op) => { _%>
   <%_ const hasTag = op.tags && op.tags.length > 0; _%>
-  <%_ const isStreaming = (op.vendorExtensions ?? {})['x-streaming']; _%>
+  <%_ const isStreaming = op.isStreaming; _%>
   <%_ const isInputOptional = (op.parameters.length === 1 && op.parametersBody && !op.parametersBody.isRequired) || op.parameters.length === 0; _%>
 
 <%- docString(op, '  ') %>  <%- hasTag ? 'private' : 'public' %> async <% if (isStreaming) { %>*<% } %><%- hasTag ? '_' : '' %><%- op.uniqueName %>(<% if (op.parameters.length > 0) { %>input<%- isInputOptional ? '?' : '' %>: <%- op.operationIdPascalCase %>Request<% } %>): <%- isStreaming ? 'AsyncIterableIterator' : 'Promise' %><<%- op.result ? op.result.typescriptType : 'void' %>> {

--- a/packages/nx-plugin/src/open-api/ts-hooks/__snapshots__/generator.spec.tsx.snap
+++ b/packages/nx-plugin/src/open-api/ts-hooks/__snapshots__/generator.spec.tsx.snap
@@ -1,0 +1,1092 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsHooksGenerator > should generate an options proxy for a mutation operation 1`] = `
+"import type { UseMutationOptions } from '@tanstack/react-query';
+import type {
+  CreateUserRequest,
+  CreateUserError,
+  CreateUser201Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._createUserMutationKey = this._createUserMutationKey.bind(this);
+    this._createUserMutationOptions =
+      this._createUserMutationOptions.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _createUserMutationKey() {
+    return [...this.queryKey(), 'createUser'];
+  }
+  private _createUserMutationOptions(
+    options?: UseMutationOptions<
+      CreateUser201Response,
+      CreateUserError,
+      CreateUserRequest
+    >,
+  ): UseMutationOptions<
+    CreateUser201Response,
+    CreateUserError,
+    CreateUserRequest
+  > {
+    return {
+      mutationFn: (input) => this.$client.createUser(input),
+      mutationKey: this._createUserMutationKey(),
+      ...options,
+    };
+  }
+
+  public createUser = {
+    mutationKey: this._createUserMutationKey.bind(this),
+    mutationOptions: this._createUserMutationOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should generate an options proxy for a query operation 1`] = `
+"import type { QueryFilters, UseQueryOptions } from '@tanstack/react-query';
+import type { GetTestError, GetTest200Response } from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._getTestQueryKey = this._getTestQueryKey.bind(this);
+    this._getTestQueryOptions = this._getTestQueryOptions.bind(this);
+    this._getTestQueryFilter = this._getTestQueryFilter.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _getTestQueryKey() {
+    return [...this.queryKey(), 'getTest'];
+  }
+  private _getTestQueryOptions(
+    options?: Omit<
+      UseQueryOptions<GetTest200Response, GetTestError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<GetTest200Response, GetTestError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<GetTest200Response, GetTestError> {
+    return {
+      queryFn: () => this.$client.getTest(),
+      queryKey: this._getTestQueryKey(),
+      ...options,
+    };
+  }
+  private _getTestQueryFilter(
+    filter?: QueryFilters<GetTest200Response, GetTestError>,
+  ): QueryFilters<GetTest200Response, GetTestError> {
+    return {
+      queryKey: this._getTestQueryKey(),
+      ...filter,
+    };
+  }
+
+  public getTest = {
+    queryKey: this._getTestQueryKey.bind(this),
+    queryOptions: this._getTestQueryOptions.bind(this),
+    queryFilter: this._getTestQueryFilter.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should generate an options proxy for a successful infinite query operation 1`] = `
+"import type {
+  QueryFilters,
+  UseQueryOptions,
+  UseInfiniteQueryOptions,
+  InfiniteData,
+} from '@tanstack/react-query';
+import type {
+  GetItemsRequest,
+  GetItemsError,
+  GetItems200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._getItemsQueryKey = this._getItemsQueryKey.bind(this);
+    this._getItemsQueryOptions = this._getItemsQueryOptions.bind(this);
+    this._getItemsQueryFilter = this._getItemsQueryFilter.bind(this);
+    this._getItemsInfiniteQueryOptions =
+      this._getItemsInfiniteQueryOptions.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _getItemsQueryKey(input: GetItemsRequest) {
+    return [...this.queryKey(), 'getItems', input];
+  }
+  private _getItemsQueryOptions(
+    input: GetItemsRequest,
+    options?: Omit<
+      UseQueryOptions<GetItems200Response, GetItemsError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<GetItems200Response, GetItemsError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<GetItems200Response, GetItemsError> {
+    return {
+      queryFn: () => this.$client.getItems(input),
+      queryKey: this._getItemsQueryKey(input),
+      ...options,
+    };
+  }
+  private _getItemsQueryFilter(
+    input: GetItemsRequest,
+    filter?: QueryFilters<GetItems200Response, GetItemsError>,
+  ): QueryFilters<GetItems200Response, GetItemsError> {
+    return {
+      queryKey: this._getItemsQueryKey(input),
+      ...filter,
+    };
+  }
+  private _getItemsInfiniteQueryOptions(
+    input: GetItemsRequest,
+    options: Omit<
+      UseInfiniteQueryOptions<
+        GetItems200Response,
+        GetItemsError,
+        InfiniteData<GetItems200Response>,
+        GetItems200Response,
+        unknown[],
+        string | undefined | null
+      >,
+      'queryFn' | 'queryKey' | 'initialPageParam'
+    > &
+      Partial<
+        Pick<
+          UseInfiniteQueryOptions<
+            GetItems200Response,
+            GetItemsError,
+            InfiniteData<GetItems200Response>,
+            GetItems200Response,
+            unknown[],
+            string | undefined | null
+          >,
+          'queryFn' | 'queryKey' | 'initialPageParam'
+        >
+      >,
+  ): UseInfiniteQueryOptions<
+    GetItems200Response,
+    GetItemsError,
+    InfiniteData<GetItems200Response>,
+    GetItems200Response,
+    unknown[],
+    string | undefined | null
+  > {
+    return {
+      queryKey: this._getItemsQueryKey(input),
+      queryFn: ({ pageParam }) =>
+        this.$client.getItems({ ...input, cursor: pageParam as any }),
+      initialPageParam: undefined,
+      ...options,
+    };
+  }
+
+  public getItems = {
+    queryKey: this._getItemsQueryKey.bind(this),
+    queryOptions: this._getItemsQueryOptions.bind(this),
+    queryFilter: this._getItemsQueryFilter.bind(this),
+    infiniteQueryOptions: this._getItemsInfiniteQueryOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle GET operation with x-mutation: true correctly 1`] = `
+"import type { UseMutationOptions } from '@tanstack/react-query';
+import type {
+  TriggerActionRequest,
+  TriggerActionError,
+  TriggerAction200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._triggerActionMutationKey = this._triggerActionMutationKey.bind(this);
+    this._triggerActionMutationOptions =
+      this._triggerActionMutationOptions.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _triggerActionMutationKey() {
+    return [...this.queryKey(), 'triggerAction'];
+  }
+  private _triggerActionMutationOptions(
+    options?: UseMutationOptions<
+      TriggerAction200Response,
+      TriggerActionError,
+      TriggerActionRequest
+    >,
+  ): UseMutationOptions<
+    TriggerAction200Response,
+    TriggerActionError,
+    TriggerActionRequest
+  > {
+    return {
+      mutationFn: (input) => this.$client.triggerAction(input),
+      mutationKey: this._triggerActionMutationKey(),
+      ...options,
+    };
+  }
+
+  public triggerAction = {
+    mutationKey: this._triggerActionMutationKey.bind(this),
+    mutationOptions: this._triggerActionMutationOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle POST operation with x-query: true correctly 1`] = `
+"import type { QueryFilters, UseQueryOptions } from '@tanstack/react-query';
+import type {
+  SearchDataRequest,
+  SearchDataError,
+  SearchData200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._searchDataQueryKey = this._searchDataQueryKey.bind(this);
+    this._searchDataQueryOptions = this._searchDataQueryOptions.bind(this);
+    this._searchDataQueryFilter = this._searchDataQueryFilter.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _searchDataQueryKey(input: SearchDataRequest) {
+    return [...this.queryKey(), 'searchData', input];
+  }
+  private _searchDataQueryOptions(
+    input: SearchDataRequest,
+    options?: Omit<
+      UseQueryOptions<SearchData200Response, SearchDataError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<SearchData200Response, SearchDataError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<SearchData200Response, SearchDataError> {
+    return {
+      queryFn: () => this.$client.searchData(input),
+      queryKey: this._searchDataQueryKey(input),
+      ...options,
+    };
+  }
+  private _searchDataQueryFilter(
+    input: SearchDataRequest,
+    filter?: QueryFilters<SearchData200Response, SearchDataError>,
+  ): QueryFilters<SearchData200Response, SearchDataError> {
+    return {
+      queryKey: this._searchDataQueryKey(input),
+      ...filter,
+    };
+  }
+
+  public searchData = {
+    queryKey: this._searchDataQueryKey.bind(this),
+    queryOptions: this._searchDataQueryOptions.bind(this),
+    queryFilter: this._searchDataQueryFilter.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle infinite query errors correctly 1`] = `
+"import type {
+  QueryFilters,
+  UseQueryOptions,
+  UseInfiniteQueryOptions,
+  InfiniteData,
+} from '@tanstack/react-query';
+import type {
+  GetItemsRequest,
+  GetItemsError,
+  GetItems200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._getItemsQueryKey = this._getItemsQueryKey.bind(this);
+    this._getItemsQueryOptions = this._getItemsQueryOptions.bind(this);
+    this._getItemsQueryFilter = this._getItemsQueryFilter.bind(this);
+    this._getItemsInfiniteQueryOptions =
+      this._getItemsInfiniteQueryOptions.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _getItemsQueryKey(input: GetItemsRequest) {
+    return [...this.queryKey(), 'getItems', input];
+  }
+  private _getItemsQueryOptions(
+    input: GetItemsRequest,
+    options?: Omit<
+      UseQueryOptions<GetItems200Response, GetItemsError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<GetItems200Response, GetItemsError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<GetItems200Response, GetItemsError> {
+    return {
+      queryFn: () => this.$client.getItems(input),
+      queryKey: this._getItemsQueryKey(input),
+      ...options,
+    };
+  }
+  private _getItemsQueryFilter(
+    input: GetItemsRequest,
+    filter?: QueryFilters<GetItems200Response, GetItemsError>,
+  ): QueryFilters<GetItems200Response, GetItemsError> {
+    return {
+      queryKey: this._getItemsQueryKey(input),
+      ...filter,
+    };
+  }
+  private _getItemsInfiniteQueryOptions(
+    input: GetItemsRequest,
+    options: Omit<
+      UseInfiniteQueryOptions<
+        GetItems200Response,
+        GetItemsError,
+        InfiniteData<GetItems200Response>,
+        GetItems200Response,
+        unknown[],
+        string | undefined | null
+      >,
+      'queryFn' | 'queryKey' | 'initialPageParam'
+    > &
+      Partial<
+        Pick<
+          UseInfiniteQueryOptions<
+            GetItems200Response,
+            GetItemsError,
+            InfiniteData<GetItems200Response>,
+            GetItems200Response,
+            unknown[],
+            string | undefined | null
+          >,
+          'queryFn' | 'queryKey' | 'initialPageParam'
+        >
+      >,
+  ): UseInfiniteQueryOptions<
+    GetItems200Response,
+    GetItemsError,
+    InfiniteData<GetItems200Response>,
+    GetItems200Response,
+    unknown[],
+    string | undefined | null
+  > {
+    return {
+      queryKey: this._getItemsQueryKey(input),
+      queryFn: ({ pageParam }) =>
+        this.$client.getItems({ ...input, cursor: pageParam as any }),
+      initialPageParam: undefined,
+      ...options,
+    };
+  }
+
+  public getItems = {
+    queryKey: this._getItemsQueryKey.bind(this),
+    queryOptions: this._getItemsQueryOptions.bind(this),
+    queryFilter: this._getItemsQueryFilter.bind(this),
+    infiniteQueryOptions: this._getItemsInfiniteQueryOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle infinite query with custom cursor parameter 1`] = `
+"import type {
+  QueryFilters,
+  UseQueryOptions,
+  UseInfiniteQueryOptions,
+  InfiniteData,
+} from '@tanstack/react-query';
+import type {
+  ListRecordsRequest,
+  ListRecordsError,
+  ListRecords200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._listRecordsQueryKey = this._listRecordsQueryKey.bind(this);
+    this._listRecordsQueryOptions = this._listRecordsQueryOptions.bind(this);
+    this._listRecordsQueryFilter = this._listRecordsQueryFilter.bind(this);
+    this._listRecordsInfiniteQueryOptions =
+      this._listRecordsInfiniteQueryOptions.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _listRecordsQueryKey(input: ListRecordsRequest) {
+    return [...this.queryKey(), 'listRecords', input];
+  }
+  private _listRecordsQueryOptions(
+    input: ListRecordsRequest,
+    options?: Omit<
+      UseQueryOptions<ListRecords200Response, ListRecordsError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<ListRecords200Response, ListRecordsError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<ListRecords200Response, ListRecordsError> {
+    return {
+      queryFn: () => this.$client.listRecords(input),
+      queryKey: this._listRecordsQueryKey(input),
+      ...options,
+    };
+  }
+  private _listRecordsQueryFilter(
+    input: ListRecordsRequest,
+    filter?: QueryFilters<ListRecords200Response, ListRecordsError>,
+  ): QueryFilters<ListRecords200Response, ListRecordsError> {
+    return {
+      queryKey: this._listRecordsQueryKey(input),
+      ...filter,
+    };
+  }
+  private _listRecordsInfiniteQueryOptions(
+    input: ListRecordsRequest,
+    options: Omit<
+      UseInfiniteQueryOptions<
+        ListRecords200Response,
+        ListRecordsError,
+        InfiniteData<ListRecords200Response>,
+        ListRecords200Response,
+        unknown[],
+        string | undefined | null
+      >,
+      'queryFn' | 'queryKey' | 'initialPageParam'
+    > &
+      Partial<
+        Pick<
+          UseInfiniteQueryOptions<
+            ListRecords200Response,
+            ListRecordsError,
+            InfiniteData<ListRecords200Response>,
+            ListRecords200Response,
+            unknown[],
+            string | undefined | null
+          >,
+          'queryFn' | 'queryKey' | 'initialPageParam'
+        >
+      >,
+  ): UseInfiniteQueryOptions<
+    ListRecords200Response,
+    ListRecordsError,
+    InfiniteData<ListRecords200Response>,
+    ListRecords200Response,
+    unknown[],
+    string | undefined | null
+  > {
+    return {
+      queryKey: this._listRecordsQueryKey(input),
+      queryFn: ({ pageParam }) =>
+        this.$client.listRecords({ ...input, nextToken: pageParam as any }),
+      initialPageParam: undefined,
+      ...options,
+    };
+  }
+
+  public listRecords = {
+    queryKey: this._listRecordsQueryKey.bind(this),
+    queryOptions: this._listRecordsQueryOptions.bind(this),
+    queryFilter: this._listRecordsQueryFilter.bind(this),
+    infiniteQueryOptions: this._listRecordsInfiniteQueryOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle mutation errors correctly 1`] = `
+"import type { UseMutationOptions } from '@tanstack/react-query';
+import type {
+  CreateUserRequest,
+  CreateUserError,
+  CreateUser201Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._createUserMutationKey = this._createUserMutationKey.bind(this);
+    this._createUserMutationOptions =
+      this._createUserMutationOptions.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _createUserMutationKey() {
+    return [...this.queryKey(), 'createUser'];
+  }
+  private _createUserMutationOptions(
+    options?: UseMutationOptions<
+      CreateUser201Response,
+      CreateUserError,
+      CreateUserRequest
+    >,
+  ): UseMutationOptions<
+    CreateUser201Response,
+    CreateUserError,
+    CreateUserRequest
+  > {
+    return {
+      mutationFn: (input) => this.$client.createUser(input),
+      mutationKey: this._createUserMutationKey(),
+      ...options,
+    };
+  }
+
+  public createUser = {
+    mutationKey: this._createUserMutationKey.bind(this),
+    mutationOptions: this._createUserMutationOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle query errors correctly 1`] = `
+"import type { QueryFilters, UseQueryOptions } from '@tanstack/react-query';
+import type { GetErrorError, GetError200Response } from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._getErrorQueryKey = this._getErrorQueryKey.bind(this);
+    this._getErrorQueryOptions = this._getErrorQueryOptions.bind(this);
+    this._getErrorQueryFilter = this._getErrorQueryFilter.bind(this);
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _getErrorQueryKey() {
+    return [...this.queryKey(), 'getError'];
+  }
+  private _getErrorQueryOptions(
+    options?: Omit<
+      UseQueryOptions<GetError200Response, GetErrorError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<GetError200Response, GetErrorError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<GetError200Response, GetErrorError> {
+    return {
+      queryFn: () => this.$client.getError(),
+      queryKey: this._getErrorQueryKey(),
+      ...options,
+    };
+  }
+  private _getErrorQueryFilter(
+    filter?: QueryFilters<GetError200Response, GetErrorError>,
+  ): QueryFilters<GetError200Response, GetErrorError> {
+    return {
+      queryKey: this._getErrorQueryKey(),
+      ...filter,
+    };
+  }
+
+  public getError = {
+    queryKey: this._getErrorQueryKey.bind(this),
+    queryOptions: this._getErrorQueryOptions.bind(this),
+    queryFilter: this._getErrorQueryFilter.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle streaming infinite query operation correctly 1`] = `
+"import type {
+  QueryFilters,
+  UseQueryOptions,
+  UseInfiniteQueryOptions,
+  InfiniteData,
+  QueryFunctionContext,
+} from '@tanstack/react-query';
+import type {
+  StreamLogsRequest,
+  StreamLogsError,
+  StreamLogs200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._streamLogsQueryKey = this._streamLogsQueryKey.bind(this);
+    this._streamLogsQueryOptions = this._streamLogsQueryOptions.bind(this);
+    this._streamLogsQueryFilter = this._streamLogsQueryFilter.bind(this);
+    this._streamLogsInfiniteQueryOptions =
+      this._streamLogsInfiniteQueryOptions.bind(this);
+  }
+
+  protected async $queryStream<T>(
+    context: QueryFunctionContext<any>,
+    stream: AsyncIterable<T>,
+  ): Promise<T[]> {
+    const query = context.client
+      .getQueryCache()
+      .find({ queryKey: context.queryKey, exact: true });
+
+    if (query && query.state.data !== undefined) {
+      query.setState({
+        status: 'pending',
+        data: undefined,
+        error: null,
+        fetchStatus: 'fetching',
+      });
+    }
+
+    const chunks: T[] = [];
+    for await (const chunk of stream) {
+      if (context.signal.aborted) {
+        break;
+      }
+      chunks.push(chunk);
+      query?.setState({
+        status: 'success',
+        fetchStatus: 'fetching',
+      });
+      context.client.setQueryData<T[]>(context.queryKey, (prev = []) =>
+        prev.concat(chunk),
+      );
+    }
+    query?.setState({
+      fetchStatus: 'idle',
+    });
+    return chunks;
+  }
+
+  protected async $waitForStream<T>(iterable: AsyncIterable<T>) {
+    const chunks: T[] = [];
+    for await (const chunk of iterable) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _streamLogsQueryKey(input: StreamLogsRequest) {
+    return [...this.queryKey(), 'streamLogs', input];
+  }
+  private _streamLogsQueryOptions(
+    input: StreamLogsRequest,
+    options?: Omit<
+      UseQueryOptions<StreamLogs200Response[], StreamLogsError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<StreamLogs200Response[], StreamLogsError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<StreamLogs200Response[], StreamLogsError> {
+    return {
+      queryFn: (context) =>
+        this.$queryStream(context, this.$client.streamLogs(input)),
+      queryKey: this._streamLogsQueryKey(input),
+      ...options,
+    };
+  }
+  private _streamLogsQueryFilter(
+    input: StreamLogsRequest,
+    filter?: QueryFilters<StreamLogs200Response[], StreamLogsError>,
+  ): QueryFilters<StreamLogs200Response[], StreamLogsError> {
+    return {
+      queryKey: this._streamLogsQueryKey(input),
+      ...filter,
+    };
+  }
+  private _streamLogsInfiniteQueryOptions(
+    input: StreamLogsRequest,
+    options: Omit<
+      UseInfiniteQueryOptions<
+        StreamLogs200Response[],
+        StreamLogsError,
+        InfiniteData<StreamLogs200Response[]>,
+        StreamLogs200Response[],
+        unknown[],
+        string | undefined | null
+      >,
+      'queryFn' | 'queryKey' | 'initialPageParam'
+    > &
+      Partial<
+        Pick<
+          UseInfiniteQueryOptions<
+            StreamLogs200Response[],
+            StreamLogsError,
+            InfiniteData<StreamLogs200Response[]>,
+            StreamLogs200Response[],
+            unknown[],
+            string | undefined | null
+          >,
+          'queryFn' | 'queryKey' | 'initialPageParam'
+        >
+      >,
+  ): UseInfiniteQueryOptions<
+    StreamLogs200Response[],
+    StreamLogsError,
+    InfiniteData<StreamLogs200Response[]>,
+    StreamLogs200Response[],
+    unknown[],
+    string | undefined | null
+  > {
+    return {
+      queryKey: this._streamLogsQueryKey(input),
+      queryFn: ({ pageParam }) =>
+        this.$waitForStream(
+          this.$client.streamLogs({ ...input, cursor: pageParam as any }),
+        ),
+      initialPageParam: undefined,
+      ...options,
+    };
+  }
+
+  public streamLogs = {
+    queryKey: this._streamLogsQueryKey.bind(this),
+    queryOptions: this._streamLogsQueryOptions.bind(this),
+    queryFilter: this._streamLogsQueryFilter.bind(this),
+    infiniteQueryOptions: this._streamLogsInfiniteQueryOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle streaming mutation operation correctly 1`] = `
+"import type {
+  UseMutationOptions,
+  QueryFunctionContext,
+} from '@tanstack/react-query';
+import type {
+  UploadStreamRequest,
+  UploadStreamError,
+  UploadStream200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._uploadStreamMutationKey = this._uploadStreamMutationKey.bind(this);
+    this._uploadStreamMutationOptions =
+      this._uploadStreamMutationOptions.bind(this);
+  }
+
+  protected async $queryStream<T>(
+    context: QueryFunctionContext<any>,
+    stream: AsyncIterable<T>,
+  ): Promise<T[]> {
+    const query = context.client
+      .getQueryCache()
+      .find({ queryKey: context.queryKey, exact: true });
+
+    if (query && query.state.data !== undefined) {
+      query.setState({
+        status: 'pending',
+        data: undefined,
+        error: null,
+        fetchStatus: 'fetching',
+      });
+    }
+
+    const chunks: T[] = [];
+    for await (const chunk of stream) {
+      if (context.signal.aborted) {
+        break;
+      }
+      chunks.push(chunk);
+      query?.setState({
+        status: 'success',
+        fetchStatus: 'fetching',
+      });
+      context.client.setQueryData<T[]>(context.queryKey, (prev = []) =>
+        prev.concat(chunk),
+      );
+    }
+    query?.setState({
+      fetchStatus: 'idle',
+    });
+    return chunks;
+  }
+
+  protected async $waitForStream<T>(iterable: AsyncIterable<T>) {
+    const chunks: T[] = [];
+    for await (const chunk of iterable) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _uploadStreamMutationKey() {
+    return [...this.queryKey(), 'uploadStream'];
+  }
+  private _uploadStreamMutationOptions(
+    options?: UseMutationOptions<
+      AsyncIterableIterator<UploadStream200Response>,
+      UploadStreamError,
+      UploadStreamRequest
+    >,
+  ): UseMutationOptions<
+    AsyncIterableIterator<UploadStream200Response>,
+    UploadStreamError,
+    UploadStreamRequest
+  > {
+    return {
+      mutationFn: async (input) => this.$client.uploadStream(input),
+      mutationKey: this._uploadStreamMutationKey(),
+      ...options,
+    };
+  }
+
+  public uploadStream = {
+    mutationKey: this._uploadStreamMutationKey.bind(this),
+    mutationOptions: this._uploadStreamMutationOptions.bind(this),
+  };
+}
+"
+`;
+
+exports[`openApiTsHooksGenerator > should handle streaming query operation correctly 1`] = `
+"import type {
+  QueryFilters,
+  UseQueryOptions,
+  QueryFunctionContext,
+} from '@tanstack/react-query';
+import type {
+  StreamEventsRequest,
+  StreamEventsError,
+  StreamEvents200Response,
+} from './types.gen.js';
+import { TestApi } from './client.gen.js';
+
+export interface TestApiOptionsProxyConfig {
+  client: TestApi;
+}
+
+export class TestApiOptionsProxy {
+  private $client: TestApi;
+
+  constructor({ client }: TestApiOptionsProxyConfig) {
+    this.$client = client;
+
+    this._streamEventsQueryKey = this._streamEventsQueryKey.bind(this);
+    this._streamEventsQueryOptions = this._streamEventsQueryOptions.bind(this);
+    this._streamEventsQueryFilter = this._streamEventsQueryFilter.bind(this);
+  }
+
+  protected async $queryStream<T>(
+    context: QueryFunctionContext<any>,
+    stream: AsyncIterable<T>,
+  ): Promise<T[]> {
+    const query = context.client
+      .getQueryCache()
+      .find({ queryKey: context.queryKey, exact: true });
+
+    if (query && query.state.data !== undefined) {
+      query.setState({
+        status: 'pending',
+        data: undefined,
+        error: null,
+        fetchStatus: 'fetching',
+      });
+    }
+
+    const chunks: T[] = [];
+    for await (const chunk of stream) {
+      if (context.signal.aborted) {
+        break;
+      }
+      chunks.push(chunk);
+      query?.setState({
+        status: 'success',
+        fetchStatus: 'fetching',
+      });
+      context.client.setQueryData<T[]>(context.queryKey, (prev = []) =>
+        prev.concat(chunk),
+      );
+    }
+    query?.setState({
+      fetchStatus: 'idle',
+    });
+    return chunks;
+  }
+
+  protected async $waitForStream<T>(iterable: AsyncIterable<T>) {
+    const chunks: T[] = [];
+    for await (const chunk of iterable) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+
+  public queryKey = () => ['TestApi'];
+
+  private _streamEventsQueryKey(input: StreamEventsRequest) {
+    return [...this.queryKey(), 'streamEvents', input];
+  }
+  private _streamEventsQueryOptions(
+    input: StreamEventsRequest,
+    options?: Omit<
+      UseQueryOptions<StreamEvents200Response[], StreamEventsError>,
+      'queryFn' | 'queryKey'
+    > &
+      Partial<
+        Pick<
+          UseQueryOptions<StreamEvents200Response[], StreamEventsError>,
+          'queryFn' | 'queryKey'
+        >
+      >,
+  ): UseQueryOptions<StreamEvents200Response[], StreamEventsError> {
+    return {
+      queryFn: (context) =>
+        this.$queryStream(context, this.$client.streamEvents(input)),
+      queryKey: this._streamEventsQueryKey(input),
+      ...options,
+    };
+  }
+  private _streamEventsQueryFilter(
+    input: StreamEventsRequest,
+    filter?: QueryFilters<StreamEvents200Response[], StreamEventsError>,
+  ): QueryFilters<StreamEvents200Response[], StreamEventsError> {
+    return {
+      queryKey: this._streamEventsQueryKey(input),
+      ...filter,
+    };
+  }
+
+  public streamEvents = {
+    queryKey: this._streamEventsQueryKey.bind(this),
+    queryOptions: this._streamEventsQueryOptions.bind(this),
+    queryFilter: this._streamEventsQueryFilter.bind(this),
+  };
+}
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
@@ -1,0 +1,210 @@
+import type {
+<%_ if (allOperations.some(op => op.isQuery)) { _%>
+  QueryFilters,
+  UseQueryOptions,
+<%_ } _%>
+<%_ if (allOperations.some(op => op.isInfiniteQuery)) { _%>
+  UseInfiniteQueryOptions,
+  InfiniteData,
+<%_ } _%>
+<%_ if (allOperations.some(op => op.isMutation)) { _%>
+  UseMutationOptions,
+<%_ } _%>
+<%_ if (allOperations.some(op => op.isStreaming)) { _%>
+  QueryFunctionContext,
+<%_ } _%>
+} from '@tanstack/react-query';
+<%_ if ((models.length + allOperations.length) > 0) { _%>
+import type {
+<%_ allOperations.filter(p => p.parameters.length > 0).forEach((op) => { _%>
+  <%- op.operationIdPascalCase %>Request,
+<%_ }); _%>
+<%_ allOperations.forEach((op) => { _%>
+  <%- op.operationIdPascalCase %>Error,
+<%_ }); _%>
+<%_ const uniq = (arr) => {
+  const set = new Set();
+  return arr.filter((item) => {
+    if (set.has(item)) {
+      return false;
+    }
+    set.add(item);
+    return true;
+  });
+} _%>
+<%_ const modelsByName = Object.fromEntries(models.map(m => [m.name, m])); _%>
+<%_ uniq(allOperations.flatMap((op) => op.result && modelsByName[op.result.type] ? [op.result.typescriptType] : [])).forEach((returnTypeModel) => { _%>
+  <%- returnTypeModel %>,
+<%_ }); _%>
+} from './types.gen.js';
+<%_ } _%>
+import { <%- className %> } from './client.gen.js';
+
+export interface <%- className %>OptionsProxyConfig {
+  client: <%- className %>;
+}
+
+export class <%- className %>OptionsProxy {
+  private $client: <%- className %>;
+
+  constructor({ client }: <%- className %>OptionsProxyConfig) {
+    this.$client = client;
+
+    <%_ allOperations.forEach((op) => { _%>
+    <%_ if (op.isQuery) { _%>
+    this._<%- op.uniqueName %>QueryKey = this._<%- op.uniqueName %>QueryKey.bind(this);
+    this._<%- op.uniqueName %>QueryOptions = this._<%- op.uniqueName %>QueryOptions.bind(this);
+    this._<%- op.uniqueName %>QueryFilter = this._<%- op.uniqueName %>QueryFilter.bind(this);
+    <%_ } _%>
+    <%_ if (op.isInfiniteQuery) { _%>
+    this._<%- op.uniqueName %>InfiniteQueryOptions = this._<%- op.uniqueName %>InfiniteQueryOptions.bind(this);
+    <%_ } _%>
+    <%_ if (op.isMutation) { _%>
+    this._<%- op.uniqueName %>MutationKey = this._<%- op.uniqueName %>MutationKey.bind(this);
+    this._<%- op.uniqueName %>MutationOptions = this._<%- op.uniqueName %>MutationOptions.bind(this);
+    <%_ } _%>
+    <%_ }); _%>
+  }
+
+<%_ if (allOperations.some(op => op.isStreaming)) { _%>
+  protected async $queryStream<T>(context: QueryFunctionContext<any>, stream: AsyncIterable<T>): Promise<T[]> {
+    const query = context.client
+      .getQueryCache()
+      .find({ queryKey: context.queryKey, exact: true });
+
+    if (query && query.state.data !== undefined) {
+      query.setState({
+        status: 'pending',
+        data: undefined,
+        error: null,
+        fetchStatus: 'fetching',
+      });
+    }
+
+    const chunks: T[] = [];
+    for await (const chunk of stream) {
+      if (context.signal.aborted) {
+        break;
+      }
+      chunks.push(chunk);
+      query?.setState({
+        status: 'success',
+        fetchStatus: 'fetching',
+      });
+      context.client.setQueryData<T[]>(context.queryKey, (prev = []) =>
+        prev.concat(chunk),
+      );
+    }
+    query?.setState({
+      fetchStatus: 'idle',
+    });
+    return chunks;
+  }
+
+  protected async $waitForStream<T>(iterable: AsyncIterable<T>) {
+    const chunks: T[] = [];
+    for await (const chunk of iterable) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+<%_ } _%>
+
+  public queryKey = () => ['<%- className %>'];
+
+  <%_ allOperations.forEach((op) => { _%>
+  <%_ const hasTag = op.tags && op.tags.length > 0; _%>
+  <%_ const isInputOptional = (op.parameters.length === 1 && op.parametersBody && !op.parametersBody.isRequired) || op.parameters.length === 0; _%>
+  <%_ const input = op.parameters.length > 0 ? `input${isInputOptional ? '?' : ''}: ${op.operationIdPascalCase}Request` : ''; _%>
+  <%_ const isStreaming = op.isStreaming; _%>
+  <%_ const resultType = op.result ? op.result.typescriptType : 'void'; _%>
+  <%_ const queryResultType = `${resultType}${isStreaming ? '[]' : ''}`; _%>
+  <%_ const mutationResultType = isStreaming ? `AsyncIterableIterator<${resultType}>` : resultType; _%>
+  <%_ const errorType = `${op.operationIdPascalCase}Error`; _%>
+  <%_ if (op.isQuery) { _%>
+  <%_ const queryOptionsType = `UseQueryOptions<${queryResultType}, ${errorType}>`; _%>
+  private _<%- op.uniqueName %>QueryKey(<%- input %>) {
+    return [...this.queryKey(), '<%- op.uniqueName %>'<% if (op.parameters.length > 0) { %>, input<% } %>];
+  }
+  private _<%- op.uniqueName %>QueryOptions(<%- input %><% if (op.parameters.length > 0) { %>, <% } %>options?: Omit<<%- queryOptionsType %>, 'queryFn' | 'queryKey'> & Partial<Pick<<%- queryOptionsType %>, 'queryFn' | 'queryKey'>>): <%- queryOptionsType %> {
+    return {
+      queryFn: (<% if (isStreaming) { %>context<% } %>) => <% if (isStreaming) { %>this.$queryStream(context, <% } %><% if (hasTag) { %>(this.$client as any)._<% } else { %>this.$client.<% } %><%- op.uniqueName %>(<% if (op.parameters.length > 0) { %>input<% } %>)<% if (isStreaming) { %>)<% } %>,
+      queryKey: this._<%- op.uniqueName %>QueryKey(<% if (op.parameters.length > 0) { %>input<% } %>),
+      ...options,
+    };
+  }
+  private _<%- op.uniqueName %>QueryFilter(<%- input %><% if (op.parameters.length > 0) { %>, <% } %>filter?: QueryFilters<<%- queryResultType %>, <%- errorType %>>): QueryFilters<<%- queryResultType %>, <%- errorType %>> {
+    return {
+      queryKey: this._<%- op.uniqueName %>QueryKey(<% if (op.parameters.length > 0) { %>input<% } %>),
+      ...filter,
+    };
+  }
+  <%_ } _%>
+  <%_ if (op.isInfiniteQuery) { _%>
+  <%_ const cursorType = `${op.infiniteQueryCursorProperty.typescriptType}${op.infiniteQueryCursorProperty.isRequired ? '' : ' | undefined'}${op.infiniteQueryCursorProperty.isNullable && op.infiniteQueryCursorProperty.type !== 'null' ? '' : ' | null'}`; _%>
+  <%_ const infiniteQueryOptionsType = `UseInfiniteQueryOptions<${queryResultType}, ${errorType}, InfiniteData<${queryResultType}>, ${queryResultType}, unknown[], ${cursorType}>`; _%>
+  <%_ emptyInitialPageParam = !op.infiniteQueryCursorProperty.isRequired ? 'undefined' : (op.infiniteQueryCursorProperty.isNullable ? 'null' : undefined); _%>
+  private _<%- op.uniqueName %>InfiniteQueryOptions(<%- input %><% if (op.parameters.length > 0) { %>, <% } %>options: Omit<<%- infiniteQueryOptionsType %>, 'queryFn' | 'queryKey'<%- emptyInitialPageParam ? ` | 'initialPageParam'` : '' %>> & Partial<Pick<<%- infiniteQueryOptionsType %>, 'queryFn' | 'queryKey'<%- emptyInitialPageParam ? ` | 'initialPageParam'` : '' %>>>): <%- infiniteQueryOptionsType %> {
+    return {
+      queryKey: this._<%- op.uniqueName %>QueryKey(<% if (op.parameters.length > 0) { %>input<% } %>),
+      queryFn: ({ pageParam }) => <% if (isStreaming) { %>this.$waitForStream(<% } %><% if (hasTag) { %>(this.$client as any)._<% } else { %>this.$client.<% } %><%- op.uniqueName %>({ ...input, <%- op.infiniteQueryCursorProperty.typescriptName %>: pageParam as any })<% if (isStreaming) { %>)<% } %>,
+      <%_ if (emptyInitialPageParam) { _%>
+      initialPageParam: <%- emptyInitialPageParam %>,
+      <%_ } _%>
+      ...options,
+    };
+  }
+  <%_ } _%>
+  <%_ if (op.isMutation) { _%>
+  private _<%- op.uniqueName %>MutationKey() {
+    return [...this.queryKey(), '<%- op.uniqueName %>'];
+  }
+  <%_ const mutationOptionsType = `UseMutationOptions<${mutationResultType}, ${errorType}, ${op.parameters.length > 0 ? `${op.operationIdPascalCase}Request` : 'void'}>` _%>
+  private _<%- op.uniqueName %>MutationOptions(options?: <%- mutationOptionsType %>): <%- mutationOptionsType %> {
+    return {
+      mutationFn: <% if (isStreaming) { %>async <% } %>(<% if (op.parameters.length > 0) { %>input<% } %>) => <% if (hasTag) { %>(this.$client as any)._<% } else { %>this.$client.<% } %><%- op.uniqueName %>(<% if (op.parameters.length > 0) { %>input<% } %>),
+      mutationKey: this._<%- op.uniqueName %>MutationKey(),
+      ...options,
+    };
+  }
+  <%_ } _%>
+  <%_ }); _%>
+
+  <%_ Object.entries(operationsByTag).forEach(([tag, operations]) => { _%>
+  public <%- tag %> = {
+    <%_ operations.forEach((op) => { _%>
+    <%- op.name %>: {
+      <%_ if (op.isQuery) { _%>
+      queryKey: this._<%- op.uniqueName %>QueryKey.bind(this),
+      queryOptions: this._<%- op.uniqueName %>QueryOptions.bind(this),
+      queryFilter: this._<%- op.uniqueName %>QueryFilter.bind(this),
+      <%_ } _%>
+      <%_ if (op.isInfiniteQuery) { _%>
+      infiniteQueryOptions: this._<%- op.uniqueName %>InfiniteQueryOptions.bind(this),
+      <%_ } _%>
+      <%_ if (op.isMutation) { _%>
+      mutationKey: this._<%- op.uniqueName %>MutationKey.bind(this),
+      mutationOptions: this._<%- op.uniqueName %>MutationOptions.bind(this),
+      <%_ } _%>
+    },
+    <%_ }); _%>
+  };
+  <%_ }); _%>
+
+  <%_ untaggedOperations.forEach((op) => { _%>
+  public <%- op.name %> = {
+    <%_ if (op.isQuery) { _%>
+    queryKey: this._<%- op.uniqueName %>QueryKey.bind(this),
+    queryOptions: this._<%- op.uniqueName %>QueryOptions.bind(this),
+    queryFilter: this._<%- op.uniqueName %>QueryFilter.bind(this),
+    <%_ } _%>
+    <%_ if (op.isInfiniteQuery) { _%>
+    infiniteQueryOptions: this._<%- op.uniqueName %>InfiniteQueryOptions.bind(this),
+    <%_ } _%>
+    <%_ if (op.isMutation) { _%>
+    mutationKey: this._<%- op.uniqueName %>MutationKey.bind(this),
+    mutationOptions: this._<%- op.uniqueName %>MutationOptions.bind(this),
+    <%_ } _%>
+  };
+  <%_ }); _%>
+}

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
@@ -1,0 +1,1783 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { Spec } from '../utils/types';
+import { openApiTsHooksGenerator } from './generator';
+import { expectTypeScriptToCompile } from '../ts-client/generator.utils.spec';
+import { importTypeScriptModule } from '../../utils/js';
+import { waitFor, render, fireEvent } from '@testing-library/react';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+  useMutation,
+  useInfiniteQuery,
+  UseQueryResult,
+  UseInfiniteQueryResult,
+  UseMutationResult,
+} from '@tanstack/react-query';
+import React from 'react';
+import { Mock } from 'vitest';
+
+describe('openApiTsHooksGenerator', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+  const baseUrl = 'https://example.com';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths, ['@tanstack/react-query']);
+  };
+
+  // Helper function to create a wrapper component with QueryClientProvider
+  const createWrapper = () => {
+    // Create a new QueryClient for testing
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  // Helper function to configure the options proxy
+  const configureOptionsProxy = async (
+    clientModule: string,
+    optionsProxyModule: string,
+    mockFetch: Mock<any, any>,
+  ) => {
+    // Dynamically import the generated modules
+    const { TestApi } = await importTypeScriptModule<any>(clientModule);
+    const { TestApiOptionsProxy } =
+      await importTypeScriptModule<any>(optionsProxyModule);
+
+    // Create client instance with mock fetch
+    const apiClient = new TestApi({ url: baseUrl, fetch: mockFetch });
+
+    // Create options proxy with the client
+    const optionsProxyInstance = new TestApiOptionsProxy({ client: apiClient });
+
+    return optionsProxyInstance;
+  };
+
+  // Helper function to test a query hook
+  const renderQueryHook = async (
+    hookOptions: any,
+  ): Promise<{
+    getLatestHookState: () => UseQueryResult<any>;
+    getHookStates: () => UseQueryResult<any>[];
+  }> => {
+    const Wrapper = createWrapper();
+
+    // Track the state of the hook on every render
+    const states: UseQueryResult<any>[] = [];
+
+    // Component that uses the query hook
+    const Component = () => {
+      const query = useQuery(hookOptions);
+      states.push(query);
+      return <div>Query Component</div>;
+    };
+
+    render(
+      <Wrapper>
+        <Component />
+      </Wrapper>,
+    );
+
+    // Wait for the query to reach a terminal state (success or error)
+    await waitFor(() =>
+      expect(states[states.length - 1].isLoading).toBe(false),
+    );
+
+    return {
+      // Return the latest state
+      getLatestHookState: () => states[states.length - 1],
+      getHookStates: () => states,
+    };
+  };
+
+  // Helper function to test a mutation hook
+  const renderMutationHook = async (
+    hookOptions: any,
+    inputData: any,
+  ): Promise<{
+    getLatestHookState: () => UseMutationResult<any>;
+  }> => {
+    const Wrapper = createWrapper();
+
+    // Track the state of the hook on every render
+    const states: UseMutationResult<any>[] = [];
+
+    // Component that uses the mutation hook
+    const Component = () => {
+      const mutation = useMutation(hookOptions);
+      states.push(mutation);
+
+      return (
+        <div>
+          <button onClick={() => mutation.mutate(inputData)}>Mutate</button>
+        </div>
+      );
+    };
+
+    const rendered = render(
+      <Wrapper>
+        <Component />
+      </Wrapper>,
+    );
+
+    // Execute the mutation
+    fireEvent.click(rendered.getByText('Mutate'));
+
+    // Wait for the mutation to reach a terminal state (success or error)
+    await waitFor(() =>
+      expect(states[states.length - 1].isPending).toBe(false),
+    );
+
+    return {
+      // Return the latest state
+      getLatestHookState: () => states[states.length - 1],
+    };
+  };
+
+  // Helper function to test an infinite query hook
+  const renderInfiniteQueryHook = async (
+    hookOptions: any,
+  ): Promise<{
+    getLatestHookState: () => UseInfiniteQueryResult<any>;
+    fetchNextPage: () => void;
+  }> => {
+    const Wrapper = createWrapper();
+
+    // Track the state of the hook on every render
+    const states: UseInfiniteQueryResult<any>[] = [];
+
+    const Component = () => {
+      const query = useInfiniteQuery(hookOptions);
+      states.push(query);
+
+      return (
+        <div>
+          <button onClick={() => query.fetchNextPage()}>Next Page</button>
+        </div>
+      );
+    };
+
+    const rendered = render(
+      <Wrapper>
+        <Component />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(states[states.length - 1].isLoading).toBe(false),
+    );
+
+    return {
+      // Return the latest state
+      getLatestHookState: () => states[states.length - 1],
+      fetchNextPage: () => {
+        fireEvent.click(rendered.getByText('Next Page'));
+      },
+    };
+  };
+
+  it('should generate an options proxy for a query operation', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            operationId: 'getTest',
+            description: 'Sends a test request!',
+            responses: {
+              '200': {
+                description: 'getTest',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        string: { type: 'string' },
+                        number: { type: 'number' },
+                        integer: { type: 'integer' },
+                        boolean: { type: 'boolean' },
+                        'nullable-string': { type: 'string', nullable: true },
+                        optionalNumber: { type: 'number' },
+                      },
+                      required: ['string', 'number', 'integer', 'boolean'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        string: 'str',
+        number: 42.3,
+        integer: 33,
+        boolean: true,
+        'nullable-string': null,
+      }),
+    });
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the root queryKey method
+    const rootQueryKey = optionsProxyInstance.queryKey();
+    expect(rootQueryKey).toEqual(['TestApi']);
+
+    // Test the operation-specific queryKey method
+    const operationQueryKey = optionsProxyInstance.getTest.queryKey();
+    expect(operationQueryKey).toEqual(['TestApi', 'getTest']);
+
+    // Test the queryFilter method
+    const queryFilter = optionsProxyInstance.getTest.queryFilter();
+    expect(queryFilter.queryKey).toEqual(['TestApi', 'getTest']);
+
+    // Test queryFilter with additional options
+    const extendedFilter = optionsProxyInstance.getTest.queryFilter({
+      exact: true,
+    });
+    expect(extendedFilter).toEqual({
+      queryKey: ['TestApi', 'getTest'],
+      exact: true,
+    });
+
+    // Test the query hook
+    const { getLatestHookState } = await renderQueryHook(
+      optionsProxyInstance.getTest.queryOptions(),
+    );
+
+    // Verify the data is correct
+    expect(getLatestHookState().data).toEqual({
+      string: 'str',
+      number: 42.3,
+      integer: 33,
+      boolean: true,
+      nullableString: null,
+    });
+
+    // Verify the fetch was called correctly
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/test`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('should generate an options proxy for a mutation operation', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/users': {
+          post: {
+            operationId: 'createUser',
+            description: 'Creates a new user',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string' },
+                      email: { type: 'string' },
+                      age: { type: 'integer' },
+                    },
+                    required: ['name', 'email'],
+                  },
+                },
+              },
+            },
+            responses: {
+              '201': {
+                description: 'User created successfully',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                        email: { type: 'string' },
+                        age: { type: 'integer' },
+                        createdAt: { type: 'string', format: 'date-time' },
+                      },
+                      required: ['id', 'name', 'email', 'createdAt'],
+                    },
+                  },
+                },
+              },
+              '400': {
+                description: 'Bad request',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        error: { type: 'string' },
+                      },
+                      required: ['error'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 201,
+      json: vi.fn().mockResolvedValue({
+        id: '123',
+        name: 'John Doe',
+        email: 'john@example.com',
+        age: 30,
+        createdAt: '2023-01-01T12:00:00Z',
+      }),
+    });
+
+    // Prepare test data
+    const userData = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      age: 30,
+    };
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the mutation hook
+    const { getLatestHookState } = await renderMutationHook(
+      optionsProxyInstance.createUser.mutationOptions(),
+      userData,
+    );
+
+    // Verify the data is correct
+    expect(getLatestHookState().data).toEqual({
+      id: '123',
+      name: 'John Doe',
+      email: 'john@example.com',
+      age: 30,
+      createdAt: new Date('2023-01-01T12:00:00Z'),
+    });
+
+    // Verify the fetch was called correctly
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/users`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(userData),
+      }),
+    );
+  });
+
+  it('should handle query errors correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/error': {
+          get: {
+            operationId: 'getError',
+            description: 'Returns an error',
+            responses: {
+              '200': {
+                description: 'Success response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        message: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+              '400': {
+                description: 'Error response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        error: { type: 'string' },
+                      },
+                      required: ['error'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function that returns an error
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 400,
+      json: vi.fn().mockResolvedValue({
+        error: 'Bad request',
+      }),
+    });
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the query hook
+    const { getLatestHookState } = await renderQueryHook(
+      optionsProxyInstance.getError.queryOptions(),
+    );
+
+    // Verify the error state
+    expect(getLatestHookState().isError).toBe(true);
+    expect(getLatestHookState().error).toBeDefined();
+    expect(getLatestHookState().error).toMatchObject({
+      status: 400,
+      error: { error: 'Bad request' },
+    });
+
+    // Verify the fetch was called correctly
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/error`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('should handle mutation errors correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/users': {
+          post: {
+            operationId: 'createUser',
+            description: 'Creates a new user',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string' },
+                      email: { type: 'string' },
+                    },
+                    required: ['name', 'email'],
+                  },
+                },
+              },
+            },
+            responses: {
+              '201': {
+                description: 'User created successfully',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+              '400': {
+                description: 'Bad request',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        error: { type: 'string' },
+                      },
+                      required: ['error'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function that returns an error
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 400,
+      json: vi.fn().mockResolvedValue({
+        error: 'Invalid email format',
+      }),
+    });
+
+    // Prepare test data
+    const userData = {
+      name: 'John Doe',
+      email: 'invalid-email',
+    };
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the mutation hook
+    const { getLatestHookState } = await renderMutationHook(
+      optionsProxyInstance.createUser.mutationOptions(),
+      userData,
+    );
+
+    // Verify the error state
+    expect(getLatestHookState().isError).toBe(true);
+    expect(getLatestHookState().error).toBeDefined();
+    expect(getLatestHookState().error).toMatchObject({
+      status: 400,
+      error: { error: 'Invalid email format' },
+    });
+
+    // Verify the fetch was called correctly
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/users`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(userData),
+      }),
+    );
+  });
+
+  it('should generate an options proxy for a successful infinite query operation', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'getItems',
+            description: 'Gets a paginated list of items',
+            parameters: [
+              {
+                name: 'cursor',
+                in: 'query',
+                description: 'Pagination cursor',
+                required: false,
+                schema: {
+                  type: 'string',
+                },
+              },
+              {
+                name: 'limit',
+                in: 'query',
+                description: 'Number of items to return',
+                required: false,
+                schema: {
+                  type: 'integer',
+                  default: 10,
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of items',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        items: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              name: { type: 'string' },
+                              description: { type: 'string' },
+                            },
+                            required: ['id', 'name'],
+                          },
+                        },
+                        nextCursor: {
+                          type: 'string',
+                        },
+                      },
+                      required: ['items'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function for first page
+    const mockFetch = vi.fn();
+
+    // First call returns first page
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        items: [
+          { id: '1', name: 'Item 1', description: 'First item' },
+          { id: '2', name: 'Item 2', description: 'Second item' },
+        ],
+        nextCursor: 'next-page-cursor',
+      }),
+    });
+
+    // Second call returns second page
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        items: [
+          { id: '3', name: 'Item 3', description: 'Third item' },
+          { id: '4', name: 'Item 4', description: 'Fourth item' },
+        ],
+      }),
+    });
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the root queryKey method
+    const rootQueryKey = optionsProxyInstance.queryKey();
+    expect(rootQueryKey).toEqual(['TestApi']);
+
+    // Test the operation-specific queryKey method
+    const operationQueryKey = optionsProxyInstance.getItems.queryKey({});
+    expect(operationQueryKey).toEqual(['TestApi', 'getItems', {}]);
+
+    // Test the queryFilter method
+    const queryFilter = optionsProxyInstance.getItems.queryFilter({});
+    expect(queryFilter.queryKey).toEqual(['TestApi', 'getItems', {}]);
+
+    const extendedFilter = optionsProxyInstance.getItems.queryFilter(
+      {},
+      { exact: true },
+    );
+    expect(extendedFilter).toEqual({
+      queryKey: ['TestApi', 'getItems', {}],
+      exact: true,
+    });
+
+    // Test with parameters
+    const withParams = optionsProxyInstance.getItems.queryKey({
+      cursor: 'test-cursor',
+      limit: 20,
+    });
+    expect(withParams).toEqual([
+      'TestApi',
+      'getItems',
+      { cursor: 'test-cursor', limit: 20 },
+    ]);
+
+    const { getLatestHookState: infiniteQuery, fetchNextPage } =
+      await renderInfiniteQueryHook(
+        optionsProxyInstance.getItems.infiniteQueryOptions(
+          {},
+          {
+            getNextPageParam: (lastPage) => lastPage.nextCursor,
+          },
+        ),
+      );
+
+    // Verify the first page data is correct
+    expect(infiniteQuery().data.pages).toHaveLength(1);
+    expect(infiniteQuery().data.pages[0]).toEqual({
+      items: [
+        { id: '1', name: 'Item 1', description: 'First item' },
+        { id: '2', name: 'Item 2', description: 'Second item' },
+      ],
+      nextCursor: 'next-page-cursor',
+    });
+
+    // Verify the fetch was called correctly for the first page
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/items`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+
+    fetchNextPage();
+
+    // Verify both pages are now available
+    await waitFor(() => expect(infiniteQuery().data.pages).toHaveLength(2));
+    expect(infiniteQuery().data.pages[1]).toEqual({
+      items: [
+        { id: '3', name: 'Item 3', description: 'Third item' },
+        { id: '4', name: 'Item 4', description: 'Fourth item' },
+      ],
+    });
+    // Verify there are no more pages as nextCursor is undefined
+    expect(infiniteQuery().hasNextPage).toBe(false);
+
+    // Verify the fetch was called correctly for the second page with the cursor
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/items?cursor=next-page-cursor`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('should handle GET operation with x-mutation: true correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/actions/trigger': {
+          get: {
+            ...{
+              'x-mutation': true,
+            },
+            operationId: 'triggerAction',
+            description: 'Triggers an action via GET',
+            parameters: [
+              {
+                name: 'actionId',
+                in: 'query',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Action triggered successfully',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        success: { type: 'boolean' },
+                        actionId: { type: 'string' },
+                      },
+                      required: ['success', 'actionId'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      vi.fn(),
+    );
+
+    // Verify that the operation has mutationKey and mutationOptions methods (not queryKey/queryOptions)
+    expect(optionsProxyInstance.triggerAction.mutationKey).toBeDefined();
+    expect(optionsProxyInstance.triggerAction.mutationOptions).toBeDefined();
+    expect(optionsProxyInstance.triggerAction.queryKey).toBeUndefined();
+    expect(optionsProxyInstance.triggerAction.queryOptions).toBeUndefined();
+
+    // Test the mutation key
+    const mutationKey = optionsProxyInstance.triggerAction.mutationKey();
+    expect(mutationKey).toEqual(['TestApi', 'triggerAction']);
+  });
+
+  it('should handle POST operation with x-query: true correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/data/search': {
+          post: {
+            ...{
+              'x-query': true,
+            },
+            operationId: 'searchData',
+            description: 'Search data via POST',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      query: { type: 'string' },
+                    },
+                    required: ['query'],
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'Search results',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        results: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              title: { type: 'string' },
+                            },
+                            required: ['id', 'title'],
+                          },
+                        },
+                        total: { type: 'integer' },
+                      },
+                      required: ['results', 'total'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      vi.fn(),
+    );
+
+    // Verify that the operation has queryKey and queryOptions methods (not mutationKey/mutationOptions)
+    expect(optionsProxyInstance.searchData.queryKey).toBeDefined();
+    expect(optionsProxyInstance.searchData.queryOptions).toBeDefined();
+    expect(optionsProxyInstance.searchData.queryFilter).toBeDefined();
+    expect(optionsProxyInstance.searchData.mutationKey).toBeUndefined();
+    expect(optionsProxyInstance.searchData.mutationOptions).toBeUndefined();
+  });
+
+  it('should handle infinite query with custom cursor parameter', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/records': {
+          get: {
+            ...{
+              'x-cursor': 'nextToken',
+            },
+            operationId: 'listRecords',
+            description: 'Lists records with nextToken pagination',
+            parameters: [
+              {
+                name: 'limit',
+                in: 'query',
+                description: 'Number of records to return',
+                required: false,
+                schema: {
+                  type: 'integer',
+                  default: 10,
+                },
+              },
+              {
+                name: 'nextToken',
+                in: 'query',
+                description: 'Pagination token',
+                required: false,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of records',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        records: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              name: { type: 'string' },
+                              value: { type: 'number' },
+                            },
+                            required: ['id', 'name'],
+                          },
+                        },
+                        nextToken: {
+                          type: 'string',
+                        },
+                      },
+                      required: ['records'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function for first page
+    const mockFetch = vi.fn();
+
+    // First call returns first page
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        records: [
+          { id: '1', name: 'Record 1', value: 100 },
+          { id: '2', name: 'Record 2', value: 200 },
+        ],
+        nextToken: 'next-page-token',
+      }),
+    });
+
+    // Second call returns second page
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        records: [
+          { id: '3', name: 'Record 3', value: 300 },
+          { id: '4', name: 'Record 4', value: 400 },
+        ],
+        // No nextToken in the response means end of pagination
+      }),
+    });
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the infinite query hook
+    const { getLatestHookState: infiniteQuery, fetchNextPage } =
+      await renderInfiniteQueryHook(
+        optionsProxyInstance.listRecords.infiniteQueryOptions(
+          {},
+          {
+            getNextPageParam: (lastPage) => lastPage.nextToken,
+          },
+        ),
+      );
+
+    // Verify the first page data is correct
+    expect(infiniteQuery().data.pages).toHaveLength(1);
+    expect(infiniteQuery().data.pages[0]).toEqual({
+      records: [
+        { id: '1', name: 'Record 1', value: 100 },
+        { id: '2', name: 'Record 2', value: 200 },
+      ],
+      nextToken: 'next-page-token',
+    });
+
+    // Verify the fetch was called correctly for the first page
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/records`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+
+    fetchNextPage();
+
+    // Verify both pages are now available
+    await waitFor(() => expect(infiniteQuery().data.pages).toHaveLength(2));
+    expect(infiniteQuery().data.pages[1]).toEqual({
+      records: [
+        { id: '3', name: 'Record 3', value: 300 },
+        { id: '4', name: 'Record 4', value: 400 },
+      ],
+    });
+
+    // Verify there are no more pages as nextToken is undefined
+    expect(infiniteQuery().hasNextPage).toBe(false);
+
+    // Verify the fetch was called correctly for the second page with the nextToken
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/records?nextToken=next-page-token`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('should handle streaming query operation correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/events/stream': {
+          get: {
+            ...{
+              'x-streaming': true,
+            },
+            operationId: 'streamEvents',
+            description: 'Streams events as they occur',
+            parameters: [
+              {
+                name: 'type',
+                in: 'query',
+                description: 'Event type filter',
+                required: false,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Stream of events',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        type: { type: 'string' },
+                        timestamp: { type: 'string', format: 'date-time' },
+                        data: {
+                          type: 'object',
+                          properties: {
+                            value: {
+                              type: 'integer',
+                            },
+                          },
+                        },
+                      },
+                      required: ['id', 'type', 'timestamp'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create a mock async iterable for streaming events
+    const mockEvents = [
+      {
+        id: '1',
+        type: 'update',
+        timestamp: '2023-01-01T12:00:00Z',
+        data: { value: 10 },
+      },
+      {
+        id: '2',
+        type: 'update',
+        timestamp: '2023-01-01T12:01:00Z',
+        data: { value: 20 },
+      },
+      {
+        id: '3',
+        type: 'update',
+        timestamp: '2023-01-01T12:02:00Z',
+        data: { value: 30 },
+      },
+    ];
+
+    // Create mock fetch function that returns an async iterable
+    const mockFetch = vi.fn();
+    const mockClient = {
+      streamEvents: vi.fn().mockImplementation(async function* () {
+        for (const event of mockEvents) {
+          // Add a delay to ensure there's time for a rerender after each event
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          yield event;
+        }
+      }),
+    };
+
+    // Configure the options proxy with our mock client
+    const { TestApiOptionsProxy } =
+      await importTypeScriptModule<any>(optionsProxy);
+    const optionsProxyInstance = new TestApiOptionsProxy({
+      client: mockClient,
+    });
+
+    // Create a mock QueryClient for testing
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    // Test the query hook
+    const { getLatestHookState, getHookStates: getStates } =
+      await renderQueryHook(
+        optionsProxyInstance.streamEvents.queryOptions(
+          { type: 'update' },
+          { client: queryClient },
+        ),
+      );
+
+    // Verify the data contains all streamed events
+    await waitFor(() => expect(getLatestHookState().data).toEqual(mockEvents));
+
+    // Check that we had individual state updates for each streamed element
+    const states = getStates();
+
+    // We should have at least initial loading state + one state per event
+    expect(states.length).toBeGreaterThan(mockEvents.length);
+
+    // Find the first success state (after loading)
+    const successStates = states.filter((state) => state.isSuccess);
+    expect(successStates.length).toBeGreaterThanOrEqual(mockEvents.length);
+
+    // Verify that we got incremental updates
+    for (
+      let i = 0;
+      i < Math.min(mockEvents.length, successStates.length);
+      i++
+    ) {
+      // Each state should have the events up to that point
+      expect(successStates[i].data).toEqual(mockEvents.slice(0, i + 1));
+    }
+
+    // Verify the client method was called correctly
+    expect(mockClient.streamEvents).toHaveBeenCalledWith({ type: 'update' });
+  });
+
+  it('should handle streaming mutation operation correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/uploads/stream': {
+          post: {
+            ...{
+              'x-streaming': true,
+            },
+            operationId: 'uploadStream',
+            description: 'Upload a file with streaming progress',
+            requestBody: {
+              required: true,
+              content: {
+                'application/octet-stream': {
+                  schema: {
+                    type: 'string',
+                    format: 'binary',
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'Upload progress and result',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        progress: { type: 'number' },
+                        bytesUploaded: { type: 'integer' },
+                        status: { type: 'string' },
+                      },
+                      required: ['progress', 'bytesUploaded', 'status'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create a mock async iterable for streaming upload progress
+    const mockProgress = [
+      { progress: 0.25, bytesUploaded: 256000, status: 'uploading' },
+      { progress: 0.5, bytesUploaded: 512000, status: 'uploading' },
+      { progress: 0.75, bytesUploaded: 768000, status: 'uploading' },
+      { progress: 1.0, bytesUploaded: 1024000, status: 'completed' },
+    ];
+
+    // Create mock client with streaming upload method
+    const mockClient = {
+      uploadStream: vi.fn().mockImplementation(async function* () {
+        for (const progress of mockProgress) {
+          yield progress;
+        }
+      }),
+    };
+
+    // Configure the options proxy with our mock client
+    const { TestApiOptionsProxy } =
+      await importTypeScriptModule<any>(optionsProxy);
+    const optionsProxyInstance = new TestApiOptionsProxy({
+      client: mockClient,
+    });
+
+    // Test the mutation hook
+    const fileData = new Blob([new Uint8Array(1024000)]);
+    const { getLatestHookState } = await renderMutationHook(
+      optionsProxyInstance.uploadStream.mutationOptions(),
+      fileData,
+    );
+
+    // Verify the mutation was called with the file data
+    expect(mockClient.uploadStream).toHaveBeenCalledWith(fileData);
+
+    // Verify the mutation returns an AsyncIterableIterator
+    expect(getLatestHookState().data).toBeDefined();
+    expect(typeof getLatestHookState().data[Symbol.asyncIterator]).toBe(
+      'function',
+    );
+  });
+
+  it('should handle streaming infinite query operation correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/logs': {
+          get: {
+            ...{
+              'x-streaming': true,
+            },
+            operationId: 'streamLogs',
+            description: 'Stream logs with pagination',
+            parameters: [
+              {
+                name: 'limit',
+                in: 'query',
+                description: 'Number of logs to return per page',
+                required: false,
+                schema: {
+                  type: 'integer',
+                  default: 10,
+                },
+              },
+              {
+                name: 'cursor',
+                in: 'query',
+                description: 'Pagination token',
+                required: false,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Stream of logs',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        message: { type: 'string' },
+                        level: { type: 'string' },
+                        timestamp: { type: 'string', format: 'date-time' },
+                      },
+                      required: ['id', 'message', 'level', 'timestamp'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock streaming data for first page
+    const mockFirstPageLogs = [
+      {
+        id: '1',
+        message: 'Starting application',
+        level: 'info',
+        timestamp: '2023-01-01T12:00:00Z',
+      },
+      {
+        id: '2',
+        message: 'Connected to database',
+        level: 'info',
+        timestamp: '2023-01-01T12:00:01Z',
+      },
+    ];
+
+    // Create mock streaming data for second page
+    const mockSecondPageLogs = [
+      {
+        id: '3',
+        message: 'User login',
+        level: 'info',
+        timestamp: '2023-01-01T12:00:02Z',
+      },
+      {
+        id: '4',
+        message: 'API request received',
+        level: 'debug',
+        timestamp: '2023-01-01T12:00:03Z',
+      },
+    ];
+
+    // Create mock client with streaming methods
+    const mockClient = {
+      streamLogs: vi
+        .fn()
+        // First call returns first page with nextToken
+        .mockImplementationOnce(async function* () {
+          for (const log of mockFirstPageLogs) {
+            yield log;
+          }
+        })
+        // Second call returns second page without nextToken
+        .mockImplementationOnce(async function* () {
+          for (const log of mockSecondPageLogs) {
+            yield log;
+          }
+        }),
+    };
+
+    // Configure the options proxy with our mock client
+    const { TestApiOptionsProxy } =
+      await importTypeScriptModule<any>(optionsProxy);
+    const optionsProxyInstance = new TestApiOptionsProxy({
+      client: mockClient,
+    });
+
+    // Test the infinite query hook
+    const { getLatestHookState: infiniteQuery, fetchNextPage } =
+      await renderInfiniteQueryHook(
+        optionsProxyInstance.streamLogs.infiniteQueryOptions(
+          {},
+          {
+            getNextPageParam: (lastPage) => lastPage[lastPage.length - 1].id,
+          },
+        ),
+      );
+
+    // Verify the first page data is correct
+    expect(infiniteQuery().data.pages).toHaveLength(1);
+    expect(infiniteQuery().data.pages[0]).toEqual(mockFirstPageLogs);
+
+    // Verify the client method was called correctly for the first page
+    expect(mockClient.streamLogs).toHaveBeenCalledWith({});
+
+    // Fetch the next page
+    fetchNextPage();
+
+    // Verify both pages are now available
+    await waitFor(() => expect(infiniteQuery().data.pages).toHaveLength(2));
+    expect(infiniteQuery().data.pages[1]).toEqual(mockSecondPageLogs);
+
+    // Verify the client method was called correctly for the second page
+    expect(mockClient.streamLogs).toHaveBeenCalledWith({ cursor: '2' });
+  });
+
+  it('should handle infinite query errors correctly', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'getItems',
+            description: 'Gets a paginated list of items',
+            parameters: [
+              {
+                name: 'cursor',
+                in: 'query',
+                description: 'Pagination cursor',
+                required: false,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of items',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        items: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: { type: 'string' },
+                              name: { type: 'string' },
+                            },
+                            required: ['id', 'name'],
+                          },
+                        },
+                        nextCursor: { type: 'string', nullable: true },
+                      },
+                      required: ['items'],
+                    },
+                  },
+                },
+              },
+              '400': {
+                description: 'Bad request',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        error: { type: 'string' },
+                      },
+                      required: ['error'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    );
+    expect(optionsProxy).toMatchSnapshot();
+
+    // Create mock fetch function that returns an error
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 400,
+      json: vi.fn().mockResolvedValue({
+        error: 'Invalid cursor format',
+      }),
+    });
+
+    // Configure the options proxy
+    const optionsProxyInstance = await configureOptionsProxy(
+      client,
+      optionsProxy,
+      mockFetch,
+    );
+
+    // Test the infinite query hook with an invalid cursor
+    const { getLatestHookState: infiniteQuery } = await renderInfiniteQueryHook(
+      optionsProxyInstance.getItems.infiniteQueryOptions(
+        {},
+        {
+          getNextPageParam: (lastPage) => lastPage.nextCursor,
+        },
+      ),
+    );
+
+    // Verify the error state
+    expect(infiniteQuery().isError).toBe(true);
+    expect(infiniteQuery().error).toBeDefined();
+    expect(infiniteQuery().error).toMatchObject({
+      status: 400,
+      error: { error: 'Invalid cursor format' },
+    });
+
+    // Verify the fetch was called correctly
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/items`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
@@ -6,7 +6,10 @@ import { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import { Spec } from '../utils/types';
 import { openApiTsHooksGenerator } from './generator';
-import { expectTypeScriptToCompile } from '../ts-client/generator.utils.spec';
+import {
+  expectTypeScriptToCompile,
+  TypeScriptVerifier,
+} from '../ts-client/generator.utils.spec';
 import { importTypeScriptModule } from '../../utils/js';
 import { waitFor, render, fireEvent } from '@testing-library/react';
 import {
@@ -26,13 +29,14 @@ describe('openApiTsHooksGenerator', () => {
   let tree: Tree;
   const title = 'TestApi';
   const baseUrl = 'https://example.com';
+  const verifier = new TypeScriptVerifier(['@tanstack/react-query']);
 
   beforeEach(() => {
     tree = createTreeUsingTsSolutionSetup();
   });
 
   const validateTypeScript = (paths: string[]) => {
-    expectTypeScriptToCompile(tree, paths, ['@tanstack/react-query']);
+    verifier.expectTypeScriptToCompile(tree, paths);
   };
 
   // Helper function to create a wrapper component with QueryClientProvider

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
@@ -2,12 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { generateFiles, Tree } from '@nx/devkit';
 import { OpenApiHooksSchema } from './schema';
 import { parseOpenApiSpec } from '../utils/parse';
 import { buildOpenApiCodeGenData } from '../utils/codegen-data';
 import { generateOpenApiTsClient } from '../ts-client/generator';
 import { formatFilesInSubtree } from '../../utils/format';
+import path from 'path';
+import { CodeGenData } from '../utils/codegen-data/types';
 
 /**
  * Generates typescript hooks from an openapi spec
@@ -21,10 +23,20 @@ export const openApiTsHooksGenerator = async (
   const data = await buildOpenApiCodeGenData(spec);
 
   generateOpenApiTsClient(tree, data, options.outputPath);
-
-  // TODO: generate hooks which wrap the client
+  generateOpenApiTsHooks(tree, data, options.outputPath);
 
   await formatFilesInSubtree(tree);
+};
+
+/**
+ * Generate OpenAPI typescript hooks in the target directory
+ */
+export const generateOpenApiTsHooks = (
+  tree: Tree,
+  data: CodeGenData,
+  outputPath: string,
+) => {
+  generateFiles(tree, path.join(__dirname, 'files'), outputPath, data);
 };
 
 export default openApiTsHooksGenerator;

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -34,3 +34,29 @@ export const PRIMITIVE_TYPES = new Set([
   'binary',
   'void',
 ]);
+
+/**
+ * Vendor extensions which are used to customise generated code
+ */
+export const VENDOR_EXTENSIONS = {
+  /**
+   * Set to 'true' to indicate this is a streaming API
+   */
+  STREAMING: 'x-streaming',
+  /**
+   * Set to true to indicate this is a mutation, regardless of its HTTP method
+   */
+  MUTATION: 'x-mutation',
+  /**
+   * Set to true to indicate this is a query, regardless of its HTTP method
+   */
+  QUERY: 'x-query',
+  /**
+   * Set to the name of the input property used as the cursor for pagination if
+   * the API accepts a cursor that is not named 'cursor'.
+   * This can also be set to false to override behaviour and indicate this is not
+   * a paginated API.
+   * Used for tanstack infinite query hooks.
+   */
+  CURSOR: 'x-cursor',
+} as const;

--- a/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
@@ -10,12 +10,56 @@ with open(sys.argv[1], 'w') as f:
 "
 `;
 
-exports[`fastapi react generator > should generate client hook > useTestApi.tsx 1`] = `
+exports[`fastapi react generator > should generate tanstack query options proxy hook > useTestApi.tsx 1`] = `
+"import { useContext } from 'react';
+import { TestApiContext } from '../components/TestApiProvider';
+import { TestApiOptionsProxy } from '../generated/test-api/options-proxy.gen';
+
+export const useTestApi = (): TestApiOptionsProxy => {
+  const optionsProxy = useContext(TestApiContext);
+
+  if (!optionsProxy) {
+    throw new Error('useTestApi must be used within a TestApiProvider');
+  }
+
+  return optionsProxy;
+};
+"
+`;
+
+exports[`fastapi react generator > should generate tanstack query options proxy provider > TestApiProvider.tsx 1`] = `
+"import { createContext, FC, PropsWithChildren, useMemo } from 'react';
+import { useTestApiClient } from '../hooks/useTestApiClient';
+import { TestApiOptionsProxy } from '../generated/test-api/options-proxy.gen';
+
+export const TestApiContext = createContext<TestApiOptionsProxy | undefined>(
+  undefined,
+);
+
+export const TestApiProvider: FC<PropsWithChildren> = ({ children }) => {
+  const client = useTestApiClient();
+  const optionsProxy = useMemo(
+    () => new TestApiOptionsProxy({ client }),
+    [client],
+  );
+
+  return (
+    <TestApiContext.Provider value={optionsProxy}>
+      {children}
+    </TestApiContext.Provider>
+  );
+};
+
+export default TestApiProvider;
+"
+`;
+
+exports[`fastapi react generator > should generate vanilla client hook > useTestApiClient.tsx 1`] = `
 "import { TestApi } from '../generated/test-api/client.gen';
 import { useRuntimeConfig } from './useRuntimeConfig';
 import { useMemo } from 'react';
 
-export const useTestApi = (): TestApi => {
+export const useTestApiClient = (): TestApi => {
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.httpApis.TestApi;
   return useMemo(
@@ -35,7 +79,7 @@ import { useSigV4 } from './useSigV4';
 import { useRuntimeConfig } from './useRuntimeConfig';
 import { useMemo } from 'react';
 
-export const useTestApi = (): TestApi => {
+export const useTestApiClient = (): TestApi => {
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.httpApis.TestApi;
   const sigv4Client = useSigV4();
@@ -48,5 +92,26 @@ export const useTestApi = (): TestApi => {
     [apiUrl, sigv4Client],
   );
 };
+"
+`;
+
+exports[`fastapi react generator > should instrument providers in main.tsx > main.tsx 1`] = `
+"import TestApiProvider from './components/TestApiProvider';
+import QueryClientProvider from './components/QueryClientProvider';
+import RuntimeConfigProvider from './components/RuntimeConfig';
+import { App } from './app';
+import { RouterProvider } from '@tanstack/react-router';
+
+export function Main() {
+  return (
+    <RuntimeConfigProvider>
+      <QueryClientProvider>
+        <TestApiProvider>
+          <RouterProvider router={router} />
+        </TestApiProvider>
+      </QueryClientProvider>
+    </RuntimeConfigProvider>
+  );
+}
 "
 `;

--- a/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
@@ -29,37 +29,20 @@ export const useTestApi = (): TestApiOptionsProxy => {
 
 exports[`fastapi react generator > should generate tanstack query options proxy provider > TestApiProvider.tsx 1`] = `
 "import { createContext, FC, PropsWithChildren, useMemo } from 'react';
-import { useTestApiClient } from '../hooks/useTestApiClient';
+import { TestApi } from '../generated/test-api/client.gen';
 import { TestApiOptionsProxy } from '../generated/test-api/options-proxy.gen';
+import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
+import { useSigV4 } from '../hooks/useSigV4';
 
 export const TestApiContext = createContext<TestApiOptionsProxy | undefined>(
   undefined,
 );
 
-export const TestApiProvider: FC<PropsWithChildren> = ({ children }) => {
-  const client = useTestApiClient();
-  const optionsProxy = useMemo(
-    () => new TestApiOptionsProxy({ client }),
-    [client],
-  );
+export const TestApiClientContext = createContext<TestApi | undefined>(
+  undefined,
+);
 
-  return (
-    <TestApiContext.Provider value={optionsProxy}>
-      {children}
-    </TestApiContext.Provider>
-  );
-};
-
-export default TestApiProvider;
-"
-`;
-
-exports[`fastapi react generator > should generate vanilla client hook > useTestApiClient.tsx 1`] = `
-"import { TestApi } from '../generated/test-api/client.gen';
-import { useRuntimeConfig } from './useRuntimeConfig';
-import { useMemo } from 'react';
-
-export const useTestApiClient = (): TestApi => {
+const useCreateTestApiClient = (): TestApi => {
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.httpApis.TestApi;
   return useMemo(
@@ -70,16 +53,60 @@ export const useTestApiClient = (): TestApi => {
     [apiUrl],
   );
 };
+
+export const TestApiProvider: FC<PropsWithChildren> = ({ children }) => {
+  const client = useCreateTestApiClient();
+  const optionsProxy = useMemo(
+    () => new TestApiOptionsProxy({ client }),
+    [client],
+  );
+
+  return (
+    <TestApiClientContext.Provider value={client}>
+      <TestApiContext.Provider value={optionsProxy}>
+        {children}
+      </TestApiContext.Provider>
+    </TestApiClientContext.Provider>
+  );
+};
+
+export default TestApiProvider;
 "
 `;
 
-exports[`fastapi react generator > should handle IAM auth option > useTestApi-IAM.tsx 1`] = `
+exports[`fastapi react generator > should generate vanilla client hook > useTestApiClient.tsx 1`] = `
 "import { TestApi } from '../generated/test-api/client.gen';
-import { useSigV4 } from './useSigV4';
-import { useRuntimeConfig } from './useRuntimeConfig';
-import { useMemo } from 'react';
+import { TestApiClientContext } from '../components/TestApiProvider';
+import { useContext } from 'react';
 
 export const useTestApiClient = (): TestApi => {
+  const client = useContext(TestApiClientContext);
+
+  if (!client) {
+    throw new Error('useTestApiClient must be used within a TestApiProvider');
+  }
+
+  return client;
+};
+"
+`;
+
+exports[`fastapi react generator > should handle IAM auth option > TestApiProvider-IAM.tsx 1`] = `
+"import { createContext, FC, PropsWithChildren, useMemo } from 'react';
+import { TestApi } from '../generated/test-api/client.gen';
+import { TestApiOptionsProxy } from '../generated/test-api/options-proxy.gen';
+import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
+import { useSigV4 } from '../hooks/useSigV4';
+
+export const TestApiContext = createContext<TestApiOptionsProxy | undefined>(
+  undefined,
+);
+
+export const TestApiClientContext = createContext<TestApi | undefined>(
+  undefined,
+);
+
+const useCreateTestApiClient = (): TestApi => {
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.httpApis.TestApi;
   const sigv4Client = useSigV4();
@@ -92,6 +119,24 @@ export const useTestApiClient = (): TestApi => {
     [apiUrl, sigv4Client],
   );
 };
+
+export const TestApiProvider: FC<PropsWithChildren> = ({ children }) => {
+  const client = useCreateTestApiClient();
+  const optionsProxy = useMemo(
+    () => new TestApiOptionsProxy({ client }),
+    [client],
+  );
+
+  return (
+    <TestApiClientContext.Provider value={client}>
+      <TestApiContext.Provider value={optionsProxy}>
+        {children}
+      </TestApiContext.Provider>
+    </TestApiClientContext.Provider>
+  );
+};
+
+export default TestApiProvider;
 "
 `;
 

--- a/packages/nx-plugin/src/py/fast-api/react/files/website/components/__apiNameClassName__Provider.tsx.template
+++ b/packages/nx-plugin/src/py/fast-api/react/files/website/components/__apiNameClassName__Provider.tsx.template
@@ -1,0 +1,20 @@
+import { createContext, FC, PropsWithChildren, useMemo } from 'react';
+import { use<%- apiNameClassName %>Client } from '../hooks/use<%- apiNameClassName %>Client';
+import { <%- apiNameClassName %>OptionsProxy } from '../<%- generatedClientDir %>/options-proxy.gen';
+
+export const <%- apiNameClassName %>Context = createContext<<%- apiNameClassName %>OptionsProxy | undefined>(undefined);
+
+export const <%- apiNameClassName %>Provider: FC<PropsWithChildren> = ({ children }) => {
+  const client = use<%- apiNameClassName %>Client();
+  const optionsProxy = useMemo(() =>
+    new <%- apiNameClassName %>OptionsProxy({ client })
+  , [client]);
+
+  return (
+    <<%- apiNameClassName %>Context.Provider value={optionsProxy}>
+      {children}
+    </<%- apiNameClassName %>Context.Provider>
+  );
+};
+
+export default <%- apiNameClassName %>Provider;

--- a/packages/nx-plugin/src/py/fast-api/react/files/website/components/__apiNameClassName__Provider.tsx.template
+++ b/packages/nx-plugin/src/py/fast-api/react/files/website/components/__apiNameClassName__Provider.tsx.template
@@ -1,19 +1,39 @@
 import { createContext, FC, PropsWithChildren, useMemo } from 'react';
-import { use<%- apiNameClassName %>Client } from '../hooks/use<%- apiNameClassName %>Client';
+import { <%- apiNameClassName %> } from '../<%- generatedClientDir %>/client.gen';
 import { <%- apiNameClassName %>OptionsProxy } from '../<%- generatedClientDir %>/options-proxy.gen';
+import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
+import { useSigV4 } from '../hooks/useSigV4';
 
 export const <%- apiNameClassName %>Context = createContext<<%- apiNameClassName %>OptionsProxy | undefined>(undefined);
 
+export const <%- apiNameClassName %>ClientContext = createContext<<%- apiNameClassName %> | undefined>(undefined);
+
+const useCreate<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
+  const runtimeConfig = useRuntimeConfig();
+  const apiUrl = runtimeConfig.httpApis.<%- apiNameClassName %>;
+  <%_ if(auth === 'IAM') { _%>
+  const sigv4Client = useSigV4();
+  <%_ } _%>
+  return useMemo(() => new <%- apiNameClassName %>({
+    url: apiUrl,
+    <%_ if(auth === 'IAM') { _%>
+    fetch: sigv4Client,
+    <%_ } _%>
+  }), [apiUrl<% if(auth === 'IAM') { %>, sigv4Client<% } %>])
+};
+
 export const <%- apiNameClassName %>Provider: FC<PropsWithChildren> = ({ children }) => {
-  const client = use<%- apiNameClassName %>Client();
+  const client = useCreate<%- apiNameClassName %>Client();
   const optionsProxy = useMemo(() =>
     new <%- apiNameClassName %>OptionsProxy({ client })
   , [client]);
 
   return (
-    <<%- apiNameClassName %>Context.Provider value={optionsProxy}>
-      {children}
-    </<%- apiNameClassName %>Context.Provider>
+    <<%- apiNameClassName %>ClientContext.Provider value={client}>
+      <<%- apiNameClassName %>Context.Provider value={optionsProxy}>
+        {children}
+      </<%- apiNameClassName %>Context.Provider>
+    </<%- apiNameClassName %>ClientContext.Provider>
   );
 };
 

--- a/packages/nx-plugin/src/py/fast-api/react/files/website/hooks/use__apiNameClassName__.tsx.template
+++ b/packages/nx-plugin/src/py/fast-api/react/files/website/hooks/use__apiNameClassName__.tsx.template
@@ -1,20 +1,15 @@
-import { <%- apiNameClassName %> } from '../<%- generatedClientDir %>/client.gen';
-<%_ if(auth === 'IAM') { _%>
-import { useSigV4 } from './useSigV4';
-<%_ } _%>
-import { useRuntimeConfig } from './useRuntimeConfig';
-import { useMemo } from 'react';
+import { useContext } from 'react';
+import { <%- apiNameClassName %>Context } from '../components/<%- apiNameClassName %>Provider';
+import { <%- apiNameClassName %>OptionsProxy } from '../<%- generatedClientDir %>/options-proxy.gen';
 
-export const use<%- apiNameClassName %> = (): <%- apiNameClassName %> => {
-  const runtimeConfig = useRuntimeConfig();
-  const apiUrl = runtimeConfig.httpApis.<%- apiNameClassName %>;
-  <%_ if(auth === 'IAM') { _%>
-  const sigv4Client = useSigV4();
-  <%_ } _%>
-  return useMemo(() => new <%- apiNameClassName %>({
-    url: apiUrl,
-    <%_ if(auth === 'IAM') { _%>
-    fetch: sigv4Client,
-    <%_ } _%>
-  }), [apiUrl<% if(auth === 'IAM') { %>, sigv4Client<% } %>])
+export const use<%- apiNameClassName %> = (): <%- apiNameClassName %>OptionsProxy => {
+  const optionsProxy = useContext(<%- apiNameClassName %>Context);
+
+  if (!optionsProxy) {
+    throw new Error(
+      'use<%- apiNameClassName %> must be used within a <%- apiNameClassName %>Provider',
+    );
+  }
+
+  return optionsProxy;
 };

--- a/packages/nx-plugin/src/py/fast-api/react/files/website/hooks/use__apiNameClassName__Client.tsx.template
+++ b/packages/nx-plugin/src/py/fast-api/react/files/website/hooks/use__apiNameClassName__Client.tsx.template
@@ -1,0 +1,20 @@
+import { <%- apiNameClassName %> } from '../<%- generatedClientDir %>/client.gen';
+<%_ if(auth === 'IAM') { _%>
+import { useSigV4 } from './useSigV4';
+<%_ } _%>
+import { useRuntimeConfig } from './useRuntimeConfig';
+import { useMemo } from 'react';
+
+export const use<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
+  const runtimeConfig = useRuntimeConfig();
+  const apiUrl = runtimeConfig.httpApis.<%- apiNameClassName %>;
+  <%_ if(auth === 'IAM') { _%>
+  const sigv4Client = useSigV4();
+  <%_ } _%>
+  return useMemo(() => new <%- apiNameClassName %>({
+    url: apiUrl,
+    <%_ if(auth === 'IAM') { _%>
+    fetch: sigv4Client,
+    <%_ } _%>
+  }), [apiUrl<% if(auth === 'IAM') { %>, sigv4Client<% } %>])
+};

--- a/packages/nx-plugin/src/py/fast-api/react/files/website/hooks/use__apiNameClassName__Client.tsx.template
+++ b/packages/nx-plugin/src/py/fast-api/react/files/website/hooks/use__apiNameClassName__Client.tsx.template
@@ -1,20 +1,13 @@
 import { <%- apiNameClassName %> } from '../<%- generatedClientDir %>/client.gen';
-<%_ if(auth === 'IAM') { _%>
-import { useSigV4 } from './useSigV4';
-<%_ } _%>
-import { useRuntimeConfig } from './useRuntimeConfig';
-import { useMemo } from 'react';
+import { <%- apiNameClassName %>ClientContext } from '../components/<%- apiNameClassName %>Provider';
+import { useContext } from 'react';
 
 export const use<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
-  const runtimeConfig = useRuntimeConfig();
-  const apiUrl = runtimeConfig.httpApis.<%- apiNameClassName %>;
-  <%_ if(auth === 'IAM') { _%>
-  const sigv4Client = useSigV4();
-  <%_ } _%>
-  return useMemo(() => new <%- apiNameClassName %>({
-    url: apiUrl,
-    <%_ if(auth === 'IAM') { _%>
-    fetch: sigv4Client,
-    <%_ } _%>
-  }), [apiUrl<% if(auth === 'IAM') { %>, sigv4Client<% } %>])
+  const client = useContext(<%- apiNameClassName %>ClientContext);
+
+  if (!client) {
+    throw new Error('use<%- apiNameClassName %>Client must be used within a <%- apiNameClassName %>Provider');
+  }
+
+  return client;
 };

--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -269,9 +269,9 @@ export function Main() {
     ).toBeDefined();
     expect(packageJson.dependencies['aws4fetch']).toBeDefined();
 
-    // Create snapshot of generated hook with IAM auth
+    // Create snapshot of generated provider with IAM auth
     expect(
-      tree.read('apps/frontend/src/hooks/useTestApiClient.tsx', 'utf-8'),
-    ).toMatchSnapshot('useTestApi-IAM.tsx');
+      tree.read('apps/frontend/src/components/TestApiProvider.tsx', 'utf-8'),
+    ).toMatchSnapshot('TestApiProvider-IAM.tsx');
   });
 });

--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -124,6 +124,11 @@ export function Main() {
     expect(projectConfig.targets.compile.dependsOn).toContain(
       'generate:test-api-client',
     );
+
+    // Verify bundle target depends on client generation
+    expect(projectConfig.targets.bundle.dependsOn).toContain(
+      'generate:test-api-client',
+    );
   });
 
   it('should generate vanilla client hook', async () => {

--- a/packages/nx-plugin/src/py/fast-api/react/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.ts
@@ -101,16 +101,21 @@ export const fastApiReactGenerator = async (
     ...frontendProjectConfig,
     targets: sortObjectKeys({
       ...frontendProjectConfig.targets,
-      // Generate should run before compile as the client is created as part of the website src
-      compile: {
-        ...frontendProjectConfig.targets?.compile,
-        dependsOn: [
-          ...(frontendProjectConfig.targets?.compile?.dependsOn ?? []).filter(
-            (t) => t !== clientGenTarget,
-          ),
-          clientGenTarget,
-        ],
-      },
+      // Generate should run before compile and bundle as the client is created as part of the website src
+      ...Object.fromEntries(
+        ['compile', 'bundle'].map((target) => [
+          target,
+          {
+            ...frontendProjectConfig.targets?.[target],
+            dependsOn: [
+              ...(
+                frontendProjectConfig.targets?.[target]?.dependsOn ?? []
+              ).filter((t) => t !== clientGenTarget),
+              clientGenTarget,
+            ],
+          },
+        ]),
+      ),
       [clientGenTarget]: {
         cache: true,
         executor: 'nx:run-commands',

--- a/packages/nx-plugin/tsconfig.lib.json
+++ b/packages/nx-plugin/tsconfig.lib.json
@@ -6,5 +6,10 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/packages/nx-plugin/tsconfig.spec.json
+++ b/packages/nx-plugin/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "jsx": "react-jsx",
     "types": [
       "vitest/globals",
       "vitest/importMeta",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.9
         version: 4.0.9(vite@5.4.8(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.29.1)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1))
+      '@tanstack/react-query':
+        specifier: ^5.59.20
+        version: 5.68.0(react@18.3.1)
+      '@testing-library/react':
+        specifier: ^16.2.0
+        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ts-morph/bootstrap':
         specifier: ^0.26.1
         version: 0.26.1
@@ -2825,6 +2831,33 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6
 
+  '@tanstack/query-core@5.68.0':
+    resolution: {integrity: sha512-r8rFYYo8/sY/LNaOqX84h12w7EQev4abFXDWy4UoDVUJzJ5d9Fbmb8ayTi7ScG+V0ap44SF3vNs/45mkzDGyGw==}
+
+  '@tanstack/react-query@5.68.0':
+    resolution: {integrity: sha512-mMOdGDKlwTP/WV72QqSNf4PAMeoBp/DqBHQ222wBfb51Looi8QUqnCnb9O98ZgvNISmy6fzxRGBJdZ+9IBvX2Q==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.2.0':
+    resolution: {integrity: sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -2856,6 +2889,9 @@ packages:
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3393,6 +3429,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -4268,6 +4307,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -5968,6 +6010,10 @@ packages:
     resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
@@ -6840,6 +6886,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6948,6 +6998,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -11443,6 +11496,34 @@ snapshots:
       tailwindcss: 4.0.9
       vite: 5.4.8(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.29.1)(sass@1.79.4)(stylus@0.64.0)(terser@5.34.1)
 
+  '@tanstack/query-core@5.68.0': {}
+
+  '@tanstack/react-query@5.68.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.68.0
+      react: 18.3.1
+
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.26.0
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@testing-library/dom': 10.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.1
+      '@types/react-dom': 19.0.4(@types/react@18.3.1)
+
   '@tootallnate/once@2.0.0': {}
 
   '@trysound/sax@0.2.0': {}
@@ -11472,6 +11553,8 @@ snapshots:
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.6
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -12260,6 +12343,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -13245,6 +13332,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15449,6 +15538,8 @@ snapshots:
 
   luxon@3.5.0: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -16651,6 +16742,12 @@ snapshots:
 
   prettier@3.4.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -16755,6 +16852,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 


### PR DESCRIPTION
### Reason for this change

* No need for users to manage state manually
* More consistent with tRPC

### Description of changes

This change implements the open-api#ts-hooks generator, which provides factory methods for options to provide to tanstack query hooks, in a similar manner to tRPC.

This saves the need for users to manage state themselves, and provides parity with tRPC.

By default, PUT/PATCH/POST/DELETE http requests are considered "mutations" and all others "queries". This behaviour can be overridden with `x-mutation` and `x-query` vendor extensions however.

Similarly to tRPC, if an operation accepts a `cursor` parameter, we consider this a paginated operation and generate an `infiniteQueryOptions` method alongside the `queryOptions` method. If an operation is paginated but has a different pagination parameter name, this can be specified using the `x-cursor` vendor extension.

We support streaming operations in a similar manner to tRPC, where a streaming query hook will continually have its data updated as chunks are received. Since a single cache entry is shared by all pages for an infinite query hook, we cannot stream multiple pages at once for a "paginated streaming" operation as this risks conflicts/race-conditions. We therefore iterate through the whole stream for each page in this case.
For mutation operations which return a stream, we don't do anything special and just return the iterator for the user to use if required.

### Description of how you validated changes

* unit tests
* walked through the dungeon adventure tutorial

### Issue # (if applicable)

Fixes #96

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*