### PR TITLE
fix(py#project): ignore reports and pycache files in version control

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -36,7 +36,7 @@ describe('python project generator', () => {
     });
 
     const projectConfig = JSON.parse(
-      tree.read('apps/test_project/project.json', 'utf-8')
+      tree.read('apps/test_project/project.json', 'utf-8'),
     );
 
     // Verify project targets
@@ -59,7 +59,7 @@ describe('python project generator', () => {
     });
 
     const pyprojectToml = parse(
-      tree.read('apps/test_project/pyproject.toml', 'utf-8')
+      tree.read('apps/test_project/pyproject.toml', 'utf-8'),
     );
 
     // Verify python version
@@ -77,10 +77,10 @@ describe('python project generator', () => {
     });
 
     const nxJson = JSON.parse(tree.read('nx.json', 'utf-8'));
-    
+
     // Verify python plugin is configured
     const pythonPlugin = nxJson.plugins.find(
-      (p) => typeof p === 'object' && p.plugin === '@nxlv/python'
+      (p) => typeof p === 'object' && p.plugin === '@nxlv/python',
     );
     expect(pythonPlugin).toBeDefined();
     expect(pythonPlugin.options.packageManager).toBe('uv');
@@ -96,5 +96,20 @@ describe('python project generator', () => {
 
     expect(tree.exists('apps/test_project/custom_module')).toBeTruthy();
     expect(tree.exists('apps/test_project/tests')).toBeTruthy();
+  });
+
+  it('should ignore additional build artifacts', async () => {
+    await pyProjectGenerator(tree, {
+      name: 'test-project',
+      directory: 'apps',
+      projectType: 'application',
+    });
+    const rootGitIgnorePatterns =
+      tree.read('.gitignore', 'utf-8')?.split('\n') ?? [];
+    expect(rootGitIgnorePatterns).toContain('/reports');
+
+    const projectGitIgnorePatterns =
+      tree.read('apps/test_project/.gitignore', 'utf-8')?.split('\n') ?? [];
+    expect(projectGitIgnorePatterns).toContain('**/__pycache__');
   });
 });

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -21,6 +21,7 @@ import { withVersions } from '../../utils/versions';
 import { getNpmScope } from '../../utils/npm-scope';
 import { toSnakeCase } from '../../utils/names';
 import { sortObjectKeys } from '../../utils/nx';
+import { updateGitIgnore } from '../../utils/git';
 
 export interface PyProjectDetails {
   readonly normalizedName: string;
@@ -141,6 +142,12 @@ export const pyProjectGenerator = async (
   };
   projectConfiguration.targets = sortObjectKeys(projectConfiguration.targets);
   updateProjectConfiguration(tree, normalizedName, projectConfiguration);
+
+  // Update root .gitignore to ignore reports directory
+  updateGitIgnore(tree, '.', (patterns) => [...patterns, '/reports']);
+
+  // Update project level .gitignore to ignore __pycache__ directories
+  updateGitIgnore(tree, dir, (patterns) => [...patterns, '**/__pycache__']);
 
   return async () => {
     await new UVProvider(tree.root, new Logger(), tree).install();


### PR DESCRIPTION
### Reason for this change

`/reports` and `__pycache__` are created from building/testing a python project and should not be committed to version control

### Description of changes

Add appropriate patterns to `.gitignore`

### Description of how you validated changes

Unit tests, and updated .gitignores with same patterns in example dungeon adventure repo

### Issue # (if applicable)

Fixes #93

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*