### PR TITLE
feat(http-api): use grantable instead of role for granting invoke access to apis

### DIFF
--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
@@ -137,7 +137,7 @@ import {
   Runtime,
   Tracing,
 } from 'aws-cdk-lib/aws-lambda';
-import { Effect, IRole, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
 import { RuntimeConfig } from './runtime-config.js';
 
 export interface HttpApiProps {
@@ -245,28 +245,24 @@ export class HttpApi extends Construct {
     };
   }
 
-  public grantInvokeAccess(role: IRole) {
+  public grantInvokeAccess(grantee: IGrantable) {
     if (this.api) {
-      role.addToPrincipalPolicy(
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: ['execute-api:Invoke'],
-          resources: [this.api.arnForExecuteApi('*', '/*', '*')],
-        }),
-      );
+      Grant.addToPrincipal({
+        grantee,
+        actions: ['execute-api:Invoke'],
+        resourceArns: [this.api.arnForExecuteApi('*', '/*', '*')],
+      });
     } else if (this.routerFunction) {
-      role.addToPrincipalPolicy(
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: ['lambda:InvokeFunctionUrl'],
-          resources: [this.routerFunction.functionArn],
-          conditions: {
-            StringEquals: {
-              'lambda:FunctionUrlAuthType': 'AWS_IAM',
-            },
+      Grant.addToPrincipal({
+        grantee,
+        actions: ['lambda:InvokeFunctionUrl'],
+        resourceArns: [this.routerFunction.functionArn],
+        conditions: {
+          StringEquals: {
+            'lambda:FunctionUrlAuthType': 'AWS_IAM',
           },
-        }),
-      );
+        },
+      });
     }
   }
 }

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -344,7 +344,7 @@ import {
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import { Code, Function, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
-import { Effect, IRole, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
 import { RuntimeConfig } from './runtime-config.js';
 
 export interface HttpApiProps {
@@ -413,14 +413,12 @@ export class HttpApi extends Construct {
     };
   }
 
-  public grantInvokeAccess(role: IRole) {
-    role.addToPrincipalPolicy(
-      new PolicyStatement({
-        effect: Effect.ALLOW,
-        actions: ['execute-api:Invoke'],
-        resources: [this.api.arnForExecuteApi('*', '/*', '*')],
-      }),
-    );
+  public grantInvokeAccess(grantee: IGrantable) {
+    Grant.addToPrincipal({
+      grantee,
+      actions: ['execute-api:Invoke'],
+      resourceArns: [this.api.arnForExecuteApi('*', '/*', '*')],
+    });
   }
 }
 "

--- a/packages/nx-plugin/src/utils/files/http-api/common/constructs/src/core/http-api.ts.template
+++ b/packages/nx-plugin/src/utils/files/http-api/common/constructs/src/core/http-api.ts.template
@@ -8,7 +8,7 @@ import {
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import { Code, Function, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
-import { Effect, IRole, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
 import { RuntimeConfig } from './runtime-config.js';
 
 export interface HttpApiProps {
@@ -77,13 +77,11 @@ export class HttpApi extends Construct {
     };
   }
 
-  public grantInvokeAccess(role: IRole) {
-    role.addToPrincipalPolicy(
-      new PolicyStatement({
-        effect: Effect.ALLOW,
-        actions: ['execute-api:Invoke'],
-        resources: [this.api.arnForExecuteApi('*', '/*', '*')],
-      }),
-    );
+  public grantInvokeAccess(grantee: IGrantable) {
+    Grant.addToPrincipal({
+      grantee,
+      actions: ['execute-api:Invoke'],
+      resourceArns: [this.api.arnForExecuteApi('*', '/*', '*')],
+    });
   }
 }


### PR DESCRIPTION
### Reason for this change

More intuitive/flexible granting of permissions to call http apis

### Description of changes

Instead of requiring a `Role`, we loosen the constraint to an `IGrantable` which allows for more flexible permission granting, for example a lambda can be passed to `grantInvokeAccess` rather than that lambda's role:

```ts
// before
api.grantInvokeAccess(someFunction.role!);

// after
api.grantInvokeAccess(someFunction);
```

### Description of how you validated changes

* Unit tests
* Deployed a sample project

### Issue # (if applicable)

Fixes #95

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*