### PR TITLE
feat(fastapi): generate an echo api by default for consistency with trpc

### DIFF
--- a/docs/src/content/docs/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/guides/api-connection/react-fastapi.mdx
@@ -880,6 +880,10 @@ function ItemsAndUsers() {
 ```
 </Drawer>
 
+:::tip
+You can also split your API using multiple `routers`. See the [FastAPI Documentation](https://fastapi.tiangolo.com/tutorial/bigger-applications/) for more details.
+:::
+
 ### Errors
 
 You can customize error responses in your FastAPI by defining custom exception classes, exception handlers, and specifying response models for different error status codes. The generated client will automatically handle these custom error types.

--- a/packages/nx-plugin/LICENSE-THIRD-PARTY
+++ b/packages/nx-plugin/LICENSE-THIRD-PARTY
@@ -3190,7 +3190,7 @@ THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @hey-api/json-schema-ref-parser (1.0.2)
+The following software may be included in this product: @hey-api/json-schema-ref-parser (1.0.3)
 This software contains the following license and notice below:
 
 MIT License
@@ -3217,7 +3217,7 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: @hey-api/openapi-ts (0.64.4)
+The following software may be included in this product: @hey-api/openapi-ts (0.64.13)
 This software contains the following license and notice below:
 
 MIT License

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -15,6 +15,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from mangum import Mangum
+from pydantic import BaseModel
 from starlette.middleware.exceptions import ExceptionMiddleware
 
 os.environ["POWERTOOLS_METRICS_NAMESPACE"] = "TestApi"
@@ -24,8 +25,14 @@ logger: Logger = Logger()
 metrics: Metrics = Metrics()
 tracer: Tracer = Tracer()
 
+class InternalServerErrorDetails(BaseModel):
+    detail: str
+
 app = FastAPI(
-    title="TestApi"
+    title="TestApi",
+    responses={
+        500: {"model": InternalServerErrorDetails}
+    }
 )
 lambda_handler = Mangum(app)
 
@@ -46,7 +53,9 @@ async def unhandled_exception_handler(request, err):
 
     metrics.add_metric(name="Failure", unit=MetricUnit.Count, value=1)
 
-    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+    return JSONResponse(status_code=500,
+                        content=InternalServerErrorDetails(
+                            detail="Internal Server Error").model_dump())
 
 @app.middleware("http")
 async def metrics_handler(request: Request, call_next):
@@ -119,14 +128,20 @@ def custom_openapi():
 
 app.openapi = custom_openapi
 ",
-  "apps/test_api/test_api/main.py": "from .init import app, lambda_handler, tracer
+  "apps/test_api/test_api/main.py": "from pydantic import BaseModel
+
+from .init import app, lambda_handler, tracer
 
 handler = lambda_handler
 
-@app.get("/")
+class EchoOutput(BaseModel):
+    message: str
+
+@app.get("/echo")
 @tracer.capture_method
-def read_root():
-    return {"Hello": "World"}",
+def echo(message: str) -> EchoOutput:
+    return EchoOutput(message=f"{message}")
+",
   "apps/test_api/tests/__init__.py": """"unit tests."""
 ",
   "apps/test_api/tests/conftest.py": """"Unit tests configuration module."""

--- a/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
+++ b/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
@@ -9,6 +9,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from mangum import Mangum
+from pydantic import BaseModel
 from starlette.middleware.exceptions import ExceptionMiddleware
 
 os.environ["POWERTOOLS_METRICS_NAMESPACE"] = "<%= apiNameClassName %>"
@@ -18,8 +19,14 @@ logger: Logger = Logger()
 metrics: Metrics = Metrics()
 tracer: Tracer = Tracer()
 
+class InternalServerErrorDetails(BaseModel):
+    detail: str
+
 app = FastAPI(
-    title="<%= apiNameClassName %>"
+    title="<%= apiNameClassName %>",
+    responses={
+        500: {"model": InternalServerErrorDetails}
+    }
 )
 lambda_handler = Mangum(app)
 
@@ -40,7 +47,9 @@ async def unhandled_exception_handler(request, err):
 
     metrics.add_metric(name="Failure", unit=MetricUnit.Count, value=1)
 
-    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+    return JSONResponse(status_code=500,
+                        content=InternalServerErrorDetails(
+                            detail="Internal Server Error").model_dump())
 
 @app.middleware("http")
 async def metrics_handler(request: Request, call_next):

--- a/packages/nx-plugin/src/py/fast-api/files/app/__name__/main.py.template
+++ b/packages/nx-plugin/src/py/fast-api/files/app/__name__/main.py.template
@@ -1,8 +1,13 @@
+from pydantic import BaseModel
+
 from .init import app, lambda_handler, tracer
 
 handler = lambda_handler
 
-@app.get("/")
+class EchoOutput(BaseModel):
+    message: str
+
+@app.get("/echo")
 @tracer.capture_method
-def read_root():
-    return {"Hello": "World"}
+def echo(message: str) -> EchoOutput:
+    return EchoOutput(message=f"{message}")


### PR DESCRIPTION
### Reason for this change

For tRPC we generate an echo procedure as an example to follow. For FastAPI we were generating a read_root operation which can be confusing for users.

### Description of changes

We update to generate an echo route for consistency with tRPC. Additionally, we define a model for the response returned by the unhandled exception middleware for better error handling in the generated code when using the api-connection.

### Description of how you validated changes

Deployed and verified the echo operation works!

### Issue # (if applicable)

Fixes #92

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*