### PR TITLE
chore: add usage metric identifiers to cloudformation stack descriptions

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -119,6 +119,16 @@ export default defineConfig({
             { label: 'license', link: '/guides/license' },
           ],
         },
+        {
+          label: 'About',
+          items: [
+            {
+              label: 'Usage Metrics',
+              link: '/about/metrics',
+            },
+          ],
+          collapsed: true,
+        },
       ],
       plugins: [
         starlightLinksValidator({

--- a/docs/src/content/docs/about/metrics.mdx
+++ b/docs/src/content/docs/about/metrics.mdx
@@ -1,0 +1,8 @@
+---
+title: Usage Metrics
+description: How @aws/nx-plugin collects metrics
+---
+
+In order to help us improve the Nx Plugin for AWS, we collect metrics on generator usage. This process involves no additional network requests, we simply leverage existing AWS usage metrics.
+
+To remain transparent, we append an ID, version, and list of generator IDs to CloudFormation Stack descriptions. This is done in the `MetricsAspect` in `common/constructs`.

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
@@ -726,9 +726,9 @@ Below is a list of all files which have been generated/updated by the `ts#infra`
 
 ```ts
 // packages/infra/src/main.ts
-import { App } from 'aws-cdk-lib';
 import { ApplicationStack } from './stacks/application-stack.js';
 import {
+  App,
   CfnGuardValidator,
   RuleSet,
 } from ':dungeon-adventure/common-constructs';
@@ -891,12 +891,12 @@ If you encounter a build/synth error for the `@dungeon-adventure/infra` project,
 
 ```diff lang="ts"
 // packages/infra/src/main.ts
-import { App } from 'aws-cdk-lib';
 import { ApplicationStack } from './stacks/application-stack.js';
--import {
+import {
+   App,
 -  CfnGuardValidator,
 -  RuleSet,
--} from ':dungeon-adventure/common-constructs';
+} from ':dungeon-adventure/common-constructs';
 -
 -const app = new App({
 -  policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -6,82 +6,97 @@
     "ts#project": {
       "factory": "./src/ts/lib/generator",
       "schema": "./src/ts/lib/schema.json",
-      "description": "Generates a TypeScript project"
+      "description": "Generates a TypeScript project",
+      "metric": "g1"
     },
     "py#project": {
       "factory": "./src/py/project/generator",
       "schema": "./src/py/project/schema.json",
-      "description": "Generates a Python project"
+      "description": "Generates a Python project",
+      "metric": "g2"
     },
     "py#fast-api": {
       "factory": "./src/py/fast-api/generator",
       "schema": "./src/py/fast-api/schema.json",
-      "description": "Generates a FastAPI Python project"
+      "description": "Generates a FastAPI Python project",
+      "metric": "g3"
     },
     "py#fast-api#react-connection": {
       "factory": "./src/py/fast-api/react/generator",
       "schema": "./src/py/fast-api/react/schema.json",
       "description": "Integrates a FastAPI with a React website",
+      "metric": "g4",
       "hidden": true
     },
     "ts#cloudscape-website": {
       "factory": "./src/cloudscape-website/app/generator",
       "schema": "./src/cloudscape-website/app/schema.json",
-      "description": "Generates a React static website based on Cloudscape"
+      "description": "Generates a React static website based on Cloudscape",
+      "metric": "g5"
     },
     "ts#cloudscape-website#auth": {
       "factory": "./src/cloudscape-website/cognito-auth/generator",
       "schema": "./src/cloudscape-website/cognito-auth/schema.json",
-      "description": "Adds auth to an existing cloudscape website"
+      "description": "Adds auth to an existing cloudscape website",
+      "metric": "g6"
     },
     "ts#cloudscape-website#runtime-config": {
       "factory": "./src/cloudscape-website/runtime-config/generator",
       "schema": "./src/cloudscape-website/runtime-config/schema.json",
       "description": "Adds runtime config to an existing cloudscape website",
+      "metric": "g7",
       "hidden": true
     },
     "ts#infra": {
       "factory": "./src/infra/app/generator",
       "schema": "./src/infra/app/schema.json",
-      "description": "Generates a cdk application"
+      "description": "Generates a cdk application",
+      "metric": "g8"
     },
     "ts#trpc-api": {
       "factory": "./src/trpc/backend/generator",
       "schema": "./src/trpc/backend/schema.json",
-      "description": "creates a trpc backend"
+      "description": "creates a trpc backend",
+      "metric": "g9"
     },
     "ts#trpc-api#react-connection": {
       "factory": "./src/trpc/react/generator",
       "schema": "./src/trpc/react/schema.json",
       "description": "provides React integration to a React website",
+      "metric": "g10",
       "hidden": true
     },
     "api-connection": {
       "factory": "./src/api-connection/generator",
       "schema": "./src/api-connection/schema.json",
-      "description": "Integrates a source project with a target API project"
+      "description": "Integrates a source project with a target API project",
+      "metric": "g11"
     },
     "open-api#ts-client": {
       "factory": "./src/open-api/ts-client/generator",
       "schema": "./src/open-api/ts-client/schema.json",
       "description": "Generate a typescript client from an OpenAPI specification",
+      "metric": "g12",
       "hidden": true
     },
     "open-api#ts-hooks": {
       "factory": "./src/open-api/ts-hooks/generator",
       "schema": "./src/open-api/ts-hooks/schema.json",
       "description": "Generate typescript hooks from an OpenAPI specification",
+      "metric": "g13",
       "hidden": true
     },
     "license": {
       "factory": "./src/license/generator",
       "schema": "./src/license/schema.json",
-      "description": "Add LICENSE files and configure source code licence headers"
+      "description": "Add LICENSE files and configure source code licence headers",
+      "metric": "g14"
     },
     "license#sync": {
       "factory": "./src/license/sync/generator",
       "schema": "./src/license/sync/schema.json",
       "description": "Sync generator for writing licence headers and subproject LICENSE files",
+      "metric": "g15",
       "hidden": true
     }
   }

--- a/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
@@ -289,6 +289,7 @@ exports[`cloudscape-website generator > should generate shared constructs > comm
 
 exports[`cloudscape-website generator > should generate shared constructs > common/constructs-core-index.ts 1`] = `
 "export * from './static-website.js';
+export * from './app.js';
 export * from './runtime-config.js';
 "
 `;

--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -24,11 +24,11 @@ import {
 } from 'typescript';
 import { AppGeneratorSchema } from './schema';
 import { applicationGenerator } from '@nx/react';
+import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-  sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs-constants';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
 import { configureTsProject } from '../../ts/lib/ts-project-utils';
 import { withVersions } from '../../utils/versions';
@@ -42,8 +42,13 @@ import {
 } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
 import { relative } from 'path';
-import { sortObjectKeys } from '../../utils/nx';
 import kebabCase from 'lodash.kebabcase';
+import { sortObjectKeys } from '../../utils/object';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+
+export const CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
 
 export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
   const npmScopePrefix = getNpmScopePrefix(tree);
@@ -430,6 +435,10 @@ export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
     ]),
     withVersions(['@tanstack/router-plugin', 'vite-tsconfig-paths']),
   );
+
+  await addGeneratorMetricsIfApplicable(tree, [
+    CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO,
+  ]);
 
   await formatFilesInSubtree(tree);
   return () => {

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -67,6 +67,7 @@ export default CognitoAuth;
 
 exports[`cognito-auth generator > should generate files > identity-index 1`] = `
 "export * from './user-identity.js';
+export * from './app.js';
 export * from './runtime-config.js';
 "
 `;
@@ -445,6 +446,7 @@ export function App() {
 
 exports[`cognito-auth generator > should update shared constructs index.ts > common/constructs-index 1`] = `
 "export * from './user-identity.js';
+export * from './app.js';
 export * from './runtime-config.js';
 "
 `;

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.ts
@@ -11,12 +11,12 @@ import {
   installPackagesTask,
   OverwriteStrategy,
 } from '@nx/devkit';
+import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import {
   TYPE_DEFINITIONS_DIR,
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-  sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs-constants';
 import { CognitoAuthGeneratorSchema as CognitoAuthGeneratorSchema } from './schema';
 import { runtimeConfigGenerator } from '../runtime-config/generator';
 import {
@@ -43,6 +43,12 @@ import {
   query,
 } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+
+export const COGNITO_AUTH_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
+
 export async function cognitoAuthGenerator(
   tree: Tree,
   options: CognitoAuthGeneratorSchema,
@@ -55,9 +61,11 @@ export async function cognitoAuthGenerator(
       `This generator has already been run on ${options.project}.`,
     );
   }
+
   await runtimeConfigGenerator(tree, {
     project: options.project,
   });
+
   await sharedConstructsGenerator(tree);
   // Add ICognitoProps interface and update IRuntimeConfig
   const runtimeConfigPath = joinPathFragments(
@@ -489,6 +497,9 @@ export async function cognitoAuthGenerator(
     );
   }
   // End update App Layout
+
+  await addGeneratorMetricsIfApplicable(tree, [COGNITO_AUTH_GENERATOR_INFO]);
+
   await formatFilesInSubtree(tree);
   return () => {
     installPackagesTask(tree);

--- a/packages/nx-plugin/src/cloudscape-website/runtime-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/runtime-config/__snapshots__/generator.spec.ts.snap
@@ -59,7 +59,8 @@ export default RuntimeConfigProvider;
 `;
 
 exports[`runtime-config generator > should generate shared constructs > common/constructs-index.ts 1`] = `
-"export * from './runtime-config.js';
+"export * from './app.js';
+export * from './runtime-config.js';
 "
 `;
 

--- a/packages/nx-plugin/src/cloudscape-website/runtime-config/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/runtime-config/generator.ts
@@ -15,6 +15,11 @@ import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
 import { formatFilesInSubtree } from '../../utils/format';
 import { prependStatements, query, replaceIfExists } from '../../utils/ast';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+
+export const RUNTIME_CONFIG_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
 
 export async function runtimeConfigGenerator(
   tree: Tree,
@@ -45,7 +50,9 @@ export async function runtimeConfigGenerator(
     console.debug('Runtime config already exists, skipping generation');
     return;
   }
+
   await sharedConstructsGenerator(tree);
+
   const npmScopePrefix = getNpmScopePrefix(tree);
   generateFiles(
     tree,
@@ -100,6 +107,8 @@ export async function runtimeConfigGenerator(
   if (!locatedTargetNode) {
     throw new Error('Could not locate the RouterProvider element in main.tsx');
   }
+
+  await addGeneratorMetricsIfApplicable(tree, [RUNTIME_CONFIG_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
 }

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -254,9 +254,8 @@ exports[`infra generator > should generate consistent file content across runs >
   }
 }
 ",
-  "src/main.ts": "import { App } from 'aws-cdk-lib';
-import { ApplicationStack } from './stacks/application-stack.js';
-import { CfnGuardValidator, RuleSet } from ':proj/common-constructs';
+  "src/main.ts": "import { ApplicationStack } from './stacks/application-stack.js';
+import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
@@ -373,9 +372,8 @@ exports[`infra generator > should generate files with correct content > cdk-json
 `;
 
 exports[`infra generator > should generate files with correct content > main-ts 1`] = `
-"import { App } from 'aws-cdk-lib';
-import { ApplicationStack } from './stacks/application-stack.js';
-import { CfnGuardValidator, RuleSet } from ':proj/common-constructs';
+"import { ApplicationStack } from './stacks/application-stack.js';
+import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
@@ -517,9 +515,8 @@ exports[`infra generator > should generate files with correct content > project-
   }
 }
 ",
-  "src/main.ts": "import { App } from 'aws-cdk-lib';
-import { ApplicationStack } from './stacks/application-stack.js';
-import { CfnGuardValidator, RuleSet } from ':proj/common-constructs';
+  "src/main.ts": "import { ApplicationStack } from './stacks/application-stack.js';
+import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
@@ -626,9 +623,8 @@ exports[`infra generator > should generate valid CDK application code > cdk-json
 `;
 
 exports[`infra generator > should generate valid CDK application code > main-ts-content 1`] = `
-"import { App } from 'aws-cdk-lib';
-import { ApplicationStack } from './stacks/application-stack.js';
-import { CfnGuardValidator, RuleSet } from ':proj/common-constructs';
+"import { ApplicationStack } from './stacks/application-stack.js';
+import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
@@ -731,9 +727,8 @@ exports[`infra generator > should handle custom project names correctly > custom
   }
 }
 ",
-  "src/main.ts": "import { App } from 'aws-cdk-lib';
-import { ApplicationStack } from './stacks/application-stack.js';
-import { CfnGuardValidator, RuleSet } from ':proj/common-constructs';
+  "src/main.ts": "import { ApplicationStack } from './stacks/application-stack.js';
+import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],

--- a/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
+++ b/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
@@ -1,6 +1,5 @@
-import { App } from 'aws-cdk-lib';
 import { ApplicationStack } from './stacks/application-stack.js';
-import { CfnGuardValidator, RuleSet } from '<%= scopeAlias %>common-constructs';
+import { App, CfnGuardValidator, RuleSet } from '<%= scopeAlias %>common-constructs';
 
 const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.<%= ruleSet %>)]

--- a/packages/nx-plugin/src/license/generator.ts
+++ b/packages/nx-plugin/src/license/generator.ts
@@ -7,6 +7,11 @@ import { LicenseGeneratorSchema } from './schema';
 import { defaultLicenseConfig, writeLicenseConfig } from './config';
 import { ensureAwsNxPluginConfig } from '../utils/config/utils';
 import { SYNC_GENERATOR_NAME } from './sync/generator';
+import { NxGeneratorInfo, getGeneratorInfo } from '../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
+
+export const LICENSE_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
 
 export async function licenseGenerator(
   tree: Tree,
@@ -38,6 +43,8 @@ export async function licenseGenerator(
       },
     },
   });
+
+  await addGeneratorMetricsIfApplicable(tree, [LICENSE_GENERATOR_INFO]);
 }
 
 export default licenseGenerator;

--- a/packages/nx-plugin/src/license/sync/generator.ts
+++ b/packages/nx-plugin/src/license/sync/generator.ts
@@ -20,8 +20,10 @@ import {
   ProjectFileToSync,
   syncProjectFile,
 } from './project-file-sync';
+import { getGeneratorInfo } from '../../utils/nx';
+import PackageJson from '../../../package.json';
 
-export const SYNC_GENERATOR_NAME = '@aws/nx-plugin:license#sync';
+export const SYNC_GENERATOR_NAME = `${PackageJson.name}:${getGeneratorInfo(__filename).id}`;
 
 interface ProjectFile {
   name: ProjectFileToSync;

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -4,15 +4,16 @@
  */
 import { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { fastApiProjectGenerator } from './generator';
+import { FAST_API_GENERATOR_INFO, fastApiProjectGenerator } from './generator';
 import { parse } from '@iarna/toml';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs-constants';
 import { joinPathFragments } from '@nx/devkit';
 import { UVPyprojectToml } from '@nxlv/python/src/provider/uv/types';
-import { sortObjectKeys } from '../../utils/nx';
+import { sortObjectKeys } from '../../utils/object';
+import { expectHasMetricTags } from '../../utils/metrics.spec';
 
 describe('fastapi project generator', () => {
   let tree: Tree;
@@ -206,5 +207,16 @@ describe('fastapi project generator', () => {
     );
     // Verify project metadata
     expect(appChanges).toMatchSnapshot('main-snapshot');
+  });
+
+  it('should add generator metric to app.ts', async () => {
+    // Call the generator function
+    await fastApiProjectGenerator(tree, {
+      name: 'test-api',
+      directory: 'apps',
+    });
+
+    // Verify the metric was added to app.ts
+    expectHasMetricTags(tree, FAST_API_GENERATOR_INFO.metric);
   });
 });

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -20,16 +20,21 @@ import { Logger } from '@nxlv/python/src/executors/utils/logger';
 import pyProjectGenerator, { getPyProjectDetails } from '../project/generator';
 import { parse, stringify } from '@iarna/toml';
 import { UVPyprojectToml } from '@nxlv/python/src/provider/uv/types';
+import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-  sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs-constants';
 import { toClassName, toKebabCase, toSnakeCase } from '../../utils/names';
 import { addStarExport } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addHttpApi } from '../../utils/http-api';
-import { sortObjectKeys } from '../../utils/nx';
+import { sortObjectKeys } from '../../utils/object';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+
+export const FAST_API_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
 
 /**
  * Generates a Python FastAPI project
@@ -200,6 +205,8 @@ export const fastApiProjectGenerator = async (
   ].concat(projectToml.project?.dependencies || []);
   projectToml['dependency-groups'] = { dev: ['fastapi[standard]>=0.115'] };
   tree.write(joinPathFragments(dir, 'pyproject.toml'), stringify(projectToml));
+
+  await addGeneratorMetricsIfApplicable(tree, [FAST_API_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
 

--- a/packages/nx-plugin/src/py/fast-api/react/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.ts
@@ -17,7 +17,7 @@ import { runtimeConfigGenerator } from '../../../cloudscape-website/runtime-conf
 import snakeCase from 'lodash.snakecase';
 import * as path from 'path';
 import kebabCase from 'lodash.kebabcase';
-import { sortObjectKeys } from '../../../utils/nx';
+import { sortObjectKeys } from '../../../utils/object';
 import { toClassName } from '../../../utils/names';
 import { formatFilesInSubtree } from '../../../utils/format';
 import { withVersions } from '../../../utils/versions';
@@ -29,6 +29,11 @@ import {
   replace,
 } from '../../../utils/ast';
 import { JsxSelfClosingElement } from 'typescript';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+
+export const FAST_API_REACT_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
 
 export const fastApiReactGenerator = async (
   tree: Tree,
@@ -269,6 +274,8 @@ export const fastApiReactGenerator = async (
     ]),
     withVersions(['@smithy/types']),
   );
+
+  await addGeneratorMetricsIfApplicable(tree, [FAST_API_REACT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
   return () => {

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readProjectConfiguration, Tree } from '@nx/devkit';
-import { trpcBackendGenerator } from './generator';
+import { TRPC_BACKEND_GENERATOR_INFO, trpcBackendGenerator } from './generator';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
 } from '../../utils/test';
+import { expectHasMetricTags } from '../../utils/metrics.spec';
 
 describe('trpc backend generator', () => {
   let tree: Tree;
@@ -116,7 +117,6 @@ describe('trpc backend generator', () => {
     await trpcBackendGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
-      unitTestRunner: 'vitest',
       bundler: 'vite',
     });
     const projectConfig = readProjectConfiguration(
@@ -128,5 +128,17 @@ describe('trpc backend generator', () => {
     expect(projectConfig.targets!.serve!.options!.commands).toEqual([
       'tsx src/local-server.ts',
     ]);
+  });
+
+  it('should add generator metric to app.ts', async () => {
+    // Call the generator function
+    await trpcBackendGenerator(tree, {
+      apiName: 'TestApi',
+      directory: 'apps',
+      bundler: 'vite',
+    });
+
+    // Verify the metric was added to app.ts
+    expectHasMetricTags(tree, TRPC_BACKEND_GENERATOR_INFO.metric);
   });
 });

--- a/packages/nx-plugin/src/trpc/react/generator.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.ts
@@ -39,6 +39,12 @@ import {
 } from '../../utils/ast';
 import { toClassName } from '../../utils/names';
 import { formatFilesInSubtree } from '../../utils/format';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+
+export const TRPC_REACT_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
+
 export async function reactGenerator(
   tree: Tree,
   options: ReactGeneratorSchema,
@@ -100,6 +106,7 @@ export async function reactGenerator(
       {},
     );
   }
+
   await runtimeConfigGenerator(tree, {
     project: options.frontendProjectName,
   });
@@ -350,6 +357,9 @@ export async function reactGenerator(
     ]),
     withVersions(['@smithy/types']),
   );
+
+  await addGeneratorMetricsIfApplicable(tree, [TRPC_REACT_GENERATOR_INFO]);
+
   await formatFilesInSubtree(tree);
   return () => {
     installPackagesTask(tree);

--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readNxJson, Tree } from '@nx/devkit';
-import { tsLibGenerator } from './generator';
+import { TS_LIB_GENERATOR_INFO, tsLibGenerator } from './generator';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import uniqBy from 'lodash.uniqby';
+import { sharedConstructsGenerator } from '../../utils/shared-constructs';
+import { expectHasMetricTags } from '../../utils/metrics.spec';
 
 describe('ts lib generator', () => {
   let tree: Tree;
@@ -175,5 +177,19 @@ describe('ts lib generator', () => {
     expect(targetDefaults.test.inputs).toHaveLength(
       uniqBy(targetDefaults.test.inputs, (x) => x).length,
     );
+  });
+
+  it('should add generator metric to app.ts', async () => {
+    // Set up test tree with shared constructs
+    await sharedConstructsGenerator(tree);
+
+    // Call the generator function
+    await tsLibGenerator(tree, {
+      name: 'test-lib',
+      skipInstall: true,
+    });
+
+    // Verify the metric was added to app.ts
+    expectHasMetricTags(tree, TS_LIB_GENERATOR_INFO.metric);
   });
 });

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -22,7 +22,13 @@ import { configureTsProject } from './ts-project-utils';
 import { toKebabCase } from '../../utils/names';
 import { relative } from 'path';
 import { formatFilesInSubtree } from '../../utils/format';
-import { sortObjectKeys } from '../../utils/nx';
+import { sortObjectKeys } from '../../utils/object';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+
+export const TS_LIB_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
+
 export interface TsLibDetails {
   /**
    * Full package name including scope (eg @foo/bar)
@@ -33,6 +39,7 @@ export interface TsLibDetails {
    */
   readonly dir: string;
 }
+
 /**
  * Returns details about the TS library to be created
  */
@@ -49,6 +56,7 @@ export const getTsLibDetails = (
   );
   return { dir, fullyQualifiedName };
 };
+
 /**
  * Generates a typescript library
  */
@@ -191,6 +199,8 @@ export const tsLibGenerator = async (
 
     return nxJson;
   });
+
+  await addGeneratorMetricsIfApplicable(tree, [TS_LIB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
 

--- a/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
@@ -1,0 +1,90 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/app/index.ts 1`] = `""`;
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/app.ts 1`] = `
+"import { App as _App, AppProps, Aspects, IAspect, Stack } from 'aws-cdk-lib';
+import { IConstruct } from 'constructs';
+
+export class App extends _App {
+  constructor(props?: AppProps) {
+    super(props);
+
+    Aspects.of(this).add(new MetricsAspect());
+  }
+}
+
+/**
+ * Adds information to CloudFormation stack descriptions to provide usage metrics for @aws/nx-plugin
+ */
+class MetricsAspect implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof Stack) {
+      const id = '';
+      const version = '';
+      const tags: string[] = [];
+      node.templateOptions.description =
+        \`\${node.templateOptions.description ?? ''} (\${id}) (version:\${version}) (tags:\${tags.join(',')})\`.trim();
+    }
+  }
+}
+"
+`;
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/index.ts 1`] = `
+"export * from './app.js';
+export * from './runtime-config.js';
+"
+`;
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/runtime-config.ts 1`] = `
+"import type { IRuntimeConfig } from ':test-scope/common-types';
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+const RuntimeConfigKey = '__RuntimeConfig__';
+
+export class RuntimeConfig extends Construct {
+  private readonly _runtimeConfig: Partial<IRuntimeConfig> = {};
+
+  static ensure(scope: Construct): RuntimeConfig {
+    const stack = Stack.of(scope);
+    return (
+      RuntimeConfig.of(scope) ?? new RuntimeConfig(stack, RuntimeConfigKey)
+    );
+  }
+
+  static of(scope: Construct): RuntimeConfig | undefined {
+    const stack = Stack.of(scope);
+    return stack.node.tryFindChild(RuntimeConfigKey) as
+      | RuntimeConfig
+      | undefined;
+  }
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+
+  get config(): Partial<IRuntimeConfig> {
+    return this._runtimeConfig;
+  }
+}
+"
+`;
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/index.ts 1`] = `
+"export * from './app/index.js';
+export * from './core/index.js';
+"
+`;
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate type definitions when they do not exist > packages/common/types/src/index.ts 1`] = `
+"export * from './runtime-config.js';
+"
+`;
+
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate type definitions when they do not exist > packages/common/types/src/runtime-config.ts 1`] = `
+"// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+export interface IRuntimeConfig {}
+"
+`;

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/app.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/app.ts.template
@@ -1,0 +1,24 @@
+import { App as _App, AppProps, Aspects, IAspect, Stack } from 'aws-cdk-lib';
+import { IConstruct } from 'constructs';
+
+export class App extends _App {
+  constructor(props?: AppProps) {
+    super(props);
+
+    Aspects.of(this).add(new MetricsAspect());
+  }
+}
+
+/**
+ * Adds information to CloudFormation stack descriptions to provide usage metrics for @aws/nx-plugin
+ */
+class MetricsAspect implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof Stack) {
+      const id = '';
+      const version = '';
+      const tags: string[] = [];
+      node.templateOptions.description = `${node.templateOptions.description ?? ''} (${id}) (version:${version}) (tags:${tags.join(',')})`.trim();
+    }
+  }
+}

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/index.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/index.ts.template
@@ -1,1 +1,2 @@
+export * from './app.js';
 export * from './runtime-config.js';

--- a/packages/nx-plugin/src/utils/http-api.ts
+++ b/packages/nx-plugin/src/utils/http-api.ts
@@ -18,7 +18,7 @@ import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   TYPE_DEFINITIONS_DIR,
-} from './shared-constructs';
+} from './shared-constructs-constants';
 import { addStarExport, prependStatements, query, replace } from './ast';
 
 export const addHttpApi = (tree: Tree, apiNameClassName: string) => {

--- a/packages/nx-plugin/src/utils/metrics.spec.ts
+++ b/packages/nx-plugin/src/utils/metrics.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from './test';
+import { sharedConstructsGenerator } from './shared-constructs';
+import {
+  addGeneratorMetricsIfApplicable,
+  METRIC_ID,
+  METRICS_ASPECT_FILE_PATH,
+  metricsAspectVariableQuery,
+} from './metrics';
+import { query } from './ast';
+import { ArrayLiteralExpression, NodeArray, StringLiteral } from 'typescript';
+
+export const expectHasMetricTags = (tree: Tree, ...metrics: string[]) => {
+  const tagsArray = query(
+    tree,
+    METRICS_ASPECT_FILE_PATH,
+    metricsAspectVariableQuery('tags', 'ArrayLiteralExpression'),
+  );
+  expect(tagsArray).toHaveLength(1);
+  const tags = (
+    ((tagsArray[0] as ArrayLiteralExpression)?.elements ??
+      []) as NodeArray<StringLiteral>
+  ).map((t) => t.text);
+  expect(tags).toEqual(expect.arrayContaining(metrics));
+};
+
+describe('metrics', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should update metrics and version in app.ts', async () => {
+    await sharedConstructsGenerator(tree);
+
+    // Create the app.ts file with MetricsAspect class
+    const appPath = METRICS_ASPECT_FILE_PATH;
+
+    expect(tree.read(appPath, 'utf-8')).toContain("const id = ''");
+    expect(tree.read(appPath, 'utf-8')).toContain("const version = ''");
+    expect(tree.read(appPath, 'utf-8')).toContain('const tags: string[] = []');
+
+    // Add metrics
+    await addGeneratorMetricsIfApplicable(tree, [
+      { id: 'ts#foo', metric: 'g1', resolvedFactoryPath: '/path/to/factory1' },
+      { id: 'py#bar', metric: 'g2', resolvedFactoryPath: '/path/to/factory2' },
+    ]);
+
+    // Check if app.ts was updated with metrics
+    expect(tree.read(appPath, 'utf-8')).toContain(`const id = '${METRIC_ID}'`);
+    expect(tree.read(appPath, 'utf-8')).toContain("const version = '0.0.0'");
+    expect(tree.read(appPath, 'utf-8')).toContain(
+      "const tags: string[] = ['g1', 'g2']",
+    );
+    expectHasMetricTags(tree, 'g1', 'g2');
+
+    // Run generator again with different metrics info, some overlapping and some not
+    await addGeneratorMetricsIfApplicable(tree, [
+      { id: 'ts#foo', metric: 'g1', resolvedFactoryPath: '/path/to/factory1' },
+      { id: 'py#baz', metric: 'g3', resolvedFactoryPath: '/path/to/factory3' },
+    ]);
+
+    // Check app.ts retains existing tags and adds the new one
+    expect(tree.read(appPath, 'utf-8')).toContain(`const id = '${METRIC_ID}'`);
+    expect(tree.read(appPath, 'utf-8')).toContain("const version = '0.0.0'");
+    expect(tree.read(appPath, 'utf-8')).toContain(
+      "const tags: string[] = ['g1', 'g2', 'g3']",
+    );
+    expectHasMetricTags(tree, 'g1', 'g2', 'g3');
+  });
+
+  it('should not throw when no app.ts exists', async () => {
+    await addGeneratorMetricsIfApplicable(tree, [
+      { id: 'ts#foo', metric: 'g1', resolvedFactoryPath: '/path/to/factory1' },
+      { id: 'py#bar', metric: 'g2', resolvedFactoryPath: '/path/to/factory2' },
+    ]);
+  });
+
+  it('should not throw when no MetricsAspect exists', async () => {
+    tree.write(METRICS_ASPECT_FILE_PATH, `export const foo = 'bar';`);
+
+    await addGeneratorMetricsIfApplicable(tree, [
+      { id: 'ts#foo', metric: 'g1', resolvedFactoryPath: '/path/to/factory1' },
+      { id: 'py#bar', metric: 'g2', resolvedFactoryPath: '/path/to/factory2' },
+    ]);
+  });
+});

--- a/packages/nx-plugin/src/utils/metrics.ts
+++ b/packages/nx-plugin/src/utils/metrics.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree, joinPathFragments } from '@nx/devkit';
+import { ArrayLiteralExpression, StringLiteral, factory } from 'typescript';
+import { replaceIfExists } from './ast';
+import { formatFilesInSubtree } from './format';
+import { NxGeneratorInfo, getPackageVersion } from './nx';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+} from './shared-constructs-constants';
+
+// Used to identify @aws/nx-plugin in AWS metrics
+export const METRIC_ID = 'uksb-4wk0bqpg5s';
+
+// File in which the MetricsAspect may exist
+export const METRICS_ASPECT_FILE_PATH = joinPathFragments(
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+  'src',
+  'core',
+  'app.ts',
+);
+
+// Query to find a particular metrics aspect variable
+export const metricsAspectVariableQuery = (
+  variableName: string,
+  valueQuery: string,
+) =>
+  `ClassDeclaration[name.name="MetricsAspect"] MethodDeclaration[name.name="visit"] VariableDeclaration:has(Identifier[name="${variableName}"]) ${valueQuery}`;
+
+/**
+ * Instruments metrics by updating the MetricsAspect in common/constructs/src/core/app.ts if the file exists
+ */
+export const addGeneratorMetricsIfApplicable = async (
+  tree: Tree,
+  generatorInfo: NxGeneratorInfo[],
+) => {
+  if (tree.exists(METRICS_ASPECT_FILE_PATH)) {
+    // Update the id
+    replaceIfExists(
+      tree,
+      METRICS_ASPECT_FILE_PATH,
+      metricsAspectVariableQuery('id', 'StringLiteral'),
+      (): StringLiteral => {
+        return factory.createStringLiteral(METRIC_ID, true);
+      },
+    );
+    // Update the version
+    replaceIfExists(
+      tree,
+      METRICS_ASPECT_FILE_PATH,
+      metricsAspectVariableQuery('version', 'StringLiteral'),
+      (): StringLiteral => {
+        return factory.createStringLiteral(getPackageVersion(), true);
+      },
+    );
+    // Add each generator as a tag
+    replaceIfExists(
+      tree,
+      METRICS_ASPECT_FILE_PATH,
+      metricsAspectVariableQuery('tags', 'ArrayLiteralExpression'),
+      (node: ArrayLiteralExpression): ArrayLiteralExpression => {
+        const existingMetrics = new Set(
+          node.elements.map((element) => (element as StringLiteral)?.text),
+        );
+
+        return factory.createArrayLiteralExpression([
+          ...node.elements,
+          ...generatorInfo
+            .filter((info) => !existingMetrics.has(info.metric))
+            .map((info) => factory.createStringLiteral(info.metric, true)),
+        ]);
+      },
+    );
+    await formatFilesInSubtree(tree, METRICS_ASPECT_FILE_PATH);
+  }
+};

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -2,14 +2,38 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { TargetConfiguration } from '@nx/devkit';
+import GeneratorsJson from '../../generators.json';
+import PackageJson from '../../package.json';
+import * as path from 'path';
 
-export const sortObjectKeys = (targets: {
-  [targetName: string]: TargetConfiguration;
-}) =>
-  Object.keys(targets)
-    .sort()
-    .reduce((obj, key) => {
-      obj[key] = targets[key];
-      return obj;
-    }, {});
+export interface NxGeneratorInfo {
+  readonly id: string;
+  readonly metric: string;
+  readonly resolvedFactoryPath: string;
+}
+
+const GENERATORS: NxGeneratorInfo[] = Object.entries(
+  GeneratorsJson.generators,
+).map(([id, { metric, factory }]) => ({
+  id,
+  metric,
+  resolvedFactoryPath: path.resolve(__dirname, '..', '..', factory),
+}));
+
+/**
+ * Return generator information. Call this from a generator method with __filename
+ */
+export const getGeneratorInfo = (
+  generatorFileName: string,
+): NxGeneratorInfo => {
+  const { dir, name } = path.parse(path.resolve(generatorFileName));
+  const resolvedFactoryPath = path.join(dir, name);
+  return GENERATORS.find(
+    (generatorInfo) =>
+      generatorInfo.resolvedFactoryPath === resolvedFactoryPath,
+  );
+};
+
+export const getPackageVersion = () => {
+  return PackageJson.version;
+};

--- a/packages/nx-plugin/src/utils/object.ts
+++ b/packages/nx-plugin/src/utils/object.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const sortObjectKeys = <T>(object: {
+  [key: string]: T;
+}): { [key: string]: T } =>
+  Object.keys(object)
+    .sort()
+    .reduce((obj, key) => {
+      obj[key] = object[key];
+      return obj;
+    }, {});

--- a/packages/nx-plugin/src/utils/shared-constructs-constants.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs-constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const PACKAGES_DIR = 'packages';
+export const TYPE_DEFINITIONS_NAME = 'common-types';
+export const SHARED_CONSTRUCTS_NAME = 'common-constructs';
+export const TYPE_DEFINITIONS_DIR = 'common/types';
+export const SHARED_CONSTRUCTS_DIR = 'common/constructs';

--- a/packages/nx-plugin/src/utils/shared-constructs.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.ts
@@ -14,14 +14,18 @@ import { getNpmScopePrefix, toScopeAlias } from './npm-scope';
 import tsLibGenerator from '../ts/lib/generator';
 import { withVersions } from './versions';
 import { formatFilesInSubtree } from './format';
-export const PACKAGES_DIR = 'packages';
-export const TYPE_DEFINITIONS_NAME = 'common-types';
-export const SHARED_CONSTRUCTS_NAME = 'common-constructs';
-export const TYPE_DEFINITIONS_DIR = 'common/types';
-export const SHARED_CONSTRUCTS_DIR = 'common/constructs';
+import {
+  PACKAGES_DIR,
+  TYPE_DEFINITIONS_DIR,
+  TYPE_DEFINITIONS_NAME,
+  SHARED_CONSTRUCTS_DIR,
+  SHARED_CONSTRUCTS_NAME,
+} from './shared-constructs-constants';
+
 export async function sharedConstructsGenerator(tree: Tree) {
   const npmScopePrefix = getNpmScopePrefix(tree);
   updateGitignore(tree);
+
   if (
     !tree.exists(
       joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'project.json'),
@@ -103,6 +107,7 @@ export async function sharedConstructsGenerator(tree: Tree) {
     await formatFilesInSubtree(tree);
   }
 }
+
 const updateGitignore = (tree: Tree) => {
   const gitignore = tree.exists('.gitignore')
     ? tree.read('.gitignore', 'utf-8')

--- a/packages/nx-plugin/tsconfig.json
+++ b/packages/nx-plugin/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "resolveJsonModule": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
### Reason for this change

In order to help us improve the Nx Plugin for AWS, we collect metrics on generator usage.

### Description of changes

This process involves no additional network requests, we simply leverage existing AWS usage metrics. We append an ID, version, and list of generator IDs to CloudFormation Stack descriptions. This is done in the `MetricsAspect` in `common/constructs`.

### Description of how you validated changes

Unit tests and tested in an example project

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*