### PR TITLE
fix(infra): include namespace in application stack id

### DIFF
--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/1.mdx
@@ -738,7 +738,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'infra-sandbox', {
+new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
@@ -904,7 +904,7 @@ import { ApplicationStack } from './stacks/application-stack.js';
 +const app = new App();
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'infra-sandbox', {
+new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/2.mdx
@@ -550,14 +550,14 @@ If you encounter any lint errors, you can run the following command to automatic
 
 Your application can now be deployed by running the following command:
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy infra-sandbox']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 Your first deployment will take around 8 minutes to complete. Subsequent deployments will take around 2 minutes.
 
 :::tip
 If you're iterating on lambda function code changes, you can deploy with the `--hotswap` flag after building the codebase for a much shorter (2-3 second) deployment time.
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy infra-sandbox --hotswap']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox --hotswap']} />
 :::
 
 <Drawer title="Deployment command" trigger="You can also deploy all stacks at once. Click here for more details.">
@@ -573,20 +573,20 @@ This is **not recommended** given that you may choose to seperate out your deplo
 Once the deployment completes, you should see some outputs similar to the following _(some values have been redacted)_:
 
 ```bash
-infra-sandbox
-infra-sandbox: deploying... [2/2]
+dungeon-adventure-infra-sandbox
+dungeon-adventure-infra-sandbox: deploying... [2/2]
 
- ✅  infra-sandbox
+ ✅  dungeon-adventure-infra-sandbox
 
 ✨  Deployment time: 354s
 
 Outputs:
-infra-sandbox.ElectroDbTableTableNameXXX = infra-sandbox-ElectroDbTableXXX-YYY
-infra-sandbox.GameApiGameApiUrlXXX = https://xxx.region.amazonaws.com/
-infra-sandbox.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
-infra-sandbox.StoryApiStoryApiUrlXXX = https://xxx.execute-api.region.amazonaws.com/
-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
+dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
+dungeon-adventure-infra-sandbox.GameApiGameApiUrlXXX = https://xxx.region.amazonaws.com/
+dungeon-adventure-infra-sandbox.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
+dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX = https://xxx.execute-api.region.amazonaws.com/
+dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
+dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
 We can test our API by either:
@@ -625,10 +625,10 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
   <TabItem label="Local">
     Start your local `game-api` server by running the following command:
 
-    <NxCommands highlights={['infra-sandbox-ElectroDbTableXXX-YYY']} env={{TABLE_NAME:"infra-sandbox-ElectroDbTableXXX-YYY"}} commands={["run @dungeon-adventure/game-api-backend:serve"]} />
+    <NxCommands highlights={['dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY']} env={{TABLE_NAME:"dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY"}} commands={["run @dungeon-adventure/game-api-backend:serve"]} />
 
     <Aside type="caution">
-    Use the CDK deploy output value of `infra-sandbox.ElectroDbTableTableNameXXX` to replace the highlighted placeholder.
+    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX` to replace the highlighted placeholder.
     </Aside>
 
     Once your server is up and running, you can call it by running the following command:
@@ -643,7 +643,7 @@ acurl ap-southeast-2 execute-api -X GET \
   https://xxx.execute-api.region.amazonaws.com/games.query\?input\="\{\}"
 ```
     <Aside type="caution">
-    Use the CDK deploy output value of `infra-sandbox.GameApiGameApiUrlXXX` to replace the highlighted placeholder and set the region accordingly..
+    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox.GameApiGameApiUrlXXX` to replace the highlighted placeholder and set the region accordingly..
     </Aside>
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/3.mdx
@@ -375,7 +375,7 @@ If you encounter any lint errors, you can run the following command to automatic
 
 Your application can now be deployed by running the following command:
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy infra-sandbox']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 This deployment will take around 2 minutes to complete.
 
@@ -393,20 +393,20 @@ This is **not recommended** given that you may choose to seperate out your deplo
 Once the deployment completes, you should see some outputs similar to the following _(some values have been redacted)_:
 
 ```bash
-infra-sandbox
-infra-sandbox: deploying... [2/2]
+dungeon-adventure-infra-sandbox
+dungeon-adventure-infra-sandbox: deploying... [2/2]
 
- ✅  infra-sandbox
+ ✅  dungeon-adventure-infra-sandbox
 
 ✨  Deployment time: 354s
 
 Outputs:
-infra-sandbox.ElectroDbTableTableNameXXX = infra-sandbox-ElectroDbTableXXX-YYY
-infra-sandbox.GameApiGameApiUrlXXX = https://xxx.region.amazonaws.com/
-infra-sandbox.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
-infra-sandbox.StoryApiStoryApiUrlXXX = https://xxx.lambda-url.ap-southeast-2.on.aws/
-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
+dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
+dungeon-adventure-infra-sandbox.GameApiGameApiUrlXXX = https://xxx.region.amazonaws.com/
+dungeon-adventure-infra-sandbox.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
+dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX = https://xxx.lambda-url.ap-southeast-2.on.aws/
+dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
+dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
 We can test our API by either:
@@ -461,7 +461,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Use the CDK deploy output value of `infra-sandbox.StoryApiStoryApiUrlXXX` to replace the highlighted url placeholder and set the region accordingly.
+    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` to replace the highlighted url placeholder and set the region accordingly.
     </Aside>
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/4.mdx
@@ -768,7 +768,7 @@ To build your code, run the following command:
 
 Now deploy your application:
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy infra-sandbox']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 Once deployed, navigate to your Cloudfront url which can be found by inspecting the cdk deploy outputs.
 

--- a/docs/src/content/docs/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -36,4 +36,4 @@ To destroy the AWS resources that were created, run the following command:
 
 <NxCommands commands={['run @dungeon-adventure/infra:destroy --all']} />
 
-This will prompt you for a list of stacks to delete which should comprise of the `waf` and `infra-sandbox`. Enter `Y` and then Cloudformation will destroy your stacks.
+This will prompt you for a list of stacks to delete which should comprise of the `waf` and `dungeon-adventure-infra-sandbox`. Enter `Y` and then Cloudformation will destroy your stacks.

--- a/docs/src/content/docs/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/guides/cloudscape-website.mdx
@@ -162,7 +162,7 @@ Your website project is configured with a `load:runtime-config` target which you
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-If you change the name of your stack in your infrastructure project's `src/main.ts`, you will need to update the `load:runtime-config` target in your website's `project.json` file to replace `infra-sandbox` with the name of the stack to load runtime configuration from.
+If you change the name of your stack in your infrastructure project's `src/main.ts`, you will need to update the `load:runtime-config` target in your website's `project.json` file with the name of the stack to load runtime configuration from.
 :::
 
 ## Local Development Server

--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -43,6 +43,7 @@ import {
 import { formatFilesInSubtree } from '../../utils/format';
 import { relative } from 'path';
 import { sortObjectKeys } from '../../utils/nx';
+import kebabCase from 'lodash.kebabcase';
 
 export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
   const npmScopePrefix = getNpmScopePrefix(tree);
@@ -82,7 +83,7 @@ export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
       description: `Load runtime config from your deployed stack for dev purposes. You must set the AWS_REGION and CDK_APP_DIR env variables whilst calling i.e: AWS_REGION=ap-southeast-2 CDK_APP_DIR=./dist/packages/infra/cdk.out pnpm exec nx run ${fullyQualifiedName}:load:runtime-config`,
     },
     options: {
-      command: `curl https://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='infra-sandbox'][].Outputs[?contains(OutputKey, 'DistributionDomainName')].OutputValue" --output text\`/runtime-config.json > './${websiteContentPath}/public/runtime-config.json'`,
+      command: `curl https://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='${kebabCase(npmScopePrefix)}-infra-sandbox'][].Outputs[?contains(OutputKey, 'DistributionDomainName')].OutputValue" --output text\`/runtime-config.json > './${websiteContentPath}/public/runtime-config.json'`,
     },
   };
   const buildTarget = targets['build'];

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -263,7 +263,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'test-sandbox', {
+new ApplicationStack(app, 'proj-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
@@ -382,7 +382,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'test-sandbox', {
+new ApplicationStack(app, 'proj-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
@@ -526,7 +526,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'test-sandbox', {
+new ApplicationStack(app, 'proj-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
@@ -635,7 +635,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'test-sandbox', {
+new ApplicationStack(app, 'proj-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
@@ -740,7 +740,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'custom-infra-sandbox', {
+new ApplicationStack(app, 'proj-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
+++ b/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
@@ -7,7 +7,7 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, '<%= name %>-sandbox', {
+new ApplicationStack(app, '<%= namespace %>-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -28,6 +28,7 @@ import { addStarExport } from '../../utils/ast';
 import path from 'path';
 import { formatFilesInSubtree } from '../../utils/format';
 import { sortObjectKeys } from '../../utils/nx';
+import kebabCase from 'lodash.kebabcase';
 
 export async function infraGenerator(
   tree: Tree,
@@ -55,6 +56,7 @@ export async function infraGenerator(
     {
       synthDir: synthDirFromProject,
       scopeAlias: scopeAlias,
+      namespace: kebabCase(npmScopePrefix),
       fullyQualifiedName,
       pkgMgrCmd: getPackageManagerCommand().exec,
       ...schema,


### PR DESCRIPTION
### Reason for this change

In order to better identify AWS resources, we prefix the stack id with the project namespace.

### Description of changes

* Prefix stack id with npm scope (this will be `monorepo` if there's no root package.json scope).
* Updated load:runtime-config task to use the updated stack id
* Updated the dungeon adventure tutorial to reflect the new stack id

### Description of how you validated changes

Tested in a local project

### Issue # (if applicable)

Fixes #85

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*