### PR TITLE
fix(ts#cloudscape-website): increase memory limit for website deployment

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
@@ -424,6 +424,7 @@ export class StaticWebsite extends Construct {
       destinationBucket: this.websiteBucket,
       // Files in the distribution's edge caches will be invalidated after files are uploaded to the destination bucket.
       distribution: this.cloudFrontDistribution,
+      memoryLimit: 1024,
     });
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,

--- a/packages/nx-plugin/src/cloudscape-website/app/files/common/constructs/src/core/static-website.ts.template
+++ b/packages/nx-plugin/src/cloudscape-website/app/files/common/constructs/src/core/static-website.ts.template
@@ -127,6 +127,7 @@ export class StaticWebsite extends Construct {
       destinationBucket: this.websiteBucket,
       // Files in the distribution's edge caches will be invalidated after files are uploaded to the destination bucket.
       distribution: this.cloudFrontDistribution,
+      memoryLimit: 1024,
     });
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,


### PR DESCRIPTION
### Reason for this change

Error when deploying reasonable-sized bundles

### Description of changes

Increase memory limit for bucket deployment

### Description of how you validated changes

Sample project

### Issue # (if applicable)

Fixes #139

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*