### PR TITLE
Update astro.config.mjs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -40,7 +40,7 @@ export default defineConfig({
           label: '日本語',
         },
         ko: {
-          label: '한국인',
+          label: '한국어',
         },
         fr: {
           label: 'Français',


### PR DESCRIPTION
"한국인" --> "한국어" Machine translate often translate Korean as people rather than language.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*