### PR TITLE
fix(api-connection): fix options proxy query filter type error with tanstack query v5.74.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@phenomnomnominal/tsquery": "6.1.3",
     "@quantco/pnpm-licenses": "^2.2.1",
     "@tailwindcss/vite": "^4.0.16",
-    "@tanstack/react-query": "^5.69.0",
+    "@tanstack/react-query": "^5.74.3",
     "@testing-library/react": "^16.2.0",
     "@ts-morph/bootstrap": "^0.26.1",
     "@types/fs-extra": "^11.0.4",

--- a/packages/nx-plugin/src/open-api/ts-hooks/__snapshots__/generator.spec.tsx.snap
+++ b/packages/nx-plugin/src/open-api/ts-hooks/__snapshots__/generator.spec.tsx.snap
@@ -98,9 +98,7 @@ export class TestApiOptionsProxy {
       ...options,
     };
   }
-  private _getTestQueryFilter(
-    filter?: QueryFilters<GetTest200Response, GetTestError>,
-  ): QueryFilters<GetTest200Response, GetTestError> {
+  private _getTestQueryFilter(filter?: QueryFilters): QueryFilters {
     return {
       queryKey: this._getTestQueryKey(),
       ...filter,
@@ -173,8 +171,8 @@ export class TestApiOptionsProxy {
   }
   private _getItemsQueryFilter(
     input: GetItemsRequest,
-    filter?: QueryFilters<GetItems200Response, GetItemsError>,
-  ): QueryFilters<GetItems200Response, GetItemsError> {
+    filter?: QueryFilters,
+  ): QueryFilters {
     return {
       queryKey: this._getItemsQueryKey(input),
       ...filter,
@@ -338,8 +336,8 @@ export class TestApiOptionsProxy {
   }
   private _searchDataQueryFilter(
     input: SearchDataRequest,
-    filter?: QueryFilters<SearchData200Response, SearchDataError>,
-  ): QueryFilters<SearchData200Response, SearchDataError> {
+    filter?: QueryFilters,
+  ): QueryFilters {
     return {
       queryKey: this._searchDataQueryKey(input),
       ...filter,
@@ -412,8 +410,8 @@ export class TestApiOptionsProxy {
   }
   private _getItemsQueryFilter(
     input: GetItemsRequest,
-    filter?: QueryFilters<GetItems200Response, GetItemsError>,
-  ): QueryFilters<GetItems200Response, GetItemsError> {
+    filter?: QueryFilters,
+  ): QueryFilters {
     return {
       queryKey: this._getItemsQueryKey(input),
       ...filter,
@@ -529,8 +527,8 @@ export class TestApiOptionsProxy {
   }
   private _listRecordsQueryFilter(
     input: ListRecordsRequest,
-    filter?: QueryFilters<ListRecords200Response, ListRecordsError>,
-  ): QueryFilters<ListRecords200Response, ListRecordsError> {
+    filter?: QueryFilters,
+  ): QueryFilters {
     return {
       queryKey: this._listRecordsQueryKey(input),
       ...filter,
@@ -687,9 +685,7 @@ export class TestApiOptionsProxy {
       ...options,
     };
   }
-  private _getErrorQueryFilter(
-    filter?: QueryFilters<GetError200Response, GetErrorError>,
-  ): QueryFilters<GetError200Response, GetErrorError> {
+  private _getErrorQueryFilter(filter?: QueryFilters): QueryFilters {
     return {
       queryKey: this._getErrorQueryKey(),
       ...filter,
@@ -809,8 +805,8 @@ export class TestApiOptionsProxy {
   }
   private _streamLogsQueryFilter(
     input: StreamLogsRequest,
-    filter?: QueryFilters<StreamLogs200Response[], StreamLogsError>,
-  ): QueryFilters<StreamLogs200Response[], StreamLogsError> {
+    filter?: QueryFilters,
+  ): QueryFilters {
     return {
       queryKey: this._streamLogsQueryKey(input),
       ...filter,
@@ -1074,8 +1070,8 @@ export class TestApiOptionsProxy {
   }
   private _streamEventsQueryFilter(
     input: StreamEventsRequest,
-    filter?: QueryFilters<StreamEvents200Response[], StreamEventsError>,
-  ): QueryFilters<StreamEvents200Response[], StreamEventsError> {
+    filter?: QueryFilters,
+  ): QueryFilters {
     return {
       queryKey: this._streamEventsQueryKey(input),
       ...filter,

--- a/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
@@ -133,7 +133,7 @@ export class <%- className %>OptionsProxy {
       ...options,
     };
   }
-  private _<%- op.uniqueName %>QueryFilter(<%- input %><% if (op.parameters.length > 0) { %>, <% } %>filter?: QueryFilters<<%- queryResultType %>, <%- errorType %>>): QueryFilters<<%- queryResultType %>, <%- errorType %>> {
+  private _<%- op.uniqueName %>QueryFilter(<%- input %><% if (op.parameters.length > 0) { %>, <% } %>filter?: QueryFilters): QueryFilters {
     return {
       queryKey: this._<%- op.uniqueName %>QueryKey(<% if (op.parameters.length > 0) { %>input<% } %>),
       ...filter,

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -17,7 +17,7 @@ export const VERSIONS = {
   '@cloudscape-design/board-components': '^3.0.94',
   '@cloudscape-design/components': '^3.0.928',
   '@cloudscape-design/global-styles': '^1.0.38',
-  '@tanstack/react-query': '5.74.2', // TODO: https://github.com/awslabs/nx-plugin-for-aws/issues/147
+  '@tanstack/react-query': '^5.74.3',
   '@trpc/tanstack-react-query': '11.0.0',
   '@trpc/client': '11.0.0',
   '@trpc/server': '11.0.0',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: ^4.0.16
         version: 4.0.16(vite@6.2.3(@types/node@22.13.13)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.29.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@tanstack/react-query':
-        specifier: ^5.69.0
-        version: 5.69.0(react@19.0.0)
+        specifier: ^5.74.3
+        version: 5.74.4(react@19.0.0)
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2846,11 +2846,11 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6
 
-  '@tanstack/query-core@5.69.0':
-    resolution: {integrity: sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==}
+  '@tanstack/query-core@5.74.4':
+    resolution: {integrity: sha512-YuG0A0+3i9b2Gfo9fkmNnkUWh5+5cFhWBN0pJAHkHilTx6A0nv8kepkk4T4GRt4e5ahbtFj2eTtkiPcVU1xO4A==}
 
-  '@tanstack/react-query@5.69.0':
-    resolution: {integrity: sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==}
+  '@tanstack/react-query@5.74.4':
+    resolution: {integrity: sha512-mAbxw60d4ffQ4qmRYfkO1xzRBPUEf/72Dgo3qqea0J66nIKuDTLEqQt0ku++SDFlMGMnB6uKDnEG1xD/TDse4Q==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -11591,11 +11591,11 @@ snapshots:
       tailwindcss: 4.0.16
       vite: 6.2.3(@types/node@22.13.13)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.29.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
-  '@tanstack/query-core@5.69.0': {}
+  '@tanstack/query-core@5.74.4': {}
 
-  '@tanstack/react-query@5.69.0(react@19.0.0)':
+  '@tanstack/react-query@5.74.4(react@19.0.0)':
     dependencies:
-      '@tanstack/query-core': 5.69.0
+      '@tanstack/query-core': 5.74.4
       react: 19.0.0
 
   '@testing-library/dom@10.4.0':


### PR DESCRIPTION
### Reason for this change

TanStack Query v5.74.3 removed the data and error type parameters from the QueryFilters type.

See: https://github.com/TanStack/query/pull/8958

### Description of changes

Remove these type parameters in the generated code

### Description of how you validated changes

Updated TanStack query in an example project

### Issue # (if applicable)

Fixes #147

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*