### PR TITLE
chore(metrics): fix tag key in cloudformation description

### DIFF
--- a/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
@@ -24,7 +24,7 @@ class MetricsAspect implements IAspect {
       const version = '';
       const tags: string[] = [];
       node.templateOptions.description =
-        \`\${node.templateOptions.description ?? ''} (\${id}) (version:\${version}) (tags:\${tags.join(',')})\`.trim();
+        \`\${node.templateOptions.description ?? ''} (\${id}) (version:\${version}) (tag:\${tags.join(',')})\`.trim();
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/app.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/app.ts.template
@@ -18,7 +18,7 @@ class MetricsAspect implements IAspect {
       const id = '';
       const version = '';
       const tags: string[] = [];
-      node.templateOptions.description = `${node.templateOptions.description ?? ''} (${id}) (version:${version}) (tags:${tags.join(',')})`.trim();
+      node.templateOptions.description = `${node.templateOptions.description ?? ''} (${id}) (version:${version}) (tag:${tags.join(',')})`.trim();
     }
   }
 }


### PR DESCRIPTION
### Reason for this change

Tags weren't showing up in our metrics

### Description of changes

The correct key is 'tag' not 'tags', updated template to fix.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*