### PR TITLE
docs: translation for components and reuseable snippets

### DIFF
--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -1,19 +1,73 @@
 ---
 import { Badge } from '@astrojs/starlight/components';
 const { schema } = Astro.props;
+const locale = Astro.currentLocale || 'en';
+const strings = {
+  parameter: {
+    en: 'Parameter',
+    jp: 'パラメータ',
+    ko: '매개변수',
+    fr: 'Paramètre',
+    it: 'Parametro',
+    es: 'Parámetro',
+    pt: 'Parâmetro',
+    zh: '参数'
+  },
+  type: {
+    en: 'Type',
+    jp: '型',
+    ko: '타입',
+    fr: 'Type',
+    it: 'Tipo',
+    es: 'Tipo',
+    pt: 'Tipo',
+    zh: '类型'
+  },
+  default: {
+    en: 'Default',
+    jp: 'デフォルト',
+    ko: '기본값',
+    fr: 'Par défaut',
+    it: 'Predefinito',
+    es: 'Predeterminado',
+    pt: 'Padrão',
+    zh: '默认值'
+  },
+  description: {
+    en: 'Description',
+    jp: '説明',
+    ko: '설명',
+    fr: 'Description',
+    it: 'Descrizione',
+    es: 'Descripción',
+    pt: 'Descrição',
+    zh: '描述'
+  },
+  required: {
+    en: 'Required',
+    jp: '必須',
+    ko: '필수',
+    fr: 'Requis',
+    it: 'Obbligatorio',
+    es: 'Requerido',
+    pt: 'Obrigatório',
+    zh: '必需'
+  },
+};
+const localeString = (name) => strings[name][locale] || strings[name]['en'];
 ---
 
 <table>
   <tr>
-    <th>Parameter</th>
-    <th>Type</th>
-    <th>Default</th>
-    <th>Description</th>
+    <th>{localeString('parameter')}</th>
+    <th>{localeString('type')}</th>
+    <th>{localeString('default')}</th>
+    <th>{localeString('description')}</th>
   </tr>
   {
     Object.entries(schema.properties).map(([parameter, parameterSchema]) => (
       <tr>
-        <td>{parameter} {(schema.required ?? []).includes(parameter) ? <Badge text="required" variant="note" /> : null}</td>
+        <td>{parameter} {(schema.required ?? []).includes(parameter) ? <Badge text={localeString('required')} variant="note" /> : null}</td>
         <td>{parameterSchema.type}</td>
         <td>{parameterSchema.default ?? '-'}</td>
         <td>{parameterSchema.description ?? '-'}</td>

--- a/docs/src/components/run-generator.astro
+++ b/docs/src/components/run-generator.astro
@@ -2,26 +2,112 @@
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import NxCommands from './nx-commands.astro';
 const { namespace = '@aws/nx-plugin', generator, requiredParameters = {}, noInteractive = false } = Astro.props;
+const locale = Astro.currentLocale || 'en';
 const cliCommand = `g ${namespace}:${generator}${Object.keys(requiredParameters).length !== 0 ? ` ${Object.entries(requiredParameters).map(([k,v]) => `--${k}=${v}`).join(' ')}` : ''}${noInteractive ? ' --no-interactive' : ''}`;
+
+const strings = {
+  installPlugin: {
+    en: 'Install the',
+    jp: 'インストール',
+    ko: '설치',
+    fr: 'Installez le',
+    it: 'Installa il',
+    es: 'Instale el',
+    pt: 'Instale o',
+    zh: '安装'
+  },
+  ifNotAlready: {
+    en: 'if you haven\'t already',
+    jp: 'まだインストールしていない場合',
+    ko: '아직 설치하지 않았다면',
+    fr: 'si ce n\'est pas déjà fait',
+    it: 'se non l\'hai già fatto',
+    es: 'si aún no lo ha hecho',
+    pt: 'se ainda não o fez',
+    zh: '如果您尚未安装'
+  },
+  openNxConsole: {
+    en: 'Open the Nx Console in VSCode',
+    jp: 'VSCodeでNxコンソールを開く',
+    ko: 'VSCode에서 Nx 콘솔 열기',
+    fr: 'Ouvrez la console Nx dans VSCode',
+    it: 'Apri la console Nx in VSCode',
+    es: 'Abra la consola Nx en VSCode',
+    pt: 'Abra o console Nx no VSCode',
+    zh: '在VSCode中打开Nx控制台'
+  },
+  clickGenerate: {
+    en: 'Click',
+    jp: 'クリック',
+    ko: '클릭',
+    fr: 'Cliquez sur',
+    it: 'Clicca su',
+    es: 'Haga clic en',
+    pt: 'Clique em',
+    zh: '点击'
+  },
+  inCommonNxCommands: {
+    en: 'in the "Common Nx Commands" section',
+    jp: '"Common Nx Commands"セクションで',
+    ko: '"Common Nx Commands" 섹션에서',
+    fr: 'dans la section "Common Nx Commands"',
+    it: 'nella sezione "Common Nx Commands"',
+    es: 'en la sección "Common Nx Commands"',
+    pt: 'na seção "Common Nx Commands"',
+    zh: '在"Common Nx Commands"部分'
+  },
+  searchFor: {
+    en: 'Search for',
+    jp: '検索',
+    ko: '검색',
+    fr: 'Recherchez',
+    it: 'Cerca',
+    es: 'Busque',
+    pt: 'Procure por',
+    zh: '搜索'
+  },
+  fillRequiredParams: {
+    en: 'Fill in the required parameters',
+    jp: '必須パラメータを入力',
+    ko: '필수 매개변수 입력',
+    fr: 'Remplissez les paramètres requis',
+    it: 'Compila i parametri richiesti',
+    es: 'Complete los parámetros requeridos',
+    pt: 'Preencha os parâmetros obrigatórios',
+    zh: '填写必需参数'
+  },
+  dryRunSummary: {
+    en: 'You can also perform a dry-run to see what files would be changed',
+    jp: '変更されるファイルを確認するためにドライランを実行することもできます',
+    ko: '어떤 파일이 변경될지 확인하기 위해 드라이 런을 수행할 수도 있습니다',
+    fr: 'Vous pouvez également effectuer une simulation pour voir quels fichiers seraient modifiés',
+    it: 'Puoi anche eseguire una prova per vedere quali file verrebbero modificati',
+    es: 'También puede realizar una ejecución en seco para ver qué archivos se cambiarían',
+    pt: 'Você também pode realizar uma execução simulada para ver quais arquivos seriam alterados',
+    zh: '您还可以执行试运行以查看哪些文件会被更改'
+  }
+};
+
+const localeString = (name) => strings[name][locale] || strings[name]['en'];
 ---
 
 <Tabs syncKey="generator-usage">
   <TabItem label="VSCode">
     <Steps>
       <ol>
-        <li>Install the <a href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console">Nx Console VSCode Plugin</a> if you haven't already</li>
-        <li>Open the Nx Console in VSCode</li>
-        <li>Click <code>Generate (UI)</code> in the "Common Nx Commands" section</li>
-        <li>Search for <code>{namespace} - {generator}</code></li>
-        <li>Fill in the required parameters<ul>{Object.keys(requiredParameters).length !== 0 && Object.entries(requiredParameters).map(([k,v]) => <li><b>{k}:</b> {v}</li>)}</ul></li>
-        <li>Click <code>Generate</code></li>
+        <li>{localeString('installPlugin')} <a href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console">Nx Console VSCode Plugin</a> {localeString('ifNotAlready')}</li>
+        <li>{localeString('openNxConsole')}</li>
+        <li>{localeString('clickGenerate')} <code>Generate (UI)</code> {localeString('inCommonNxCommands')}</li>
+        <li>{localeString('searchFor')} <code>{namespace} - {generator}</code></li>
+        <li>{localeString('fillRequiredParams')}<ul>{Object.keys(requiredParameters).length !== 0 && Object.entries(requiredParameters).map(([k,v]) => <li><b>{k}:</b> {v}</li>)}</ul></li>
+        <li>{localeString('clickGenerate')} <code>Generate</code></li>
       </ol>
     </Steps>
   </TabItem>
   <TabItem label="CLI">
     <NxCommands commands={[cliCommand]} />
     <details>
-      <summary>You can also perform a dry-run to see what files would be changed</summary>
+      <summary>{localeString('dryRunSummary')}</summary>
       <NxCommands commands={[`${cliCommand} --dry-run`]} />
     </details>
   </TabItem>

--- a/docs/src/components/snippet.astro
+++ b/docs/src/components/snippet.astro
@@ -1,0 +1,11 @@
+---
+import { Aside } from '@astrojs/starlight/components';
+const locale = Astro.currentLocale || 'en';
+const snippets = Object.values(import.meta.glob('../content/docs/*/snippets/**/*.mdx', { eager: true }));
+const { name } = Astro.props;
+const snippet = snippets.find(s => s.file.endsWith(`content/docs/${locale}/snippets/${name}.mdx`));
+---
+
+{
+  snippet ? <snippet.Content /> : <Aside type="danger">Unable to load snippet {name} for locale {locale}</Aside>
+}

--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -4,7 +4,7 @@ description: A quick start on how to use @aws/nx-plugin.
 ---
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -20,7 +20,7 @@ For a more in-depth tutorial for building a full-stack application, check out th
 
 The following global dependencies are needed before proceeding:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## Step 1: Initialize a New Nx Workspace
 

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/overview.mdx
@@ -4,7 +4,7 @@ description: A walkthrough of how to build an AI powered dungeon adventure game 
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -63,5 +63,5 @@ The AI powered dungeon adventure game will be built using the following componen
 
 The following global dependencies are needed before proceeding:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - Ensure your AWS account has enabled access to the Anthropic Claude 3.5 Sonnet v2 model within Bedrock for your target region via the steps outlined in [this guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).

--- a/docs/src/content/docs/en/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/prerequisites.mdx
@@ -1,3 +1,6 @@
+---
+title: Prerequisites
+---
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (We recommend using something like [NVM](https://github.com/nvm-sh/nvm) to manage your node versions)
   - verify by running `node --version`

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "Una introducción rápida sobre cómo usar @aws/nx-plugin."
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ Para un tutorial más detallado sobre cómo construir una aplicación full-stack
 
 Se necesitan las siguientes dependencias globales antes de continuar:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## Paso 1: Inicializar un nuevo espacio de trabajo Nx
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/overview.mdx
@@ -6,7 +6,7 @@ description: "Un tutorial de cómo construir un juego de aventuras de mazmorra c
 
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -65,5 +65,5 @@ El juego de aventuras tipo mazmorra con IA se construirá usando la siguiente ar
 
 Se necesitan las siguientes dependencias globales antes de continuar:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - Asegúrate de que tu cuenta AWS tiene acceso habilitado al modelo Anthropic Claude 3.5 Sonnet v2 en Bedrock para tu región objetivo, siguiendo los pasos de [esta guía](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "Un démarrage rapide sur l'utilisation de @aws/nx-plugin."
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ Pour un tutoriel plus approfondi sur la création d'une application full-stack, 
 
 Les dépendances globales suivantes sont nécessaires avant de continuer :
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## Étape 1 : Initialiser un nouvel espace de travail Nx
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/overview.mdx
@@ -6,7 +6,7 @@ description: "Un guide pas à pas pour construire un jeu d'aventure de donjon al
 
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -65,5 +65,5 @@ L'architecture du jeu utilise les composants suivants :
 
 Les dépendances globales suivantes sont nécessaires :
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - Vérifiez que votre compte AWS a activé l'accès au modèle Anthropic Claude 3.5 Sonnet v2 dans Bedrock pour votre région cible en suivant les étapes décrites dans [ce guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "Un avvio rapido su come utilizzare @aws/nx-plugin."
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ Per un tutorial più approfondito sulla creazione di un'applicazione full-stack,
 
 Sono necessarie le seguenti dipendenze globali prima di procedere:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## Step 1: Inizializzare una nuova workspace Nx
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/overview.mdx
@@ -6,7 +6,7 @@ description: "Una guida dettagliata su come costruire un gioco di avventura dung
 
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -65,5 +65,5 @@ L'architettura del gioco utilizza i seguenti componenti:
 
 Sono necessarie le seguenti dipendenze globali prima di procedere:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - Assicurati che il tuo account AWS abbia abilitato l'accesso al modello Anthropic Claude 3.5 Sonnet v2 in Bedrock per la regione target, seguendo i passaggi descritti in [questa guida](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "@aws/nx-pluginの使い方に関するクイックスタート。"
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ import NxCommands from '@components/nx-commands.astro';
 
 始める前に以下のグローバル依存関係が必要です:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## ステップ1: 新しいNxワークスペースの初期化
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/overview.mdx
@@ -7,7 +7,7 @@ description: "@aws/nx-pluginを使用してAIパワードのダンジョン冒�
 
 ```mdx
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -66,6 +66,6 @@ AI駆動ダンジョンアドベンチャーゲームは以下のコンポーネ
 
 作業を進める前に以下のグローバル依存関係が必要です：
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - AWSアカウントで対象リージョンのBedrockにおいてAnthropic Claude 3.5 Sonnet v2モデルへのアクセスが有効化されていることを確認してください（設定手順は[こちらのガイド](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)を参照）。
 ```

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "@aws/nx-plugin 사용 방법에 대한 빠른 시작"
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ import NxCommands from '@components/nx-commands.astro';
 
 진행 전 다음 전역 종속성이 필요합니다:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## 단계 1: 새 Nx 작업 공간 초기화
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/overview.mdx
@@ -6,7 +6,7 @@ description: "@aws/nx-plugin을 사용하여 AI 기반 던전 모험 게임을 �
 
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -65,5 +65,5 @@ AI 기반 던전 어드벤처 게임은 다음 컴포넌트 아키텍처로 구�
 
 진행 전 다음 전역 종속성이 필요합니다:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - AWS 계정이 대상 리전에서 Bedrock의 Anthropic Claude 3.5 Sonnet v2 모델 접근을 허용했는지 확인하세요. [이 가이드](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)에 설명된 단계를 따라 진행하시기 바랍니다.

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "Um início rápido sobre como usar @aws/nx-plugin."
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ Para um tutorial mais detalhado sobre a construção de uma aplicação full-sta
 
 As seguintes dependências globais são necessárias antes de prosseguir:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## Passo 1: Inicializar um Novo Workspace Nx
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/overview.mdx
@@ -6,7 +6,7 @@ description: "Um guia passo a passo de como construir um jogo de aventura de dun
 
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -65,5 +65,5 @@ O jogo será construído usando a seguinte arquitetura de componentes:
 
 Os seguintes requisitos globais são necessários:
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - Garanta que sua conta AWS tenha acesso ao modelo Anthropic Claude 3.5 Sonnet v2 no Bedrock para sua região-alvo, seguindo as etapas deste [guia](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -7,7 +7,7 @@ description: "关于如何使用 @aws/nx-plugin 的快速入门。"
 
 import { Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import InstallCommand from '@components/install-command.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,7 +23,7 @@ import NxCommands from '@components/nx-commands.astro';
 
 开始前需安装以下全局依赖：
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 
 ## 步骤 1：初始化新的 Nx 工作区
 

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/overview.mdx
@@ -6,7 +6,7 @@ description: "使用 @aws/nx-plugin 构建人工智能驱动的地牢冒险游�
 
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import { Content as Prerequisites } from '@snippets/prerequisites.mdx';
+import Snippet from '@components/snippet.astro';
 import { Image } from 'astro:assets';
 import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -65,5 +65,5 @@ AI地牢冒险游戏将采用以下组件架构：
 
 开始前需确保以下全局依赖已安装：
 
-<Prerequisites />
+<Snippet name="prerequisites" />
 - 按照[本指南](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)的步骤，确保目标区域的AWS账户已在Bedrock中启用Anthropic Claude 3.5 Sonnet v2模型的访问权限。

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,20 +1,14 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "include": [
-    ".astro/types.d.ts",
-    "**/*"
-  ],
-  "exclude": [
-    "dist"
-  ],
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"],
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "baseUrl": ".",
     "paths": {
       "@components/*": ["src/components/*"],
-      "@snippets/*": ["src/snippets/*"],
-      "@assets/*": ["src/content/docs/assets/*"],
+      "@assets/*": ["src/content/docs/assets/*"]
     }
   }
 }


### PR DESCRIPTION
### Reason for this change

Components and snippets were not taking the locale into account.

### Description of changes

For components, simply translate the English strings and reference based on the locale.

For snippets, we move them into the docs/content/<locale> folder such that they will be automatically translated, and provide a component for rendering them which will take the locale into account.

### Description of how you validated changes

Local docs site

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*