### PR TITLE
feat(cloudscape-website): load runtimeconfig from s3 bucket

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
@@ -429,6 +429,9 @@ export class StaticWebsite extends Construct {
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,
     });
+    new CfnOutput(this, 'WebsiteBucketName', {
+      value: this.websiteBucket.bucketName,
+    });
   }
   private resolveTokens = (payload: any) => {
     const _payload: Record<string, any> = {};

--- a/packages/nx-plugin/src/cloudscape-website/app/files/common/constructs/src/core/static-website.ts.template
+++ b/packages/nx-plugin/src/cloudscape-website/app/files/common/constructs/src/core/static-website.ts.template
@@ -132,6 +132,9 @@ export class StaticWebsite extends Construct {
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,
     });
+    new CfnOutput(this, 'WebsiteBucketName', {
+      value: this.websiteBucket.bucketName,
+    });
   }
   private resolveTokens = (payload: any) => {
     const _payload: Record<string, any> = {};

--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -85,10 +85,10 @@ export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
   targets['load:runtime-config'] = {
     executor: 'nx:run-commands',
     metadata: {
-      description: `Load runtime config from your deployed stack for dev purposes. You must set the AWS_REGION and CDK_APP_DIR env variables whilst calling i.e: AWS_REGION=ap-southeast-2 CDK_APP_DIR=./dist/packages/infra/cdk.out pnpm exec nx run ${fullyQualifiedName}:load:runtime-config`,
+      description: `Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm exec nx run ${fullyQualifiedName}:load:runtime-config'`,
     },
     options: {
-      command: `curl https://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='${kebabCase(npmScopePrefix)}-infra-sandbox'][].Outputs[?contains(OutputKey, 'DistributionDomainName')].OutputValue" --output text\`/runtime-config.json > './${websiteContentPath}/public/runtime-config.json'`,
+      command: `aws s3 cp s3://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='${kebabCase(npmScopePrefix)}-infra-sandbox'][].Outputs[?contains(OutputKey, 'WebsiteBucketName')].OutputValue" --output text\`/runtime-config.json './${websiteContentPath}/public/runtime-config.json'`,
     },
   };
   const buildTarget = targets['build'];


### PR DESCRIPTION
### Reason for this change

`website:load:runtime-config` currently pulls `runtime-config.json` via web request. If there are changes during the deployment, it won't be reflected for quite some time, invalidations during deployment are not predictable (at least based on my experience).

### Description of changes

Since AWS CLI is used in the current version, a direct s3 download is a viable option and the latest deployment's changes are reflected immediately.

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*