### PR TITLE
fix(cloudscape-website): update build outputPath to the bundle

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -116,7 +116,7 @@ export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
       ...(buildTarget.dependsOn ?? []),
     ],
     options: {
-      outputPath: joinPathFragments('dist', websiteContentPath),
+      outputPath: joinPathFragments('dist', websiteContentPath, 'bundle'),
     },
   };
   projectConfiguration.targets = sortObjectKeys(targets);


### PR DESCRIPTION
### Reason for this change

`preview` and `serve-static` targets both rely on the outputPath of the build task to determine where the static files are located. The two options are to either:

1.) update the `outputPath` to point to the bundle (this PR)
2.) add a `staticFilePath` to each of `preview` and `serve-static` to point to the bundle.

I have chosen to implement 1 as the `outputPath` of the `build` target is not used presently and the primary output is the `bundle`.

### Description of changes

- updated outputPath of `build` to be the generated bundle.

### Description of how you validated changes

- local testing.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*