### PR TITLE
test: create project graph prior to running tests

### DIFF
--- a/packages/nx-plugin/src/setup-tests.ts
+++ b/packages/nx-plugin/src/setup-tests.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createProjectGraphAsync } from '@nx/devkit';
+
+// Global Setup https://vitest.dev/config/#globalsetup
+export default async () => {
+  // Create the project graph in global setup to ensure it's cached in the daemon
+  await createProjectGraphAsync();
+};

--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -40,5 +40,6 @@ export default defineConfig({
     },
     testTimeout: 60000,
     hookTimeout: 60000,
+    globalSetup: ['./src/setup-tests.ts'],
   },
 });


### PR DESCRIPTION
### Reason for this change

Unit tests have been flakey recently - seems to be due to the project graph being calculated for every test and the daemon deadlocking and timing out.

### Description of changes

Create the project graph before running any tests to ensure it's cached in the daemon before spamming it with graph requests.

### Description of how you validated changes

A couple of PR builds lol

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*