### PR TITLE
test: enable daemon in unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CI: 'true'
+  NX_DAEMON: 'true'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CI: 'true'
+  NX_DAEMON: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -78,7 +78,7 @@ describe('smoke test - dungeon-adventure', () => {
     );
     await runCLI(`sync --verbose`, opts);
     await runCLI(
-      `run-many --target build --all --parallel 12 --output-style=stream --skip-nx-cache --verbose`,
+      `run-many --target build --all --parallel 1 --output-style=stream --skip-nx-cache --verbose`,
       opts,
     );
 
@@ -258,7 +258,7 @@ describe('smoke test - dungeon-adventure', () => {
     await runCLI(`sync --verbose`, opts);
     await runCLI(`run-many --target lint --configuration=fix --all`, opts);
     await runCLI(
-      `run-many --target build --all --parallel 12 --output-style=stream --verbose`,
+      `run-many --target build --all --parallel 1 --output-style=stream --verbose`,
       opts,
     );
 
@@ -331,7 +331,7 @@ describe('smoke test - dungeon-adventure', () => {
     await runCLI(`sync --verbose`, opts);
     await runCLI(`run-many --target lint --configuration=fix --all`, opts);
     await runCLI(
-      `run-many --target build --all --parallel 12 --output-style=stream --verbose`,
+      `run-many --target build --all --parallel 1 --output-style=stream --verbose`,
       opts,
     );
 
@@ -416,7 +416,7 @@ describe('smoke test - dungeon-adventure', () => {
     await runCLI(`sync --verbose`, opts);
     await runCLI(`run-many --target lint --configuration=fix --all`, opts);
     await runCLI(
-      `run-many --target build --all --parallel 12 --output-style=stream --verbose`,
+      `run-many --target build --all --parallel 1 --output-style=stream --verbose`,
       opts,
     );
   });

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -35,7 +35,7 @@ describe('smoke test - dungeon-adventure', () => {
       },
     );
     const projectRoot = `${targetDir}/dungeon-adventure`;
-    const opts = { cwd: projectRoot };
+    const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
     await runCLI(
       `generate @aws/nx-plugin:ts#trpc-api --apiName=GameApi --no-interactive`,

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -108,7 +108,7 @@ export const smokeTest = (
       );
       await runCLI(`sync --verbose`, opts);
       await runCLI(
-        `run-many --target build --all --parallel 12 --output-style=stream --skip-nx-cache --verbose`,
+        `run-many --target build --all --parallel 1 --output-style=stream --skip-nx-cache --verbose`,
         opts,
       );
     });

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -33,7 +33,7 @@ export const smokeTest = (
         },
       );
       const projectRoot = `${tmpProjPath()}/${pkgMgr}/e2e-test`;
-      const opts = { cwd: projectRoot };
+      const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
       if (onProjectCreate) {
         onProjectCreate(projectRoot);
       }

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -43,8 +43,8 @@ export async function runCLI(
             cwd: opts.cwd || tmpProjPath(),
             env: {
               PATH: process.env.PATH,
-              ...opts.env,
               ...process.env,
+              ...opts.env,
             },
             encoding: 'utf-8',
             stdio: 'inherit',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nx/playwright": "~21.0.3",
     "@nx/react": "~21.0.3",
     "@nx/vite": "~21.0.3",
-    "@nxlv/python": "^20.15.0",
+    "@nxlv/python": "^21.0.0",
     "@phenomnomnominal/tsquery": "6.1.3",
     "@quantco/pnpm-licenses": "^2.2.1",
     "@tailwindcss/vite": "^4.0.16",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -28,7 +28,7 @@
     "@nx/js": "~21.0.3",
     "@nx/react": "~21.0.3",
     "@nx/vite": "~21.0.3",
-    "@nxlv/python": "^20.12.0",
+    "@nxlv/python": "^21.0.0",
     "@phenomnomnominal/tsquery": "6.1.3",
     "fast-glob": "^3.3.3",
     "lodash.camelcase": "^4.3.0",

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -11,7 +11,7 @@ export const VERSIONS = {
   '@aws-lambda-powertools/logger': '^2.17.0',
   '@aws-lambda-powertools/metrics': '^2.17.0',
   '@aws-lambda-powertools/tracer': '^2.17.0',
-  '@nxlv/python': '^20.15.0',
+  '@nxlv/python': '^21.0.0',
   '@nx/devkit': '~21.0.3',
   '@modelcontextprotocol/sdk': '^1.10.2',
   '@tanstack/react-router': '^1.114.27',

--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -31,24 +31,7 @@ export default defineConfig({
       enabled: true,
       reporter: ['lcov'],
     },
-    env: {
-      NX_DAEMON: 'true',
-    },
     pool: 'threads',
-    // Tests that use the ts library generator end up with Nx computing a project
-    // graph on the daemon (the eslint generator calls createProjectGraphAsync).
-    // Too much parallelism spams the daemon too hard causing it to deadlock on
-    // less powerful machines, ie our CI worker, so we reduce it in CI mode.
-    ...(process.env.CI
-      ? {
-          poolOptions: {
-            threads: {
-              minThreads: 1,
-              maxThreads: 4,
-            },
-          },
-        }
-      : {}),
     sequence: {
       hooks: 'list',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ~21.0.3
         version: 21.0.3(@babel/traverse@7.27.0)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15))(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))(typescript@5.8.2)(verdaccio@6.1.0(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.3(@types/node@22.13.13)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.29.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.9)
       '@nxlv/python':
-        specifier: ^20.15.0
-        version: 20.15.1(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
+        specifier: ^21.0.0
+        version: 21.0.0(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
       '@phenomnomnominal/tsquery':
         specifier: 6.1.3
         version: 6.1.3(typescript@5.8.2)
@@ -320,8 +320,8 @@ importers:
         specifier: ~21.0.3
         version: 21.0.3(@babel/traverse@7.27.0)(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15))(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))(typescript@5.8.2)(verdaccio@6.1.0(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.3(@types/node@22.13.13)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.29.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.9)
       '@nxlv/python':
-        specifier: ^20.12.0
-        version: 20.12.0(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
+        specifier: ^21.0.0
+        version: 21.0.0(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
       '@phenomnomnominal/tsquery':
         specifier: 6.1.3
         version: 6.1.3(typescript@5.8.2)
@@ -2028,11 +2028,6 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nx/devkit@20.6.4':
-    resolution: {integrity: sha512-lyEidfyPhTuHt1X6EsskugBREazS5VOKSPIcreQ8Qt0MaULxn0bQ9o0N6C+BQaw5Zu6RTaMRMWKGW0I0Qni0UA==}
-    peerDependencies:
-      nx: '>= 19 <= 21'
-
   '@nx/devkit@21.0.3':
     resolution: {integrity: sha512-PnEZWenJ3fOoAU+Es9v0xxANyrROtFj+rjDHCjfyqGs3jMihMyTsCDQLpsjdnrUF5jjp9VUawfms76ocSLmwpw==}
     peerDependencies:
@@ -2140,11 +2135,8 @@ packages:
   '@nx/workspace@21.0.3':
     resolution: {integrity: sha512-yM1hCR7kbN0VuXum2P6m5SY+CXqSAez5fJYh8vHtXRfnzGRoerQJS2G2ZYQ828sxLeXB4Tft50IUUAgHEVh8tw==}
 
-  '@nxlv/python@20.12.0':
-    resolution: {integrity: sha512-2xX0eyhu9dTIwiNiLBZdjlovCorR2HZP/R1ayorjUHO7NXtkoEM3CRF8EUJPKITuzY3IQdPvX0ghzHyjOLllWQ==}
-
-  '@nxlv/python@20.15.1':
-    resolution: {integrity: sha512-Yw2NHmLfHdZJDrAZv8svBjAJd/AePSD5KSu5wJwtKhnqE7ZkM0xJ+O35s5dQPw+ei545xCtZf80M9APoyL7mbA==}
+  '@nxlv/python@21.0.0':
+    resolution: {integrity: sha512-CWZVTRAa80WMjn9Z3zq5YFPna8eI1fVNoFcWGvdpqmTJiz1gEriu+9dCIfVR9vgV8DuPTIY+av6Vy9JUF2X01A==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -10551,18 +10543,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nx/devkit@20.6.4(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))':
-    dependencies:
-      ejs: 3.1.10
-      enquirer: 2.3.6
-      ignore: 5.3.2
-      minimatch: 9.0.3
-      nx: 21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15))
-      semver: 7.7.1
-      tmp: 0.2.3
-      tslib: 2.8.1
-      yargs-parser: 21.1.1
-
   '@nx/devkit@21.0.3(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))':
     dependencies:
       ejs: 3.1.10
@@ -10838,30 +10818,14 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nxlv/python@20.12.0(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))':
+  '@nxlv/python@21.0.0(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))':
     dependencies:
       '@iarna/toml': 2.2.5
-      '@nx/devkit': 20.6.4(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
+      '@nx/devkit': 21.0.3(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
       chalk: 4.1.2
       command-exists: 1.2.9
       cross-spawn: 7.0.6
-      file-uri-to-path: 2.0.0
-      fs-extra: 11.3.0
-      lodash: 4.17.21
-      ora: 5.3.0
-      semver: 7.7.1
-      tslib: 2.8.1
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - nx
-
-  '@nxlv/python@20.15.1(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))':
-    dependencies:
-      '@iarna/toml': 2.2.5
-      '@nx/devkit': 20.6.4(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
-      chalk: 4.1.2
-      command-exists: 1.2.9
-      cross-spawn: 7.0.6
+      enquirer: 2.3.6
       file-uri-to-path: 2.0.0
       fs-extra: 11.3.0
       lodash: 4.17.21


### PR DESCRIPTION
- The `env` in vite config wasn't actually enabling the daemon in the unit tests. With the daemon on in the unit tests it's the same behaviour as running them locally and seems to be passing a bit more consistently! I've updated the gitlab workflows to ensure it's set, but have disabled it in the e2e tests as daemon errors started to pop up.
- Reduce parallelism to 1 in smoke tests to avoid transient python clashing issue
- Upgrade @nxlv/python to 21 in line with Nx 21

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*