### PR TITLE
fix(py#project): ignore .coverage build artifact

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -113,6 +113,7 @@ describe('python project generator', () => {
     const projectGitIgnorePatterns =
       tree.read('apps/test_project/.gitignore', 'utf-8')?.split('\n') ?? [];
     expect(projectGitIgnorePatterns).toContain('**/__pycache__');
+    expect(projectGitIgnorePatterns).toContain('.coverage');
   });
 
   it('should add a dependency on the python plugin', async () => {

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -152,11 +152,15 @@ export const pyProjectGenerator = async (
   projectConfiguration.targets = sortObjectKeys(projectConfiguration.targets);
   updateProjectConfiguration(tree, normalizedName, projectConfiguration);
 
-  // Update root .gitignore to ignore reports directory
+  // Update root .gitignore
   updateGitIgnore(tree, '.', (patterns) => [...patterns, '/reports']);
 
-  // Update project level .gitignore to ignore __pycache__ directories
-  updateGitIgnore(tree, dir, (patterns) => [...patterns, '**/__pycache__']);
+  // Update project level .gitignore
+  updateGitIgnore(tree, dir, (patterns) => [
+    ...patterns,
+    '**/__pycache__',
+    '.coverage',
+  ]);
 
   await addGeneratorMetricsIfApplicable(tree, [PY_PROJECT_GENERATOR_INFO]);
 


### PR DESCRIPTION
Add .coverage to .gitignore as it's generated at build time

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*