### PR TITLE
docs: refactor generator parameters component for easier usage

### DIFF
--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -1,6 +1,11 @@
 ---
 import { Badge } from '@astrojs/starlight/components';
-const { schema } = Astro.props;
+const { generator } = Astro.props;
+
+import GeneratorsJson from '../../../packages/nx-plugin/generators.json';
+const schemas = Object.entries(import.meta.glob('../../../packages/nx-plugin/**/schema.json', { eager: true, query: '?raw' }));
+const schema = JSON.parse(schemas.find(([file]) => file.endsWith(GeneratorsJson.generators[generator].schema.slice(2)))[1].default);
+
 const locale = Astro.currentLocale || 'en';
 const strings = {
   parameter: {

--- a/docs/src/content/docs/en/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/en/guides/api-connection/react-fastapi.mdx
@@ -9,7 +9,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
 The `api-connection` generator provides a way to quickly integrate your React website with your FastAPI backend. It sets up all necessary configuration for connecting to your FastAPI backends in a type-safe manner, including client and [TanStack Query](https://tanstack.com/query/v5) hooks generation, AWS IAM authentication support and proper error handling.
 
@@ -48,7 +47,7 @@ root.render(
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/en/guides/api-connection/react-trpc.mdx
@@ -6,7 +6,6 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
 AWS Plugin for Nx provides a generator to quickly integrate your <Link path="guides/trpc">tRPC API</Link> with a React website. It sets up all necessary configuration for connecting to your tRPC backends, including AWS IAM authentication support and proper error handling. The integration provides full end-to-end type safety between your frontend and tRPC backend(s).
 
@@ -46,7 +45,7 @@ root.render(
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/cloudscape-website-auth.mdx
@@ -7,7 +7,6 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
 The CloudScape Website Authentication generator adds authentication to your CloudScape website using [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -23,7 +22,7 @@ You can add authentication to your CloudScape website in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/en/guides/cloudscape-website.mdx
@@ -7,7 +7,6 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
 This generator creates a new [React](https://react.dev/) website with [CloudScape](http://cloudscape.design/) configured, along with the AWS CDK infrastructure to deploy your website to the cloud as a static website hosted in [S3](https://aws.amazon.com/s3/), served by [CloudFront](https://aws.amazon.com/cloudfront/) and protected by [WAF](https://aws.amazon.com/waf/).
 
@@ -27,7 +26,7 @@ You can generate a new CloudScape Website in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/fastapi.mdx
+++ b/docs/src/content/docs/en/guides/fastapi.mdx
@@ -9,7 +9,6 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
 [FastAPI](https://fastapi.tiangolo.com/) is a framework for building APIs in Python.
 
@@ -25,7 +24,7 @@ You can generate a new FastAPI in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 

--- a/docs/src/content/docs/en/guides/license.mdx
+++ b/docs/src/content/docs/en/guides/license.mdx
@@ -5,7 +5,6 @@ description: Reference documentation for the License generator
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
 Automatically manage `LICENSE` files and source code headers in your workspace.
 
@@ -19,7 +18,7 @@ This generator registers a [sync generator](https://nx.dev/concepts/sync-generat
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/nx-generator.mdx
+++ b/docs/src/content/docs/en/guides/nx-generator.mdx
@@ -9,7 +9,6 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
 Adds an [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) to a TypeScript project, to help you automate repetitive tasks such as scaffolding components or enforcing particular project structures.
 
@@ -23,7 +22,7 @@ You can generate a generator in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/en/guides/python-lambda-function.mdx
@@ -7,7 +7,6 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
 The Python Lambda Function generator provides the ability to add a lambda function to an existing python project.
 
@@ -23,7 +22,7 @@ You can generate a new Lambda Function in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/python-project.mdx
+++ b/docs/src/content/docs/en/guides/python-project.mdx
@@ -6,7 +6,6 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
 The Python project generator can be used to create a modern [Python](https://www.python.org/) library or application configured with best practices, managed with [UV](https://docs.astral.sh/uv/), a single lockfile and virtual environment in an [UV workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) for running tests, and [Ruff](https://docs.astral.sh/ruff/) for static analysis.
 
@@ -20,7 +19,7 @@ You can generate a new Python project in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -8,7 +8,6 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
 [tRPC](https://trpc.io/) is a framework for building APIs in TypeScript with end-to-end type safety. Using tRPC, updates to API operation inputs and outputs are immediately reflected in client code and are visible in your IDE without the need to rebuild your project.
 
@@ -24,7 +23,7 @@ You can generate a new tRPC API in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 

--- a/docs/src/content/docs/en/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/en/guides/ts-mcp-server.mdx
@@ -31,7 +31,7 @@ You can generate a TypeScript MCP server in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -7,7 +7,6 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
 [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) is a framework for defining cloud infrastructure in code and provisioning it through AWS CloudFormation.
 
@@ -23,7 +22,7 @@ You can generate a new infrastructure project in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/typescript-project.mdx
+++ b/docs/src/content/docs/en/guides/typescript-project.mdx
@@ -7,7 +7,6 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
 The TypeScript project generator can be used to create a modern [TypeScript](https://www.typescriptlang.org/) library or application configured with best practices such as [ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html), [Vitest](https://vitest.dev/) for running tests and [ESLint](https://eslint.org/) for static analysis.
 
@@ -21,7 +20,7 @@ You can generate a new TypeScript project in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/es/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/es/guides/api-connection/react-fastapi.mdx
@@ -11,16 +11,15 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-El generador `api-connection` proporciona una forma rápida de integrar tu aplicación React con tu backend FastAPI. Configura toda la configuración necesaria para conectarse a tus backends FastAPI de manera tipada, incluyendo generación de clientes y hooks de [TanStack Query](https://tanstack.com/query/v5), soporte para autenticación AWS IAM y manejo adecuado de errores.
+El generador `api-connection` proporciona una forma rápida de integrar tu sitio React con tu backend FastAPI. Configura toda la infraestructura necesaria para conectar con tus backends FastAPI de manera type-safe, incluyendo generación de clientes y hooks de [TanStack Query](https://tanstack.com/query/v5), soporte para autenticación AWS IAM y manejo adecuado de errores.
 
 ## Requisitos previos
 
 Antes de usar este generador, asegúrate que tu aplicación React tenga:
 
 1. Un archivo `main.tsx` que renderice tu aplicación
-2. Un backend FastAPI funcional (generado usando el generador FastAPI)
+2. Un backend FastAPI funcional (generado usando el generador de FastAPI)
 
 <details>
 <summary>Ejemplo de estructura requerida para `main.tsx`</summary>
@@ -50,7 +49,7 @@ root.render(
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## Salida del generador
 
@@ -59,7 +58,7 @@ El generador modificará los siguientes archivos en tu proyecto FastAPI:
 <FileTree>
 
 - scripts
-  - generate_open_api.py Añade un script que genera la especificación OpenAPI para tu API
+  - generate_open_api.py Agrega un script que genera la especificación OpenAPI para tu API
 - project.json Se añade un nuevo target al build que invoca el script de generación
 
 </FileTree>
@@ -76,16 +75,16 @@ El generador modificará los siguientes archivos en tu aplicación React:
     - use\<ApiName>.tsx Añade un hook para llamar a tu API con estado gestionado por TanStack Query
     - use\<ApiName>Client.tsx Añade un hook para instanciar el cliente vanilla que puede llamar a tu API
     - useSigV4.tsx Añade un hook para firmar peticiones HTTP con SigV4 (si seleccionaste autenticación IAM)
-- project.json Se añade un nuevo target al build que genera el cliente tipado
-- .gitignore Los archivos generados del cliente se ignoran por defecto
+- project.json Se añade un nuevo target al build que genera el cliente type-safe
+- .gitignore Los archivos del cliente generado se ignoran por defecto
 
 </FileTree>
 
-El generador también añadirá Runtime Config a la infraestructura de tu sitio web si no existe, asegurando que la URL de la API para FastAPI esté disponible en el sitio y configurada automáticamente por el hook `use<ApiName>.tsx`.
+El generador también añadirá Runtime Config a la infraestructura de tu sitio web si no existe, asegurando que la URL de la API para FastAPI esté disponible y sea configurada automáticamente por el hook `use<ApiName>.tsx`.
 
 ### Generación de código
 
-Durante el build, se genera un cliente tipado a partir de la especificación OpenAPI de tu FastAPI. Esto añadirá tres nuevos archivos a tu aplicación React:
+Durante el build, se genera un cliente type-safe a partir de la especificación OpenAPI de tu FastAPI. Esto añadirá tres nuevos archivos a tu aplicación React:
 
 <FileTree>
 
@@ -93,27 +92,27 @@ Durante el build, se genera un cliente tipado a partir de la especificación Ope
   - generated
     - \<ApiName>
       - types.gen.ts Tipos generados de los modelos pydantic definidos en tu FastAPI
-      - client.gen.ts Cliente tipado para llamar a tu API
+      - client.gen.ts Cliente type-safe para llamar a tu API
       - options-proxy.gen.ts Provee métodos para crear opciones de hooks TanStack Query que interactúan con tu API
 
 </FileTree>
 
 :::tip
-Por defecto, el cliente generado se ignora en control de versiones. Si prefieres incluirlo, puedes eliminar la entrada del archivo `.gitignore` de tu aplicación React, pero ten en cuenta que cualquier cambio manual en los archivos `.gen.ts` se sobrescribirá al construir el proyecto.
+Por defecto, el cliente generado se ignora del control de versiones. Si prefieres incluirlo, puedes eliminar la entrada del archivo `.gitignore` de tu aplicación React, pero ten en cuenta que cualquier cambio manual en los archivos `.gen.ts` será sobrescrito al construir el proyecto.
 :::
 
 ## Usando el código generado
 
-El cliente tipado generado puede usarse para llamar a tu FastAPI desde la aplicación React. Se recomienda usar los hooks de TanStack Query, pero también puedes usar el cliente vanilla si prefieres.
+El cliente type-safe generado puede usarse para llamar a tu FastAPI desde la aplicación React. Se recomienda usar los hooks de TanStack Query, pero también puedes usar el cliente vanilla si lo prefieres.
 
 :::note
-Cada vez que modifiques tu FastAPI, debes reconstruir tu proyecto para que los cambios se reflejen en el cliente generado. Por ejemplo:
+Cuando hagas cambios en tu FastAPI, necesitas reconstruir tu proyecto para que se reflejen en el cliente generado. Por ejemplo:
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
 :::tip
-Si estás trabajando simultáneamente en tu aplicación React y FastAPI, puedes usar [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar el cliente cada vez que hagas cambios en la API:
+Si estás trabajando simultáneamente en tu aplicación React y FastAPI, puedes usar [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar el cliente automáticamente:
 
 <NxCommands
   commands={[
@@ -123,13 +122,13 @@ Si estás trabajando simultáneamente en tu aplicación React y FastAPI, puedes 
 />
 :::
 
-### Usando el hook de la API
+### Usando el hook de API
 
 El generador provee un hook `use<ApiName>` que puedes usar para llamar a tu API con TanStack Query.
 
 ### Consultas
 
-Puedes usar el método `queryOptions` para obtener las opciones requeridas para llamar a la API usando el hook `useQuery` de TanStack Query:
+Puedes usar el método `queryOptions` para obtener las opciones requeridas para llamar a tu API usando el hook `useQuery` de TanStack Query:
 
 ```tsx {7}
 import { useQuery } from '@tanstack/react-query';
@@ -147,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="Usar el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
+<Drawer title="Usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -190,7 +189,7 @@ import { useMyApi } from './hooks/useMyApi';
 
 function CreateItemForm() {
   const api = useMyApi();
-  // Crear una mutación usando las opciones generadas
+  // Crea una mutación usando las opciones generadas
   const createItem = useMutation(api.createItem.mutationOptions());
 
   const handleSubmit = (e) => {
@@ -337,7 +336,7 @@ function ItemList() {
 
   return (
     <div>
-      {/* Aplanar el array de páginas para renderizar todos los ítems */}
+      {/* Aplana el array de páginas para renderizar todos los ítems */}
       <ul>
         {items.data.pages.flatMap(page =>
           page.items.map(item => (
@@ -364,7 +363,7 @@ function ItemList() {
 Los hooks generados manejan automáticamente la paginación basada en cursor si tu API lo soporta. El valor `nextCursor` se extrae de la respuesta y se usa para obtener la próxima página.
 
 :::tip
-Si tienes una API paginada cuyo parámetro de paginación tiene un nombre distinto a `cursor`, puedes [personalizarlo usando la extensión OpenAPI `x-cursor`](#custom-pagination-cursor).
+Si tienes una API paginada cuyo parámetro de paginación tiene un nombre diferente a `cursor`, puedes [personalizarlo usando la extensión OpenAPI `x-cursor`](#custom-pagination-cursor).
 :::
 
 <Drawer title="Paginación usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
@@ -452,7 +451,7 @@ function ItemList() {
 
 ### Manejo de errores
 
-La integración incluye manejo de errores incorporado con respuestas de error tipadas. Se genera un tipo `<operation-name>Error` que encapsula las posibles respuestas de error definidas en la especificación OpenAPI. Cada error tiene una propiedad `status` y `error`, y al verificar el valor de `status` puedes determinar el tipo específico de error.
+La integración incluye manejo de errores con respuestas tipadas. Se genera un tipo `<operation-name>Error` que encapsula las posibles respuestas de error definidas en la especificación OpenAPI. Cada error tiene una propiedad `status` y `error`, y al verificar el valor de `status` puedes restringir a un tipo específico de error.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -561,9 +560,9 @@ function MyComponent() {
 ```
 </Drawer>
 
-### Consumir un stream
+### Consumiendo un stream
 
-Si has <Link path="guides/fastapi#streaming">configurado tu FastAPI para transmitir respuestas</Link>, tu hook `useQuery` se actualizará automáticamente con nuevos datos a medida que lleguen fragmentos del stream.
+Si has <Link path="guides/fastapi#streaming">configurado tu FastAPI para streamear respuestas</Link>, tu hook `useQuery` se actualizará automáticamente a medida que lleguen nuevos fragmentos del stream.
 
 Por ejemplo:
 
@@ -587,7 +586,7 @@ function MyStreamingComponent() {
 Puedes usar las propiedades `isLoading` y `fetchStatus` para determinar el estado actual del stream si es necesario. Un stream sigue este ciclo de vida:
 
 <Steps>
-  1. Se envía la petición HTTP para iniciar el stream
+  1. Se envía la petición HTTP para iniciar el streaming
 
       - `isLoading` es `true`
       - `fetchStatus` es `'fetching'`
@@ -595,26 +594,26 @@ Puedes usar las propiedades `isLoading` y `fetchStatus` para determinar el estad
 
   2. Se recibe el primer fragmento del stream
 
-      - `isLoading` pasa a `false`
-      - `fetchStatus` sigue siendo `'fetching'`
+      - `isLoading` cambia a `false`
+      - `fetchStatus` permanece `'fetching'`
       - `data` se convierte en un array con el primer fragmento
 
-  3. Se reciben fragmentos subsiguientes
+  3. Se reciben fragmentos posteriores
 
-      - `isLoading` sigue siendo `false`
-      - `fetchStatus` sigue siendo `'fetching'`
-      - `data` se actualiza con cada nuevo fragmento recibido
+      - `isLoading` permanece `false`
+      - `fetchStatus` permanece `'fetching'`
+      - `data` se actualiza con cada nuevo fragmento
 
   4. El stream finaliza
 
-      - `isLoading` sigue siendo `false`
-      - `fetchStatus` pasa a `'idle'`
+      - `isLoading` permanece `false`
+      - `fetchStatus` cambia a `'idle'`
       - `data` es un array con todos los fragmentos recibidos
 </Steps>
 
 <Drawer title="Streaming usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 
-Si has <Link path="guides/fastapi#streaming">configurado tu FastAPI para transmitir respuestas</Link>, el cliente generado incluirá métodos tipados para iterar asincrónicamente sobre los fragmentos del stream usando sintaxis `for await`.
+Si has <Link path="guides/fastapi#streaming">configurado tu FastAPI para streamear respuestas</Link>, el cliente generado incluirá métodos type-safe para iterar asincrónicamente sobre los fragmentos usando sintaxis `for await`.
 
 Por ejemplo:
 
@@ -647,7 +646,7 @@ function MyStreamingComponent() {
 </Drawer>
 
 :::note
-Si tienes una API de streaming que acepta un parámetro `cursor`, cuando uses el hook `useInfiniteQuery`, cada página esperará a que el stream finalice antes de considerarse cargada.
+Si tienes una API de streaming que acepta un parámetro `cursor`, cuando uses el hook `useInfiniteQuery`, cada página esperará a que el stream finalice antes de cargarse.
 :::
 
 ## Personalizando el código generado
@@ -717,7 +716,7 @@ def list_items(page_token: str = None, limit: int = 10):
     }
 ```
 
-Si no quieres generar `infiniteQueryOptions` para una operación, puedes establecer `x-cursor` en `False`:
+Si no quieres generar `infiniteQueryOptions` para una operación, puedes establecer `x-cursor` como `False`:
 
 ```python
 @app.get(
@@ -737,9 +736,9 @@ def list_items(page: int = 1, limit: int = 10):
     }
 ```
 
-### Agrupación de operaciones
+### Agrupando operaciones
 
-Los hooks y métodos del cliente generados se organizan automáticamente según los tags OpenAPI en tus endpoints FastAPI. Esto ayuda a mantener organizadas las llamadas API y facilita encontrar operaciones relacionadas.
+Los hooks y métodos del cliente generado se organizan automáticamente según los tags OpenAPI en tus endpoints FastAPI. Esto ayuda a mantener organizadas las llamadas API y facilita encontrar operaciones relacionadas.
 
 Por ejemplo:
 
@@ -768,7 +767,7 @@ def list():
     # ...
 ```
 
-Los hooks generados se agruparán según estos tags:
+Los hooks generados se agruparán por estos tags:
 
 ```tsx
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -777,11 +776,11 @@ import { useMyApi } from './hooks/useMyApi';
 function ItemsAndUsers() {
   const api = useMyApi();
 
-  // Las operaciones de Items se agrupan bajo api.items
+  // Las operaciones de items se agrupan bajo api.items
   const items = useQuery(api.items.list.queryOptions());
   const createItem = useMutation(api.items.create.mutationOptions());
 
-  // Las operaciones de Users se agrupan bajo api.users
+  // Las operaciones de users se agrupan bajo api.users
   const users = useQuery(api.users.list.queryOptions());
 
   // Ejemplo de uso
@@ -812,7 +811,7 @@ function ItemsAndUsers() {
 
 Esta agrupación facilita organizar tus llamadas API y provee mejor autocompletado en tu IDE.
 
-<Drawer title="Operaciones agrupadas usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
+<Drawer title="Operaciones agrupadas usando el cliente directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -829,11 +828,11 @@ function ItemsAndUsers() {
       try {
         setIsLoading(true);
 
-        // Operaciones de Items agrupadas bajo api.items
+        // Operaciones de items agrupadas bajo api.items
         const itemsData = await api.items.list();
         setItems(itemsData);
 
-        // Operaciones de Users agrupadas bajo api.users
+        // Operaciones de users agrupadas bajo api.users
         const usersData = await api.users.list();
         setUsers(usersData);
       } catch (error) {
@@ -883,14 +882,14 @@ function ItemsAndUsers() {
 </Drawer>
 
 :::tip
-También puedes dividir tu API usando múltiples `routers`. Consulta la [Documentación de FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/) para más detalles.
+También puedes dividir tu API usando múltiples `routers`. Consulta la [documentación de FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/) para más detalles.
 :::
 
 ### Errores
 
-Puedes personalizar las respuestas de error en tu FastAPI definiendo clases de excepción personalizadas, manejadores de excepción y especificando modelos de respuesta para diferentes códigos de estado. El cliente generado manejará automáticamente estos tipos de error personalizados.
+Puedes personalizar las respuestas de error en tu FastAPI definiendo clases de excepción personalizadas, manejadores de excepciones y especificando modelos de respuesta para diferentes códigos de estado. El cliente generado manejará automáticamente estos tipos de error personalizados.
 
-#### Definir modelos de error personalizados
+#### Definiendo modelos de error personalizados
 
 Primero, define tus modelos de error usando Pydantic:
 
@@ -905,7 +904,7 @@ class ValidationError(BaseModel):
     field_errors: list[str]
 ```
 
-#### Crear excepciones personalizadas
+#### Creando excepciones personalizadas
 
 Luego crea clases de excepción para diferentes escenarios:
 
@@ -919,9 +918,9 @@ class ValidationException(Exception):
         self.details = details
 ```
 
-#### Añadir manejadores de excepción
+#### Añadiendo manejadores de excepciones
 
-Registra manejadores de excepción para convertir tus excepciones en respuestas HTTP:
+Registra manejadores de excepciones para convertir tus excepciones en respuestas HTTP:
 
 ```python title="main.py"
 from fastapi import Request
@@ -946,7 +945,7 @@ async def validation_error_handler(request: Request, exc: ValidationException):
 `JSONResponse` acepta un diccionario, así que usamos el método `model_dump` de nuestro modelo Pydantic.
 :::
 
-#### Especificar modelos de respuesta
+#### Especificando modelos de respuesta
 
 Finalmente, especifica los modelos de respuesta para diferentes códigos de estado en tus endpoints:
 
@@ -982,9 +981,9 @@ def create_item(item: Item) -> Item:
     return save_item(item)
 ```
 
-#### Usar tipos de error personalizados en React
+#### Usando tipos de error personalizados en React
 
-El cliente generado manejará automáticamente estos tipos de error personalizados, permitiéndote tipar y manejar diferentes respuestas de error:
+El cliente generado manejará automáticamente estos tipos de error, permitiéndote verificar tipos y manejar diferentes respuestas de error:
 
 ```tsx
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -996,7 +995,7 @@ function ItemComponent() {
   const getItem = useQuery({
     ...api.getItem.queryOptions({ itemId: '123' }),
     onError: (error) => {
-      // El error está tipado según las respuestas en tu FastAPI
+      // Error está tipado según las respuestas en tu FastAPI
       switch (error.status) {
         case 404:
           // error.error es un string como se especificó en las respuestas
@@ -1045,7 +1044,7 @@ function ItemComponent() {
 }
 ```
 
-<Drawer title="Manejar errores personalizados con el cliente directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
+<Drawer title="Manejo de errores personalizados con el cliente directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
 ```tsx
 import { useState, useEffect } from 'react';
 
@@ -1063,7 +1062,7 @@ function ItemComponent() {
         const data = await api.getItem({ itemId: '123' });
         setItem(data);
       } catch (e) {
-        // El error está tipado según las respuestas en tu FastAPI
+        // Error está tipado según las respuestas en tu FastAPI
         const err = e as GetItemError;
         setError(err);
 
@@ -1129,7 +1128,7 @@ function ItemComponent() {
 </Drawer>
 
 :::tip
-Al definir respuestas de error en FastAPI, siempre usa el parámetro `responses` para especificar el modelo de cada código de estado. Esto asegura que el cliente generado tendrá información de tipos adecuada para el manejo de errores.
+Al definir respuestas de error en FastAPI, siempre usa el parámetro `responses` para especificar el modelo de cada código de estado. Esto asegura que el cliente generado tenga información de tipos adecuada para el manejo de errores.
 :::
 
 ## Mejores prácticas
@@ -1165,7 +1164,7 @@ function ItemList() {
           />
         );
       default:
-        return <ErrorMessage message="Error desconocido" />;
+        return <ErrorMessage message="Ocurrió un error desconocido" />;
     }
   }
 
@@ -1179,7 +1178,7 @@ function ItemList() {
 }
 ```
 
-<Drawer title="Manejar estados de carga usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
+<Drawer title="Manejar estados de carga usando el cliente directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
@@ -1221,7 +1220,7 @@ function ItemList() {
           />
         );
       default:
-        return <ErrorMessage message="Error desconocido" />;
+        return <ErrorMessage message="Ocurrió un error desconocido" />;
     }
   }
 
@@ -1257,7 +1256,7 @@ function ItemList() {
       // Cancelar cualquier recarga pendiente
       await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
 
-      // Tomar instantánea del valor previo
+      // Tomar snapshot del valor anterior
       const previousItems = queryClient.getQueryData(api.listItems.queryKey());
 
       // Actualizar optimistamente al nuevo valor
@@ -1266,13 +1265,13 @@ function ItemList() {
         (old) => old.filter((item) => item.id !== itemId)
       );
 
-      // Retornar un objeto de contexto con la instantánea
+      // Retornar un objeto de contexto con el snapshot
       return { previousItems };
     },
     onError: (err, itemId, context) => {
       // Si la mutación falla, usa el contexto para revertir
       queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-      console.error('Error eliminando ítem:', err);
+      console.error('Error al eliminar ítem:', err);
     },
     onSettled: () => {
       // Siempre recargar después de error o éxito para sincronizar datos
@@ -1285,7 +1284,7 @@ function ItemList() {
   }
 
   if (itemsQuery.isError) {
-    return <ErrorMessage message="Error cargando ítems" />;
+    return <ErrorMessage message="Error al cargar ítems" />;
   }
 
   return (
@@ -1306,23 +1305,23 @@ function ItemList() {
 }
 ```
 
-<Drawer title="Actualizaciones optimistas usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
+<Drawer title="Actualizaciones optimistas usando el cliente directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
   const [items, setItems] = useState([]);
 
   const handleDelete = async (itemId) => {
-    // Eliminar optimistamente el ítem
+    // Eliminación optimista
     const previousItems = items;
     setItems(items.filter((item) => item.id !== itemId));
 
     try {
       await api.deleteItem(itemId);
     } catch (error) {
-      // Restaurar ítems previos en caso de error
+      // Restaurar ítems anteriores en caso de error
       setItems(previousItems);
-      console.error('Error eliminando ítem:', error);
+      console.error('Error al eliminar ítem:', error);
     }
   };
 
@@ -1350,10 +1349,10 @@ import { useMutation } from '@tanstack/react-query';
 function ItemForm() {
   const api = useMyApi();
 
-  // Mutación tipada para crear ítems
+  // Mutación type-safe para crear ítems
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
-    // ✅ Error de tipo si el callback onSuccess no maneja el tipo de respuesta correcto
+    // ✅ Error de tipo si onSuccess no maneja el tipo de respuesta correcto
     onSuccess: (data) => {
       // data está completamente tipado según el schema de respuesta de tu API
       console.log(`Ítem creado con ID: ${data.id}`);
@@ -1361,7 +1360,7 @@ function ItemForm() {
   });
 
   const handleSubmit = (data: CreateItemInput) => {
-    // ✅ Error de tipo si la entrada no coincide con el schema
+    // ✅ Error de tipo si el input no coincide con el schema
     createItem.mutate(data);
   };
 
@@ -1403,7 +1402,7 @@ function ItemForm() {
 }
 ```
 
-<Drawer title="Seguridad de tipos usando el cliente de API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente directamente.">
+<Drawer title="Seguridad de tipos usando el cliente directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx
 function ItemForm() {
   const api = useMyApiClient();
@@ -1411,7 +1410,7 @@ function ItemForm() {
 
   const handleSubmit = async (data: CreateItemInput) => {
     try {
-      // ✅ Error de tipo si la entrada no coincide con el schema
+      // ✅ Error de tipo si el input no coincide con el schema
       await api.createItem(data);
     } catch (e) {
       // ✅ El tipo de error incluye todas las posibles respuestas de error

--- a/docs/src/content/docs/es/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/es/guides/api-connection/react-trpc.mdx
@@ -9,20 +9,19 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-El Plugin AWS para Nx proporciona un generador para integrar rápidamente tu <Link path="guides/trpc">API tRPC</Link> con un sitio web React. Configura toda la infraestructura necesaria para conectar con tus backends tRPC, incluyendo soporte para autenticación IAM de AWS y manejo adecuado de errores. La integración ofrece seguridad de tipos completa de extremo a extremo entre tu frontend y backend(s) tRPC.
+El plugin de AWS para Nx proporciona un generador para integrar rápidamente tu <Link path="guides/trpc">API tRPC</Link> con un sitio web en React. Configura toda la infraestructura necesaria para conectar con tus backends tRPC, incluyendo soporte para autenticación IAM de AWS y manejo adecuado de errores. La integración provee seguridad de tipos de extremo a extremo entre tu frontend y los backends tRPC.
 
 ## Requisitos previos
 
-Antes de usar este generador, asegúrate que tu aplicación React tiene:
+Antes de usar este generador, asegúrate que tu aplicación React tenga:
 
-1. Un archivo `main.tsx` que renderiza tu aplicación
+1. Un archivo `main.tsx` que renderice tu aplicación
 2. Un elemento JSX `<App/>` donde se inyectará automáticamente el proveedor tRPC
-3. Un backend tRPC funcional (generado usando el generador de backend tRPC)
+3. Un backend tRPC funcional (generado usando el generador de backends tRPC)
 
 <details>
-<summary>Ejemplo de estructura requerida para `main.tsx`</summary>
+<summary>Ejemplo de estructura requerida en `main.tsx`</summary>
 
 ```tsx
 import { StrictMode } from 'react';
@@ -49,9 +48,9 @@ root.render(
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
-## Salida del generador
+## Resultado del generador
 
 El generador crea la siguiente estructura en tu aplicación React:
 
@@ -61,12 +60,12 @@ El generador crea la siguiente estructura en tu aplicación React:
   - components
     - TrpcClients
       - index.tsx
-      - TrpcProvider.tsx Proveedor reutilizable para múltiples APIs tRPC
-      - TrpcApis.tsx Objeto con todas tus conexiones API tRPC
+      - TrpcProvider.tsx Proveedor que se reutiliza para múltiples APIs tRPC
+      - TrpcApis.tsx Objeto que contiene todas tus conexiones a APIs tRPC
       - TrpcClientProviders.tsx Configura los clientes tRPC y su vinculación con los esquemas del backend
     - QueryClientProvider.tsx Proveedor del cliente TanStack React Query
   - hooks
-    - useSigV4.tsx Hook para firmar solicitudes HTTP con SigV4 (solo IAM)
+    - useSigV4.tsx Hook para firmar peticiones HTTP con SigV4 (solo IAM)
     - use\<ApiName>.tsx Hook para la API backend específica. ApiName corresponderá al nombre de la API
 
 </FileTree>
@@ -80,9 +79,9 @@ Adicionalmente, instala las dependencias requeridas:
 
 ## Usando el código generado
 
-### Usando el Hook tRPC
+### Usando el hook tRPC
 
-El generador proporciona un hook `use<ApiName>` que te da acceso al cliente tRPC con seguridad de tipos:
+El generador provee un hook `use<ApiName>` que te da acceso al cliente tRPC con seguridad de tipos:
 
 ```tsx {5,8,11}
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -148,7 +147,7 @@ function MyComponent() {
 
 ## Mejores prácticas
 
-### Manejo de estados de carga
+### Manejar estados de carga
 
 Siempre maneja los estados de carga y error para una mejor experiencia de usuario:
 
@@ -178,7 +177,7 @@ function UserList() {
 
 ### Actualizaciones optimistas
 
-Usa actualizaciones optimistas para mejorar la experiencia de usuario:
+Usa actualizaciones optimistas para una mejor experiencia de usuario:
 
 ```tsx {15-17,20-22,28-31}
 import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
@@ -191,7 +190,7 @@ function UserList() {
   const deleteMutation = useMutation(
     trpc.users.delete.mutationOptions({
       onMutate: async (userId) => {
-        // Cancelar solicitudes pendientes
+        // Cancelar fetches pendientes
         await queryClient.cancelQueries(trpc.users.list.queryFilter());
 
         // Obtener snapshot de datos actuales
@@ -207,7 +206,7 @@ function UserList() {
         return { previousUsers };
       },
       onError: (err, userId, context) => {
-        // Restaurar datos anteriores en caso de error
+        // Restaurar datos anteriores en error
         queryClient.setQueryData(
           trpc.users.list.queryKey(),
           context?.previousUsers,
@@ -229,9 +228,9 @@ function UserList() {
 }
 ```
 
-### Precarga de datos
+### Pre-carga de datos
 
-Precarga datos para mejor rendimiento:
+Pre-carga datos para mejor rendimiento:
 
 ```tsx {8}
 function UserList() {
@@ -239,7 +238,7 @@ function UserList() {
   const users = useQuery(trpc.users.list.queryOptions());
   const queryClient = useQueryClient();
 
-  // Precargar detalles de usuario al pasar el mouse
+  // Pre-cargar detalles de usuario al hacer hover
   const prefetchUser = async (userId: string) => {
     await queryClient.prefetchQuery(trpc.users.getById.queryOptions(userId));
   };
@@ -290,11 +289,11 @@ function UserList() {
 }
 ```
 
-Es importante notar que las consultas infinitas solo pueden usarse para procedimientos que tengan una propiedad de entrada llamada `cursor`.
+Es importante notar que las consultas infinitas solo pueden usarse para procedimientos con una propiedad de entrada llamada `cursor`.
 
 ## Seguridad de tipos
 
-La integración provee seguridad de tipos completa de extremo a extremo. Tu IDE ofrecerá autocompletado y verificación de tipos para todas las llamadas API:
+La integración provee seguridad de tipos completa de extremo a extremo. Tu IDE proveerá autocompletado y validación de tipos para todas las llamadas API:
 
 ```tsx
 function UserForm() {
@@ -312,7 +311,7 @@ function UserForm() {
 }
 ```
 
-Los tipos se infieren automáticamente de las definiciones del router y esquema de tu backend, asegurando que cualquier cambio en tu API se refleje inmediatamente en tu código frontend sin necesidad de compilar.
+Los tipos se infieren automáticamente desde el router y definiciones de esquema de tu backend, asegurando que cualquier cambio en tu API se refleje inmediatamente en tu código frontend sin necesidad de compilar.
 
 ## Más información
 

--- a/docs/src/content/docs/es/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/cloudscape-website-auth.mdx
@@ -10,27 +10,26 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
-El generador de Autenticación para CloudScape Website agrega autenticación a tu sitio web CloudScape utilizando [Amazon Cognito](https://aws.amazon.com/cognito/).
+El generador de Autenticación para Sitio Web CloudScape agrega autenticación a tu sitio web de CloudScape usando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
-Este generador configura la infraestructura CDK para crear un User Pool de Cognito y un Identity Pool asociado, así como una interfaz de usuario alojada para manejar flujos de inicio de sesión, y su integración con tu sitio web CloudScape.
+Este generador configura la infraestructura de CDK para crear un User Pool de Cognito y un Identity Pool asociado, así como una interfaz hospedada para manejar flujos de inicio de sesión y su integración con tu sitio web de CloudScape.
 
 ## Uso
 
-### Agregar autenticación a tu sitio web CloudScape
+### Agregar autenticación a tu sitio web de CloudScape
 
-Puedes agregar autenticación a tu sitio web CloudScape de dos formas:
+Puedes agregar autenticación a tu sitio web de CloudScape de dos maneras:
 
 <RunGenerator generator="ts#cloudscape-website#auth" />
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
 ## Salida del generador
 
-Encontrarás los siguientes cambios en tu aplicación React:
+Encontrarás los siguientes cambios en tu sitio web de React:
 
 <FileTree>
   - src
@@ -50,7 +49,7 @@ También se generará el siguiente código de infraestructura en `packages/commo
 
 ## Uso de infraestructura
 
-Debes agregar el construct `UserIdentity` a tu stack, declarándolo _antes_ del construct del sitio web:
+Debes agregar el constructo `UserIdentity` a tu stack, declarándolo _antes_ del constructo del sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
 import { Stack } from 'aws-cdk-lib';
@@ -68,11 +67,11 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-El construct `UserIdentity` agrega automáticamente la <Link path="guides/cloudscape-website#runtime-configuration">Configuración de Runtime</Link> necesaria para que tu sitio web pueda acceder al User Pool de Cognito correcto.
+El constructo `UserIdentity` agrega automáticamente la <Link path="guides/cloudscape-website#runtime-configuration">Configuración en tiempo de ejecución</Link> necesaria para que tu sitio web pueda apuntar al User Pool de Cognito correcto.
 
 ### Otorgar acceso a usuarios autenticados
 
-Para permitir que usuarios autenticados realicen acciones específicas, como otorgar permisos para invocar una API, puedes agregar políticas IAM al rol autenticado del identity pool:
+Para permitir que usuarios autenticados realicen ciertas acciones, como otorgar permisos para invocar una API, puedes agregar declaraciones de políticas de IAM al rol autenticado del identity pool:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/es/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/es/guides/cloudscape-website.mdx
@@ -10,27 +10,26 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
-Este generador crea un nuevo sitio web en [React](https://react.dev/) configurado con [CloudScape](http://cloudscape.design/), junto con la infraestructura de AWS CDK para desplegar tu sitio web en la nube como un sitio estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
+Este generador crea un nuevo sitio web en [React](https://react.dev/) con [CloudScape](http://cloudscape.design/) configurado, junto con la infraestructura de AWS CDK para desplegar tu sitio web en la nube como un sitio estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
 
-La aplicación generada utiliza [Vite](https://vite.dev/) como herramienta de construcción y empaquetado. Emplea [TanStack Router](https://tanstack.com/router/v1) para el enrutamiento tipado.
+La aplicación generada utiliza [Vite](https://vite.dev/) como herramienta de construcción y bundler. Emplea [TanStack Router](https://tanstack.com/router/v1) para el enrutamiento con verificación de tipos.
 
-:::note
+:::nota
 Aunque este generador te configura con CloudScape, en última instancia es un generador de proyectos React, y puedes modificar tu código para migrar a un sistema de diseño o biblioteca de componentes alternativo si lo deseas.
 :::
 
 ## Uso
 
-### Generar un sitio web con CloudScape
+### Generar un sitio web de CloudScape
 
-Puedes generar un nuevo sitio web con CloudScape de dos formas:
+Puedes generar un nuevo sitio web de CloudScape de dos formas:
 
 <RunGenerator generator="ts#cloudscape-website" />
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
 ## Salida del generador
 
@@ -38,22 +37,22 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
 <FileTree>
   - index.html Punto de entrada HTML
-  - public Recursos estáticos
+  - public Assets estáticos
   - src
     - main.tsx Punto de entrada de la aplicación con configuración React
     - config.ts Configuración de la aplicación (ej. logo)
     - components
-      - AppLayout Componentes para el diseño general de CloudScape y barra de navegación
+      - AppLayout Componentes para el layout general de CloudScape y barra de navegación
     - hooks
       - useAppLayout.tsx Hook para ajustar el AppLayout desde componentes anidados
     - routes
       - welcome
-        - index.tsx Ruta (o página) de ejemplo para @tanstack/react-router
+        - index.tsx Ruta de ejemplo (o página) para @tanstack/react-router
     - styles.css Estilos globales
   - vite.config.ts Configuración de Vite y Vitest
-  - tsconfig.json Configuración base de TypeScript para código y pruebas
+  - tsconfig.json Configuración base de TypeScript para código fuente y tests
   - tsconfig.app.json Configuración TypeScript para código fuente
-  - tsconfig.spec.json Configuración TypeScript para pruebas
+  - tsconfig.spec.json Configuración TypeScript para tests
 </FileTree>
 
 El generador también creará código de infraestructura CDK para desplegar tu sitio web en el directorio `packages/common/constructs`:
@@ -62,25 +61,25 @@ El generador también creará código de infraestructura CDK para desplegar tu s
   - src
     - app
       - static-websites
-        - \<name>.ts Infraestructura específica para tu sitio web
+        - \<name>.ts Infraestructura específica de tu sitio web
     - core
       - static-website.ts Construct genérico StaticWebsite
 </FileTree>
 
-## Implementando tu sitio web con CloudScape
+## Implementando tu sitio web de CloudScape
 
-La [documentación de React](https://react.dev/learn) es un buen punto de partida para aprender los fundamentos de desarrollo con React. Puedes consultar la [documentación de CloudScape](https://cloudscape.design/components/) para detalles sobre los componentes disponibles y su uso.
+La [documentación de React](https://react.dev/learn) es un buen punto de partida para aprender los fundamentos de desarrollo con React. Puedes consultar la [documentación de CloudScape](https://cloudscape.design/components/) para detalles sobre los componentes disponibles y cómo usarlos.
 
 ### Rutas
 
 #### Crear una ruta/página
 
-Tu sitio web CloudScape incluye [TanStack Router](https://tanstack.com/router/v1) configurado. Esto facilita la adición de nuevas rutas:
+Tu sitio web de CloudScape incluye [TanStack Router](https://tanstack.com/router/v1) configurado. Esto facilita añadir nuevas rutas:
 
 <Steps>
-  1. [Ejecutar el servidor de desarrollo local](#local-development-server)
-  2. Crear un nuevo archivo `<nombre-pagina>.tsx` en `src/routes`, donde la posición en el árbol de archivos representa la ruta
-  3. Notarás que se generan automáticamente un `Route` y `RouteComponent`. ¡Puedes empezar a construir tu página aquí!
+  1. [Ejecutar el servidor de desarrollo local](#servidor-de-desarrollo-local)
+  2. Crear un nuevo archivo `<nombre-pagina>.tsx` en `src/routes`, donde su posición en el árbol de archivos representa la ruta
+  3. Observa que se generan automáticamente un `Route` y `RouteComponent`. ¡Puedes empezar a construir tu página aquí!
 </Steps>
 
 #### Navegar entre páginas
@@ -112,13 +111,13 @@ Para más detalles, consulta la [documentación de TanStack Router](https://tans
 
 ## Configuración en tiempo de ejecución
 
-La configuración de tu infraestructura AWS CDK se proporciona a tu sitio web mediante Runtime Configuration. Esto permite que tu sitio web acceda a detalles como URLs de API que no se conocen hasta que la aplicación está desplegada.
+La configuración de tu infraestructura AWS CDK se proporciona a tu sitio web mediante Configuración en Tiempo de Ejecución. Esto permite que tu sitio web acceda a detalles como URLs de API que no se conocen hasta que la aplicación es desplegada.
 
 ### Infraestructura
 
 El construct CDK `RuntimeConfig` puede usarse para añadir y recuperar configuración en tu infraestructura CDK. Los constructs CDK generados por `@aws/nx-plugin` (como <Link path="guides/trpc">APIs tRPC</Link> y <Link path="guides/fastapi">FastAPIs</Link>) añadirán automáticamente valores apropiados al `RuntimeConfig`.
 
-Tu construct de sitio web CDK desplegará la configuración de tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
+Tu construct CDK del sitio web desplegará la configuración de tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {9-10,12-13}
 import { Stack } from 'aws-cdk-lib';
@@ -138,8 +137,8 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::warning
-Debes asegurarte de declarar tu sitio web _después_ de cualquier construct que añada valores al `RuntimeConfig`, de lo contrario no estarán presentes en tu archivo `runtime-config.json`.
+:::advertencia
+Debes asegurarte de declarar tu sitio web _después_ de cualquier construct que añada valores al `RuntimeConfig`, de lo contrario faltarán en tu archivo `runtime-config.json`.
 :::
 
 ### Código del sitio web
@@ -159,19 +158,19 @@ const MyComponent = () => {
 
 ### Configuración local en tiempo de ejecución
 
-Al ejecutar el [servidor de desarrollo local](#local-development-server), necesitarás un archivo `runtime-config.json` en tu directorio `public` para que tu sitio local conozca las URLs del backend, configuración de identidad, etc.
+Al ejecutar el [servidor de desarrollo local](#servidor-de-desarrollo-local), necesitarás un archivo `runtime-config.json` en tu directorio `public` para que tu sitio web local conozca las URLs del backend, configuración de identidad, etc.
 
-Tu proyecto de sitio web está configurado con un target `load:runtime-config` que puedes usar para descargar el archivo `runtime-config.json` desde una aplicación desplegada:
+Tu proyecto de sitio web está configurado con un target `load:runtime-config` que puedes usar para descargar el archivo `runtime-config.json` de una aplicación desplegada:
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
-:::warning
-Si cambias el nombre de tu stack en el archivo `src/main.ts` de tu proyecto de infraestructura, deberás actualizar el target `load:runtime-config` en el archivo `project.json` de tu sitio web con el nombre del stack del cual cargar la configuración.
+:::advertencia
+Si cambias el nombre de tu stack en el `src/main.ts` de tu proyecto de infraestructura, deberás actualizar el target `load:runtime-config` en el archivo `project.json` de tu sitio web con el nombre del stack del cual cargar la configuración.
 :::
 
 ## Servidor de desarrollo local
 
-Antes de ejecutar el servidor de desarrollo local, asegúrate de haber desplegado tu infraestructura y haber [cargado la configuración local](#local-runtime-config).
+Antes de ejecutar tu servidor de desarrollo local, asegúrate de haber desplegado tu infraestructura y haber [cargado la configuración local de tiempo de ejecución](#configuración-local-en-tiempo-de-ejecución).
 
 Luego puedes ejecutar el target `serve`:
 
@@ -179,13 +178,13 @@ Luego puedes ejecutar el target `serve`:
 
 ## Construcción
 
-Puedes construir tu sitio web usando el target `build`. Esto utiliza Vite para crear un paquete de producción en el directorio raíz `dist/packages/<my-website>/bundle`, además de verificar tipos, compilar y analizar tu sitio web.
+Puedes construir tu sitio web usando el target `build`. Esto utiliza Vite para crear un bundle de producción en el directorio `dist/packages/<my-website>/bundle`, además de verificar tipos, compilar y hacer linting de tu sitio web.
 
 <NxCommands commands={['run <my-website>:build']} />
 
 ## Pruebas
 
-Probar tu sitio web es similar a escribir pruebas en un proyecto TypeScript estándar, por lo que te recomendamos consultar la <Link path="guides/typescript-project#testing">guía de proyectos TypeScript</Link> para más detalles.
+Probar tu sitio web es similar a escribir pruebas en un proyecto TypeScript estándar, por favor consulta la <Link path="guides/typescript-project#testing">guía de proyectos TypeScript</Link> para más detalles.
 
 Para pruebas específicas de React, React Testing Library ya está instalado y disponible para escribir tests. Para más detalles sobre su uso, consulta la [documentación de React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 

--- a/docs/src/content/docs/es/guides/fastapi.mdx
+++ b/docs/src/content/docs/es/guides/fastapi.mdx
@@ -11,23 +11,22 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
 [FastAPI](https://fastapi.tiangolo.com/) es un framework para construir APIs en Python.
 
-El generador de FastAPI crea una nueva API con configuración de infraestructura AWS CDK. El backend generado utiliza AWS Lambda para despliegue serverless, expuesto a través de un API Gateway de AWS. Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidad, incluyendo registro de logs, trazas con AWS X-Ray y métricas de CloudWatch.
+El generador de FastAPI crea una nueva aplicación FastAPI con configuración de infraestructura en AWS CDK. El backend generado utiliza AWS Lambda para implementación sin servidor, expuesto a través de un API Gateway de AWS. Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidad, incluyendo logging, trazado con AWS X-Ray y métricas de CloudWatch.
 
 ## Uso
 
 ### Generar una FastAPI
 
-Puedes generar una nueva FastAPI de dos formas:
+Puedes generar una nueva aplicación FastAPI de dos maneras:
 
 <RunGenerator generator="py#fast-api" />
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -37,7 +36,7 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
 <FileTree>
 
-- project.json Configuración del proyecto y objetivos de compilación
+- project.json Configuración del proyecto y objetivos de build
 - pyproject.toml Configuración del proyecto Python y dependencias
 - \<module_name>
   - \_\_init\_\_.py Inicialización del módulo
@@ -48,7 +47,7 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
 </FileTree>
 
-El generador también crea constructos CDK para desplegar tu API, ubicados en el directorio `packages/common/constructs`.
+El generador también crea constructos CDK para implementar tu API, ubicados en el directorio `packages/common/constructs`.
 
 ## Implementando tu FastAPI
 
@@ -80,9 +79,9 @@ El generador configura automáticamente:
 
 ### Observabilidad con AWS Lambda Powertools
 
-#### Registro de logs
+#### Logging
 
-El generador configura registro estructurado usando AWS Lambda Powertools. Accede al logger en tus handlers:
+Configura logging estructurado con AWS Lambda Powertools. Accede al logger en tus handlers:
 
 ```python
 from .init import app, logger
@@ -95,14 +94,14 @@ def read_item(item_id: int):
 
 El logger incluye automáticamente:
 
-- IDs de correlación para trazas
+- IDs de correlación para trazabilidad
 - Ruta y método de la solicitud
 - Información del contexto Lambda
 - Indicadores de cold start
 
-#### Trazas
+#### Trazado
 
-La traza con AWS X-Ray se configura automáticamente. Puedes añadir subsegmentos personalizados:
+El trazado con AWS X-Ray se configura automáticamente. Puedes añadir subsegmentos personalizados:
 
 ```python
 from .init import app, tracer
@@ -110,13 +109,15 @@ from .init import app, tracer
 @app.get("/items/{item_id}")
 @tracer.capture_method
 def read_item(item_id: int):
+    # Crea un nuevo subsegmento
     with tracer.provider.in_subsegment("fetch-item-details"):
+        # Tu lógica aquí
         return {"item_id": item_id}
 ```
 
 #### Métricas
 
-Se recopilan métricas de CloudWatch automáticamente. Añade métricas personalizadas:
+Se recopilan métricas en CloudWatch automáticamente. Añade métricas personalizadas:
 
 ```python
 from .init import app, metrics
@@ -137,7 +138,7 @@ Métricas por defecto incluyen:
 
 ### Manejo de errores
 
-El generador incluye manejo robusto de errores:
+El generador incluye manejo de errores completo:
 
 ```python
 from fastapi import HTTPException
@@ -149,15 +150,15 @@ def read_item(item_id: int):
     return {"item_id": item_id}
 ```
 
-Excepciones no controladas son capturadas por el middleware y:
+Las excepciones no controladas son capturadas por el middleware y:
 
 1. Registran la excepción completa con stack trace
 2. Registran métrica de fallo
-3. Devuelven respuesta 500 segura al cliente
+3. Retornan respuesta 500 segura al cliente
 4. Preservan el ID de correlación
 
 :::tip
-Se recomienda especificar modelos de respuesta para mejor generación de código si usas el generador `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Más detalles aquí</Link>.
+Se recomienda especificar modelos de respuesta para las operaciones de la API si usas el generador `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Más detalles aquí</Link>.
 :::
 
 ### Streaming
@@ -166,10 +167,10 @@ Con FastAPI, puedes transmitir respuestas usando [`StreamingResponse`](https://f
 
 #### Cambios en infraestructura
 
-Como API Gateway no soporta streaming, necesitarás desplegar en una plataforma que lo permita. La opción más simple es usar Function URL de AWS Lambda. Reemplaza el constructo generado `common/constructs/src/app/apis/<name>-api.ts` por uno que use function URL.
+Como API Gateway de AWS no soporta streaming, necesitarás implementar tu FastAPI en una plataforma que lo soporte. La opción más simple es usar Function URL de AWS Lambda. Para esto, puedes reemplazar el constructo generado `common/constructs/src/app/apis/<name>-api.ts` con uno que implemente Function URL.
 
 <details>
-<summary>Ejemplo de Construct FunctionURL para Streaming</summary>
+<summary>Ejemplo de constructo FunctionURL para streaming</summary>
 
 ```ts
 import { Duration, Stack, CfnOutput } from 'aws-cdk-lib';
@@ -239,6 +240,7 @@ export class MyApi extends Construct {
 
     new CfnOutput(this, 'MyApiUrl', { value: functionUrl.url });
 
+    // Registrar URL en configuración para descubrimiento de clientes
     RuntimeConfig.ensure(this).config.apis = {
       ...RuntimeConfig.ensure(this).config.apis!,
       MyApi: functionUrl.url,
@@ -264,16 +266,16 @@ export class MyApi extends Construct {
 </details>
 
 :::note
-Para un ejemplo completo, consulta el <Link path="/get_started/tutorials/dungeon-game/overview">Tutorial Dungeon Adventure</Link>
+Para un ejemplo completo, consulta el <Link path="/get_started/tutorials/dungeon-game/overview">Tutorial de Dungeon Adventure</Link>
 :::
 
 #### Implementación
 
-Una vez actualizada la infraestructura, puedes implementar streaming en FastAPI. La API debe:
+Actualizada la infraestructura, puedes implementar streaming en FastAPI. La API debe:
 
-- Devolver un [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)
+- Retornar un [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)
 - Declarar el tipo de cada fragmento de respuesta
-- Añadir la extensión OpenAPI `x-streaming: true` si usas <Link path="guides/api-connection/react-fastapi">API Connection</Link>.
+- Añadir la extensión OpenAPI `x-streaming: true` si usarás <Link path="guides/api-connection/react-fastapi">API Connection</Link>.
 
 Ejemplo para transmitir objetos JSON:
 
@@ -298,7 +300,7 @@ def my_stream() -> Chunk:
 
 Para consumir streams, usa el <Link path="guides/api-connection/react-fastapi#consuming-a-stream">Generador API Connection</Link> que provee métodos tipados para iterar fragmentos.
 
-## Despliegue de tu FastAPI
+## Implementando tu FastAPI
 
 El generador crea un constructo CDK en `common/constructs`. Úsalo en una aplicación CDK:
 
@@ -307,6 +309,7 @@ import { MyApi } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
+    // Añade la API al stack
     const api = new MyApi(this, 'MyApi', {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
@@ -319,9 +322,9 @@ Esto configura:
 1. Función AWS Lambda por operación
 2. API Gateway HTTP/REST como trigger
 3. Roles IAM y permisos
-4. Grupo de logs CloudWatch
-5. Configuración de trazas X-Ray
-6. Namespace de métricas CloudWatch
+4. Grupo de logs en CloudWatch
+5. Configuración de trazado X-Ray
+6. Namespace de métricas en CloudWatch
 
 ### Integraciones Tipadas
 
@@ -329,18 +332,18 @@ Esto configura:
 
 #### Generación de código
 
-Como las operaciones se definen en Python y la infraestructura en TypeScript, generamos código para proveer metadatos tipados al constructo CDK.
+Las operaciones se definen en Python y la infraestructura en TypeScript. Usamos generación de código para proveer metadatos tipados al constructo CDK.
 
-El target `generate:<ApiName>-metadata` en `project.json` genera `packages/common/constructs/src/generated/my-api/metadata.gen.ts`. Este archivo se ignora en control de versiones.
+El target `generate:<ApiName>-metadata` en `project.json` genera archivos como `packages/common/constructs/src/generated/my-api/metadata.gen.ts`. Este archivo se ignora en control de versiones.
 
 :::note
-Ejecuta build tras cambios en la API para actualizar tipos:
+Debes ejecutar un build tras cambios en la API para actualizar los tipos:
 
 <NxCommands commands={["run-many --target build --all"]} />
 :::
 
 :::tip
-Para desarrollo activo, usa [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar tipos automáticamente:
+Para desarrollo activo, usa [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) y regenerar tipos automáticamente:
 
 <NxCommands
   commands={[
@@ -352,7 +355,7 @@ Para desarrollo activo, usa [`nx watch`](https://nx.dev/nx-api/nx/documents/watc
 
 ### Otorgar acceso
 
-Usa `grantInvokeAccess` para permitir acceso:
+Usa `grantInvokeAccess` para dar acceso a la API:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -360,16 +363,16 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## Desarrollo local
 
-El generador configura un servidor de desarrollo ejecutable con:
+El generador configura un servidor de desarrollo local. Ejecuta:
 
 <NxCommands commands={['run my-api:serve']} />
 
-Esto inicia un servidor FastAPI con:
+Esto inicia un servidor FastAPI local con:
 
-- Recarga automática ante cambios
-- Documentación interactiva en `/docs` y `/redoc`
+- Recarga automática
+- Documentación interactiva en `/docs` o `/redoc`
 - Esquema OpenAPI en `/openapi.json`
 
-## Invocación de tu FastAPI
+## Invocando tu FastAPI
 
 Para invocar la API desde React, usa el generador <Link path="guides/api-connection/react-fastapi">`api-connection`</Link>.

--- a/docs/src/content/docs/es/guides/license.mdx
+++ b/docs/src/content/docs/es/guides/license.mdx
@@ -8,11 +8,10 @@ description: "Documentación de referencia para el generador de licencias"
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
-Gestiona automáticamente los archivos `LICENSE` y las cabeceras en el código fuente de tu espacio de trabajo.
+Administra automáticamente los archivos `LICENSE` y las cabeceras de licencia en el código fuente de tu espacio de trabajo.
 
-Este generador registra un [generador de sincronización](https://nx.dev/concepts/sync-generators) que se ejecuta como parte de tus objetivos `lint` para garantizar que los archivos fuente cumplan con el contenido y formato de licencia deseado, así como asegurar que los archivos `LICENSE` de tus proyectos sean correctos y que la información de licencia esté incluida en archivos de proyecto relevantes (`package.json`, `pyproject.toml`).
+Este generador registra un [generador de sincronización](https://nx.dev/concepts/sync-generators) que se ejecuta como parte de tus objetivos `lint`, asegurando que tus archivos fuente cumplan con el contenido y formato de licencia deseado. También garantiza que los archivos `LICENSE` de tus proyectos sean correctos y que la información de licencia esté incluida en archivos de proyecto relevantes (`package.json`, `pyproject.toml`).
 
 ## Uso
 
@@ -22,81 +21,81 @@ Este generador registra un [generador de sincronización](https://nx.dev/concept
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## Salida del generador
 
 El generador creará o actualizará los siguientes archivos:
 
 <FileTree>
-  - nx.json El objetivo lint está configurado para ejecutar el generador de sincronización de licencias
+  - nx.json El objetivo lint se configura para ejecutar el generador de sincronización de licencias
   - aws-nx-plugin.config.mts Configuración para el generador de sincronización de licencias
 </FileTree>
 
-Se agrega una configuración predeterminada para el contenido y formato de cabeceras de licencia en `aws-nx-plugin.config.mts` para escribir cabeceras apropiadas en varios tipos de archivos. Puedes personalizar esto más adelante; consulta la [sección de configuración](#configuration) a continuación.
+Se agrega una configuración predeterminada para el contenido y formato de cabeceras de licencia en `aws-nx-plugin.config.mts`, adecuada para varios tipos de archivo. Puedes personalizar esto según sea necesario; consulta la [sección de configuración](#configuración) más abajo.
 
 ## Flujo de trabajo
 
-Cada vez que construyas tus proyectos (y se ejecute un objetivo `lint`), el generador de sincronización de licencias asegurará que las licencias en tu proyecto coincidan con tu configuración (ver [comportamiento de sincronización más abajo](#license-sync-behaviour)). Si detecta desincronización, recibirás un mensaje como:
+Cada vez que construyas tus proyectos (y se ejecute un objetivo `lint`), el generador de sincronización de licencias asegurará que las licencias en tu proyecto coincidan con tu configuración (ver [comportamiento de sincronización más abajo](#comportamiento-de-sincronización-de-licencias)). Si detecta discrepancias, recibirás un mensaje como:
 
 ```bash
-  NX   The workspace is out of sync
+  NX   El espacio de trabajo está desincronizado
 
-[@aws/nx-plugin:license#sync]: Project LICENSE files are out of sync:
+[@aws/nx-plugin:license#sync]: Archivos LICENSE del proyecto están desincronizados:
 - LICENSE
 - packages/<my-project>LICENSE
 
-Project package.json files are out of sync:
+Archivos package.json del proyecto están desincronizados:
 - package.json
 
-Project pyproject.toml files are out of sync:
+Archivos pyproject.toml del proyecto están desincronizados:
 - pyproject.toml
 - packages/<my-python-project>/pyproject.toml
 
-License headers are out of sync in the following source files:
+Cabeceras de licencia desincronizadas en los siguientes archivos fuente:
 - packages/<my-project>/src/index.ts
 - packages/<my-python-project>/main.py
 
-This will result in an error in CI.
+Esto resultará en un error en CI.
 
-? Would you like to sync the identified changes to get your workspace up to date?
-Yes, sync the changes and run the tasks
-No, run the tasks without syncing the changes
+¿Deseas sincronizar los cambios identificados para actualizar el espacio de trabajo?
+Sí, sincronizar los cambios y ejecutar las tareas
+No, ejecutar las tareas sin sincronizar los cambios
 ```
 
-Selecciona `Yes` para sincronizar los cambios.
+Selecciona `Sí` para sincronizar los cambios.
 
 :::note
-Asegúrate de revisar los cambios que realiza el generador de sincronización en el control de versiones para evitar fallos en las tareas de integración continua debido a licencias desincronizadas.
+Asegúrate de revisar los cambios realizados por el generador en el control de versiones para evitar fallos en tareas de integración continua debido a licencias desincronizadas.
 :::
 
 ## Comportamiento de sincronización de licencias
 
-El generador de sincronización realiza tres tareas principales:
+El generador realiza tres tareas principales:
 
 ### 1. Sincronizar cabeceras de licencia en archivos fuente
 
-Al ejecutarse, el generador asegurará que todos los archivos de código fuente en tu espacio de trabajo (según tu configuración) contengan la cabecera de licencia adecuada. La cabecera se escribe como el primer comentario de bloque o serie consecutiva de comentarios de línea en el archivo (excluyendo shebang/hashbang si está presente).
+El generador asegura que todos los archivos fuente en tu espacio de trabajo (según tu configuración) contengan la cabecera de licencia apropiada. La cabecera se escribe como el primer comentario de bloque o serie de comentarios de línea consecutivos en el archivo (excluyendo shebang/hashbang si está presente).
 
-Puedes actualizar la configuración en cualquier momento para cambiar qué archivos incluir/excluir, así como el contenido o formato de las cabeceras para diferentes tipos de archivo. Más detalles en la [sección de configuración](#configuration).
+Puedes actualizar la configuración para cambiar qué archivos incluir/excluir, así como el contenido o formato de cabeceras para diferentes tipos de archivo. Más detalles en la [sección de configuración](#configuración).
 
 ### 2. Sincronizar archivos LICENSE
 
-El generador asegurará que el archivo raíz `LICENSE` corresponda a tu licencia configurada, y que todos los subproyectos contengan el archivo `LICENSE` correcto.
+El generador asegura que el archivo raíz `LICENSE` y los archivos `LICENSE` de subproyectos correspondan a tu licencia configurada.
 
-Puedes excluir proyectos en la configuración si es necesario. Más detalles en la [sección de configuración](#configuration).
+Puedes excluir proyectos en la configuración. Más detalles en la [sección de configuración](#configuración).
 
 ### 3. Sincronizar información de licencia en archivos de proyecto
 
-El generador asegurará que los campos `license` en archivos `package.json` y `pyproject.toml` coincidan con tu licencia configurada.
+El generador asegura que los campos `license` en archivos `package.json` y `pyproject.toml` coincidan con tu licencia configurada.
 
-Puedes excluir proyectos en la configuración si es necesario. Más detalles en la [sección de configuración](#configuration).
+Puedes excluir proyectos en la configuración. Más detalles en la [sección de configuración](#configuración).
 
 ## Configuración
 
-La configuración se define en el archivo `aws-nx-plugin.config.mts` en la raíz de tu espacio de trabajo.
+La configuración se define en el archivo `aws-nx-plugin.config.mts` en la raíz del espacio de trabajo.
 
-### SPDX y titular de derechos
+### SPDX y Titular de derechos
 
 Puedes actualizar la licencia mediante la propiedad `spdx`:
 
@@ -126,9 +125,9 @@ export default {
 
 #### Contenido
 
-El contenido de las cabeceras se puede configurar de dos formas:
+El contenido de la cabecera se puede configurar de dos formas:
 
-1. Contenido directo:
+1. Contenido inline:
 
 ```typescript title="aws-nx-plugin.config.mts" {5-9}
 export default {
@@ -164,14 +163,14 @@ export default {
 
 #### Formato
 
-Puedes especificar cómo formatear cabeceras para diferentes tipos de archivo usando patrones glob. Soporta comentarios de línea, bloque o combinaciones:
+Puedes especificar el formato de cabeceras para diferentes tipos de archivo usando patrones glob. Soporta comentarios de línea, bloque o combinaciones:
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
   license: {
     header: {
       content: {
-        lines: ['Copyright notice here'],
+        lines: ['Aviso de copyright aquí'],
       },
       format: {
         // Comentarios de línea
@@ -189,7 +188,7 @@ export default {
           lineStart: ' * ',
           blockEnd: ' */',
         },
-        // Comentarios de línea con cabecera/pie
+        // Comentarios con encabezado/pie
         '**/*.py': {
           blockStart: '# ------------',
           lineStart: '# ',
@@ -209,14 +208,14 @@ Opciones de formato soportadas:
 
 #### Sintaxis de comentarios personalizada
 
-Para tipos de archivo no soportados, puedes definir sintaxis personalizada:
+Para tipos de archivo no soportados nativamente:
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
   license: {
     header: {
       content: {
-        lines: ['My license header'],
+        lines: ['Mi cabecera de licencia'],
       },
       format: {
         '**/*.xyz': {
@@ -241,16 +240,14 @@ export default {
 
 #### Excluir archivos
 
-Por defecto, en repositorios git se respetan los `.gitignore`. En otros casos, todos los archivos se consideran a menos que se excluyan explícitamente.
-
-Puedes excluir archivos adicionales con patrones glob:
+Por defecto se respetan los `.gitignore`. En repositorios no-git, se excluyen mediante configuración:
 
 ```typescript title="aws-nx-plugin.config.mts" {12-16}
 export default {
   license: {
     header: {
       content: {
-        lines: ['My license header'],
+        lines: ['Mi cabecera de licencia'],
       },
       format: {
         '**/*.ts': {
@@ -263,9 +260,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-### Excluir archivos de proyecto de la sincronización
-
-Todos los archivos `LICENSE`, `package.json` y `pyproject.toml` se sincronizan por defecto.
+### Excluir archivos de proyecto de sincronización
 
 Puedes excluir proyectos o archivos específicos:
 
@@ -284,10 +279,10 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-## Desactivar la sincronización de licencias
+## Desactivar sincronización de licencias
 
 Para desactivar el generador:
-1. Elimina la sección `license` en `aws-nx-plugin.config.mts` (o elimina el archivo)
-2. Elimina el generador `@aws/nx-plugin:license#sync` de `targetDefaults.lint.syncGenerators`
+1. Elimina la sección `license` en `aws-nx-plugin.config.mts`
+2. Elimina `@aws/nx-plugin:license#sync` de `targetDefaults.lint.syncGenerators`
 
-Para reactivarlo, ejecuta nuevamente el generador `license`.
+Para reactivarlo, ejecuta el generador `license` nuevamente.

--- a/docs/src/content/docs/es/guides/nx-generator.mdx
+++ b/docs/src/content/docs/es/guides/nx-generator.mdx
@@ -11,13 +11,12 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
-Agrega un [Generador de Nx](https://nx.dev/extending-nx/recipes/local-generators) a un proyecto TypeScript, para ayudarte a automatizar tareas repetitivas como la creación de componentes o la implementación de estructuras de proyecto específicas.
+Agrega un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a un proyecto TypeScript para ayudarte a automatizar tareas repetitivas como la creación de componentes o la aplicación de estructuras de proyecto específicas.
 
 ## Uso
 
-### Generar un Generador
+### Generar un generador
 
 Puedes generar un generador de dos formas:
 
@@ -25,28 +24,28 @@ Puedes generar un generador de dos formas:
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
-## Resultado del Generador
+## Salida del generador
 
-El generador creará los siguientes archivos de proyecto dentro del `pluginProject` especificado:
+El generador creará los siguientes archivos en el `pluginProject` seleccionado:
 
 <FileTree>
   - src/\<name>/
-    - schema.json Esquema para la entrada de tu generador
-    - schema.d.ts Tipos TypeScript para tu esquema
+    - schema.json Esquema para la entrada del generador
+    - schema.d.ts Tipos TypeScript para el esquema
     - generator.ts Implementación base del generador
-    - generator.spec.ts Pruebas para tu generador
+    - generator.spec.ts Pruebas para el generador
   - generators.json Configuración de Nx para definir tus generadores
-  - package.json Creado o actualizado para agregar una entrada "generators"
+  - package.json Creado o actualizado para agregar entrada "generators"
   - tsconfig.json Actualizado para usar CommonJS
 </FileTree>
 
 :::warning
-Este generador actualizará el `pluginProject` seleccionado para usar CommonJS, ya que los Generadores de Nx actualmente solo admiten CommonJS ([consulta este issue de GitHub para el soporte de ESM](https://github.com/nrwl/nx/issues/15682)).
+Este generador actualizará el `pluginProject` seleccionado para usar CommonJS, ya que los generadores de Nx solo admiten CommonJS actualmente ([consulta este issue de GitHub para soporte de ESM](https://github.com/nrwl/nx/issues/15682)).
 :::
 
-## Generadores Locales
+## Generadores locales
 
 :::tip
 Recomendamos generar primero un proyecto TypeScript dedicado para todos tus generadores usando el generador `ts#project`. Por ejemplo:
@@ -54,13 +53,13 @@ Recomendamos generar primero un proyecto TypeScript dedicado para todos tus gene
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-Selecciona tu proyecto local `nx-plugin` cuando ejecutes el generador `ts#nx-generator`, y especifica un nombre junto con un directorio y descripción opcionales.
+Selecciona tu proyecto local `nx-plugin` al ejecutar el generador `ts#nx-generator`, y especifica un nombre junto con un directorio y descripción opcionales.
 
-### Definiendo el Esquema
+### Definiendo el esquema
 
 El archivo `schema.json` define las opciones que acepta tu generador. Sigue el formato [JSON Schema](https://json-schema.org/) con [extensiones específicas de Nx](https://nx.dev/extending-nx/recipes/generator-options).
 
-#### Estructura Básica
+#### Estructura básica
 
 Un archivo schema.json tiene la siguiente estructura básica:
 
@@ -72,13 +71,13 @@ Un archivo schema.json tiene la siguiente estructura básica:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // Tus opciones de generador van aquí
+    // Your generator options go here
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
 ```
 
-#### Ejemplo Simple
+#### Ejemplo simple
 
 Aquí un ejemplo simple con algunas opciones básicas:
 
@@ -110,9 +109,9 @@ Aquí un ejemplo simple con algunas opciones básicas:
 }
 ```
 
-#### Prompts Interactivos (CLI)
+#### Prompts interactivos (CLI)
 
-Puedes personalizar los prompts mostrados al ejecutar tu generador mediante la CLI agregando la propiedad `x-prompt`:
+Puedes personalizar los prompts mostrados al ejecutar tu generador vía CLI agregando la propiedad `x-prompt`:
 
 ```json
 "name": {
@@ -122,7 +121,7 @@ Puedes personalizar los prompts mostrados al ejecutar tu generador mediante la C
 }
 ```
 
-Para opciones booleanas, puedes usar un prompt de sí/no:
+Para opciones booleanas, puedes usar un prompt sí/no:
 
 ```json
 "withTests": {
@@ -132,9 +131,9 @@ Para opciones booleanas, puedes usar un prompt de sí/no:
 }
 ```
 
-#### Selecciones en Menú Desplegable
+#### Selecciones desplegables
 
-Para opciones con un conjunto fijo de opciones, usa `enum` para que los usuarios puedan seleccionar una de ellas.
+Para opciones con un conjunto fijo de opciones, usa `enum` para que los usuarios puedan seleccionar una:
 
 ```json
 "style": {
@@ -145,9 +144,9 @@ Para opciones con un conjunto fijo de opciones, usa `enum` para que los usuarios
 }
 ```
 
-#### Menú Desplegable de Selección de Proyecto
+#### Desplegable de selección de proyecto
 
-Un patrón común es permitir que los usuarios seleccionen entre proyectos existentes en el workspace:
+Un patrón común es permitir a los usuarios seleccionar entre proyectos existentes en el workspace:
 
 ```json
 "project": {
@@ -158,9 +157,9 @@ Un patrón común es permitir que los usuarios seleccionen entre proyectos exist
 }
 ```
 
-La propiedad `x-dropdown: "projects"` indica a Nx que llene el menú con todos los proyectos del workspace.
+La propiedad `x-dropdown: "projects"` indica a Nx que llene el desplegable con todos los proyectos del workspace.
 
-#### Argumentos Posicionales
+#### Argumentos posicionales
 
 Puedes configurar opciones para que se pasen como argumentos posicionales al ejecutar el generador desde la línea de comandos:
 
@@ -178,7 +177,7 @@ Puedes configurar opciones para que se pasen como argumentos posicionales al eje
 
 Esto permite a los usuarios ejecutar tu generador como `nx g your-generator my-component` en lugar de `nx g your-generator --name=my-component`.
 
-#### Estableciendo Prioridades
+#### Estableciendo prioridades
 
 Usa la propiedad `x-priority` para indicar qué opciones son más importantes:
 
@@ -190,11 +189,11 @@ Usa la propiedad `x-priority` para indicar qué opciones son más importantes:
 }
 ```
 
-Las opciones pueden tener prioridades de `"important"` o `"internal"`. Esto ayuda a Nx a ordenar las propiedades en la extensión VSCode de Nx y en la CLI de Nx.
+Las opciones pueden tener prioridades de `"important"` o `"internal"`. Esto ayuda a Nx a ordenar propiedades en la extensión VSCode de Nx y en la CLI.
 
-#### Valores Predeterminados
+#### Valores predeterminados
 
-Puedes proporcionar valores predeterminados para las opciones:
+Puedes proveer valores predeterminados para las opciones:
 
 ```json
 "directory": {
@@ -204,13 +203,13 @@ Puedes proporcionar valores predeterminados para las opciones:
 }
 ```
 
-#### Más Información
+#### Más información
 
-Para más detalles sobre esquemas, consulta la [documentación de Opciones de Generador de Nx](https://nx.dev/extending-nx/recipes/generator-options).
+Para más detalles sobre esquemas, consulta la [documentación de Opciones de Generadores de Nx](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Tipos TypeScript con schema.d.ts
 
-Junto con `schema.json`, el generador crea un archivo `schema.d.ts` que proporciona tipos TypeScript para las opciones de tu generador:
+Junto con `schema.json`, el generador crea un archivo `schema.d.ts` que provee tipos TypeScript para las opciones:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -220,7 +219,7 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Esta interfaz se usa en la implementación de tu generador para proporcionar seguridad de tipos y autocompletado:
+Esta interfaz se usa en la implementación del generador para proveer seguridad de tipos y autocompletado:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
@@ -242,15 +241,15 @@ Cada vez que modifiques `schema.json`, debes actualizar `schema.d.ts` para que c
 La interfaz TypeScript debe reflejar fielmente la estructura definida en tu esquema JSON.
 :::
 
-### Implementando un Generador
+### Implementando un generador
 
-Después de crear el nuevo generador como se indicó anteriormente, puedes escribir tu implementación en `generator.ts`.
+Después de crear el nuevo generador como arriba, puedes escribir tu implementación en `generator.ts`.
 
-Un generador es una función que muta un sistema de archivos virtual (`Tree`), leyendo y escribiendo archivos para realizar los cambios deseados. Los cambios del `Tree` solo se escriben en disco una vez que el generador termina de ejecutarse, a menos que se ejecute en modo "dry-run".
+Un generador es una función que muta un sistema de archivos virtual (`Tree`), leyendo y escribiendo archivos para realizar los cambios deseados. Los cambios del `Tree` solo se escriben en disco cuando el generador termina de ejecutarse, a menos que se ejecute en modo "dry-run".
 
 Aquí hay algunas operaciones comunes que podrías realizar en tu generador:
 
-#### Lectura y Escritura de Archivos
+#### Leer y escribir archivos
 
 ```typescript
 // Leer un archivo
@@ -265,7 +264,7 @@ if (tree.exists('path/to/file.ts')) {
 }
 ```
 
-#### Generación de Archivos desde Plantillas
+#### Generar archivos desde plantillas
 
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
@@ -285,7 +284,7 @@ generateFiles(
 );
 ```
 
-#### Manipulación de AST (Árbol de Sintaxis Abstracta) de TypeScript
+#### Manipulación de AST (Abstract Syntax Tree) de TypeScript
 
 Recomendamos instalar [TSQuery](https://github.com/phenomnomnominal/tsquery) para ayudar con la manipulación de AST.
 
@@ -319,7 +318,7 @@ if (nodes.length > 0) {
     () => ts.factory.createNumericLiteral(newVersion),
   );
 
-  // Escribir el contenido actualizado en el árbol
+  // Escribir el contenido actualizado de vuelta al tree
   tree.write(
     'path/to/version.ts',
     ts
@@ -335,7 +334,7 @@ if (nodes.length > 0) {
 Puedes probar selectores en línea en el [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
 :::
 
-#### Agregar Dependencias
+#### Agregar dependencias
 
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
@@ -365,7 +364,7 @@ return () => {
 ```
 :::
 
-#### Formatear Archivos Generados
+#### Formatear archivos generados
 
 ```typescript
 import { formatFiles } from '@nx/devkit';
@@ -374,7 +373,7 @@ import { formatFiles } from '@nx/devkit';
 await formatFiles(tree);
 ```
 
-#### Leer y Actualizar Archivos JSON
+#### Leer y actualizar archivos JSON
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
@@ -392,19 +391,19 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
-### Ejecutando Tu Generador
+### Ejecutar tu generador
 
 Puedes ejecutar tu generador de dos formas:
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-Si no ves tu generador en la interfaz del plugin de VSCode, puedes actualizar tu workspace de Nx con:
+Si no ves tu generador en la UI del plugin de VSCode, puedes refrescar tu workspace de Nx con:
 
 <NxCommands commands={['reset']} />
 :::
 
-### Probando Tu Generador
+### Probar tu generador
 
 Las pruebas unitarias para generadores son sencillas de implementar. Aquí un patrón típico:
 
@@ -416,7 +415,7 @@ describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
-    // Crear un árbol de workspace vacío
+    // Crear un workspace tree vacío
     tree = createTreeWithEmptyWorkspace();
 
     // Agregar archivos que deban existir previamente
@@ -441,7 +440,7 @@ describe('your generator', () => {
     // Verificar creación de archivos
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
 
-    // Verificar contenido de archivo
+    // Verificar contenido del archivo
     const content = tree.read('src/test/file.ts', 'utf-8');
     expect(content).toContain('export const test');
 
@@ -466,7 +465,7 @@ describe('your generator', () => {
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
-        // Agregar opciones que causen un error
+        // Agregar opciones que causen error
       }),
     ).rejects.toThrow('Expected error message');
   });
@@ -477,11 +476,11 @@ Puntos clave para probar generadores:
 
 - Usa `createTreeWithEmptyWorkspace()` para crear un sistema de archivos virtual
 - Configura archivos prerrequisitos antes de ejecutar el generador
-- Prueba tanto la creación de nuevos archivos como actualizaciones a existentes
-- Usa snapshots para contenido de archivos complejos
-- Prueba condiciones de error para asegurar un fallo controlado
+- Prueba creación de nuevos archivos y actualización de existentes
+- Usa snapshots para contenido complejo
+- Prueba condiciones de error para asegurar fallos controlados
 
-## Contribuyendo Generadores a @aws/nx-plugin
+## Contribuir generadores a @aws/nx-plugin
 
 También puedes usar `ts#nx-generator` para crear un generador dentro de `@aws/nx-plugin`.
 
@@ -489,8 +488,8 @@ Cuando este generador se ejecuta en nuestro repositorio, generará los siguiente
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Esquema para la entrada de tu generador
-    - schema.d.ts Tipos TypeScript para tu esquema
+    - schema.json Esquema para la entrada del generador
+    - schema.d.ts Tipos TypeScript para el esquema
     - generator.ts Implementación del generador
     - generator.spec.ts Pruebas para tu generador
   - docs/src/content/docs/guides/
@@ -498,7 +497,7 @@ Cuando este generador se ejecuta en nuestro repositorio, generará los siguiente
   - packages/nx-plugin/generators.json Actualizado para incluir tu generador
 </FileTree>
 
-Podrás entonces comenzar a implementar tu generador.
+Luego puedes comenzar a implementar tu generador.
 
 :::tip
 Para una guía más detallada sobre cómo contribuir al Nx Plugin para AWS, consulta el <Link path="get_started/tutorials/contribute-generator">tutorial aquí</Link>.

--- a/docs/src/content/docs/es/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/es/guides/python-lambda-function.mdx
@@ -9,11 +9,10 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
-El generador de Funciones Lambda en Python permite agregar una función lambda a un proyecto existente de Python.
+El generador de Funciones Lambda en Python permite añadir una función lambda a un proyecto existente de Python.
 
-Este generador crea un nuevo manejador lambda en Python con configuración de infraestructura AWS CDK. El backend generado utiliza AWS Lambda para despliegues serverless, con opción de validación de tipos usando el [Parser de AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidad, incluyendo registro de logs, trazado con AWS X-Ray y métricas en CloudWatch.
+Este generador crea un nuevo manejador de lambda en Python con configuración de infraestructura usando AWS CDK. El backend generado utiliza AWS Lambda para implementación serverless, con opción de validación de tipos usando el [Parser de AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidad, incluyendo logging, trazado con AWS X-Ray y métricas de CloudWatch.
 
 ## Uso
 
@@ -25,11 +24,11 @@ Puedes generar una nueva función Lambda de dos formas:
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
-## Resultado del generador
+## Salida del generador
 
-El generador agregará los siguientes archivos a tu proyecto:
+El generador añadirá los siguientes archivos a tu proyecto:
 
 <FileTree>
 
@@ -38,9 +37,9 @@ El generador agregará los siguientes archivos a tu proyecto:
 
 </FileTree>
 
-El generador también crea constructos CDK para desplegar tu función, ubicados en el directorio `packages/common/constructs`.
+El generador también crea constructs de CDK para implementar tu función, ubicados en el directorio `packages/common/constructs`.
 
-Si se provee la opción `functionPath`, el generador agregará los archivos en la ruta especificada:
+Si se provee la opción `functionPath`, el generador añadirá los archivos en la ruta especificada:
 
 <FileTree>
 
@@ -95,9 +94,9 @@ El generador configura automáticamente:
 
 ### Observabilidad con AWS Lambda Powertools
 
-#### Registro de logs
+#### Logging
 
-El generador configura registro estructurado usando AWS Lambda Powertools.
+El generador configura logging estructurado usando AWS Lambda Powertools.
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -105,18 +104,18 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 ```
 
 :::tip
-Se recomienda establecer un ID de correlación para todas las solicitudes únicas para facilitar depuración y monitoreo. Consulta la documentación de [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) para mejores prácticas.
+Se recomienda establecer un correlation id para requests únicos para facilitar depuración y monitoreo. Consulta la documentación de [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) para mejores prácticas.
 :::
 
 El logger incluye automáticamente:
 
 - Solicitudes de eventos
-- Información del contexto Lambda  
+- Información del contexto Lambda
 - Indicadores de cold start
 
 #### Trazado
 
-El trazado con AWS X-Ray se configura automáticamente. Puedes agregar subsegmentos personalizados:
+El trazado con AWS X-Ray se configura automáticamente. Puedes añadir subsegmentos personalizados:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -128,7 +127,7 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 #### Métricas
 
-Las métricas de CloudWatch se recolectan automáticamente. Puedes agregar métricas personalizadas:
+Las métricas de CloudWatch se recolectan automáticamente. Puedes añadir métricas personalizadas:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -138,13 +137,13 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 Métricas por defecto incluyen:
 
-- Conteo de invocaciones  
-- Conteos de éxito/fallo  
+- Conteo de invocaciones
+- Conteo de éxitos/fallos  
 - Métricas de cold start
 
 #### Validación de tipos
 
-Si elegiste un `eventSource` al generar tu función, esta se instrumenta con [`@event_parser` de AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Ejemplo:
+Si seleccionaste un `eventSource` al generar tu función, esta se instrumenta con [`@event_parser` de AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Por ejemplo:
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
@@ -155,21 +154,21 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 Esto permite definir modelos de datos usando [Pydantic](https://docs.pydantic.dev/latest/), similar a trabajar con <Link path="guides/fastapi">Fast API</Link>.
 
 :::tip
-Si tienes datos personalizados anidados en un evento, como un stream de DynamoDB o evento de EventBridge, puedes usar [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) para garantizar tipado seguro.
+Si tienes datos personalizados anidados en un evento, como un stream de DynamoDB o evento de EventBridge, puedes usar [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) para validar esos datos.
 :::
 
 Si no deseas tipar tu evento, selecciona `Any` como `eventSource`.
 
-## Desplegando tu función
+## Implementando tu función
 
-El generador crea un constructo CDK para despliegue en `common/constructs`. Puedes usarlo en una aplicación CDK:
+El generador crea un construct CDK en `common/constructs` para implementar tu función. Puedes usarlo en una aplicación CDK:
 
 ```ts
 import { MyProjectMyFunction } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    // Agrega la función al stack
+    // Añade la función a tu stack
     const fn = new MyProjectMyFunction(this, 'MyFunction');
   }
 }
@@ -177,18 +176,18 @@ export class ExampleStack extends Stack {
 
 Esto configura:
 
-1. Función AWS Lambda  
-2. Grupo de logs en CloudWatch  
+1. Función AWS Lambda
+2. Grupo de logs en CloudWatch
 3. Configuración de trazado X-Ray  
-4. Namespace para métricas CloudWatch
+4. Namespace de métricas en CloudWatch
 
-La función puede usarse como objetivo para cualquier [origen de eventos lambda](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/):
+La función puede usarse como destino para cualquier [origen de evento](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) de Lambda:
 
 :::note
-Asegúrate que el origen de eventos coincida con la opción `eventSource` seleccionada para un manejo adecuado en tu función.
+Asegúrate que el origen del evento coincida con la opción `eventSource` seleccionada para un manejo adecuado.
 :::
 
-Este ejemplo muestra código CDK para invocar tu función en un horario usando Event Bridge:
+Este ejemplo muestra código CDK para invocar tu función en un schedule usando Event Bridge:
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';
@@ -197,10 +196,10 @@ import { MyProjectMyFunction } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    // Agrega la función al stack
+    // Añade la función al stack
     const fn = new MyProjectMyFunction(this, 'MyFunction');
 
-    // Configura una regla de EventBridge
+    // Añade la función a una regla de EventBridge
     const eventRule = new Rule(this, 'MyFunctionScheduleRule', {
       schedule: Schedule.cron({ minute: '15' }),
       targets: [new LambdaFunction(fn)],

--- a/docs/src/content/docs/es/guides/python-project.mdx
+++ b/docs/src/content/docs/es/guides/python-project.mdx
@@ -9,7 +9,6 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
 El generador de proyectos Python permite crear bibliotecas o aplicaciones modernas de [Python](https://www.python.org/) configuradas con mejores prácticas, gestionadas con [UV](https://docs.astral.sh/uv/), un único archivo de bloqueo y entorno virtual en un [espacio de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para ejecutar pruebas, y [Ruff](https://docs.astral.sh/ruff/) para análisis estático.
 
@@ -17,68 +16,68 @@ El generador de proyectos Python permite crear bibliotecas o aplicaciones modern
 
 ### Generar un proyecto Python
 
-Puedes crear un nuevo proyecto Python de dos formas:
+Puedes generar un nuevo proyecto Python de dos formas:
 
 <RunGenerator generator="py#project" />
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
-## Resultado del generador
+## Resultado del Generador
 
-El generador creará la siguiente estructura de proyecto en el directorio `<directorio>/<nombre>`:
+El generador creará la siguiente estructura de proyecto en el directorio `<directory>/<name>`:
 
 <FileTree>
 
-  - \<nombre-del-módulo>
+  - \<module-name>
     - \_\_init\_\_.py Inicialización del módulo
-    - hello.py Archivo ejemplo de código Python
+    - hello.py Archivo de ejemplo con código Python
   - tests
     - \_\_init\_\_.py Inicialización del módulo
     - conftest.py Configuración de pruebas
-    - test_hello.py Ejemplo de pruebas
+    - test_hello.py Pruebas de ejemplo
   - project.json Configuración del proyecto y objetivos de build
   - pyproject.toml Archivo de configuración de empaquetado usado por UV
   - .python-version Contiene la versión de Python del proyecto
 
 </FileTree>
 
-También notarás estos archivos creados/actualizados en la raíz de tu espacio de trabajo:
+También podrás observar estos archivos creados/actualizados en la raíz del workspace:
 
 <FileTree>
 
-  - pyproject.toml Configuración de empaquetado a nivel de espacio de trabajo para UV
-  - .python-version Contiene la versión de Python del espacio de trabajo
+  - pyproject.toml Configuración de empaquetado a nivel de workspace para UV
+  - .python-version Contiene la versión de Python del workspace
   - uv.lock Archivo de bloqueo de dependencias Python
 
 </FileTree>
 
-## Escribiendo código Python
+## Escribir código Python
 
-Añade tu código fuente Python en el directorio `<nombre-del-módulo>`.
+Añade tu código fuente Python en el directorio `<module-name>`.
 
-### Importando tu biblioteca en otros proyectos
+### Importar tu biblioteca en otros proyectos
 
-Gracias a la configuración de [espacios de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), puedes referenciar tu proyecto Python desde cualquier otro proyecto en tu espacio de trabajo:
+Como tienes configurados [espacios de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), puedes referenciar tu proyecto Python desde cualquier otro proyecto Python en tu workspace:
 
 ```python title="packages/my_other_project/my_other_project/main.py"
 from "my_library.hello" import say_hello
 ```
 
-Aquí, `my_library` es el nombre del módulo, `hello` corresponde al archivo fuente `hello.py`, y `say_hello` es un método definido en `hello.py`
+Aquí, `my_library` es el nombre del módulo, `hello` corresponde al archivo fuente Python `hello.py`, y `say_hello` es un método definido en `hello.py`
 
 ### Dependencias
 
-Para añadir dependencias a tu proyecto, ejecuta el objetivo `add` en tu proyecto Python:
+Para añadir dependencias a tu proyecto, puedes ejecutar el objetivo `add` en tu proyecto Python, por ejemplo:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
 Esto añadirá la dependencia al archivo `pyproject.toml` de tu proyecto y actualizará el `uv.lock` raíz.
 
-#### Código en producción
+#### Código en tiempo de ejecución
 
-Cuando uses tu proyecto Python como código en producción (por ejemplo como handler de una función AWS Lambda), necesitarás crear un paquete con el código fuente y sus dependencias. Puedes lograrlo añadiendo un objetivo como este en tu `project.json`:
+Cuando uses tu proyecto Python como código de runtime (por ejemplo como handler para una función AWS Lambda), necesitarás crear un paquete del código fuente y todas sus dependencias. Puedes lograrlo añadiendo un objetivo como el siguiente en tu archivo `project.json`:
 
 ```json title="project.json"
 {
@@ -102,25 +101,25 @@ Cuando uses tu proyecto Python como código en producción (por ejemplo como han
 }
 ```
 
-### Compilación
+### Construcción
 
-Tu proyecto Python incluye un objetivo `build` (definido en `project.json`) que puedes ejecutar con:
+Tu proyecto Python está configurado con un objetivo `build` (definido en `project.json`), que puedes ejecutar mediante:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-Donde `<project-name>` es el nombre completo de tu proyecto.
+Donde `<project-name>` es el nombre completo calificado de tu proyecto.
 
-El objetivo `build` compilará, verificará estilo y ejecutará pruebas del proyecto.
+El objetivo `build` compilará, linteará y probará tu proyecto.
 
-La salida del build se encontrará en la carpeta `dist` raíz de tu espacio de trabajo, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<mi-biblioteca>/build`
+La salida del build se encontrará en la carpeta `dist` raíz de tu workspace, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<my-library>/build`
 
 ## Pruebas
 
-El proyecto está configurado con [pytest](https://docs.pytest.org/en/stable/) para ejecutar pruebas.
+[pytest](https://docs.pytest.org/en/stable/) está configurado para probar tu proyecto.
 
-### Escribiendo pruebas
+### Escribir pruebas
 
-Las pruebas deben escribirse en el directorio `test` de tu proyecto, en archivos Python con prefijo `test_`, por ejemplo:
+Las pruebas deben escribirse en el directorio `test` dentro de tu proyecto, en archivos Python con prefijo `test_`, por ejemplo:
 
 <FileTree>
   - my_library
@@ -129,7 +128,7 @@ Las pruebas deben escribirse en el directorio `test` de tu proyecto, en archivos
     - test_hello.py Pruebas para hello.py
 </FileTree>
 
-Las pruebas son métodos que comienzan con `test_` y realizan aserciones para verificar expectativas:
+Las pruebas son métodos que comienzan con `test_` y realizan aserciones para verificar expectativas, por ejemplo:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -140,32 +139,32 @@ def test_say_hello():
 
 Para más detalles sobre cómo escribir pruebas, consulta la [documentación de pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
 
-### Ejecutando pruebas
+### Ejecutar pruebas
 
-Las pruebas se ejecutan como parte del objetivo `build`, pero también puedes ejecutarlas separadamente con:
+Las pruebas se ejecutarán como parte del objetivo `build` de tu proyecto, pero también puedes ejecutarlas por separado con el objetivo `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puedes ejecutar una prueba individual usando el flag `-k` con el nombre del archivo o método:
+Puedes ejecutar una prueba individual o un conjunto usando el flag `-k`, especificando el nombre del archivo o método de prueba:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## Verificación de estilo
+## Linting
 
-Los proyectos Python usan [Ruff](https://docs.astral.sh/ruff/) para verificación de estilo.
+Los proyectos Python usan [Ruff](https://docs.astral.sh/ruff/) para linting.
 
-### Ejecutando el linter
+### Ejecutar el Linter
 
-Para ejecutar el linter y verificar tu proyecto:
+Para invocar el linter y verificar tu proyecto, ejecuta el objetivo `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corrigiendo problemas
+### Corregir problemas de linting
 
-La mayoría de problemas de estilo pueden corregirse automáticamente. Ejecuta Ruff con el argumento `--configuration=fix`:
+La mayoría de problemas de linting o formato pueden corregirse automáticamente. Puedes indicar a Ruff que corrija problemas ejecutando con el argumento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Para corregir problemas en todos los paquetes de tu espacio de trabajo:
+De forma similar, si quieres corregir todos los problemas de linting en todos los paquetes de tu workspace, ejecuta:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -11,11 +11,10 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/) es un framework para construir APIs en TypeScript con seguridad de tipos de extremo a extremo. Con tRPC, las actualizaciones en las entradas y salidas de las operaciones de la API se reflejan inmediatamente en el código cliente y son visibles en tu IDE sin necesidad de reconstruir el proyecto.
+[tRPC](https://trpc.io/) es un framework para construir APIs en TypeScript con seguridad de tipos de extremo a extremo. Usando tRPC, las actualizaciones en las entradas y salidas de las operaciones de la API se reflejan inmediatamente en el código cliente y son visibles en tu IDE sin necesidad de reconstruir el proyecto.
 
-El generador de API tRPC crea una nueva API tRPC con configuración de infraestructura AWS CDK. El backend generado utiliza AWS Lambda para implementación sin servidor e incluye validación de esquemas usando [Zod](https://zod.dev/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) para observabilidad, incluyendo logging, trazas con AWS X-Ray y métricas de CloudWatch.
+El generador de API tRPC crea una nueva API tRPC con configuración de infraestructura AWS CDK. El backend generado utiliza AWS Lambda para despliegue serverless e incluye validación de esquemas usando [Zod](https://zod.dev/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) para observabilidad, incluyendo logging, trazado con AWS X-Ray y métricas de Cloudwatch.
 
 ## Uso
 
@@ -27,11 +26,11 @@ Puedes generar una nueva API tRPC de dos formas:
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
-## Resultado del Generador
+## Salida del Generador
 
 El generador creará la siguiente estructura de proyecto en el directorio `<directory>/<api-name>`:
 
@@ -42,26 +41,27 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
       - procedures
         - echo.ts Definiciones de esquema compartidas para el procedimiento "echo", usando Zod
     - tsconfig.json Configuración de TypeScript
-    - project.json Configuración de proyecto y objetivos de build
+    - project.json Configuración del proyecto y objetivos de build
   - backend
     - src
       - init.ts Inicialización del backend tRPC
-      - router.ts Definición del router tRPC (punto de entrada del handler Lambda)
+      - router.ts Definición del router tRPC (punto de entrada del manejador Lambda)
       - procedures Procedimientos (u operaciones) expuestos por tu API
         - echo.ts Procedimiento de ejemplo
       - middleware
         - error.ts Middleware para manejo de errores
-        - logger.ts middleware para configurar AWS Powertools para logging en Lambda
-        - tracer.ts middleware para configurar AWS Powertools para trazas en Lambda
-        - metrics.ts middleware para configurar AWS Powertools para métricas en Lambda
+        - logger.ts Middleware para configurar AWS Powertools para logging en Lambda
+        - tracer.ts Middleware para configurar AWS Powertools para trazado en Lambda
+        - metrics.ts Middleware para configurar AWS Powertools para métricas en Lambda
       - local-server.ts Punto de entrada del adaptador standalone de tRPC para servidor de desarrollo local
       - client
         - index.ts Cliente tipado para llamadas máquina-a-máquina a la API
     - tsconfig.json Configuración de TypeScript
-    - project.json Configuración de proyecto y objetivos de build
+    - project.json Configuración del proyecto y objetivos de build
+
 </FileTree>
 
-El generador también creará constructs CDK que pueden usarse para implementar tu API, ubicados en el directorio `packages/common/constructs`.
+El generador también creará constructs CDK que pueden usarse para desplegar tu API, ubicados en el directorio `packages/common/constructs`.
 
 ## Implementando tu API tRPC
 
@@ -73,7 +73,7 @@ Tanto `schema` como `backend` son proyectos TypeScript, por lo que puedes consul
 
 ### Schema
 
-El paquete schema define los tipos compartidos entre tu código cliente y servidor. En este paquete, estos tipos se definen usando [Zod](https://zod.dev/), una librería TypeScript-first para declaración y validación de esquemas.
+El paquete schema define los tipos compartidos entre tu código cliente y servidor. En este paquete, estos tipos se definen usando [Zod](https://zod.dev/), una biblioteca TypeScript-first para declaración y validación de esquemas.
 
 Un esquema de ejemplo podría verse así:
 
@@ -101,7 +101,7 @@ interface User {
 }
 ```
 
-Los esquemas son compartidos por código servidor y cliente, proporcionando un único lugar para actualizar cuando se modifican las estructuras usadas en tu API.
+Los esquemas son compartidos por el código del servidor y cliente, proporcionando un único lugar para actualizar cuando se modifican las estructuras usadas en tu API.
 
 Los esquemas son validados automáticamente por tu API tRPC en tiempo de ejecución, lo que evita tener que crear lógica de validación manual en el backend.
 
@@ -109,9 +109,9 @@ Zod proporciona utilidades poderosas para combinar o derivar esquemas como `.mer
 
 ### Backend
 
-La carpeta anidada `backend` contiene tu implementación de API, donde defines las operaciones de tu API y sus entradas, salidas e implementación.
+La carpeta anidada `backend` contiene la implementación de tu API, donde defines las operaciones de tu API y sus entradas, salidas e implementación.
 
-El punto de entrada de tu API está en `src/router.ts`. Este archivo contiene el handler Lambda que enruta solicitudes a "procedimientos" según la operación invocada. Cada procedimiento define la entrada esperada, salida e implementación.
+El punto de entrada de tu API está en `src/router.ts`. Este archivo contiene el manejador Lambda que enruta las solicitudes a los "procedimientos" según la operación invocada. Cada procedimiento define la entrada esperada, salida e implementación.
 
 El router de ejemplo generado tiene una sola operación llamada `echo`:
 
@@ -134,12 +134,12 @@ export const echo = publicProcedure
 
 Desglosando lo anterior:
 
-- `publicProcedure` define un método público en la API, incluyendo el middleware configurado en `src/middleware`. Este middleware incluye integración con AWS Lambda Powertools para logging, tracing y métricas.
+- `publicProcedure` define un método público en la API, incluyendo el middleware configurado en `src/middleware`. Este middleware incluye integración con AWS Lambda Powertools para logging, trazado y métricas.
 - `input` acepta un esquema Zod que define la entrada esperada para la operación. Las solicitudes para esta operación se validan automáticamente contra este esquema.
 - `output` acepta un esquema Zod que define la salida esperada. Verás errores de tipo en tu implementación si no devuelves una salida que cumpla con el esquema.
-- `query` acepta una función que define la implementación de tu API. Esta implementación recibe `opts`, que contiene el `input` pasado a la operación, así como otro contexto configurado por middleware, disponible en `opts.ctx`. La función pasada a `query` debe devolver una salida que cumpla con el esquema `output`.
+- `query` acepta una función que define la implementación de tu API. Esta implementación recibe `opts`, que contiene el `input` pasado a la operación, así como otro contexto configurado por el middleware, disponible en `opts.ctx`. La función pasada a `query` debe devolver una salida que cumpla con el esquema de `output`.
 
-El uso de `query` para definir la implementación indica que la operación no es mutativa. Úsalo para definir métodos de obtención de datos. Para operaciones mutativas, usa el método `mutation` en su lugar.
+El uso de `query` para definir la implementación indica que la operación no es mutativa. Úsalo para definir métodos de recuperación de datos. Para operaciones mutativas, usa el método `mutation` en su lugar.
 
 Si añades una nueva operación, asegúrate de registrarla añadiéndola al router en `src/router.ts`.
 
@@ -158,7 +158,7 @@ throw new TRPCError({
 
 ### Organizando tus Operaciones
 
-A medida que crece tu API, puedes querer agrupar operaciones relacionadas.
+A medida que crece tu API, quizás quieras agrupar operaciones relacionadas.
 
 Puedes agrupar operaciones usando routers anidados, por ejemplo:
 
@@ -175,7 +175,7 @@ const appRouter = router({
 })
 ```
 
-Los clientes luego reciben esta agrupación de operaciones, por ejemplo invocar la operación `listUsers` en este caso se vería así:
+Los clientes verán esta agrupación de operaciones, por ejemplo, invocar la operación `listUsers` se vería así:
 
 ```ts
 client.users.list.query();
@@ -183,7 +183,7 @@ client.users.list.query();
 
 ### Logging
 
-El logger de AWS Lambda Powertools se configura en `src/middleware/logger.ts`, y puede accederse en una implementación de API via `opts.ctx.logger`. Puedes usarlo para registrar en CloudWatch Logs y/o controlar valores adicionales a incluir en cada mensaje de log estructurado. Por ejemplo:
+El logger de AWS Lambda Powertools está configurado en `src/middleware/logger.ts`, y se puede acceder a él en una implementación de API mediante `opts.ctx.logger`. Puedes usarlo para registrar en CloudWatch Logs y/o controlar valores adicionales a incluir en cada mensaje de log estructurado. Por ejemplo:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -200,7 +200,7 @@ Para más información sobre el logger, consulta la [documentación de AWS Lambd
 
 ### Registro de Métricas
 
-Las métricas de AWS Lambda Powertools se configuran en `src/middleware/metrics.ts`, y pueden accederse en una implementación de API via `opts.ctx.metrics`. Puedes usarlas para registrar métricas en CloudWatch sin necesidad de importar y usar el AWS SDK, por ejemplo:
+Las métricas de AWS Lambda Powertools están configuradas en `src/middleware/metrics.ts`, y se puede acceder a ellas mediante `opts.ctx.metrics`. Puedes usarlas para registrar métricas en CloudWatch sin necesidad de importar y usar el AWS SDK, por ejemplo:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -215,16 +215,16 @@ export const echo = publicProcedure
 
 Para más información, consulta la [documentación de AWS Lambda Powertools Metrics](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/).
 
-### Ajuste Fino de Trazas X-Ray
+### Ajuste Fino del Trazado con X-Ray
 
-El tracer de AWS Lambda Powertools se configura en `src/middleware/tracer.ts`, y puede accederse en una implementación de API via `opts.ctx.tracer`. Puedes usarlo para añadir trazas con AWS X-Ray y obtener insights detallados sobre el rendimiento y flujo de las solicitudes a la API. Por ejemplo:
+El tracer de AWS Lambda Powertools está configurado en `src/middleware/tracer.ts`, y se puede acceder a él mediante `opts.ctx.tracer`. Puedes usarlo para añadir trazas con AWS X-Ray y obtener insights detallados sobre el rendimiento y flujo de las solicitudes a la API. Por ejemplo:
 
 ```ts {5-7}
 export const echo = publicProcedure
    .input(...)
    .output(...)
    .query(async (opts) => {
-      const subSegment = opts.ctx.tracer.getSegment()!.addNewSubsegment('MiAlgoritmo');
+      const subSegment = opts.ctx.tracer.getSegment()!.addNewSubsegment('MyAlgorithm');
       // ... lógica de mi algoritmo para capturar
       subSegment.close();
 
@@ -238,7 +238,7 @@ Para más información, consulta la [documentación de AWS Lambda Powertools Tra
 
 Puedes añadir valores adicionales al contexto proporcionado a los procedimientos implementando middleware.
 
-Como ejemplo, implementemos middleware para extraer detalles sobre el usuario que llama a nuestra API en `src/middleware/identity.ts`.
+Como ejemplo, implementemos middleware para extraer detalles del usuario que llama a nuestra API en `src/middleware/identity.ts`.
 
 Primero, definimos lo que añadiremos al contexto:
 
@@ -253,7 +253,7 @@ export interface IIdentityContext {
 
 Nota que definimos una propiedad adicional _opcional_ al contexto. tRPC se encarga de asegurar que esto esté definido en procedimientos que hayan configurado correctamente este middleware.
 
-Luego, implementamos el middleware mismo. Tiene la siguiente estructura:
+Luego implementamos el middleware. Tiene la siguiente estructura:
 
 ```ts
 export const createIdentityPlugin = () => {
@@ -270,7 +270,7 @@ export const createIdentityPlugin = () => {
 };
 ```
 
-En nuestro caso, queremos extraer detalles del usuario de Cognito que llama. Hacemos esto extrayendo el ID de sujeto (o "sub") del usuario del evento de API Gateway, y recuperando detalles del usuario desde Cognito. La implementación varía según si el evento fue provisto por una REST API o una HTTP API:
+En nuestro caso, queremos extraer detalles del usuario de Cognito. Lo haremos extrayendo el ID de sujeto (o "sub") del usuario del evento de API Gateway, y recuperando detalles del usuario de Cognito. La implementación varía según si el evento fue provisto por una API REST o HTTP:
 
 <Tabs>
 <TabItem label="REST">
@@ -309,7 +309,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
-      // Supone que el ID del grupo de usuarios está configurado en el entorno de Lambda
+      // Asume que el ID del user pool está configurado en el entorno lambda
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -378,7 +378,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
-      // Supone que el ID del grupo de usuarios está configurado en el entorno de Lambda
+      // Asume que el ID del user pool está configurado en el entorno lambda
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -407,9 +407,9 @@ export const createIdentityPlugin = () => {
 </TabItem>
 </Tabs>
 
-## Implementando tu API tRPC
+## Desplegando tu API tRPC
 
-El generador de backend tRPC crea un construct CDK para implementar tu API en la carpeta `common/constructs`. Puedes consumirlo en una aplicación CDK, por ejemplo:
+El generador de backend tRPC crea un construct CDK para desplegar tu API en la carpeta `common/constructs`. Puedes usarlo en una aplicación CDK, por ejemplo:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
@@ -424,7 +424,7 @@ export class ExampleStack extends Stack {
 }
 ```
 
-Esto configura la infraestructura de tu API, incluyendo una REST API o HTTP API de AWS API Gateway, funciones AWS Lambda para lógica de negocio, y autenticación IAM.
+Esto configura la infraestructura de tu API, incluyendo una API REST o HTTP de AWS API Gateway, funciones AWS Lambda para lógica de negocio, y autenticación IAM.
 
 ### Integraciones Tipadas
 
@@ -434,9 +434,9 @@ Esto configura la infraestructura de tu API, incluyendo una REST API o HTTP API 
 Cuando añades o eliminas un procedimiento en tu API tRPC, estos cambios se reflejarán inmediatamente en el construct CDK sin necesidad de reconstruir.
 :::
 
-### Otorgando Acceso
+### Concediendo Acceso
 
-Puedes usar el método `grantInvokeAccess` para otorgar acceso a tu API, por ejemplo podrías querer dar acceso a usuarios autenticados de Cognito:
+Puedes usar el método `grantInvokeAccess` para conceder acceso a tu API. Por ejemplo, podrías querer dar acceso a usuarios autenticados de Cognito:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -444,15 +444,15 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## Servidor Local tRPC
 
-Puedes usar el target `serve` para ejecutar un servidor local para tu API, por ejemplo:
+Puedes usar el target `serve` para ejecutar un servidor local de tu API, por ejemplo:
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
-El punto de entrada para el servidor local está en `src/local-server.ts`.
+El punto de entrada del servidor local está en `src/local-server.ts`.
 
 ## Invocando tu API tRPC
 
-Puedes crear un cliente tRPC para invocar tu API de forma tipada. Si estás llamando a tu API tRPC desde otro backend, puedes usar el cliente en `src/client/index.ts`, por ejemplo:
+Puedes crear un cliente tRPC para invocar tu API de forma tipada. Si llamas a tu API tRPC desde otro backend, puedes usar el cliente en `src/client/index.ts`, por ejemplo:
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -462,7 +462,7 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: '¡Hola mundo!' });
 ```
 
-Si estás llamando a tu API desde un sitio React, considera usar el generador <Link path="guides/api-connection/react-trpc">Conexión API</Link> para configurar el cliente.
+Si llamas a tu API desde un sitio web React, considera usar el generador <Link path="guides/api-connection/react-trpc">API Connection</Link> para configurar el cliente.
 
 ## Más Información
 

--- a/docs/src/content/docs/es/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/es/guides/ts-mcp-server.mdx
@@ -14,13 +14,13 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 # Generador de Servidor MCP en TypeScript
 
-Genera un servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript para proporcionar contexto a Modelos de Lenguaje Grande (LLMs).
+Genera un servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript para proporcionar contexto a Modelos de Lenguaje Grandes (LLMs).
 
 ## ¿Qué es MCP?
 
 El [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) es un estándar abierto que permite a los asistentes de IA interactuar con herramientas y recursos externos. Proporciona una forma consistente para que los LLMs puedan:
 
-- Ejecutar herramientas (funciones) que realizan acciones u obtienen información
+- Ejecutar herramientas (funciones) que realizan acciones o recuperan información
 - Acceder a recursos que proveen contexto o datos
 
 ## Uso
@@ -33,7 +33,7 @@ Puedes generar un servidor MCP en TypeScript de dos formas:
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## Salida del Generador
 
@@ -42,7 +42,7 @@ El generador creará los siguientes archivos del proyecto:
 <FileTree>
   - packages/\<nombre>/
     - README.md Documentación del servidor MCP con instrucciones de uso
-    - project.json Configuración de proyecto Nx con objetivos de build, bundle y dev
+    - project.json Configuración del proyecto Nx con objetivos de build, bundle y dev
     - src/
       - index.ts Punto de entrada del servidor MCP
       - server.ts Definición principal del servidor, con herramientas y recursos
@@ -59,10 +59,10 @@ Consulta la <Link path="/guides/typescript-project">documentación del generador
 
 ### Añadiendo Herramientas
 
-Las herramientas son funciones que el asistente de IA puede llamar para realizar acciones. Puedes añadir nuevas herramientas en el archivo `server.ts`:
+Las herramientas son funciones que el asistente de IA puede ejecutar. Puedes añadir nuevas herramientas en el archivo `server.ts`:
 
 ```typescript
-server.tool("toolName",
+server.tool("nombreHerramienta",
   { param1: z.string(), param2: z.number() }, // Esquema de entrada usando Zod
   async ({ param1, param2 }) => {
     // Implementación de la herramienta
@@ -96,23 +96,23 @@ server.resource('recurso-dinamico', 'dynamic://recurso', async (uri) => {
 
 ## Configuración con Asistentes de IA
 
-Para usar tu servidor MCP con asistentes de IA, primero debes agruparlo (bundle):
+Para usar tu servidor MCP con asistentes de IA, primero debes empaquetarlo:
 
-<NxCommands commands={['run tu-servidor-mcp:bundle']} />
+<NxCommands commands={['run your-mcp-server:bundle']} />
 
-Esto crea una versión agrupada en `dist/packages/tu-servidor-mcp/bundle/index.js` (la ruta puede variar según tu configuración).
+Esto crea una versión empaquetada en `dist/packages/your-mcp-server/bundle/index.js` (la ruta puede variar según tu configuración).
 
 ### Archivos de Configuración
 
-La mayoría de asistentes de IA que soportan MCP usan un enfoque similar de configuración. Deberás crear o actualizar un archivo de configuración con los detalles de tu servidor MCP:
+La mayoría de asistentes de IA que soportan MCP usan un enfoque similar. Deberás crear/actualizar un archivo de configuración con los detalles de tu servidor:
 
 ```json
 {
   "mcpServers": {
-    "tu-servidor-mcp": {
+    "your-mcp-server": {
       "command": "node",
       "args": [
-        "/ruta/al/workspace/dist/packages/tu-servidor-mcp/bundle/index.js"
+        "/ruta/al/workspace/dist/packages/your-mcp-server/bundle/index.js"
       ],
       "transportType": "stdio"
     }
@@ -120,15 +120,15 @@ La mayoría de asistentes de IA que soportan MCP usan un enfoque similar de conf
 }
 ```
 
-Reemplaza `/ruta/al/workspace/dist/packages/tu-servidor-mcp/bundle/index.js` con la ruta real a tu servidor MCP agrupado.
+Reemplaza `/ruta/al/workspace/dist/packages/your-mcp-server/bundle/index.js` con la ruta real a tu servidor empaquetado.
 
 :::caution
-Si recibes un error como `ENOENT node` al conectar con tu servidor, posiblemente necesites especificar la ruta completa a `node`, que puedes obtener ejecutando `which node` en tu terminal.
+Si recibes un error como `ENOENT node` al conectar, quizás debes especificar la ruta completa a `node`, que puedes obtener ejecutando `which node` en tu terminal.
 :::
 
 ### Configuración Específica por Asistente
 
-Consulta la siguiente documentación para configurar MCP con asistentes de IA específicos:
+Consulta estas guías para configurar MCP con asistentes específicos:
 
 - [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
 - [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
@@ -136,31 +136,31 @@ Consulta la siguiente documentación para configurar MCP con asistentes de IA es
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
 
 :::tip
-Algunos asistentes de IA, como Amazon Q Developer, permiten especificar configuración de servidores MCP a nivel de workspace, lo cual es particularmente útil para definir los servidores MCP relevantes para un proyecto específico.
+Algunos asistentes como Amazon Q Developer permiten configuración de servidores MCP a nivel de workspace, útil para definir servidores relevantes a un proyecto.
 :::
 
 ## Flujo de Desarrollo
 
 ### Objetivos de Build
 
-El generador está construido sobre el <Link path="/guides/typescript-project">generador de proyectos TypeScript</Link> y por tanto hereda sus objetivos, además de añadir los siguientes:
+Este generador se basa en el <Link path="/guides/typescript-project">generador de proyectos TypeScript</Link> y hereda sus objetivos, añadiendo estos adicionales:
 
 #### Bundle
 
-La tarea `bundle` usa [esbuild](https://esbuild.github.io/) para crear un único archivo JavaScript agrupado que puede usarse con asistentes de IA:
+El objetivo `bundle` usa [esbuild](https://esbuild.github.io/) para crear un único archivo JavaScript empaquetado:
 
-<NxCommands commands={['run tu-servidor-mcp:bundle']} />
+<NxCommands commands={['run your-mcp-server:bundle']} />
 
-Esto crea una versión agrupada en `dist/packages/tu-servidor-mcp/bundle/index.js` (la ruta puede variar según tu configuración).
+Esto genera el bundle en `dist/packages/your-mcp-server/bundle/index.js` (ruta puede variar).
 
 #### Dev
 
-La tarea `dev` monitorea cambios en tu proyecto y reconstruye automáticamente el bundle:
+El objetivo `dev` monitorea cambios y reconstruye automáticamente:
 
-<NxCommands commands={['run tu-servidor-mcp:dev']} />
+<NxCommands commands={['run your-mcp-server:dev']} />
 
-Es particularmente útil durante el desarrollo, ya que asegura que tu asistente de IA utilice la última versión de tu servidor MCP.
+Es útil durante desarrollo para que tu asistente use siempre la última versión.
 
 :::note
-Algunos asistentes de IA requerirán que reinicies el servidor MCP para que los cambios surtan efecto.
+Algunos asistentes requieren reiniciar el servidor MCP para aplicar cambios.
 :::

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -10,9 +10,8 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
-El [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) es un framework para definir infraestructura cloud en código y aprovisionarla mediante AWS CloudFormation.
+[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) es un framework para definir infraestructura en la nube mediante código y provisionarla a través de AWS CloudFormation.
 
 El generador de infraestructura TypeScript crea una aplicación de infraestructura AWS CDK escrita en TypeScript. La aplicación generada incluye mejores prácticas de seguridad mediante verificaciones de [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html).
 
@@ -26,25 +25,25 @@ Puedes generar un nuevo proyecto de infraestructura de dos formas:
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
-## Salida del generador
+## Resultado del generador
 
 El generador creará la siguiente estructura de proyecto en el directorio `<directory>/<name>`:
 
 <FileTree>
 
   - src
-    - main.ts Punto de entrada de la aplicación instanciando stacks CDK para desplegar
-    - stacks Definiciones de stacks CDK
+    - main.ts Punto de entrada de la aplicación que instancia los stacks de CDK a desplegar
+    - stacks Definiciones de stacks de CDK
       - application-stack.ts Stack principal de la aplicación
   - cdk.json Configuración de CDK
-  - project.json Configuración del proyecto y objetivos de construcción
+  - project.json Configuración del proyecto y objetivos de build
 
 </FileTree>
 
-:::tip
-Tu infraestructura es un proyecto TypeScript, por lo que puedes consultar la <Link path="guides/typescript-project">documentación de proyectos TypeScript</Link> para más detalles sobre su uso general.
+:::consejo
+Tu infraestructura es un proyecto TypeScript, por lo que puedes consultar la <Link path="guides/typescript-project">documentación de proyectos TypeScript</Link> para obtener más detalles sobre su uso general.
 :::
 
 ## Implementando tu infraestructura CDK
@@ -66,11 +65,11 @@ export class ApplicationStack extends cdk.Stack {
 }
 ```
 
-### Infraestructura de API
+### Infraestructura para API
 
-Si has usado los generadores <Link path="guides/trpc">tRPC API</Link> o <Link path="guides/fastapi">FastAPI</Link> para crear APIs, notarás que ya tienes algunos constructos disponibles en `packages/common/constructs` para desplegarlas.
+Si has utilizado los generadores <Link path="guides/trpc">tRPC API</Link> o <Link path="guides/fastapi">FastAPI</Link> para crear APIs, notarás que ya tienes algunos constructos disponibles en `packages/common/constructs` para desplegarlos.
 
-Si, por ejemplo, creaste una API tRPC llamada `my-api`, simplemente puedes importar e instanciar el constructo para añadir toda la infraestructura necesaria para desplegarla:
+Si, por ejemplo, creaste una API tRPC llamada `my-api`, simplemente puedes importar e instanciar el constructo para añadir toda la infraestructura necesaria:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -87,9 +86,9 @@ export class ApplicationStack extends cdk.Stack {
 }
 ```
 
-### Infraestructura de sitio web
+### Infraestructura para sitios web
 
-Si has usado el generador <Link path="guides/cloudscape-website">CloudScape website</Link>, notarás que ya tienes un constructo en `packages/common/constructs` para desplegarlo. Por ejemplo:
+Si has usado el generador <Link path="guides/cloudscape-website">sitio web CloudScape</Link>, notarás que ya tienes un constructo en `packages/common/constructs` para desplegarlo. Por ejemplo:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -106,23 +105,23 @@ export class ApplicationStack extends cdk.Stack {
 }
 ```
 
-:::warning
-Es importante asegurarse de que el sitio web se declare _después_ de cualquier constructo de API para que la <Link path="guides/cloudscape-website#runtime-configuration">Configuración en tiempo de ejecución</Link> del sitio web incluya toda la configuración de las APIs.
+:::advertencia
+Es importante asegurarse de que el sitio web se declare _después_ de cualquier constructo de API para que la <Link path="guides/cloudscape-website#runtime-configuration">Configuración en Tiempo de Ejecución</Link> del sitio web incluya toda la configuración de las APIs.
 :::
 
 ## Sintetizando tu infraestructura
 
-Como parte de tu objetivo `build`, además de ejecutar los <Link path="guides/typescript-project#building">objetivos predeterminados de compilación, lint y pruebas</Link>, tu proyecto de infraestructura se _sintetiza_ a CloudFormation. Esto también puede ejecutarse de forma independiente mediante el objetivo `synth`:
+Como parte de tu objetivo `build`, además de ejecutar los <Link path="guides/typescript-project#building">objetivos predeterminados de compilación, lint y pruebas</Link>, tu proyecto de infraestructura se _sintetiza_ en CloudFormation. Esto también puede ejecutarse de forma independiente mediante el objetivo `synth`:
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
 Encontrarás tu cloud assembly sintetizado en la carpeta `dist` raíz, bajo `dist/packages/<my-infra-project>/cdk.out`.
 
-## Preparando tu(s) cuenta(s) de AWS
+## Bootstrapping de tu(s) cuenta(s) AWS
 
-Si estás desplegando una aplicación CDK en una cuenta de AWS por primera vez, será necesario prepararla primero.
+Si estás desplegando una aplicación CDK en una cuenta AWS por primera vez, necesitarás hacer bootstrap primero.
 
-Primero, asegúrate de haber [configurado credenciales para tu cuenta de AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
+Primero, asegúrate de haber [configurado credenciales para tu cuenta AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
 Luego, puedes usar el comando `cdk bootstrap`:
 
@@ -132,33 +131,33 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 Para más detalles, consulta la [documentación de CDK](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html).
 
-## Desplegando en AWS
+## Despliegue en AWS
 
-Después de una construcción, puedes desplegar tu infraestructura en AWS usando el objetivo `deploy`.
+Después de un build, puedes desplegar tu infraestructura en AWS usando el objetivo `deploy`.
 
-:::caution
-Usa el objetivo `deploy-ci` si despliegas en un pipeline CI/CD. Ver más detalles abajo.
+:::precaución
+Utiliza el objetivo `deploy-ci` si desplegas en un pipeline de CI/CD. Ver más detalles abajo.
 :::
 
-Primero, asegúrate de haber [configurado credenciales para tu cuenta de AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
+Primero, asegúrate de haber [configurado credenciales para tu cuenta AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
 Luego, ejecuta el objetivo deploy:
 
 <NxCommands commands={['run <my-infra>:deploy --all']} />
 
-:::tip
+:::consejo
 El comando anterior despliega _todos_ los stacks definidos en `main.ts`. Puedes querer apuntar a un stack individual, especialmente si has configurado múltiples etapas de una aplicación:
 
 <NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
 :::
 
-## Desplegando en AWS en un pipeline CI/CD
+## Despliegue en AWS en un pipeline de CI/CD
 
-Usa el objetivo `deploy-ci` si despliegas en AWS como parte de un pipeline CI/CD.
+Utiliza el objetivo `deploy-ci` si estás desplegando en AWS como parte de un pipeline de CI/CD.
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-Este objetivo difiere ligeramente del objetivo `deploy` regular en que garantiza que se despliegue una cloud-assembly pre-sintetizada, en lugar de sintetizarla sobre la marcha. Esto ayuda a evitar posibles problemas de no determinismo debido a cambios en versiones de paquetes, asegurando que cada etapa del pipeline despliegue usando la misma cloud-assembly.
+Este objetivo difiere ligeramente del objetivo `deploy` regular en que asegura que se despliegue una cloud-assembly pre-sintetizada, en lugar de sintetizarla sobre la marcha. Esto ayuda a evitar posibles problemas de no determinismo debido a cambios en versiones de paquetes, garantizando que cada etapa del pipeline despliegue usando la misma cloud-assembly.
 
 ## Más información
 

--- a/docs/src/content/docs/es/guides/typescript-project.mdx
+++ b/docs/src/content/docs/es/guides/typescript-project.mdx
@@ -10,7 +10,6 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
 El generador de proyectos TypeScript permite crear bibliotecas o aplicaciones modernas con [TypeScript](https://www.typescriptlang.org/) configuradas con mejores prácticas como [Módulos ECMAScript (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), [referencias de proyecto](https://www.typescriptlang.org/docs/handbook/project-references.html) de TypeScript, [Vitest](https://vitest.dev/) para ejecutar pruebas y [ESLint](https://eslint.org/) para análisis estático.
 
@@ -18,15 +17,15 @@ El generador de proyectos TypeScript permite crear bibliotecas o aplicaciones mo
 
 ### Generar un proyecto TypeScript
 
-Puedes crear un nuevo proyecto TypeScript de dos formas:
+Puedes generar un nuevo proyecto TypeScript de dos formas:
 
 <RunGenerator generator="ts#project" />
 
 ### Opciones
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
-## Resultado del generador
+## Salida del generador
 
 El generador creará la siguiente estructura de proyecto en el directorio `<directory>/<name>`:
 
@@ -34,8 +33,8 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
   - src Código fuente TypeScript
     - index.ts
-  - project.json Configuración del proyecto y objetivos de compilación
-  - tsconfig.json Configuración base de TypeScript para este proyecto (extiende tsconfig.base.json del espacio de trabajo)
+  - project.json Configuración del proyecto y objetivos de build
+  - tsconfig.json Configuración base de TypeScript para este proyecto (extiende tsconfig.base.json del workspace)
   - tsconfig.lib.json Configuración TypeScript para tu biblioteca (código de ejecución o empaquetado)
   - tsconfig.spec.json Configuración TypeScript para tus pruebas
   - vite.config.ts Configuración para Vitest
@@ -44,15 +43,15 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 </FileTree>
 
 :::tip
-¡Observa que no se crea ningún archivo `package.json` para este proyecto! Puedes descubrir por qué [a continuación](#dependencies).
+¡Observa que no se crea ningún archivo `package.json` para este proyecto! Puedes descubrir por qué [abajo](#dependencies).
 :::
 
-También notarás cambios en los siguientes archivos del directorio raíz:
+También notarás cambios en los siguientes archivos en la raíz de tu workspace:
 
 <FileTree>
 
   - nx.json La configuración de Nx se actualiza para configurar el plugin @nx/js/typescript para tu proyecto
-  - tsconfig.base.json Se establece un alias TypeScript para tu proyecto permitiendo su importación desde otros proyectos
+  - tsconfig.base.json Se configura un alias TypeScript para tu proyecto para que pueda ser importado por otros proyectos
   - tsconfig.json Se añade una referencia de proyecto TypeScript para tu proyecto
 
 </FileTree>
@@ -63,19 +62,19 @@ Añade tu código TypeScript en el directorio `src`.
 
 ### Sintaxis de importación ESM
 
-Al ser tu proyecto un Módulo ES, usa la sintaxis ESM correcta en las importaciones, incluyendo explícitamente la extensión de archivo:
+Como tu proyecto TypeScript es un Módulo ES, asegúrate de escribir las sentencias de importación con la sintaxis ESM correcta, incluyendo explícitamente la extensión del archivo:
 
 ```ts title="index.ts" ".js"
 import { sayHello } from './hello.js';
 ```
 
 :::note
-Aunque usemos TypeScript y `sayHello` esté definido en `hello.ts`, usamos la extensión `.js` en la importación. Más detalles [aquí](https://www.typescriptlang.org/docs/handbook/modules/reference.html).
+Aunque usemos TypeScript y `sayHello` esté definido en `hello.ts`, usamos la extensión `.js` en la importación. Puedes leer más sobre esto [aquí](https://www.typescriptlang.org/docs/handbook/modules/reference.html).
 :::
 
 ### Exportar para otros proyectos TypeScript
 
-El punto de entrada es `src/index.ts`. Añade aquí las exportaciones que quieras compartir:
+El punto de entrada de tu proyecto TypeScript es `src/index.ts`. Puedes añadir exports aquí para cualquier elemento que quieras que otros proyectos puedan importar:
 
 ```ts title="src/index.ts"
 export { sayHello } from './hello.js';
@@ -84,17 +83,17 @@ export * from './algorithms/index.js';
 
 ### Importar tu biblioteca en otros proyectos
 
-Los [alias TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) configurados en `tsconfig.base.json` permiten referenciar tu proyecto desde otros:
+Los [alias de TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) para tu proyecto se configuran en el archivo `tsconfig.base.json` del workspace, permitiendo referenciar tu proyecto TypeScript desde otros proyectos:
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
 ```
 
 :::note
-Los alias comienzan con `:` para evitar conflictos con paquetes remotos en [NPM](https://www.npmjs.com/).
+Los alias para proyectos TypeScript comienzan con `:` en lugar del tradicional `@`, evitando posibles conflictos de nombres entre paquetes locales en tu workspace y paquetes remotos en [NPM](https://www.npmjs.com/).
 :::
 
-Al añadir una importación a un nuevo proyecto, podrías ver un error como este:
+Cuando añadas una sentencia de importación para un nuevo proyecto en tu workspace por primera vez, es probable que veas un error en tu IDE similar a este:
 
 <details>
 <summary>Error de importación</summary>
@@ -108,16 +107,16 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 </details>
 
-Esto ocurre porque falta una [referencia de proyecto](https://www.typescriptlang.org/docs/handbook/project-references.html).
+Esto ocurre porque no se ha configurado una [referencia de proyecto](https://www.typescriptlang.org/docs/handbook/project-references.html).
 
-Los proyectos TypeScript vienen configurados con el generador de sincronización de Nx. Ejecuta este comando para añadir la configuración necesaria:
+Los proyectos TypeScript vienen configurados con el generador Nx TypeScript Sync, evitando que necesites configurar manualmente las referencias. Simplemente ejecuta el siguiente comando y Nx añadirá la configuración requerida:
 
 <NxCommands commands={['sync']} />
 
-Tras esto, el error debería desaparecer.
+Después de esto, el error en tu IDE debería desaparecer y podrás usar tu biblioteca.
 
 :::tip
-Al compilar tu proyecto, verás un mensaje como:
+También puedes simplemente construir tu proyecto y verás un mensaje como:
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -129,22 +128,24 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Selecciona `Yes` para actualizar las referencias.
+Selecciona `Yes` para permitir que Nx actualice tus referencias de proyecto.
 :::
 
 ### Dependencias
 
-Tu proyecto TypeScript no tiene `package.json`. Para añadir dependencias:
+Notarás que tu proyecto TypeScript no tiene archivo `package.json`, lo cual puede resultar inesperado si estás acostumbrado a monorepos TypeScript tradicionales.
 
-1. Añádelas al `package.json` raíz de tu espacio de trabajo usando tu gestor de paquetes:
+Para añadir una dependencia a cualquier paquete TypeScript en tu monorepo, simplemente añádela al `package.json` en la raíz de tu workspace. Puedes hacerlo vía línea de comandos:
 
 <InstallCommand pkg="some-npm-package" />
 
+La dependencia estará disponible para cualquier proyecto TypeScript en tu workspace.
+
 #### Código de ejecución
 
-Para usar tu proyecto como código de ejecución (ej: en AWS Lambda), se recomienda usar [`esbuild`](https://esbuild.github.io/) para empaquetarlo y aplicar [tree-shaking](https://esbuild.github.io/api/#tree-shaking).
+Cuando uses tu proyecto TypeScript como código de ejecución (por ejemplo como handler de una función AWS Lambda), se recomienda usar una herramienta como [`esbuild`](https://esbuild.github.io/) para empaquetar tu proyecto, ya que permite [tree-shaking](https://esbuild.github.io/api/#tree-shaking) para incluir solo las dependencias usadas.
 
-Añade un objetivo como este en `project.json`:
+Puedes lograrlo añadiendo un objetivo como este en tu `project.json`:
 
 ```json
 {
@@ -164,81 +165,94 @@ Añade un objetivo como este en `project.json`:
 ```
 
 :::note
-El punto de entrada `src/index.ts` incluirá en el bundle todo su código y dependencias.
+En el objetivo anterior usamos `src/index.ts` como punto de entrada, lo que significa que el código exportado desde este archivo se incluirá en el bundle junto con sus dependencias.
 :::
 
 #### Publicar en NPM
 
-Si publicas tu proyecto en NPM, debes crear un `package.json`. Usa el [plugin ESLint de NX](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) para verificar dependencias.
+Si vas a publicar tu proyecto TypeScript en NPM, debes crear un archivo `package.json` para él.
 
-### Compilación
+Este debe declarar las dependencias que usa tu proyecto. Como en tiempo de build las dependencias se resuelven desde el `package.json` raíz, se recomienda configurar el [plugin ESLint de NX para verificación de dependencias](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) para asegurar que tu `package.json` publicado incluye todas las dependencias usadas.
 
-El objetivo `build` compila, verifica y prueba tu proyecto. Ejecútalo con:
+### Construcción
+
+Tu proyecto TypeScript tiene un objetivo `build` (definido en `project.json`) que puedes ejecutar con:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-La salida se encuentra en `dist/packages/<my-library>/tsc`.
+Donde `<project-name>` es el nombre completo de tu proyecto.
+
+El objetivo `build` compilará, linteará y probará tu proyecto.
+
+La salida del build se encuentra en la carpeta `dist` raíz de tu workspace, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<my-library>/tsc`
 
 ## Pruebas
 
-[Vitest](https://vitest.dev/) está configurado para testing.
+[Vitest](https://vitest.dev/) está configurado para probar tu proyecto.
 
-### Escribir pruebas
+### Escribiendo pruebas
 
-Crea archivos `.spec.ts` o `.test.ts` junto a tu código:
+Las pruebas deben escribirse en archivos `.spec.ts` o `.test.ts`, ubicados junto al código en la carpeta `src`.
+
+Ejemplo:
 
 <FileTree>
   - src
-    - hello.ts Código fuente
+    - hello.ts Código de la biblioteca
     - hello.spec.ts Pruebas para hello.ts
 </FileTree>
 
-Ejemplo de prueba:
+Vitest provee sintaxis similar a Jest para definir pruebas, con utilidades como `describe`, `it`, `test` y `expect`.
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
 
 describe('sayHello', () => {
 
-  it('debería saludar al usuario', () => {
-    expect(sayHello('Darth Vader')).toBe('¡Hola, Darth Vader!');
+  it('debe saludar al llamador', () => {
+    expect(sayHello('Darth Vader')).toBe('Hello, Darth Vader!');
   });
 
 });
+
 ```
 
-Consulta la [documentación de Vitest](https://vitest.dev/guide/#writing-tests) para más detalles.
+Para más detalles sobre cómo escribir pruebas y características como mocks, consulta la [documentación de Vitest](https://vitest.dev/guide/#writing-tests)
 
-### Ejecutar pruebas
+### Ejecutando pruebas
 
-Ejecuta todas las pruebas con:
+Las pruebas se ejecutan como parte del objetivo `build`, pero también puedes ejecutarlas por separado con el objetivo `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Para pruebas específicas:
+Puedes ejecutar una prueba individual con el flag `-t`:
 
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-Usuarios de VSCode: instala la extensión [Vitest Runner](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) para ejecutar pruebas desde el IDE.
+Si usas VSCode, recomendamos instalar la extensión [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) para ejecutar, monitorear o depurar pruebas desde tu IDE.
 :::
 
 ## Linting
 
-Los proyectos usan [ESLint](https://eslint.org/) y [Prettier](https://prettier.io/). Configúralos en los archivos raíz `eslint.config.mjs` y `.prettierrc`.
+Los proyectos TypeScript usan [ESLint](https://eslint.org/) para linting junto con [Prettier](https://prettier.io/) para formateo.
 
-### Ejecutar el linter
+Recomendamos configurar ESLint en el archivo `eslint.config.mjs` raíz del workspace, ya que los cambios aplicarán a todos los proyectos y garantizarán consistencia.
 
-Verifica tu proyecto con:
+De igual forma, puedes configurar Prettier en el archivo `.prettierrc` raíz.
+
+### Ejecutando el linter
+
+Para ejecutar el linter y verificar tu proyecto, usa el objetivo `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corregir problemas
+### Corrigiendo problemas de lint
 
-Corrige automáticamente con:
+La mayoría de problemas de lint o formateo pueden corregirse automáticamente. Puedes indicar a ESLint que corrija los problemas ejecutando con el argumento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Para todo el espacio de trabajo:
+Para corregir todos los problemas en todos los paquetes de tu workspace, ejecuta:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/fr/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/api-connection/react-fastapi.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Réagir à FastAPI"
-description: "Connecter un site web React à un Python FastAPI"
+description: "Connecter un site web React à un FastAPI Python"
 ---
 
 
@@ -11,16 +11,15 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Le générateur `api-connection` permet d'intégrer rapidement votre site React avec votre backend FastAPI. Il configure tous les éléments nécessaires pour connecter vos backends FastAPI de manière typée, incluant la génération de client et de hooks [TanStack Query](https://tanstack.com/query/v5), le support de l'authentification AWS IAM et une gestion d'erreurs appropriée.
+Le générateur `api-connection` permet d'intégrer rapidement votre site React avec votre backend FastAPI. Il configure toute la configuration nécessaire pour se connecter à vos backends FastAPI de manière type-safe, incluant la génération de client et de hooks [TanStack Query](https://tanstack.com/query/v5), le support de l'authentification AWS IAM et une gestion d'erreurs appropriée.
 
 ## Prérequis
 
 Avant d'utiliser ce générateur, assurez-vous que votre application React possède :
 
 1. Un fichier `main.tsx` qui rend votre application
-2. Un backend FastAPI fonctionnel (généré avec le générateur FastAPI)
+2. Un backend FastAPI fonctionnel (généré via le générateur FastAPI)
 
 <details>
 <summary>Exemple de structure requise pour `main.tsx`</summary>
@@ -50,7 +49,7 @@ root.render(
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## Résultat du générateur
 
@@ -60,7 +59,7 @@ Le générateur modifiera les fichiers suivants dans votre projet FastAPI :
 
 - scripts
   - generate_open_api.py Ajoute un script générant la spécification OpenAPI pour votre API
-- project.json Une nouvelle cible est ajoutée à la build pour exécuter le script de génération
+- project.json Ajoute une nouvelle cible de build invoquant le script de génération
 
 </FileTree>
 
@@ -73,19 +72,19 @@ Le générateur modifiera les fichiers suivants dans votre application React :
     - \<ApiName>Provider.tsx Provider pour le client de votre API
     - QueryClientProvider.tsx Provider du client TanStack React Query
   - hooks
-    - use\<ApiName>.tsx Ajoute un hook pour appeler votre API avec état géré par TanStack Query
+    - use\<ApiName>.tsx Ajoute un hook pour appeler votre API avec l'état géré par TanStack Query
     - use\<ApiName>Client.tsx Ajoute un hook pour instancier le client vanilla pouvant appeler votre API
     - useSigV4.tsx Ajoute un hook pour signer les requêtes HTTP avec SigV4 (si l'authentification IAM est sélectionnée)
-- project.json Une nouvelle cible est ajoutée à la build pour générer un client typé
+- project.json Ajoute une nouvelle cible de build générant un client type-safe
 - .gitignore Les fichiers clients générés sont ignorés par défaut
 
 </FileTree>
 
-Le générateur ajoutera aussi une configuration Runtime à votre infrastructure de site si absente, garantissant que l'URL de l'API FastAPI est disponible dans le site et configurée automatiquement par le hook `use<ApiName>.tsx`.
+Le générateur ajoutera également une configuration Runtime à votre infrastructure de site si elle n'est pas déjà présente, garantissant que l'URL de l'API FastAPI est disponible dans le site et configurée automatiquement par le hook `use<ApiName>.tsx`.
 
 ### Génération de code
 
-Lors de la build, un client typé est généré à partir de la spécification OpenAPI de votre FastAPI. Cela ajoutera trois nouveaux fichiers à votre application React :
+Au moment du build, un client type-safe est généré à partir de la spécification OpenAPI de votre FastAPI. Cela ajoutera trois nouveaux fichiers à votre application React :
 
 <FileTree>
 
@@ -93,27 +92,27 @@ Lors de la build, un client typé est généré à partir de la spécification O
   - generated
     - \<ApiName>
       - types.gen.ts Types générés à partir des modèles pydantic de votre FastAPI
-      - client.gen.ts Client typé pour appeler votre API
+      - client.gen.ts Client type-safe pour appeler votre API
       - options-proxy.gen.ts Fournit des méthodes pour créer des options de hooks TanStack Query interagissant avec votre API
 
 </FileTree>
 
-:::tip
-Par défaut, le client généré est ignoré du contrôle de version. Pour l'inclure, supprimez l'entrée du fichier `.gitignore` de votre application React. Notez que toute modification manuelle des fichiers `.gen.ts` sera écrasée lors de la build.
+:::astuce
+Par défaut, le client généré est ignoré du contrôle de version. Si vous préférez l'inclure, vous pouvez supprimer l'entrée du fichier `.gitignore` de votre application React, mais notez que toute modification manuelle des fichiers `.gen.ts` sera écrasée lors du build.
 :::
 
 ## Utiliser le code généré
 
-Le client typé généré permet d'appeler votre FastAPI depuis votre application React. Il est recommandé d'utiliser les hooks TanStack Query, mais le client vanilla est aussi disponible.
+Le client type-safe généré peut être utilisé pour appeler votre FastAPI depuis votre application React. Il est recommandé d'utiliser les hooks TanStack Query, mais le client vanilla est également disponible.
 
 :::note
-Après toute modification de votre FastAPI, reconstruisez votre projet pour refléter les changements dans le client généré. Exemple :
+Après toute modification de votre FastAPI, vous devez reconstruire votre projet pour refléter ces changements dans le client généré. Par exemple :
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
-:::tip
-Pour régénérer automatiquement le client lors des modifications de l'API, utilisez [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) :
+:::astuce
+Si vous travaillez simultanément sur votre application React et votre FastAPI, vous pouvez utiliser [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) pour régénérer le client à chaque modification :
 
 <NxCommands
   commands={[
@@ -129,7 +128,7 @@ Le générateur fournit un hook `use<ApiName>` pour appeler votre API avec TanSt
 
 ### Requêtes
 
-Utilisez `queryOptions` pour récupérer les options nécessaires à `useQuery` de TanStack Query :
+Utilisez la méthode `queryOptions` pour récupérer les options nécessaires à l'appel de votre API via le hook `useQuery` de TanStack Query :
 
 ```tsx {7}
 import { useQuery } from '@tanstack/react-query';
@@ -147,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="Utilisation directe du client API" trigger="Cliquez ici pour un exemple utilisant directement le client vanilla.">
+<Drawer title="Utiliser le client API directement" trigger="Cliquez ici pour un exemple utilisant le client vanilla directement.">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -182,7 +181,7 @@ function MyComponent() {
 
 ### Mutations
 
-Les hooks générés supportent les mutations avec `useMutation` de TanStack Query, gérant les états de chargement, les erreurs et les mises à jour optimistes.
+Les hooks générés incluent la prise en charge des mutations via le hook `useMutation` de TanStack Query. Cela permet de gérer les opérations de création, mise à jour et suppression avec des états de chargement, la gestion d'erreurs et des mises à jour optimistes.
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -190,7 +189,7 @@ import { useMyApi } from './hooks/useMyApi';
 
 function CreateItemForm() {
   const api = useMyApi();
-  // Crée une mutation avec les options générées
+  // Créer une mutation avec les options générées
   const createItem = useMutation(api.createItem.mutationOptions());
 
   const handleSubmit = (e) => {
@@ -230,19 +229,24 @@ Vous pouvez ajouter des callbacks pour différents états de mutation :
 const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
+    // Exécuté lorsque la mutation réussit
     console.log('Élément créé :', data);
+    // Navigation vers le nouvel élément
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
+    // Exécuté en cas d'échec
     console.error('Échec de la création :', error);
   },
   onSettled: () => {
+    // Exécuté après succès ou erreur
+    // Invalider les requêtes concernées
     queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
   }
 });
 ```
 
-<Drawer title="Mutations avec le client API directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Mutations avec le client API directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
 ```tsx
 import { useState } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -264,6 +268,8 @@ function CreateItemForm() {
         description: 'Un nouvel élément'
       });
       setCreatedItem(newItem);
+      // Navigation vers le nouvel élément
+      // navigate(`/items/${newItem.id}`);
     } catch (err) {
       setError(err);
       console.error('Échec de la création :', err);
@@ -301,7 +307,7 @@ function CreateItemForm() {
 
 ### Pagination avec requêtes infinies
 
-Pour les endpoints utilisant un paramètre `cursor`, les hooks générés supportent les requêtes infinies avec `useInfiniteQuery` de TanStack Query, facilitant l'implémentation de fonctionnalités "charger plus" ou de défilement infini.
+Pour les endpoints acceptant un paramètre `cursor`, les hooks générés prennent en charge les requêtes infinies via le hook `useInfiniteQuery` de TanStack Query. Cela facilite l'implémentation de fonctionnalités "charger plus" ou de défilement infini.
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -311,8 +317,10 @@ function ItemList() {
   const api = useMyApi();
   const items = useInfiniteQuery({
     ...api.listItems.infiniteQueryOptions({
-      limit: 10,
+      limit: 10, // Nombre d'éléments par page
     }, {
+      // Définir une fonction getNextPageParam retournant
+      // le paramètre 'cursor' pour la page suivante
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor || undefined
       }),
@@ -328,6 +336,7 @@ function ItemList() {
 
   return (
     <div>
+      {/* Aplatir les pages pour afficher tous les éléments */}
       <ul>
         {items.data.pages.flatMap(page =>
           page.items.map(item => (
@@ -351,13 +360,13 @@ function ItemList() {
 }
 ```
 
-Le `nextCursor` est extrait automatiquement de la réponse pour récupérer la page suivante.
+Les hooks générés gèrent automatiquement la pagination par curseur si votre API la supporte. La valeur `nextCursor` est extraite de la réponse et utilisée pour récupérer la page suivante.
 
-:::tip
-Si votre API utilise un paramètre de pagination différent de `cursor`, personnalisez-le avec l'extension OpenAPI `x-cursor`.
+:::astuce
+Si votre API paginée utilise un paramètre autre que `cursor`, vous pouvez le personnaliser via l'extension OpenAPI `x-cursor`.
 :::
 
-<Drawer title="Pagination avec le client API directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Pagination avec le client API directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -370,6 +379,7 @@ function ItemList() {
   const [nextCursor, setNextCursor] = useState(null);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
+  // Récupération initiale
   useEffect(() => {
     const fetchItems = async () => {
       try {
@@ -387,6 +397,7 @@ function ItemList() {
     fetchItems();
   }, [api]);
 
+  // Charger plus d'éléments
   const loadMore = async () => {
     if (!nextCursor) return;
 
@@ -440,7 +451,7 @@ function ItemList() {
 
 ### Gestion des erreurs
 
-L'intégration inclut une gestion d'erreurs typée. Le type `<operation-name>Error` encapsule les réponses d'erreur possibles. En vérifiant le `status`, vous pouvez traiter chaque type d'erreur spécifique.
+L'intégration inclut une gestion d'erreurs typée. Un type `<operation-name>Error` est généré, encapsulant les réponses d'erreur possibles définies dans la spécification OpenAPI. Chaque erreur possède des propriétés `status` et `error`, permettant de cibler un type d'erreur spécifique via `status`.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -456,6 +467,7 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
+        // error.error est typé comme CreateItem400Response
         return (
           <div>
             <h2>Entrée invalide :</h2>
@@ -468,6 +480,7 @@ function MyComponent() {
           </div>
         );
       case 403:
+        // error.error est typé comme CreateItem403Response
         return (
           <div>
             <h2>Non autorisé :</h2>
@@ -476,6 +489,7 @@ function MyComponent() {
         );
       case 500:
       case 502:
+        // error.error est typé comme CreateItem5XXResponse
         return (
           <div>
             <h2>Erreur serveur :</h2>
@@ -490,7 +504,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="Gestion des erreurs avec le client API directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Gestion des erreurs avec le client API directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
 ```tsx {9,15}
 function MyComponent() {
   const api = useMyApiClient();
@@ -508,6 +522,7 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
+        // error.error est typé comme CreateItem400Response
         return (
           <div>
             <h2>Entrée invalide :</h2>
@@ -520,6 +535,7 @@ function MyComponent() {
           </div>
         );
       case 403:
+        // error.error est typé comme CreateItem403Response
         return (
           <div>
             <h2>Non autorisé :</h2>
@@ -528,6 +544,7 @@ function MyComponent() {
         );
       case 500:
       case 502:
+        // error.error est typé comme CreateItem5XXResponse
         return (
           <div>
             <h2>Erreur serveur :</h2>
@@ -543,9 +560,9 @@ function MyComponent() {
 ```
 </Drawer>
 
-### Consommation d'un flux
+### Consommer un flux
 
-Si vous avez <Link path="guides/fastapi#streaming">configuré le streaming dans FastAPI</Link>, le hook `useQuery` mettra automatiquement à jour ses données à l'arrivée de nouveaux chunks.
+Si vous avez <Link path="guides/fastapi#streaming">configuré votre FastAPI pour streamer les réponses</Link>, votre hook `useQuery` mettra automatiquement à jour ses données à chaque réception de nouveau chunk.
 
 Exemple :
 
@@ -566,35 +583,39 @@ function MyStreamingComponent() {
 }
 ```
 
-Le cycle de vie d'un flux :
+Les propriétés `isLoading` et `fetchStatus` permettent de suivre l'état du flux :
 
 <Steps>
-  1. Envoi de la requête HTTP
+  1. La requête HTTP est envoyée
 
-      - `isLoading` : `true`
-      - `fetchStatus` : `'fetching'`
-      - `data` : `undefined`
+      - `isLoading` est `true`
+      - `fetchStatus` est `'fetching'`
+      - `data` est `undefined`
 
-  2. Réception du premier chunk
+  2. Premier chunk reçu
 
-      - `isLoading` : `false`
-      - `fetchStatus` : `'fetching'`
-      - `data` : tableau avec le premier chunk
+      - `isLoading` devient `false`
+      - `fetchStatus` reste `'fetching'`
+      - `data` contient le premier chunk
 
-  3. Réception des chunks suivants
+  3. Chunks suivants
 
-      - `isLoading` : `false`
-      - `fetchStatus` : `'fetching'`
-      - `data` : mis à jour à chaque nouveau chunk
+      - `isLoading` reste `false`
+      - `fetchStatus` reste `'fetching'`
+      - `data` est mis à jour à chaque chunk
 
   4. Fin du flux
 
-      - `isLoading` : `false`
-      - `fetchStatus` : `'idle'`
-      - `data` : tableau complet des chunks
+      - `isLoading` reste `false`
+      - `fetchStatus` devient `'idle'`
+      - `data` contient tous les chunks
 </Steps>
 
-<Drawer title="Streaming avec le client API directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Streaming avec le client API directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
+
+Si vous avez <Link path="guides/fastapi#streaming">configuré le streaming dans FastAPI</Link>, le client généré permet d'itérer sur les chunks via `for await`.
+
+Exemple :
 
 ```tsx {8}
 function MyStreamingComponent() {
@@ -625,14 +646,14 @@ function MyStreamingComponent() {
 </Drawer>
 
 :::note
-Si votre API de streaming utilise un paramètre `cursor`, chaque page attendra la fin du stream avant d'être chargée avec `useInfiniteQuery`.
+Pour les APIs de streaming avec paramètre `cursor`, chaque page via `useInfiniteQuery` attend la fin du stream avant d'être chargée.
 :::
 
-## Personnalisation du code généré
+## Personnaliser le code généré
 
 ### Requêtes et mutations
 
-Par défaut, les méthodes HTTP `PUT`, `POST`, `PATCH` et `DELETE` sont considérées comme des mutations. Ce comportement peut être modifié avec `x-query` et `x-mutation`.
+Par défaut, les opérations FastAPI utilisant `PUT`, `POST`, `PATCH` ou `DELETE` sont considérées comme mutations. Ce comportement peut être modifié via `x-query` et `x-mutation`.
 
 #### x-query
 
@@ -647,7 +668,7 @@ def list_items():
     # ...
 ```
 
-Génère des `queryOptions` pour une méthode POST :
+Le hook généré fournira `queryOptions` malgré la méthode `POST` :
 
 ```tsx
 const items = useQuery(api.listItems.queryOptions());
@@ -666,7 +687,7 @@ def start_processing():
     # ...
 ```
 
-Génère des `mutationOptions` pour une méthode GET :
+Le hook généré fournira `mutationOptions` malgré la méthode `GET` :
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
@@ -674,7 +695,7 @@ const startProcessing = useMutation(api.startProcessing.mutationOptions());
 
 ### Curseur de pagination personnalisé
 
-Par défaut, le paramètre de pagination est nommé `cursor`. Personnalisez-le avec `x-cursor` :
+Par défaut, les hooks supposent un paramètre `cursor`. Personnalisez ce comportement via `x-cursor` :
 
 ```python
 @app.get(
@@ -691,7 +712,7 @@ def list_items(page_token: str = None, limit: int = 10):
     }
 ```
 
-Pour désactiver la pagination :
+Pour désactiver `infiniteQueryOptions`, définissez `x-cursor` à `False` :
 
 ```python
 @app.get(
@@ -732,43 +753,137 @@ def create(item: Item):
     # ...
 ```
 
-Les hooks générés seront groupés :
-
-```tsx
-const api = useMyApi();
-
-// Opérations groupées sous api.items
-const items = useQuery(api.items.list.queryOptions());
-const createItem = useMutation(api.items.create.mutationOptions());
-
-// Opérations groupées sous api.users
-const users = useQuery(api.users.list.queryOptions());
+```python title="users.py"
+@app.get(
+    "/users",
+    tags=["users"],
+)
+def list():
+    # ...
 ```
 
-<Drawer title="Regroupement avec le client API directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+Les hooks générés seront groupés par tags :
+
 ```tsx
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function ItemsAndUsers() {
+  const api = useMyApi();
+
+  // Opérations items groupées sous api.items
+  const items = useQuery(api.items.list.queryOptions());
+  const createItem = useMutation(api.items.create.mutationOptions());
+
+  // Opérations users groupées sous api.users
+  const users = useQuery(api.users.list.queryOptions());
+
+  return (
+    <div>
+      <h2>Éléments</h2>
+      <ul>
+        {items.data?.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+      <button onClick={() => createItem.mutate({ name: 'Nouvel élément' })}>
+        Ajouter
+      </button>
+
+      <h2>Utilisateurs</h2>
+      <ul>
+        {users.data?.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+<Drawer title="Regroupement avec le client API directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
+```tsx
+import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
 
-// Opérations groupées sous api.items
-const itemsData = await api.items.list();
-const newItem = await api.items.create({ name: 'Nouvel élément' });
+function ItemsAndUsers() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
-// Opérations groupées sous api.users
-const usersData = await api.users.list();
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+
+        // Opérations items groupées sous api.items
+        const itemsData = await api.items.list();
+        setItems(itemsData);
+
+        // Opérations users groupées sous api.users
+        const usersData = await api.users.list();
+        setUsers(usersData);
+      } catch (error) {
+        console.error('Erreur :', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [api]);
+
+  const handleCreateItem = async () => {
+    try {
+      const newItem = await api.items.create({ name: 'Nouvel élément' });
+      setItems(prevItems => [...prevItems, newItem]);
+    } catch (error) {
+      console.error('Erreur :', error);
+    }
+  };
+
+  if (isLoading) {
+    return <div>Chargement...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Éléments</h2>
+      <ul>
+        {items.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+      <button onClick={handleCreateItem}>Ajouter</button>
+
+      <h2>Utilisateurs</h2>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 ```
 </Drawer>
 
-:::tip
-Vous pouvez diviser votre API avec plusieurs `routers`. Voir la [documentation FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/).
+:::astuce
+Vous pouvez diviser votre API avec plusieurs `routers`. Voir la [documentation FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/) pour plus de détails.
 :::
 
 ### Erreurs
 
-Personnalisez les réponses d'erreur avec des modèles d'exception et des gestionnaires. Le client généré gérera ces types automatiquement.
+Personnalisez les réponses d'erreur dans FastAPI en définissant des classes d'exceptions, des gestionnaires et des modèles de réponse. Le client généré gérera automatiquement ces types.
 
-#### Définition de modèles d'erreur
+#### Modèles d'erreur personnalisés
+
+Définissez des modèles d'erreur avec Pydantic :
 
 ```python title="models.py"
+from pydantic import BaseModel
+
 class ErrorDetails(BaseModel):
     message: str
 
@@ -777,7 +892,9 @@ class ValidationError(BaseModel):
     field_errors: list[str]
 ```
 
-#### Création d'exceptions
+#### Exceptions personnalisées
+
+Créez des classes d'exceptions :
 
 ```python title="exceptions.py"
 class NotFoundException(Exception):
@@ -791,7 +908,12 @@ class ValidationException(Exception):
 
 #### Gestionnaires d'exceptions
 
+Enregistrez des gestionnaires :
+
 ```python title="main.py"
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
 @app.exception_handler(NotFoundException)
 async def not_found_handler(request: Request, exc: NotFoundException):
     return JSONResponse(
@@ -807,81 +929,203 @@ async def validation_error_handler(request: Request, exc: ValidationException):
     )
 ```
 
-#### Spécification des modèles de réponse
+#### Modèles de réponse
+
+Spécifiez les modèles de réponse dans vos endpoints :
 
 ```python title="main.py"
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str},
+        404: {"model": str}
         500: {"model": ErrorDetails}
     }
 )
 def get_item(item_id: str) -> Item:
-    # ...
+    item = find_item(item_id)
+    if not item:
+        raise NotFoundException(message=f"Élément {item_id} introuvable")
+    return item
 ```
 
 #### Utilisation dans React
 
-Le client gère les types d'erreur personnalisés :
+Le client gère ces types d'erreurs :
 
 ```tsx
-switch (error.status) {
-  case 404:
-    console.error('Non trouvé :', error.error);
-    break;
-  case 500:
-    console.error('Erreur serveur :', error.error.message);
-    break;
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+function ItemComponent() {
+  const api = useMyApi();
+
+  const getItem = useQuery({
+    ...api.getItem.queryOptions({ itemId: '123' }),
+    onError: (error) => {
+      switch (error.status) {
+        case 404:
+          console.error('Introuvable :', error.error);
+          break;
+        case 500:
+          console.error('Erreur serveur :', error.error.message);
+          break;
+      }
+    }
+  });
+
+  // Affichage des erreurs
+  if (getItem.isError) {
+    if (getItem.error.status === 404) {
+      return <NotFoundMessage message={getItem.error.error} />;
+    } else {
+      return <ErrorMessage message={getItem.error.error.message} />;
+    }
+  }
+
+  return <div>{/* Contenu */}</div>;
 }
 ```
 
-<Drawer title="Gestion d'erreurs personnalisées avec le client directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Gestion d'erreurs personnalisées avec le client directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
 ```tsx
-try {
-  await api.createItem(data);
-} catch (e) {
-  const err = e as CreateItemError;
-  switch (err.status) {
-    case 400:
-      console.error('Erreur de validation :', err.error.message);
-      break;
-    case 403:
-      console.error('Interdit :', err.error);
-      break;
+import { useState, useEffect } from 'react';
+
+function ItemComponent() {
+  const api = useMyApiClient();
+  const [item, setItem] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchItem = async () => {
+      try {
+        setLoading(true);
+        const data = await api.getItem({ itemId: '123' });
+        setItem(data);
+      } catch (e) {
+        const err = e as GetItemError;
+        setError(err);
+
+        switch (err.status) {
+          case 404:
+            console.error('Introuvable :', err.error);
+            break;
+          case 500:
+            console.error('Erreur serveur :', err.error.message);
+            break;
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItem();
+  }, [api]);
+
+  if (loading) {
+    return <LoadingSpinner />;
   }
+
+  if (error) {
+    if (error.status === 404) {
+      return <NotFoundMessage message={error.error} />;
+    } else if (error.status === 500) {
+      return <ErrorMessage message={error.error.message} />;
+    }
+  }
+
+  return <div>{/* Contenu */}</div>;
 }
 ```
 </Drawer>
 
-:::tip
-Utilisez toujours le paramètre `responses` dans FastAPI pour spécifier les modèles d'erreur, garantissant un typage correct dans le client.
+:::astuce
+Utilisez toujours le paramètre `responses` dans FastAPI pour spécifier les modèles d'erreur, garantissant un typage correct dans le client généré.
 :::
 
 ## Bonnes pratiques
 
-### Gestion des états de chargement
+### Gérer les états de chargement
 
 Toujours gérer les états de chargement et d'erreur :
 
 ```tsx
-if (items.isLoading) {
-  return <LoadingSpinner />;
-}
+import { useQuery } from '@tanstack/react-query';
 
-if (items.isError) {
-  return <ErrorMessage message="Échec du chargement" />;
+function ItemList() {
+  const api = useMyApi();
+  const items = useQuery(api.listItems.queryOptions());
+
+  if (items.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (items.isError) {
+    const err = items.error;
+    switch (err.status) {
+      case 403:
+        return <ErrorMessage message={err.error.reason} />;
+      case 500:
+        return <ErrorMessage message={err.error.message} />;
+      default:
+        return <ErrorMessage message="Erreur inconnue" />;
+    }
+  }
+
+  return (
+    <ul>
+      {items.data.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 
-<Drawer title="Gestion des états avec le client directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Gestion des états avec le client directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
 ```tsx
-if (loading) {
-  return <LoadingSpinner />;
-}
+function ItemList() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-if (error) {
-  return <ErrorMessage message={error.message} />;
+  useEffect(() => {
+    const fetchItems = async () => {
+      try {
+        const data = await api.listItems();
+        setItems(data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchItems();
+  }, [api]);
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    const err = error as ListItemsError;
+    switch (err.status) {
+      case 403:
+        return <ErrorMessage message={err.error.reason} />;
+      case 500:
+        return <ErrorMessage message={err.error.message} />;
+      default:
+        return <ErrorMessage message="Erreur inconnue" />;
+    }
+  }
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 </Drawer>
@@ -891,66 +1135,163 @@ if (error) {
 Implémentez des mises à jour optimistes pour une meilleure expérience utilisateur :
 
 ```tsx
-const deleteMutation = useMutation({
-  ...api.deleteItem.mutationOptions(),
-  onMutate: async (itemId) => {
-    await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
-    const previousItems = queryClient.getQueryData(api.listItems.queryKey());
-    queryClient.setQueryData(
-      api.listItems.queryKey(),
-      (old) => old.filter((item) => item.id !== itemId)
-    );
-    return { previousItems };
-  },
-  onError: (err, itemId, context) => {
-    queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-  },
-});
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+function ItemList() {
+  const api = useMyApi();
+  const queryClient = useQueryClient();
+
+  const itemsQuery = useQuery(api.listItems.queryOptions());
+
+  const deleteMutation = useMutation({
+    ...api.deleteItem.mutationOptions(),
+    onMutate: async (itemId) => {
+      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+
+      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+
+      queryClient.setQueryData(
+        api.listItems.queryKey(),
+        (old) => old.filter((item) => item.id !== itemId)
+      );
+
+      return { previousItems };
+    },
+    onError: (err, itemId, context) => {
+      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    },
+  });
+
+  return (
+    <ul>
+      {itemsQuery.data.map((item) => (
+        <li key={item.id}>
+          {item.name}
+          <button
+            onClick={() => deleteMutation.mutate(item.id)}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? 'Suppression...' : 'Supprimer'}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
 ```
 
-<Drawer title="Mises à jour optimistes avec le client directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
+<Drawer title="Mises à jour optimistes avec le client directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
 ```tsx
-const handleDelete = async (itemId) => {
-  const previousItems = items;
-  setItems(items.filter((item) => item.id !== itemId));
-  try {
-    await api.deleteItem(itemId);
-  } catch (error) {
-    setItems(previousItems);
-  }
-};
-```
-</Drawer>
+function ItemList() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
 
-## Sécurité des types
+  const handleDelete = async (itemId) => {
+    const previousItems = items;
+    setItems(items.filter((item) => item.id !== itemId));
 
-L'intégration assure une sécurité de type complète. Votre IDE fournira de l'autocomplétion et du typage pour tous les appels d'API :
+    try {
+      await api.deleteItem(itemId);
+    } catch (error) {
+      setItems(previousItems);
+    }
+  };
 
-```tsx
-const createItem = useMutation({
-  ...api.createItem.mutationOptions(),
-  onSuccess: (data) => {
-    // data est typé selon le schéma de réponse
-    console.log(`ID : ${data.id}`);
-  },
-});
-
-const handleSubmit = (data: CreateItemInput) => {
-  // Erreur de type si l'entrée ne correspond pas
-  createItem.mutate(data);
-};
-```
-
-<Drawer title="Sécurité des types avec le client directement" trigger="Cliquez ici pour un exemple utilisant directement le client.">
-```tsx
-try {
-  // Erreur de type si l'entrée est incorrecte
-  await api.createItem(data);
-} catch (e) {
-  const err = e as CreateItemError;
-  // Gestion typée des erreurs
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>
+          {item.name}
+          <button onClick={() => handleDelete(item.id)}>Supprimer</button>
+        </li>
+      ))}
+    </ul>
+  );
 }
 ```
 </Drawer>
 
-Les types sont générés automatiquement à partir du schéma OpenAPI, reflétant toute modification de l'API après une build.
+## Sécurité de typage
+
+L'intégration assure une sécurité de typage de bout en bout. Votre IDE fournira l'autocomplétion et la vérification de types pour tous les appels API :
+
+```tsx
+import { useMutation } from '@tanstack/react-query';
+
+function ItemForm() {
+  const api = useMyApi();
+
+  const createItem = useMutation({
+    ...api.createItem.mutationOptions(),
+    onSuccess: (data) => {
+      console.log(`ID : ${data.id}`);
+    },
+  });
+
+  const handleSubmit = (data: CreateItemInput) => {
+    createItem.mutate(data);
+  };
+
+  if (createItem.error) {
+    const error = createItem.error;
+    switch (error.status) {
+      case 400:
+        return <FormError errors={error.error.validationErrors} />;
+      case 403:
+        return <AuthError reason={error.error.reason} />;
+      default:
+        return <ServerError message={error.error.message} />;
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault();
+      handleSubmit({ name: 'Nouvel élément' });
+    }}>
+      <button
+        type="submit"
+        disabled={createItem.isPending}
+      >
+        {createItem.isPending ? 'Création...' : 'Créer'}
+      </button>
+    </form>
+  );
+}
+```
+
+<Drawer title="Sécurité de typage avec le client directement" trigger="Cliquez ici pour un exemple utilisant le client directement.">
+```tsx
+function ItemForm() {
+  const api = useMyApiClient();
+  const [error, setError] = useState<CreateItemError | null>(null);
+
+  const handleSubmit = async (data: CreateItemInput) => {
+    try {
+      await api.createItem(data);
+    } catch (e) {
+      const err = e as CreateItemError;
+      setError(err);
+    }
+  };
+
+  if (error) {
+    switch (error.status) {
+      case 400:
+        return <FormError errors={error.error.validationErrors} />;
+      case 403:
+        return <AuthError reason={error.error.reason} />;
+      default:
+        return <ServerError message={error.error.message} />;
+    }
+  }
+
+  return <form onSubmit={handleSubmit}>{/* ... */}</form>;
+}
+```
+</Drawer>
+
+Les types sont générés automatiquement à partir du schéma OpenAPI de votre FastAPI, garantissant que toute modification de l'API est reflétée dans le frontend après un build.

--- a/docs/src/content/docs/fr/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/fr/guides/api-connection/react-trpc.mdx
@@ -9,17 +9,16 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Le plugin AWS pour Nx fournit un générateur pour intégrer rapidement votre <Link path="guides/trpc">API tRPC</Link> avec un site React. Il configure tous les éléments nécessaires pour connecter vos backends tRPC, y compris le support de l'authentification IAM AWS et une gestion d'erreurs appropriée. L'intégration offre une sécurité de type de bout en bout entre votre frontend et vos backends tRPC.
+Le plugin AWS pour Nx fournit un générateur pour intégrer rapidement votre <Link path="guides/trpc">API tRPC</Link> avec un site React. Il configure tous les éléments nécessaires pour connecter vos backends tRPC, incluant le support d'authentification AWS IAM et une gestion d'erreurs appropriée. Cette intégration offre une sécurité de type de bout en bout entre votre frontend et vos backends tRPC.
 
 ## Prérequis
 
 Avant d'utiliser ce générateur, assurez-vous que votre application React possède :
 
 1. Un fichier `main.tsx` qui rend votre application
-2. Un élément JSX `<App/>` où le fournisseur tRPC sera injecté automatiquement
-3. Un backend tRPC fonctionnel (généré avec le générateur de backend tRPC)
+2. Un élément JSX `<App/>` où le provider tRPC sera injecté automatiquement
+3. Un backend tRPC fonctionnel (généré via le générateur de backend tRPC)
 
 <details>
 <summary>Exemple de structure requise pour `main.tsx`</summary>
@@ -49,9 +48,9 @@ root.render(
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
-## Sortie du générateur
+## Résultat du générateur
 
 Le générateur crée la structure suivante dans votre application React :
 
@@ -64,14 +63,14 @@ Le générateur crée la structure suivante dans votre application React :
       - TrpcProvider.tsx Provider réutilisable pour plusieurs APIs tRPC
       - TrpcApis.tsx Objet contenant toutes vos connexions d'API tRPC
       - TrpcClientProviders.tsx Configure les clients tRPC et les liaisons avec vos schémas backend
-    - QueryClientProvider.tsx Fournisseur de client TanStack React Query
+    - QueryClientProvider.tsx Provider du client TanStack React Query
   - hooks
     - useSigV4.tsx Hook pour signer les requêtes HTTP avec SigV4 (IAM uniquement)
-    - use\<ApiName>.tsx Hook dédié à l'API backend spécifiée. ApiName correspondra au nom de l'API
+    - use\<ApiName>.tsx Hook dédié à l'API backend spécifiée. ApiName correspond au nom de l'API
 
 </FileTree>
 
-De plus, il installe les dépendances requises :
+Le générateur installe également les dépendances requises :
 
   - `@trpc/client`
   - `@trpc/tanstack-react-query`
@@ -82,7 +81,7 @@ De plus, il installe les dépendances requises :
 
 ### Utilisation du hook tRPC
 
-Le générateur fournit un hook `use<ApiName>` qui donne accès au client tRPC typé :
+Le générateur fournit un hook `use<ApiName>` donnant accès au client tRPC typé :
 
 ```tsx {5,8,11}
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -91,7 +90,7 @@ import { useMyApi } from './hooks/useMyApi';
 function MyComponent() {
   const trpc = useMyApi();
 
-  // Exemple de requête
+  // Exemple de query
   const { data, isLoading, error } = useQuery(trpc.users.list.queryOptions());
 
   // Exemple de mutation
@@ -118,7 +117,7 @@ function MyComponent() {
 
 ### Gestion des erreurs
 
-L'intégration inclut une gestion d'erreurs intégrée qui traite correctement les erreurs tRPC :
+L'intégration inclut une gestion d'erreurs prête à l'emploi :
 
 ```tsx {4, 6}
 function MyComponent() {
@@ -129,7 +128,7 @@ function MyComponent() {
   if (error) {
     return (
       <div>
-        <h2>Erreur survenue :</h2>
+        <h2>Erreur :</h2>
         <p>{error.message}</p>
         {error.data?.code && <p>Code : {error.data.code}</p>}
       </div>
@@ -148,7 +147,7 @@ function MyComponent() {
 
 ## Bonnes pratiques
 
-### Gérer les états de chargement
+### Gestion des états de chargement
 
 Toujours gérer les états de chargement et d'erreur pour une meilleure expérience utilisateur :
 
@@ -191,15 +190,15 @@ function UserList() {
   const deleteMutation = useMutation(
     trpc.users.delete.mutationOptions({
       onMutate: async (userId) => {
-        // Annuler les requêtes en cours
+        // Annule les requêtes en cours
         await queryClient.cancelQueries(trpc.users.list.queryFilter());
 
-        // Capturer l'état actuel des données
+        // Capture l'état actuel
         const previousUsers = queryClient.getQueryData(
           trpc.users.list.queryKey(),
         );
 
-        // Suppression optimiste de l'utilisateur
+        // Suppression optimiste
         queryClient.setQueryData(trpc.users.list.queryKey(), (old) =>
           old?.filter((user) => user.id !== userId),
         );
@@ -207,7 +206,7 @@ function UserList() {
         return { previousUsers };
       },
       onError: (err, userId, context) => {
-        // Restaurer les données précédentes en cas d'erreur
+        // Restaure les données précédentes en cas d'erreur
         queryClient.setQueryData(
           trpc.users.list.queryKey(),
           context?.previousUsers,
@@ -231,7 +230,7 @@ function UserList() {
 
 ### Préchargement des données
 
-Préchargez les données pour de meilleures performances :
+Préchargez les données pour améliorer les performances :
 
 ```tsx {8}
 function UserList() {
@@ -239,7 +238,7 @@ function UserList() {
   const users = useQuery(trpc.users.list.queryOptions());
   const queryClient = useQueryClient();
 
-  // Précharger les détails utilisateur au survol
+  // Précharge les détails au survol
   const prefetchUser = async (userId: string) => {
     await queryClient.prefetchQuery(trpc.users.getById.queryOptions(userId));
   };
@@ -258,7 +257,7 @@ function UserList() {
 
 ### Requêtes infinies
 
-Gérez la pagination avec des requêtes infinies :
+Gérez la pagination avec les requêtes infinies :
 
 ```tsx {5-12}
 function UserList() {
@@ -290,7 +289,7 @@ function UserList() {
 }
 ```
 
-Il est important de noter que les requêtes infinies ne peuvent être utilisées que pour les procédures possédant une propriété d'entrée nommée `cursor`.
+Notez que les requêtes infinies ne peuvent être utilisées qu'avec des procédures possédant une propriété d'entrée nommée `cursor`.
 
 ## Sécurité de type
 
@@ -300,7 +299,7 @@ L'intégration fournit une sécurité de type complète de bout en bout. Votre I
 function UserForm() {
   const trpc = useMyApi();
 
-  // ✅ L'entrée est entièrement typée
+  // ✅ L'entrée est parfaitement typée
   const createUser = trpc.users.create.useMutation();
 
   const handleSubmit = (data: CreateUserInput) => {
@@ -312,10 +311,10 @@ function UserForm() {
 }
 ```
 
-Les types sont automatiquement inférés à partir des définitions de routeur et de schéma de votre backend, garantissant que toute modification de votre API se reflète immédiatement dans votre code frontend sans nécessiter de compilation.
+Les types sont automatiquement inférés depuis les définitions de votre routeur backend, garantissant que tout changement d'API est immédiatement reflété dans votre frontend sans nécessiter de build.
 
-## Plus d'informations
+## Informations complémentaires
 
 Pour plus d'informations, consultez la [documentation tRPC TanStack React Query](https://trpc.io/docs/client/tanstack-react-query/usage).
 
-Vous pouvez également vous référer directement à la [documentation TanStack Query](https://tanstack.com/query/v5).
+Vous pouvez également consulter directement la [documentation TanStack Query](https://tanstack.com/query/v5).

--- a/docs/src/content/docs/fr/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/cloudscape-website-auth.mdx
@@ -10,25 +10,24 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
 Le générateur d'authentification pour site web CloudScape ajoute une authentification à votre site web CloudScape en utilisant [Amazon Cognito](https://aws.amazon.com/cognito/).
 
-Ce générateur configure l'infrastructure CDK pour créer un User Pool Cognito et un Identity Pool associé, ainsi qu'une interface hébergée pour gérer les flux de connexion utilisateur et son intégration avec votre site web CloudScape.
+Ce générateur configure l'infrastructure CDK pour créer un User Pool Cognito et un Identity Pool associé, ainsi qu'une interface hébergée pour gérer les flux de connexion utilisateur, et son intégration avec votre site web CloudScape.
 
 ## Utilisation
 
 ### Ajouter l'authentification à votre site web CloudScape
 
-Vous pouvez ajouter l'authentification à votre site web CloudScape de deux façons :
+Vous pouvez ajouter l'authentification à votre site web CloudScape de deux manières :
 
 <RunGenerator generator="ts#cloudscape-website#auth" />
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
-## Sortie du générateur
+## Résultat du générateur
 
 Vous trouverez les modifications suivantes dans votre application React :
 
@@ -45,7 +44,7 @@ Vous trouverez également le code d'infrastructure suivant généré dans `packa
 <FileTree>
   - src
     - core
-      - user-identity.ts Construct qui définit le user pool et l'identity pool
+      - user-identity.ts Construct définissant le user pool et l'identity pool
 </FileTree>
 
 ## Utilisation de l'infrastructure
@@ -70,9 +69,9 @@ export class ApplicationStack extends Stack {
 
 Le construct `UserIdentity` ajoute automatiquement la <Link path="guides/cloudscape-website#runtime-configuration">Configuration Runtime</Link> nécessaire pour que votre site web puisse pointer vers le bon Cognito User Pool pour l'authentification.
 
-### Accorder des accès aux utilisateurs authentifiés
+### Accorder des droits aux utilisateurs authentifiés
 
-Pour accorder aux utilisateurs authentifiés l'accès à certaines actions, comme l'autorisation d'appeler une API, vous pouvez ajouter des instructions de stratégie IAM au rôle authentifié du pool d'identités :
+Pour accorder aux utilisateurs authentifiés l'accès à certaines actions, comme l'autorisation d'appeler une API, vous pouvez ajouter des politiques IAM au rôle authentifié de l'identity pool :
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/fr/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/fr/guides/cloudscape-website.mdx
@@ -10,19 +10,18 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
-Ce générateur crée un nouveau site [React](https://react.dev/) avec [CloudScape](http://cloudscape.design/) configuré, ainsi que l'infrastructure AWS CDK pour déployer votre site web dans le cloud en tant que site statique hébergé dans [S3](https://aws.amazon.com/s3/), servi par [CloudFront](https://aws.amazon.com/cloudfront/) et protégé par [WAF](https://aws.amazon.com/waf/).
+Ce générateur crée un nouveau site [React](https://react.dev/) préconfiguré avec [CloudScape](http://cloudscape.design/), ainsi que l'infrastructure AWS CDK pour déployer votre site web dans le cloud en tant que site statique hébergé dans [S3](https://aws.amazon.com/s3/), servi par [CloudFront](https://aws.amazon.com/cloudfront/) et protégé par [WAF](https://aws.amazon.com/waf/).
 
 L'application générée utilise [Vite](https://vite.dev/) comme outil de build et bundler. Elle utilise [TanStack Router](https://tanstack.com/router/v1) pour le routage typé.
 
 :::note
-Bien que ce générateur vous configure avec CloudScape, il s'agit fondamentalement d'un générateur de projet React. Vous pouvez modifier votre code pour passer à un autre système de design ou bibliothèque de composants si vous le souhaitez.
+Bien que ce générateur configure CloudScape par défaut, il s'agit fondamentalement d'un générateur de projet React. Vous pouvez modifier votre code pour migrer vers un autre système de design ou bibliothèque de composants si vous le souhaitez.
 :::
 
 ## Utilisation
 
-### Générer un site CloudScape
+### Générer un site web CloudScape
 
 Vous pouvez générer un nouveau site CloudScape de deux manières :
 
@@ -30,9 +29,9 @@ Vous pouvez générer un nouveau site CloudScape de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
-## Sortie du générateur
+## Résultat du générateur
 
 Le générateur créera la structure de projet suivante dans le répertoire `<directory>/<name>` :
 
@@ -40,10 +39,10 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
   - index.html Point d'entrée HTML
   - public Assets statiques
   - src
-    - main.tsx Point d'entrée de l'application avec configuration React
+    - main.tsx Point d'entrée de l'application avec la configuration React
     - config.ts Configuration de l'application (ex: logo)
     - components
-      - AppLayout Composants pour la mise en page globale CloudScape et la barre de navigation
+      - AppLayout Composants pour le layout CloudScape et la barre de navigation
     - hooks
       - useAppLayout.tsx Hook pour ajuster l'AppLayout depuis des composants imbriqués
     - routes
@@ -51,20 +50,20 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
         - index.tsx Exemple de route (ou page) pour @tanstack/react-router
     - styles.css Styles globaux
   - vite.config.ts Configuration Vite et Vitest
-  - tsconfig.json Configuration TypeScript de base pour le code source et les tests
+  - tsconfig.json Configuration TypeScript de base pour le code et les tests
   - tsconfig.app.json Configuration TypeScript pour le code source
   - tsconfig.spec.json Configuration TypeScript pour les tests
 </FileTree>
 
-Le générateur créera également le code d'infrastructure CDK pour déployer votre site dans le répertoire `packages/common/constructs` :
+Le générateur créera également le code d'infrastructure CDK pour déployer votre site web dans le répertoire `packages/common/constructs` :
 
 <FileTree>
   - src
     - app
       - static-websites
-        - \<name>.ts Infrastructure spécifique à votre site
+        - \<name>.ts Infrastructure spécifique à votre site web
     - core
-      - static-website.ts Construct StaticWebsite générique
+      - static-website.ts Construct générique StaticWebsite
 </FileTree>
 
 ## Implémentation de votre site CloudScape
@@ -75,7 +74,7 @@ La [documentation React](https://react.dev/learn) est un bon point de départ po
 
 #### Création d'une route/page
 
-Votre site CloudScape est préconfiguré avec [TanStack Router](https://tanstack.com/router/v1), ce qui facilite l'ajout de nouvelles routes :
+Votre site CloudScape est préconfiguré avec [TanStack Router](https://tanstack.com/router/v1) pour faciliter l'ajout de nouvelles routes :
 
 <Steps>
   1. [Lancer le serveur de développement local](#local-development-server)
@@ -85,7 +84,7 @@ Votre site CloudScape est préconfiguré avec [TanStack Router](https://tanstack
 
 #### Navigation entre pages
 
-Vous pouvez utiliser le composant `Link` ou le hook `useNavigate` pour naviguer entre les pages :
+Utilisez le composant `Link` ou le hook `useNavigate` pour naviguer entre les pages :
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -95,14 +94,14 @@ export const MyComponent = () => {
 
   const submit = async () => {
     const id = await ...
-    // Utiliser `navigate` pour rediriger après une action asynchrone
+    // Utiliser `navigate` pour les redirections après une action asynchrone
     navigate({ to: '/products/$id', { params: { id }} });
   };
 
   return (
     <>
       <Link to="/products">Annuler</Link>
-      <Button onClick={submit}>Soumettre</Button>
+      <Button onClick={submit}>Valider</Button>
     </>
   )
 };
@@ -110,15 +109,15 @@ export const MyComponent = () => {
 
 Pour plus de détails, consultez la [documentation TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
-## Configuration à l'exécution
+## Configuration d'exécution
 
-La configuration de votre infrastructure AWS CDK est fournie à votre site via une Configuration à l'exécution. Cela permet à votre site d'accéder à des détails comme les URLs d'API qui ne sont connus qu'au moment du déploiement.
+La configuration de votre infrastructure AWS CDK est fournie à votre site web via la Configuration d'exécution. Cela permet d'accéder à des détails comme les URLs d'API qui ne sont connus qu'après le déploiement.
 
 ### Infrastructure
 
-Le construct CDK `RuntimeConfig` peut être utilisé pour ajouter et récupérer la configuration dans votre infrastructure CDK. Les constructs CDK générés par `@aws/nx-plugin` (comme les <Link path="guides/trpc">API tRPC</Link> et les <Link path="guides/fastapi">FastAPI</Link>) ajouteront automatiquement les valeurs appropriées au `RuntimeConfig`.
+Le construct CDK `RuntimeConfig` permet d'ajouter et récupérer des valeurs de configuration dans votre infrastructure. Les constructs CDK générés par `@aws/nx-plugin` (comme les <Link path="guides/trpc">API tRPC</Link> et <Link path="guides/fastapi">FastAPIs</Link>) ajoutent automatiquement les valeurs appropriées au `RuntimeConfig`.
 
-Votre construct CDK de site web déploiera la configuration d'exécution sous forme de fichier `runtime-config.json` à la racine de votre bucket S3.
+Votre construct CDK de site web déploiera la configuration d'exécution dans un fichier `runtime-config.json` à la racine de votre bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {9-10,12-13}
 import { Stack } from 'aws-cdk-lib';
@@ -132,19 +131,19 @@ export class ApplicationStack extends Stack {
     // Ajoute automatiquement des valeurs au RuntimeConfig
     new MyApi(this, 'MyApi');
 
-    // Déploie automatiquement la config d'exécution dans runtime-config.json
+    // Déploie automatiquement la config dans runtime-config.json
     new MyWebsite(this, 'MyWebsite');
   }
 }
 ```
 
 :::warning
-Vous devez vous assurer de déclarer votre site web _après_ tous les constructs qui ajoutent des valeurs au `RuntimeConfig`, sans quoi elles seront absentes du fichier `runtime-config.json`.
+Vous devez déclarer votre site web _après_ tous les constructs qui ajoutent des valeurs au `RuntimeConfig`, sans quoi elles seront absentes du fichier `runtime-config.json`.
 :::
 
-### Code du site
+### Code du site web
 
-Dans votre site, vous pouvez utiliser le hook `useRuntimeConfig` pour récupérer les valeurs de la configuration d'exécution :
+Dans votre site web, utilisez le hook `useRuntimeConfig` pour récupérer les valeurs de configuration :
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -152,52 +151,52 @@ import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
 const MyComponent = () => {
   const runtimeConfig = useRuntimeConfig();
 
-  // Accéder aux valeurs de la configuration ici
+  // Accédez aux valeurs de configuration ici
   const apiUrl = runtimeConfig.httpApis.MyApi;
 };
 ```
 
 ### Configuration d'exécution locale
 
-Pour utiliser le [serveur de développement local](#local-development-server), vous aurez besoin d'un fichier `runtime-config.json` dans votre répertoire `public` afin que votre site local connaisse les URLs backend, la configuration d'identité, etc.
+Pour le [serveur de développement local](#local-development-server), vous aurez besoin d'un fichier `runtime-config.json` dans votre répertoire `public` afin que votre site local puisse accéder aux URLs backend et à la configuration d'identité.
 
-Votre projet de site est configuré avec une cible `load:runtime-config` que vous pouvez utiliser pour télécharger le fichier `runtime-config.json` depuis une application déployée :
+Votre projet inclut une cible `load:runtime-config` pour télécharger le fichier `runtime-config.json` depuis une application déployée :
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-Si vous modifiez le nom de votre stack dans le fichier `src/main.ts` de votre projet d'infrastructure, vous devrez mettre à jour la cible `load:runtime-config` dans le fichier `project.json` de votre site avec le nom de la stack à utiliser.
+Si vous modifiez le nom de votre stack dans le `src/main.ts` de votre projet d'infrastructure, mettez à jour la cible `load:runtime-config` dans le fichier `project.json` de votre site web avec le nom de la stack à utiliser.
 :::
 
 ## Serveur de développement local
 
-Avant de lancer le serveur de développement local, assurez-vous d'avoir déployé votre infrastructure et [chargé la configuration d'exécution locale](#local-runtime-config).
+Avant de lancer le serveur, assurez-vous d'avoir déployé votre infrastructure et [chargé la configuration d'exécution locale](#local-runtime-config).
 
-Vous pouvez ensuite exécuter la cible `serve` :
+Exécutez ensuite la cible `serve` :
 
 <NxCommands commands={['run <my-website>:serve']} />
 
 ## Build
 
-Vous pouvez builder votre site avec la cible `build`. Cela utilise Vite pour créer un bundle de production dans le répertoire `dist/packages/<my-website>/bundle`, ainsi que la vérification de types, la compilation et le linting.
+Utilisez la cible `build` pour construire votre site web. Cela génère un bundle de production via Vite dans `dist/packages/<my-website>/bundle`, ainsi que la vérification de types et le linting.
 
 <NxCommands commands={['run <my-website>:build']} />
 
 ## Tests
 
-Tester votre site fonctionne comme pour un projet TypeScript standard. Reportez-vous au <Link path="guides/typescript-project#testing">guide des projets TypeScript</Link> pour plus de détails.
+Tester votre site web s'apparente aux tests standard TypeScript. Consultez le <Link path="guides/typescript-project#testing">guide des projets TypeScript</Link> pour plus de détails.
 
-Pour les tests spécifiques à React, React Testing Library est déjà installé et disponible. Consultez la [documentation React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro) pour son utilisation.
+Pour les tests React, React Testing Library est préinstallé. Consultez sa [documentation](https://testing-library.com/docs/react-testing-library/example-intro) pour son utilisation.
 
-Vous pouvez exécuter vos tests avec la cible `test` :
+Exécutez les tests avec la cible `test` :
 
 <NxCommands commands={['run <my-website>:test']} />
 
-## Déploiement du site
+## Déploiement du site web
 
-Pour déployer votre site, nous recommandons d'utiliser le <Link path="guides/typescript-infrastructure">Générateur d'Infrastructure TypeScript</Link> pour créer une application CDK.
+Pour déployer, nous recommandons d'utiliser le <Link path="guides/typescript-infrastructure">Générateur d'Infrastructure TypeScript</Link> pour créer une application CDK.
 
-Vous pouvez utiliser le construct CDK généré dans `packages/common/constructs` pour déployer votre site.
+Utilisez le construct CDK généré dans `packages/common/constructs` pour déployer votre site :
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -11,29 +11,28 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
-[FastAPI](https://fastapi.tiangolo.com/) est un framework pour construire des API en Python.
+[FastAPI](https://fastapi.tiangolo.com/) est un framework pour construire des APIs en Python.
 
-Le générateur FastAPI crée une nouvelle application FastAPI avec une configuration d'infrastructure AWS CDK. Le backend généré utilise AWS Lambda pour un déploiement serverless, exposé via une API AWS API Gateway. Il configure [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) pour l'observabilité, incluant la journalisation, le tracing AWS X-Ray et les métriques CloudWatch.
+Le générateur FastAPI crée une nouvelle application FastAPI avec une infrastructure AWS CDK configurée. Le backend généré utilise AWS Lambda pour un déploiement serverless, exposé via une API AWS API Gateway. Il configure [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) pour l'observabilité, incluant la journalisation, le tracing AWS X-Ray et les métriques CloudWatch.
 
 ## Utilisation
 
-### Générer une API FastAPI
+### Générer une application FastAPI
 
-Vous pouvez générer une nouvelle API FastAPI de deux manières :
+Vous pouvez générer une nouvelle application FastAPI de deux manières :
 
 <RunGenerator generator="py#fast-api" />
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
-## Sortie du générateur
+## Résultat du générateur
 
-Le générateur va créer la structure de projet suivante dans le répertoire `<directory>/<api-name>` :
+Le générateur créera la structure de projet suivante dans le répertoire `<directory>/<api-name>` :
 
 <FileTree>
 
@@ -48,7 +47,7 @@ Le générateur va créer la structure de projet suivante dans le répertoire `<
 
 </FileTree>
 
-Le générateur crée également des constructs CDK pour déployer votre API, situés dans le répertoire `packages/common/constructs`.
+Le générateur créera également des constructs CDK pour déployer votre API, situés dans le répertoire `packages/common/constructs`.
 
 ## Implémentation de votre FastAPI
 
@@ -72,9 +71,9 @@ def create_item(item: Item):
 
 Le générateur configure automatiquement plusieurs fonctionnalités :
 
-1. Intégration AWS Lambda Powertools pour l'observabilité
+1. Intégration d'AWS Lambda Powertools pour l'observabilité
 2. Middleware de gestion d'erreurs
-3. Corrélation requêtes/réponses  
+3. Corrélation requêtes/réponses
 4. Collecte de métriques
 5. Handler AWS Lambda utilisant Mangum
 
@@ -95,10 +94,10 @@ def read_item(item_id: int):
 
 Le logger inclut automatiquement :
 
-- IDs de corrélation pour le tracing
-- Chemin et méthode de la requête  
-- Contexte Lambda
-- Indicateurs de cold start
+- Des IDs de corrélation pour le tracing
+- Le chemin et la méthode de la requête
+- Les informations de contexte Lambda
+- Des indicateurs de cold start
 
 #### Tracing
 
@@ -110,7 +109,9 @@ from .init import app, tracer
 @app.get("/items/{item_id}")
 @tracer.capture_method
 def read_item(item_id: int):
+    # Crée un nouveau sous-segment
     with tracer.provider.in_subsegment("fetch-item-details"):
+        # Votre logique ici
         return {"item_id": item_id}
 ```
 
@@ -130,10 +131,10 @@ def read_item(item_id: int):
 
 Les métriques par défaut incluent :
 
-- Nombre de requêtes
-- Statistiques succès/échecs
-- Métriques de cold start
-- Métriques par route
+- Le nombre de requêtes
+- Les succès/échecs
+- Les métriques de cold start
+- Des métriques par route
 
 ### Gestion des erreurs
 
@@ -151,22 +152,22 @@ def read_item(item_id: int):
 
 Les exceptions non gérées sont capturées par le middleware et :
 
-1. Journalisent l'exception complète avec stack trace
+1. Journalisent l'exception complète avec la stack trace
 2. Enregistrent une métrique d'échec
-3. Renvoient une réponse 500 sécurisée
+3. Renvoient une réponse 500 sécurisée au client
 4. Préservent l'ID de corrélation
 
 :::tip
-Il est recommandé de spécifier des modèles de réponse pour vos opérations API si vous utilisez le générateur `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Plus de détails ici</Link>.
+Il est recommandé de spécifier des modèles de réponse pour vos opérations API afin d'améliorer la génération de code si vous utilisez le générateur `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Voir ici pour plus de détails</Link>.
 :::
 
 ### Streaming
 
-Avec FastAPI, vous pouvez streamer une réponse avec le type [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse).
+Avec FastAPI, vous pouvez streamer une réponse au client avec le type de réponse [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse).
 
 #### Modifications d'infrastructure
 
-Comme AWS API Gateway ne supporte pas les réponses streamées, vous devrez déployer votre FastAPI sur une plateforme qui le supporte. L'option la plus simple est d'utiliser une Function URL AWS Lambda. Pour ce faire, remplacez le construct généré `common/constructs/src/app/apis/<name>-api.ts` par un construct déployant une Function URL.
+Comme AWS API Gateway ne supporte pas les réponses streamées, vous devrez déployer votre FastAPI sur une plateforme qui le supporte. L'option la plus simple est d'utiliser une Function URL AWS Lambda. Pour cela, vous pouvez remplacer le construct généré `common/constructs/src/app/apis/<name>-api.ts` par un qui déploie une Function URL.
 
 <details>
 <summary>Exemple de construct FunctionURL pour le streaming</summary>
@@ -239,6 +240,7 @@ export class MyApi extends Construct {
 
     new CfnOutput(this, 'MyApiUrl', { value: functionUrl.url });
 
+    // Enregistre l'URL de l'API dans la configuration runtime pour la découverte client
     RuntimeConfig.ensure(this).config.apis = {
       ...RuntimeConfig.ensure(this).config.apis!,
       MyApi: functionUrl.url,
@@ -269,13 +271,13 @@ Pour un exemple complet, référez-vous au <Link path="/get_started/tutorials/du
 
 #### Implémentation
 
-Après avoir mis à jour l'infrastructure pour supporter le streaming, vous pouvez implémenter une API de streaming dans FastAPI. L'API doit :
+Une fois l'infrastructure mise à jour pour supporter le streaming, vous pouvez implémenter une API de streaming dans FastAPI. L'API doit :
 
-- Retourner un [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) 
-- Déclarer le type de chaque chunk de réponse
-- Ajouter l'extension OpenAPI `x-streaming: true` si vous utilisez <Link path="guides/api-connection/react-fastapi">API Connection</Link>.
+- Retourner un [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)
+- Déclarer le type de retour de chaque chunk de réponse
+- Ajouter l'extension vendor OpenAPI `x-streaming: true` si vous comptez utiliser <Link path="guides/api-connection/react-fastapi">API Connection</Link>.
 
-Exemple pour streamer des objets JSON :
+Par exemple, pour streamer une série d'objets JSON depuis votre API :
 
 ```py /return (StreamingResponse)/ /openapi_extra[^)]*/ /-> (Chunk)/
 from pydantic import BaseModel
@@ -296,17 +298,18 @@ def my_stream() -> Chunk:
 
 #### Consommation
 
-Pour consommer un flux de réponses, utilisez le <Link path="guides/api-connection/react-fastapi#consuming-a-stream">Générateur API Connection</Link> qui fournit une méthode typée pour itérer sur les chunks.
+Pour consommer un flux de réponses, vous pouvez utiliser le <Link path="guides/api-connection/react-fastapi#consuming-a-stream">Générateur API Connection</Link> qui fournira une méthode type-safe pour itérer sur les chunks streamés.
 
 ## Déploiement de votre FastAPI
 
-Le générateur crée un construct CDK pour déployer votre API dans `common/constructs`. Utilisez-le dans une application CDK :
+Le générateur FastAPI crée un construct CDK pour déployer votre API dans le dossier `common/constructs`. Vous pouvez l'utiliser dans une application CDK :
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
+    // Ajoute l'API à votre stack
     const api = new MyApi(this, 'MyApi', {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
@@ -316,12 +319,12 @@ export class ExampleStack extends Stack {
 
 Ceci configure :
 
-1. Une fonction AWS Lambda par opération
-2. Une API Gateway HTTP/REST comme déclencheur
-3. Rôles IAM et permissions  
-4. Groupe de logs CloudWatch
-5. Configuration du tracing X-Ray
-6. Namespace de métriques CloudWatch
+1. Une fonction AWS Lambda par opération dans l'application FastAPI
+2. Une API HTTP/REST API Gateway comme déclencheur
+3. Les rôles et permissions IAM
+4. Un groupe de logs CloudWatch
+5. La configuration de tracing X-Ray
+6. Un namespace de métriques CloudWatch
 
 ### Intégrations Type-Safe
 
@@ -329,18 +332,18 @@ Ceci configure :
 
 #### Génération de code
 
-Les opérations FastAPI étant définies en Python et l'infrastructure en TypeScript, nous utilisons de la génération de code pour fournir des métadonnées au construct CDK.
+Les opérations FastAPI étant définies en Python et l'infrastructure en TypeScript, nous instrumentons la génération de code pour fournir des métadonnées au construct CDK afin d'offrir une interface type-safe pour les intégrations.
 
-Une cible `generate:<ApiName>-metadata` est ajoutée au `project.json` des constructs pour générer un fichier comme `packages/common/constructs/src/generated/my-api/metadata.gen.ts`. Ce fichier est ignoré dans le contrôle de version.
+Une cible `generate:<ApiName>-metadata` est ajoutée au `project.json` des constructs communs pour faciliter cette génération de code, produisant un fichier tel que `packages/common/constructs/src/generated/my-api/metadata.gen.ts`. Ce fichier étant généré au build, il est ignoré dans le contrôle de version.
 
 :::note
-Exécutez un build après chaque modification de l'API pour mettre à jour les types :
+Vous devrez exécuter un build après chaque modification de votre API pour maintenir les types consommés par le construct CDK à jour.
 
 <NxCommands commands={["run-many --target build --all"]} />
 :::
 
 :::tip
-Pour régénérer automatiquement les types pendant le développement, utilisez [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) :
+Si vous travaillez simultanément sur l'infrastructure CDK et le FastAPI, vous pouvez utiliser [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) pour régénérer ces types à chaque modification :
 
 <NxCommands
   commands={[
@@ -352,7 +355,7 @@ Pour régénérer automatiquement les types pendant le développement, utilisez 
 
 ### Octroi d'accès
 
-Utilisez `grantInvokeAccess` pour octroyer l'accès à votre API :
+Vous pouvez utiliser la méthode `grantInvokeAccess` pour octroyer l'accès à votre API :
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -360,16 +363,16 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## Développement local
 
-Le générateur configure un serveur de développement local que vous pouvez lancer avec :
+Le générateur configure un serveur de développement local que vous pouvez exécuter avec :
 
 <NxCommands commands={['run my-api:serve']} />
 
-Ceci démarre un serveur FastAPI local avec :
+Ceci démarre un serveur de développement FastAPI local avec :
 
-- Rechargement automatique
-- Documentation interactive sur `/docs` ou `/redoc`  
+- Rechargement automatique sur modification
+- Documentation interactive de l'API sur `/docs` ou `/redoc`
 - Schéma OpenAPI sur `/openapi.json`
 
 ## Invocation de votre FastAPI
 
-Pour invoquer votre API depuis une application React, utilisez le <Link path="guides/api-connection/react-fastapi">générateur `api-connection`</Link>.
+Pour invoquer votre API depuis un site React, vous pouvez utiliser le générateur <Link path="guides/api-connection/react-fastapi">`api-connection`</Link>.

--- a/docs/src/content/docs/fr/guides/license.mdx
+++ b/docs/src/content/docs/fr/guides/license.mdx
@@ -8,11 +8,10 @@ description: "Documentation de référence pour le générateur de licence"
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
 Gérez automatiquement les fichiers `LICENSE` et les en-têtes de code source dans votre espace de travail.
 
-Ce générateur enregistre un [générateur de synchronisation](https://nx.dev/concepts/sync-generators) qui s'exécute dans le cadre de vos cibles `lint` pour garantir que vos fichiers sources respectent le contenu et le format de licence souhaités, tout en assurant que les fichiers `LICENSE` de vos projets sont corrects et que les informations de licence sont incluses dans les fichiers de projet concernés (`package.json`, `pyproject.toml`).
+Ce générateur enregistre un [générateur de synchronisation](https://nx.dev/concepts/sync-generators) qui s'exécute dans le cadre de vos cibles `lint` pour garantir que vos fichiers sources respectent le contenu et le format de licence souhaités, ainsi que la validité des fichiers `LICENSE` de vos projets et l'inclusion des informations de licence dans les fichiers de projet concernés (`package.json`, `pyproject.toml`).
 
 ## Utilisation
 
@@ -22,22 +21,22 @@ Ce générateur enregistre un [générateur de synchronisation](https://nx.dev/c
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## Résultat du générateur
 
 Le générateur créera ou mettra à jour les fichiers suivants :
 
 <FileTree>
-  - nx.json La cible lint est configurée pour exécuter le générateur de synchronisation de licence
-  - aws-nx-plugin.config.mts Configuration pour le générateur de synchronisation de licence
+  - nx.json La cible lint est configurée pour exécuter le générateur de synchronisation des licences
+  - aws-nx-plugin.config.mts Configuration du générateur de synchronisation des licences
 </FileTree>
 
-Une configuration par défaut pour le contenu et le format des en-têtes de licence est ajoutée à `aws-nx-plugin.config.mts` pour écrire des en-têtes appropriés pour plusieurs types de fichiers. Vous pouvez personnaliser cette configuration ; consultez la [section de configuration](#configuration) ci-dessous.
+Une configuration par défaut pour le contenu et le format des en-têtes de licence est ajoutée à `aws-nx-plugin.config.mts` pour générer des en-têtes appropriés pour plusieurs types de fichiers. Vous pouvez personnaliser cette configuration ; consultez la [section de configuration](#configuration) ci-dessous.
 
 ## Workflow
 
-Lorsque vous construisez vos projets (et qu'une cible `lint` s'exécute), le générateur de synchronisation de licence vérifiera que la licence de votre projet correspond à votre configuration (voir [comportement de synchronisation](#license-sync-behaviour)). Si des incohérences sont détectées, vous recevrez un message tel que :
+Lorsque vous construisez vos projets (et qu'une cible `lint` s'exécute), le générateur de synchronisation des licences vérifiera que les licences correspondent à votre configuration (voir [comportement de synchronisation](#license-sync-behaviour)). Si des incohérences sont détectées, vous recevrez un message tel que :
 
 ```bash
   NX   The workspace is out of sync
@@ -67,38 +66,38 @@ No, run the tasks without syncing the changes
 Sélectionnez `Yes` pour synchroniser les modifications.
 
 :::note
-Vérifiez les modifications apportées par le générateur dans le contrôle de version pour éviter des erreurs dans les tâches d'intégration continue dues à des licences non synchronisées.
+Vérifiez les modifications apportées par le générateur dans le contrôle de version pour éviter les échecs des tâches d'intégration continue dus à des licences désynchronisées.
 :::
 
 ## Comportement de synchronisation des licences
 
-Le générateur de synchronisation effectue trois tâches principales :
+Le générateur effectue trois tâches principales :
 
-### 1. Synchroniser les en-têtes de licence des fichiers sources
+### 1. Synchronisation des en-têtes de licence
 
-Le générateur vérifie que tous les fichiers source contiennent l'en-tête de licence approprié. L'en-tête est écrit comme premier commentaire de bloc ou série de commentaires linéaires (après un shebang/hashbang éventuel).
+Le générateur vérifie que tous les fichiers sources contiennent l'en-tête de licence approprié. L'en-tête est écrit comme premier commentaire de bloc ou série de commentaires linéaires (après un shebang le cas échéant).
 
-Vous pouvez modifier la configuration à tout moment pour changer les fichiers inclus/exclus, ou le contenu/format des en-têtes. Voir la [section de configuration](#configuration).
+La configuration permet de modifier les fichiers concernés et le format des en-têtes. Voir [section de configuration](#configuration).
 
-### 2. Synchroniser les fichiers LICENSE
+### 2. Synchronisation des fichiers LICENSE
 
-Le générateur vérifie que le fichier racine `LICENSE` et ceux des sous-projets correspondent à votre licence configurée.
+Le générateur vérifie que le fichier racine `LICENSE` et ceux des sous-projets correspondent à la licence configurée. 
 
-Vous pouvez exclure des projets dans la configuration. Voir la [section de configuration](#configuration).
+L'exclusion de projets est possible via la configuration. Voir [section de configuration](#configuration).
 
-### 3. Synchroniser les informations de licence dans les fichiers de projet
+### 3. Synchronisation des informations de licence dans les fichiers de projet
 
-Le générateur met à jour les champs `license` des fichiers `package.json` et `pyproject.toml` selon votre configuration.
+Le générateur met à jour les champs `license` des fichiers `package.json` et `pyproject.toml` selon la licence configurée.
 
-Vous pouvez exclure des projets dans la configuration. Voir la [section de configuration](#configuration).
+L'exclusion de projets est possible via la configuration. Voir [section de configuration](#configuration).
 
 ## Configuration
 
-La configuration est définie dans le fichier `aws-nx-plugin.config.mts` à la racine de votre espace de travail.
+La configuration se trouve dans `aws-nx-plugin.config.mts` à la racine.
 
 ### SPDX et détenteur du copyright
 
-La licence peut être mise à jour via la propriété `spdx` :
+La licence peut être modifiée via la propriété `spdx` :
 
 ```typescript title="aws-nx-plugin.config.mts" {3}
 export default {
@@ -108,9 +107,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-Les fichiers `LICENSE`, `package.json` et `pyproject.toml` seront mis à jour selon la licence configurée.
+Les fichiers `LICENSE`, `package.json` et `pyproject.toml` seront mis à jour en conséquence.
 
-Vous pouvez aussi configurer le détenteur du copyright et l'année :
+Le détenteur du copyright et l'année peuvent aussi être configurés :
 
 ```typescript title="aws-nx-plugin.config.mts" {4,5}
 export default {
@@ -126,7 +125,7 @@ export default {
 
 #### Contenu
 
-Le contenu des en-têtes peut être configuré de deux façons :
+Le contenu peut être défini de deux façons :
 
 1. Contenu inline :
 
@@ -164,7 +163,7 @@ export default {
 
 #### Format
 
-Définissez le format des en-têtes par type de fichier avec des glob patterns :
+Le format des en-têtes peut être spécifié par type de fichier :
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
@@ -174,22 +173,18 @@ export default {
         lines: ['Copyright notice here'],
       },
       format: {
-        // Commentaires linéaires
         '**/*.ts': {
           lineStart: '// ',
         },
-        // Commentaires de bloc
         '**/*.css': {
           blockStart: '/*',
           blockEnd: '*/',
         },
-        // Commentaires de bloc avec préfixes
         '**/*.java': {
           blockStart: '/*',
           lineStart: ' * ',
           blockEnd: ' */',
         },
-        // Commentaires avec en-tête/pied
         '**/*.py': {
           blockStart: '# ------------',
           lineStart: '# ',
@@ -201,16 +196,15 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-Options de format :
-
-- `blockStart` : Texte avant le contenu de licence
-- `lineStart` : Préfixe de ligne
-- `lineEnd` : Suffixe de ligne
-- `blockEnd` : Texte après le contenu de licence
+Options supportées :
+- `blockStart`: Texte avant le contenu
+- `lineStart`: Préfixe de ligne
+- `lineEnd`: Suffixe de ligne
+- `blockEnd`: Texte après le contenu
 
 #### Syntaxe de commentaire personnalisée
 
-Définissez une syntaxe pour les types de fichiers non pris en charge :
+Pour les formats non supportés :
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
@@ -226,7 +220,7 @@ export default {
       },
       commentSyntax: {
         xyz: {
-          line: '##', // Syntaxe de commentaire linéaire
+          line: '##',
         },
         abc: {
           block: {
@@ -242,7 +236,7 @@ export default {
 
 #### Exclusion de fichiers
 
-Excluez des fichiers avec des glob patterns :
+Fichiers exclus par défaut selon `.gitignore`. Exclusion supplémentaire possible :
 
 ```typescript title="aws-nx-plugin.config.mts" {12-16}
 export default {
@@ -264,16 +258,14 @@ export default {
 
 ### Exclusion de fichiers de projet
 
-Excluez des projets ou fichiers de la synchronisation :
+Exclusion de projets/fichiers via motifs glob :
 
 ```typescript title="aws-nx-plugin.config.mts" {3-10}
 export default {
   license: {
     files: {
       exclude: [
-        // Exclure LICENSE, package.json et pyproject.toml
         'packages/excluded-project',
-        // Exclure LICENSE mais pas package.json/pyproject.toml
         'apps/internal/LICENSE',
       ];
     }
@@ -281,11 +273,10 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-## Désactiver la synchronisation
+## Désactivation de la synchronisation
 
 Pour désactiver le générateur :
-
-1. Supprimez la section `license` de `aws-nx-plugin.config.mts` (ou supprimez le fichier)
+1. Supprimez la section `license` de `aws-nx-plugin.config.mts`
 2. Retirez `@aws/nx-plugin:license#sync` de `targetDefaults.lint.syncGenerators`
 
 Pour réactiver, exécutez à nouveau le générateur `license`.

--- a/docs/src/content/docs/fr/guides/nx-generator.mdx
+++ b/docs/src/content/docs/fr/guides/nx-generator.mdx
@@ -11,7 +11,6 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
 Ajoute un [Générateur Nx](https://nx.dev/extending-nx/recipes/local-generators) à un projet TypeScript pour automatiser des tâches répétitives comme la création de composants ou l'application de structures de projet spécifiques.
 
@@ -25,7 +24,7 @@ Vous pouvez générer un générateur de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
 ## Résultat du générateur
 
@@ -33,7 +32,7 @@ Le générateur créera les fichiers suivants dans le `pluginProject` spécifié
 
 <FileTree>
   - src/\<name>/
-    - schema.json Schéma d'entrée pour votre générateur
+    - schema.json Schéma des entrées pour votre générateur
     - schema.d.ts Types TypeScript pour votre schéma
     - generator.ts Implémentation de base du générateur
     - generator.spec.ts Tests pour votre générateur
@@ -54,7 +53,7 @@ Nous recommandons de générer d'abord un projet TypeScript dédié pour tous vo
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-Sélectionnez votre projet local `nx-plugin` lors de l'exécution du générateur `ts#nx-generator`, et spécifiez un nom ainsi qu'un répertoire et une description optionnels.
+Sélectionnez votre projet local `nx-plugin` lors de l'exécution du générateur `ts#nx-generator`, puis spécifiez un nom ainsi qu'un répertoire et une description optionnels.
 
 ### Définition du schéma
 
@@ -72,7 +71,7 @@ Un fichier schema.json a la structure de base suivante :
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // Your generator options go here
+    // Vos options de générateur ici
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
@@ -112,29 +111,29 @@ Voici un exemple simple avec quelques options basiques :
 
 #### Invites interactives (CLI)
 
-Personnalisez les invites affichées dans le CLI avec la propriété `x-prompt` :
+Vous pouvez personnaliser les invites affichées lors de l'exécution de votre générateur via la CLI en ajoutant la propriété `x-prompt` :
 
 ```json
 "name": {
   "type": "string",
   "description": "Component name",
-  "x-prompt": "Quel est le nom de votre composant ?"
+  "x-prompt": "What is the name of your component?"
 }
 ```
 
-Pour les options booléennes :
+Pour les options booléennes, utilisez une invite oui/non :
 
 ```json
 "withTests": {
   "type": "boolean",
   "description": "Whether to generate test files",
-  "x-prompt": "Souhaitez-vous générer des fichiers de tests ?"
+  "x-prompt": "Would you like to generate test files?"
 }
 ```
 
-#### Sélections par menu déroulant
+#### Sélections déroulantes
 
-Pour des choix prédéfinis, utilisez `enum` :
+Pour les options avec un ensemble fixe de choix, utilisez `enum` pour permettre aux utilisateurs de sélectionner une option.
 
 ```json
 "style": {
@@ -145,24 +144,24 @@ Pour des choix prédéfinis, utilisez `enum` :
 }
 ```
 
-#### Sélection de projet
+#### Menu déroulant de sélection de projet
 
-Permettez aux utilisateurs de sélectionner un projet existant :
+Un pattern courant est de permettre aux utilisateurs de sélectionner parmi les projets existants :
 
 ```json
 "project": {
   "type": "string",
   "description": "The project to add the component to",
-  "x-prompt": "Dans quel projet souhaitez-vous ajouter le composant ?",
+  "x-prompt": "Which project would you like to add the component to?",
   "x-dropdown": "projects"
 }
 ```
 
-La propriété `x-dropdown: "projects"` indique à Nx de peupler le menu avec tous les projets du workspace.
+La propriété `x-dropdown: "projects"` indique à Nx de peupler le menu déroulant avec tous les projets du workspace.
 
 #### Arguments positionnels
 
-Configurez des options comme arguments positionnels :
+Vous pouvez configurer des options pour qu'elles soient passées comme arguments positionnels via la ligne de commande :
 
 ```json
 "name": {
@@ -176,11 +175,11 @@ Configurez des options comme arguments positionnels :
 }
 ```
 
-Cela permet d'exécuter le générateur via `nx g your-generator mon-composant`.
+Cela permet d'exécuter le générateur via `nx g your-generator my-component` au lieu de `nx g your-generator --name=my-component`.
 
-#### Définir les priorités
+#### Définition des priorités
 
-Utilisez `x-priority` pour indiquer l'importance des options :
+Utilisez la propriété `x-priority` pour indiquer les options les plus importantes :
 
 ```json
 "name": {
@@ -190,25 +189,27 @@ Utilisez `x-priority` pour indiquer l'importance des options :
 }
 ```
 
+Les priorités possibles sont `"important"` ou `"internal"`. Cela aide Nx à ordonner les propriétés dans l'extension VSCode et la CLI.
+
 #### Valeurs par défaut
 
-Définissez des valeurs par défaut :
+Vous pouvez fournir des valeurs par défaut :
 
 ```json
 "directory": {
   "type": "string",
-  "description": "Répertoire de création du composant",
+  "description": "Directory where the component will be created",
   "default": "src/components"
 }
 ```
 
 #### Plus d'informations
 
-Consultez la [documentation Nx sur les options de générateur](https://nx.dev/extending-nx/recipes/generator-options).
+Pour plus de détails sur les schémas, consultez la [documentation Nx sur les options des générateurs](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Types TypeScript avec schema.d.ts
 
-Le générateur crée un fichier `schema.d.ts` avec des types TypeScript :
+Avec `schema.json`, le générateur crée un fichier `schema.d.ts` fournissant les types TypeScript pour les options :
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -218,47 +219,48 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Cette interface assure la sécurité des types dans l'implémentation :
+Cette interface est utilisée dans l'implémentation pour la sécurité des types et l'autocomplétion :
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
+  // TypeScript connaît les types de toutes les options
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-Après toute modification de `schema.json`, mettez à jour `schema.d.ts` en conséquence :
+Toute modification de `schema.json` nécessite une mise à jour de `schema.d.ts` correspondante, incluant :
 
 - Ajout/suppression de propriétés
 - Modification des types
-- Propriétés requises/optionnelles (`?` pour optionnel)
+- Définition de propriétés requises/optionnelles (utilisez `?` pour les optionnelles)
 
 L'interface TypeScript doit refléter fidèlement le schéma JSON.
 :::
 
 ### Implémentation d'un générateur
 
-Après avoir créé le générateur, implémentez sa logique dans `generator.ts`.
+Après avoir créé le générateur, vous pouvez écrire son implémentation dans `generator.ts`.
 
-Un générateur manipule un système de fichiers virtuel (`Tree`). Les modifications ne sont écrites sur le disque qu'après son exécution complète (sauf en mode "dry-run").
+Un générateur est une fonction qui modifie un système de fichiers virtuel (`Tree`), lisant et écrivant des fichiers. Les modifications ne sont écrites sur le disque qu'après l'exécution complète, sauf en mode "dry-run".
 
-Opérations courantes :
+Opérations courantes dans un générateur :
 
-#### Lecture/écriture de fichiers
+#### Lecture/Écriture de fichiers
 
 ```typescript
 // Lire un fichier
-const content = tree.read('chemin/vers/fichier.ts', 'utf-8');
+const content = tree.read('path/to/file.ts', 'utf-8');
 
 // Écrire un fichier
-tree.write('chemin/vers/nouveau-fichier.ts', 'export const hello = "world";');
+tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
 // Vérifier l'existence d'un fichier
-if (tree.exists('chemin/vers/fichier.ts')) {
-  // ...
+if (tree.exists('path/to/file.ts')) {
+  // Faire quelque chose
 }
 ```
 
@@ -267,45 +269,61 @@ if (tree.exists('chemin/vers/fichier.ts')) {
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 
+// Générer des fichiers depuis des templates
 generateFiles(
   tree,
-  joinPathFragments(__dirname, 'files'), // Dossier template
-  'chemin/vers/sortie', // Dossier de sortie
+  joinPathFragments(__dirname, 'files'), // Répertoire des templates
+  'path/to/output', // Répertoire de sortie
   {
+    // Variables de remplacement
     name: options.name,
     nameCamelCase: camelCase(options.name),
-    // ...
+    nameKebabCase: kebabCase(options.name),
   },
 );
 ```
 
 #### Manipulation d'AST TypeScript
 
-Nous recommandons [TSQuery](https://github.com/phenomnomnominal/tsquery) :
+Nous recommandons d'installer [TSQuery](https://github.com/phenomnomnominal/tsquery) pour manipuler l'AST.
 
 ```typescript
 import { tsquery } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
 
 // Exemple : Incrémenter un numéro de version
-const sourceFile = tsquery.ast(tree.read('chemin/vers/version.ts', 'utf-8'));
+
+// Parser le contenu en AST
+const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
+
+// Trouver les nodes correspondants
 const nodes = tsquery.query(
   sourceFile,
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
 );
 
 if (nodes.length > 0) {
+  // Récupérer la node numérique
   const numericNode = nodes[0] as ts.NumericLiteral;
-  const newVersion = Number(numericNode.text) + 1;
+
+  // Incrémenter la version
+  const currentVersion = Number(numericNode.text);
+  const newVersion = currentVersion + 1;
+
+  // Remplacer la node
   const result = tsquery.replace(
     sourceFile,
     'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
     () => ts.factory.createNumericLiteral(newVersion),
   );
+
+  // Écrire le contenu modifié
   tree.write(
-    'chemin/vers/version.ts',
+    'path/to/version.ts',
     ts
-      .createPrinter({ newLine: ts.NewLineKind.LineFeed })
+      .createPrinter({
+        newLine: ts.NewLineKind.LineFeed,
+      })
       .printNode(ts.EmitHint.Unspecified, result, sourceFile),
   );
 }
@@ -320,48 +338,61 @@ Testez vos sélecteurs dans le [TSQuery Playground](https://tsquery-playground.f
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
 
+// Ajouter des dépendances à package.json
 addDependenciesToPackageJson(
   tree,
-  { 'nouvelle-dependance': '^1.0.0' },
-  { 'nouvelle-dev-dependance': '^2.0.0' },
+  {
+    'new-dependency': '^1.0.0',
+  },
+  {
+    'new-dev-dependency': '^2.0.0',
+  },
 );
 ```
 
 :::note
-Pour installer les dépendances après génération :
+Si vous ajoutez des dépendances, vous pouvez les installer via une tâche :
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
+// Retourner une callback pour installer les dépendances
 return () => {
   installPackagesTask(tree);
 };
 ```
 :::
 
-#### Formatage des fichiers
+#### Formatage des fichiers générés
 
 ```typescript
 import { formatFiles } from '@nx/devkit';
 
+// Formater tous les fichiers modifiés
 await formatFiles(tree);
 ```
 
-#### Manipulation de fichiers JSON
+#### Lecture/Mise à jour de fichiers JSON
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
+// Lire un JSON
 const packageJson = readJson(tree, 'package.json');
 
-updateJson(tree, 'tsconfig.json', (json) => ({
-  compilerOptions: { ...json.compilerOptions, strict: true }
-}));
+// Mettre à jour un JSON
+updateJson(tree, 'tsconfig.json', (json) => {
+  json.compilerOptions = {
+    ...json.compilerOptions,
+    strict: true,
+  };
+  return json;
+});
 ```
 
 ### Exécution du générateur
 
-Deux méthodes d'exécution :
+Deux méthodes pour exécuter votre générateur :
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
@@ -373,7 +404,7 @@ Si le générateur n'apparaît pas dans l'UI VSCode, rafraîchissez le workspace
 
 ### Tests du générateur
 
-Exemple de tests unitaires :
+Les tests unitaires pour les générateurs sont simples à implémenter :
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -383,45 +414,84 @@ describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
+    // Créer un workspace vide
     tree = createTreeWithEmptyWorkspace();
+
+    // Ajouter des fichiers existants
+    tree.write(
+      'project.json',
+      JSON.stringify({
+        name: 'test-project',
+        sourceRoot: 'src',
+      }),
+    );
+
     tree.write('src/existing-file.ts', 'export const existing = true;');
   });
 
   it('should generate expected files', async () => {
-    await yourGenerator(tree, { name: 'test' });
+    // Exécuter le générateur
+    await yourGenerator(tree, {
+      name: 'test',
+    });
+
+    // Vérifier les fichiers générés
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
+
+    // Vérifier le contenu
+    const content = tree.read('src/test/file.ts', 'utf-8');
+    expect(content).toContain('export const test');
+
+    // Utiliser des snapshots
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
+  it('should update existing files', async () => {
+    await yourGenerator(tree, {
+      name: 'test',
+    });
+
+    const content = tree.read('src/existing-file.ts', 'utf-8');
+    expect(content).toContain('import { test } from');
+  });
+
   it('should handle errors', async () => {
-    await expect(yourGenerator(tree, { name: 'invalid' }))
-      .rejects.toThrow('Message d\'erreur attendu');
+    await expect(
+      yourGenerator(tree, {
+        name: 'invalid',
+      }),
+    ).rejects.toThrow('Expected error message');
   });
 });
 ```
 
-Points clés :
+Points clés pour les tests :
 
-- Utilisez `createTreeWithEmptyWorkspace()` pour simuler un système de fichiers
-- Testez la création et la modification de fichiers
-- Utilisez des snapshots pour les contenus complexes
-- Testez les cas d'erreur
+- Utiliser `createTreeWithEmptyWorkspace()`
+- Configurer les fichiers prérequis
+- Tester création et modification de fichiers
+- Utiliser des snapshots pour le contenu complexe
+- Tester les cas d'erreur
 
 ## Contribution de générateurs à @aws/nx-plugin
 
-Le générateur `ts#nx-generator` peut aussi scaffold des générateurs dans `@aws/nx-plugin` :
+Le générateur `ts#nx-generator` peut aussi scaffold un générateur dans `@aws/nx-plugin`.
+
+Dans notre dépôt, il générera :
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Schéma du générateur
+    - schema.json Schéma des entrées
     - schema.d.ts Types TypeScript
     - generator.ts Implémentation
     - generator.spec.ts Tests
   - docs/src/content/docs/guides/
-    - \<name>.mdx Documentation
-  - packages/nx-plugin/generators.json Mise à jour de la configuration
+    - \<name>.mdx Page de documentation
+  - packages/nx-plugin/generators.json Mis à jour
 </FileTree>
 
+Vous pouvez ensuite implémenter votre générateur.
+
 :::tip
-Pour un guide complet sur la contribution, consultez le <Link path="get_started/tutorials/contribute-generator">tutoriel dédié</Link>.
+Pour un guide détaillé sur la contribution au plugin Nx pour AWS, consultez le <Link path="get_started/tutorials/contribute-generator">tutoriel ici</Link>.
 :::

--- a/docs/src/content/docs/fr/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/fr/guides/python-lambda-function.mdx
@@ -9,11 +9,10 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
 Le générateur de fonction Lambda Python permet d'ajouter une fonction lambda à un projet Python existant.
 
-Ce générateur crée un nouveau gestionnaire de fonction Lambda Python avec une configuration d'infrastructure AWS CDK. Le backend généré utilise AWS Lambda pour un déploiement serverless, avec une option de sécurité des types via le [Parser d'AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Il configure [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) pour l'observabilité, incluant la journalisation, le traçage AWS X-Ray et les métriques CloudWatch.
+Ce générateur crée un nouveau gestionnaire de fonction lambda Python avec une configuration d'infrastructure AWS CDK. Le backend généré utilise AWS Lambda pour un déploiement serverless, avec une validation de types optionnelle via le [Parser d'AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Il configure [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) pour l'observabilité, incluant la journalisation, le tracing AWS X-Ray et les métriques CloudWatch.
 
 ## Utilisation
 
@@ -25,7 +24,7 @@ Vous pouvez générer une nouvelle fonction Lambda de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
 ## Résultat du générateur
 
@@ -38,7 +37,7 @@ Le générateur ajoutera les fichiers suivants à votre projet :
 
 </FileTree>
 
-Le générateur créera également des constructs CDK utilisables pour déployer votre fonction, situés dans le répertoire `packages/common/constructs`.
+Le générateur crée également des constructs CDK pour déployer votre fonction, situés dans le répertoire `packages/common/constructs`.
 
 Si l'option `functionPath` est spécifiée, le générateur ajoutera les fichiers nécessaires au chemin indiqué :
 
@@ -78,20 +77,20 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     metrics.add_metric(name="InvocationCount", unit=MetricUnit.Count, value=1)
 
     try:
-        # TODO: Implement
+        # TODO: Implémenter
         metrics.add_metric(name="SuccessCount", unit=MetricUnit.Count, value=1)
-        # TODO: Implement success response if required
+        # TODO: Implémenter la réponse en cas de succès si nécessaire
     except Exception as e:
         logger.exception(e)
         metrics.add_metric(name="ErrorCount", unit=MetricUnit.Count, value=1)
-        # TODO: Implement error response if required
+        # TODO: Implémenter la réponse en cas d'erreur si nécessaire
 ```
 
 Le générateur configure automatiquement plusieurs fonctionnalités :
 
 1. Intégration d'AWS Lambda Powertools pour l'observabilité
 2. Collecte de métriques  
-3. Sécurité des types via `@event_parser`
+3. Validation de types avec `@event_parser`
 
 ### Observabilité avec AWS Lambda Powertools
 
@@ -104,19 +103,19 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     logger.info("Received event", extra={"event": event.model_dump()})
 ```
 
-:::tip
-Il est recommandé de définir un identifiant de corrélation pour chaque requête unique afin de faciliter le débogage et la surveillance. Consultez la documentation du [logger AWS Powertools](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) pour les bonnes pratiques.
+:::astuce
+Il est recommandé de définir un identifiant de corrélation pour chaque requête unique afin de faciliter le débogage et le monitoring. Consultez la documentation [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) pour les bonnes pratiques.
 :::
 
 Le logger inclut automatiquement :
 
 - Les requêtes d'événements
 - Les informations de contexte Lambda  
-- Les indicateurs de démarrage à froid
+- Les indicateurs de cold start
 
-#### Traçage
+#### Tracing
 
-Le traçage AWS X-Ray est configuré automatiquement. Vous pouvez ajouter des sous-segments personnalisés :
+Le tracing AWS X-Ray est configuré automatiquement. Vous pouvez ajouter des sous-segments personnalisés :
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -138,27 +137,27 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 Les métriques par défaut incluent :
 
-- Nombre d'invocations
-- Métriques de succès/échec  
-- Métriques de démarrage à froid
+- Nombre d'invocations  
+- Taux de succès/échec  
+- Métriques de cold start
 
-#### Sécurité des types
+#### Validation de types
 
-Si vous avez choisi une `eventSource` lors de la génération, votre fonction est instrumentée avec [`@event_parser` d'AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Exemple :
+Si vous avez choisi une `eventSource` lors de la génération, votre fonction utilise [`@event_parser` d'AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Exemple :
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
-    event.detail_type # <- sécurité des types avec autocomplétion de l'IDE
+    event.detail_type # <- typage fort avec autocomplétion IDE
 ```
 
-Cela permet de définir des modèles de données avec [Pydantic](https://docs.pydantic.dev/latest/), similaire à <Link path="guides/fastapi">FastAPI</Link>.
+Ceci permet de définir des modèles de données avec [Pydantic](https://docs.pydantic.dev/latest/), similaire à <Link path="guides/fastapi">Fast API</Link>.
 
-:::tip
-Pour des données personnalisées imbriquées (ex: flux DynamoDB ou événement EventBridge), utilisez [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) pour assurer la sécurité des types.
+:::astuce
+Pour des données personnalisées dans un événement (ex: flux DynamoDB ou événement EventBridge), utilisez [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) pour assurer le typage.
 :::
 
-Pour ignorer le typage, sélectionnez `Any` comme `eventSource`.
+Si vous ne souhaitez pas typer votre événement, sélectionnez `Any` comme `eventSource`.
 
 ## Déploiement de votre fonction
 
@@ -177,18 +176,18 @@ export class ExampleStack extends Stack {
 
 Ceci configure :
 
-1. Fonction AWS Lambda
-2. Groupe de logs CloudWatch  
-3. Configuration du traçage X-Ray
-4. Namespace de métriques CloudWatch
+1. La fonction AWS Lambda  
+2. Le groupe de logs CloudWatch  
+3. La configuration du tracing X-Ray  
+4. L'espace de noms des métriques CloudWatch
 
-La fonction peut ensuite être utilisée comme cible pour toute [source d'événement Lambda](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) :
+La fonction peut ensuite être utilisée comme cible pour n'importe quelle [source d'événement lambda](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/).
 
-:::note
+:::remarque
 Assurez-vous que la source d'événement correspond à l'option `eventSource` sélectionnée pour un traitement correct.
 :::
 
-L'exemple suivant montre comment invoquer votre fonction selon un planning avec EventBridge :
+L'exemple suivant montre comment invoquer votre fonction selon un planning avec Event Bridge :
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';
@@ -200,7 +199,7 @@ export class ExampleStack extends Stack {
     // Ajoute la fonction à votre stack
     const fn = new MyProjectMyFunction(this, 'MyFunction');
 
-    // Ajoute la fonction à une règle EventBridge
+    // Configure une règle EventBridge
     const eventRule = new Rule(this, 'MyFunctionScheduleRule', {
       schedule: Schedule.cron({ minute: '15' }),
       targets: [new LambdaFunction(fn)],

--- a/docs/src/content/docs/fr/guides/python-project.mdx
+++ b/docs/src/content/docs/fr/guides/python-project.mdx
@@ -9,9 +9,8 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
-Le générateur de projets Python permet de créer des bibliothèques ou applications [Python](https://www.python.org/) modernes configurées avec les bonnes pratiques, gérées avec [UV](https://docs.astral.sh/uv/), un fichier de verrouillage unique et un environnement virtuel dans un [espace de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) pour exécuter les tests, et [Ruff](https://docs.astral.sh/ruff/) pour l'analyse statique.
+Le générateur de projet Python permet de créer une bibliothèque ou application [Python](https://www.python.org/) moderne configurée avec les meilleures pratiques, gérée avec [UV](https://docs.astral.sh/uv/), un fichier de verrouillage unique et un environnement virtuel dans un [espace de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) pour exécuter les tests, et [Ruff](https://docs.astral.sh/ruff/) pour l'analyse statique.
 
 ## Utilisation
 
@@ -23,7 +22,7 @@ Vous pouvez générer un nouveau projet Python de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
 ## Résultat du générateur
 
@@ -44,7 +43,7 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
 
 </FileTree>
 
-Vous remarquerez également ces fichiers créés/mis à jour à la racine de votre espace de travail :
+Vous remarquerez également les fichiers suivants créés/mis à jour à la racine de votre espace de travail :
 
 <FileTree>
 
@@ -54,31 +53,31 @@ Vous remarquerez également ces fichiers créés/mis à jour à la racine de vot
 
 </FileTree>
 
-## Écrire du code Python
+## Écrire du code source Python
 
 Ajoutez votre code source Python dans le répertoire `<module-name>`.
 
-### Importer votre bibliothèque dans d'autres projets
+### Importer votre code bibliothèque dans d'autres projets
 
-Grâce à la configuration des [espaces de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), vous pouvez référencer votre projet Python depuis n'importe quel autre projet Python dans votre espace de travail :
+Étant donné que des [espaces de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/) sont configurés pour vous, vous pouvez référencer votre projet Python depuis n'importe quel autre projet Python dans votre espace de travail :
 
 ```python title="packages/my_other_project/my_other_project/main.py"
 from "my_library.hello" import say_hello
 ```
 
-Ici, `my_library` correspond au nom du module, `hello` au fichier source Python `hello.py`, et `say_hello` est une méthode définie dans `hello.py`.
+Ci-dessus, `my_library` est le nom du module, `hello` correspond au fichier source Python `hello.py`, et `say_hello` est une méthode définie dans `hello.py`
 
 ### Dépendances
 
-Pour ajouter des dépendances à votre projet, exécutez la cible `add` dans votre projet Python, par exemple :
+Pour ajouter des dépendances à votre projet, vous pouvez exécuter la cible `add` dans votre projet Python, par exemple :
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-Cela ajoutera la dépendance au fichier `pyproject.toml` de votre projet et mettra à jour le fichier `uv.lock` racine.
+Cela ajoutera la dépendance au fichier `pyproject.toml` de votre projet et mettra à jour le `uv.lock` racine.
 
 #### Code d'exécution
 
-Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple comme gestionnaire d'une fonction AWS Lambda), vous devrez créer un bundle du code source et de toutes ses dépendances. Vous pouvez y parvenir en ajoutant une cible comme celle-ci dans votre fichier `project.json` :
+Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple comme gestionnaire pour une fonction AWS Lambda), vous devrez créer un bundle du code source et de toutes ses dépendances. Vous pouvez y parvenir en ajoutant une cible comme celle-ci à votre fichier `project.json` :
 
 ```json title="project.json"
 {
@@ -104,7 +103,7 @@ Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple c
 
 ### Construction
 
-Votre projet Python est configuré avec une cible `build` (définie dans `project.json`) que vous pouvez exécuter via :
+Votre projet Python est configuré avec une cible `build` (définie dans `project.json`), que vous pouvez exécuter via :
 
 <NxCommands commands={['run <project-name>:build']} />
 
@@ -112,7 +111,7 @@ Où `<project-name>` est le nom qualifié complet de votre projet.
 
 La cible `build` compilera, linttera et testera votre projet.
 
-Le résultat du build se trouve dans le dossier `dist` racine de votre espace de travail, dans un répertoire spécifique à votre package et à la cible, par exemple `dist/packages/<my-library>/build`.
+Le résultat de la construction se trouve dans le dossier `dist` racine de votre espace de travail, dans un répertoire pour votre package et la cible, par exemple `dist/packages/<my-library>/build`
 
 ## Tests
 
@@ -142,17 +141,17 @@ Pour plus de détails sur l'écriture de tests, consultez la [documentation pyte
 
 ### Exécuter les tests
 
-Les tests s'exécutent automatiquement avec la cible `build`, mais vous pouvez aussi les lancer séparément via la cible `test` :
+Les tests s'exécutent dans le cadre de la cible `build` de votre projet, mais vous pouvez aussi les exécuter séparément via la cible `test` :
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Vous pouvez exécuter un test individuel ou un groupe de tests avec le flag `-k`, en spécifiant le nom du fichier ou de la méthode de test :
+Vous pouvez exécuter un test individuel ou une suite de tests en utilisant le flag `-k`, en spécifiant le nom du fichier de test ou de la méthode :
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## Vérification du code
+## Linting
 
-Les projets Python utilisent [Ruff](https://docs.astral.sh/ruff/) pour la vérification du code.
+Les projets Python utilisent [Ruff](https://docs.astral.sh/ruff/) pour le linting.
 
 ### Exécuter le linter
 
@@ -160,12 +159,12 @@ Pour invoquer le linter et vérifier votre projet, exécutez la cible `lint` :
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corriger les problèmes
+### Corriger les problèmes de lint
 
-La plupart des problèmes de linting ou de formatage peuvent être corrigés automatiquement. Activez la correction automatique avec l'argument `--configuration=fix` :
+La majorité des problèmes de lint ou de formatage peuvent être corrigés automatiquement. Vous pouvez demander à Ruff de corriger les problèmes de lint en utilisant l'argument `--configuration=fix` :
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-De même, pour corriger tous les problèmes dans tous les packages de votre espace de travail :
+De même, si vous souhaitez corriger tous les problèmes de lint dans tous les packages de votre espace de travail, exécutez :
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -11,11 +11,10 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/) est un framework pour construire des APIs en TypeScript avec une sécurité de typage de bout en bout. Avec tRPC, les mises à jour des entrées et sorties des opérations de l'API sont immédiatement reflétées dans le code client et visibles dans votre IDE sans avoir à reconstruire votre projet.
+[tRPC](https://trpc.io/) est un framework pour construire des APIs en TypeScript avec une sécurité de type de bout en bout. Avec tRPC, les mises à jour des entrées et sorties des opérations d'API sont immédiatement reflétées dans le code client et visibles dans votre IDE sans avoir à reconstruire votre projet.
 
-Le générateur d'API tRPC crée une nouvelle API tRPC avec une infrastructure AWS CDK configurée. Le backend généré utilise AWS Lambda pour un déploiement serverless et inclut une validation de schéma via [Zod](https://zod.dev/). Il configure [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) pour l'observabilité, incluant la journalisation, le tracing AWS X-Ray et les métriques CloudWatch.
+Le générateur d'API tRPC crée une nouvelle API tRPC avec une infrastructure AWS CDK configurée. Le backend généré utilise AWS Lambda pour un déploiement serverless et inclut une validation de schéma via [Zod](https://zod.dev/). Il configure [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) pour l'observabilité, incluant le logging, le tracing AWS X-Ray et les métriques Cloudwatch.
 
 ## Utilisation
 
@@ -27,7 +26,7 @@ Vous pouvez générer une nouvelle API tRPC de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -41,22 +40,22 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
       - index.ts Point d'entrée du schéma
       - procedures
         - echo.ts Définitions de schéma partagées pour la procédure "echo", utilisant Zod
-    - tsconfig.json Configuration TypeScript  
+    - tsconfig.json Configuration TypeScript
     - project.json Configuration du projet et cibles de build
   - backend
     - src
       - init.ts Initialisation tRPC du backend
-      - router.ts Définition du routeur tRPC (point d'entrée de l'API du gestionnaire Lambda)
+      - router.ts Définition du routeur tRPC (point d'entrée de l'API du handler Lambda)
       - procedures Procédures (ou opérations) exposées par votre API
         - echo.ts Exemple de procédure
       - middleware
-        - error.ts Middleware de gestion d'erreurs
-        - logger.ts Middleware pour configurer AWS Powertools pour la journalisation Lambda
-        - tracer.ts Middleware pour configurer AWS Powertools pour le tracing Lambda  
-        - metrics.ts Middleware pour configurer AWS Powertools pour les métriques Lambda
+        - error.ts Middleware de gestion des erreurs
+        - logger.ts middleware pour configurer AWS Powertools pour le logging Lambda
+        - tracer.ts middleware pour configurer AWS Powertools pour le tracing Lambda
+        - metrics.ts middleware pour configurer AWS Powertools pour les métriques Lambda
       - local-server.ts Point d'entrée de l'adaptateur standalone tRPC pour le serveur de développement local
       - client
-        - index.ts Client typé pour les appels API machine-à-machine
+        - index.ts Client type-safe pour les appels API machine-à-machine
     - tsconfig.json Configuration TypeScript
     - project.json Configuration du projet et cibles de build
 </FileTree>
@@ -65,7 +64,7 @@ Le générateur créera également des constructs CDK utilisables pour déployer
 
 ## Implémentation de votre API tRPC
 
-Comme vu ci-dessus, une API tRPC comporte deux composants principaux, [`schema`](#schema) et [`backend`](#backend), définis comme des packages distincts dans votre espace de travail.
+Comme vu ci-dessus, une API tRPC comporte deux composants principaux, [`schema`](#schema) et [`backend`](#backend), définis comme des packages individuels dans votre workspace.
 
 :::tip
 `schema` et `backend` sont tous deux des projets TypeScript. Vous pouvez donc consulter la <Link path="guides/typescript-project">documentation des projets TypeScript</Link> pour plus de détails sur leur utilisation générale.
@@ -73,7 +72,7 @@ Comme vu ci-dessus, une API tRPC comporte deux composants principaux, [`schema`]
 
 ### Schema
 
-Le package schema définit les types partagés entre votre code client et serveur. Ces types sont définis en utilisant [Zod](https://zod.dev/), une bibliothèque de déclaration et validation de schémas orientée TypeScript.
+Le package schema définit les types partagés entre votre code client et serveur. Dans ce package, ces types sont définis avec [Zod](https://zod.dev/), une bibliothèque de déclaration et validation de schémas orientée TypeScript.
 
 Un exemple de schéma pourrait ressembler à ceci :
 
@@ -101,19 +100,19 @@ interface User {
 }
 ```
 
-Les schémas sont partagés entre le code serveur et client, fournissant un seul endroit à modifier pour les structures utilisées dans votre API.
+Les schémas sont partagés entre le code serveur et client, fournissant un seul endroit à modifier pour changer les structures utilisées dans votre API.
 
-Les schémas sont automatiquement validés par votre API tRPC à l'exécution, évitant d'avoir à écrire manuellement une logique de validation dans le backend.
+Les schémas sont automatiquement validés par votre API tRPC au runtime, évitant d'avoir à écrire manuellement une logique de validation personnalisée dans votre backend.
 
 Zod fournit des utilitaires puissants pour combiner ou dériver des schémas comme `.merge`, `.pick`, `.omit` et plus encore. Vous trouverez plus d'informations sur le [site de documentation Zod](https://zod.dev/?id=basic-usage).
 
 ### Backend
 
-Le dossier `backend` contient l'implémentation de votre API, où vous définissez les opérations et leurs entrées, sorties et implémentations.
+Le dossier imbriqué `backend` contient l'implémentation de votre API, où vous définissez les opérations de votre API ainsi que leurs entrées, sorties et implémentations.
 
-Le point d'entrée de votre API se trouve dans `src/router.ts`. Ce fichier contient le gestionnaire Lambda qui route les requêtes vers les "procédures" selon l'opération invoquée. Chaque procédure définit l'entrée attendue, la sortie et l'implémentation.
+Le point d'entrée de votre API se trouve dans `src/router.ts`. Ce fichier contient le handler Lambda qui route les requêtes vers les "procédures" en fonction de l'opération invoquée. Chaque procédure définit l'entrée attendue, la sortie et l'implémentation.
 
-Le routeur généré comme exemple contient une seule opération appelée `echo` :
+Le routeur exemple généré pour vous possède une seule opération appelée `echo` :
 
 ```ts
 import { echo } from './procedures/echo.js';
@@ -123,7 +122,7 @@ export const appRouter = router({
 });
 ```
 
-La procédure `echo` exemple est générée dans `src/procedures/echo.ts` :
+La procédure exemple `echo` est générée pour vous dans `src/procedures/echo.ts` :
 
 ```ts
 export const echo = publicProcedure
@@ -134,33 +133,33 @@ export const echo = publicProcedure
 
 Décomposons ce code :
 
-- `publicProcedure` définit une méthode publique de l'API, incluant le middleware configuré dans `src/middleware`. Ce middleware inclut l'intégration d'AWS Lambda Powertools pour la journalisation, le tracing et les métriques.
-- `input` accepte un schéma Zod définissant l'entrée attendue pour l'opération. Les requêtes pour cette opération sont automatiquement validées contre ce schéma.
-- `output` accepte un schéma Zod définissant la sortie attendue. Vous verrez des erreurs de type dans votre implémentation si vous ne retournez pas une sortie conforme.
-- `query` accepte une fonction définissant l'implémentation de l'API. Cette implémentation reçoit `opts`, qui contient l'`input` passé à l'opération, ainsi que le contexte configuré par le middleware, disponible dans `opts.ctx`. La fonction doit retourner une sortie conforme au schéma `output`.
+- `publicProcedure` définit une méthode publique sur l'API, incluant le middleware configuré dans `src/middleware`. Ce middleware inclut l'intégration d'AWS Lambda Powertools pour le logging, tracing et les métriques.
+- `input` accepte un schéma Zod définissant l'entrée attendue pour l'opération. Les requêtes envoyées pour cette opération sont automatiquement validées contre ce schéma.
+- `output` accepte un schéma Zod définissant la sortie attendue pour l'opération. Vous verrez des erreurs de type dans votre implémentation si vous ne retournez pas une sortie conforme au schéma.
+- `query` accepte une fonction définissant l'implémentation de votre API. Cette implémentation reçoit `opts`, qui contient l'`input` passé à votre opération, ainsi que d'autres contextes configurés par le middleware, disponibles dans `opts.ctx`. La fonction passée à `query` doit retourner une sortie conforme au schéma `output`.
 
-L'utilisation de `query` indique que l'opération est non mutation. Utilisez-le pour des méthodes de récupération de données. Pour une opération mutation, utilisez plutôt `mutation`.
+L'utilisation de `query` pour définir l'implémentation indique que l'opération n'est pas mutative. Utilisez ceci pour définir des méthodes de récupération de données. Pour implémenter une opération mutative, utilisez plutôt la méthode `mutation`.
 
-Si vous ajoutez une nouvelle opération, assurez-vous de l'enregistrer dans le routeur dans `src/router.ts`.
+Si vous ajoutez une nouvelle opération, assurez-vous de l'enregistrer en l'ajoutant au routeur dans `src/router.ts`.
 
 ## Personnalisation de votre API tRPC
 
-### Gestion des erreurs
+### Erreurs
 
-Dans votre implémentation, vous pouvez retourner des erreurs aux clients en lançant une `TRPCError`. Elles acceptent un `code` indiquant le type d'erreur, par exemple :
+Dans votre implémentation, vous pouvez retourner des réponses d'erreur aux clients en lançant une `TRPCError`. Celles-ci acceptent un `code` indiquant le type d'erreur, par exemple :
 
 ```ts
 throw new TRPCError({
   code: 'NOT_FOUND',
-  message: 'La ressource demandée est introuvable',
+  message: 'La ressource demandée n\'a pas pu être trouvée',
 });
 ```
 
 ### Organisation des opérations
 
-Si votre API grandit, vous pouvez regrouper des opérations liées.
+Au fur et à mesure que votre API grandit, vous pourriez souhaiter regrouper des opérations liées.
 
-Utilisez des routeurs imbriqués pour grouper des opérations, par exemple :
+Vous pouvez regrouper des opérations avec des routeurs imbriqués, par exemple :
 
 ```ts
 import { getUser } from './procedures/users/get.js';
@@ -175,32 +174,32 @@ const appRouter = router({
 })
 ```
 
-Les clients verront alors ce regroupement, par exemple invoquer `listUsers` ressemblera à :
+Les clients verront alors ce regroupement d'opérations. Par exemple, invoquer l'opération `listUsers` ressemblerait à ceci :
 
 ```ts
 client.users.list.query();
 ```
 
-### Journalisation
+### Logging
 
-Le logger AWS Lambda Powertools est configuré dans `src/middleware/logger.ts`, et accessible dans une implémentation via `opts.ctx.logger`. Utilisez-le pour journaliser dans CloudWatch Logs et contrôler les valeurs supplémentaires incluses dans chaque message de log structuré. Exemple :
+Le logger AWS Lambda Powertools est configuré dans `src/middleware/logger.ts`, et est accessible dans une implémentation d'API via `opts.ctx.logger`. Vous pouvez l'utiliser pour logger dans CloudWatch Logs, et/ou contrôler les valeurs supplémentaires à inclure dans chaque message de log structuré. Par exemple :
 
 ```ts {5}
 export const echo = publicProcedure
    .input(...)
    .output(...)
    .query(async (opts) => {
-      opts.ctx.logger.info('Opération appelée avec input', opts.input);
+      opts.ctx.logger.info('Opération appelée avec l\'entrée', opts.input);
 
       return ...;
    });
 ```
 
-Pour plus d'informations, consultez la [documentation AWS Lambda Powertools Logger](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/).
+Pour plus d'informations sur le logger, référez-vous à la [documentation AWS Lambda Powertools Logger](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/).
 
 ### Enregistrement de métriques
 
-Les métriques AWS Lambda Powertools sont configurées dans `src/middleware/metrics.ts`, et accessibles via `opts.ctx.metrics`. Utilisez-les pour enregistrer des métriques dans CloudWatch sans utiliser le SDK AWS, par exemple :
+Les métriques AWS Lambda Powertools sont configurées dans `src/middleware/metrics.ts`, et sont accessibles dans une implémentation d'API via `opts.ctx.metrics`. Vous pouvez les utiliser pour enregistrer des métriques dans CloudWatch sans avoir à importer et utiliser l'AWS SDK, par exemple :
 
 ```ts {5}
 export const echo = publicProcedure
@@ -213,11 +212,11 @@ export const echo = publicProcedure
    });
 ```
 
-Plus d'informations dans la [documentation AWS Lambda Powertools Metrics](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/).
+Pour plus d'informations, référez-vous à la [documentation AWS Lambda Powertools Metrics](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/).
 
-### Ajustement du tracing X-Ray
+### Ajustement fin du tracing X-Ray
 
-Le tracer AWS Lambda Powertools est configuré dans `src/middleware/tracer.ts`, et accessible via `opts.ctx.tracer`. Utilisez-le pour ajouter des traces AWS X-Ray afin d'obtenir des insights détaillés sur les performances et le flux des requêtes. Exemple :
+Le tracer AWS Lambda Powertools est configuré dans `src/middleware/tracer.ts`, et est accessible dans une implémentation d'API via `opts.ctx.tracer`. Vous pouvez l'utiliser pour ajouter des traces avec AWS X-Ray afin de fournir des insights détaillés sur les performances et le flux des requêtes API. Par exemple :
 
 ```ts {5-7}
 export const echo = publicProcedure
@@ -225,22 +224,22 @@ export const echo = publicProcedure
    .output(...)
    .query(async (opts) => {
       const subSegment = opts.ctx.tracer.getSegment()!.addNewSubsegment('MyAlgorithm');
-      // ... logique de l'algorithme à tracer
+      // ... logique de mon algorithme à capturer
       subSegment.close();
 
       return ...;
    });
 ```
 
-Référez-vous à la [documentation AWS Lambda Powertools Tracer](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/).
+Pour plus d'informations, référez-vous à la [documentation AWS Lambda Powertools Tracer](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/).
 
 ### Implémentation de middleware personnalisé
 
-Vous pouvez ajouter des valeurs personnalisées au contexte des procédures en implémentant du middleware.
+Vous pouvez ajouter des valeurs supplémentaires au contexte fourni aux procédures en implémentant du middleware.
 
-Prenons l'exemple d'un middleware pour extraire des détails sur l'utilisateur appelant depuis Cognito dans `src/middleware/identity.ts`.
+Par exemple, implémentons un middleware pour extraire des détails sur l'utilisateur appelant notre API dans `src/middleware/identity.ts`.
 
-D'abord, définissons ce que nous ajoutons au contexte :
+D'abord, nous définissons ce que nous ajouterons au contexte :
 
 ```ts
 export interface IIdentityContext {
@@ -251,26 +250,26 @@ export interface IIdentityContext {
 }
 ```
 
-Notez que nous définissons une propriété _optionnelle_. tRPC s'assure qu'elle est définie dans les procédures utilisant ce middleware.
+Notez que nous définissons une propriété supplémentaire _optionnelle_ dans le contexte. tRPC s'assure que cette propriété est définie dans les procédures ayant correctement configuré ce middleware.
 
-Implémentons ensuite le middleware :
+Ensuite, nous implémentons le middleware lui-même. Il a la structure suivante :
 
 ```ts
 export const createIdentityPlugin = () => {
    const t = initTRPC.context<...>().create();
    return t.procedure.use(async (opts) => {
-      // Logique exécutée avant la procédure
+      // Ajoutez ici la logique à exécuter avant la procédure
 
       const response = await opts.next(...);
 
-      // Logique exécutée après la procédure
+      // Ajoutez ici la logique à exécuter après la procédure
 
       return response;
    });
 };
 ```
 
-Dans notre cas, nous voulons extraire les détails de l'utilisateur Cognito. L'implémentation varie selon que l'événement provient d'une API REST ou HTTP :
+Dans notre cas, nous voulons extraire les détails de l'utilisateur Cognito appelant. Nous le ferons en extrayant l'ID de sujet (ou "sub") de l'utilisateur depuis l'événement API Gateway, et en récupérant les détails de l'utilisateur depuis Cognito. L'implémentation varie légèrement selon que l'événement est fourni par une API REST ou HTTP :
 
 <Tabs>
 <TabItem label="REST">
@@ -309,7 +308,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
-      // Suppose que l'ID du pool utilisateur est configuré dans l'environnement Lambda
+      // Suppose que l'ID du user pool est configuré dans l'environnement Lambda
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -322,7 +321,7 @@ export const createIdentityPlugin = () => {
       });
     }
 
-    // Fournit l'identité au contexte des autres procédures
+    // Fournit l'identité aux autres procédures dans le contexte
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -378,7 +377,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
-      // Suppose que l'ID du pool utilisateur est configuré dans l'environnement Lambda
+      // Suppose que l'ID du user pool est configuré dans l'environnement Lambda
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -391,7 +390,7 @@ export const createIdentityPlugin = () => {
       });
     }
 
-    // Fournit l'identité au contexte des autres procédures
+    // Fournit l'identité aux autres procédures dans le contexte
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -409,14 +408,14 @@ export const createIdentityPlugin = () => {
 
 ## Déploiement de votre API tRPC
 
-Le générateur crée un construct CDK pour déployer votre API dans `common/constructs`. Utilisez-le dans une application CDK :
+Le générateur de backend tRPC génère un construct CDK pour déployer votre API dans le dossier `common/constructs`. Vous pouvez l'utiliser dans une application CDK, par exemple :
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
 
 export class ExampleStack extends Stack {
    constructor(scope: Construct, id: string) {
-      // Ajoute l'API à votre stack
+      // Ajoute l'api à votre stack
       const api = new MyApi(this, 'MyApi', {
         integrations: MyApi.defaultIntegrations(this).build(),
       });
@@ -424,19 +423,19 @@ export class ExampleStack extends Stack {
 }
 ```
 
-Ceci configure l'infrastructure API, incluant une API Gateway REST/HTTP, des fonctions Lambda et l'authentification IAM.
+Ceci configure l'infrastructure de votre API, incluant une API Gateway REST ou HTTP AWS, des fonctions Lambda pour la logique métier, et une authentification IAM.
 
 ### Intégrations type-safe
 
 <Snippet name="api/type-safe-api-integrations" />
 
 :::tip
-Les ajouts/suppressions de procédures dans votre API tRPC sont immédiatement reflétés dans le construct CDK sans reconstruction.
+Lorsque vous ajoutez ou supprimez une procédure dans votre API tRPC, ces changements sont immédiatement reflétés dans le construct CDK sans avoir à reconstruire.
 :::
 
 ### Octroi d'accès
 
-Utilisez `grantInvokeAccess` pour octroyer l'accès à votre API. Par exemple, pour accorder l'accès aux utilisateurs Cognito authentifiés :
+Vous pouvez utiliser la méthode `grantInvokeAccess` pour octroyer l'accès à votre API. Par exemple, vous pourriez vouloir autoriser les utilisateurs Cognito authentifiés à accéder à votre API :
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -444,7 +443,7 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## Serveur tRPC local
 
-Utilisez la cible `serve` pour exécuter un serveur local :
+Vous pouvez utiliser la cible `serve` pour exécuter un serveur local pour votre API, par exemple :
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
@@ -452,7 +451,7 @@ Le point d'entrée du serveur local est `src/local-server.ts`.
 
 ## Invocation de votre API tRPC
 
-Créez un client tRPC pour appeler votre API de manière type-safe. Pour des appels depuis un autre backend, utilisez le client dans `src/client/index.ts` :
+Vous pouvez créer un client tRPC pour invoquer votre API de manière type-safe. Si vous appelez votre API tRPC depuis un autre backend, vous pouvez utiliser le client dans `src/client/index.ts`, par exemple :
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -462,8 +461,8 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-Pour un appel depuis un site React, utilisez le générateur <Link path="guides/api-connection/react-trpc">API Connection</Link>.
+Si vous appelez votre API depuis un site React, envisagez d'utiliser le générateur <Link path="guides/api-connection/react-trpc">Connexion API</Link> pour configurer le client.
 
 ## Plus d'informations
 
-Consultez la [documentation tRPC](https://trpc.io/docs) pour en savoir plus.
+Pour plus d'informations sur tRPC, référez-vous à la [documentation tRPC](https://trpc.io/docs).

--- a/docs/src/content/docs/fr/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/fr/guides/ts-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ts#mcp-server"
-description: "Générer un serveur de protocole de contexte de modèle (MCP) TypeScript pour fournir un contexte aux modèles de langage de grande taille"
+description: "Générer un serveur de protocole de contexte de modèle (MCP) TypeScript pour fournir du contexte aux modèles de langage de grande taille"
 ---
 
 
@@ -14,13 +14,13 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 # Générateur de serveur MCP TypeScript
 
-Générez un serveur [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript pour fournir du contexte aux modèles de langage (LLMs).
+Générez un serveur [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript pour fournir du contexte aux Grands Modèles de Langage (LLMs).
 
 ## Qu'est-ce que le MCP ?
 
 Le [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) est un standard ouvert permettant aux assistants IA d'interagir avec des outils et ressources externes. Il fournit une méthode cohérente pour que les LLMs puissent :
 
-- Exécuter des outils (fonctions) qui effectuent des actions ou récupèrent des informations
+- Exécuter des outils (fonctions) réalisant des actions ou récupérant des informations
 - Accéder à des ressources fournissant du contexte ou des données
 
 ## Utilisation
@@ -33,26 +33,26 @@ Vous pouvez générer un serveur MCP TypeScript de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## Résultat du générateur
 
-Le générateur créera les fichiers de projet suivants :
+Le générateur créera les fichiers projet suivants :
 
 <FileTree>
-  - packages/\<nom>/
-    - README.md Documentation du serveur MCP avec des instructions d'utilisation
-    - project.json Configuration de projet Nx avec des cibles de build, bundle et dev
+  - packages/\<name>/
+    - README.md Documentation du serveur MCP avec instructions d'utilisation
+    - project.json Configuration de projet Nx avec les cibles build, bundle et dev
     - src/
       - index.ts Point d'entrée du serveur MCP
-      - server.ts Définition principale du serveur, décrivant les outils et ressources
-      - global.d.ts Déclarations de types TypeScript pour l'import de fichiers Markdown
+      - server.ts Définition principale du serveur, décrivant outils et ressources
+      - global.d.ts Déclarations de types TypeScript pour l'import de fichiers markdown
       - resources/
-        - example-context.md Exemple de fichier Markdown utilisé comme ressource pour le serveur MCP
+        - example-context.md Exemple de fichier markdown utilisé comme ressource pour le serveur MCP
 </FileTree>
 
 :::note
-Veuillez consulter la <Link path="/guides/typescript-project">documentation du générateur de projet TypeScript</Link> pour plus de détails sur le résultat du générateur.
+Veuillez consulter la <Link path="/guides/typescript-project">documentation du générateur de projet TypeScript</Link> pour plus de détails concernant le résultat du générateur.
 :::
 
 ## Utilisation de votre serveur MCP
@@ -62,12 +62,12 @@ Veuillez consulter la <Link path="/guides/typescript-project">documentation du g
 Les outils sont des fonctions que l'assistant IA peut appeler pour effectuer des actions. Vous pouvez ajouter de nouveaux outils dans le fichier `server.ts` :
 
 ```typescript
-server.tool("nomOutil",
+server.tool("toolName",
   { param1: z.string(), param2: z.number() }, // Schéma d'entrée utilisant Zod
   async ({ param1, param2 }) => {
     // Implémentation de l'outil
     return {
-      content: [{ type: "text", text: "Résultat" }]
+      content: [{ type: "text", text: "Result" }]
     };
   }
 );
@@ -81,12 +81,12 @@ Les ressources fournissent du contexte à l'assistant IA. Vous pouvez ajouter de
 // Ressource statique depuis un fichier
 import exampleContext from './resources/example-context.md';
 
-server.resource('nom-ressource', 'example://ressource', async (uri) => ({
+server.resource('resource-name', 'example://resource', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
 // Ressource dynamique
-server.resource('ressource-dynamique', 'dynamic://ressource', async (uri) => {
+server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
   const data = await fetchSomeData();
   return {
     contents: [{ uri: uri.href, text: data }],
@@ -94,25 +94,25 @@ server.resource('ressource-dynamique', 'dynamic://ressource', async (uri) => {
 });
 ```
 
-## Configuration avec des assistants IA
+## Configuration avec les assistants IA
 
-Pour utiliser votre serveur MCP avec des assistants IA, vous devez d'abord le packager :
+Pour utiliser votre serveur MCP avec des assistants IA, vous devez d'abord le regrouper :
 
-<NxCommands commands={['run votre-serveur-mcp:bundle']} />
+<NxCommands commands={['run your-mcp-server:bundle']} />
 
-Ceci crée une version packagée dans `dist/packages/votre-serveur-mcp/bundle/index.js` (le chemin peut varier selon votre configuration).
+Ceci crée une version regroupée dans `dist/packages/your-mcp-server/bundle/index.js` (le chemin peut varier selon votre configuration).
 
 ### Fichiers de configuration
 
-La plupart des assistants IA compatibles MCP utilisent une approche de configuration similaire. Vous devrez créer ou mettre à jour un fichier de configuration avec les détails de votre serveur MCP :
+La plupart des assistants IA supportant MCP utilisent une approche de configuration similaire. Vous devrez créer ou mettre à jour un fichier de configuration avec les détails de votre serveur MCP :
 
 ```json
 {
   "mcpServers": {
-    "votre-serveur-mcp": {
+    "your-mcp-server": {
       "command": "node",
       "args": [
-        "/chemin/vers/workspace/dist/packages/votre-serveur-mcp/bundle/index.js"
+        "/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js"
       ],
       "transportType": "stdio"
     }
@@ -120,10 +120,10 @@ La plupart des assistants IA compatibles MCP utilisent une approche de configura
 }
 ```
 
-Remplacez `/chemin/vers/workspace/dist/packages/votre-serveur-mcp/bundle/index.js` par le chemin réel vers votre serveur MCP packagé.
+Remplacez `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` par le chemin réel vers votre serveur MCP regroupé.
 
 :::caution
-Si vous obtenez une erreur comme `ENOENT node` lors de la connexion à votre serveur, vous devrez peut-être spécifier le chemin complet vers `node`, que vous pouvez obtenir en exécutant `which node` dans votre terminal.
+Si vous recevez une erreur telle que `ENOENT node` lors de la connexion à votre serveur, vous devrez peut-être spécifier le chemin complet vers `node`, que vous pouvez obtenir en exécutant `which node` dans votre terminal.
 :::
 
 ### Configuration spécifique aux assistants
@@ -136,31 +136,31 @@ Veuillez consulter les documentations suivantes pour configurer MCP avec des ass
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
 
 :::tip
-Certains assistants IA, comme Amazon Q Developer, permettent de spécifier une configuration MCP au niveau du workspace, particulièrement utile pour définir les serveurs MCP pertinents pour un projet donné.
+Certains assistants IA, comme Amazon Q Developer, permettent de spécifier une configuration MCP au niveau de l'espace de travail, particulièrement utile pour définir les serveurs MCP pertinents pour un projet donné.
 :::
 
 ## Workflow de développement
 
 ### Cibles de construction
 
-Ce générateur est basé sur le <Link path="/guides/typescript-project">générateur de projet TypeScript</Link> et hérite donc de ses cibles, tout en ajoutant les cibles supplémentaires suivantes :
+Le générateur est basé sur le <Link path="/guides/typescript-project">générateur de projet TypeScript</Link> et hérite donc de ses cibles, tout en ajoutant les cibles supplémentaires suivantes :
 
 #### Bundle
 
-La tâche `bundle` utilise [esbuild](https://esbuild.github.io/) pour créer un fichier JavaScript unique pouvant être utilisé avec des assistants IA :
+La tâche `bundle` utilise [esbuild](https://esbuild.github.io/) pour créer un fichier JavaScript unique regroupé, utilisable avec les assistants IA :
 
-<NxCommands commands={['run votre-serveur-mcp:bundle']} />
+<NxCommands commands={['run your-mcp-server:bundle']} />
 
-Ceci crée une version packagée dans `dist/packages/votre-serveur-mcp/bundle/index.js` (le chemin peut varier selon votre configuration).
+Ceci crée une version regroupée dans `dist/packages/your-mcp-server/bundle/index.js` (le chemin peut varier selon votre configuration).
 
 #### Dev
 
 La tâche `dev` surveille les modifications de votre projet et reconstruit automatiquement le bundle :
 
-<NxCommands commands={['run votre-serveur-mcp:dev']} />
+<NxCommands commands={['run your-mcp-server:dev']} />
 
-Ceci est particulièrement utile pendant le développement car il garantit que votre assistant IA utilise toujours la dernière version de votre serveur MCP.
+Ceci est particulièrement utile pendant le développement car il garantit que votre assistant IA utilise la dernière version de votre serveur MCP.
 
 :::note
-Certains assistants IA nécessitent un redémarrage du serveur MCP pour que les modifications prennent effet.
+Certains assistants IA nécessiteront un redémarrage du serveur MCP pour que les modifications prennent effet.
 :::

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -10,11 +10,10 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
 [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) est un framework permettant de définir une infrastructure cloud via du code et de la déployer via AWS CloudFormation.
 
-Le générateur d'infrastructure TypeScript crée une application d'infrastructure AWS CDK écrite en TypeScript. L'application générée intègre des bonnes pratiques de sécurité via des contrôles [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html).
+Le générateur d'infrastructure TypeScript crée une application d'infrastructure AWS CDK écrite en TypeScript. L'application générée intègre des bonnes pratiques de sécurité grâce à des vérifications [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html).
 
 ## Utilisation
 
@@ -26,7 +25,7 @@ Vous pouvez générer un nouveau projet d'infrastructure de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
 ## Résultat du générateur
 
@@ -68,9 +67,9 @@ export class ApplicationStack extends cdk.Stack {
 
 ### Infrastructure d'API
 
-Si vous avez utilisé les générateurs <Link path="guides/trpc">tRPC API</Link> ou <Link path="guides/fastapi">FastAPI</Link>, vous remarquerez que des constructs sont déjà disponibles dans `packages/common/constructs` pour les déployer.
+Si vous avez utilisé les générateurs <Link path="guides/trpc">tRPC API</Link> ou <Link path="guides/fastapi">FastAPI</Link> pour créer des APIs, vous remarquerez que des constructs sont déjà disponibles dans `packages/common/constructs` pour les déployer.
 
-Si vous avez par exemple créé une API tRPC appelée `my-api`, vous pouvez simplement importer et instancier le construct pour ajouter toute l'infrastructure nécessaire à son déploiement :
+Par exemple, si vous avez créé une API tRPC appelée `my-api`, vous pouvez simplement importer et instancier le construct pour ajouter toute l'infrastructure nécessaire à son déploiement :
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -107,30 +106,30 @@ export class ApplicationStack extends cdk.Stack {
 ```
 
 :::warning
-Il est important de s'assurer que le site web est déclaré _après_ tout construct d'API afin que la <Link path="guides/cloudscape-website#runtime-configuration">configuration runtime</Link> du site inclue tous les paramètres des API.
+Il est important de s'assurer que le site web est déclaré _après_ tout construct d'API afin que la <Link path="guides/cloudscape-website#runtime-configuration">Configuration Runtime</Link> du site web inclue toutes les configurations d'API.
 :::
 
 ## Synthèse de votre infrastructure
 
-Dans le cadre de votre cible `build`, en plus des <Link path="guides/typescript-project#building">tâches de compilation, lint et test par défaut</Link>, votre projet d'infrastructure est _synthétisé_ en CloudFormation. Cela peut aussi être exécuté séparément via la cible `synth` :
+Dans le cadre de votre cible `build`, en plus des <Link path="guides/typescript-project#building">cibles par défaut de compilation, lint et tests</Link>, votre projet d'infrastructure est _synthétisé_ en CloudFormation. Cela peut également être exécuté séparément via la cible `synth` :
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
-Vous trouverez votre assembly cloud synthétisée dans le dossier racine `dist`, sous `dist/packages/<my-infra-project>/cdk.out`.
+Vous trouverez votre assembly cloud synthétisé dans le dossier racine `dist`, sous `dist/packages/<my-infra-project>/cdk.out`.
 
 ## Initialisation de votre/vos compte(s) AWS
 
-Si vous déployez une application CDK sur un compte AWS pour la première fois, celui-ci doit être initialisé.
+Si vous déployez une application CDK sur un compte AWS pour la première fois, celui-ci doit d'abord être initialisé.
 
-D'abord, assurez-vous d'avoir [configuré les credentials pour votre compte AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
+Premièrement, assurez-vous d'avoir [configuré des identifiants pour votre compte AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
-Ensuite, utilisez la commande `cdk bootstrap` :
+Ensuite, vous pouvez utiliser la commande `cdk bootstrap` :
 
 ```bash
 npx cdk bootstrap aws://<account-id>/<region>
 ```
 
-Pour plus de détails, consultez la [documentation CDK](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html).
+Pour plus de détails, référez-vous à la [documentation CDK](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html).
 
 ## Déploiement sur AWS
 
@@ -140,7 +139,7 @@ Après un build, vous pouvez déployer votre infrastructure sur AWS via la cible
 Utilisez la cible `deploy-ci` pour les déploiements en pipeline CI/CD. Voir ci-dessous pour plus de détails.
 :::
 
-D'abord, assurez-vous d'avoir [configuré les credentials pour votre compte AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
+Premièrement, assurez-vous d'avoir [configuré des identifiants pour votre compte AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
 Ensuite, exécutez la cible deploy :
 
@@ -154,12 +153,12 @@ La commande ci-dessus déploie _toutes_ les stacks définies dans `main.ts`. Vou
 
 ## Déploiement sur AWS dans un pipeline CI/CD
 
-Utilisez la cible `deploy-ci` pour déployer sur AWS via un pipeline CI/CD.
+Utilisez la cible `deploy-ci` pour déployer sur AWS dans le cadre d'un pipeline CI/CD.
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-Cette cible diffère légèrement de `deploy` en ce qu'elle déploie une cloud-assembly pré-synthétisée plutôt que de synthétiser à la volée. Cela évite les problèmes potentiels de non-déterminisme dus aux changements de versions de packages, garantissant que chaque étape du pipeline déploie la même cloud-assembly.
+Cette cible diffère légèrement de la cible `deploy` standard car elle déploie une assembly cloud pré-synthétisée plutôt que de synthétiser à la volée. Cela évite les problèmes potentiels de non-déterminisme dus aux changements de versions de packages, garantissant que chaque étape du pipeline déploie la même assembly cloud.
 
 ## Plus d'informations
 
-Pour en savoir plus sur CDK, consultez le [Guide développeur CDK](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) et la [Référence d'API](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html).
+Pour plus d'informations sur CDK, consultez le [Guide du développeur CDK](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) et la [Référence d'API](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html).

--- a/docs/src/content/docs/fr/guides/typescript-project.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-project.mdx
@@ -10,9 +10,8 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
-Le générateur de projets TypeScript permet de créer une bibliothèque ou une application moderne [TypeScript](https://www.typescriptlang.org/) configurée avec les meilleures pratiques comme les [Modules ECMAScript (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), les [références de projet](https://www.typescriptlang.org/docs/handbook/project-references.html) TypeScript, [Vitest](https://vitest.dev/) pour exécuter les tests et [ESLint](https://eslint.org/) pour l'analyse statique.
+Le générateur de projet TypeScript permet de créer une bibliothèque ou une application moderne [TypeScript](https://www.typescriptlang.org/) configurée avec les meilleures pratiques comme les [modules ECMAScript (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), les [références de projet TypeScript](https://www.typescriptlang.org/docs/handbook/project-references.html), [Vitest](https://vitest.dev/) pour l'exécution des tests et [ESLint](https://eslint.org/) pour l'analyse statique.
 
 ## Utilisation
 
@@ -24,7 +23,7 @@ Vous pouvez générer un nouveau projet TypeScript de deux manières :
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## Résultat du générateur
 
@@ -34,9 +33,9 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
 
   - src Code source TypeScript
     - index.ts
-  - project.json Configuration du projet et cibles de build
-  - tsconfig.json Configuration TypeScript de base pour ce projet (étend tsconfig.base.json à la racine du workspace)
-  - tsconfig.lib.json Configuration TypeScript pour votre bibliothèque (code d'exécution ou source empaquetée)
+  - project.json Configuration du projet et cibles de construction
+  - tsconfig.json Configuration TypeScript de base pour ce projet (étend le tsconfig.base.json racine de l'espace de travail)
+  - tsconfig.lib.json Configuration TypeScript pour votre bibliothèque (code exécuté ou empaqueté)
   - tsconfig.spec.json Configuration TypeScript pour vos tests
   - vite.config.ts Configuration pour Vitest
   - eslint.config.mjs Configuration pour ESLint
@@ -44,10 +43,10 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
 </FileTree>
 
 :::tip
-Remarquez qu'aucun fichier `package.json` n'est créé pour ce projet ! Vous pouvez découvrir pourquoi [ci-dessous](#dependencies).
+Notez qu'aucun fichier `package.json` n'est créé pour ce projet ! Vous pouvez comprendre pourquoi [ci-dessous](#dependencies).
 :::
 
-Vous remarquerez également des modifications dans les fichiers suivants à la racine de votre workspace :
+Vous remarquerez également des modifications dans les fichiers suivants à la racine de votre espace de travail :
 
 <FileTree>
 
@@ -75,7 +74,7 @@ Bien que nous utilisions TypeScript et que `sayHello` soit défini dans `hello.t
 
 ### Exporter pour d'autres projets TypeScript
 
-Le point d'entrée de votre projet TypeScript est `src/index.ts`. Vous pouvez y ajouter des exports pour tous les éléments que d'autres projets devraient pouvoir importer :
+Le point d'entrée de votre projet TypeScript est `src/index.ts`. Vous pouvez y exporter les éléments que vous souhaitez rendre disponibles pour d'autres projets :
 
 ```ts title="src/index.ts"
 export { sayHello } from './hello.js';
@@ -84,17 +83,17 @@ export * from './algorithms/index.js';
 
 ### Importer votre bibliothèque dans d'autres projets
 
-Les [alias TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) pour votre projet sont configurés dans `tsconfig.base.json` à la racine du workspace, ce qui permet de référencer votre projet TypeScript depuis d'autres projets :
+Les [alias TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) pour votre projet sont configurés dans le `tsconfig.base.json` de l'espace de travail, ce qui permet d'importer votre projet depuis d'autres projets TypeScript :
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
 ```
 
 :::note
-Les alias pour vos projets TypeScript commencent par `:` plutôt que le `@` traditionnel, pour éviter les conflits de noms entre les packages locaux de votre workspace et les packages distants sur [NPM](https://www.npmjs.com/).
+Les alias des projets TypeScript commencent par `:` plutôt que par `@` traditionnel, pour éviter les conflits de noms entre les packages locaux et les packages distants sur [NPM](https://www.npmjs.com/).
 :::
 
-Lorsque vous ajoutez une instruction d'import pour un nouveau projet dans votre workspace pour la première fois, vous verrez probablement une erreur similaire à celle-ci dans votre IDE :
+Lorsque vous ajoutez un import vers un nouveau projet pour la première fois, une erreur peut apparaître dans votre IDE :
 
 <details>
 <summary>Erreur d'importation</summary>
@@ -108,16 +107,16 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 </details>
 
-Cela signifie qu'une [référence de projet](https://www.typescriptlang.org/docs/handbook/project-references.html) n'a pas encore été configurée.
+Cela signifie qu'une [référence de projet](https://www.typescriptlang.org/docs/handbook/project-references.html) n'est pas encore configurée.
 
-Les projets TypeScript sont préconfigurés avec le générateur Nx TypeScript Sync, vous évitant de configurer manuellement les références. Exécutez simplement la commande suivante pour ajouter la configuration requise :
+Les projets TypeScript sont préconfigurés avec le générateur Nx TypeScript Sync. Exécutez simplement la commande suivante pour ajouter la configuration nécessaire :
 
 <NxCommands commands={['sync']} />
 
-Après cela, l'erreur dans votre IDE devrait disparaître et vous pourrez utiliser votre bibliothèque.
+Après cela, l'erreur devrait disparaître et votre bibliothèque sera utilisable.
 
 :::tip
-Vous pouvez aussi simplement build votre projet et vous verrez un message comme :
+Vous pouvez aussi lancer la construction de votre projet. Un message comme celui-ci apparaîtra :
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -129,24 +128,22 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Sélectionnez `Yes` pour permettre à Nx de mettre à jour vos références de projet.
+Sélectionnez `Yes` pour permettre à Nx de mettre à jour les références de projet.
 :::
 
 ### Dépendances
 
-Vous remarquerez que votre projet TypeScript n'a pas de fichier `package.json`, ce qui peut surprendre si vous avez l'habitude des monorepos TypeScript traditionnels.
-
-Pour ajouter une dépendance à un package TypeScript dans votre monorepo, ajoutez-la simplement au `package.json` à la racine de votre workspace. Vous pouvez le faire via la ligne de commande de votre gestionnaire de packages :
+Votre projet TypeScript n'a pas de fichier `package.json`. Pour ajouter une dépendance, ajoutez-la au `package.json` racine de votre espace de travail :
 
 <InstallCommand pkg="some-npm-package" />
 
-La dépendance devient alors disponible pour tous les projets TypeScript de votre workspace.
+La dépendance sera alors disponible pour tous les projets TypeScript.
 
-#### Code d'exécution
+#### Code exécutable
 
-Lorsque vous utilisez votre projet TypeScript comme code d'exécution (par exemple comme gestionnaire pour une fonction AWS Lambda), il est recommandé d'utiliser un outil comme [`esbuild`](https://esbuild.github.io/) pour empaqueter votre projet, car il permet le [tree-shaking](https://esbuild.github.io/api/#tree-shaking) pour n'inclure que les dépendances réellement utilisées.
+Pour un usage runtime (ex: handler AWS Lambda), il est recommandé d'utiliser un outil comme [`esbuild`](https://esbuild.github.io/) pour empaqueter le projet et effectuer du [tree-shaking](https://esbuild.github.io/api/#tree-shaking).
 
-Vous pouvez configurer cela en ajoutant une cible comme celle-ci dans votre fichier `project.json` :
+Ajoutez une cible comme celle-ci dans votre `project.json` :
 
 ```json
 {
@@ -166,44 +163,40 @@ Vous pouvez configurer cela en ajoutant une cible comme celle-ci dans votre fich
 ```
 
 :::note
-Dans cet exemple, nous avons choisi `src/index.ts` comme point d'entrée, ce qui signifie que le code exporté depuis ce fichier sera inclus dans le bundle avec toutes ses dépendances.
+Dans cet exemple, `src/index.ts` est le point d'entrée. Le code exporté depuis ce fichier sera inclus dans le bundle avec ses dépendances.
 :::
 
 #### Publication sur NPM
 
-Si vous publiez votre projet TypeScript sur NPM, vous devez créer un fichier `package.json` pour celui-ci.
+Pour publier sur NPM, vous devez créer un `package.json` pour votre projet. 
 
-Ce fichier doit déclarer toutes les dépendances utilisées. Comme les dépendances sont résolues via le `package.json` racine au moment du build, il est recommandé d'utiliser le [plugin ESLint Nx Dependency Checks](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) pour vérifier que votre `package.json` inclut bien toutes les dépendances nécessaires.
+Utilisez le [plugin ESLint de vérification des dépendances Nx](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) pour garantir que toutes les dépendances utilisées sont déclarées.
 
-### Build
+### Construction
 
-Votre projet TypeScript est configuré avec une cible `build` (définie dans `project.json`), que vous pouvez exécuter via :
+Le projet est configuré avec une cible `build` (définie dans `project.json`) :
 
 <NxCommands commands={['run <project-name>:build']} />
 
 Où `<project-name>` est le nom complet de votre projet.
 
-La cible `build` compilera, linttera et testera votre projet.
-
-Le résultat du build se trouve dans le dossier `dist` à la racine de votre workspace, dans un sous-répertoire correspondant à votre package et cible, par exemple `dist/packages/<my-library>/tsc`
+Les artefacts de construction se trouvent dans `dist/packages/<my-library>/tsc`.
 
 ## Tests
 
-[Vitest](https://vitest.dev/) est configuré pour tester votre projet.
+[Vitest](https://vitest.dev/) est configuré pour les tests.
 
 ### Écrire des tests
 
-Écrivez vos tests dans des fichiers `.spec.ts` ou `.test.ts`, placés dans le dossier `src` de votre projet.
-
-Exemple :
+Placez vos tests dans des fichiers `.spec.ts` ou `.test.ts` à côté du code source :
 
 <FileTree>
   - src
-    - hello.ts Code source de la bibliothèque
+    - hello.ts Code source
     - hello.spec.ts Tests pour hello.ts
 </FileTree>
 
-Vitest fournit une syntaxe similaire à Jest pour définir des tests, avec des utilitaires comme `describe`, `it`, `test` et `expect`.
+Utilisez la syntaxe de type Jest avec `describe`, `it`, `test` et `expect`.
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
@@ -217,42 +210,38 @@ describe('sayHello', () => {
 });
 ```
 
-Pour plus de détails sur l'écriture de tests et des fonctionnalités comme le mocking, consultez la [documentation Vitest](https://vitest.dev/guide/#writing-tests)
+Consultez la [documentation Vitest](https://vitest.dev/guide/#writing-tests) pour plus de détails.
 
 ### Exécuter les tests
 
-Les tests s'exécutent lors de la cible `build`, mais vous pouvez aussi les lancer séparément via la cible `test` :
+Exécutez tous les tests avec :
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Vous pouvez exécuter un test ou un groupe de tests spécifique avec le flag `-t` :
+Ou un test spécifique avec :
 
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-Si vous utilisez VSCode, nous recommandons d'installer l'extension [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) pour exécuter, surveiller ou déboguer vos tests directement depuis l'IDE.
+Pour VSCode, installez l'extension [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) pour exécuter des tests directement depuis l'IDE.
 :::
 
 ## Linting
 
-Les projets TypeScript utilisent [ESLint](https://eslint.org/) pour le linting et [Prettier](https://prettier.io/) pour le formatage.
+Les projets utilisent [ESLint](https://eslint.org/) et [Prettier](https://prettier.io/). Configurez-les dans les fichiers racines `eslint.config.mjs` et `.prettierrc`.
 
-Nous recommandons de configurer ESLint dans le fichier `eslint.config.mjs` à la racine du workspace, afin que les modifications s'appliquent à tous les projets et garantissent une cohérence.
+### Vérification
 
-Configurez Prettier dans le fichier `.prettierrc` racine.
-
-### Exécuter le linter
-
-Pour vérifier votre projet avec le linter, exécutez la cible `lint` :
+Lancez le linter avec :
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corriger les problèmes de lint
+### Correction automatique
 
-La plupart des problèmes de lint ou de formatage peuvent être corrigés automatiquement. Utilisez l'argument `--configuration=fix` pour corriger automatiquement :
+Corrigez les problèmes de lint avec :
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Pour corriger tous les problèmes dans l'ensemble du workspace, exécutez :
+Ou pour tous les projets :
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/it/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/it/guides/api-connection/react-fastapi.mdx
@@ -1,6 +1,6 @@
 ---
-title: "React con FastAPI"
-description: "Connettere un sito web React a un'API Python FastAPI"
+title: "React to FastAPI"
+description: "Connetti un sito web React a un'API Python FastAPI"
 ---
 
 
@@ -11,16 +11,15 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Il generatore `api-connection` fornisce un modo rapido per integrare il tuo sito React con il backend FastAPI. Configura tutto il necessario per connettersi ai backend FastAPI in modo type-safe, inclusa la generazione di client e hook [TanStack Query](https://tanstack.com/query/v5), il supporto per l'autenticazione AWS IAM e una corretta gestione degli errori.
+Il generatore `api-connection` fornisce un modo per integrare rapidamente il tuo sito React con il backend FastAPI. Configura tutte le impostazioni necessarie per connettersi ai backend FastAPI in modo type-safe, inclusi la generazione del client e degli hook [TanStack Query](https://tanstack.com/query/v5), il supporto per l'autenticazione AWS IAM e una corretta gestione degli errori.
 
 ## Prerequisiti
 
-Prima di usare questo generatore, assicurati che la tua applicazione React abbia:
+Prima di utilizzare questo generatore, assicurati che la tua applicazione React abbia:
 
 1. Un file `main.tsx` che renderizza l'applicazione
-2. Un backend FastAPI funzionante (generato usando il generatore FastAPI)
+2. Un backend FastAPI funzionante (generato utilizzando il generatore FastAPI)
 
 <details>
 <summary>Esempio della struttura richiesta per `main.tsx`</summary>
@@ -44,76 +43,76 @@ root.render(
 
 ## Utilizzo
 
-### Esegui il Generatore
+### Esegui il generatore
 
 <RunGenerator generator="api-connection" />
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
-## Output del Generatore
+## Output del generatore
 
-Il generatore modificherà i seguenti file nel tuo progetto FastAPI:
+Il generatore apporterà modifiche ai seguenti file nel tuo progetto FastAPI:
 
 <FileTree>
 
 - scripts
-  - generate_open_api.py Aggiunge uno script per generare la specifica OpenAPI dell'API
-- project.json Aggiunge un nuovo target alla build che invoca lo script di generazione
+  - generate_open_api.py Aggiunge uno script che genera una specifica OpenAPI per la tua API
+- project.json Viene aggiunto un nuovo target alla build che richiama lo script di generazione
 
 </FileTree>
 
-Il generatore modificherà i seguenti file nella tua applicazione React:
+Il generatore apporterà modifiche ai seguenti file nella tua applicazione React:
 
 <FileTree>
 
 - src
   - components
-    - \<ApiName>Provider.tsx Provider per il client API
+    - \<ApiName>Provider.tsx Provider per il client della tua API
     - QueryClientProvider.tsx Provider del client TanStack React Query
   - hooks
-    - use\<ApiName>.tsx Aggiunge un hook per chiamare l'API con stato gestito da TanStack Query
-    - use\<ApiName>Client.tsx Aggiunge un hook per istanziare il client API vanilla
+    - use\<ApiName>.tsx Aggiunge un hook per chiamare la tua API con lo stato gestito da TanStack Query
+    - use\<ApiName>Client.tsx Aggiunge un hook per istanziare il client API vanilla che può chiamare la tua API
     - useSigV4.tsx Aggiunge un hook per firmare le richieste HTTP con SigV4 (se è stata selezionata l'autenticazione IAM)
-- project.json Aggiunge un nuovo target alla build che genera un client type-safe
-- .gitignore I file generati del client vengono ignorati per default
+- project.json Viene aggiunto un nuovo target alla build che genera un client type-safe
+- .gitignore I file del client generato vengono ignorati per impostazione predefinita
 
 </FileTree>
 
-Il generatore aggiungerà anche Runtime Config all'infrastruttura del tuo sito web se non presente, garantendo che l'URL dell'API FastAPI sia disponibile nel sito e configurato automaticamente dall'hook `use<ApiName>.tsx`.
+Il generatore aggiungerà anche la Runtime Config all'infrastruttura del tuo sito web se non è già presente, garantendo che l'URL dell'API per il tuo FastAPI sia disponibile nel sito e configurato automaticamente dall'hook `use<ApiName>.tsx`.
 
-### Generazione del Codice
+### Generazione del codice
 
-Durante la build, viene generato un client type-safe dalla specifica OpenAPI di FastAPI. Questo aggiungerà tre nuovi file all'applicazione React:
+Durante la build, viene generato un client type-safe dalla specifica OpenAPI del tuo FastAPI. Questo aggiungerà tre nuovi file alla tua applicazione React:
 
 <FileTree>
 
 - src
   - generated
     - \<ApiName>
-      - types.gen.ts Tipi generati dai modelli pydantic definiti in FastAPI
-      - client.gen.ts Client type-safe per chiamare l'API
-      - options-proxy.gen.ts Fornisce metodi per creare opzioni degli hook TanStack Query
+      - types.gen.ts Tipi generati dai modelli pydantic definiti nel tuo FastAPI
+      - client.gen.ts Client type-safe per chiamare la tua API
+      - options-proxy.gen.ts Fornisce metodi per creare opzioni degli hook TanStack Query per interagire con la tua API utilizzando TanStack Query
 
 </FileTree>
 
 :::tip
-Per default, il client generato viene ignorato dal versioning. Se preferisci includerlo, puoi rimuovere la voce dal file `.gitignore` dell'applicazione React, ma qualsiasi modifica manuale ai file `.gen.ts` verrà sovrascritta durante la build.
+Per impostazione predefinita, il client generato viene ignorato dal controllo versione. Se preferisci includerlo, puoi rimuovere la voce dal file `.gitignore` della tua applicazione React, ma tieni presente che eventuali modifiche manuali ai file `.gen.ts` verranno sovrascritte durante la build del progetto.
 :::
 
-## Utilizzo del Codice Generato
+## Utilizzo del codice generato
 
-Il client type-safe generato può essere usato per chiamare FastAPI dall'applicazione React. Si consiglia di utilizzarlo tramite gli hook TanStack Query, ma è possibile usare il client vanilla se preferisci.
+Il client type-safe generato può essere utilizzato per chiamare il tuo FastAPI dall'applicazione React. Si consiglia di utilizzare il client tramite gli hook TanStack Query, ma è possibile utilizzare il client vanilla se preferisci.
 
 :::note
-Ogni modifica a FastAPI richiede una rebuild del progetto per riflettersi nel client generato. Esempio:
+Ogni volta che apporti modifiche al tuo FastAPI, devi ricostruire il progetto per riflettere tali modifiche nel client generato. Ad esempio:
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
 :::tip
-Se stai lavorando contemporaneamente su React e FastAPI, puoi usare [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) per rigenerare il client ad ogni modifica:
+Se stai lavorando contemporaneamente sia sulla tua applicazione React che sul FastAPI, puoi utilizzare [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) per rigenerare il client ogni volta che apporti modifiche all'API:
 
 <NxCommands
   commands={[
@@ -123,13 +122,13 @@ Se stai lavorando contemporaneamente su React e FastAPI, puoi usare [`nx watch`]
 />
 :::
 
-### Utilizzo dell'Hook API
+### Utilizzo dell'hook API
 
-Il generatore fornisce un hook `use<ApiName>` per chiamare l'API con TanStack Query.
+Il generatore fornisce un hook `use<ApiName>` che puoi utilizzare per chiamare la tua API con TanStack Query.
 
 ### Query
 
-Puoi usare il metodo `queryOptions` per ottenere le opzioni necessarie per chiamare l'API con l'hook `useQuery` di TanStack Query:
+Puoi utilizzare il metodo `queryOptions` per recuperare le opzioni richieste per chiamare l'API utilizzando l'hook `useQuery` di TanStack Query:
 
 ```tsx {7}
 import { useQuery } from '@tanstack/react-query';
@@ -147,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="Utilizzo diretto del client API" trigger="Fai clic qui per un esempio che utilizza direttamente il client vanilla.">
+<Drawer title="Utilizzo diretto del client API" trigger="Clicca qui per un esempio che utilizza direttamente il client vanilla.">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -182,7 +181,7 @@ function MyComponent() {
 
 ### Mutazioni
 
-Gli hook generati supportano le mutazioni con l'hook `useMutation` di TanStack Query, offrendo un modo pulito per gestire operazioni di creazione, aggiornamento e cancellazione con stati di caricamento, gestione errori e aggiornamenti ottimistici.
+Gli hook generati includono il supporto per le mutazioni utilizzando l'hook `useMutation` di TanStack Query. Questo fornisce un modo pulito per gestire operazioni di creazione, aggiornamento ed eliminazione con stati di caricamento, gestione degli errori e aggiornamenti ottimistici.
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -190,7 +189,7 @@ import { useMyApi } from './hooks/useMyApi';
 
 function CreateItemForm() {
   const api = useMyApi();
-  // Crea una mutazione usando le opzioni generate
+  // Crea una mutazione utilizzando le opzioni di mutazione generate
   const createItem = useMutation(api.createItem.mutationOptions());
 
   const handleSubmit = (e) => {
@@ -205,12 +204,12 @@ function CreateItemForm() {
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Creazione...' : 'Crea Item'}
+        {createItem.isPending ? 'Creazione in corso...' : 'Crea elemento'}
       </button>
 
       {createItem.isSuccess && (
         <div className="success">
-          Item creato con ID: {createItem.data.id}
+          Elemento creato con ID: {createItem.data.id}
         </div>
       )}
 
@@ -224,30 +223,30 @@ function CreateItemForm() {
 }
 ```
 
-Puoi aggiungere callback per diversi stati della mutazione:
+Puoi anche aggiungere callback per diversi stati della mutazione:
 
 ```tsx
 const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
-    // Eseguito quando la mutazione ha successo
-    console.log('Item creato:', data);
-    // Naviga verso il nuovo item
+    // Questo viene eseguito quando la mutazione ha successo
+    console.log('Elemento creato:', data);
+    // Puoi navigare verso il nuovo elemento
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
-    // Eseguito in caso di errore
-    console.error('Creazione fallita:', error);
+    // Questo viene eseguito quando la mutazione fallisce
+    console.error('Creazione elemento fallita:', error);
   },
   onSettled: () => {
-    // Eseguito al completamento (successo o errore)
-    // Luogo ideale per invalidare query correlate
+    // Questo viene eseguito al completamento della mutazione (successo o errore)
+    // Buon punto per invalidare query che potrebbero essere interessate
     queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
   }
 });
 ```
 
-<Drawer title="Mutazioni con client API diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Mutazioni utilizzando direttamente il client API" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 import { useState } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -269,11 +268,11 @@ function CreateItemForm() {
         description: 'A new item'
       });
       setCreatedItem(newItem);
-      // Naviga verso il nuovo item
+      // Puoi navigare verso il nuovo elemento
       // navigate(`/items/${newItem.id}`);
     } catch (err) {
       setError(err);
-      console.error('Creazione fallita:', err);
+      console.error('Creazione elemento fallita:', err);
     } finally {
       setIsLoading(false);
     }
@@ -286,12 +285,12 @@ function CreateItemForm() {
         type="submit"
         disabled={isLoading}
       >
-        {isLoading ? 'Creazione...' : 'Crea Item'}
+        {isLoading ? 'Creazione in corso...' : 'Crea elemento'}
       </button>
 
       {createdItem && (
         <div className="success">
-          Item creato con ID: {createdItem.id}
+          Elemento creato con ID: {createdItem.id}
         </div>
       )}
 
@@ -308,7 +307,7 @@ function CreateItemForm() {
 
 ### Paginazione con Infinite Query
 
-Per endpoint che accettano un parametro `cursor`, gli hook generati supportano infinite query con l'hook `useInfiniteQuery` di TanStack Query, semplificando l'implementazione di funzionalità "carica più elementi" o scroll infinito.
+Per endpoint che accettano un parametro `cursor` come input, gli hook generati forniscono supporto per infinite query utilizzando l'hook `useInfiniteQuery` di TanStack Query. Questo semplifica l'implementazione della funzionalità "carica più" o scroll infinito.
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -320,8 +319,9 @@ function ItemList() {
     ...api.listItems.infiniteQueryOptions({
       limit: 10, // Numero di elementi per pagina
     }, {
-      // Definisci una funzione getNextPageParam per restituire
-      // il parametro da passare come 'cursor' per la pagina successiva
+      // Assicurati di definire una funzione getNextPageParam per restituire
+      // il parametro che dovrebbe essere passato come 'cursor' per la
+      // prossima pagina
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor || undefined
       }),
@@ -353,7 +353,7 @@ function ItemList() {
         {items.isFetchingNextPage
           ? 'Caricamento...'
           : items.hasNextPage
-          ? 'Carica Altro'
+          ? 'Carica più'
           : 'Nessun altro elemento'}
       </button>
     </div>
@@ -361,13 +361,13 @@ function ItemList() {
 }
 ```
 
-Gli hook generati gestiscono automaticamente la paginazione basata su cursor se l'API la supporta. Il valore `nextCursor` viene estratto dalla risposta e usato per recuperare la pagina successiva.
+Gli hook generati gestiscono automaticamente la paginazione basata su cursor se la tua API la supporta. Il valore `nextCursor` viene estratto dalla risposta e utilizzato per recuperare la pagina successiva.
 
 :::tip
-Se la tua API usa un parametro di paginazione diverso da `cursor`, puoi [personalizzarlo usando l'estensione OpenAPI `x-cursor`](#custom-pagination-cursor).
+Se hai un'API paginata che utilizza un parametro di paginazione con un nome diverso da `cursor`, puoi [personalizzarlo utilizzando l'estensione OpenAPI `x-cursor`](#custom-pagination-cursor).
 :::
 
-<Drawer title="Paginazione con client API diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Paginazione utilizzando direttamente il client API" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -380,7 +380,7 @@ function ItemList() {
   const [nextCursor, setNextCursor] = useState(null);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
-  // Recupera dati iniziali
+  // Recupera i dati iniziali
   useEffect(() => {
     const fetchItems = async () => {
       try {
@@ -441,7 +441,7 @@ function ItemList() {
         {isFetchingMore
           ? 'Caricamento...'
           : nextCursor
-          ? 'Carica Altro'
+          ? 'Carica più'
           : 'Nessun altro elemento'}
       </button>
     </div>
@@ -450,9 +450,9 @@ function ItemList() {
 ```
 </Drawer>
 
-### Gestione degli Errori
+### Gestione degli errori
 
-L'integrazione include una gestione errori con risposte tipizzate. Viene generato un tipo `<operation-name>Error` che incapsula le possibili risposte di errore definite nella specifica OpenAPI. Ogni errore ha proprietà `status` e `error`, e controllando il valore di `status` puoi identificare un tipo specifico di errore.
+L'integrazione include una gestione degli errori integrata con risposte di errore tipizzate. Viene generato un tipo `<operation-name>Error` che incapsula le possibili risposte di errore definite nella specifica OpenAPI. Ogni errore ha una proprietà `status` e `error`, e controllando il valore di `status` puoi restringere a un tipo specifico di errore.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -493,7 +493,7 @@ function MyComponent() {
         // error.error è tipizzato come CreateItem5XXResponse
         return (
           <div>
-            <h2>Errore server:</h2>
+            <h2>Errore del server:</h2>
             <p>{createItem.error.error.message}</p>
             <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
@@ -501,11 +501,11 @@ function MyComponent() {
     }
   }
 
-  return <button onClick={handleClick}>Crea Item</button>;
+  return <button onClick={handleClick}>Crea elemento</button>;
 }
 ```
 
-<Drawer title="Gestione errori con client API diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Gestione errori utilizzando direttamente il client API" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx {9,15}
 function MyComponent() {
   const api = useMyApiClient();
@@ -548,7 +548,7 @@ function MyComponent() {
         // error.error è tipizzato come CreateItem5XXResponse
         return (
           <div>
-            <h2>Errore server:</h2>
+            <h2>Errore del server:</h2>
             <p>{error.error.message}</p>
             <p>Trace ID: {error.error.traceId}</p>
           </div>
@@ -556,14 +556,14 @@ function MyComponent() {
     }
   }
 
-  return <button onClick={handleClick}>Crea Item</button>;
+  return <button onClick={handleClick}>Crea elemento</button>;
 }
 ```
 </Drawer>
 
-### Consumo di uno Stream
+### Consumo di uno stream
 
-Se hai <Link path="guides/fastapi#streaming">configurato FastAPI per streammare risposte</Link>, l'hook `useQuery` aggiornerà automaticamente i dati al ricevere nuovi chunk.
+Se hai <Link path="guides/fastapi#streaming">configurato il tuo FastAPI per streammare le risposte</Link>, il tuo hook `useQuery` aggiornerà automaticamente i dati man mano che arrivano nuovi chunk dello stream.
 
 Esempio:
 
@@ -584,37 +584,37 @@ function MyStreamingComponent() {
 }
 ```
 
-Puoi usare le proprietà `isLoading` e `fetchStatus` per determinare lo stato corrente dello stream:
+Puoi utilizzare le proprietà `isLoading` e `fetchStatus` per determinare lo stato corrente dello stream se necessario. Uno stream segue questo ciclo di vita:
 
 <Steps>
-  1. La richiesta HTTP per iniziare lo streaming viene inviata
+  1. Viene inviata la richiesta HTTP per avviare lo streaming
 
       - `isLoading` è `true`
       - `fetchStatus` è `'fetching'`
       - `data` è `undefined`
 
-  2. Ricevuto il primo chunk
+  2. Viene ricevuto il primo chunk dello stream
 
       - `isLoading` diventa `false`
       - `fetchStatus` rimane `'fetching'`
-      - `data` diventa un array con il primo chunk
+      - `data` diventa un array contenente il primo chunk
 
-  3. Ricevuti chunk successivi
+  3. Vengono ricevuti chunk successivi
 
       - `isLoading` rimane `false`
       - `fetchStatus` rimane `'fetching'`
-      - `data` viene aggiornato ad ogni nuovo chunk
+      - `data` viene aggiornato con ogni chunk successivo non appena viene ricevuto
 
-  4. Stream completato
+  4. Lo stream viene completato
 
       - `isLoading` rimane `false`
       - `fetchStatus` diventa `'idle'`
-      - `data` contiene tutti i chunk ricevuti
+      - `data` è un array di tutti i chunk ricevuti
 </Steps>
 
-<Drawer title="Streaming con client API diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Streaming utilizzando direttamente il client API" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 
-Se hai <Link path="guides/fastapi#streaming">configurato lo streaming in FastAPI</Link>>, il client generato include metodi type-safe per iterare asincronamente sui chunk usando la sintassi `for await`.
+Se hai <Link path="guides/fastapi#streaming">configurato il tuo FastAPI per streammare le risposte</Link>, il client generato includerà metodi type-safe per iterare in modo asincrono sui chunk dello stream utilizzando la sintassi `for await`.
 
 Esempio:
 
@@ -647,14 +647,16 @@ function MyStreamingComponent() {
 </Drawer>
 
 :::note
-Se un'API streaming accetta un parametro `cursor`, quando si usa `useInfiniteQuery`, ogni pagina attenderà il completamento dello stream prima di essere considerata caricata.
+Se hai un'API streaming che accetta un parametro `cursor`, quando utilizzi l'hook `useInfiniteQuery`, ogni pagina attenderà il completamento dello stream prima di essere considerata caricata.
 :::
 
-## Personalizzazione del Codice Generato
+## Personalizzazione del codice generato
 
-### Query e Mutazioni
+### Query e mutazioni
 
-Per default, le operazioni FastAPI che usano metodi HTTP `PUT`, `POST`, `PATCH` e `DELETE` sono considerate mutazioni. Puoi modificare questo comportamento con `x-query` e `x-mutation`.
+Per impostazione predefinita, le operazioni nel tuo FastAPI che utilizzano i metodi HTTP `PUT`, `POST`, `PATCH` e `DELETE` sono considerate mutazioni, mentre tutte le altre sono considerate query.
+
+Puoi modificare questo comportamento utilizzando `x-query` e `x-mutation`.
 
 #### x-query
 
@@ -669,7 +671,7 @@ def list_items():
     # ...
 ```
 
-L'hook generato fornirà `queryOptions` nonostante usi il metodo `POST`:
+L'hook generato fornirà `queryOptions` nonostante utilizzi il metodo HTTP `POST`:
 
 ```tsx
 const items = useQuery(api.listItems.queryOptions());
@@ -688,21 +690,22 @@ def start_processing():
     # ...
 ```
 
-L'hook generato fornirà `mutationOptions` nonostante usi `GET`:
+L'hook generato fornirà `mutationOptions` nonostante utilizzi il metodo HTTP `GET`:
 
 ```tsx
+// L'hook generato includerà le opzioni personalizzate
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
 ```
 
-### Cursor di Paginazione Personalizzato
+### Cursor di paginazione personalizzato
 
-Per default gli hook assumono un parametro `cursor` per la paginazione. Puoi personalizzarlo con l'estensione `x-cursor`:
+Per impostazione predefinita, gli hook generati assumono una paginazione basata su cursor con un parametro chiamato `cursor`. Puoi personalizzare questo comportamento utilizzando l'estensione `x-cursor`:
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
-        # Specifica un nome diverso per il parametro
+        # Specifica un nome diverso per il parametro del cursor
         "x-cursor": "page_token"
     }
 )
@@ -714,13 +717,13 @@ def list_items(page_token: str = None, limit: int = 10):
     }
 ```
 
-Per disabilitare `infiniteQueryOptions` per un endpoint:
+Se non vuoi generare `infiniteQueryOptions` per un'operazione, puoi impostare `x-cursor` su `False`:
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
-        # Disabilita la paginazione basata su cursor
+        # Disabilita la paginazione basata su cursor per questo endpoint
         "x-cursor": False
     }
 )
@@ -734,9 +737,9 @@ def list_items(page: int = 1, limit: int = 10):
     }
 ```
 
-### Raggruppamento Operazioni
+### Raggruppamento delle operazioni
 
-Gli hook e metodi client vengono organizzati in base ai tag OpenAPI degli endpoint FastAPI, aiutando a mantenere organizzate le chiamate API.
+Gli hook e i metodi del client generati vengono organizzati automaticamente in base ai tag OpenAPI nei tuoi endpoint FastAPI. Questo aiuta a mantenere organizzate le chiamate API e facilita la ricerca di operazioni correlate.
 
 Esempio:
 
@@ -765,7 +768,7 @@ def list():
     # ...
 ```
 
-Gli hook generati saranno raggruppati per tag:
+Gli hook generati saranno raggruppati per questi tag:
 
 ```tsx
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -774,26 +777,29 @@ import { useMyApi } from './hooks/useMyApi';
 function ItemsAndUsers() {
   const api = useMyApi();
 
-  // Operazioni items sotto api.items
+  // Le operazioni items sono raggruppate sotto api.items
   const items = useQuery(api.items.list.queryOptions());
   const createItem = useMutation(api.items.create.mutationOptions());
 
-  // Operazioni users sotto api.users
+  // Le operazioni users sono raggruppate sotto api.users
   const users = useQuery(api.users.list.queryOptions());
+
+  // Esempio di utilizzo
+  const handleCreateItem = () => {
+    createItem.mutate({ name: 'New Item' });
+  };
 
   return (
     <div>
-      <h2>Items</h2>
+      <h2>Elementi</h2>
       <ul>
         {items.data?.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-      <button onClick={() => createItem.mutate({ name: 'New Item' })}>
-        Aggiungi Item
-      </button>
+      <button onClick={handleCreateItem}>Aggiungi elemento</button>
 
-      <h2>Users</h2>
+      <h2>Utenti</h2>
       <ul>
         {users.data?.map(user => (
           <li key={user.id}>{user.name}</li>
@@ -804,9 +810,9 @@ function ItemsAndUsers() {
 }
 ```
 
-Questo raggruppamento facilita l'organizzazione delle chiamate API e migliora il completamento codice nell'IDE.
+Questo raggruppamento semplifica l'organizzazione delle chiamate API e fornisce un migliore completamento del codice nel tuo IDE.
 
-<Drawer title="Operazioni raggruppate con client API diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Operazioni raggruppate utilizzando direttamente il client API" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -817,20 +823,21 @@ function ItemsAndUsers() {
   const [users, setUsers] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Carica i dati
   useEffect(() => {
     const fetchData = async () => {
       try {
         setIsLoading(true);
 
-        // Operazioni items sotto api.items
+        // Operazioni items raggruppate sotto api.items
         const itemsData = await api.items.list();
         setItems(itemsData);
 
-        // Operazioni users sotto api.users
+        // Operazioni users raggruppate sotto api.users
         const usersData = await api.users.list();
         setUsers(usersData);
       } catch (error) {
-        console.error('Errore nel fetch dati:', error);
+        console.error('Errore nel recupero dei dati:', error);
       } finally {
         setIsLoading(false);
       }
@@ -841,10 +848,11 @@ function ItemsAndUsers() {
 
   const handleCreateItem = async () => {
     try {
+      // Crea elemento utilizzando il metodo raggruppato
       const newItem = await api.items.create({ name: 'New Item' });
       setItems(prevItems => [...prevItems, newItem]);
     } catch (error) {
-      console.error('Errore creazione item:', error);
+      console.error('Errore nella creazione dell\'elemento:', error);
     }
   };
 
@@ -854,15 +862,15 @@ function ItemsAndUsers() {
 
   return (
     <div>
-      <h2>Items</h2>
+      <h2>Elementi</h2>
       <ul>
         {items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-      <button onClick={handleCreateItem}>Aggiungi Item</button>
+      <button onClick={handleCreateItem}>Aggiungi elemento</button>
 
-      <h2>Users</h2>
+      <h2>Utenti</h2>
       <ul>
         {users.map(user => (
           <li key={user.id}>{user.name}</li>
@@ -875,16 +883,16 @@ function ItemsAndUsers() {
 </Drawer>
 
 :::tip
-Puoi anche dividere la tua API usando multipli `router`. Vedi la [documentazione FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/) per dettagli.
+Puoi anche dividere la tua API utilizzando più `router`. Consulta la [documentazione di FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/) per maggiori dettagli.
 :::
 
 ### Errori
 
-Puoi personalizzare le risposte di errore in FastAPI definendo classi di eccezione custom, handler di eccezione e specificando modelli di risposta per diversi status code. Il client generato gestirà automaticamente questi tipi di errore.
+Puoi personalizzare le risposte di errore nel tuo FastAPI definendo classi di eccezioni personalizzate, gestori di eccezioni e specificando modelli di risposta per diversi codici di stato degli errori. Il client generato gestirà automaticamente questi tipi di errore personalizzati.
 
-#### Definizione Modelli Errore
+#### Definizione di modelli di errore personalizzati
 
-Definisci modelli errore con Pydantic:
+Prima definisci i tuoi modelli di errore utilizzando Pydantic:
 
 ```python title="models.py"
 from pydantic import BaseModel
@@ -897,9 +905,9 @@ class ValidationError(BaseModel):
     field_errors: list[str]
 ```
 
-#### Creazione Eccezioni Custom
+#### Creazione di eccezioni personalizzate
 
-Crea classi di eccezione per diversi scenari:
+Poi crea classi di eccezione personalizzate per diversi scenari di errore:
 
 ```python title="exceptions.py"
 class NotFoundException(Exception):
@@ -911,9 +919,9 @@ class ValidationException(Exception):
         self.details = details
 ```
 
-#### Aggiunta Exception Handlers
+#### Aggiunta di gestori di eccezioni
 
-Registra handler per convertire eccezioni in risposte HTTP:
+Registra i gestori di eccezioni per convertire le tue eccezioni in risposte HTTP:
 
 ```python title="main.py"
 from fastapi import Request
@@ -935,12 +943,12 @@ async def validation_error_handler(request: Request, exc: ValidationException):
 ```
 
 :::tip
-`JSONResponse` accetta un dizionario, quindi usiamo `model_dump` del modello Pydantic.
+`JSONResponse` accetta un dizionario, quindi utilizziamo il metodo `model_dump` del nostro modello Pydantic.
 :::
 
-#### Specifica Modelli di Risposta
+#### Specifica dei modelli di risposta
 
-Specifica i modelli di risposta per diversi status code negli endpoint:
+Infine, specifica i modelli di risposta per diversi codici di stato degli errori nelle definizioni degli endpoint:
 
 ```python title="main.py"
 @app.get(
@@ -953,7 +961,7 @@ Specifica i modelli di risposta per diversi status code negli endpoint:
 def get_item(item_id: str) -> Item:
     item = find_item(item_id)
     if not item:
-        raise NotFoundException(message=f"Item {item_id} non trovato")
+        raise NotFoundException(message=f"Elemento con ID {item_id} non trovato")
     return item
 
 @app.post(
@@ -967,16 +975,16 @@ def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
             ValidationError(
-                message="Dati item non validi",
-                field_errors=["name è obbligatorio"]
+                message="Dati elemento non validi",
+                field_errors=["Il nome è obbligatorio"]
             )
         )
     return save_item(item)
 ```
 
-#### Utilizzo Tipi Errore in React
+#### Utilizzo di tipi di errore personalizzati in React
 
-Il client gestirà automaticamente questi tipi, permettendo type-check e gestione errori:
+Il client generato gestirà automaticamente questi tipi di errore personalizzati, permettendoti di effettuare il type-check e gestire diverse risposte di errore:
 
 ```tsx
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -988,33 +996,39 @@ function ItemComponent() {
   const getItem = useQuery({
     ...api.getItem.queryOptions({ itemId: '123' }),
     onError: (error) => {
+      // L'errore è tipizzato in base alle risposte nel tuo FastAPI
       switch (error.status) {
         case 404:
+          // error.error è una stringa come specificato nelle risposte
           console.error('Non trovato:', error.error);
           break;
         case 500:
-          console.error('Errore server:', error.error.message);
+          // error.error è tipizzato come ErrorDetails
+          console.error('Errore del server:', error.error.message);
           break;
       }
     }
   });
 
-  // Mutation con gestione errori tipizzata
+  // Mutazione con gestione errori tipizzata
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
       switch (error.status) {
         case 400:
-          console.error('Errore validazione:', error.error.message);
-          console.error('Errori campo:', error.error.field_errors);
+          // error.error è tipizzato come ValidationError
+          console.error('Errore di validazione:', error.error.message);
+          console.error('Errori nei campi:', error.error.field_errors);
           break;
         case 403:
+          // error.error è una stringa come specificato nelle risposte
           console.error('Accesso negato:', error.error);
           break;
       }
     }
   });
 
+  // Renderizzazione del componente con gestione errori
   if (getItem.isError) {
     if (getItem.error.status === 404) {
       return <NotFoundMessage message={getItem.error.error} />;
@@ -1023,11 +1037,15 @@ function ItemComponent() {
     }
   }
 
-  return <div>{/* Contenuto componente */}</div>;
+  return (
+    <div>
+      {/* Contenuto del componente */}
+    </div>
+  );
 }
 ```
 
-<Drawer title="Gestione errori custom con client diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Gestione errori personalizzati con il client direttamente" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 import { useState, useEffect } from 'react';
 
@@ -1037,6 +1055,7 @@ function ItemComponent() {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  // Recupera elemento con gestione errori
   useEffect(() => {
     const fetchItem = async () => {
       try {
@@ -1044,15 +1063,18 @@ function ItemComponent() {
         const data = await api.getItem({ itemId: '123' });
         setItem(data);
       } catch (e) {
+        // L'errore è tipizzato in base alle risposte nel tuo FastAPI
         const err = e as GetItemError;
         setError(err);
 
         switch (err.status) {
           case 404:
+            // err.error è una stringa come specificato nelle risposte
             console.error('Non trovato:', err.error);
             break;
           case 500:
-            console.error('Errore server:', err.error.message);
+            // err.error è tipizzato come ErrorDetails
+            console.error('Errore del server:', err.error.message);
             break;
         }
       } finally {
@@ -1063,6 +1085,7 @@ function ItemComponent() {
     fetchItem();
   }, [api]);
 
+  // Crea elemento con gestione errori
   const handleCreateItem = async (data) => {
     try {
       await api.createItem(data);
@@ -1071,16 +1094,19 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          console.error('Errore validazione:', err.error.message);
-          console.error('Errori campo:', err.error.field_errors);
+          // err.error è tipizzato come ValidationError
+          console.error('Errore di validazione:', err.error.message);
+          console.error('Errori nei campi:', err.error.field_errors);
           break;
         case 403:
+          // err.error è una stringa come specificato nelle risposte
           console.error('Accesso negato:', err.error);
           break;
       }
     }
   };
 
+  // Renderizzazione del componente con gestione errori
   if (loading) {
     return <LoadingSpinner />;
   }
@@ -1093,20 +1119,24 @@ function ItemComponent() {
     }
   }
 
-  return <div>{/* Contenuto componente */}</div>;
+  return (
+    <div>
+      {/* Contenuto del componente */}
+    </div>
+  );
 }
 ```
 </Drawer>
 
 :::tip
-Quando definisci risposte di errore in FastAPI, usa sempre il parametro `responses` per specificare il modello di ogni status code. Questo garantisce type information corretto nel client generato.
+Quando definisci risposte di errore in FastAPI, utilizza sempre il parametro `responses` per specificare il modello per ogni codice di stato. Questo garantisce che il client generato avrà le corrette informazioni sui tipi per la gestione degli errori.
 :::
 
 ## Best Practices
 
-### Gestione Stati di Caricamento
+### Gestione degli stati di caricamento
 
-Gestisci sempre stati di caricamento ed errori per una migliore UX:
+Gestisci sempre gli stati di caricamento e di errore per una migliore esperienza utente:
 
 ```tsx
 import { useQuery } from '@tanstack/react-query';
@@ -1123,9 +1153,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
+        // err.error è tipizzato come ListItems403Response
         return <ErrorMessage message={err.error.reason} />;
       case 500:
       case 502:
+        // err.error è tipizzato come ListItems5XXResponse
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1147,7 +1179,7 @@ function ItemList() {
 }
 ```
 
-<Drawer title="Gestione stati caricamento con client diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Gestione stati di caricamento con il client direttamente" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
@@ -1170,16 +1202,18 @@ function ItemList() {
   }, [api]);
 
   if (loading) {
-    return <LoadingSpinner />;
+    return <div>Caricamento...</div>;
   }
 
   if (error) {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
+        // err.error è tipizzato come ListItems403Response
         return <ErrorMessage message={err.error.reason} />;
       case 500:
       case 502:
+        // err.error è tipizzato come ListItems5XXResponse
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1202,9 +1236,9 @@ function ItemList() {
 ```
 </Drawer>
 
-### Aggiornamenti Ottimistici
+### Aggiornamenti ottimistici
 
-Implementa aggiornamenti ottimistici per una UX migliore:
+Implementa aggiornamenti ottimistici per una migliore esperienza utente:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -1213,27 +1247,35 @@ function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
+  // Query per recuperare gli elementi
   const itemsQuery = useQuery(api.listItems.queryOptions());
 
+  // Mutazione per eliminare elementi con aggiornamenti ottimistici
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
     onMutate: async (itemId) => {
+      // Annulla qualsiasi richiesta di ricaricamento in corso
       await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
 
+      // Salva una copia del valore precedente
       const previousItems = queryClient.getQueryData(api.listItems.queryKey());
 
+      // Aggiorna ottimisticamente al nuovo valore
       queryClient.setQueryData(
         api.listItems.queryKey(),
         (old) => old.filter((item) => item.id !== itemId)
       );
 
+      // Restituisci un oggetto contesto con la copia precedente
       return { previousItems };
     },
     onError: (err, itemId, context) => {
+      // Se la mutazione fallisce, utilizza il contesto per ripristinare
       queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-      console.error('Cancellazione fallita:', err);
+      console.error('Eliminazione fallita:', err);
     },
     onSettled: () => {
+      // Ricarica i dati dopo errore o successo
       queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
     },
   });
@@ -1243,7 +1285,7 @@ function ItemList() {
   }
 
   if (itemsQuery.isError) {
-    return <ErrorMessage message="Errore caricamento items" />;
+    return <ErrorMessage message="Caricamento fallito" />;
   }
 
   return (
@@ -1255,7 +1297,7 @@ function ItemList() {
             onClick={() => deleteMutation.mutate(item.id)}
             disabled={deleteMutation.isPending}
           >
-            {deleteMutation.isPending ? 'Cancellazione...' : 'Elimina'}
+            {deleteMutation.isPending ? 'Eliminazione...' : 'Elimina'}
           </button>
         </li>
       ))}
@@ -1264,21 +1306,23 @@ function ItemList() {
 }
 ```
 
-<Drawer title="Aggiornamenti ottimistici con client diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Aggiornamenti ottimistici con il client direttamente" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
   const [items, setItems] = useState([]);
 
   const handleDelete = async (itemId) => {
+    // Rimozione ottimistica
     const previousItems = items;
     setItems(items.filter((item) => item.id !== itemId));
 
     try {
       await api.deleteItem(itemId);
     } catch (error) {
+      // Ripristina gli elementi precedenti in caso di errore
       setItems(previousItems);
-      console.error('Cancellazione fallita:', error);
+      console.error('Eliminazione fallita:', error);
     }
   };
 
@@ -1296,9 +1340,9 @@ function ItemList() {
 ```
 </Drawer>
 
-## Type Safety
+## Sicurezza dei tipi
 
-L'integrazione garantisce type safety end-to-end. L'IDE fornirà autocompletamento e type checking per tutte le chiamate API:
+L'integrazione fornisce una completa sicurezza dei tipi end-to-end. Il tuo IDE fornirà autocompletamento e type checking per tutte le chiamate API:
 
 ```tsx
 import { useMutation } from '@tanstack/react-query';
@@ -1306,21 +1350,27 @@ import { useMutation } from '@tanstack/react-query';
 function ItemForm() {
   const api = useMyApi();
 
+  // Mutazione type-safe per creare elementi
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
+    // ✅ Errore di tipo se la callback onSuccess non gestisce il tipo di risposta corretto
     onSuccess: (data) => {
-      console.log(`Item creato con ID: ${data.id}`);
+      // data è completamente tipizzato in base allo schema di risposta dell'API
+      console.log(`Elemento creato con ID: ${data.id}`);
     },
   });
 
   const handleSubmit = (data: CreateItemInput) => {
+    // ✅ Errore di tipo se l'input non corrisponde allo schema
     createItem.mutate(data);
   };
 
+  // UI degli errori può utilizzare il type narrowing per gestire diversi tipi di errore
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
       case 400:
+        // error.error è tipizzato come CreateItem400Response
         return (
           <FormError
             message="Input non valido"
@@ -1328,8 +1378,10 @@ function ItemForm() {
           />
         );
       case 403:
+        // error.error è tipizzato come CreateItem403Response
         return <AuthError reason={error.error.reason} />;
       default:
+        // error.error è tipizzato come CreateItem5XXResponse per 500, 502, ecc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1339,18 +1391,19 @@ function ItemForm() {
       e.preventDefault();
       handleSubmit({ name: 'New Item' });
     }}>
+      {/* Campi del form */}
       <button
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Creazione...' : 'Crea Item'}
+        {createItem.isPending ? 'Creazione in corso...' : 'Crea elemento'}
       </button>
     </form>
   );
 }
 ```
 
-<Drawer title="Type safety con client diretto" trigger="Fai clic qui per un esempio che utilizza il client direttamente.">
+<Drawer title="Sicurezza dei tipi con il client direttamente" trigger="Clicca qui per un esempio che utilizza direttamente il client.">
 ```tsx
 function ItemForm() {
   const api = useMyApiClient();
@@ -1358,20 +1411,25 @@ function ItemForm() {
 
   const handleSubmit = async (data: CreateItemInput) => {
     try {
+      // ✅ Errore di tipo se l'input non corrisponde allo schema
       await api.createItem(data);
     } catch (e) {
+      // ✅ Il tipo di errore include tutte le possibili risposte di errore
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          console.error('Errori validazione:', err.error.validationErrors);
+          // err.error è tipizzato come CreateItem400Response
+          console.error('Errori di validazione:', err.error.validationErrors);
           break;
         case 403:
+          // err.error è tipizzato come CreateItem403Response
           console.error('Accesso negato:', err.error.reason);
           break;
         case 500:
         case 502:
+          // err.error è tipizzato come CreateItem5XXResponse
           console.error(
-            'Errore server:',
+            'Errore del server:',
             err.error.message,
             'Trace:',
             err.error.traceId,
@@ -1382,6 +1440,7 @@ function ItemForm() {
     }
   };
 
+  // UI degli errori può utilizzare il type narrowing per gestire diversi tipi di errore
   if (error) {
     switch (error.status) {
       case 400:
@@ -1403,4 +1462,4 @@ function ItemForm() {
 ```
 </Drawer>
 
-I tipi vengono generati automaticamente dallo schema OpenAPI di FastAPI, garantendo che modifiche all'API si riflettano nel frontend dopo una build.
+I tipi vengono generati automaticamente dallo schema OpenAPI del tuo FastAPI, garantendo che qualsiasi modifica all'API si rifletta nel codice frontend dopo una build.

--- a/docs/src/content/docs/it/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/it/guides/api-connection/react-trpc.mdx
@@ -9,9 +9,8 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Il plugin AWS per Nx fornisce un generatore per integrare rapidamente la tua <Link path="guides/trpc">API tRPC</Link> con un sito web React. Configura tutte le impostazioni necessarie per connettersi ai backend tRPC, incluso il supporto per l'autenticazione IAM di AWS e una corretta gestione degli errori. L'integrazione garantisce una completa type safety end-to-end tra frontend e backend tRPC.
+Il plugin AWS per Nx fornisce un generatore per integrare rapidamente la tua <Link path="guides/trpc">API tRPC</Link> con un sito web React. Configura automaticamente tutto il necessario per connettersi ai backend tRPC, incluso il supporto per l'autenticazione IAM di AWS e una corretta gestione degli errori. L'integrazione garantisce una completa type safety end-to-end tra frontend e backend tRPC.
 
 ## Prerequisiti
 
@@ -19,7 +18,7 @@ Prima di utilizzare questo generatore, assicurati che la tua applicazione React 
 
 1. Un file `main.tsx` che renderizza l'applicazione
 2. Un elemento JSX `<App/>` dove il provider tRPC verrà iniettato automaticamente
-3. Un backend tRPC funzionante (generato usando il generatore di backend tRPC)
+3. Un backend tRPC funzionante (generato usando il generatore per backend tRPC)
 
 <details>
 <summary>Esempio della struttura richiesta per `main.tsx`</summary>
@@ -43,15 +42,15 @@ root.render(
 
 ## Utilizzo
 
-### Esegui il Generatore
+### Esegui il generatore
 
 <RunGenerator generator="api-connection" />
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
-## Output del Generatore
+## Output del generatore
 
 Il generatore crea la seguente struttura nella tua applicazione React:
 
@@ -62,12 +61,12 @@ Il generatore crea la seguente struttura nella tua applicazione React:
     - TrpcClients
       - index.tsx
       - TrpcProvider.tsx Provider riutilizzabile per multiple API tRPC
-      - TrpcApis.tsx Oggetto contenente tutte le connessioni API tRPC
-      - TrpcClientProviders.tsx Configura i client tRPC e i binding agli schemi backend
+      - TrpcApis.tsx Oggetto contenente tutte le connessioni alle API tRPC
+      - TrpcClientProviders.tsx Configura i client tRPC e i binding agli schemi dei backend
     - QueryClientProvider.tsx Provider del client TanStack React Query
   - hooks
     - useSigV4.tsx Hook per firmare richieste HTTP con SigV4 (solo IAM)
-    - use\<ApiName>.tsx Hook specifico per l'API backend. ApiName corrisponderà al nome dell'API
+    - use\<ApiName>.tsx Hook dedicato per una specifica API backend. ApiName corrisponderà al nome dell'API
 
 </FileTree>
 
@@ -78,9 +77,9 @@ Inoltre, installa le dipendenze necessarie:
   - `@tanstack/react-query`
   - `aws4fetch` (se si utilizza l'autenticazione IAM)
 
-## Utilizzo del Codice Generato
+## Utilizzo del codice generato
 
-### Utilizzo dell'Hook tRPC
+### Utilizzo dell'hook tRPC
 
 Il generatore fornisce un hook `use<ApiName>` che dà accesso al client tRPC con type safety:
 
@@ -116,7 +115,7 @@ function MyComponent() {
 }
 ```
 
-### Gestione degli Errori
+### Gestione degli errori
 
 L'integrazione include una gestione degli errori integrata che processa correttamente gli errori tRPC:
 
@@ -129,9 +128,9 @@ function MyComponent() {
   if (error) {
     return (
       <div>
-        <h2>Error occurred:</h2>
+        <h2>Errore rilevato:</h2>
         <p>{error.message}</p>
-        {error.data?.code && <p>Code: {error.data.code}</p>}
+        {error.data?.code && <p>Codice: {error.data.code}</p>}
       </div>
     );
   }
@@ -148,9 +147,9 @@ function MyComponent() {
 
 ## Best Practices
 
-### Gestione degli Stati di Caricamento
+### Gestione degli stati di caricamento
 
-Gestisci sempre gli stati di caricamento ed errore per una migliore esperienza utente:
+Gestisci sempre gli stati di caricamento e errore per una migliore user experience:
 
 ```tsx {6}
 function UserList() {
@@ -176,9 +175,9 @@ function UserList() {
 }
 ```
 
-### Aggiornamenti Ottimistici
+### Aggiornamenti ottimistici
 
-Utilizza aggiornamenti ottimistici per migliorare l'esperienza utente:
+Utilizza gli aggiornamenti ottimistici per una migliore user experience:
 
 ```tsx {15-17,20-22,28-31}
 import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
@@ -194,7 +193,7 @@ function UserList() {
         // Annulla le richieste in corso
         await queryClient.cancelQueries(trpc.users.list.queryFilter());
 
-        // Ottieni snapshot dei dati correnti
+        // Ottieni uno snapshot dei dati correnti
         const previousUsers = queryClient.getQueryData(
           trpc.users.list.queryKey(),
         );
@@ -229,9 +228,9 @@ function UserList() {
 }
 ```
 
-### Prefetch dei Dati
+### Prefetch dei dati
 
-Esegui il prefetch dei dati per migliorare le performance:
+Esegui il prefetch dei dati per migliorare le prestazioni:
 
 ```tsx {8}
 function UserList() {
@@ -256,7 +255,7 @@ function UserList() {
 }
 ```
 
-### Query Infinite
+### Query infinite
 
 Gestisci la paginazione con query infinite:
 
@@ -282,7 +281,7 @@ function UserList() {
 
       {hasNextPage && (
         <button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
-          {isFetchingNextPage ? 'Caricamento...' : 'Carica Altri'}
+          {isFetchingNextPage ? 'Caricamento...' : 'Carica altro'}
         </button>
       )}
     </div>
@@ -312,10 +311,10 @@ function UserForm() {
 }
 ```
 
-I tipi vengono inferiti automaticamente dal router e dalle definizioni dello schema del backend, garantendo che qualsiasi modifica all'API si rifletta immediatamente nel codice frontend senza necessità di build.
+I tipi vengono automaticamente inferiti dal router e dagli schemi del tuo backend, garantendo che qualsiasi modifica all'API si rifletta immediatamente nel codice frontend senza necessità di build.
 
-## Ulteriori Informazioni
+## Ulteriori informazioni
 
-Per maggiori informazioni, consulta la [documentazione di tRPC TanStack React Query](https://trpc.io/docs/client/tanstack-react-query/usage).
+Per maggiori informazioni, consulta la [documentazione tRPC TanStack React Query](https://trpc.io/docs/client/tanstack-react-query/usage).
 
-Puoi anche riferirti direttamente alla [documentazione di TanStack Query](https://tanstack.com/query/v5).
+Puoi anche fare riferimento direttamente alla [documentazione di TanStack Query](https://tanstack.com/query/v5).

--- a/docs/src/content/docs/it/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/cloudscape-website-auth.mdx
@@ -10,11 +10,10 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
 Il generatore CloudScape Website Authentication aggiunge l'autenticazione al tuo sito web CloudScape utilizzando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
-Questo generatore configura l'infrastruttura CDK per creare un Cognito User Pool e un Identity Pool associato, oltre a un'interfaccia utente ospitata per gestire i flussi di login degli utenti e la sua integrazione con il tuo sito web CloudScape.
+Questo generatore configura l'infrastruttura CDK per creare un Cognito User Pool e un Identity Pool associato, insieme a un'interfaccia utente ospitata per gestire i flussi di login degli utenti e la sua integrazione con il tuo sito web CloudScape.
 
 ## Utilizzo
 
@@ -26,17 +25,17 @@ Puoi aggiungere l'autenticazione al tuo sito web CloudScape in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
-## Output del generatore
+## Output del Generatore
 
-Troverai le seguenti modifiche nel tuo sito web React:
+Troverai le seguenti modifiche nella tua applicazione React:
 
 <FileTree>
   - src
     - components
       - CognitoAuth
-        - index.tsx Componente principale per l'autenticazione
+        - index.tsx Componente principale di autenticazione
     - main.tsx Aggiornato per integrare il componente CognitoAuth
 </FileTree>
 
@@ -45,10 +44,10 @@ Troverai anche il seguente codice infrastrutturale generato in `packages/common/
 <FileTree>
   - src
     - core
-      - user-identity.ts Construct che definisce il user pool e l'identity pool
+      - user-identity.ts Construct che definisce il user pool e identity pool
 </FileTree>
 
-## Utilizzo dell'infrastruttura
+## Utilizzo dell'Infrastruttura
 
 Dovrai aggiungere il construct `UserIdentity` al tuo stack, dichiarandolo _prima_ del construct del sito web:
 
@@ -68,11 +67,11 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-Il construct `UserIdentity` aggiunge automaticamente la <Link path="guides/cloudscape-website#runtime-configuration">Configurazione Runtime</Link> necessaria per garantire che il tuo sito web possa puntare al corretto Cognito User Pool per l'autenticazione.
+Il construct `UserIdentity` aggiunge automaticamente la necessaria <Link path="guides/cloudscape-website#runtime-configuration">Configurazione Runtime</Link> per garantire che il tuo sito web possa puntare al corretto Cognito User Pool per l'autenticazione.
 
-### Concessione dell'accesso agli utenti autenticati
+### Concessione Accesso agli Utenti Autenticati
 
-Per concedere agli utenti autenticati l'accesso a determinate azioni, come concedere permessi per richiamare un'API, puoi aggiungere policy IAM al ruolo autenticato dell'identity pool:
+Per concedere agli utenti autenticati l'accesso a determinate azioni, come concedere permessi per invocare un'API, puoi aggiungere policy IAM al ruolo autenticato dell'identity pool:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/it/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/it/guides/cloudscape-website.mdx
@@ -10,50 +10,49 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
 Questo generatore crea un nuovo sito web [React](https://react.dev/) con [CloudScape](http://cloudscape.design/) configurato, insieme all'infrastruttura AWS CDK per distribuire il tuo sito web sul cloud come sito statico ospitato in [S3](https://aws.amazon.com/s3/), servito da [CloudFront](https://aws.amazon.com/cloudfront/) e protetto da [WAF](https://aws.amazon.com/waf/).
 
 L'applicazione generata utilizza [Vite](https://vite.dev/) come strumento di build e bundler. Utilizza [TanStack Router](https://tanstack.com/router/v1) per il routing type-safe.
 
 :::note
-Sebbene questo generatore ti configuri con CloudScape, si tratta fondamentalmente di un generatore di progetti React, e puoi modificare il tuo codice per passare a un sistema di design alternativo o a una libreria di componenti se lo desideri.
+Sebbene questo generatore ti configuri con CloudScape, si tratta fondamentalmente di un generatore di progetti React, e puoi modificare il tuo codice per passare a un sistema di design o libreria di componenti alternativo se lo desideri.
 :::
 
 ## Utilizzo
 
-### Genera un sito web CloudScape
+### Genera un Sito Web CloudScape
 
-Puoi generare un nuovo sito web CloudScape in due modi:
+Puoi generare un nuovo Sito Web CloudScape in due modi:
 
 <RunGenerator generator="ts#cloudscape-website" />
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
-## Output del generatore
+## Output del Generatore
 
 Il generatore creerà la seguente struttura del progetto nella directory `<directory>/<name>`:
 
 <FileTree>
-  - index.html Punto di ingresso HTML
-  - public Asset statici
+  - index.html punto di ingresso HTML
+  - public asset statici
   - src
-    - main.tsx Punto di ingresso dell'applicazione con configurazione React
-    - config.ts Configurazione dell'applicazione (es. logo)
+    - main.tsx punto di ingresso dell'applicazione con setup React
+    - config.ts configurazione dell'applicazione (es. logo)
     - components
-      - AppLayout Componenti per il layout generale CloudScape e barra di navigazione
+      - AppLayout componenti per il layout CloudScape generale e la barra di navigazione
     - hooks
-      - useAppLayout.tsx Hook per regolare l'AppLayout da componenti annidati
+      - useAppLayout.tsx hook per regolare l'AppLayout da componenti annidati
     - routes
       - welcome
-        - index.tsx Route (o pagina) di esempio per @tanstack/react-router
-    - styles.css Stili globali
-  - vite.config.ts Configurazione Vite e Vitest
-  - tsconfig.json Configurazione TypeScript base per sorgenti e test
-  - tsconfig.app.json Configurazione TypeScript per il codice sorgente
-  - tsconfig.spec.json Configurazione TypeScript per i test
+        - index.tsx route (o pagina) di esempio per @tanstack/react-router
+    - styles.css stili globali
+  - vite.config.ts configurazione di Vite e Vitest
+  - tsconfig.json configurazione TypeScript base per sorgenti e test
+  - tsconfig.app.json configurazione TypeScript per il codice sorgente
+  - tsconfig.spec.json configurazione TypeScript per i test
 </FileTree>
 
 Il generatore creerà anche il codice dell'infrastruttura CDK per distribuire il tuo sito web nella directory `packages/common/constructs`:
@@ -62,14 +61,14 @@ Il generatore creerà anche il codice dell'infrastruttura CDK per distribuire il
   - src
     - app
       - static-websites
-        - \<name>.ts Infrastruttura specifica per il tuo sito web
+        - \<name>.ts infrastruttura specifica per il tuo sito web
     - core
-      - static-website.ts Costrutto generico StaticWebsite
+      - static-website.ts costrutto generico StaticWebsite
 </FileTree>
 
-## Implementazione del tuo sito web CloudScape
+## Implementazione del Tuo Sito Web CloudScape
 
-La [documentazione di React](https://react.dev/learn) è un buon punto di partenza per apprendere le basi dello sviluppo con React. Puoi consultare la [documentazione di CloudScape](https://cloudscape.design/components/) per dettagli sui componenti disponibili e il loro utilizzo.
+La [documentazione React](https://react.dev/learn) è un buon punto di partenza per apprendere le basi dello sviluppo con React. Puoi consultare la [documentazione CloudScape](https://cloudscape.design/components/) per dettagli sui componenti disponibili e sul loro utilizzo.
 
 ### Route
 
@@ -78,12 +77,12 @@ La [documentazione di React](https://react.dev/learn) è un buon punto di parten
 Il tuo sito web CloudScape include [TanStack Router](https://tanstack.com/router/v1) preconfigurato. Questo semplifica l'aggiunta di nuove route:
 
 <Steps>
-  1. [Esegui il server di sviluppo locale](#local-development-server)
+  1. [Avvia il Server di Sviluppo Locale](#local-development-server)
   2. Crea un nuovo file `<page-name>.tsx` in `src/routes`, con la posizione nell'albero dei file che rappresenta il percorso
   3. Noterai che un `Route` e `RouteComponent` vengono generati automaticamente. Puoi iniziare a costruire la tua pagina qui!
 </Steps>
 
-#### Navigazione tra pagine
+#### Navigazione tra Pagine
 
 Puoi usare il componente `Link` o l'hook `useNavigate` per navigare tra le pagine:
 
@@ -108,17 +107,17 @@ export const MyComponent = () => {
 };
 ```
 
-Per maggiori dettagli, consulta la [documentazione di TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
+Per maggiori dettagli, consulta la [documentazione TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
 ## Configurazione Runtime
 
-La configurazione dalla tua infrastruttura AWS CDK viene fornita al tuo sito web tramite Runtime Configuration. Questo permette al tuo sito web di accedere a dettagli come URL di API che non sono noti finché l'applicazione non viene distribuita.
+La configurazione dalla tua infrastruttura AWS CDK viene fornita al tuo sito web tramite Runtime Configuration. Questo permette al tuo sito web di accedere a dettagli come URL di API che non sono noti fino al deployment dell'applicazione.
 
 ### Infrastruttura
 
-Il costrutto CDK `RuntimeConfig` può essere usato per aggiungere e recuperare configurazioni nella tua infrastruttura CDK. I costrutti CDK generati da `@aws/nx-plugin` (come <Link path="guides/trpc">API tRPC</Link> e <Link path="guides/fastapi">FastAPI</Link>) aggiungeranno automaticamente valori appropriati a `RuntimeConfig`.
+Il costrutto CDK `RuntimeConfig` può essere utilizzato per aggiungere e recuperare configurazione nella tua infrastruttura CDK. I costrutti CDK generati da `@aws/nx-plugin` (come <Link path="guides/trpc">API tRPC</Link> e <Link path="guides/fastapi">FastAPI</Link>) aggiungeranno automaticamente valori appropriati a `RuntimeConfig`.
 
-Il tuo costrutto CDK per il sito web distribuirà la configurazione runtime come file `runtime-config.json` nella root del tuo bucket S3.
+Il tuo costrutto CDK per il sito web distribuirà la runtime configuration come file `runtime-config.json` alla root del tuo bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {9-10,12-13}
 import { Stack } from 'aws-cdk-lib';
@@ -132,7 +131,7 @@ export class ApplicationStack extends Stack {
     // Aggiunge automaticamente valori a RuntimeConfig
     new MyApi(this, 'MyApi');
 
-    // Distribuisce automaticamente la config runtime in runtime-config.json
+    // Distribuisce automaticamente la runtime config in runtime-config.json
     new MyWebsite(this, 'MyWebsite');
   }
 }
@@ -142,9 +141,9 @@ export class ApplicationStack extends Stack {
 Devi assicurarti di dichiarare il tuo sito web _dopo_ qualsiasi costrutto che aggiunge valori a `RuntimeConfig`, altrimenti mancheranno nel file `runtime-config.json`.
 :::
 
-### Codice del sito web
+### Codice del Sito Web
 
-Nel tuo sito web, puoi usare l'hook `useRuntimeConfig` per recuperare valori dalla configurazione runtime:
+Nel tuo sito web, puoi usare l'hook `useRuntimeConfig` per recuperare valori dalla runtime configuration:
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -152,26 +151,26 @@ import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
 const MyComponent = () => {
   const runtimeConfig = useRuntimeConfig();
 
-  // Accedi ai valori della config runtime qui
+  // Accedi ai valori della runtime config qui
   const apiUrl = runtimeConfig.httpApis.MyApi;
 };
 ```
 
 ### Configurazione Runtime Locale
 
-Quando esegui il [server di sviluppo locale](#local-development-server), avrai bisogno di un file `runtime-config.json` nella tua directory `public` per far conoscere al sito web locale gli URL di backend, la configurazione di identità, ecc.
+Quando esegui il [server di sviluppo locale](#local-development-server), avrai bisogno di un file `runtime-config.json` nella tua directory `public` per far conoscere al sito web locale gli URL dei backend, la configurazione di identità, ecc.
 
 Il tuo progetto sito web è configurato con un target `load:runtime-config` che puoi usare per scaricare il file `runtime-config.json` da un'applicazione distribuita:
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-Se modifichi il nome del tuo stack nel `src/main.ts` del progetto infrastruttura, dovrai aggiornare il target `load:runtime-config` nel file `project.json` del tuo sito web con il nome dello stack da cui caricare la configurazione runtime.
+Se modifichi il nome del tuo stack nel `src/main.ts` del progetto infrastruttura, dovrai aggiornare il target `load:runtime-config` nel file `project.json` del tuo sito web con il nome dello stack da cui caricare la runtime configuration.
 :::
 
-## Server di sviluppo locale
+## Server di Sviluppo Locale
 
-Prima di eseguire il server di sviluppo locale, assicurati di aver distribuito la tua infrastruttura e aver [caricato la configurazione runtime locale](#local-runtime-config).
+Prima di avviare il server di sviluppo locale, assicurati di aver distribuito la tua infrastruttura e di aver [caricato la runtime configuration locale](#local-runtime-config).
 
 Puoi quindi eseguire il target `serve`:
 
@@ -185,7 +184,7 @@ Puoi compilare il tuo sito web usando il target `build`. Questo utilizza Vite pe
 
 ## Test
 
-Testare il tuo sito web è simile a scrivere test in un normale progetto TypeScript, quindi consulta la <Link path="guides/typescript-project#testing">guida ai progetti TypeScript</Link> per maggiori dettagli.
+Testare il tuo sito web è simile a scrivere test in un progetto TypeScript standard, quindi consulta la <Link path="guides/typescript-project#testing">guida ai progetti TypeScript</Link> per maggiori dettagli.
 
 Per i test specifici di React, React Testing Library è già installato e disponibile per scrivere test. Per dettagli sul suo utilizzo, consulta la [documentazione di React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
@@ -193,7 +192,7 @@ Puoi eseguire i test usando il target `test`:
 
 <NxCommands commands={['run <my-website>:test']} />
 
-## Distribuzione del sito web
+## Distribuzione del Tuo Sito Web
 
 Per distribuire il tuo sito web, raccomandiamo di usare il <Link path="guides/typescript-infrastructure">Generatore di Infrastruttura TypeScript</Link> per creare un'applicazione CDK.
 

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -11,23 +11,22 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
 [FastAPI](https://fastapi.tiangolo.com/) è un framework per la creazione di API in Python.
 
-Il generatore FastAPI crea una nuova applicazione FastAPI con configurazione infrastrutturale AWS CDK. Il backend generato utilizza AWS Lambda per il deployment serverless, esposto tramite un'API AWS API Gateway. Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) per l'osservabilità, inclusi logging, tracciamento AWS X-Ray e metriche CloudWatch.
+Il generatore FastAPI crea una nuova applicazione FastAPI con configurazione infrastrutturale AWS CDK. Il backend generato utilizza AWS Lambda per il deployment serverless, esposto tramite un'API AWS API Gateway. Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) per l'osservabilità, inclusi logging, tracciamento AWS X-Ray e metriche Cloudwatch.
 
 ## Utilizzo
 
-### Generare un'API FastAPI
+### Genera una FastAPI
 
-Puoi generare una nuova API FastAPI in due modi:
+Puoi generare una nuova FastAPI in due modi:
 
 <RunGenerator generator="py#fast-api" />
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -44,13 +43,13 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
   - init.py Configura l'app FastAPI e il middleware powertools
   - main.py Implementazione dell'API
 - scripts
-  - generate_open_api.py Script per generare lo schema OpenAPI dall'app FastAPI
+  - generate_open_api.py Script per generare uno schema OpenAPI dall'app FastAPI
 
 </FileTree>
 
 Il generatore creerà anche costrutti CDK utilizzabili per il deploy dell'API, residenti nella directory `packages/common/constructs`.
 
-## Implementazione dell'API FastAPI
+## Implementazione della tua FastAPI
 
 L'implementazione principale dell'API si trova in `main.py`. Qui si definiscono le route API e le relative implementazioni. Ecco un esempio:
 
@@ -82,7 +81,7 @@ Il generatore configura automaticamente diverse funzionalità:
 
 #### Logging
 
-Il generatore configura il logging strutturato usando AWS Lambda Powertools. Puoi accedere al logger negli handler delle route:
+Il generatore configura il logging strutturato usando AWS Lambda Powertools. Puoi accedere al logger nei tuoi route handler:
 
 ```python
 from .init import app, logger
@@ -139,7 +138,7 @@ Le metriche predefinite includono:
 
 ### Gestione degli Errori
 
-Il generatore include una gestione degli errori completa:
+Il generatore include una gestione errori completa:
 
 ```python
 from fastapi import HTTPException
@@ -159,16 +158,16 @@ Le eccezioni non gestite vengono catturate dal middleware e:
 4. Mantengono l'ID di correlazione
 
 :::tip
-Si raccomanda di specificare modelli di risposta per le operazioni API per una migliore generazione del codice se si utilizza il generatore `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Vedi qui per dettagli</Link>.
+Si consiglia di specificare modelli di risposta per le operazioni API per una migliore generazione del codice se si utilizza il generatore `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Vedi qui per maggiori dettagli</Link>.
 :::
 
 ### Streaming
 
-Con FastAPI, puoi inviare risposte in streaming al chiamante usando il tipo di risposta [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse).
+Con FastAPI, puoi inviare una risposta in streaming al chiamante usando il tipo di risposta [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse).
 
 #### Modifiche Infrastrutturali
 
-Poiché AWS API Gateway non supporta risposte in streaming, dovrai deployare la tua FastAPI su una piattaforma che lo supporti. L'opzione più semplice è usare un AWS Lambda Function URL. Per farlo, puoi sostituire il costrutto generato `common/constructs/src/app/apis/<name>-api.ts` con uno che deploya un Function URL.
+Dato che AWS API Gateway non supporta risposte in streaming, dovrai deployare la tua FastAPI su una piattaforma che lo supporti. L'opzione più semplice è usare un AWS Lambda Function URL. Per farlo, puoi sostituire il costrutto generato `common/constructs/src/app/apis/<name>-api.ts` con uno che deploya un Function URL.
 
 <details>
 <summary>Esempio di Costrutto FunctionURL per Streaming</summary>
@@ -241,7 +240,7 @@ export class MyApi extends Construct {
 
     new CfnOutput(this, 'MyApiUrl', { value: functionUrl.url });
 
-    // Registra l'URL API nella configurazione runtime per il discovery client
+    // Registra l'URL API nella runtime configuration per il client discovery
     RuntimeConfig.ensure(this).config.apis = {
       ...RuntimeConfig.ensure(this).config.apis!,
       MyApi: functionUrl.url,
@@ -299,11 +298,11 @@ def my_stream() -> Chunk:
 
 #### Consumo
 
-Per consumare uno stream di risposte, puoi utilizzare il <Link path="guides/api-connection/react-fastapi#consuming-a-stream">Generatore API Connection</Link> che fornirà un metodo type-safe per iterare sui chunk.
+Per consumare uno stream di risposte, puoi utilizzare il <Link path="guides/api-connection/react-fastapi#consuming-a-stream">Generatore API Connection</Link> che fornirà un metodo type-safe per iterare sui chunk dello stream.
 
-## Deploy dell'API FastAPI
+## Deploy della tua FastAPI
 
-Il generatore crea un costrutto CDK per il deploy nella cartella `common/constructs`. Puoi usarlo in un'applicazione CDK:
+Il generatore FastAPI crea un costrutto CDK per il deploy nella cartella `common/constructs`. Puoi usarlo in un'applicazione CDK:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs';
@@ -320,12 +319,12 @@ export class ExampleStack extends Stack {
 
 Questo configura:
 
-1. Una funzione AWS Lambda per ogni operazione dell'API
+1. Una funzione AWS Lambda per ogni operazione nell'app FastAPI
 2. API Gateway HTTP/REST API come trigger
 3. Ruoli IAM e permessi
 4. Log group CloudWatch
 5. Configurazione tracciamento X-Ray
-6. Namespace metriche CloudWatch
+6. Namespace per metriche CloudWatch
 
 ### Integrazioni Type-Safe
 
@@ -333,18 +332,18 @@ Questo configura:
 
 #### Generazione Codice
 
-Poiché le operazioni FastAPI sono definite in Python e l'infrastruttura in TypeScript, utilizziamo la generazione codice per fornire metadati al costrutto CDK, garantendo un'interfaccia type-safe.
+Dato che le operazioni in FastAPI sono definite in Python e l'infrastruttura in TypeScript, utilizziamo code-generation per fornire metadati al costrutto CDK e garantire un'interfaccia type-safe.
 
-Un target `generate:<ApiName>-metadata` viene aggiunto al `project.json` dei costrutti per generare file come `packages/common/constructs/src/generated/my-api/metadata.gen.ts`. Essendo generato al build time, viene ignorato dal version control.
+Un target `generate:<ApiName>-metadata` viene aggiunto al `project.json` dei costrutti comuni per generare file come `packages/common/constructs/src/generated/my-api/metadata.gen.ts`. Essendo generato al build time, questo file è ignorato dal version control.
 
 :::note
-È necessario eseguire un build dopo modifiche all'API per aggiornare i tipi consumati dal costrutto CDK:
+Dovrai eseguire un build dopo ogni modifica all'API per aggiornare i tipi usati dal costrutto CDK.
 
 <NxCommands commands={["run-many --target build --all"]} />
 :::
 
 :::tip
-Se stai modificando sia l'infrastruttura CDK che l'API, puoi usare [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) per rigenerare i tipi automaticamente:
+Se stai lavorando contemporaneamente su infrastruttura CDK e FastAPI, puoi usare [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) per rigenerare i tipi automaticamente:
 
 <NxCommands
   commands={[
@@ -368,12 +367,12 @@ Il generatore configura un server di sviluppo locale eseguibile con:
 
 <NxCommands commands={['run my-api:serve']} />
 
-Avvia un server FastAPI locale con:
+Questo avvia un server di sviluppo FastAPI con:
 
 - Auto-reload alle modifiche
 - Documentazione API interattiva su `/docs` o `/redoc`
 - Schema OpenAPI su `/openapi.json`
 
-## Invocazione dell'API
+## Invocazione della tua FastAPI
 
 Per invocare l'API da un sito React, puoi usare il generatore <Link path="guides/api-connection/react-fastapi">`api-connection`</Link>.

--- a/docs/src/content/docs/it/guides/license.mdx
+++ b/docs/src/content/docs/it/guides/license.mdx
@@ -8,11 +8,10 @@ description: "Documentazione di riferimento per il generatore di Licenze"
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
 Gestisci automaticamente i file `LICENSE` e le intestazioni del codice sorgente nel tuo workspace.
 
-Questo generatore registra un [sync generator](https://nx.dev/concepts/sync-generators) da eseguire come parte dei tuoi target `lint` per garantire che i file sorgente rispettino il contenuto e il formato desiderati per le licenze, assicurando inoltre che i file `LICENSE` dei progetti siano corretti e che le informazioni sulle licenze siano incluse nei file di progetto rilevanti (`package.json`, `pyproject.toml`).
+Questo generatore registra un [generatore di sincronizzazione](https://nx.dev/concepts/sync-generators) che viene eseguito come parte dei tuoi target `lint` per garantire che i file sorgente rispettino il contenuto e il formato della licenza desiderati, oltre a verificare che i file `LICENSE` dei progetti siano corretti e che le informazioni sulla licenza siano incluse nei file di progetto rilevanti (`package.json`, `pyproject.toml`).
 
 ## Utilizzo
 
@@ -22,7 +21,7 @@ Questo generatore registra un [sync generator](https://nx.dev/concepts/sync-gene
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## Output del generatore
 
@@ -33,72 +32,72 @@ Il generatore creerà o aggiornerà i seguenti file:
   - aws-nx-plugin.config.mts Configurazione per il generatore di sincronizzazione delle licenze
 </FileTree>
 
-Una configurazione predefinita per il contenuto e il formato delle intestazioni delle licenze viene aggiunta a `aws-nx-plugin.config.mts` per scrivere intestazioni appropriate per diversi tipi di file. Potresti voler personalizzare ulteriormente questa configurazione; consulta la [sezione di configurazione](#configuration) qui sotto.
+Una configurazione predefinita per il contenuto e il formato delle intestazioni di licenza viene aggiunta a `aws-nx-plugin.config.mts` per scrivere intestazioni appropriate per diversi tipi di file. Potresti voler personalizzare ulteriormente questa configurazione; consulta la [sezione di configurazione](#configuration) qui sotto.
 
-## Flusso di lavoro
+## Workflow
 
-Ogni volta che costruisci i tuoi progetti (e viene eseguito un target `lint`), il generatore di sincronizzazione delle licenze verificherà che le licenze nei tuoi progetti corrispondano alla configurazione (vedi [comportamento della sincronizzazione delle licenze qui sotto](#license-sync-behaviour)). Se rileva delle discrepanze, riceverai un messaggio come:
+Ogni volta che costruisci i tuoi progetti (e viene eseguito un target `lint`), il generatore di sincronizzazione delle licenze si assicurerà che le licenze nei tuoi progetti corrispondano alla tua configurazione (vedi [comportamento della sincronizzazione delle licenze qui sotto](#license-sync-behaviour)). Se rileva che qualcosa non è sincronizzato, riceverai un messaggio come:
 
 ```bash
   NX   The workspace is out of sync
 
-[@aws/nx-plugin:license#sync]: Project LICENSE files are out of sync:
+[@aws/nx-plugin:license#sync]: I file LICENSE del progetto non sono sincronizzati:
 - LICENSE
 - packages/<my-project>LICENSE
 
-Project package.json files are out of sync:
+I file package.json del progetto non sono sincronizzati:
 - package.json
 
-Project pyproject.toml files are out of sync:
+I file pyproject.toml del progetto non sono sincronizzati:
 - pyproject.toml
 - packages/<my-python-project>/pyproject.toml
 
-License headers are out of sync in the following source files:
+Le intestazioni di licenza non sono sincronizzate nei seguenti file sorgente:
 - packages/<my-project>/src/index.ts
 - packages/<my-python-project>/main.py
 
-This will result in an error in CI.
+Questo causerà un errore in CI.
 
-? Would you like to sync the identified changes to get your workspace up to date?
-Yes, sync the changes and run the tasks
-No, run the tasks without syncing the changes
+? Desideri sincronizzare le modifiche identificate per aggiornare il workspace?
+Sì, sincronizza le modifiche ed esegui i task
+No, esegui i task senza sincronizzare le modifiche
 ```
 
-Seleziona `Yes` per sincronizzare le modifiche.
+Seleziona `Sì` per sincronizzare le modifiche.
 
 :::note
-Assicurati di verificare le modifiche apportate dal generatore di sincronizzazione delle licenze nel controllo delle versioni per evitare che i task di integrazione continua falliscano a causa di licenze non sincronizzate.
+Assicurati di verificare le modifiche apportate dal generatore di sincronizzazione delle licenze nel controllo delle versioni, per evitare che i task di integrazione continua falliscano a causa di licenze non sincronizzate.
 :::
 
 ## Comportamento della sincronizzazione delle licenze
 
-Il generatore di sincronizzazione delle licenze esegue tre attività principali:
+Il generatore di sincronizzazione esegue tre attività principali:
 
-### 1. Sincronizza le intestazioni delle licenze nei file sorgente
+### 1. Sincronizza le intestazioni di licenza nei file sorgente
 
-Quando il generatore di sincronizzazione viene eseguito, assicura che tutti i file sorgente nel workspace (in base alla configurazione) contengano l'intestazione della licenza appropriata. L'intestazione viene scritta come primo commento a blocco o serie consecutiva di commenti a linea nel file (escludendo eventuali shebang/hashbang presenti).
+Quando viene eseguito, il generatore si assicura che tutti i file sorgente nel workspace (in base alla configurazione) contengano l'intestazione di licenza appropriata. L'intestazione viene scritta come primo commento a blocco o serie consecutiva di commenti a linea nel file (escludendo eventuali shebang/hashbang presenti).
 
-Puoi aggiornare la configurazione in qualsiasi momento per modificare quali file includere/escludere, oltre al contenuto o formato delle intestazioni per diversi tipi di file. Per maggiori dettagli, consulta la [sezione di configurazione](#configuration) qui sotto.
+Puoi aggiornare la configurazione in qualsiasi momento per modificare quali file includere/escludere, oltre al contenuto o formato delle intestazioni per diversi tipi di file. Per maggiori dettagli, consulta la [sezione di configurazione](#configuration).
 
 ### 2. Sincronizza i file LICENSE
 
-Quando il generatore di sincronizzazione viene eseguito, verifica che il file `LICENSE` principale corrisponda alla licenza configurata e che tutti i sottoprogetti nel workspace contengano il file `LICENSE` corretto.
+Il generatore verifica che il file `LICENSE` principale corrisponda alla licenza configurata, e che tutti i sottoprogetti nel workspace contengano il file `LICENSE` corretto.
 
-Puoi escludere progetti specifici nella configurazione se necessario. Per maggiori dettagli, consulta la [sezione di configurazione](#configuration) qui sotto.
+Puoi escludere progetti specifici nella configurazione. Per dettagli, vedi [sezione di configurazione](#configuration).
 
-### 3. Sincronizza le informazioni sulle licenze nei file di progetto
+### 3. Sincronizza le informazioni di licenza nei file di progetto
 
-Quando il generatore di sincronizzazione viene eseguito, assicura che i campi `license` nei file `package.json` e `pyproject.toml` siano impostati secondo la licenza configurata.
+Il generatore assicura che i campi `license` nei file `package.json` e `pyproject.toml` siano impostati secondo la licenza configurata.
 
-Puoi escludere progetti specifici nella configurazione se necessario. Per maggiori dettagli, consulta la [sezione di configurazione](#configuration) qui sotto.
+Puoi escludere progetti specifici nella configurazione. Per dettagli, vedi [sezione di configurazione](#configuration).
 
 ## Configurazione
 
-La configurazione è definita nel file `aws-nx-plugin.config.mts` nella radice del workspace.
+La configurazione è definita nel file `aws-nx-plugin.config.mts` nella root del workspace.
 
 ### SPDX e titolare del copyright
 
-La licenza selezionata può essere aggiornata in qualsiasi momento tramite la proprietà di configurazione `spdx`:
+La licenza selezionata può essere aggiornata in qualsiasi momento tramite la proprietà `spdx`:
 
 ```typescript title="aws-nx-plugin.config.mts" {3}
 export default {
@@ -108,9 +107,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-Quando il generatore di sincronizzazione viene eseguito, tutti i file `LICENSE`, `package.json` e `pyproject.toml` saranno aggiornati per riflettere la licenza configurata.
+All'esecuzione del generatore, tutti i file `LICENSE`, `package.json` e `pyproject.toml` verranno aggiornati con la licenza configurata.
 
-Puoi inoltre configurare il titolare del copyright e l'anno del copyright, inclusi in alcuni file `LICENSE`:
+Puoi inoltre configurare titolare e anno del copyright, inclusi in alcuni file `LICENSE`:
 
 ```typescript title="aws-nx-plugin.config.mts" {4,5}
 export default {
@@ -122,13 +121,13 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-### Intestazioni delle licenze
+### Intestazioni di licenza
 
 #### Contenuto
 
-Il contenuto dell'intestazione della licenza può essere configurato in due modi:
+Il contenuto dell'intestazione può essere configurato in due modi:
 
-1. Utilizzando contenuto inline:
+1. Contenuto inline:
 
 ```typescript title="aws-nx-plugin.config.mts" {5-9}
 export default {
@@ -141,22 +140,22 @@ export default {
           'All rights reserved',
         ];
       }
-      // ... format configuration
+      // ... configurazione formato
     }
   }
 } satisfies AwsNxPluginConfig;
 ```
 
-2. Caricando da un file:
+2. Caricamento da file:
 
 ```typescript title="aws-nx-plugin.config.mts" {5}
 export default {
   license: {
     header: {
       content: {
-        filePath: 'license-header.txt'; // relativo alla radice del workspace
+        filePath: 'license-header.txt'; // relativo alla root del workspace
       }
-      // ... format configuration
+      // ... configurazione formato
     }
   }
 } satisfies AwsNxPluginConfig;
@@ -164,7 +163,7 @@ export default {
 
 #### Formato
 
-Puoi specificare come formattare le intestazioni delle licenze per diversi tipi di file utilizzando pattern glob. La configurazione del formato supporta commenti a linea, a blocco o una combinazione di entrambi:
+Puoi specificare come formattare le intestazioni per diversi tipi di file usando pattern glob. Sono supportati commenti a linea, a blocco o combinazioni:
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
@@ -183,13 +182,13 @@ export default {
           blockStart: '/*',
           blockEnd: '*/',
         },
-        // Commenti a blocco con prefisso per linea
+        // Commenti a blocco con prefissi
         '**/*.java': {
           blockStart: '/*',
           lineStart: ' * ',
           blockEnd: ' */',
         },
-        // Commenti a linea con intestazione/piè di pagina
+        // Commenti a linea con header/footer
         '**/*.py': {
           blockStart: '# ------------',
           lineStart: '# ',
@@ -201,16 +200,16 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-La configurazione del formato supporta:
+Le opzioni di formato supportate:
 
-- `blockStart`: Testo scritto prima del contenuto della licenza (es. per iniziare un commento a blocco)
-- `lineStart`: Testo preposto a ogni linea del contenuto della licenza
-- `lineEnd`: Testo aggiunto a ogni linea del contenuto della licenza
-- `blockEnd`: Testo scritto dopo il contenuto della licenza (es. per terminare un commento a blocco)
+- `blockStart`: Testo prima del contenuto della licenza (es. per iniziare un blocco)
+- `lineStart`: Prefisso per ogni riga della licenza
+- `lineEnd`: Suffisso per ogni riga della licenza
+- `blockEnd`: Testo dopo il contenuto della licenza (es. per chiudere un blocco)
 
-#### Sintassi personalizzata per i commenti
+#### Sintassi personalizzata per commenti
 
-Per tipi di file non supportati nativamente, puoi specificare una sintassi personalizzata per identificare le intestazioni delle licenze esistenti.
+Per tipi di file non supportati nativamente, puoi definire sintassi personalizzate per identificare le intestazioni esistenti:
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
@@ -226,11 +225,11 @@ export default {
       },
       commentSyntax: {
         xyz: {
-          line: '##', // Definisci la sintassi per i commenti a linea
+          line: '##', // Sintassi per commenti a linea
         },
         abc: {
           block: {
-            // Definisci la sintassi per i commenti a blocco
+            // Sintassi per commenti a blocco
             start: '<!--',
             end: '-->',
           },
@@ -243,9 +242,9 @@ export default {
 
 #### Escludere file
 
-Per impostazione predefinita, in un repository git, tutti i file `.gitignore` vengono rispettati per sincronizzare solo i file gestiti dal controllo delle versioni. In repository non git, tutti i file vengono considerati a meno che non siano esplicitamente esclusi nella configurazione.
+Per default, in repository git, tutti i file `.gitignore` vengono rispettati. In repository non git, tutti i file sono considerati a meno di esclusioni esplicite.
 
-Puoi escludere ulteriori file dalla sincronizzazione delle intestazioni utilizzando pattern glob:
+Puoi escludere ulteriori file usando pattern glob:
 
 ```typescript title="aws-nx-plugin.config.mts" {12-16}
 export default {
@@ -267,18 +266,18 @@ export default {
 
 ### Escludere file di progetto dalla sincronizzazione
 
-Tutti i file `LICENSE`, `package.json` e `pyproject.toml` vengono sincronizzati con la licenza configurata per impostazione predefinita.
+Tutti i file `LICENSE`, `package.json` e `pyproject.toml` vengono sincronizzati per default.
 
-Puoi escludere progetti o file specifici dalla sincronizzazione utilizzando pattern glob:
+Puoi escludere progetti o file specifici usando pattern glob:
 
 ```typescript title="aws-nx-plugin.config.mts" {3-10}
 export default {
   license: {
     files: {
       exclude: [
-        // non sincronizzare file LICENSE, package.json o pyproject.toml
+        // non sincronizzare LICENSE, package.json o pyproject.toml
         'packages/excluded-project',
-        // non sincronizzare il file LICENSE, ma sincronizza package.json e/o pyproject.toml
+        // non sincronizzare LICENSE, ma sincronizza package.json/pyproject.toml
         'apps/internal/LICENSE',
       ];
     }
@@ -288,9 +287,9 @@ export default {
 
 ## Disabilitare la sincronizzazione delle licenze
 
-Per disabilitare il generatore di sincronizzazione delle licenze:
+Per disabilitare il generatore:
 
-1. Rimuovi la sezione `license` dalla configurazione in `aws-nx-plugin.config.mts` (o elimina il file)
+1. Rimuovi la sezione `license` da `aws-nx-plugin.config.mts` (o elimina il file)
 2. Rimuovi il generatore `@aws/nx-plugin:license#sync` da `targetDefaults.lint.syncGenerators`
 
-Per riattivare la sincronizzazione, esegui nuovamente il generatore `license`.
+Per riattivare, esegui nuovamente il generatore `license`.

--- a/docs/src/content/docs/it/guides/nx-generator.mdx
+++ b/docs/src/content/docs/it/guides/nx-generator.mdx
@@ -11,9 +11,8 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
-Aggiunge un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a un progetto TypeScript, per aiutarti ad automatizzare task ripetitivi come la generazione di componenti o l'imposizione di strutture di progetto specifiche.
+Aggiunge un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a un progetto TypeScript, per aiutarti ad automatizzare task ripetitivi come la creazione di componenti o l'imposizione di strutture di progetto specifiche.
 
 ## Utilizzo
 
@@ -25,11 +24,11 @@ Puoi generare un generatore in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
 ## Output del Generatore
 
-Il generatore creerà i seguenti file all'interno del progetto `pluginProject` specificato:
+Il generatore creerà i seguenti file all'interno del `pluginProject` specificato:
 
 <FileTree>
   - src/\<name>/
@@ -43,7 +42,7 @@ Il generatore creerà i seguenti file all'interno del progetto `pluginProject` s
 </FileTree>
 
 :::warning
-Questo generatore aggiornerà il progetto `pluginProject` selezionato per utilizzare CommonJS, poiché gli Nx Generator supportano solo CommonJS al momento ([fai riferimento a questa issue GitHub per il supporto ESM](https://github.com/nrwl/nx/issues/15682)).
+Questo generatore aggiornerà il `pluginProject` selezionato per utilizzare CommonJS, poiché attualmente i generatori Nx supportano solo CommonJS ([fai riferimento a questa issue GitHub per il supporto ESM](https://github.com/nrwl/nx/issues/15682)).
 :::
 
 ## Generator Locali
@@ -54,11 +53,11 @@ Consigliamo di generare prima un progetto TypeScript dedicato per tutti i tuoi g
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-Seleziona il tuo progetto locale `nx-plugin` quando esegui il generatore `ts#nx-generator`, specificando un nome e opzionalmente una directory e una descrizione.
+Seleziona il tuo progetto locale `nx-plugin` quando esegui il generatore `ts#nx-generator`, e specifica un nome, una directory opzionale e una descrizione.
 
 ### Definizione dello Schema
 
-Il file `schema.json` definisce le opzioni accettate dal generatore. Segue il formato [JSON Schema](https://json-schema.org/) con [estensioni specifiche per Nx](https://nx.dev/extending-nx/recipes/generator-options).
+Il file `schema.json` definisce le opzioni accettate dal generatore. Segue il formato [JSON Schema](https://json-schema.org/) con [estensioni specifiche di Nx](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Struttura Base
 
@@ -68,11 +67,11 @@ Un file schema.json ha la seguente struttura base:
 {
   "$schema": "https://json-schema.org/schema",
   "$id": "YourGeneratorName",
-  "title": "Your Generator Title",
-  "description": "Description of what your generator does",
+  "title": "Titolo del Generatore",
+  "description": "Descrizione delle funzionalità del generatore",
   "type": "object",
   "properties": {
-    // Your generator options go here
+    // Le opzioni del generatore vanno qui
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
@@ -86,23 +85,23 @@ Ecco un esempio semplice con alcune opzioni base:
 {
   "$schema": "https://json-schema.org/schema",
   "$id": "ComponentGenerator",
-  "title": "Create a Component",
-  "description": "Creates a new React component",
+  "title": "Crea un Componente",
+  "description": "Crea un nuovo componente React",
   "type": "object",
   "properties": {
     "name": {
       "type": "string",
-      "description": "Component name",
+      "description": "Nome del componente",
       "x-priority": "important"
     },
     "directory": {
       "type": "string",
-      "description": "Directory where the component will be created",
+      "description": "Directory in cui verrà creato il componente",
       "default": "src/components"
     },
     "withTests": {
       "type": "boolean",
-      "description": "Whether to generate test files",
+      "description": "Generare i file di test",
       "default": true
     }
   },
@@ -112,12 +111,12 @@ Ecco un esempio semplice con alcune opzioni base:
 
 #### Prompt Interattivi (CLI)
 
-Puoi personalizzare i prompt mostrati durante l'esecuzione del generatore via CLI aggiungendo la proprietà `x-prompt`:
+Puoi personalizzare i prompt visualizzati durante l'esecuzione del generatore via CLI aggiungendo la proprietà `x-prompt`:
 
 ```json
 "name": {
   "type": "string",
-  "description": "Component name",
+  "description": "Nome del componente",
   "x-prompt": "Qual è il nome del componente?"
 }
 ```
@@ -127,8 +126,8 @@ Per opzioni booleane, puoi usare un prompt sì/no:
 ```json
 "withTests": {
   "type": "boolean",
-  "description": "Whether to generate test files",
-  "x-prompt": "Vuoi generare i file di test?"
+  "description": "Generare i file di test",
+  "x-prompt": "Desideri generare i file di test?"
 }
 ```
 
@@ -139,20 +138,20 @@ Per opzioni con un set fisso di scelte, usa `enum` per permettere agli utenti di
 ```json
 "style": {
   "type": "string",
-  "description": "The styling approach to use",
+  "description": "Approccio di stile da utilizzare",
   "enum": ["css", "scss", "styled-components", "none"],
   "default": "css"
 }
 ```
 
-#### Selezione Progetto a Tendina
+#### Selezione Progetto da Tendina
 
 Un pattern comune è permettere agli utenti di selezionare tra progetti esistenti nel workspace:
 
 ```json
 "project": {
   "type": "string",
-  "description": "The project to add the component to",
+  "description": "Progetto a cui aggiungere il componente",
   "x-prompt": "A quale progetto vuoi aggiungere il componente?",
   "x-dropdown": "projects"
 }
@@ -167,7 +166,7 @@ Puoi configurare opzioni da passare come argomenti posizionali quando si esegue 
 ```json
 "name": {
   "type": "string",
-  "description": "Component name",
+  "description": "Nome del componente",
   "x-priority": "important",
   "$default": {
     "$source": "argv",
@@ -176,7 +175,7 @@ Puoi configurare opzioni da passare come argomenti posizionali quando si esegue 
 }
 ```
 
-Questo permette agli utenti di eseguire il generatore con `nx g your-generator my-component` invece di `nx g your-generator --name=my-component`.
+Ciò consente agli utenti di eseguire il generatore come `nx g your-generator my-component` invece di `nx g your-generator --name=my-component`.
 
 #### Impostazione Priorità
 
@@ -185,12 +184,12 @@ Usa la proprietà `x-priority` per indicare le opzioni più importanti:
 ```json
 "name": {
   "type": "string",
-  "description": "Component name",
+  "description": "Nome del componente",
   "x-priority": "important"
 }
 ```
 
-Le opzioni possono avere priorità `"important"` o `"internal"`. Questo aiuta Nx a ordinare le proprietà nell'estensione VSCode e nella CLI Nx.
+Le opzioni possono avere priorità `"important"` o `"internal"`. Questo aiuta Nx a ordinare le proprietà nell'estensione VSCode di Nx e nella CLI.
 
 #### Valori Predefiniti
 
@@ -199,18 +198,18 @@ Puoi fornire valori predefiniti per le opzioni:
 ```json
 "directory": {
   "type": "string",
-  "description": "Directory where the component will be created",
+  "description": "Directory in cui verrà creato il componente",
   "default": "src/components"
 }
 ```
 
 #### Ulteriori Informazioni
 
-Per maggiori dettagli sugli schemi, consulta la [documentazione Nx Generator Options](https://nx.dev/extending-nx/recipes/generator-options).
+Per maggiori dettagli sugli schemi, consulta la [documentazione di Nx Generator Options](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Tipi TypeScript con schema.d.ts
 
-Oltre a `schema.json`, il generatore crea un file `schema.d.ts` che fornisce tipi TypeScript per le opzioni:
+Insieme a `schema.json`, il generatore crea un file `schema.d.ts` che fornisce tipi TypeScript per le opzioni:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -233,30 +232,30 @@ export default async function (tree: Tree, options: YourGeneratorSchema) {
 ```
 
 :::caution
-Ogni volta che modifichi `schema.json`, devi aggiornare `schema.d.ts` per rispecchiare le modifiche. Questo include:
+Ogni volta che modifichi `schema.json`, devi aggiornare `schema.d.ts` per corrispondere. Ciò include:
 
-- Aggiunta o rimozione di proprietà
-- Cambio di tipo delle proprietà
-- Rendere proprietà obbligatorie o opzionali (usa il suffisso `?` per le proprietà opzionali)
+- Aggiungere o rimuovere proprietà
+- Cambiare i tipi delle proprietà
+- Rendere proprietà obbligatorie o opzionali (usa il suffisso `?` per proprietà opzionali)
 
-L'interfaccia TypeScript deve corrispondere esattamente alla struttura definita nello schema JSON.
+L'interfaccia TypeScript deve riflettere accuratamente la struttura definita nello schema JSON.
 :::
 
 ### Implementazione di un Generatore
 
 Dopo aver creato il nuovo generatore come sopra, puoi scrivere l'implementazione in `generator.ts`.
 
-Un generatore è una funzione che modifica un filesystem virtuale (`Tree`), leggendo e scrivendo file per apportare le modifiche desiderate. Le modifiche al `Tree` vengono scritte su disco solo al termine dell'esecuzione, a meno che non sia eseguito in modalità "dry-run".
+Un generatore è una funzione che modifica un filesystem virtuale (`Tree`), leggendo e scrivendo file per apportare le modifiche desiderate. Le modifiche dal `Tree` vengono scritte su disco solo al termine dell'esecuzione del generatore, a meno che non sia eseguito in modalità "dry-run".
 
 Ecco alcune operazioni comuni che potresti voler eseguire nel generatore:
 
 #### Lettura e Scrittura di File
 
 ```typescript
-// Leggi un file
+// Legge un file
 const content = tree.read('path/to/file.ts', 'utf-8');
 
-// Scrivi un file
+// Scrive un file
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
 // Verifica se un file esiste
@@ -305,7 +304,7 @@ const nodes = tsquery.query(
 );
 
 if (nodes.length > 0) {
-  // Ottieni il nodo del literal numerico
+  // Ottieni il nodo del letterale numerico
   const numericNode = nodes[0] as ts.NumericLiteral;
 
   // Ottieni la versione corrente e incrementala
@@ -340,7 +339,7 @@ Puoi testare i selettori online nel [TSQuery Playground](https://tsquery-playgro
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
 
-// Aggiungi dipendenze a package.json
+// Aggiunge dipendenze a package.json
 addDependenciesToPackageJson(
   tree,
   {
@@ -353,12 +352,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-Se aggiungi dipendenze a un package.json, puoi installarle per l'utente come parte del callback del generatore:
+Se aggiungi dipendenze a un package.json, puoi installarle per l'utente come parte della callback del generatore:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// I generatori restituiscono un callback che può eseguire task post-generazione, come l'installazione di dipendenze
+// I generatori restituiscono una callback che può eseguire task post-generazione, come l'installazione di dipendenze
 return () => {
   installPackagesTask(tree);
 };
@@ -379,7 +378,7 @@ await formatFiles(tree);
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// Leggi un file JSON
+// Legge un file JSON
 const packageJson = readJson(tree, 'package.json');
 
 // Aggiorna un file JSON
@@ -399,7 +398,7 @@ Puoi eseguire il generatore in due modi:
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-Se non vedi il generatore nell'interfaccia dell'estensione VSCode, puoi aggiornare il workspace Nx con:
+Se non vedi il generatore nell'interfaccia UI del plugin VSCode, puoi aggiornare il tuo Nx Workspace con:
 
 <NxCommands commands={['reset']} />
 :::
@@ -412,14 +411,14 @@ I test unitari per i generatori sono semplici da implementare. Ecco un pattern t
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { yourGenerator } from './generator';
 
-describe('your generator', () => {
+describe('tuo generatore', () => {
   let tree;
 
   beforeEach(() => {
     // Crea un workspace tree vuoto
     tree = createTreeWithEmptyWorkspace();
 
-    // Aggiungi eventuali file che devono esistere nel tree
+    // Aggiungi eventuali file che dovrebbero già esistere
     tree.write(
       'project.json',
       JSON.stringify({
@@ -445,7 +444,7 @@ describe('your generator', () => {
     const content = tree.read('src/test/file.ts', 'utf-8');
     expect(content).toContain('export const test');
 
-    // Puoi anche usare snapshot
+    // Puoi usare anche gli snapshot
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
@@ -456,17 +455,17 @@ describe('your generator', () => {
       // Aggiungi altre opzioni richieste
     });
 
-    // Verifica aggiornamenti a file esistenti
+    // Verifica che i file esistenti siano stati aggiornati
     const content = tree.read('src/existing-file.ts', 'utf-8');
     expect(content).toContain('import { test } from');
   });
 
-  it('dovrebbe gestire errori', async () => {
-    // Verifica che il generatore generi un errore in certe condizioni
+  it('dovrebbe gestire gli errori', async () => {
+    // Aspettati che il generatore sollevi un errore in certe condizioni
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
-        // Aggiungi opzioni che causano errore
+        // Aggiungi opzioni che dovrebbero causare un errore
       }),
     ).rejects.toThrow('Messaggio di errore atteso');
   });
@@ -476,16 +475,16 @@ describe('your generator', () => {
 Punti chiave per testare i generatori:
 
 - Usa `createTreeWithEmptyWorkspace()` per creare un filesystem virtuale
-- Prepara eventuali file prerequisiti prima di eseguire il generatore
-- Testa sia la creazione di nuovi file che l'aggiornamento di esistenti
-- Usa snapshot per contenuti complessi
+- Configura eventuali file prerequisiti prima di eseguire il generatore
+- Testa sia la creazione di nuovi file che gli aggiornamenti a file esistenti
+- Usa snapshot per contenuti di file complessi
 - Testa condizioni di errore per garantire un fallimento controllato
 
-## Contribuire a Generator per @aws/nx-plugin
+## Contribuire ai Generatori per @aws/nx-plugin
 
-Puoi usare `ts#nx-generator` anche per scaffoldare un generatore all'interno di `@aws/nx-plugin`.
+Puoi anche usare `ts#nx-generator` per scaffoldare un generatore all'interno di `@aws/nx-plugin`.
 
-Quando eseguito nel nostro repository, questo generatore creerà i seguenti file:
+Quando questo generatore viene eseguito nel nostro repository, genererà i seguenti file:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
@@ -498,8 +497,8 @@ Quando eseguito nel nostro repository, questo generatore creerà i seguenti file
   - packages/nx-plugin/generators.json Aggiornato per includere il generatore
 </FileTree>
 
-Potrai quindi iniziare a implementare il generatore.
+Potrai quindi iniziare a implementare il tuo generatore.
 
 :::tip
-Per una guida più approfondita su come contribuire a Nx Plugin per AWS, consulta il <Link path="get_started/tutorials/contribute-generator">tutorial qui</Link>.
+Per una guida più approfondita su come contribuire all'Nx Plugin per AWS, consulta il <Link path="get_started/tutorials/contribute-generator">tutorial qui</Link>.
 :::

--- a/docs/src/content/docs/it/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/it/guides/python-lambda-function.mdx
@@ -9,25 +9,24 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
-Il generatore di Python Lambda Function permette di aggiungere una funzione lambda a un progetto Python esistente.
+Il generatore di funzioni Lambda Python offre la possibilità di aggiungere una funzione lambda a un progetto Python esistente.
 
-Questo generatore crea un nuovo handler per lambda function Python con la configurazione dell'infrastruttura AWS CDK. Il backend generato utilizza AWS Lambda per il deployment serverless, con opzionale type-safety tramite il [Parser di AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) per l'osservabilità, inclusi logging, tracciamento AWS X-Ray e metriche Cloudwatch.
+Questo generatore crea un nuovo handler per funzioni lambda Python con la configurazione dell'infrastruttura AWS CDK. Il backend generato utilizza AWS Lambda per il deployment serverless, con opzionale type-safety tramite il [Parser di AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) per l'osservabilità, inclusi logging, tracciamento AWS X-Ray e metriche CloudWatch.
 
 ## Utilizzo
 
-### Genera una Lambda Function
+### Genera una funzione Lambda
 
-Puoi generare una nuova Lambda Function in due modi:
+Puoi generare una nuova funzione Lambda in due modi:
 
 <RunGenerator generator="py#lambda-function" />
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
-## Output del Generatore
+## Output del generatore
 
 Il generatore aggiungerà i seguenti file al tuo progetto:
 
@@ -50,7 +49,7 @@ Se viene fornita l'opzione `functionPath`, il generatore aggiungerà i file nece
 
 </FileTree>
 
-## Implementazione della Funzione
+## Implementazione della funzione
 
 L'implementazione principale della funzione si trova in `<function-name>.py`. Ecco un esempio:
 
@@ -89,15 +88,15 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 Il generatore configura automaticamente diverse funzionalità:
 
-1. Integrazione con AWS Lambda Powertools per l'osservabilità
+1. Integrazione di AWS Lambda Powertools per l'osservabilità
 2. Raccolta delle metriche
-3. Type-safety usando `@event_parser`
+3. Type-safety tramite `@event_parser`
 
 ### Osservabilità con AWS Lambda Powertools
 
 #### Logging
 
-Il generatore configura il logging strutturato usando AWS Lambda Powertools.
+Il generatore configura il logging strutturato utilizzando AWS Lambda Powertools.
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -105,18 +104,18 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 ```
 
 :::tip
-Si consiglia di impostare un correlation id per tutte le richieste uniche per facilitare debug e monitoraggio. Consulta la documentazione di [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) per le best practice sui correlation id.
+Si consiglia di impostare un correlation ID per tutte le richieste uniche per facilitare il debug e il monitoraggio. Consulta la documentazione di [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) per le best practice sui correlation ID.
 :::
 
 Il logger include automaticamente:
 
-- Richieste degli eventi
+- Richieste di eventi
 - Informazioni sul contesto Lambda
 - Indicatori di cold start
 
-#### Tracing
+#### Tracciamento
 
-Il tracciamento AWS X-Ray è configurato automaticamente. Puoi aggiungere sottosegmenti personalizzati:
+Il tracciamento AWS X-Ray viene configurato automaticamente. Puoi aggiungere sottosegmenti personalizzati:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -144,7 +143,7 @@ Le metriche predefinite includono:
 
 #### Type Safety
 
-Se hai selezionato un `eventSource` durante la generazione della funzione, questa sarà strumentata con [`@event_parser` di AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Esempio:
+Se hai selezionato un `eventSource` durante la generazione della funzione, questa viene strumentata con [`@event_parser` di AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Esempio:
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
@@ -152,15 +151,15 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     event.detail_type # <- type-safe con autocompletamento IDE
 ```
 
-Questo permette di definire modelli dati usando [Pydantic](https://docs.pydantic.dev/latest/), in modo simile al lavoro con <Link path="guides/fastapi">Fast API</Link>.
+Questo permette di definire modelli dati usando [Pydantic](https://docs.pydantic.dev/latest/), in modo simile al funzionamento con <Link path="guides/fastapi">Fast API</Link>.
 
 :::tip
-Se hai dati personalizzati annidati in un evento, ad esempio uno stream DynamoDB o un evento EventBridge, puoi utilizzare gli [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) per garantire type-safety.
+Se hai dati personalizzati annidati in un evento, ad esempio in uno stream DynamoDB o un evento EventBridge, puoi beneficiare degli [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) per garantire il type-safety.
 :::
 
-Se non vuoi tipizzare l'evento, puoi selezionare `Any` come `eventSource`.
+Se non desideri tipizzare l'evento, puoi selezionare `Any` come `eventSource`.
 
-## Deployment della Funzione
+## Deployment della funzione
 
 Il generatore crea un costrutto CDK per il deployment nella cartella `common/constructs`. Puoi utilizzarlo in un'applicazione CDK:
 
@@ -175,20 +174,20 @@ export class ExampleStack extends Stack {
 }
 ```
 
-Questa configurazione include:
+Questo configura:
 
 1. Funzione AWS Lambda
 2. Log group CloudWatch
 3. Configurazione tracciamento X-Ray
 4. Namespace per metriche CloudWatch
 
-La funzione può quindi essere usata come target per qualsiasi [event source](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) lambda:
+La funzione può essere utilizzata come target per qualsiasi [sorgente evento lambda](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/):
 
 :::note
-Assicurati che l'event source corrisponda all'opzione `eventSource` selezionata per garantire una corretta gestione dell'evento.
+Assicurati che la sorgente dell'evento corrisponda all'opzione `eventSource` selezionata per garantire una corretta gestione nell'handler.
 :::
 
-L'esempio seguente mostra il codice CDK per invocare la funzione su una schedule usando Event Bridge:
+L'esempio seguente mostra il codice CDK per invocare la funzione su una schedule tramite Event Bridge:
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';
@@ -200,7 +199,7 @@ export class ExampleStack extends Stack {
     // Aggiungi la funzione allo stack
     const fn = new MyProjectMyFunction(this, 'MyFunction');
 
-    // Aggiungi la funzione a una regola EventBridge
+    // Aggiungi la funzione a un task EventBridge
     const eventRule = new Rule(this, 'MyFunctionScheduleRule', {
       schedule: Schedule.cron({ minute: '15' }),
       targets: [new LambdaFunction(fn)],

--- a/docs/src/content/docs/it/guides/python-project.mdx
+++ b/docs/src/content/docs/it/guides/python-project.mdx
@@ -9,13 +9,12 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
-Il generatore di progetti Python consente di creare una libreria o applicazione [Python](https://www.python.org/) moderna configurata con le migliori pratiche, gestita con [UV](https://docs.astral.sh/uv/), un singolo file di lock e un ambiente virtuale in un [workspace UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) per l'esecuzione dei test e [Ruff](https://docs.astral.sh/ruff/) per l'analisi statica.
+Il generatore di progetti Python può essere utilizzato per creare una moderna libreria o applicazione [Python](https://www.python.org/) configurata con le migliori pratiche, gestita con [UV](https://docs.astral.sh/uv/), un singolo file di lock e un ambiente virtuale in un [UV workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) per l'esecuzione dei test, e [Ruff](https://docs.astral.sh/ruff/) per l'analisi statica.
 
 ## Utilizzo
 
-### Generare un progetto Python
+### Genera un Progetto Python
 
 Puoi generare un nuovo progetto Python in due modi:
 
@@ -23,50 +22,50 @@ Puoi generare un nuovo progetto Python in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
-## Output del generatore
+## Output del Generatore
 
 Il generatore creerà la seguente struttura del progetto nella directory `<directory>/<name>`:
 
 <FileTree>
 
   - \<module-name>
-    - \_\_init\_\_.py Inizializzazione del modulo
+    - \_\_init\_\_.py Inizializzazione modulo
     - hello.py File Python di esempio
   - tests
-    - \_\_init\_\_.py Inizializzazione del modulo  
-    - conftest.py Configurazione dei test
+    - \_\_init\_\_.py Inizializzazione modulo
+    - conftest.py Configurazione test
     - test_hello.py Test di esempio
-  - project.json Configurazione del progetto e target di build
-  - pyproject.toml File di configurazione per il packaging utilizzato da UV
+  - project.json Configurazione progetto e target di build
+  - pyproject.toml File di configurazione packaging per UV
   - .python-version Contiene la versione Python del progetto
 
 </FileTree>
 
-Potresti inoltre notare i seguenti file creati/aggiornati nella root del workspace:
+Potresti anche notare questi file creati/aggiornati nella root del workspace:
 
 <FileTree>
 
-  - pyproject.toml Configurazione del packaging a livello workspace per UV
-  - .python-version Contiene la versione Python del workspace  
+  - pyproject.toml Configurazione packaging a livello workspace per UV
+  - .python-version Contiene la versione Python del workspace
   - uv.lock File di lock per le dipendenze Python
 
 </FileTree>
 
-## Scrivere codice Python
+## Scrittura del Codice Python
 
 Aggiungi il tuo codice sorgente Python nella directory `<module-name>`.
 
-### Importare il codice della libreria in altri progetti
+### Importare il Codice della Libreria in Altri Progetti
 
-Grazie alla configurazione dei [workspace UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), puoi referenziare il tuo progetto Python da qualsiasi altro progetto Python nel workspace:
+Essendo configurati gli [UV workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/), puoi referenziare il tuo progetto Python da qualsiasi altro progetto Python nel workspace:
 
 ```python title="packages/my_other_project/my_other_project/main.py"
 from "my_library.hello" import say_hello
 ```
 
-Nell'esempio sopra, `my_library` è il nome del modulo, `hello` corrisponde al file sorgente Python `hello.py`, e `say_hello` è un metodo definito in `hello.py`.
+Nell'esempio, `my_library` è il nome del modulo, `hello` corrisponde al file sorgente Python `hello.py`, e `say_hello` è un metodo definito in `hello.py`
 
 ### Dipendenze
 
@@ -74,11 +73,11 @@ Per aggiungere dipendenze al tuo progetto, puoi eseguire il target `add` nel tuo
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-Questo aggiungerà la dipendenza al file `pyproject.toml` del progetto e aggiornerà il file `uv.lock` root.
+Questo aggiungerà la dipendenza al file `pyproject.toml` del progetto e aggiornerà il file `uv.lock` principale.
 
-#### Codice runtime
+#### Codice Runtime
 
-Quando utilizzi il tuo progetto Python come codice runtime (ad esempio come handler per una funzione AWS Lambda), dovrai creare un bundle del codice sorgente e di tutte le dipendenze. Puoi farlo aggiungendo un target come il seguente al tuo file `project.json`:
+Quando utilizzi il tuo progetto Python come codice runtime (ad esempio come handler per una funzione AWS lambda), dovrai creare un bundle del codice sorgente e di tutte le dipendenze. Puoi ottenere questo aggiungendo un target come il seguente al tuo file `project.json`:
 
 ```json title="project.json"
 {
@@ -104,7 +103,7 @@ Quando utilizzi il tuo progetto Python come codice runtime (ad esempio come hand
 
 ### Build
 
-Il tuo progetto Python è configurato con un target `build` (definito in `project.json`), eseguibile tramite:
+Il tuo progetto Python è configurato con un target `build` (definito in `project.json`), che puoi eseguire tramite:
 
 <NxCommands commands={['run <project-name>:build']} />
 
@@ -112,13 +111,13 @@ Dove `<project-name>` è il nome completo del tuo progetto.
 
 Il target `build` eseguirà la compilazione, il linting e i test del progetto.
 
-L'output della build si troverà nella cartella `dist` root del workspace, all'interno di una directory specifica per il pacchetto e il target, ad esempio `dist/packages/<my-library>/build`.
+L'output della build si trova nella cartella `dist` principale del workspace, all'interno di una directory per il tuo pacchetto e target, ad esempio `dist/packages/<my-library>/build`
 
 ## Testing
 
-[pytest](https://docs.pytest.org/en/stable/) è configurato per il testing del progetto.
+[pytest](https://docs.pytest.org/en/stable/) è configurato per testare il tuo progetto.
 
-### Scrivere test
+### Scrittura dei Test
 
 I test dovrebbero essere scritti nella directory `test` del progetto, in file Python prefissati con `test_`, ad esempio:
 
@@ -138,15 +137,15 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-Per maggiori dettagli sulla scrittura dei test, consultare la [documentazione pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
+Per maggiori dettagli sulla scrittura dei test, consulta la [documentazione pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
 
-### Eseguire i test
+### Esecuzione dei Test
 
-I test vengono eseguiti come parte del target `build`, ma puoi anche eseguirli separatamente tramite il target `test`:
+I test vengono eseguiti durante il target `build` del progetto, ma puoi anche eseguirli separatamente con il target `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puoi eseguire un singolo test o un gruppo di test usando il flag `-k`, specificando il nome del file o del metodo di test:
+Puoi eseguire un singolo test o un gruppo di test usando il flag `-k`, specificando il nome del file di test o del metodo:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -154,18 +153,18 @@ Puoi eseguire un singolo test o un gruppo di test usando il flag `-k`, specifica
 
 I progetti Python utilizzano [Ruff](https://docs.astral.sh/ruff/) per il linting.
 
-### Eseguire il linter
+### Esecuzione del Linter
 
-Per invocare il linter e verificare il progetto, esegui il target `lint`:
+Per invocare il linter e verificare il progetto, puoi eseguire il target `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Correggere i problemi di linting
+### Correzione degli Errori di Linting
 
-La maggior parte dei problemi di linting/formattazione può essere risolta automaticamente. Puoi chiedere a Ruff di correggere i problemi eseguendo con l'argomento `--configuration=fix`:
+La maggior parte degli errori di linting o formattazione può essere corretta automaticamente. Puoi chiedere a Ruff di correggere gli errori eseguendo con l'argomento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Analogamente, per correggere tutti i problemi di linting in tutti i pacchetti del workspace:
+Analogamente, per correggere tutti gli errori di linting in tutti i pacchetti del workspace:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -11,11 +11,10 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/) è un framework per costruire API in TypeScript con type safety end-to-end. Utilizzando tRPC, gli aggiornamenti agli input e output delle operazioni API si riflettono immediatamente nel codice client e sono visibili nel tuo IDE senza bisogno di ricostruire il progetto.
+[tRPC](https://trpc.io/) è un framework per la creazione di API in TypeScript con sicurezza dei tipi end-to-end. Utilizzando tRPC, gli aggiornamenti agli input e output delle operazioni API si riflettono immediatamente nel codice client e sono visibili nel tuo IDE senza necessità di ricostruire il progetto.
 
-Il generatore di API tRPC crea una nuova API tRPC con configurazione dell'infrastruttura AWS CDK. Il backend generato utilizza AWS Lambda per il deployment serverless e include la validazione degli schemi tramite [Zod](https://zod.dev/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) per l'osservabilità, inclusi logging, tracciamento AWS X-Ray e metriche Cloudwatch.
+Il generatore di API tRPC crea una nuova API tRPC con configurazione dell'infrastruttura AWS CDK. Il backend generato utilizza AWS Lambda per la distribuzione serverless e include la validazione degli schemi tramite [Zod](https://zod.dev/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) per l'osservabilità, inclusi logging, tracciamento AWS X-Ray e metriche CloudWatch.
 
 ## Utilizzo
 
@@ -27,7 +26,7 @@ Puoi generare una nuova API tRPC in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -40,13 +39,13 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
     - src
       - index.ts Punto di ingresso dello schema
       - procedures
-        - echo.ts Definizioni condivise dello schema per la procedura "echo", usando Zod
+        - echo.ts Definizioni condivise dello schema per la procedura "echo", utilizzando Zod
     - tsconfig.json Configurazione TypeScript
     - project.json Configurazione del progetto e target di build
   - backend
     - src
-      - init.ts Inizializzazione tRPC del backend
-      - router.ts Definizione del router tRPC (punto di ingresso dell'handler Lambda)
+      - init.ts Inizializzazione del backend tRPC
+      - router.ts Definizione del router tRPC (punto di ingresso API del gestore Lambda)
       - procedures Procedure (o operazioni) esposte dalla tua API
         - echo.ts Procedura di esempio
       - middleware
@@ -54,18 +53,19 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
         - logger.ts Middleware per configurare AWS Powertools per il logging Lambda
         - tracer.ts Middleware per configurare AWS Powertools per il tracciamento Lambda
         - metrics.ts Middleware per configurare AWS Powertools per le metriche Lambda
-      - local-server.ts Punto di ingresso dell'adapter standalone tRPC per server di sviluppo locale
+      - local-server.ts Punto di ingresso dell'adapter standalone tRPC per il server di sviluppo locale
       - client
         - index.ts Client type-safe per chiamate API machine-to-machine
     - tsconfig.json Configurazione TypeScript
     - project.json Configurazione del progetto e target di build
+
 </FileTree>
 
-Il generatore creerà anche costrutti CDK utilizzabili per deployare la tua API, residenti nella directory `packages/common/constructs`.
+Il generatore creerà anche costrutti CDK utilizzabili per distribuire la tua API, residenti nella directory `packages/common/constructs`.
 
-## Implementare la tua API tRPC
+## Implementazione della tua API tRPC
 
-Come visto sopra, ci sono due componenti principali di un'API tRPC: [`schema`](#schema) e [`backend`](#backend), definiti come singoli package nel tuo workspace.
+Come visto sopra, ci sono due componenti principali di un'API tRPC, [`schema`](#schema) e [`backend`](#backend), definiti come singoli package nel tuo workspace.
 
 :::tip
 `schema` e `backend` sono entrambi progetti TypeScript, quindi puoi consultare la <Link path="guides/typescript-project">documentazione dei progetti TypeScript</Link> per maggiori dettagli sull'utilizzo generale.
@@ -73,9 +73,9 @@ Come visto sopra, ci sono due componenti principali di un'API tRPC: [`schema`](#
 
 ### Schema
 
-Il package schema definisce i tipi condivisi tra codice client e server. In questo package, questi tipi sono definiti usando [Zod](https://zod.dev/), una libreria TypeScript-first per dichiarazione e validazione di schemi.
+Il package schema definisce i tipi condivisi tra il codice client e server. In questo package, questi tipi sono definiti utilizzando [Zod](https://zod.dev/), una libreria TypeScript-first per la dichiarazione e validazione degli schemi.
 
-Uno schema di esempio potrebbe essere:
+Uno schema di esempio potrebbe essere il seguente:
 
 ```ts
 import { z } from 'zod';
@@ -109,9 +109,9 @@ Zod fornisce utility potenti per combinare o derivare schemi come `.merge`, `.pi
 
 ### Backend
 
-La cartella annidata `backend` contiene l'implementazione della tua API, dove definisci le operazioni e i loro input, output e implementazione.
+La cartella annidata `backend` contiene l'implementazione della tua API, dove definisci le operazioni API e i relativi input, output e implementazione.
 
-Il punto di ingresso dell'API si trova in `src/router.ts`. Questo file contiene l'handler Lambda che instrada le richieste alle "procedure" in base all'operazione invocata. Ogni procedura definisce l'input atteso, l'output e l'implementazione.
+Il punto di ingresso della tua API si trova in `src/router.ts`. Questo file contiene il gestore Lambda che instrada le richieste alle "procedure" in base all'operazione invocata. Ogni procedura definisce l'input atteso, l'output e l'implementazione.
 
 Il router di esempio generato ha una singola operazione chiamata `echo`:
 
@@ -132,22 +132,22 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-Analizzando il codice:
+Analizzando il codice sopra:
 
 - `publicProcedure` definisce un metodo pubblico sull'API, includendo il middleware configurato in `src/middleware`. Questo middleware include l'integrazione di AWS Lambda Powertools per logging, tracciamento e metriche.
 - `input` accetta uno schema Zod che definisce l'input atteso per l'operazione. Le richieste per questa operazione sono automaticamente validate rispetto a questo schema.
 - `output` accetta uno schema Zod che definisce l'output atteso. Vedrai errori di tipo nell'implementazione se non restituisci un output conforme allo schema.
-- `query` accetta una funzione che definisce l'implementazione dell'API. Questa implementazione riceve `opts`, che contiene l'`input` passato all'operazione e altro contesto configurato dal middleware, disponibile in `opts.ctx`. La funzione passata a `query` deve restituire un output conforme allo schema `output`.
+- `query` accetta una funzione che definisce l'implementazione della tua API. Questa implementazione riceve `opts`, che contiene l'`input` passato all'operazione, oltre ad altro contesto configurato dal middleware, disponibile in `opts.ctx`. La funzione passata a `query` deve restituire un output conforme allo schema `output`.
 
-L'uso di `query` per definire l'implementazione indica che l'operazione non è mutativa. Usalo per definire metodi di recupero dati. Per operazioni mutative, usa invece il metodo `mutation`.
+L'uso di `query` per definire l'implementazione indica che l'operazione non è mutativa. Usalo per definire metodi di recupero dati. Per implementare un'operazione mutativa, usa invece il metodo `mutation`.
 
 Se aggiungi una nuova operazione, assicurati di registrarla aggiungendola al router in `src/router.ts`.
 
-## Personalizzare la tua API tRPC
+## Personalizzazione della tua API tRPC
 
 ### Errori
 
-Nell'implementazione, puoi restituire errori ai client lanciando un `TRPCError`. Questi accettano un `code` che indica il tipo di errore, ad esempio:
+Nella tua implementazione, puoi restituire errori ai client lanciando un `TRPCError`. Questi accettano un `code` che indica il tipo di errore, ad esempio:
 
 ```ts
 throw new TRPCError({
@@ -156,11 +156,11 @@ throw new TRPCError({
 });
 ```
 
-### Organizzare le Operazioni
+### Organizzazione delle Operazioni
 
-Man mano che l'API cresce, potresti voler raggruppare operazioni correlate.
+Man mano che la tua API cresce, potresti voler raggruppare operazioni correlate.
 
-Puoi raggruppare operazioni usando router annidati, ad esempio:
+Puoi raggruppare operazioni utilizzando router annidati, ad esempio:
 
 ```ts
 import { getUser } from './procedures/users/get.js';
@@ -175,7 +175,7 @@ const appRouter = router({
 })
 ```
 
-I client riceveranno questo raggruppamento, ad esempio invocare l'operazione `listUsers` apparirebbe così:
+I client riceveranno questo raggruppamento, ad esempio invocare l'operazione `listUsers` in questo caso apparirebbe così:
 
 ```ts
 client.users.list.query();
@@ -183,7 +183,7 @@ client.users.list.query();
 
 ### Logging
 
-Il logger AWS Lambda Powertools è configurato in `src/middleware/logger.ts` e accessibile nell'implementazione via `opts.ctx.logger`. Puoi usarlo per loggare su CloudWatch Logs e/o controllare valori aggiuntivi da includere in ogni messaggio di log strutturato. Ad esempio:
+Il logger AWS Lambda Powertools è configurato in `src/middleware/logger.ts` e può essere accessibile in un'implementazione API via `opts.ctx.logger`. Puoi usarlo per loggare su CloudWatch Logs e/o controllare valori aggiuntivi da includere in ogni messaggio di log strutturato. Ad esempio:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -198,9 +198,9 @@ export const echo = publicProcedure
 
 Per maggiori informazioni sul logger, consulta la [documentazione AWS Lambda Powertools Logger](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/).
 
-### Registrare Metriche
+### Registrazione Metriche
 
-Le metriche AWS Lambda Powertools sono configurate in `src/middleware/metrics.ts` e accessibili via `opts.ctx.metrics`. Puoi usarle per registrare metriche in CloudWatch senza bisogno di importare l'AWS SDK, ad esempio:
+Le metriche AWS Lambda Powertools sono configurate in `src/middleware/metrics.ts` e possono essere accessibili in un'implementazione API via `opts.ctx.metrics`. Puoi usarlo per registrare metriche in CloudWatch senza bisogno di importare e usare l'AWS SDK, ad esempio:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -215,9 +215,9 @@ export const echo = publicProcedure
 
 Per maggiori informazioni, consulta la [documentazione AWS Lambda Powertools Metrics](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/).
 
-### Ottimizzare il Tracciamento X-Ray
+### Ottimizzazione Tracciamento X-Ray
 
-Il tracer AWS Lambda Powertools è configurato in `src/middleware/tracer.ts` e accessibile via `opts.ctx.tracer`. Puoi usarlo per aggiungere tracce con AWS X-Ray per ottenere dettagli sulle prestazioni e il flusso delle richieste API. Ad esempio:
+Il tracer AWS Lambda Powertools è configurato in `src/middleware/tracer.ts` e può essere accessibile in un'implementazione API via `opts.ctx.tracer`. Puoi usarlo per aggiungere tracce con AWS X-Ray per fornire insight dettagliati sulle prestazioni e il flusso delle richieste API. Ad esempio:
 
 ```ts {5-7}
 export const echo = publicProcedure
@@ -225,7 +225,7 @@ export const echo = publicProcedure
    .output(...)
    .query(async (opts) => {
       const subSegment = opts.ctx.tracer.getSegment()!.addNewSubsegment('MyAlgorithm');
-      // ... logica dell'algoritmo da tracciare
+      // ... logica del mio algoritmo da catturare
       subSegment.close();
 
       return ...;
@@ -234,13 +234,13 @@ export const echo = publicProcedure
 
 Per maggiori informazioni, consulta la [documentazione AWS Lambda Powertools Tracer](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/).
 
-### Implementare Middleware Personalizzati
+### Implementazione Middleware Personalizzato
 
-Puoi aggiungere valori personalizzati al contesto delle procedure implementando middleware.
+Puoi aggiungere valori aggiuntivi al contesto fornito alle procedure implementando middleware.
 
-Ad esempio, implementiamo un middleware per estrarre dettagli sull'utente chiamante dalla nostra API in `src/middleware/identity.ts`.
+Come esempio, implementiamo un middleware per estrarre dettagli sull'utente chiamante dalla nostra API in `src/middleware/identity.ts`.
 
-Prima definiamo cosa aggiungere al contesto:
+Prima definiamo cosa aggiungeremo al contesto:
 
 ```ts
 export interface IIdentityContext {
@@ -251,26 +251,26 @@ export interface IIdentityContext {
 }
 ```
 
-Nota che definiamo una proprietà _opzionale_ aggiuntiva nel contesto. tRPC gestisce l'assicurazione che questa sia definita nelle procedure che hanno configurato correttamente questo middleware.
+Nota che definiamo una proprietà _opzionale_ aggiuntiva al contesto. tRPC gestisce l'assicurazione che questa sia definita nelle procedure che hanno configurato correttamente questo middleware.
 
-Ora implementiamo il middleware. Ha la seguente struttura:
+Successivamente implementiamo il middleware stesso. Ha la seguente struttura:
 
 ```ts
 export const createIdentityPlugin = () => {
    const t = initTRPC.context<...>().create();
    return t.procedure.use(async (opts) => {
-      // Aggiungi logica da eseguire prima della procedura
+      // Aggiungi logica qui da eseguire prima della procedura
 
       const response = await opts.next(...);
 
-      // Aggiungi logica da eseguire dopo la procedura
+      // Aggiungi logica qui da eseguire dopo la procedura
 
       return response;
    });
 };
 ```
 
-Nel nostro caso, vogliamo estrarre dettagli sull'utente Cognito chiamante. Lo faremo estraendo l'ID subject (o "sub") dall'evento API Gateway e recuperando i dettagli utente da Cognito. L'implementazione varia leggermente se l'evento è fornito da un'API REST o HTTP:
+Nel nostro caso, vogliamo estrarre dettagli sull'utente Cognito chiamante. Lo faremo estraendo l'ID soggetto (o "sub") dell'utente dall'evento API Gateway e recuperando i dettagli utente da Cognito. L'implementazione varia leggermente a seconda che l'evento sia fornito da un'API REST o HTTP:
 
 <Tabs>
 <TabItem label="REST">
@@ -304,12 +304,12 @@ export const createIdentityPlugin = () => {
     if (!sub) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `Impossibile identificare l'utente chiamante`,
+        message: `Impossibile determinare l'utente chiamante`,
       });
     }
 
     const { Users } = await cognito.listUsers({
-      // Assume che l'ID del user pool sia configurato nell'ambiente lambda
+      // Assume che l'ID del pool utenti sia configurato nell'ambiente lambda
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -322,7 +322,7 @@ export const createIdentityPlugin = () => {
       });
     }
 
-    // Fornisce l'identity ad altre procedure nel contesto
+    // Fornisci l'identità ad altre procedure nel contesto
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -373,12 +373,12 @@ export const createIdentityPlugin = () => {
     if (!sub) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `Impossibile identificare l'utente chiamante`,
+        message: `Impossibile determinare l'utente chiamante`,
       });
     }
 
     const { Users } = await cognito.listUsers({
-      // Assume che l'ID del user pool sia configurato nell'ambiente lambda
+      // Assume che l'ID del pool utenti sia configurato nell'ambiente lambda
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -391,7 +391,7 @@ export const createIdentityPlugin = () => {
       });
     }
 
-    // Fornisce l'identity ad altre procedure nel contesto
+    // Fornisci l'identità ad altre procedure nel contesto
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -407,9 +407,9 @@ export const createIdentityPlugin = () => {
 </TabItem>
 </Tabs>
 
-## Deploy della tua API tRPC
+## Distribuzione della tua API tRPC
 
-Il generatore tRPC backend crea un costrutto CDK per il deploy dell'API nella cartella `common/constructs`. Puoi utilizzarlo in un'applicazione CDK, ad esempio:
+Il generatore di backend tRPC genera un costrutto CDK per distribuire la tua API nella cartella `common/constructs`. Puoi utilizzarlo in un'applicazione CDK, ad esempio:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
@@ -424,19 +424,19 @@ export class ExampleStack extends Stack {
 }
 ```
 
-Questo configura l'infrastruttura API, inclusi AWS API Gateway REST/HTTP API, funzioni AWS Lambda per la logica e autenticazione IAM.
+Questo configura l'infrastruttura della tua API, inclusi un AWS API Gateway REST o HTTP API, funzioni AWS Lambda per la logica di business e autenticazione IAM.
 
 ### Integrazioni Type-Safe
 
 <Snippet name="api/type-safe-api-integrations" />
 
 :::tip
-Quando aggiungi o rimuovi una procedura nella tua API tRPC, questi cambiamenti si rifletteranno immediatamente nel costrutto CDK senza bisogno di ricostruire.
+Quando aggiungi o rimuovi una procedura nella tua API tRPC, queste modifiche si rifletteranno immediatamente nel costrutto CDK senza necessità di ricostruire.
 :::
 
-### Concedere Accesso
+### Concessione Accessi
 
-Puoi usare il metodo `grantInvokeAccess` per concedere accesso all'API, ad esempio per consentire l'accesso agli utenti autenticati Cognito:
+Puoi usare il metodo `grantInvokeAccess` per concedere accessi alla tua API, ad esempio potresti voler concedere accesso agli utenti Cognito autenticati:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -444,15 +444,15 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## Server tRPC Locale
 
-Puoi usare il target `serve` per eseguire un server locale per l'API, ad esempio:
+Puoi usare il target `serve` per eseguire un server locale per la tua API, ad esempio:
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
-Il punto di ingresso del server locale è `src/local-server.ts`.
+Il punto di ingresso per il server locale è `src/local-server.ts`.
 
-## Invocare la tua API tRPC
+## Invocazione della tua API tRPC
 
-Puoi creare un client tRPC per invocare l'API in modo type-safe. Se chiami l'API da un altro backend, puoi usare il client in `src/client/index.ts`, ad esempio:
+Puoi creare un client tRPC per invocare la tua API in modo type-safe. Se stai chiamando la tua API tRPC da un altro backend, puoi usare il client in `src/client/index.ts`, ad esempio:
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -462,7 +462,7 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-Se chiami l'API da un sito React, considera l'uso del generatore <Link path="guides/api-connection/react-trpc">API Connection</Link> per configurare il client.
+Se stai chiamando la tua API da un sito React, considera l'uso del generatore <Link path="guides/api-connection/react-trpc">API Connection</Link> per configurare il client.
 
 ## Ulteriori Informazioni
 

--- a/docs/src/content/docs/it/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/it/guides/ts-mcp-server.mdx
@@ -12,13 +12,13 @@ import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
-# Generatore di Server TypeScript MCP
+# Generatore di Server MCP TypeScript
 
-Genera un server TypeScript per il [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) per fornire contesto ai Large Language Model (LLM).
+Genera un server [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) in TypeScript per fornire contesto ai Large Language Model (LLM).
 
-## Cos'è il MCP?
+## Cos'è l'MCP?
 
-Il [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) è uno standard aperto che consente agli assistenti AI di interagire con strumenti e risorse esterne. Fornisce un modo coerente per i LLM di:
+Il [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) è uno standard aperto che consente agli assistenti AI di interagire con strumenti e risorse esterne. Fornisce un metodo consistente per i LLM per:
 
 - Eseguire strumenti (funzioni) che compiono azioni o recuperano informazioni  
 - Accedere a risorse che forniscono contesto o dati
@@ -33,29 +33,29 @@ Puoi generare un server MCP TypeScript in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## Output del Generatore
 
-Il generatore creerà i seguenti file del progetto:
+Il generatore creerà i seguenti file di progetto:
 
 <FileTree>
   - packages/\<name>/
-    - README.md Documentazione del server MCP con istruzioni d'uso
+    - README.md Documentazione del server MCP con istruzioni per l'uso
     - project.json Configurazione del progetto Nx con target per build, bundle e dev
     - src/
-      - index.ts Punto d'ingresso del server MCP
+      - index.ts Punto di ingresso del server MCP
       - server.ts Definizione principale del server, con strumenti e risorse
       - global.d.ts Dichiarazioni di tipo TypeScript per importare file markdown
       - resources/
-        - example-context.md File markdown di esempio usato come risorsa per il server MCP
+        - example-context.md File markdown di esempio utilizzato come risorsa per il server MCP
 </FileTree>
 
 :::note
 Consulta la <Link path="/guides/typescript-project">documentazione del generatore di progetti TypeScript</Link> per ulteriori dettagli sull'output del generatore.
 :::
 
-## Lavorare con il Tuo Server MCP
+## Lavorare con il Server MCP
 
 ### Aggiungere Strumenti
 
@@ -63,7 +63,7 @@ Gli strumenti sono funzioni che l'assistente AI può chiamare per eseguire azion
 
 ```typescript
 server.tool("toolName",
-  { param1: z.string(), param2: z.number() }, // Schema di input usando Zod
+  { param1: z.string(), param2: z.number() }, // Schema di input utilizzando Zod
   async ({ param1, param2 }) => {
     // Implementazione dello strumento
     return {
@@ -78,7 +78,7 @@ server.tool("toolName",
 Le risorse forniscono contesto all'assistente AI. Puoi aggiungere risorse statiche da file o risorse dinamiche:
 
 ```typescript
-// Risorsa statica da file
+// Risorsa statica da un file
 import exampleContext from './resources/example-context.md';
 
 server.resource('resource-name', 'example://resource', async (uri) => ({
@@ -100,11 +100,11 @@ Per utilizzare il tuo server MCP con assistanti AI, devi prima creare un bundle:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-Questo crea una versione aggregata in `dist/packages/your-mcp-server/bundle/index.js` (il percorso può variare in base alle impostazioni della directory).
+Questo crea una versione bundled in `dist/packages/your-mcp-server/bundle/index.js` (il percorso può variare in base alle impostazioni della directory).
 
 ### File di Configurazione
 
-La maggior parte degli assistanti AI che supportano MCP utilizza un approccio simile alla configurazione. Dovrai creare o aggiornare un file di configurazione con i dettagli del tuo server MCP:
+La maggior parte degli assistanti AI che supportano MCP utilizza un approccio di configurazione simile. Dovrai creare o aggiornare un file di configurazione con i dettagli del tuo server MCP:
 
 ```json
 {
@@ -120,7 +120,7 @@ La maggior parte degli assistanti AI che supportano MCP utilizza un approccio si
 }
 ```
 
-Sostituisci `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` con il percorso effettivo del tuo server MCP aggregato.
+Sostituisci `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` con il percorso effettivo del tuo server MCP bundled.
 
 :::caution
 Se ricevi un errore come `ENOENT node` durante la connessione al server, potrebbe essere necessario specificare il percorso completo di `node`, ottenibile eseguendo `which node` nel terminale.
@@ -136,22 +136,22 @@ Consulta la seguente documentazione per configurare MCP con assistenti AI specif
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
 
 :::tip
-Alcuni assistenti AI, come Amazon Q Developer, permettono di specificare configurazioni MCP a livello di workspace, particolarmente utili per definire i server MCP rilevanti per un progetto specifico.
+Alcuni assistenti AI, come Amazon Q Developer, consentono di specificare una configurazione MCP a livello di workspace, particolarmente utile per definire i server MCP rilevanti per un progetto specifico.
 :::
 
-## Workflow di Sviluppo
+## Flusso di Sviluppo
 
 ### Target di Build
 
-Il generatore si basa sul <Link path="/guides/typescript-project">generatore di progetti TypeScript</Link> e ne eredita i target, aggiungendo inoltre i seguenti target:
+Il generatore è basato sul <Link path="/guides/typescript-project">generatore di progetti TypeScript</Link> e ne eredita i target, aggiungendo inoltre i seguenti target:
 
 #### Bundle
 
-Il task `bundle` utilizza [esbuild](https://esbuild.github.io/) per creare un singolo file JavaScript aggregato utilizzabile con gli assistenti AI:
+Il task `bundle` utilizza [esbuild](https://esbuild.github.io/) per creare un singolo file JavaScript che può essere utilizzato con gli assistenti AI:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-Questo crea una versione aggregata in `dist/packages/your-mcp-server/bundle/index.js` (il percorso può variare in base alle impostazioni della directory).
+Questo crea una versione bundled in `dist/packages/your-mcp-server/bundle/index.js` (il percorso può variare in base alle impostazioni della directory).
 
 #### Dev
 
@@ -159,7 +159,7 @@ Il task `dev` monitora le modifiche nel progetto e ricostruisce automaticamente 
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-Particolarmente utile durante lo sviluppo, garantisce che l'assistente AI utilizzi sempre l'ultima versione del tuo server MCP.
+Particolarmente utile durante lo sviluppo, garantisce che l'assistente AI utilizzi l'ultima versione del server MCP.
 
 :::note
 Alcuni assistenti AI richiederanno il riavvio del server MCP per applicare le modifiche.

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -10,15 +10,14 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
-[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) è un framework per definire l'infrastruttura cloud tramite codice e distribuirla attraverso AWS CloudFormation.
+[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) è un framework per definire infrastrutture cloud tramite codice e provisionarle attraverso AWS CloudFormation.
 
-Il generatore di infrastruttura TypeScript crea un'applicazione AWS CDK per l'infrastruttura scritta in TypeScript. L'applicazione generata include best practice di sicurezza attraverso controlli [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html).
+Il generatore di infrastrutture TypeScript crea un'applicazione AWS CDK per l'infrastruttura scritta in TypeScript. L'applicazione generata include le migliori pratiche di sicurezza tramite controlli [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html).
 
 ## Utilizzo
 
-### Genera un Progetto di Infrastruttura
+### Generare un Progetto di Infrastruttura
 
 Puoi generare un nuovo progetto di infrastruttura in due modi:
 
@@ -26,7 +25,7 @@ Puoi generare un nuovo progetto di infrastruttura in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
 ## Output del Generatore
 
@@ -35,7 +34,7 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
 <FileTree>
 
   - src
-    - main.ts Punto d'ingresso dell'applicazione che istanzia gli stack CDK da distribuire
+    - main.ts Punto d'ingresso dell'applicazione che istanzia gli stack CDK da deployare
     - stacks Definizioni degli stack CDK
       - application-stack.ts Stack applicativo principale
   - cdk.json Configurazione CDK
@@ -68,9 +67,9 @@ export class ApplicationStack extends cdk.Stack {
 
 ### Infrastruttura per API
 
-Se hai utilizzato i generatori per <Link path="guides/trpc">API tRPC</Link> o <Link path="guides/fastapi">FastAPI</Link>, noterai che sono già disponibili alcuni costrutti in `packages/common/constructs` per distribuirli.
+Se hai utilizzato i generatori <Link path="guides/trpc">tRPC API</Link> o <Link path="guides/fastapi">FastAPI</Link> per creare API, noterai che sono già disponibili alcuni construct in `packages/common/constructs` per deployarle.
 
-Ad esempio, se hai creato un'API tRPC chiamata `my-api`, puoi semplicemente importare e istanziare il costrutto per aggiungere tutta l'infrastruttura necessaria alla sua distribuzione:
+Ad esempio, se hai creato un'API tRPC chiamata `my-api`, puoi semplicemente importare e istanziare il construct per aggiungere tutta l'infrastruttura necessaria al suo deploy:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -81,15 +80,15 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Aggiungi l'infrastruttura per la tua API
+    // Aggiungi infrastruttura per la tua API
     new MyApi(this, 'MyApi');
   }
 }
 ```
 
-### Infrastruttura per Siti Web
+### Infrastruttura per Sito Web
 
-Se hai utilizzato il generatore per <Link path="guides/cloudscape-website">siti web CloudScape</Link>, noterai che è già disponibile un costrutto in `packages/common/constructs` per distribuirli. Ad esempio:
+Se hai utilizzato il generatore <Link path="guides/cloudscape-website">CloudScape website</Link>, noterai che è già disponibile un construct in `packages/common/constructs` per deployarlo. Ad esempio:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -100,27 +99,27 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Aggiungi l'infrastruttura per il sito web
+    // Aggiungi infrastruttura per il sito web
     new MyWebsite(this, 'MyWebsite');
   }
 }
 ```
 
 :::warning
-È importante dichiarare il sito web _dopo_ eventuali costrutti API per garantire che la <Link path="guides/cloudscape-website#runtime-configuration">Configurazione Runtime</Link> del sito web includa tutte le configurazioni delle API.
+È importante assicurarsi che il sito web venga dichiarato _dopo_ eventuali construct di API per permettere alla <Link path="guides/cloudscape-website#runtime-configuration">Runtime Config</Link> del sito di includere tutte le configurazioni delle API.
 :::
 
 ## Sintetizzare la tua Infrastruttura
 
-Come parte del target `build`, oltre ad eseguire i <Link path="guides/typescript-project#building">target predefiniti di compilazione, lint e test</Link>, il progetto di infrastruttura viene _sintetizzato_ in CloudFormation. Questa operazione può essere eseguita anche in modo autonomo tramite il target `synth`:
+Come parte del target `build`, oltre all'esecuzione dei <Link path="guides/typescript-project#building">target predefiniti di compilazione, lint e test</Link>, il progetto di infrastruttura viene _sintetizzato_ in CloudFormation. Questa operazione può essere eseguita anche separatamente tramite il target `synth`:
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
-Troverai la tua cloud assembly sintetizzata nella cartella `dist` principale, sotto `dist/packages/<my-infra-project>/cdk.out`.
+Troverai la cloud assembly sintetizzata nella cartella `dist` principale, sotto `dist/packages/<my-infra-project>/cdk.out`.
 
 ## Bootstrap del Tuo Account AWS
 
-Se stai distribuendo un'applicazione CDK su un account AWS per la prima volta, sarà necessario eseguire il bootstrap.
+Se stai deployando un'applicazione CDK in un account AWS per la prima volta, sarà necessario eseguire il bootstrap.
 
 Prima, assicurati di aver [configurato le credenziali per il tuo account AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
@@ -132,12 +131,12 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 Per maggiori dettagli, consulta la [documentazione CDK](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html).
 
-## Distribuire su AWS
+## Deploy su AWS
 
-Dopo una build, puoi distribuire la tua infrastruttura su AWS usando il target `deploy`.
+Dopo una build, puoi effettuare il deploy dell'infrastruttura su AWS usando il target `deploy`.
 
 :::caution
-Utilizza il target `deploy-ci` per la distribuzione in una pipeline CI/CD. Vedi sotto per dettagli.
+Utilizza il target `deploy-ci` per il deploy in una pipeline CI/CD. Vedi sotto per dettagli.
 :::
 
 Prima, assicurati di aver [configurato le credenziali per il tuo account AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
@@ -147,18 +146,18 @@ Quindi, esegui il target deploy:
 <NxCommands commands={['run <my-infra>:deploy --all']} />
 
 :::tip
-Il comando sopra distribuisce _tutti_ gli stack definiti in `main.ts`. Potresti voler specificare uno stack individuale, specialmente se hai configurato più ambienti di un'applicazione:
+Il comando sopra deploya _tutti_ gli stack definiti in `main.ts`. Potresti voler targettare uno stack specifico, specialmente se hai configurato più stage di un'applicazione:
 
 <NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
 :::
 
-## Distribuire su AWS in una Pipeline CI/CD
+## Deploy su AWS in una Pipeline CI/CD
 
-Utilizza il target `deploy-ci` se stai distribuendo su AWS come parte di una pipeline CI/CD.
+Utilizza il target `deploy-ci` se stai effettuando il deploy su AWS come parte di una pipeline CI/CD.
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-Questo target differisce leggermente dal normale target `deploy` in quanto garantisce la distribuzione di una cloud-assembly pre-sintetizzata, invece di sintetizzarla al volo. Questo aiuta a evitare potenziali problemi di non-determinismo dovuti a cambiamenti nelle versioni dei pacchetti, assicurando che ogni fase della pipeline distribuisca usando la stessa cloud-assembly.
+Questo target differisce leggermente dal normale target `deploy` in quanto garantisce il deploy di una cloud-assembly pre-sintetizzata, invece di sintetizzarla al volo. Questo aiuta a evitare potenziali problemi di non-determinismo dovuti a cambiamenti nelle versioni dei pacchetti, assicurando che ogni stage della pipeline deployi utilizzando la stessa cloud-assembly.
 
 ## Ulteriori Informazioni
 

--- a/docs/src/content/docs/it/guides/typescript-project.mdx
+++ b/docs/src/content/docs/it/guides/typescript-project.mdx
@@ -10,13 +10,12 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
-Il generatore di progetti TypeScript può essere utilizzato per creare una libreria o applicazione moderna [TypeScript](https://www.typescriptlang.org/) configurata con best practice come [ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), i [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) di TypeScript, [Vitest](https://vitest.dev/) per l'esecuzione dei test ed [ESLint](https://eslint.org/) per l'analisi statica.
+Il generatore di progetti TypeScript può essere utilizzato per creare una moderna libreria o applicazione [TypeScript](https://www.typescriptlang.org/) configurata con le migliori pratiche come i [Moduli ECMAScript (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), i [riferimenti di progetto TypeScript](https://www.typescriptlang.org/docs/handbook/project-references.html), [Vitest](https://vitest.dev/) per l'esecuzione dei test e [ESLint](https://eslint.org/) per l'analisi statica.
 
 ## Utilizzo
 
-### Genera un progetto TypeScript
+### Generare un Progetto TypeScript
 
 Puoi generare un nuovo progetto TypeScript in due modi:
 
@@ -24,7 +23,7 @@ Puoi generare un nuovo progetto TypeScript in due modi:
 
 ### Opzioni
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## Output del Generatore
 
@@ -35,8 +34,8 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
   - src Codice sorgente TypeScript
     - index.ts
   - project.json Configurazione del progetto e target di build
-  - tsconfig.json Configurazione TypeScript base per il progetto (estende tsconfig.base.json nella root del workspace)
-  - tsconfig.lib.json Configurazione TypeScript per la libreria (codice runtime o da pubblicare)
+  - tsconfig.json Configurazione TypeScript base per questo progetto (estende tsconfig.base.json della root del workspace)
+  - tsconfig.lib.json Configurazione TypeScript per la tua libreria (codice runtime o da pubblicare)
   - tsconfig.spec.json Configurazione TypeScript per i test
   - vite.config.ts Configurazione per Vitest
   - eslint.config.mjs Configurazione per ESLint
@@ -47,23 +46,23 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
 Nota che non viene creato alcun file `package.json` per questo progetto! Puoi scoprire il motivo [qui sotto](#dependencies).
 :::
 
-Noterai anche modifiche ai seguenti file nella root del workspace:
+Noterai anche alcune modifiche ai seguenti file nella root del workspace:
 
 <FileTree>
 
   - nx.json La configurazione di Nx viene aggiornata per configurare il plugin @nx/js/typescript per il tuo progetto
-  - tsconfig.base.json Viene impostato un alias TypeScript per il progetto per consentirne l'importazione da altri progetti nel workspace
-  - tsconfig.json Viene aggiunto un project reference TypeScript per il tuo progetto
+  - tsconfig.base.json Viene impostato un alias TypeScript per il tuo progetto per consentirne l'importazione da altri progetti nel workspace
+  - tsconfig.json Viene aggiunto un riferimento al progetto TypeScript
 
 </FileTree>
 
-## Scrittura del Codice TypeScript
+## Scrivere Codice TypeScript
 
 Aggiungi il tuo codice TypeScript nella directory `src`.
 
 ### Sintassi di Importazione ESM
 
-Poiché il tuo progetto TypeScript è un ES Module, assicurati di scrivere le istruzioni di importazione con la corretta sintassi ESM, includendo esplicitamente l'estensione del file:
+Poiché il tuo progetto TypeScript è un Modulo ES, assicurati di scrivere le istruzioni di importazione con la sintassi ESM corretta, riferendoti esplicitamente all'estensione del file:
 
 ```ts title="index.ts" ".js"
 import { sayHello } from './hello.js';
@@ -73,28 +72,28 @@ import { sayHello } from './hello.js';
 Nonostante stiamo usando TypeScript e `sayHello` sia definito in `hello.ts`, utilizziamo l'estensione `.js` nell'import. Puoi leggere maggiori dettagli [qui](https://www.typescriptlang.org/docs/handbook/modules/reference.html).
 :::
 
-### Esportazione per Altri Progetti TypeScript
+### Esportare per Altri Progetti TypeScript
 
-Il punto di ingresso del progetto TypeScript è `src/index.ts`. Puoi aggiungere export qui per qualsiasi elemento che desideri rendere disponibile ad altri progetti:
+Il punto di ingresso del tuo progetto TypeScript è `src/index.ts`. Puoi aggiungere qui le esportazioni per qualsiasi elemento che desideri rendere disponibile ad altri progetti:
 
 ```ts title="src/index.ts"
 export { sayHello } from './hello.js';
 export * from './algorithms/index.js';
 ```
 
-### Importazione del Codice della Libreria in Altri Progetti
+### Importare il Codice della Libreria in Altri Progetti
 
-Gli [alias TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) per il tuo progetto sono configurati nel file `tsconfig.base.json` del workspace, consentendo di riferirsi al progetto TypeScript da altri progetti:
+Gli [alias TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) per il tuo progetto sono configurati nel file `tsconfig.base.json` del workspace, permettendoti di riferirti al progetto TypeScript da altri progetti TypeScript:
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
 ```
 
 :::note
-Gli alias per i progetti TypeScript iniziano con `:` invece del tradizionale `@`, per evitare conflitti di nomi tra pacchetti locali nel workspace e pacchetti remoti su [NPM](https://www.npmjs.com/).
+Gli alias per i progetti TypeScript iniziano con `:` invece del tradizionale `@`, per evitare conflitti di nomi tra i pacchetti locali nel workspace e quelli remoti su [NPM](https://www.npmjs.com/).
 :::
 
-Quando aggiungi un'istruzione di import per un nuovo progetto nel workspace per la prima volta, potresti vedere un errore simile al seguente nel tuo IDE:
+Quando aggiungi un'istruzione di import per un nuovo progetto nel workspace per la prima volta, potresti vedere un errore nel tuo IDE simile al seguente:
 
 <details>
 <summary>Errore di importazione</summary>
@@ -108,16 +107,16 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 </details>
 
-Questo avviene perché non è stato configurato un [project reference](https://www.typescriptlang.org/docs/handbook/project-references.html).
+Questo accade perché non è stato configurato un [riferimento di progetto](https://www.typescriptlang.org/docs/handbook/project-references.html).
 
-I progetti TypeScript sono preconfigurati con il generatore Nx TypeScript Sync, evitando la necessità di configurare manualmente i project reference. Esegui semplicemente il seguente comando e Nx aggiungerà la configurazione richiesta:
+I progetti TypeScript sono preconfigurati con il generatore Nx TypeScript Sync, evitandoti di dover configurare manualmente i riferimenti. Esegui semplicemente il seguente comando e Nx aggiungerà la configurazione necessaria:
 
 <NxCommands commands={['sync']} />
 
-Dopo questa operazione, l'errore nell'IDE dovrebbe scomparire e sarai pronto a utilizzare la tua libreria.
+Dopo questo passaggio, l'errore nell'IDE dovrebbe scomparire e sarai pronto a utilizzare la tua libreria.
 
 :::tip
-Puoi anche semplicemente buildare il progetto e riceverai un messaggio come:
+Puoi anche semplicemente eseguire la build del progetto e verrai informato con un messaggio come:
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -129,14 +128,14 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Seleziona `Yes` per consentire a Nx di aggiornare i project reference.
+Seleziona `Yes` per consentire a Nx di aggiornare i riferimenti del progetto.
 :::
 
 ### Dipendenze
 
-Noterai che il progetto TypeScript non ha un file `package.json`, cosa che potrebbe risultare insolita se sei abituato a monorepo TypeScript tradizionali.
+Noterai che il tuo progetto TypeScript non ha un file `package.json`, cosa che potrebbe sorprendere se sei abituato a monorepo TypeScript tradizionali.
 
-Per aggiungere una dipendenza a qualsiasi pacchetto TypeScript nel monorepo, basta aggiungere la dipendenza al `package.json` nella root del workspace. Puoi farlo tramite la riga di comando del tuo package manager:
+Per aggiungere una dipendenza a qualsiasi pacchetto TypeScript nel tuo monorepo, aggiungi semplicemente la dipendenza al `package.json` nella root del workspace. Puoi farlo tramite la riga di comando del tuo package manager:
 
 <InstallCommand pkg="some-npm-package" />
 
@@ -144,9 +143,9 @@ La dipendenza sarà quindi disponibile per tutti i progetti TypeScript nel works
 
 #### Codice Runtime
 
-Quando utilizzi il progetto TypeScript come codice runtime (ad esempio come handler per una funzione AWS Lambda), si consiglia di usare strumenti come [`esbuild`](https://esbuild.github.io/) per il bundling, poiché supporta il [tree-shaking](https://esbuild.github.io/api/#tree-shaking) per includere solo le dipendenze effettivamente utilizzate.
+Quando utilizzi il tuo progetto TypeScript come codice runtime (ad esempio come handler per una funzione AWS Lambda), si consiglia di utilizzare uno strumento come [`esbuild`](https://esbuild.github.io/) per creare un bundle del progetto, poiché può effettuare il [tree-shaking](https://esbuild.github.io/api/#tree-shaking) per includere solo le dipendenze effettivamente utilizzate.
 
-Puoi ottenere questo aggiungendo un target come il seguente nel file `project.json`:
+Puoi ottenere questo aggiungendo un target come il seguente al tuo file `project.json`:
 
 ```json
 {
@@ -166,34 +165,34 @@ Puoi ottenere questo aggiungendo un target come il seguente nel file `project.js
 ```
 
 :::note
-Nota che nel target sopra abbiamo scelto `src/index.ts` come entrypoint del bundle, quindi il codice esportato da questo file verrà incluso nel bundle insieme a tutte le sue dipendenze.
+Nota che nel target sopra abbiamo scelto `src/index.ts` come punto di ingresso per il bundle, il che significa che il codice esportato da questo file verrà incluso nel bundle insieme a tutte le sue dipendenze.
 :::
 
 #### Pubblicazione su NPM
 
-Se intendi pubblicare il progetto TypeScript su NPM, devi creare un file `package.json` per esso.
+Se intendi pubblicare il tuo progetto TypeScript su NPM, devi creare un file `package.json` per esso.
 
-Questo deve dichiarare tutte le dipendenze utilizzate. Poiché durante la build le dipendenze vengono risolte dal `package.json` della root del workspace, si consiglia di configurare il [Nx Dependency Checks ESLint Plugin](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) per garantire che il `package.json` pubblicato includa tutte le dipendenze effettivamente utilizzate.
+Questo deve dichiarare tutte le dipendenze utilizzate dal progetto. Poiché durante la build le dipendenze vengono risolte tramite il `package.json` della root del workspace, si consiglia di configurare il [Plugin ESLint per i Controlli delle Dipendenze di Nx](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) per assicurarti che il `package.json` del progetto pubblicato includa tutte le dipendenze utilizzate.
 
 ### Build
 
-Il progetto TypeScript è configurato con un target `build` (definito in `project.json`), eseguibile tramite:
+Il tuo progetto TypeScript è configurato con un target `build` (definito in `project.json`), che puoi eseguire tramite:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-Dove `<project-name>` è il nome completo del progetto.
+Dove `<project-name>` è il nome completo del tuo progetto.
 
 Il target `build` compilerà, eseguirà il linting e i test del progetto.
 
-L'output della build si trova nella cartella `dist` della root del workspace, all'interno di una directory dedicata al progetto e al target, ad esempio `dist/packages/<my-library>/tsc`
+L'output della build si troverà nella cartella `dist` della root del workspace, all'interno di una directory specifica per il pacchetto e il target, ad esempio `dist/packages/<my-library>/tsc`
 
 ## Testing
 
 [Vitest](https://vitest.dev/) è configurato per eseguire i test del progetto.
 
-### Scrittura dei Test
+### Scrivere Test
 
-I test vanno scritti in file `.spec.ts` o `.test.ts`, posizionati nella cartella `src` del progetto.
+I test dovrebbero essere scritti in file `.spec.ts` o `.test.ts`, posizionati nella cartella `src` del progetto.
 
 Esempio:
 
@@ -203,14 +202,14 @@ Esempio:
     - hello.spec.ts Test per hello.ts
 </FileTree>
 
-Vitest offre una sintassi simile a Jest per definire i test, con utility come `describe`, `it`, `test` e `expect`.
+Vitest fornisce una sintassi simile a Jest per definire i test, con utility come `describe`, `it`, `test` e `expect`.
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
 
 describe('sayHello', () => {
 
-  it('dovrebbe salutare il chiamante', () => {
+  it('should greet the caller', () => {
     expect(sayHello('Darth Vader')).toBe('Hello, Darth Vader!');
   });
 
@@ -218,42 +217,42 @@ describe('sayHello', () => {
 
 ```
 
-Per dettagli su come scrivere test e funzionalità come il mocking delle dipendenze, consulta la [documentazione di Vitest](https://vitest.dev/guide/#writing-tests)
+Per maggiori dettagli su come scrivere test e funzionalità come il mocking delle dipendenze, consulta la [documentazione di Vitest](https://vitest.dev/guide/#writing-tests)
 
-### Esecuzione dei Test
+### Eseguire Test
 
-I test vengono eseguiti durante il target `build`, ma puoi eseguirli separatamente con il target `test`:
+I test verranno eseguiti come parte del target `build` del progetto, ma puoi anche eseguirli separatamente tramite il target `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puoi eseguire un singolo test o una suite specifica usando il flag `-t`:
+Puoi eseguire un singolo test o una suite di test utilizzando il flag `-t`:
 
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-Se utilizzi VSCode, consigliamo di installare l'estensione [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), che permette di eseguire, monitorare o debuggare i test direttamente dall'IDE.
+Se utilizzi VSCode, ti consigliamo di installare l'estensione [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), che permette di eseguire, monitorare o debuggare i test direttamente dall'IDE.
 :::
 
 ## Linting
 
 I progetti TypeScript utilizzano [ESLint](https://eslint.org/) per il linting e [Prettier](https://prettier.io/) per la formattazione.
 
-Consigliamo di configurare ESLint nel file `eslint.config.mjs` della root del workspace, così eventuali modifiche si applicheranno a tutti i progetti TypeScript garantendo coerenza.
+Consigliamo di configurare ESLint nel file `eslint.config.mjs` della root del workspace, in modo che le modifiche si applichino a tutti i progetti TypeScript nel workspace garantendo coerenza.
 
 Allo stesso modo, puoi configurare Prettier nel file `.prettierrc` della root.
 
-### Esecuzione del Linter
+### Eseguire il Linter
 
-Per eseguire il linter e verificare il progetto, utilizza il target `lint`:
+Per invocare il linter e verificare il progetto, puoi eseguire il target `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Correzione degli Errori di Linting
+### Correggere Problemi di Linting
 
-La maggior parte degli errori di linting o formattazione può essere corretta automaticamente. Puoi chiedere a ESLint di applicare le correzioni eseguendo con l'argomento `--configuration=fix`:
+La maggior parte dei problemi di linting o formattazione può essere corretta automaticamente. Puoi chiedere a ESLint di correggere i problemi eseguendolo con l'argomento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Analogamente, per correggere tutti gli errori di linting in tutti i pacchetti del workspace:
+Analogamente, se vuoi correggere tutti i problemi di linting in tutti i pacchetti del workspace, puoi eseguire:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/jp/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/api-connection/react-fastapi.mdx
@@ -11,19 +11,18 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-`api-connection`ジェネレータは、ReactウェブサイトとFastAPIバックエンドを迅速に統合する方法を提供します。タイプセーフな方法でFastAPIバックエンドに接続するために必要なすべての設定（クライアントと[TanStack Query](https://tanstack.com/query/v5)フックの生成、AWS IAM認証のサポート、適切なエラーハンドリングを含む）を行います。
+`api-connection` ジェネレータは、React ウェブサイトと FastAPI バックエンドを迅速に統合する方法を提供します。型安全な方法で FastAPI バックエンドに接続するために必要なすべての設定（クライアントと [TanStack Query](https://tanstack.com/query/v5) フックの生成、AWS IAM 認証のサポート、適切なエラーハンドリングを含む）を行います。
 
 ## 前提条件
 
-このジェネレータを使用する前に、Reactアプリケーションが以下を備えていることを確認してください：
+このジェネレータを使用する前に、React アプリケーションが以下を満たしていることを確認してください:
 
-1. アプリケーションをレンダリングする`main.tsx`ファイル
-2. 動作するFastAPIバックエンド（FastAPIジェネレータで生成されたもの）
+1. アプリケーションをレンダリングする `main.tsx` ファイルが存在すること
+2. FastAPI ジェネレータで生成された動作可能な FastAPI バックエンドが存在すること
 
 <details>
-<summary>必要な`main.tsx`の構造例</summary>
+<summary>必要な `main.tsx` の構造例</summary>
 
 ```tsx
 import { StrictMode } from 'react';
@@ -50,70 +49,70 @@ root.render(
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## ジェネレータの出力
 
-ジェネレータはFastAPIプロジェクトの以下のファイルを変更します：
+ジェネレータは FastAPI プロジェクトの以下のファイルを変更します:
 
 <FileTree>
 
 - scripts
-  - generate_open_api.py APIのOpenAPI仕様を生成するスクリプトを追加
+  - generate_open_api.py API の OpenAPI 仕様を生成するスクリプトを追加
 - project.json 上記の生成スクリプトを呼び出す新しいビルドターゲットを追加
 
 </FileTree>
 
-ジェネレータはReactアプリケーションの以下のファイルを変更します：
+ジェネレータは React アプリケーションの以下のファイルを変更します:
 
 <FileTree>
 
 - src
   - components
-    - \<ApiName>Provider.tsx APIクライアントのプロバイダ
-    - QueryClientProvider.tsx TanStack React Queryクライアントプロバイダ
+    - \<ApiName>Provider.tsx API クライアント用プロバイダ
+    - QueryClientProvider.tsx TanStack React Query クライアントプロバイダ
   - hooks
-    - use\<ApiName>.tsx TanStack Queryで状態管理されたAPI呼び出し用フックを追加
-    - use\<ApiName>Client.tsx 直接APIを呼び出すバニラクライアント生成用フックを追加
-    - useSigV4.tsx IAM認証選択時にHTTPリクエストのSigV4署名用フックを追加
-- project.json タイプセーフなクライアントを生成する新しいビルドターゲットを追加
+    - use\<ApiName>.tsx TanStack Query で状態管理された API 呼び出し用フックを追加
+    - use\<ApiName>Client.tsx 通常の API クライアントをインスタンス化するフックを追加
+    - useSigV4.tsx IAM 認証を選択した場合、SigV4 で HTTP リクエストに署名するフックを追加
+- project.json 型安全なクライアントを生成する新しいビルドターゲットを追加
 - .gitignore 生成されたクライアントファイルをデフォルトで無視
 
 </FileTree>
 
-また、ジェネレータはウェブサイトインフラにRuntime Configを追加します（まだ存在しない場合）。これにより、FastAPIのAPI URLがウェブサイトで利用可能になり、`use<ApiName>.tsx`フックによって自動的に設定されます。
+また、ジェネレータはウェブサイトインフラに Runtime Config を追加します（まだ存在しない場合）。これにより、FastAPI の API URL がウェブサイトで利用可能になり、`use<ApiName>.tsx` フックによって自動的に設定されます。
 
 ### コード生成
 
-ビルド時に、FastAPIのOpenAPI仕様からタイプセーフなクライアントが生成されます。これによりReactアプリケーションに3つの新しいファイルが追加されます：
+ビルド時に、FastAPI の OpenAPI 仕様から型安全なクライアントが生成されます。これにより React アプリケーションに3つの新しいファイルが追加されます:
 
 <FileTree>
 
 - src
   - generated
     - \<ApiName>
-      - types.gen.ts FastAPIで定義されたpydanticモデルから生成された型
-      - client.gen.ts API呼び出し用タイプセーフクライアント
-      - options-proxy.gen.ts TanStack Queryを使用したAPI操作のためのフックオプション生成メソッドを提供
+      - types.gen.ts FastAPI で定義された pydantic モデルから生成された型
+      - client.gen.ts API 呼び出し用の型安全なクライアント
+      - options-proxy.gen.ts TanStack Query を使用して API とやり取りするためのクエリフックオプションを作成するメソッドを提供
 
 </FileTree>
 
 :::tip
-デフォルトでは生成されたクライアントはバージョン管理から除外されます。チェックインしたい場合はReactアプリケーションの`.gitignore`からエントリを削除できますが、.gen.tsファイルへの手動変更はプロジェクトビルド時に上書きされる点に注意してください。
+デフォルトでは、生成されたクライアントはバージョン管理から除外されます。チェックインしたい場合は React アプリケーションの `.gitignore` からエントリを削除できますが、`.gen.ts` ファイルへの手動変更はプロジェクトビルド時に上書きされることに注意してください。
 :::
 
 ## 生成コードの使用方法
 
-生成されたタイプセーフクライアントを使用して、ReactアプリケーションからFastAPIを呼び出すことができます。TanStack Queryフック経由での使用が推奨されますが、直接クライアントを使用することも可能です。
+生成された型安全なクライアントを使用して、React アプリケーションから FastAPI を呼び出すことができます。TanStack Query フックを介してクライアントを使用することを推奨しますが、通常のクライアントを直接使用することも可能です。
 
 :::note
-FastAPIに変更を加えた場合、生成クライアントに反映するにはプロジェクトの再ビルドが必要です。例：
+FastAPI に変更を加えた場合、生成クライアントに変更を反映させるにはプロジェクトを再ビルドする必要があります。例:
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
 :::tip
-ReactアプリケーションとFastAPIを同時に開発する場合、[`nx watch`](https://nx.dev/nx-api/nx/documents/watch)を使用してAPI変更のたびにクライアントを再生成できます：
+React アプリケーションと FastAPI を同時に開発している場合、[`nx watch`](https://nx.dev/nx-api/nx/documents/watch) を使用して API 変更のたびにクライアントを再生成できます:
 
 <NxCommands
   commands={[
@@ -123,13 +122,13 @@ ReactアプリケーションとFastAPIを同時に開発する場合、[`nx wat
 />
 :::
 
-### APIフックの使用
+### API フックの使用
 
-ジェネレータは`use<ApiName>`フックを提供し、TanStack QueryでAPIを呼び出すことができます。
+ジェネレータが提供する `use<ApiName>` フックを使用して、TanStack Query で API を呼び出すことができます。
 
 ### クエリ
 
-`queryOptions`メソッドを使用して、TanStack Queryの`useQuery`フックでAPIを呼び出すためのオプションを取得できます：
+`queryOptions` メソッドを使用して、TanStack Query の `useQuery` フックで API を呼び出すためのオプションを取得できます:
 
 ```tsx {7}
 import { useQuery } from '@tanstack/react-query';
@@ -147,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="APIクライアントの直接使用" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="API クライアントを直接使用する例" trigger="クリックして通常クライアントを直接使用する例を表示">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -182,7 +181,7 @@ function MyComponent() {
 
 ### ミューテーション
 
-生成されたフックには、TanStack Queryの`useMutation`フックを使用したミューテーションサポートが含まれます。これにより、ローディング状態、エラーハンドリング、楽観的更新を備えた作成・更新・削除操作が可能になります。
+生成されたフックは、TanStack Query の `useMutation` フックを使用したミューテーションのサポートを含みます。これにより、作成・更新・削除操作のローディング状態、エラーハンドリング、オプティミスティック更新を効率的に処理できます。
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -224,25 +223,28 @@ function CreateItemForm() {
 }
 ```
 
-ミューテーション状態ごとにコールバックを追加できます：
+ミューテーション状態に応じたコールバックも追加可能です:
 
 ```tsx
 const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
+    // ミューテーション成功時に実行
     console.log('アイテム作成:', data);
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
+    // ミューテーション失敗時に実行
     console.error('アイテム作成失敗:', error);
   },
   onSettled: () => {
+    // ミューテーション完了時（成功/失敗問わず）に実行
     queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
   }
 });
 ```
 
-<Drawer title="クライアント直接使用のミューテーション例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したミューテーション例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
 import { useState } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -301,7 +303,7 @@ function CreateItemForm() {
 
 ### 無限クエリによるページネーション
 
-`cursor`パラメータを受け入れるエンドポイントに対して、生成されたフックはTanStack Queryの`useInfiniteQuery`フックを使用した無限クエリをサポートします。「さらに読み込む」や無限スクロール機能の実装が容易になります。
+`cursor` パラメータを受け入れるエンドポイントに対して、生成されたフックは TanStack Query の `useInfiniteQuery` フックを使用した無限クエリをサポートします。「さらに読み込む」や無限スクロール機能の実装が容易になります。
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -341,23 +343,23 @@ function ItemList() {
         disabled={!items.hasNextPage || items.isFetchingNextPage}
       >
         {items.isFetchingNextPage
-          ? 'さらに読み込み中...'
+          ? '読み込み中...'
           : items.hasNextPage
           ? 'さらに読み込む'
-          : 'これ以上ありません'}
+          : 'これ以上アイテムはありません'}
       </button>
     </div>
   );
 }
 ```
 
-生成されたフックは、APIがサポートする場合のカーソルベースページネーションを自動処理します。`nextCursor`値はレスポンスから抽出され、次のページの取得に使用されます。
+API がカーソルベースのページネーションをサポートしている場合、生成されたフックは自動的に処理します。`nextCursor` 値はレスポンスから抽出され、次のページの取得に使用されます。
 
 :::tip
-`cursor`以外の名前のページネーションパラメータを使用する場合、[`x-cursor` OpenAPIベンダ拡張を使用してカスタマイズ可能です](#custom-pagination-cursor)。
+ページネーションパラメータ名が `cursor` 以外の場合、[`x-cursor` OpenAPI 拡張](#custom-pagination-cursor)を使用してカスタマイズ可能です。
 :::
 
-<Drawer title="クライアント直接使用のページネーション例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したページネーション例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -430,7 +432,7 @@ function ItemList() {
           ? '読み込み中...'
           : nextCursor
           ? 'さらに読み込む'
-          : 'これ以上ありません'}
+          : 'これ以上アイテムはありません'}
       </button>
     </div>
   );
@@ -440,7 +442,7 @@ function ItemList() {
 
 ### エラーハンドリング
 
-統合には型指定されたエラーレスポンスが含まれます。OpenAPI仕様で定義された可能なエラーレスポンスをカプセル化する`<operation-name>Error`型が生成されます。各エラーは`status`と`error`プロパティを持ち、`status`値をチェックすることで特定のエラー種別を判別できます。
+統合には型指定されたエラーレスポンスを伴う組み込みのエラーハンドリングが含まれます。OpenAPI 仕様で定義された可能なエラーレスポンスをカプセル化する `<operation-name>Error` 型が生成されます。各エラーは `status` と `error` プロパティを持ち、`status` 値をチェックすることで特定のエラータイプを判別できます。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -490,7 +492,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="クライアント直接使用のエラーハンドリング例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したエラーハンドリング例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx {9,15}
 function MyComponent() {
   const api = useMyApiClient();
@@ -545,9 +547,9 @@ function MyComponent() {
 
 ### ストリームの消費
 
-<Link path="guides/fastapi#streaming">FastAPIでストリーム応答を設定</Link>している場合、`useQuery`フックは新しいストリームチャンクが到着するたびにデータを自動更新します。
+FastAPI の[ストリーミングレスポンス設定](path="guides/fastapi#streaming")がある場合、`useQuery` フックは新しいストリームチャンクが到着するたびにデータを自動更新します。
 
-例：
+例:
 
 ```tsx {3}
 function MyStreamingComponent() {
@@ -566,10 +568,10 @@ function MyStreamingComponent() {
 }
 ```
 
-`isLoading`と`fetchStatus`プロパティを使用してストリームの現在の状態を確認できます。ストリームのライフサイクル：
+ストリームの状態を判断するために `isLoading` と `fetchStatus` プロパティを使用できます。ストリームのライフサイクル:
 
 <Steps>
-  1. HTTPリクエスト送信
+  1. ストリーミング開始の HTTP リクエスト送信
 
       - `isLoading`: `true`
       - `fetchStatus`: `'fetching'`
@@ -585,7 +587,7 @@ function MyStreamingComponent() {
 
       - `isLoading`: `false`
       - `fetchStatus`: `'fetching'`
-      - `data`: 各チャンク到着時に更新
+      - `data`: 受信したチャンクで随時更新
 
   4. ストリーム完了
 
@@ -594,11 +596,11 @@ function MyStreamingComponent() {
       - `data`: 全受信チャンクの配列
 </Steps>
 
-<Drawer title="クライアント直接使用のストリーミング例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したストリーミング例" trigger="クリックして通常クライアントを使用する例を表示">
 
-<Link path="guides/fastapi#streaming">FastAPIでストリーム応答を設定</Link>している場合、生成されたクライアントには`for await`構文を使用したストリームチャンクの非同期反復処理メソッドが含まれます。
+FastAPI の[ストリーミングレスポンス設定](path="guides/fastapi#streaming")がある場合、生成クライアントは `for await` 構文を使用したストリームチャンクの非同期反復処理をサポートします。
 
-例：
+例:
 
 ```tsx {8}
 function MyStreamingComponent() {
@@ -629,14 +631,14 @@ function MyStreamingComponent() {
 </Drawer>
 
 :::note
-`cursor`パラメータを受け取るストリーミングAPIを使用する場合、`useInfiniteQuery`フックを使用すると各ページはストリームが完了するまで待機します。
+`cursor` パラメータを受け取るストリーミング API の場合、`useInfiniteQuery` フック使用時、各ページはストリーム終了を待ってからロードされます。
 :::
 
 ## 生成コードのカスタマイズ
 
 ### クエリとミューテーション
 
-デフォルトでは、HTTPメソッド`PUT`、`POST`、`PATCH`、`DELETE`を使用するFastAPIの操作はミューテーションとみなされ、それ以外はクエリとみなされます。`x-query`と`x-mutation`を使用してこの動作を変更できます。
+デフォルトでは、HTTP メソッド `PUT`, `POST`, `PATCH`, `DELETE` を使用する FastAPI 操作はミューテーションと見なされ、他はクエリと見なされます。`x-query` と `x-mutation` でこの動作を変更できます。
 
 #### x-query
 
@@ -651,7 +653,7 @@ def list_items():
     # ...
 ```
 
-生成フックは`POST`メソッド使用時でも`queryOptions`を提供します：
+`POST` メソッド使用でも `queryOptions` を提供:
 
 ```tsx
 const items = useQuery(api.listItems.queryOptions());
@@ -670,7 +672,7 @@ def start_processing():
     # ...
 ```
 
-生成フックは`GET`メソッド使用時でも`mutationOptions`を提供します：
+`GET` メソッド使用でも `mutationOptions` を提供:
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
@@ -678,7 +680,7 @@ const startProcessing = useMutation(api.startProcessing.mutationOptions());
 
 ### カスタムページネーションカーソル
 
-デフォルトでは、生成フックは`cursor`という名前のパラメータを想定します。`x-cursor`拡張でカスタマイズ可能です：
+デフォルトのカーソルパラメータ名 `cursor` を `x-cursor` 拡張でカスタマイズ可能:
 
 ```python
 @app.get(
@@ -695,7 +697,7 @@ def list_items(page_token: str = None, limit: int = 10):
     }
 ```
 
-`infiniteQueryOptions`の生成を無効化するには`x-cursor`を`False`に設定：
+`infiniteQueryOptions` の生成を無効化:
 
 ```python
 @app.get(
@@ -716,9 +718,9 @@ def list_items(page: int = 1, limit: int = 10):
 
 ### 操作のグループ化
 
-生成されたフックとクライアントメソッドは、FastAPIエンドポイントのOpenAPIタグに基づいて自動的に整理されます。関連する操作を簡単に見つけられるようになります。
+生成されるフックとクライアントメソッドは、FastAPI エンドポイントの OpenAPI タグに基づいて自動的に整理されます。関連する操作を簡単に見つけられるようになります。
 
-例：
+例:
 
 ```python title="items.py"
 @app.get(
@@ -745,9 +747,12 @@ def list():
     # ...
 ```
 
-生成フックはタグでグループ化されます：
+生成フックはタグでグループ化:
 
 ```tsx
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
 function ItemsAndUsers() {
   const api = useMyApi();
 
@@ -777,8 +782,11 @@ function ItemsAndUsers() {
 }
 ```
 
-<Drawer title="クライアント直接使用のグループ化例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したグループ化例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
+import { useState, useEffect } from 'react';
+import { useMyApiClient } from './hooks/useMyApiClient';
+
 function ItemsAndUsers() {
   const api = useMyApiClient();
   const [items, setItems] = useState([]);
@@ -788,9 +796,9 @@ function ItemsAndUsers() {
   useEffect(() => {
     const fetchData = async () => {
       try {
+        setIsLoading(true);
         const itemsData = await api.items.list();
         setItems(itemsData);
-
         const usersData = await api.users.list();
         setUsers(usersData);
       } catch (error) {
@@ -802,6 +810,15 @@ function ItemsAndUsers() {
 
     fetchData();
   }, [api]);
+
+  const handleCreateItem = async () => {
+    try {
+      const newItem = await api.items.create({ name: 'New Item' });
+      setItems(prevItems => [...prevItems, newItem]);
+    } catch (error) {
+      console.error('アイテム作成エラー:', error);
+    }
+  };
 
   if (isLoading) {
     return <div>読み込み中...</div>;
@@ -815,6 +832,7 @@ function ItemsAndUsers() {
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
+      <button onClick={handleCreateItem}>アイテム追加</button>
 
       <h2>ユーザー</h2>
       <ul>
@@ -829,18 +847,20 @@ function ItemsAndUsers() {
 </Drawer>
 
 :::tip
-APIを複数の`router`で分割することも可能です。詳細は[FastAPIドキュメント](https://fastapi.tiangolo.com/tutorial/bigger-applications/)を参照してください。
+API を複数の `router` で分割可能です。[FastAPI ドキュメント](https://fastapi.tiangolo.com/tutorial/bigger-applications/)を参照。
 :::
 
 ### エラー
 
-カスタム例外クラス、例外ハンドラ、レスポンスモデルを定義することでエラーレスポンスをカスタマイズできます。生成クライアントはこれらのカスタムエラー型を自動処理します。
+カスタム例外クラス、例外ハンドラ、レスポンスモデルを定義することでエラーレスポンスをカスタマイズ可能です。生成クライアントはこれらのカスタムエラータイプを自動処理します。
 
 #### カスタムエラーモデルの定義
 
-Pydanticでエラーモデルを定義：
+Pydantic でエラーモデルを定義:
 
 ```python title="models.py"
+from pydantic import BaseModel
+
 class ErrorDetails(BaseModel):
     message: str
 
@@ -851,7 +871,7 @@ class ValidationError(BaseModel):
 
 #### カスタム例外の作成
 
-例外クラスを作成：
+例外クラスを作成:
 
 ```python title="exceptions.py"
 class NotFoundException(Exception):
@@ -865,9 +885,12 @@ class ValidationException(Exception):
 
 #### 例外ハンドラの追加
 
-例外をHTTPレスポンスに変換：
+例外を HTTP レスポンスに変換:
 
 ```python title="main.py"
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
 @app.exception_handler(NotFoundException)
 async def not_found_handler(request: Request, exc: NotFoundException):
     return JSONResponse(
@@ -885,7 +908,7 @@ async def validation_error_handler(request: Request, exc: ValidationException):
 
 #### レスポンスモデルの指定
 
-エンドポイント定義でエラーステータスコードのレスポンスモデルを指定：
+エンドポイント定義でエラーステータスコードのレスポンスモデルを指定:
 
 ```python title="main.py"
 @app.get(
@@ -896,24 +919,19 @@ async def validation_error_handler(request: Request, exc: ValidationException):
     }
 )
 def get_item(item_id: str) -> Item:
-    # ...
-
-@app.post(
-    "/items",
-    responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
-    }
-)
-def create_item(item: Item) -> Item:
-    # ...
+    item = find_item(item_id)
+    if not item:
+        raise NotFoundException(message=f"Item with ID {item_id} not found")
+    return item
 ```
 
-#### Reactでのカスタムエラー型の使用
+#### React でのカスタムエラータイプの使用
 
-生成クライアントはカスタムエラー型を処理し、型チェックを可能にします：
+生成クライアントはカスタムエラータイプを自動処理:
 
 ```tsx
+import { useMutation, useQuery } from '@tanstack/react-query';
+
 function ItemComponent() {
   const api = useMyApi();
 
@@ -931,20 +949,7 @@ function ItemComponent() {
     }
   });
 
-  const createItem = useMutation({
-    ...api.createItem.mutationOptions(),
-    onError: (error) => {
-      switch (error.status) {
-        case 400:
-          console.error('検証エラー:', error.error.message);
-          break;
-        case 403:
-          console.error('権限なし:', error.error);
-          break;
-      }
-    }
-  });
-
+  // コンポーネントレンダリング
   if (getItem.isError) {
     if (getItem.error.status === 404) {
       return <NotFoundMessage message={getItem.error.error} />;
@@ -953,22 +958,29 @@ function ItemComponent() {
     }
   }
 
-  return <div>{/* コンポーネントコンテンツ */}</div>;
+  return <div>{/* コンテンツ */}</div>;
 }
 ```
 
-<Drawer title="クライアント直接使用のエラーハンドリング例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したエラーハンドリング例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
+import { useState, useEffect } from 'react';
+
 function ItemComponent() {
   const api = useMyApiClient();
-  const [error, setError] = useState<GetItemError | null>(null);
+  const [item, setItem] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchItem = async () => {
       try {
-        await api.getItem({ itemId: '123' });
+        setLoading(true);
+        const data = await api.getItem({ itemId: '123' });
+        setItem(data);
       } catch (e) {
         const err = e as GetItemError;
+        setError(err);
         switch (err.status) {
           case 404:
             console.error('見つかりません:', err.error);
@@ -977,32 +989,44 @@ function ItemComponent() {
             console.error('サーバーエラー:', err.error.message);
             break;
         }
-        setError(err);
+      } finally {
+        setLoading(false);
       }
     };
+
     fetchItem();
   }, [api]);
 
-  if (error?.status === 404) {
-    return <NotFoundMessage message={error.error} />;
+  if (loading) {
+    return <LoadingSpinner />;
   }
 
-  return <div>{/* コンポーネントコンテンツ */}</div>;
+  if (error) {
+    if (error.status === 404) {
+      return <NotFoundMessage message={error.error} />;
+    } else if (error.status === 500) {
+      return <ErrorMessage message={error.error.message} />;
+    }
+  }
+
+  return <div>{/* コンテンツ */}</div>;
 }
 ```
 </Drawer>
 
 :::tip
-FastAPIでエラーレスポンスを定義する際は、常に`responses`パラメータを使用して各ステータスコードのモデルを指定してください。これにより生成クライアントが適切な型情報を持つようになります。
+FastAPI でエラーレスポンスを定義する際は、常に `responses` パラメータを使用して各ステータスコードのモデルを指定してください。これにより生成クライアントが適切な型情報を持つようになります。
 :::
 
 ## ベストプラクティス
 
 ### ローディング状態の処理
 
-ユーザーエクスペリエンス向上のため、ローディングとエラー状態を常に処理：
+ユーザーエクスペリエンス向上のため、ローディングとエラー状態を常に処理:
 
 ```tsx
+import { useQuery } from '@tanstack/react-query';
+
 function ItemList() {
   const api = useMyApi();
   const items = useQuery(api.listItems.queryOptions());
@@ -1017,9 +1041,15 @@ function ItemList() {
       case 403:
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-        return <ErrorMessage message={err.error.message} />;
+      case 502:
+        return (
+          <ErrorMessage
+            message={err.error.message}
+            details={`トレースID: ${err.error.traceId}`}
+          />
+        );
       default:
-        return <ErrorMessage message="不明なエラー" />;
+        return <ErrorMessage message="不明なエラーが発生しました" />;
     }
   }
 
@@ -1033,10 +1063,11 @@ function ItemList() {
 }
 ```
 
-<Drawer title="クライアント直接使用のローディング処理例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したローディング処理例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
+  const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -1054,15 +1085,25 @@ function ItemList() {
     fetchItems();
   }, [api]);
 
-  if (loading) return <LoadingSpinner />;
+  if (loading) {
+    return <LoadingSpinner />;
+  }
 
   if (error) {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
         return <ErrorMessage message={err.error.reason} />;
+      case 500:
+      case 502:
+        return (
+          <ErrorMessage
+            message={err.error.message}
+            details={`トレースID: ${err.error.traceId}`}
+          />
+        );
       default:
-        return <ErrorMessage message="不明なエラー" />;
+        return <ErrorMessage message="不明なエラーが発生しました" />;
     }
   }
 
@@ -1077,18 +1118,23 @@ function ItemList() {
 ```
 </Drawer>
 
-### 楽観的更新
+### オプティミスティック更新
 
-ユーザーエクスペリエンス向上のため楽観的更新を実装：
+ユーザーエクスペリエンス向上のためオプティミスティック更新を実装:
 
 ```tsx
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
 function ItemList() {
+  const api = useMyApi();
   const queryClient = useQueryClient();
+
+  const itemsQuery = useQuery(api.listItems.queryOptions());
 
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
     onMutate: async (itemId) => {
-      await queryClient.cancelQueries(api.listItems.queryKey());
+      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
       const previousItems = queryClient.getQueryData(api.listItems.queryKey());
       queryClient.setQueryData(
         api.listItems.queryKey(),
@@ -1098,9 +1144,10 @@ function ItemList() {
     },
     onError: (err, itemId, context) => {
       queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      console.error('アイテム削除失敗:', err);
     },
     onSettled: () => {
-      queryClient.invalidateQueries(api.listItems.queryKey());
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
     },
   });
 
@@ -1122,25 +1169,27 @@ function ItemList() {
 }
 ```
 
-<Drawer title="クライアント直接使用の楽観的更新例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用したオプティミスティック更新例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
 function ItemList() {
+  const api = useMyApiClient();
   const [items, setItems] = useState([]);
 
   const handleDelete = async (itemId) => {
     const previousItems = items;
-    setItems(items.filter(item => item.id !== itemId));
+    setItems(items.filter((item) => item.id !== itemId));
 
     try {
       await api.deleteItem(itemId);
     } catch (error) {
       setItems(previousItems);
+      console.error('アイテム削除失敗:', error);
     }
   };
 
   return (
     <ul>
-      {items.map(item => (
+      {items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button onClick={() => handleDelete(item.id)}>削除</button>
@@ -1152,18 +1201,20 @@ function ItemList() {
 ```
 </Drawer>
 
-## タイプセーフティ
+## 型安全性
 
-統合は完全なエンドツーエンドのタイプセーフティを提供します。IDEはすべてのAPI呼び出しに対して完全なオートコンプリートと型チェックを提供します：
+統合は完全なエンドツーエンドの型安全性を提供します。IDE はすべての API 呼び出しに対して完全なオートコンプリートと型チェックを提供します:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function ItemForm() {
   const api = useMyApi();
 
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onSuccess: (data) => {
-      console.log(`作成されたアイテムID: ${data.id}`);
+      console.log(`アイテム作成ID: ${data.id}`);
     },
   });
 
@@ -1172,13 +1223,19 @@ function ItemForm() {
   };
 
   if (createItem.error) {
-    switch (createItem.error.status) {
+    const error = createItem.error;
+    switch (error.status) {
       case 400:
-        return <FormError errors={createItem.error.error.validationErrors} />;
+        return (
+          <FormError
+            message="無効な入力"
+            errors={error.error.validationErrors}
+          />
+        );
       case 403:
-        return <AuthError reason={createItem.error.error.reason} />;
+        return <AuthError reason={error.error.reason} />;
       default:
-        return <ServerError message={createItem.error.error.message} />;
+        return <ServerError message={error.error.message} />;
     }
   }
 
@@ -1187,7 +1244,10 @@ function ItemForm() {
       e.preventDefault();
       handleSubmit({ name: 'New Item' });
     }}>
-      <button type="submit" disabled={createItem.isPending}>
+      <button
+        type="submit"
+        disabled={createItem.isPending}
+      >
         {createItem.isPending ? '作成中...' : 'アイテム作成'}
       </button>
     </form>
@@ -1195,9 +1255,10 @@ function ItemForm() {
 }
 ```
 
-<Drawer title="クライアント直接使用のタイプセーフティ例" trigger="バニラクライアントを直接使用する例を見るにはここをクリック">
+<Drawer title="クライアント直接使用した型安全性例" trigger="クリックして通常クライアントを使用する例を表示">
 ```tsx
 function ItemForm() {
+  const api = useMyApiClient();
   const [error, setError] = useState<CreateItemError | null>(null);
 
   const handleSubmit = async (data: CreateItemInput) => {
@@ -1207,10 +1268,14 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          console.error('検証エラー:', err.error.validationErrors);
+          console.error('バリデーションエラー:', err.error.validationErrors);
           break;
         case 403:
           console.error('権限なし:', err.error.reason);
+          break;
+        case 500:
+        case 502:
+          console.error('サーバーエラー:', err.error.message, 'トレース:', err.error.traceId);
           break;
       }
       setError(err);
@@ -1220,7 +1285,7 @@ function ItemForm() {
   if (error) {
     switch (error.status) {
       case 400:
-        return <FormError errors={error.error.validationErrors} />;
+        return <FormError message="無効な入力" errors={error.error.validationErrors} />;
       case 403:
         return <AuthError reason={error.error.reason} />;
       default:
@@ -1233,4 +1298,4 @@ function ItemForm() {
 ```
 </Drawer>
 
-型はFastAPIのOpenAPIスキーマから自動生成されるため、APIへの変更はビルド後にフロントエンドコードに反映されます。
+型は FastAPI の OpenAPI スキーマから自動生成されるため、API への変更はビルド後にフロントエンドコードに反映されます。

--- a/docs/src/content/docs/jp/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/jp/guides/api-connection/react-trpc.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ReactからtRPCへ"
+title: "ReactからtRPC"
 description: "ReactウェブサイトをtRPCのAPIに接続する"
 ---
 
@@ -9,16 +9,15 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Nx向けAWSプラグインは、<Link path="guides/trpc">tRPC API</Link>をReactウェブサイトと迅速に統合するジェネレータを提供します。AWS IAM認証サポートや適切なエラーハンドリングを含む、tRPCバックエンド接続に必要なすべての設定をセットアップします。この統合により、フロントエンドとtRPCバックエンド間の完全なエンドツーエンド型安全性を実現します。
+Nx向けAWSプラグインは、<Link path="guides/trpc">tRPC API</Link>をReactウェブサイトに迅速に統合するジェネレータを提供します。AWS IAM認証サポートと適切なエラーハンドリングを含む、tRPCバックエンド接続に必要なすべての設定を行います。この統合により、フロントエンドとtRPCバックエンド間の完全なエンドツーエンド型安全性が保証されます。
 
 ## 前提条件
 
 このジェネレータを使用する前に、Reactアプリケーションが以下を満たしていることを確認してください:
 
-1. アプリケーションをレンダリングする`main.tsx`ファイルが存在する
-2. tRPCプロバイダが自動注入される`<App/>` JSX要素が存在する
+1. アプリケーションをレンダリングする`main.tsx`ファイルが存在すること
+2. tRPCプロバイダが自動注入される`<App/>` JSX要素が存在すること
 3. 動作するtRPCバックエンド（tRPCバックエンドジェネレータで生成されたもの）
 
 <details>
@@ -49,7 +48,7 @@ root.render(
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## ジェネレータの出力
 
@@ -63,11 +62,11 @@ root.render(
       - index.tsx
       - TrpcProvider.tsx 複数のtRPC APIで再利用されるプロバイダ
       - TrpcApis.tsx すべてのtRPC API接続を含むオブジェクト
-      - TrpcClientProviders.tsx tRPCクライアントのセットアップとバックエンドスキーマへのバインディング
+      - TrpcClientProviders.tsx tRPCクライアントとバックエンドスキーマへのバインディングを設定
     - QueryClientProvider.tsx TanStack React Queryクライアントプロバイダ
   - hooks
-    - useSigV4.tsx SigV4を使用したHTTPリクエスト署名用フック（IAMのみ）
-    - use\<ApiName>.tsx 特定のバックエンドAPI用フック。ApiNameはAPI名に解決される
+    - useSigV4.tsx SigV4によるHTTPリクエスト署名用フック（IAM専用）
+    - use\<ApiName>.tsx 特定のバックエンドAPI用フック（ApiNameはAPI名に解決）
 
 </FileTree>
 
@@ -82,7 +81,7 @@ root.render(
 
 ### tRPCフックの使用
 
-ジェネレータは型安全なtRPCクライアントにアクセスするための`use<ApiName>`フックを提供します:
+ジェネレータが提供する`use<ApiName>`フックを使用して、型安全なtRPCクライアントにアクセスできます:
 
 ```tsx {5,8,11}
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -150,7 +149,7 @@ function MyComponent() {
 
 ### ローディング状態の処理
 
-ユーザーエクスペリエンス向上のため、ローディング状態とエラー状態を常に処理してください:
+ユーザーエクスペリエンス向上のため、常にローディングとエラー状態を処理してください:
 
 ```tsx {6}
 function UserList() {
@@ -176,9 +175,9 @@ function UserList() {
 }
 ```
 
-### 楽観的更新
+### オプティミスティック更新
 
-ユーザーエクスペリエンス向上のために楽観的更新を使用します:
+ユーザーエクスペリエンス向上のためオプティミスティック更新を使用:
 
 ```tsx {15-17,20-22,28-31}
 import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
@@ -194,12 +193,12 @@ function UserList() {
         // 進行中のフェッチをキャンセル
         await queryClient.cancelQueries(trpc.users.list.queryFilter());
 
-        // 現在のデータのスナップショットを取得
+        // 現在のデータのスナップショット取得
         const previousUsers = queryClient.getQueryData(
           trpc.users.list.queryKey(),
         );
 
-        // ユーザーを楽観的に削除
+        // ユーザーをオプティミスティックに削除
         queryClient.setQueryData(trpc.users.list.queryKey(), (old) =>
           old?.filter((user) => user.id !== userId),
         );
@@ -231,7 +230,7 @@ function UserList() {
 
 ### データのプリフェッチ
 
-パフォーマンス向上のためにデータをプリフェッチします:
+パフォーマンス向上のためデータをプリフェッチ:
 
 ```tsx {8}
 function UserList() {
@@ -258,7 +257,7 @@ function UserList() {
 
 ### 無限クエリ
 
-ページネーションを無限クエリで処理します:
+ページネーションを無限クエリで処理:
 
 ```tsx {5-12}
 function UserList() {
@@ -290,11 +289,11 @@ function UserList() {
 }
 ```
 
-無限クエリは入力プロパティ名が`cursor`のプロシージャでのみ使用可能です。
+無限クエリは`cursor`という名前の入力プロパティを持つプロシージャでのみ使用可能です。
 
 ## 型安全性
 
-この統合は完全なエンドツーエンド型安全性を提供します。IDEはすべてのAPI呼び出しに対して完全なオートコンプリートと型チェックを提供します:
+この統合は完全なエンドツーエンドの型安全性を提供します。IDEはすべてのAPI呼び出しに対して完全なオートコンプリートと型チェックを提供します:
 
 ```tsx
 function UserForm() {
@@ -304,7 +303,7 @@ function UserForm() {
   const createUser = trpc.users.create.useMutation();
 
   const handleSubmit = (data: CreateUserInput) => {
-    // ✅ 入力がスキーマと一致しない場合は型エラー
+    // ✅ 入力がスキーマと一致しない場合に型エラー
     createUser.mutate(data);
   };
 
@@ -312,10 +311,10 @@ function UserForm() {
 }
 ```
 
-型はバックエンドのルーターとスキーマ定義から自動的に推論されるため、APIへの変更が即座にフロントエンドコードに反映され、ビルドが不要になります。
+型はバックエンドのルーターとスキーマ定義から自動的に推論されるため、APIに変更があった場合でもフロントエンドコードをビルドすることなく即座に反映されます。
 
 ## 詳細情報
 
-詳細については、[tRPC TanStack React Queryドキュメント](https://trpc.io/docs/client/tanstack-react-query/usage)を参照してください。
+詳細については、[tRPC TanStack React Query ドキュメント](https://trpc.io/docs/client/tanstack-react-query/usage)を参照してください。
 
-直接[TanStack Queryドキュメント](https://tanstack.com/query/v5)を参照することもできます。
+直接[TanStack Query ドキュメント](https://tanstack.com/query/v5)を参照することもできます。

--- a/docs/src/content/docs/jp/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/cloudscape-website-auth.mdx
@@ -1,6 +1,6 @@
 ---
-title: "クラウドスケープウェブサイト認証"
-description: "クラウドスケープウェブサイト認証のリファレンスドキュメント"
+title: "クラウドスケープ ウェブサイト認証"
+description: "クラウドスケープ ウェブサイト認証のリファレンスドキュメント"
 ---
 
 
@@ -10,47 +10,46 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
-CloudScape Website Authentication ジェネレータは、[Amazon Cognito](https://aws.amazon.com/cognito/) を使用してCloudScapeウェブサイトに認証機能を追加します。
+CloudScape Website Authentication ジェネレータは、[Amazon Cognito](https://aws.amazon.com/cognito/) を使用して CloudScape ウェブサイトに認証機能を追加します。
 
-このジェネレータは、Cognitoユーザープールと関連するIDプール、ユーザーログインフローを処理するホスト型UI、およびCloudScapeウェブサイトとの統合を設定するCDKインフラストラクチャを構成します。
+このジェネレータは、Cognito ユーザープールと関連する Identity Pool、ユーザーログインフローを処理するホステッド UI、および CloudScape ウェブサイトとの統合を作成するための CDK インフラストラクチャを設定します。
 
-## 使い方
+## 使用方法
 
-### CloudScapeウェブサイトに認証を追加する
+### CloudScape ウェブサイトに認証を追加する
 
-CloudScapeウェブサイトに認証を追加する方法は2通りあります:
+以下の2つの方法で CloudScape ウェブサイトに認証を追加できます:
 
 <RunGenerator generator="ts#cloudscape-website#auth" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
 ## ジェネレータの出力内容
 
-Reactウェブサイトに以下の変更が適用されます:
+React ウェブサイトに以下の変更が加えられます:
 
 <FileTree>
   - src
     - components
       - CognitoAuth
-        - index.tsx メインの認証コンポーネント
-    - main.tsx CognitoAuthコンポーネントを組み込むよう更新
+        - index.tsx メイン認証コンポーネント
+    - main.tsx CognitoAuth コンポーネントを組み込むよう更新
 </FileTree>
 
-インフラストラクチャコードは `packages/common/constructs` に生成されます:
+また、`packages/common/constructs` に以下のインフラストラクチャコードが生成されます:
 
 <FileTree>
   - src
     - core
-      - user-identity.ts ユーザープールとIDプールを定義するコンストラクト
+      - user-identity.ts ユーザープールと Identity Pool を定義するコンストラクト
 </FileTree>
 
 ## インフラストラクチャの使用方法
 
-`UserIdentity` コンストラクトをウェブサイトコンストラクトの**前に**宣言する必要があります:
+`UserIdentity` コンストラクトをスタックに追加する必要があります。ウェブサイトコンストラクトの**前に**宣言してください:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
 import { Stack } from 'aws-cdk-lib';
@@ -68,11 +67,11 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-`UserIdentity` コンストラクトは自動的に必要な<Link path="guides/cloudscape-website#runtime-configuration">ランタイム設定</Link>を追加し、ウェブサイトが正しいCognitoユーザープールを参照できるようにします。
+`UserIdentity` コンストラクトは、ウェブサイトが認証用に正しい Cognito ユーザープールを指すようにするための <Link path="guides/cloudscape-website#runtime-configuration">ランタイム設定</Link> を自動的に追加します。
 
 ### 認証済みユーザーへのアクセス権付与
 
-認証済みユーザーにAPI呼び出しなどの特定のアクションを許可するには、IDプールの認証済みロールにIAMポリシーステートメントを追加します:
+API の呼び出し権限など、認証済みユーザーに特定のアクションを許可するには、Identity Pool の認証済みロールに IAM ポリシーステートメントを追加できます:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/jp/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/jp/guides/cloudscape-website.mdx
@@ -10,27 +10,26 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
-このジェネレータは[React](https://react.dev/)のウェブサイトを新規作成し、[CloudScape](http://cloudscape.design/)の設定と、静的ウェブサイトをクラウドにデプロイするための[AWS CDK](https://aws.amazon.com/cdk/)インフラストラクチャ（[S3](https://aws.amazon.com/s3/)ホスティング、[CloudFront](https://aws.amazon.com/cloudfront/)配信、[WAF](https://aws.amazon.com/waf/)保護）を提供します。
+このジェネレータは[React](https://react.dev/)ウェブサイトを新規作成し、[CloudScape](http://cloudscape.design/)の設定と、静的ウェブサイトをクラウドにデプロイするためのAWS CDKインフラストラクチャを構成します。デプロイ先は[S3](https://aws.amazon.com/s3/)でホストされ、[CloudFront](https://aws.amazon.com/cloudfront/)で配信され、[WAF](https://aws.amazon.com/waf/)で保護されます。
 
-生成されるアプリケーションはビルドツールとして[Vite](https://vite.dev/)を、型安全なルーティングに[TanStack Router](https://tanstack.com/router/v1)を使用します。
+生成されるアプリケーションはビルドツールとバンドラーとして[Vite](https://vite.dev/)を使用します。型安全なルーティングには[TanStack Router](https://tanstack.com/router/v1)を採用しています。
 
 :::note
-このジェネレータはCloudScapeの初期設定を行いますが、本質的にはReactプロジェクトジェネレータです。必要に応じて別のデザインシステムやコンポーネントライブラリに変更可能です。
+このジェネレータはCloudScapeの初期設定を行いますが、本質的にはReactプロジェクトジェネレータです。必要に応じて別のデザインシステムやコンポーネントライブラリに移行するようにコードを変更可能です。
 :::
 
 ## 使用方法
 
-### CloudScape Websiteの生成
+### CloudScapeウェブサイトの生成
 
-新しいCloudScape Websiteを2つの方法で生成できます：
+新しいCloudScapeウェブサイトは2つの方法で生成できます：
 
 <RunGenerator generator="ts#cloudscape-website" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
 ## ジェネレータの出力
 
@@ -43,9 +42,9 @@ import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/
     - main.tsx Reactセットアップを含むアプリケーションエントリポイント
     - config.ts アプリケーション設定（ロゴなど）
     - components
-      - AppLayout CloudScapeレイアウトとナビゲーションバー用コンポーネント
+      - AppLayout CloudScapeレイアウトとナビゲーションバーのコンポーネント
     - hooks
-      - useAppLayout.tsx ネストコンポーネントからAppLayoutを調整するフック
+      - useAppLayout.tsx ネストされたコンポーネントからAppLayoutを調整するフック
     - routes
       - welcome
         - index.tsx @tanstack/react-router用のサンプルルート（ページ）
@@ -56,7 +55,7 @@ import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/
   - tsconfig.spec.json テスト用TypeScript設定
 </FileTree>
 
-また`packages/common/constructs`ディレクトリにウェブサイトデプロイ用のCDKインフラストラクチャコードを作成します：
+また、`packages/common/constructs`ディレクトリにウェブサイトデプロイ用のCDKインフラストラクチャコードを作成します：
 
 <FileTree>
   - src
@@ -67,19 +66,19 @@ import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/
       - static-website.ts 汎用StaticWebsiteコンストラクト
 </FileTree>
 
-## CloudScape Websiteの実装
+## CloudScapeウェブサイトの実装
 
-[Reactドキュメント](https://react.dev/learn)はReact開発の基礎を学ぶのに適しています。[CloudScapeドキュメント](https://cloudscape.design/components/)では利用可能なコンポーネントとその使用方法を確認できます。
+[Reactドキュメント](https://react.dev/learn)はReact開発の基本を学ぶのに最適です。[CloudScapeドキュメント](https://cloudscape.design/components/)では利用可能なコンポーネントとその使用方法を確認できます。
 
 ### ルーティング
 
 #### ルート/ページの作成
 
-[TanStack Router](https://tanstack.com/router/v1)が設定済みの状態で、新しいルートを簡単に追加できます：
+CloudScapeウェブサイトには[TanStack Router](https://tanstack.com/router/v1)が設定済みです。新しいルートの追加が容易です：
 
 <Steps>
   1. [ローカル開発サーバーを起動](#local-development-server)
-  2. `src/routes`に新しい`<page-name>.tsx`ファイルを作成（ファイルツリーの位置がパスを表現）
+  2. `src/routes`に新しい`<page-name>.tsx`ファイルを作成（ファイルツリー上の位置がパスを表現）
   3. `Route`と`RouteComponent`が自動生成されます。ここでページの構築を開始できます！
 </Steps>
 
@@ -112,11 +111,11 @@ export const MyComponent = () => {
 
 ## ランタイム設定
 
-AWS CDKインフラストラクチャからの設定はRuntime Configurationを通じてウェブサイトに提供されます。これにより、デプロイ時まで不明なAPI URLなどの詳細情報にアクセス可能です。
+AWS CDKインフラストラクチャからの設定は、ランタイム設定を通じてウェブサイトに提供されます。これにより、デプロイ時まで不明なAPI URLなどの詳細情報にアクセス可能になります。
 
 ### インフラストラクチャ
 
-`RuntimeConfig`コンストラクトを使用してCDKインフラストラクチャで設定値を追加・取得できます。`@aws/nx-plugin`が生成するCDKコンストラクト（<Link path="guides/trpc">tRPC API</Link>や<Link path="guides/fastapi">FastAPI</Link>など）は自動的に適切な値を`RuntimeConfig`に追加します。
+`RuntimeConfig` CDKコンストラクトを使用して設定の追加と取得が可能です。`@aws/nx-plugin`で生成されるCDKコンストラクト（<Link path="guides/trpc">tRPC API</Link>や<Link path="guides/fastapi">FastAPI</Link>など）は自動的に適切な値を`RuntimeConfig`に追加します。
 
 ウェブサイトCDKコンストラクトはランタイム設定を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
 
@@ -132,19 +131,19 @@ export class ApplicationStack extends Stack {
     // RuntimeConfigに値を自動追加
     new MyApi(this, 'MyApi');
 
-    // runtime-config.jsonへ自動デプロイ
+    // runtime-config.jsonにランタイム設定を自動デプロイ
     new MyWebsite(this, 'MyWebsite');
   }
 }
 ```
 
 :::warning
-`runtime-config.json`ファイルに値が確実に含まれるよう、`RuntimeConfig`に値を追加するコンストラクトの後にウェブサイトを宣言してください。
+`runtime-config.json`ファイルから設定が欠落しないよう、`RuntimeConfig`に追加するコンストラクトの後にウェブサイトを宣言する必要があります。
 :::
 
 ### ウェブサイトコード
 
-`useRuntimeConfig`フックを使用してランタイム設定値を取得できます：
+ウェブサイト側では`useRuntimeConfig`フックを使用してランタイム設定値を取得できます：
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -152,52 +151,52 @@ import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
 const MyComponent = () => {
   const runtimeConfig = useRuntimeConfig();
 
-  // ランタイム設定値にアクセス
+  // ランタイム設定値にここでアクセス
   const apiUrl = runtimeConfig.httpApis.MyApi;
 };
 ```
 
 ### ローカルランタイム設定
 
-[ローカル開発サーバー](#local-development-server)を実行する際、バックエンドURLや認証設定などを認識させるため`public`ディレクトリに`runtime-config.json`ファイルが必要です。
+[ローカル開発サーバー](#local-development-server)を実行する際、バックエンドURLや認証設定などを認識させるため、`public`ディレクトリに`runtime-config.json`ファイルが必要です。
 
-`load:runtime-config`ターゲットを使用してデプロイ済みアプリケーションから設定ファイルを取得できます：
+ウェブサイトプロジェクトには、デプロイ済みアプリケーションから`runtime-config.json`ファイルを取得する`load:runtime-config`ターゲットが設定されています：
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-インフラストラクチャプロジェクトの`src/main.ts`でスタック名を変更した場合、ウェブサイトの`project.json`ファイル内の`load:runtime-config`ターゲットを更新する必要があります。
+インフラストラクチャプロジェクトの`src/main.ts`でスタック名を変更した場合、ウェブサイトの`project.json`ファイル内の`load:runtime-config`ターゲットを更新して、設定を読み込むスタック名を変更する必要があります。
 :::
 
 ## ローカル開発サーバー
 
 ローカル開発サーバーを起動する前に、インフラストラクチャのデプロイと[ローカルランタイム設定の読み込み](#local-runtime-config)が完了していることを確認してください。
 
-`serve`ターゲットを実行します：
+その後、`serve`ターゲットを実行できます：
 
 <NxCommands commands={['run <my-website>:serve']} />
 
 ## ビルド
 
-`build`ターゲットを使用して本番用バンドルを生成します。Viteがルートの`dist/packages/<my-website>/bundle`ディレクトリに本番バンドルを作成し、型チェック・コンパイル・リンタを実行します。
+`build`ターゲットを使用してウェブサイトをビルドできます。Viteがルートの`dist/packages/<my-website>/bundle`ディレクトリに本番用バンドルを作成し、型チェック、コンパイル、リンターを実行します。
 
 <NxCommands commands={['run <my-website>:build']} />
 
 ## テスト
 
-テストの作成方法は標準的なTypeScriptプロジェクトと同様です。<Link path="guides/typescript-project#testing">TypeScriptプロジェクトガイド</Link>を参照してください。
+テストの作成方法は標準のTypeScriptプロジェクトと同様です。詳細は<Link path="guides/typescript-project#testing">TypeScriptプロジェクトガイド</Link>を参照してください。
 
-React Testing Libraryがインストール済みで、テスト作成に使用できます。詳細は[React Testing Libraryドキュメント](https://testing-library.com/docs/react-testing-library/example-intro)を参照してください。
+React固有のテストには、React Testing Libraryが事前インストールされています。使用方法は[React Testing Libraryドキュメント](https://testing-library.com/docs/react-testing-library/example-intro)を参照してください。
 
-`test`ターゲットでテストを実行します：
+`test`ターゲットでテストを実行できます：
 
 <NxCommands commands={['run <my-website>:test']} />
 
 ## ウェブサイトのデプロイ
 
-<Link path="guides/typescript-infrastructure">TypeScript Infrastructure Generator</Link>を使用してCDKアプリケーションを作成することを推奨します。
+ウェブサイトのデプロイには、CDKアプリケーション作成用の<Link path="guides/typescript-infrastructure">TypeScriptインフラストラクチャジェネレータ</Link>の使用を推奨します。
 
-`packages/common/constructs`に生成されたCDKコンストラクトを使用してウェブサイトをデプロイできます：
+`packages/common/constructs`に生成されたCDKコンストラクトを使用してウェブサイトをデプロイできます。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -11,29 +11,28 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
-[FastAPI](https://fastapi.tiangolo.com/) はPython用のAPI構築フレームワークです。
+[FastAPI](https://fastapi.tiangolo.com/) はPythonでAPIを構築するためのフレームワークです。
 
-このFastAPIジェネレータは、AWS CDKインフラストラクチャがセットアップされた新しいFastAPIを生成します。生成されるバックエンドはサーバーレスデプロイ用にAWS Lambdaを使用し、AWS API Gateway API経由で公開されます。ロギング、AWS X-Rayトレーシング、Cloudwatchメトリクスを含むオブザーバビリティのために[AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)を設定します。
+FastAPIジェネレータは、AWS CDKインフラストラクチャがセットアップされた新しいFastAPIプロジェクトを作成します。生成されるバックエンドはサーバーレスデプロイのためAWS Lambdaを使用し、AWS API Gateway API経由で公開されます。[AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) を設定し、ロギング、AWS X-Rayトレーシング、Cloudwatchメトリクスを含むオブザーバビリティを実現します。
 
 ## 使用方法
 
 ### FastAPIの生成
 
-新しいFastAPIは2つの方法で生成できます：
+新しいFastAPIプロジェクトは2つの方法で生成できます:
 
 <RunGenerator generator="py#fast-api" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
 ## ジェネレータの出力
 
-ジェネレータは`<directory>/<api-name>`ディレクトリに以下のプロジェクト構造を作成します：
+ジェネレータは`<directory>/<api-name>`ディレクトリに以下のプロジェクト構造を作成します:
 
 <FileTree>
 
@@ -48,11 +47,11 @@ import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.
 
 </FileTree>
 
-ジェネレータはまた、APIのデプロイに使用できるCDKコンストラクトを`packages/common/constructs`ディレクトリに作成します。
+また、`packages/common/constructs`ディレクトリにAPIのデプロイに使用できるCDKコンストラクトも作成します。
 
 ## FastAPIの実装
 
-メインのAPI実装は`main.py`にあります。ここでAPIルートとその実装を定義します。例：
+メインのAPI実装は`main.py`に記述します。ここでAPIルートとその実装を定義します。例:
 
 ```python
 from .init import app, tracer
@@ -70,11 +69,11 @@ def create_item(item: Item):
     return ...
 ```
 
-ジェネレータは以下の機能を自動的に設定します：
+ジェネレータは以下の機能を自動的に設定します:
 
 1. オブザーバビリティのためのAWS Lambda Powertools統合
 2. エラーハンドリングミドルウェア
-3. リクエスト/レスポンス相関関係
+3. リクエスト/レスポンス相関ID
 4. メトリクス収集
 5. Mangumを使用したAWS Lambdaハンドラ
 
@@ -82,7 +81,7 @@ def create_item(item: Item):
 
 #### ロギング
 
-構造化ロギングをAWS Lambda Powertoolsで設定します。ルートハンドラでロガーにアクセス可能：
+構造化ロギングをAWS Lambda Powertoolsで設定します。ルートハンドラでロガーにアクセス可能:
 
 ```python
 from .init import app, logger
@@ -93,16 +92,16 @@ def read_item(item_id: int):
     return {"item_id": item_id}
 ```
 
-ロガーには自動的に以下が含まれます：
+ロガーには自動的に以下が含まれます:
 
-- リクエストトレーシングのための相関ID
+- リクエストトレースのための相関ID
 - リクエストパスとメソッド
 - Lambdaコンテキスト情報
-- コールドスタート指標
+- コールドスタートインジケータ
 
 #### トレーシング
 
-AWS X-Rayトレーシングが自動設定されます。カスタムサブセグメントを追加可能：
+AWS X-Rayトレーシングが自動設定されます。カスタムサブセグメントを追加可能:
 
 ```python
 from .init import app, tracer
@@ -118,7 +117,7 @@ def read_item(item_id: int):
 
 #### メトリクス
 
-リクエストごとにCloudWatchメトリクスが自動収集されます。カスタムメトリクスを追加可能：
+CloudWatchメトリクスが各リクエストで自動収集されます。カスタムメトリクスを追加可能:
 
 ```python
 from .init import app, metrics
@@ -130,16 +129,16 @@ def read_item(item_id: int):
     return {"item_id": item_id}
 ```
 
-デフォルトメトリクスには以下が含まれます：
+デフォルトメトリクスには以下が含まれます:
 
-- リクエスト数
-- 成功/失敗数
-- コールドスタート指標
+- リクエストカウント
+- 成功/失敗カウント
+- コールドスタートメトリクス
 - ルート別メトリクス
 
 ### エラーハンドリング
 
-包括的なエラーハンドリングが含まれます：
+包括的なエラーハンドリングが含まれます:
 
 ```python
 from fastapi import HTTPException
@@ -151,24 +150,24 @@ def read_item(item_id: int):
     return {"item_id": item_id}
 ```
 
-未処理例外はミドルウェアで捕捉され：
+未処理例外はミドルウェアで捕捉され:
 
-1. スタックトレース付きで完全な例外を記録
+1. スタックトレース付きで例外をログ記録
 2. 失敗メトリクスを記録
-3. 安全な500レスポンスをクライアントに返却
+3. クライアントに安全な500レスポンスを返却
 4. 相関IDを保持
 
 :::tip
-`api-connection`ジェネレータを使用する場合、より良いコード生成のためAPI操作のレスポンスモデルを指定することを推奨します。<Link path="guides/api-connection/react-fastapi#errors">詳細はこちら</Link>。
+`api-connection`ジェネレータを使用する場合、より良いコード生成のためAPI操作にレスポンスモデルを指定することを推奨します。<Link path="guides/api-connection/react-fastapi#errors">詳細はこちら</Link>
 :::
 
 ### ストリーミング
 
-FastAPIでは[`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)レスポンスタイプを使用してストリーミングレスポンスを実装できます。
+FastAPIでは[`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)レスポンスタイプを使用してストリームレスポンスを実装できます。
 
 #### インフラストラクチャ変更
 
-AWS API Gatewayはストリーミングレスポンスをサポートしていないため、これをサポートするプラットフォームにFastAPIをデプロイする必要があります。最も簡単なオプションはAWS Lambda Function URLを使用することです。これを行うには、生成された`common/constructs/src/app/apis/<name>-api.ts`コンストラクトをFunction URLをデプロイするものに置き換えます。
+AWS API Gatewayはストリーミングレスポンスをサポートしていないため、ストリーミングをサポートするプラットフォームへのデプロイが必要です。最も簡単な方法はAWS Lambda Function URLを使用することです。生成された`common/constructs/src/app/apis/<name>-api.ts`コンストラクトをFunction URLをデプロイするものに置き換えることで実現できます。
 
 <details>
 <summary>ストリーミングFunctionURLコンストラクトの例</summary>
@@ -241,7 +240,7 @@ export class MyApi extends Construct {
 
     new CfnOutput(this, 'MyApiUrl', { value: functionUrl.url });
 
-    // クライアントディスカバリのため実行時設定にAPI URLを登録
+    // クライアントディスカバリのためランタイム設定にAPI URLを登録
     RuntimeConfig.ensure(this).config.apis = {
       ...RuntimeConfig.ensure(this).config.apis!,
       MyApi: functionUrl.url,
@@ -272,13 +271,13 @@ export class MyApi extends Construct {
 
 #### 実装方法
 
-インフラストラクチャをストリーミング対応に更新したら、FastAPIでストリーミングAPIを実装できます。APIは以下を行う必要があります：
+ストリーミングをサポートするようインフラストラクチャを更新したら、FastAPIでストリーミングAPIを実装できます。APIは以下を行う必要があります:
 
 - [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)を返す
-- 各レスポンスチャンクの戻り型を宣言する
-- <Link path="guides/api-connection/react-fastapi">API Connection</Link>を使用する場合はOpenAPIベンダー拡張`x-streaming: true`を追加する
+- 各レスポンスチャンクの戻り値型を宣言する
+- <Link path="guides/api-connection/react-fastapi">API接続</Link>を使用する場合はOpenAPIベンダー拡張`x-streaming: true`を追加
 
-例：APIからJSONオブジェクトのストリームを送信する場合：
+例: APIからJSONオブジェクトのストリームを送信する場合:
 
 ```py /return (StreamingResponse)/ /openapi_extra[^)]*/ /-> (Chunk)/
 from pydantic import BaseModel
@@ -299,11 +298,11 @@ def my_stream() -> Chunk:
 
 #### 消費方法
 
-ストリームレスポンスを消費するには、<Link path="guides/api-connection/react-fastapi#consuming-a-stream">API Connection Generator</Link>を使用してタイプセーフな反復処理メソッドを利用できます。
+ストリームレスポンスを消費するには、<Link path="guides/api-connection/react-fastapi#consuming-a-stream">API接続ジェネレータ</Link>を使用してタイプセーフなストリーム処理メソッドを利用できます。
 
 ## FastAPIのデプロイ
 
-FastAPIジェネレータは`common/constructs`フォルダにデプロイ用CDKコンストラクトを作成します。CDKアプリケーションで使用可能：
+FastAPIジェネレータは`common/constructs`フォルダにデプロイ用CDKコンストラクトを作成します。CDKアプリケーションで使用可能:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs';
@@ -318,14 +317,14 @@ export class ExampleStack extends Stack {
 }
 ```
 
-これにより以下が設定されます：
+これにより以下が設定されます:
 
 1. FastAPIアプリの各操作用AWS Lambda関数
 2. 関数トリガーとしてのAPI Gateway HTTP/REST API
 3. IAMロールと権限
 4. CloudWatchロググループ
 5. X-Rayトレーシング設定
-6. CloudWatchメトリクス名前空間
+6. CloudWatchメトリクスネームスペース
 
 ### タイプセーフな統合
 
@@ -333,18 +332,18 @@ export class ExampleStack extends Stack {
 
 #### コード生成
 
-FastAPIの操作はPythonで定義され、インフラストラクチャはTypeScriptで定義されるため、タイプセーフな統合インターフェースを提供するためメタデータをCDKコンストラクトに供給するコード生成を実施します。
+FastAPIの操作はPythonで、インフラはTypeScriptで定義されるため、タイプセーフな統合インターフェースを提供するためメタデータをCDKコンストラクトに供給するコード生成を実施します。
 
-タイプセーフな統合を容易にするため、共通コンストラクトの`project.json`に`generate:<ApiName>-metadata`ターゲットが追加され、`packages/common/constructs/src/generated/my-api/metadata.gen.ts`のようなファイルを生成します。これはビルド時に生成されるためバージョン管理対象外です。
+共通コンストラクトの`project.json`に`generate:<ApiName>-metadata`ターゲットが追加され、`packages/common/constructs/src/generated/my-api/metadata.gen.ts`のようなファイルを生成します。ビルド時に生成されるためバージョン管理対象外です。
 
 :::note
-APIを変更する際は、CDKコンストラクトが消費するタイプを最新に保つためビルドを実行する必要があります。
+APIを変更する際は、CDKコンストラクトが最新のタイプを消費できるようビルドを実行する必要があります。
 
 <NxCommands commands={["run-many --target build --all"]} />
 :::
 
 :::tip
-CDKインフラストラクチャとFastAPIの両方を同時に開発する場合、[`nx watch`](https://nx.dev/nx-api/nx/documents/watch)を使用してAPI変更のたびにタイプを再生成できます：
+CDKインフラとFastAPIを同時に開発する場合、[`nx watch`](https://nx.dev/nx-api/nx/documents/watch)を使用してAPI変更のたびにタイプを再生成できます:
 
 <NxCommands
   commands={[
@@ -354,9 +353,9 @@ CDKインフラストラクチャとFastAPIの両方を同時に開発する場�
 />
 :::
 
-### アクセス権付与
+### アクセス権限付与
 
-`grantInvokeAccess`メソッドでAPIへのアクセス権を付与できます：
+`grantInvokeAccess`メソッドでAPIへのアクセス権限を付与できます:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -364,16 +363,16 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## ローカル開発
 
-ジェネレータはローカル開発サーバーを設定します。以下で起動可能：
+ジェネレータが設定するローカル開発サーバーを以下で起動:
 
 <NxCommands commands={['run my-api:serve']} />
 
-これにより以下を含むローカルFastAPI開発サーバーが起動します：
+これにより以下を含むローカルFastAPI開発サーバーが起動:
 
 - コード変更時の自動リロード
-- `/docs`または`/redoc`でのインタラクティブAPIドキュメント
-- `/openapi.json`でのOpenAPIスキーマ
+- `/docs`または`/redoc`のインタラクティブAPIドキュメント
+- `/openapi.json`のOpenAPIスキーマ
 
 ## FastAPIの呼び出し
 
-ReactウェブサイトからAPIを呼び出すには<Link path="guides/api-connection/react-fastapi">`api-connection`</Link>ジェネレータを使用できます。
+ReactウェブサイトからAPIを呼び出すには<Link path="guides/api-connection/react-fastapi">`api-connection`ジェネレータ</Link>を使用できます。

--- a/docs/src/content/docs/jp/guides/license.mdx
+++ b/docs/src/content/docs/jp/guides/license.mdx
@@ -8,13 +8,12 @@ description: "ライセンスジェネレーターのリファレンスドキュ
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
 ワークスペース内の`LICENSE`ファイルとソースコードヘッダーを自動的に管理します。
 
-このジェネレータは[同期ジェネレータ](https://nx.dev/concepts/sync-generators)を登録し、`lint`ターゲットの一部として実行されます。これにより、ソースファイルが指定されたライセンスの内容と形式に準拠していることを保証し、プロジェクトの`LICENSE`ファイルが正しいことを確認するとともに、関連するプロジェクトファイル（`package.json`、`pyproject.toml`）にライセンス情報が含まれるようにします。
+このジェネレータは[同期ジェネレータ](https://nx.dev/concepts/sync-generators)を登録し、`lint`ターゲットの一部として実行されます。これにより、ソースファイルが所定のライセンス内容と形式に準拠していること、プロジェクトの`LICENSE`ファイルが正しいこと、関連プロジェクトファイル（`package.json`、`pyproject.toml`）にライセンス情報が含まれていることが保証されます。
 
-## 使い方
+## 使用方法
 
 ### ジェネレータの実行
 
@@ -22,22 +21,22 @@ import schema from '../../../../../../packages/nx-plugin/src/license/schema.json
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## ジェネレータの出力
 
 ジェネレータは以下のファイルを作成または更新します：
 
 <FileTree>
-  - nx.json lintターゲットがライセンス同期ジェネレータを実行するように設定されます
+  - nx.json lintターゲットがライセンス同期ジェネレータを実行するよう設定
   - aws-nx-plugin.config.mts ライセンス同期ジェネレータの設定ファイル
 </FileTree>
 
-いくつかのファイルタイプ向けのデフォルトライセンスヘッダー設定が`aws-nx-plugin.config.mts`に追加されます。必要に応じて[設定セクション](#configuration)を参照し、カスタマイズしてください。
+ライセンスヘッダーの内容と形式に関するデフォルト設定が`aws-nx-plugin.config.mts`に追加され、複数のファイルタイプに適切なヘッダーが書き込まれます。必要に応じて[設定セクション](#configuration)でカスタマイズ可能です。
 
 ## ワークフロー
 
-プロジェクトのビルド時に（`lint`ターゲットが実行されると）、ライセンス同期ジェネレータが設定に基づいてプロジェクトのライセンスをチェックします。[ライセンス同期動作](#license-sync-behaviour)で説明するように、同期が必要な変更を検出すると次のようなメッセージが表示されます：
+プロジェクトをビルドする度に（`lint`ターゲットが実行されると）、ライセンス同期ジェネレータが設定に基づいてプロジェクトのライセンス整合性を確認します。同期が必要な変更を検出すると、以下のようなメッセージが表示されます：
 
 ```bash
   NX   ワークスペースが同期されていません
@@ -57,48 +56,48 @@ import schema from '../../../../../../packages/nx-plugin/src/license/schema.json
 - packages/<my-project>/src/index.ts
 - packages/<my-python-project>/main.py
 
-この状態ではCIでエラーが発生します。
+CI環境ではエラーが発生します。
 
-? 検出された変更を同期してワークスペースを最新状態にしますか？
-はい、変更を同期してタスクを実行します
-いいえ、同期せずにタスクを実行します
+? 同期が必要な変更を適用してワークスペースを最新状態にしますか？
+はい、変更を同期してタスクを実行
+いいえ、同期せずにタスクを実行
 ```
 
 `はい`を選択して変更を同期します。
 
 :::note
-継続的インテグレーションのビルドがライセンスの非同期で失敗しないよう、バージョン管理システムにコミットする前にライセンス同期ジェネレータによる変更内容を必ず確認してください。
+継続的インテグレーションのビルドタスクがライセンス非同期で失敗しないよう、ライセンス同期ジェネレータが行った変更を必ずバージョン管理システムにコミットしてください。
 :::
 
-## ライセンス同期動作
+## ライセンス同期の動作
 
-ライセンス同期ジェネレータは3つの主要なタスクを実行します：
+ライセンス同期ジェネレータは3つの主要タスクを実行します：
 
 ### 1. ソースファイルのライセンスヘッダー同期
 
-同期ジェネレータは、設定に基づきワークスペース内のすべてのソースコードファイルに適切なライセンスヘッダーが含まれるようにします。ヘッダーはファイルの先頭にブロックコメントまたは連続したラインコメントとして書き込まれます（shebang/hashbangが存在する場合はその後に配置されます）。
+同期ジェネレータは、設定に基づきワークスペース内の全ソースコードファイルに適切なライセンスヘッダーが含まれることを保証します。ヘッダーはファイルの先頭ブロックコメントまたは連続した行コメントとして書き込まれます（shebang/hashbangが存在する場合はその後に配置）。
 
-ファイルタイプごとの対象ファイルやヘッダー内容・形式は設定で変更可能です。詳細は[設定セクション](#configuration)を参照してください。
+設定ファイルで対象ファイルの包含/除外ルールや、ファイルタイプ別のヘッダー内容/形式を随時更新可能です。詳細は[設定セクション](#configuration)を参照してください。
 
 ### 2. LICENSEファイルの同期
 
-同期ジェネレータは、ルートの`LICENSE`ファイルが設定されたライセンスに一致することを保証し、ワークスペース内のすべてのサブプロジェクトにも正しい`LICENSE`ファイルが存在するようにします。
+同期ジェネレータは、ルートの`LICENSE`ファイルが設定ライセンスに準拠していること、および全サブプロジェクトに正しい`LICENSE`ファイルが存在することを保証します。
 
-プロジェクトの除外設定が可能です。詳細は[設定セクション](#configuration)を参照してください。
+必要に応じて設定でプロジェクトを除外可能です。詳細は[設定セクション](#configuration)を参照してください。
 
 ### 3. プロジェクトファイルのライセンス情報同期
 
-同期ジェネレータは、`package.json`と`pyproject.toml`ファイルの`license`フィールドが設定されたライセンスに一致するようにします。
+同期ジェネレータは、`package.json`と`pyproject.toml`ファイルの`license`フィールドが設定ライセンスに設定されていることを保証します。
 
-プロジェクトの除外設定が可能です。詳細は[設定セクション](#configuration)を参照してください。
+必要に応じて設定でプロジェクトを除外可能です。詳細は[設定セクション](#configuration)を参照してください。
 
 ## 設定
 
-設定はワークスペースルートの`aws-nx-plugin.config.mts`ファイルで定義されます。
+設定はワークスペースルートの`aws-nx-plugin.config.mts`ファイルで定義します。
 
 ### SPDXと著作権者
 
-ライセンスは`spdx`設定プロパティでいつでも更新可能です：
+ライセンスは`spdx`設定プロパティで随時更新可能です：
 
 ```typescript title="aws-nx-plugin.config.mts" {3}
 export default {
@@ -108,9 +107,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-同期ジェネレータ実行時、すべての`LICENSE`ファイル、`package.json`、`pyproject.toml`ファイルが設定されたライセンスに更新されます。
+同期ジェネレータ実行時、全`LICENSE`ファイルと`package.json`/`pyproject.toml`ファイルが設定ライセンスに更新されます。
 
-著作権者と著作権年も追加設定可能です：
+著作権者と著作年を追加設定可能です（一部LICENSEファイルに記載）：
 
 ```typescript title="aws-nx-plugin.config.mts" {4,5}
 export default {
@@ -164,7 +163,7 @@ export default {
 
 #### フォーマット
 
-ファイルタイプごとにグロブパターンでライセンスヘッダーのフォーマットを指定可能です：
+ファイルタイプ別にライセンスヘッダーのフォーマットをglobパターンで指定可能です。行コメント、ブロックコメント、またはその組み合わせを設定できます：
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
@@ -174,7 +173,7 @@ export default {
         lines: ['Copyright notice here'],
       },
       format: {
-        // ラインコメント
+        // 行コメント
         '**/*.ts': {
           lineStart: '// ',
         },
@@ -183,13 +182,13 @@ export default {
           blockStart: '/*',
           blockEnd: '*/',
         },
-        // 接頭辞付きブロックコメント
+        // 行プレフィックス付きブロックコメント
         '**/*.java': {
           blockStart: '/*',
           lineStart: ' * ',
           blockEnd: ' */',
         },
-        // ヘッダー/フッター付きラインコメント
+        // ヘッダー/フッター付き行コメント
         '**/*.py': {
           blockStart: '# ------------',
           lineStart: '# ',
@@ -201,16 +200,16 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-サポートされるフォーマット設定：
+フォーマット設定でサポートするプロパティ：
 
-- `blockStart`: ライセンスコンテンツ前に記述するテキスト（ブロックコメント開始など）
-- `lineStart`: ライセンス各行の先頭に付与するテキスト
-- `lineEnd`: ライセンス各行の末尾に付与するテキスト
-- `blockEnd`: ライセンスコンテンツ後に記述するテキスト（ブロックコメント終了など）
+- `blockStart`: ライセンスコンテンツ前に記述するテキスト（例：ブロックコメント開始）
+- `lineStart`: ライセンス各行の先頭に付加するテキスト
+- `lineEnd`: ライセンス各行の末尾に付加するテキスト
+- `blockEnd`: ライセンスコンテンツ後に記述するテキスト（例：ブロックコメント終了）
 
 #### カスタムコメント構文
 
-ネイティブでサポートされていないファイルタイプ向けに、カスタムコメント構文を定義可能です：
+ネイティブサポートされないファイルタイプの場合、カスタムコメント構文を指定して既存ライセンスヘッダーを識別可能です：
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
@@ -226,11 +225,11 @@ export default {
       },
       commentSyntax: {
         xyz: {
-          line: '##', // ラインコメント構文
+          line: '##', // 行コメント構文の定義
         },
         abc: {
           block: {
-            // ブロックコメント構文
+            // ブロックコメント構文の定義
             start: '<!--',
             end: '-->',
           },
@@ -243,9 +242,9 @@ export default {
 
 #### ファイルの除外
 
-デフォルトでgitリポジトリの場合、バージョン管理対象外のファイルを同期しないよう`.gitignore`が適用されます。git以外のリポジトリでは、明示的に除外しない限りすべてのファイルが対象になります。
+デフォルトではgitリポジトリで`.gitignore`ファイルが適用され、バージョン管理下のファイルのみ同期対象となります。非git環境では明示的に除外しない限り全ファイルが対象です。
 
-グロブパターンでライセンスヘッ�ダー同期から除外するファイルを指定可能です：
+globパターンでライセンスヘッダー同期から除外するファイルを追加指定可能です：
 
 ```typescript title="aws-nx-plugin.config.mts" {12-16}
 export default {
@@ -267,18 +266,18 @@ export default {
 
 ### プロジェクトファイルの同期除外
 
-デフォルトですべての`LICENSE`、`package.json`、`pyproject.toml`ファイルが同期対象となります。
+デフォルトで全`LICENSE`、`package.json`、`pyproject.toml`ファイルが同期対象です。
 
-グロブパターンで特定のプロジェクトやファイルを同期から除外可能です：
+globパターンで特定プロジェクト/ファイルの同期を除外可能です：
 
 ```typescript title="aws-nx-plugin.config.mts" {3-10}
 export default {
   license: {
     files: {
       exclude: [
-        // LICENSEファイル、package.json、pyproject.tomlを同期しない
+        // LICENSEファイル、package.json、pyproject.tomlの同期を除外
         'packages/excluded-project',
-        // LICENSEファイルは同期しないが、package.json/pyproject.tomlは同期する
+        // LICENSEファイルの同期を除外（package.json/pyproject.tomlは同期）
         'apps/internal/LICENSE',
       ];
     }
@@ -288,7 +287,7 @@ export default {
 
 ## ライセンス同期の無効化
 
-ライセンス同期を無効化するには：
+ライセンス同期を無効化する手順：
 
 1. `aws-nx-plugin.config.mts`から`license`セクションを削除（またはファイル自体を削除）
 2. `targetDefaults.lint.syncGenerators`から`@aws/nx-plugin:license#sync`ジェネレータを削除

--- a/docs/src/content/docs/jp/guides/nx-generator.mdx
+++ b/docs/src/content/docs/jp/guides/nx-generator.mdx
@@ -11,54 +11,53 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
-[Nx Generator](https://nx.dev/extending-nx/recipes/local-generators)をTypeScriptプロジェクトに追加し、コンポーネントのスキャフォールディングや特定のプロジェクト構造の強制など、反復的なタスクの自動化を支援します。
+TypeScriptプロジェクトに[Nx Generator](https://nx.dev/extending-nx/recipes/local-generators)を追加し、コンポーネントのスキャフォールディングや特定のプロジェクト構造の強制など、反復的なタスクの自動化を支援します。
 
 ## 使用方法
 
-### ジェネレーターの生成
+### ジェネレータの生成
 
-ジェネレーターは2つの方法で生成できます:
+ジェネレータは2つの方法で生成できます:
 
 <RunGenerator generator="ts#nx-generator" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
-## ジェネレーターの出力
+## ジェネレータの出力
 
-ジェネレーターは指定された`pluginProject`内に以下のプロジェクトファイルを作成します:
+ジェネレータは指定された`pluginProject`内に以下のプロジェクトファイルを作成します:
 
 <FileTree>
   - src/\<name>/
-    - schema.json ジェネレーターの入力スキーマ
+    - schema.json ジェネレータ入力用スキーマ
     - schema.d.ts スキーマのTypeScript型定義
-    - generator.ts ジェネレーター実装のスタブ
-    - generator.spec.ts ジェネレーターのテスト
-  - generators.json ジェネレーター定義用Nx設定
-  - package.json 「generators」エントリを追加/更新
+    - generator.ts ジェネレータ実装のスタブ
+    - generator.spec.ts ジェネレータのテスト
+  - generators.json ジェネレータ定義用Nx設定
+  - package.json 「generators」エントリが追加または更新
   - tsconfig.json CommonJS使用に更新
 </FileTree>
 
 :::warning
-現在NxジェネレーターはCommonJSのみをサポートしているため、このジェネレーターは選択された`pluginProject`をCommonJS使用に更新します（[ESMサポートに関するGitHub Issue](https://github.com/nrwl/nx/issues/15682)）。
+現在NxジェネレータはCommonJSのみをサポートしているため、このジェネレータは選択した`pluginProject`をCommonJS使用に更新します（[ESMサポートに関するGitHubイシュー](https://github.com/nrwl/nx/issues/15682)）。
 :::
 
-## ローカルジェネレーター
+## ローカルジェネレータ
 
 :::tip
-すべてのジェネレーター用に専用TypeScriptプロジェクトを`ts#project`ジェネレーターで最初に生成することを推奨します。例:
+ジェネレータ用に専用のTypeScriptプロジェクトを`ts#project`ジェネレータで先に生成することを推奨します。例:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-`ts#nx-generator`ジェネレーター実行時にローカルの`nx-plugin`プロジェクトを選択し、名前とオプションのディレクトリ、説明を指定してください。
+`ts#nx-generator`ジェネレータ実行時にローカルの`nx-plugin`プロジェクトを選択し、名前とオプションのディレクトリ、説明を指定します。
 
 ### スキーマの定義
 
-`schema.json`ファイルはジェネレーターが受け入れるオプションを定義します。[JSON Schema](https://json-schema.org/)形式に[Nx拡張](https://nx.dev/extending-nx/recipes/generator-options)を加えた形式です。
+`schema.json`ファイルはジェネレータが受け入れるオプションを定義します。[JSON Schema](https://json-schema.org/)形式に[Nx固有の拡張](https://nx.dev/extending-nx/recipes/generator-options)を加えた形式です。
 
 #### 基本構造
 
@@ -72,13 +71,13 @@ schema.jsonファイルの基本構造:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // ジェネレーターオプションをここに記述
+    // ジェネレータオプション
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
 ```
 
-#### シンプルな例
+#### 簡単な例
 
 基本的なオプションを含むシンプルな例:
 
@@ -110,7 +109,7 @@ schema.jsonファイルの基本構造:
 }
 ```
 
-#### インタラクティブプロンプト（CLI）
+#### 対話型プロンプト（CLI）
 
 `x-prompt`プロパティを追加してCLI実行時のプロンプトをカスタマイズ:
 
@@ -122,7 +121,7 @@ schema.jsonファイルの基本構造:
 }
 ```
 
-真偽値オプションではyes/noプロンプトを使用:
+booleanオプションではyes/noプロンプトを使用:
 
 ```json
 "withTests": {
@@ -132,7 +131,7 @@ schema.jsonファイルの基本構造:
 }
 ```
 
-#### ドロップダウン選択肢
+#### ドロップダウン選択
 
 固定選択肢があるオプションには`enum`を使用:
 
@@ -147,7 +146,7 @@ schema.jsonファイルの基本構造:
 
 #### プロジェクト選択ドロップダウン
 
-ワークスペース内の既存プロジェクトから選択させる一般的なパターン:
+ワークスペースの既存プロジェクトから選択させる一般的なパターン:
 
 ```json
 "project": {
@@ -158,11 +157,11 @@ schema.jsonファイルの基本構造:
 }
 ```
 
-`x-dropdown: "projects"`プロパティはNxにワークスペース内の全プロジェクトをドロップダウンに表示するよう指示します。
+`x-dropdown: "projects"`プロパティはNxにワークスペースの全プロジェクトをドロップダウン表示させます。
 
 #### 位置引数
 
-コマンドラインから位置引数としてオプションを渡す設定:
+コマンドライン実行時に位置引数としてオプションを渡す設定:
 
 ```json
 "name": {
@@ -176,11 +175,11 @@ schema.jsonファイルの基本構造:
 }
 ```
 
-これにより`nx g your-generator my-component`のように名前を引数で渡せるようになります。
+これにより`nx g your-generator my-component`のように実行可能になります。
 
-#### 優先度の設定
+#### 優先度設定
 
-`x-priority`プロパティで重要度を表示:
+`x-priority`プロパティで重要オプションを表示:
 
 ```json
 "name": {
@@ -190,11 +189,11 @@ schema.jsonファイルの基本構造:
 }
 ```
 
-優先度は`"important"`または`"internal"`を指定可能。Nx VSCode拡張やCLIでのプロパティ順序付けに役立ちます。
+`"important"`または`"internal"`優先度を設定可能。Nx VSCode拡張とCLIでのプロパティ順序制御に役立ちます。
 
 #### デフォルト値
 
-オプションにデフォルト値を設定:
+オプションのデフォルト値を設定:
 
 ```json
 "directory": {
@@ -206,11 +205,11 @@ schema.jsonファイルの基本構造:
 
 #### 詳細情報
 
-スキーマの詳細については[Nx Generator Optionsドキュメント](https://nx.dev/extending-nx/recipes/generator-options)を参照。
+スキーマの詳細は[Nx Generator Optionsドキュメント](https://nx.dev/extending-nx/recipes/generator-options)を参照。
 
-#### schema.d.tsによるTypeScript型
+#### schema.d.tsのTypeScript型
 
-`schema.json`と共に生成される`schema.d.ts`ファイルはジェネレーターオプションのTypeScript型を提供します:
+`schema.json`と共に生成される`schema.d.ts`はジェネレータオプションのTypeScript型を提供:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -220,40 +219,40 @@ export interface YourGeneratorSchema {
 }
 ```
 
-このインターフェースはジェネレーター実装で型安全性とコード補完に使用されます:
+このインターフェースは型安全性とコード補完のために実装で使用:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // オプションの型がTypeScriptで認識される
+  // オプションの型が認識される
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-`schema.json`を変更する際は、必ず`schema.d.ts`も更新してください。具体的には:
+`schema.json`を変更する際は、必ず`schema.d.ts`も更新してください。変更内容には以下が含まれます:
 
 - プロパティの追加/削除
 - プロパティ型の変更
-- 必須/オプションの変更（オプションの場合は`?`接尾辞を使用）
+- 必須/オプションの変更（オプションは`?`接尾辞）
 
 TypeScriptインターフェースはJSONスキーマの構造を正確に反映する必要があります。
 :::
 
-### ジェネレーターの実装
+### ジェネレータの実装
 
-上記の方法でジェネレーターを作成後、`generator.ts`に実装を記述できます。
+上記でジェネレータを作成後、`generator.ts`に実装を記述します。
 
-ジェネレーターは仮想ファイルシステム（`Tree`）を操作する関数です。変更はジェネレーター終了時（dry-runモードでない場合）にのみディスクに書き込まれます。
+ジェネレータは仮想ファイルシステム（`Tree`）を操作し、変更をディスクに書き込みます（「dry-run」モードでない場合）。
 
-代表的な操作例:
+一般的な操作例:
 
 #### ファイルの読み書き
 
 ```typescript
-// ファイル読み取り
+// ファイル読み込み
 const content = tree.read('path/to/file.ts', 'utf-8');
 
 // ファイル書き込み
@@ -261,7 +260,7 @@ tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
 // ファイル存在確認
 if (tree.exists('path/to/file.ts')) {
-  // 処理を実行
+  // 処理
 }
 ```
 
@@ -276,43 +275,42 @@ generateFiles(
   joinPathFragments(__dirname, 'files'), // テンプレートディレクトリ
   'path/to/output', // 出力ディレクトリ
   {
-    // テンプレート置換用変数
+    // テンプレート変数
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
-    // 必要に応じて変数を追加
   },
 );
 ```
 
 #### TypeScript AST操作
 
-[TSQuery](https://github.com/phenomnomnominal/tsquery)の使用を推奨します。
+[TSQuery](https://github.com/phenomnomnominal/tsquery)の使用を推奨:
 
 ```typescript
 import { tsquery } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
 
-// 例: ファイル内バージョン番号のインクリメント
+// 例: バージョン番号の更新
 
-// ファイル内容をTypeScript ASTにパース
+// ファイル内容をASTに解析
 const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
 
-// セレクターに一致するノードを検索
+// セレクタに一致するノードを検索
 const nodes = tsquery.query(
   sourceFile,
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
 );
 
 if (nodes.length > 0) {
-  // 数値リテラルノードを取得
+  // 数値リテラルノード取得
   const numericNode = nodes[0] as ts.NumericLiteral;
 
-  // 現在のバージョンを取得してインクリメント
+  // バージョン番号をインクリメント
   const currentVersion = Number(numericNode.text);
   const newVersion = currentVersion + 1;
 
-  // ASTノードを置換
+  // ASTノード置換
   const result = tsquery.replace(
     sourceFile,
     'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
@@ -332,7 +330,7 @@ if (nodes.length > 0) {
 ```
 
 :::tip
-セレクターは[TSQuery Playground](https://tsquery-playground.firebaseapp.com/)でオンライン検証可能です。
+セレクタは[TSQuery Playground](https://tsquery-playground.firebaseapp.com/)でテスト可能です。
 :::
 
 #### 依存関係の追加
@@ -340,7 +338,7 @@ if (nodes.length > 0) {
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
 
-// package.jsonに依存関係を追加
+// package.jsonに依存関係追加
 addDependenciesToPackageJson(
   tree,
   {
@@ -353,12 +351,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-package.jsonに依存関係を追加後、ジェネレーターコールバックでインストール可能:
+依存関係を追加後、インストールタスクをコールバックで実行:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// ジェネレーターは依存関係インストールなどの後処理タスクを実行するコールバックを返す
+// ジェネレータが依存関係インストールタスクを返す
 return () => {
   installPackagesTask(tree);
 };
@@ -370,16 +368,16 @@ return () => {
 ```typescript
 import { formatFiles } from '@nx/devkit';
 
-// 変更された全ファイルをフォーマット
+// 変更ファイルをフォーマット
 await formatFiles(tree);
 ```
 
-#### JSONファイルの読み書き
+#### JSONファイルの操作
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// JSONファイル読み取り
+// JSONファイル読み込み
 const packageJson = readJson(tree, 'package.json');
 
 // JSONファイル更新
@@ -392,21 +390,21 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
-### ジェネレーターの実行
+### ジェネレータの実行
 
-ジェネレーターは2つの方法で実行できます:
+2つの方法でジェネレータを実行可能:
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-VSCodeプラグインUIにジェネレーターが表示されない場合、Nxワークスペースを更新:
+VSCodeプラグインUIにジェネレータが表示されない場合、Nxワークスペースを更新:
 
 <NxCommands commands={['reset']} />
 :::
 
-### ジェネレーターのテスト
+### ジェネレータのテスト
 
-ジェネレーターの単体テストは簡単に実装できます。代表的なパターン:
+ジェネレータの単体テスト実装例:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -416,10 +414,10 @@ describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
-    // 空のワークスペースtreeを作成
+    // 空のワークスペース作成
     tree = createTreeWithEmptyWorkspace();
 
-    // treeに既存ファイルを追加
+    // 既存ファイルの追加
     tree.write(
       'project.json',
       JSON.stringify({
@@ -432,10 +430,10 @@ describe('your generator', () => {
   });
 
   it('should generate expected files', async () => {
-    // ジェネレーター実行
+    // ジェネレータ実行
     await yourGenerator(tree, {
       name: 'test',
-      // その他必須オプション
+      // 必須オプション
     });
 
     // ファイル生成確認
@@ -445,24 +443,24 @@ describe('your generator', () => {
     const content = tree.read('src/test/file.ts', 'utf-8');
     expect(content).toContain('export const test');
 
-    // スナップショットも使用可能
+    // スナップショットテスト
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should update existing files', async () => {
-    // ジェネレーター実行
+    // ジェネレータ実行
     await yourGenerator(tree, {
       name: 'test',
-      // その他必須オプション
+      // 必須オプション
     });
 
-    // 既存ファイルの更新確認
+    // 既存ファイル更新確認
     const content = tree.read('src/existing-file.ts', 'utf-8');
     expect(content).toContain('import { test } from');
   });
 
   it('should handle errors', async () => {
-    // 特定条件でのエラー発生を確認
+    // エラー発生条件のテスト
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
@@ -476,30 +474,30 @@ describe('your generator', () => {
 テストの要点:
 
 - `createTreeWithEmptyWorkspace()`で仮想ファイルシステムを作成
-- ジェネレーター実行前の前提条件ファイルを設定
-- 新規ファイル生成と既存ファイル更新の両方をテスト
+- 事前に必要なファイルをセットアップ
+- 新規ファイル生成と既存ファイル更新をテスト
 - 複雑なファイル内容にはスナップショットを使用
-- エラー発生条件をテストして適切な失敗を確認
+- エラー条件をテストして適切なエラーハンドリングを確認
 
-## @aws/nx-pluginへのジェネレーターの提供
+## @aws/nx-pluginへのジェネレータ提供
 
-`ts#nx-generator`を使用して`@aws/nx-plugin`内にジェネレーターのスキャフォールドを作成できます。
+`ts#nx-generator`を使用して`@aws/nx-plugin`内にジェネレータをスキャフォールドできます。
 
-このジェネレーターをリポジトリ内で実行すると、以下のファイルが生成されます:
+当リポジトリで実行すると、以下のファイルが生成されます:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json ジェネレーター入力スキーマ
+    - schema.json ジェネレータ入力用スキーマ
     - schema.d.ts スキーマのTypeScript型定義
-    - generator.ts ジェネレーター実装
+    - generator.ts ジェネレータ実装
     - generator.spec.ts テスト
   - docs/src/content/docs/guides/
-    - \<name>.mdx ジェネレーターのドキュメントページ
-  - packages/nx-plugin/generators.json ジェネレーター定義を更新
+    - \<name>.mdx ジェネレータのドキュメントページ
+  - packages/nx-plugin/generators.json ジェネレータ定義を更新
 </FileTree>
 
-その後、ジェネレーターの実装を開始できます。
+実装を開始できます。
 
 :::tip
-AWS向けNx Pluginへの貢献に関する詳細ガイドは、<Link path="get_started/tutorials/contribute-generator">こちらのチュートリアル</Link>を参照してください。
+AWS向けNxプラグインへの貢献に関する詳細ガイドは<Link path="get_started/tutorials/contribute-generator">こちらのチュートリアル</Link>を参照してください。
 :::

--- a/docs/src/content/docs/jp/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/jp/guides/python-lambda-function.mdx
@@ -9,11 +9,10 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
 Python Lambda Function ジェネレータは、既存のPythonプロジェクトにLambda関数を追加する機能を提供します。
 
-このジェネレータはAWS CDKインフラストラクチャ設定を含む新しいPython Lambdaハンドラを作成します。生成されるバックエンドはサーバーレスデプロイにAWS Lambdaを使用し、[AWS Lambda PowertoolsのParser](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)を使った型安全性をオプションで追加します。ロギング、AWS X-Rayトレーシング、Cloudwatchメトリクスを含む可観測性のために[AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)を設定します。
+このジェネレータはAWS CDKインフラストラクチャ設定を含む新しいPython Lambdaハンドラを作成します。生成されるバックエンドはサーバーレスデプロイにAWS Lambdaを使用し、[AWS Lambda PowertoolsのParser](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)を使用した型安全性をオプションで追加します。ロギング、AWS X-Rayトレーシング、Cloudwatchメトリクスを含む可観測性のために[AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)を設定します。
 
 ## 使用方法
 
@@ -25,7 +24,7 @@ Python Lambda Function ジェネレータは、既存のPythonプロジェクト
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
 ## ジェネレータの出力
 
@@ -109,14 +108,13 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 :::
 
 ロガーには自動的に以下が含まれます:
-
 - イベントリクエスト
 - Lambdaコンテキスト情報
 - コールドスタートインジケータ
 
 #### トレーシング
 
-AWS X-Rayトレーシングが自動的に設定されます。カスタムサブセグメントを追加できます:
+AWS X-Rayトレーシングが自動的に設定されます。トレースにカスタムサブセグメントを追加できます:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -128,7 +126,7 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 #### メトリクス
 
-CloudWatchメトリクスは各リクエストに対して自動的に収集されます。カスタムメトリクスを追加できます:
+CloudWatchメトリクスは各リクエストごとに自動収集されます。カスタムメトリクスを追加できます:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -137,14 +135,13 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 ```
 
 デフォルトのメトリクスには以下が含まれます:
-
 - 呼び出し回数
 - 成功/失敗回数
 - コールドスタートメトリクス
 
 #### 型安全性
 
-Lambda関数生成時に`eventSource`を選択した場合、関数は[AWS Lambda Powertoolsの`@event_parser`](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)で装飾されます。例:
+Lambda関数生成時に`eventSource`を選択した場合、関数は[AWS Lambda Powertoolsの`@event_parser`](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)で計装されます。例:
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
@@ -155,14 +152,14 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 これは<Link path="guides/fastapi">Fast API</Link>と同様の方法で[Pydantic](https://docs.pydantic.dev/latest/)を使用したデータモデル定義を可能にします。
 
 :::tip
-DynamoDBストリームやEventBridgeイベント内のカスタムデータなど、ネストされたカスタムデータがある場合、[Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes)を使用して型安全性を確保できます。
+DynamoDBストリームやEventBridgeイベント内のカスタムデータなどがある場合、[Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes)を使用して型安全性を提供することを検討してください。
 :::
 
-イベントの型指定が必要ない場合は、`eventSource`で`Any`を選択できます。
+イベントを型付けしない場合は、`eventSource`に`Any`を選択できます。
 
 ## 関数のデプロイ
 
-Python Lambda Functionジェネレータは`common/constructs`フォルダにCDKコンストラクトを作成します。CDKアプリケーションで使用できます:
+Python Lambda Functionジェネレータは`common/constructs`フォルダに関数のデプロイ用CDKコンストラクトを作成します。CDKアプリケーションで使用できます:
 
 ```ts
 import { MyProjectMyFunction } from ':my-scope/common-constructs';
@@ -176,7 +173,6 @@ export class ExampleStack extends Stack {
 ```
 
 これにより以下が設定されます:
-
 1. AWS Lambda関数
 2. CloudWatchロググループ
 3. X-Rayトレーシング設定
@@ -188,7 +184,7 @@ export class ExampleStack extends Stack {
 イベントがハンドラ関数内で適切に処理されるよう、イベントソースが選択した`eventSource`オプションと一致していることを確認してください。
 :::
 
-以下の例はEvent Bridgeを使用したスケジュール実行でLambda関数を呼び出すCDKコードを示しています:
+以下の例はEvent Bridgeを使用したスケジュール実行でLambda関数を呼び出すCDKコードです:
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';

--- a/docs/src/content/docs/jp/guides/python-project.mdx
+++ b/docs/src/content/docs/jp/guides/python-project.mdx
@@ -9,9 +9,8 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
-Pythonプロジェクトジェネレータは、モダンな[Python](https://www.python.org/)ライブラリまたはアプリケーションを作成するために使用できます。これらのプロジェクトはベストプラクティスに基づいて設定され、[UV](https://docs.astral.sh/uv/)による依存関係管理、単一のロックファイル、[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)内の仮想環境、テスト実行用の[pytest](https://docs.pytest.org/en/stable/)、静的解析用の[Ruff](https://docs.astral.sh/ruff/)が構成されます。
+Pythonプロジェクトジェネレータは、ベストプラクティスに基づいて設定された最新の[Python](https://www.python.org/)ライブラリまたはアプリケーションを作成するために使用できます。これらは[UV](https://docs.astral.sh/uv/)による依存関係管理、単一のロックファイルと[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)内の仮想環境、テスト実行用の[pytest](https://docs.pytest.org/en/stable/)、静的解析用の[Ruff](https://docs.astral.sh/ruff/)で構成されています。
 
 ## 使用方法
 
@@ -23,7 +22,7 @@ Pythonプロジェクトジェネレータは、モダンな[Python](https://www
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
 ## ジェネレータの出力
 
@@ -32,15 +31,15 @@ Pythonプロジェクトジェネレータは、モダンな[Python](https://www
 <FileTree>
 
   - \<module-name>
-    - \_\_init\_\_.py モジュール初期化
+    - \_\_init\_\_.py モジュール初期化ファイル
     - hello.py サンプルPythonソースファイル
   - tests
-    - \_\_init\_\_.py モジュール初期化
-    - conftest.py テスト設定
+    - \_\_init\_\_.py モジュール初期化ファイル
+    - conftest.py テスト設定ファイル
     - test_hello.py サンプルテスト
   - project.json プロジェクト設定とビルドターゲット
   - pyproject.toml UV用パッケージ設定ファイル
-  - .python-version プロジェクトのPythonバージョン記載
+  - .python-version プロジェクトのPythonバージョン情報
 
 </FileTree>
 
@@ -49,7 +48,7 @@ Pythonプロジェクトジェネレータは、モダンな[Python](https://www
 <FileTree>
 
   - pyproject.toml UV用ワークスペースレベルのパッケージ設定
-  - .python-version ワークスペースのPythonバージョン記載
+  - .python-version ワークスペースのPythonバージョン情報
   - uv.lock Python依存関係のロックファイル
 
 </FileTree>
@@ -66,19 +65,19 @@ Pythonソースコードは`<module-name>`ディレクトリに追加します�
 from "my_library.hello" import say_hello
 ```
 
-上記の例では、`my_library`がモジュール名、`hello`は`hello.py`ファイルに対応し、`say_hello`は`hello.py`で定義されたメソッドです。
+上記例では、`my_library`がモジュール名、`hello`はPythonソースファイル`hello.py`に対応し、`say_hello`は`hello.py`で定義されたメソッドです
 
-### 依存関係
+### 依存関係の管理
 
-プロジェクトに依存関係を追加するには、以下のように`add`ターゲットを実行します:
+プロジェクトに依存関係を追加するには、Pythonプロジェクトで`add`ターゲットを実行します:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-これによりプロジェクトの`pyproject.toml`に依存関係が追加され、ルートの`uv.lock`が更新されます。
+これによりプロジェクトの`pyproject.toml`ファイルに依存関係が追加され、ルートの`uv.lock`が更新されます。
 
 #### ランタイムコード
 
-Pythonプロジェクトをランタイムコード（例: AWS Lambda関数のハンドラ）として使用する場合、ソースコードとすべての依存関係をバンドルする必要があります。`project.json`に以下のようなターゲットを追加することで実現できます:
+Pythonプロジェクトをランタイムコード（例: AWS Lambda関数のハンドラー）として使用する場合、ソースコードとすべての依存関係をバンドルする必要があります。`project.json`ファイルに以下のようなターゲットを追加することで実現できます:
 
 ```json title="project.json"
 {
@@ -104,23 +103,23 @@ Pythonプロジェクトをランタイムコード（例: AWS Lambda関数の�
 
 ### ビルド
 
-Pythonプロジェクトには`build`ターゲット（`project.json`で定義）が構成されており、以下のコマンドで実行できます:
+Pythonプロジェクトには`build`ターゲット（`project.json`で定義）が設定されており、以下のコマンドで実行できます:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 `<project-name>`はプロジェクトの完全修飾名です。
 
-`build`ターゲットはプロジェクトのコンパイル、リント、テストを実行します。
+`build`ターゲットはプロジェクトのコンパイル、リンター実行、テストを実施します。
 
-ビルド出力はワークスペースルートの`dist`フォルダ内（例: `dist/packages/<my-library>/build`）に生成されます。
+ビルド出力はワークスペースルートの`dist`フォルダ内に生成されます（例: `dist/packages/<my-library>/build`）
 
 ## テスト
 
-[pytest](https://docs.pytest.org/en/stable/)がプロジェクトのテスト用に構成されています。
+[pytest](https://docs.pytest.org/en/stable/)がプロジェクトのテスト用に設定されています。
 
 ### テストの記述
 
-テストはプロジェクト内の`test`ディレクトリに`test_`プレフィックス付きのPythonファイルとして記述します:
+テストはプロジェクト内の`test`ディレクトリに`test_`プレフィックス付きのPythonファイルで記述します:
 
 <FileTree>
   - my_library
@@ -138,34 +137,34 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-テストの書き方の詳細は[pytestドキュメント](https://docs.pytest.org/en/stable/how-to/assert.html#)を参照してください。
+テストの記述方法の詳細は[pytestドキュメント](https://docs.pytest.org/en/stable/how-to/assert.html#)を参照してください。
 
 ### テストの実行
 
-テストは`build`ターゲットの一部として実行されますが、`test`ターゲットで個別に実行することも可能です:
+テストはプロジェクトの`build`ターゲットの一部として実行されますが、`test`ターゲットで個別に実行することも可能です:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-`-k`フラグを使用して特定のテストファイルやメソッドを指定できます:
+`-k`フラグを使用して特定のテストファイルやメソッドを指定して実行できます:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## リンティング
+## リンター
 
-Pythonプロジェクトでは[Ruff](https://docs.astral.sh/ruff/)を使用してリンティングを実施します。
+Pythonプロジェクトでは[Ruff](https://docs.astral.sh/ruff/)をリンターとして使用しています。
 
-### リンティングの実行
+### リンターの実行
 
-プロジェクトのリンティングチェックには`lint`ターゲットを実行します:
+プロジェクトのリンターを実行するには`lint`ターゲットを使用します:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### リント問題の修正
+### リンター問題の修正
 
-ほとんどのリンティング/フォーマット問題は自動修正可能です。`--configuration=fix`引数を付けて実行することで修正できます:
+ほとんどのリンターやフォーマッターの問題は自動修正可能です。`--configuration=fix`引数を付けて実行することで修正できます:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-ワークスペース内の全パッケージのリント問題を修正するには:
+ワークスペース内の全パッケージのリンター問題を修正するには以下を実行します:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -11,71 +11,70 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/)は、エンドツーエンドの型安全性を備えたTypeScript API構築フレームワークです。tRPCを使用すると、API操作の入力と出力の更新が即座にクライアントコードに反映され、プロジェクトの再ビルドなしにIDEで確認できます。
+[tRPC](https://trpc.io/) はエンドツーエンドの型安全性を備えた TypeScript での API 構築フレームワークです。tRPC を使用すると、API 操作の入力と出力の更新が即座にクライアントコードに反映され、プロジェクトの再ビルドなしに IDE 上で確認できます。
 
-tRPC APIジェネレータは、AWS CDKインフラストラクチャがセットアップされた新しいtRPC APIを作成します。生成されるバックエンドはサーバーレスデプロイメントにAWS Lambdaを使用し、[Zod](https://zod.dev/)を用いたスキーマ検証を含みます。また、ロギング、AWS X-Rayトレーシング、Cloudwatchメトリクスなどの観測可能性のために[AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/)を設定します。
+tRPC API ジェネレータは AWS CDK インフラストラクチャがセットアップされた新しい tRPC API を作成します。生成されるバックエンドはサーバーレスデプロイメントに AWS Lambda を使用し、[Zod](https://zod.dev/) を利用したスキーマ検証を含みます。ロギング、AWS X-Ray トレーシング、Cloudwatch メトリクスを含む可観測性のために [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) が設定されます。
 
 ## 使用方法
 
-### tRPC APIの生成
+### tRPC API の生成
 
-新しいtRPC APIは2つの方法で生成できます:
+新しい tRPC API は2つの方法で生成できます:
 
 <RunGenerator generator="ts#trpc-api" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
 ## ジェネレータの出力
 
-ジェネレータは`<directory>/<api-name>`ディレクトリに以下のプロジェクト構造を作成します:
+ジェネレータは `<directory>/<api-name>` ディレクトリに以下のプロジェクト構造を作成します:
 
 <FileTree>
   - schema
     - src
-      - index.ts スキーマのエントリポイント
+      - index.ts スキーマエントリポイント
       - procedures
-        - echo.ts "echo"プロシージャの共有スキーマ定義（Zod使用）
-    - tsconfig.json TypeScriptの設定
+        - echo.ts "echo" プロシージャの共有スキーマ定義（Zod 使用）
+    - tsconfig.json TypeScript 設定
     - project.json プロジェクト設定とビルドターゲット
   - backend
     - src
-      - init.ts バックエンドtRPC初期化
-      - router.ts tRPCルータ定義（LambdaハンドラAPIエントリポイント）
-      - procedures APIが公開するプロシージャ（操作）
+      - init.ts バックエンド tRPC 初期化
+      - router.ts tRPC ルーター定義（Lambda ハンドラー API エントリポイント）
+      - procedures API が公開するプロシージャ（操作）
         - echo.ts サンプルプロシージャ
       - middleware
         - error.ts エラーハンドリング用ミドルウェア
-        - logger.ts Lambdaロギング用AWS Powertools設定ミドルウェア
-        - tracer.ts Lambdaトレーシング用AWS Powertools設定ミドルウェア
-        - metrics.ts Lambdaメトリクス用AWS Powertools設定ミドルウェア
-      - local-server.ts ローカル開発サーバー用tRPCスタンドアロンアダプタ
+        - logger.ts AWS Powertools のロギング設定用ミドルウェア
+        - tracer.ts AWS Powertools のトレーシング設定用ミドルウェア
+        - metrics.ts AWS Powertools のメトリクス設定用ミドルウェア
+      - local-server.ts ローカル開発サーバー用 tRPC スタンドアロンアダプターエントリポイント
       - client
-        - index.ts マシン間API呼び出し用型安全クライアント
-    - tsconfig.json TypeScriptの設定
+        - index.ts マシン間 API 呼び出し用型安全クライアント
+    - tsconfig.json TypeScript 設定
     - project.json プロジェクト設定とビルドターゲット
 </FileTree>
 
-また、ジェネレータはAPIデプロイ用のCDKコンストラクトを`packages/common/constructs`ディレクトリに作成します。
+ジェネレータはまた `packages/common/constructs` ディレクトリに API のデプロイに使用できる CDK コンストラクトを作成します。
 
-## tRPC APIの実装
+## tRPC API の実装
 
-上記のように、tRPC APIにはワークスペース内の個別パッケージとして定義された[`schema`](#schema)と[`backend`](#backend)の2つの主要コンポーネントがあります。
+上記のように、tRPC API にはワークスペース内で個別のパッケージとして定義される [`schema`](#schema) と [`backend`](#backend) の2つの主要コンポーネントがあります。
 
 :::tip
-`schema`と`backend`はどちらもTypeScriptプロジェクトです。一般的な使用方法の詳細については<Link path="guides/typescript-project">TypeScriptプロジェクトドキュメント</Link>を参照してください。
+`schema` と `backend` はどちらも TypeScript プロジェクトです。一般的な使用方法の詳細については <Link path="guides/typescript-project">TypeScript プロジェクトドキュメント</Link> を参照してください。
 :::
 
 ### スキーマ
 
-schemaパッケージはクライアントとサーバーコード間で共有される型を定義します。これらの型はTypeScriptファーストのスキーマ宣言・検証ライブラリである[Zod](https://zod.dev/)を使用して定義されます。
+スキーマパッケージはクライアントとサーバーコード間で共有される型を定義します。これらの型は TypeScript 優先のスキーマ宣言・検証ライブラリである [Zod](https://zod.dev/) を使用して定義されます。
 
-サンプルスキーマ:
+サンプルスキーマは以下のようになります:
 
 ```ts
 import { z } from 'zod';
@@ -87,11 +86,11 @@ export const UserSchema = z.object({
   dateOfBirth: z.string().datetime(),
 });
 
-// 対応するTypeScriptの型
+// 対応する TypeScript 型
 export type User = z.TypeOf<typeof UserSchema>;
 ```
 
-上記スキーマの場合、`User`型は以下のTypeScriptと同等です:
+上記のスキーマの場合、`User` 型は以下の TypeScript と同等です:
 
 ```ts
 interface User {
@@ -101,19 +100,19 @@ interface User {
 }
 ```
 
-スキーマはサーバーとクライアントコードの両方で共有され、APIで使用される構造を変更する際の単一の更新ポイントを提供します。
+スキーマはサーバーとクライアントコードの両方で共有され、API で使用される構造を変更する際の単一の更新ポイントを提供します。
 
-スキーマは実行時にtRPC APIによって自動検証され、バックエンドでカスタム検証ロジックを手作業で作成する必要がなくなります。
+スキーマは実行時に tRPC API によって自動検証され、バックエンドでカスタム検証ロジックを手動で作成する手間を省きます。
 
-Zodはスキーマの結合や派生のための`.merge`、`.pick`、`.omit`などの強力なユーティリティを提供します。詳細は[Zod公式ドキュメント](https://zod.dev/?id=basic-usage)を参照してください。
+Zod はスキーマを結合または派生させるための `.merge`、`.pick`、`.omit` などの強力なユーティリティを提供します。詳細は [Zod ドキュメント](https://zod.dev/?id=basic-usage) を参照してください。
 
 ### バックエンド
 
-`backend`フォルダにはAPI実装が含まれ、API操作とその入力、出力、実装を定義します。
+ネストされた `backend` フォルダには API の実装が含まれ、API 操作とその入力、出力、実装を定義します。
 
-APIのエントリポイントは`src/router.ts`にあります。このファイルには、呼び出される操作に基づいてリクエストを「プロシージャ」にルーティングするLambdaハンドラが含まれます。各プロシージャは入力、出力、実装を定義します。
+API のエントリポイントは `src/router.ts` にあります。このファイルにはリクエストを呼び出される操作に基づいて「プロシージャ」にルーティングする Lambda ハンドラーが含まれます。各プロシージャは期待される入力、出力、実装を定義します。
 
-生成されるサンプルルータには`echo`という単一の操作が含まれます:
+生成されるサンプルルーターには `echo` という単一の操作が含まれます:
 
 ```ts
 import { echo } from './procedures/echo.js';
@@ -123,7 +122,7 @@ export const appRouter = router({
 });
 ```
 
-サンプルの`echo`プロシージャは`src/procedures/echo.ts`に生成されます:
+サンプルの `echo` プロシージャは `src/procedures/echo.ts` に生成されます:
 
 ```ts
 export const echo = publicProcedure
@@ -132,35 +131,35 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-上記の解説:
+上記の分解:
 
-- `publicProcedure`はAPIの公開メソッドを定義し、`src/middleware`に設定されたミドルウェアを含みます。このミドルウェアにはロギング、トレーシング、メトリクスのためのAWS Lambda Powertools統合が含まれます
-- `input`は操作の期待する入力を定義するZodスキーマを受け付けます。この操作へのリクエストは自動的にこのスキーマに対して検証されます
-- `output`は操作の期待する出力を定義するZodスキーマを受け付けます。スキーマに適合しない出力を返す場合、実装で型エラーが発生します
-- `query`はAPIの実装を定義する関数を受け付けます。この実装は`opts`を受け取り、`opts.input`で操作への入力、`opts.ctx`でミドルウェアが設定したコンテキストにアクセスできます。`query`に渡す関数は`output`スキーマに適合する出力を返す必要があります
+- `publicProcedure` は `src/middleware` に設定されたミドルウェアを含む API の公開メソッドを定義。このミドルウェアにはロギング、トレーシング、メトリクスのための AWS Lambda Powertools 統合が含まれます
+- `input` は操作の期待される入力を定義する Zod スキーマを受け入れます。この操作に送信されるリクエストは自動的にこのスキーマに対して検証されます
+- `output` は操作の期待される出力を定義する Zod スキーマを受け入れます。スキーマに準拠しない出力を返す場合、実装で型エラーが表示されます
+- `query` は API の実装を定義する関数を受け入れます。この実装は `opts.input` で渡される入力と、`opts.ctx` で利用可能なミドルウェアによって設定されたコンテキストを受け取ります。`query` に渡される関数は `output` スキーマに準拠する出力を返す必要があります
 
-`query`の使用は操作が非変更であることを示します。データ取得メソッドの定義に使用します。変更操作を実装する場合は`mutation`メソッドを使用してください。
+`query` の使用は操作が非変更であることを示します。データ取得メソッドの定義に使用します。変更操作を実装する場合は、代わりに `mutation` メソッドを使用してください。
 
-新しい操作を追加する場合は、`src/router.ts`のルータに登録する必要があります。
+新しい操作を追加する場合は、`src/router.ts` のルーターに登録してください。
 
-## tRPC APIのカスタマイズ
+## tRPC API のカスタマイズ
 
-### エラーハンドリング
+### エラー処理
 
-実装では`TRPCError`をスローしてクライアントにエラーレスポンスを返せます。エラータイプを示す`code`を受け付けます:
+実装では `TRPCError` をスローしてクライアントにエラーレスポンスを返せます。エラータイプを示す `code` を受け入れます:
 
 ```ts
 throw new TRPCError({
   code: 'NOT_FOUND',
-  message: 'リクエストされたリソースが見つかりませんでした',
+  message: 'リクエストされたリソースが見つかりません',
 });
 ```
 
 ### 操作の整理
 
-APIが成長するにつれ、関連する操作をグループ化したい場合があります。
+API が成長するにつれ、関連する操作をグループ化したい場合があります。
 
-ネストしたルータを使用して操作をグループ化できます:
+ネストされたルーターを使用して操作をグループ化できます:
 
 ```ts
 import { getUser } from './procedures/users/get.js';
@@ -175,7 +174,7 @@ const appRouter = router({
 })
 ```
 
-クライアントはこのグループ化された操作を受け取り、例えば`listUsers`操作の呼び出しは以下のようになります:
+クライアントはこの操作グループを受け取り、例えば `listUsers` 操作の呼び出しは以下のようになります:
 
 ```ts
 client.users.list.query();
@@ -183,24 +182,24 @@ client.users.list.query();
 
 ### ロギング
 
-AWS Lambda Powertoolsロガーは`src/middleware/logger.ts`で設定され、`opts.ctx.logger`でAPI実装からアクセスできます。CloudWatch Logsへのロギングや、構造化ログメッセージに含める追加値の制御に使用できます:
+AWS Lambda Powertools ロガーは `src/middleware/logger.ts` で設定され、API 実装で `opts.ctx.logger` 経由でアクセス可能です。CloudWatch Logs へのロギングや、構造化ログメッセージに含める追加値の制御に使用できます:
 
 ```ts {5}
 export const echo = publicProcedure
    .input(...)
    .output(...)
    .query(async (opts) => {
-      opts.ctx.logger.info('操作が入力値で呼び出されました', opts.input);
+      opts.ctx.logger.info('操作が入力で呼び出されました', opts.input);
 
       return ...;
    });
 ```
 
-ロガーの詳細は[AWS Lambda Powertools Loggerドキュメント](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/)を参照してください。
+ロガーの詳細は [AWS Lambda Powertools Logger ドキュメント](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/) を参照してください。
 
-### メトリクス記録
+### メトリクスの記録
 
-AWS Lambda Powertoolsメトリクスは`src/middleware/metrics.ts`で設定され、`opts.ctx.metrics`でアクセスできます。AWS SDKをインポートせずにCloudWatchにメトリクスを記録するのに使用できます:
+AWS Lambda Powertools メトリクスは `src/middleware/metrics.ts` で設定され、API 実装で `opts.ctx.metrics` 経由でアクセス可能です。AWS SDK をインポートせずに CloudWatch にメトリクスを記録できます:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -213,11 +212,11 @@ export const echo = publicProcedure
    });
 ```
 
-詳細は[AWS Lambda Powertools Metricsドキュメント](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/)を参照してください。
+詳細は [AWS Lambda Powertools Metrics ドキュメント](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/) を参照してください。
 
-### X-Rayトレーシングの微調整
+### X-Ray トレーシングの微調整
 
-AWS Lambda Powertoolsトレーサーは`src/middleware/tracer.ts`で設定され、`opts.ctx.tracer`でアクセスできます。APIリクエストのパフォーマンスとフローの詳細な可視化のためにAWS X-Rayトレースを追加できます:
+AWS Lambda Powertools トレーサーは `src/middleware/tracer.ts` で設定され、API 実装で `opts.ctx.tracer` 経由でアクセス可能です。API リクエストのパフォーマンスとフローの詳細な可視化のために AWS X-Ray トレースを追加できます:
 
 ```ts {5-7}
 export const echo = publicProcedure
@@ -232,13 +231,13 @@ export const echo = publicProcedure
    });
 ```
 
-詳細は[AWS Lambda Powertools Tracerドキュメント](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/)を参照してください。
+詳細は [AWS Lambda Powertools Tracer ドキュメント](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/) を参照してください。
 
 ### カスタムミドルウェアの実装
 
-ミドルウェアを実装して、プロシージャに提供するコンテキストに追加値を設定できます。
+ミドルウェアを実装することで、プロシージャに提供されるコンテキストに追加の値を設定できます。
 
-例として、APIの呼び出し元ユーザーの詳細を抽出するミドルウェアを`src/middleware/identity.ts`に実装します。
+例として、API の呼び出し元ユーザーの詳細を抽出するミドルウェアを `src/middleware/identity.ts` に実装します。
 
 まず、コンテキストに追加する内容を定義:
 
@@ -251,7 +250,9 @@ export interface IIdentityContext {
 }
 ```
 
-次にミドルウェアを実装:
+この追加の _オプショナル_ プロパティが正しく設定されたミドルウェアを持つプロシージャで確実に定義されるよう、tRPC が管理します。
+
+次に、ミドルウェア自体を実装。以下の構造を持ちます:
 
 ```ts
 export const createIdentityPlugin = () => {
@@ -267,6 +268,8 @@ export const createIdentityPlugin = () => {
    });
 };
 ```
+
+この例では、API Gateway イベントからユーザーの subject ID（"sub"）を抽出し、Cognito からユーザー詳細を取得します。実装は REST API と HTTP API で若干異なります:
 
 <Tabs>
 <TabItem label="REST">
@@ -305,6 +308,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
+      // Lambda 環境にユーザープールIDが設定されている前提
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -313,10 +317,11 @@ export const createIdentityPlugin = () => {
     if (!Users || Users.length !== 1) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `subjectId ${sub}のユーザーが見つかりません`,
+        message: `subjectId ${sub} のユーザーが見つかりません`,
       });
     }
 
+    // コンテキストに identity を提供
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -380,10 +385,11 @@ export const createIdentityPlugin = () => {
     if (!Users || Users.length !== 1) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `subjectId ${sub}のユーザーが見つかりません`,
+        message: `subjectId ${sub} のユーザーが見つかりません`,
       });
     }
 
+    // コンテキストに identity を提供
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -399,15 +405,16 @@ export const createIdentityPlugin = () => {
 </TabItem>
 </Tabs>
 
-## tRPC APIのデプロイ
+## tRPC API のデプロイ
 
-tRPCバックエンドジェネレータは`common/constructs`フォルダにAPIデプロイ用CDKコンストラクトを生成します。CDKアプリケーションで使用例:
+tRPC バックエンドジェネレータは `common/constructs` フォルダに API デプロイ用の CDK コンストラクトを生成します。CDK アプリケーションで使用できます:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
 
 export class ExampleStack extends Stack {
    constructor(scope: Construct, id: string) {
+      // API をスタックに追加
       const api = new MyApi(this, 'MyApi', {
         integrations: MyApi.defaultIntegrations(this).build(),
       });
@@ -415,35 +422,35 @@ export class ExampleStack extends Stack {
 }
 ```
 
-これにより、AWS API Gateway REST/HTTP API、ビジネスロジック用Lambda関数、IAM認証を含むAPIインフラが設定されます。
+これにより、AWS API Gateway REST/HTTP API、ビジネスロジック用 AWS Lambda 関数、IAM 認証を含む API インフラストラクチャが設定されます。
 
 ### 型安全な統合
 
 <Snippet name="api/type-safe-api-integrations" />
 
 :::tip
-tRPC APIでプロシージャを追加/削除すると、再ビルドなしでCDKコンストラクトに即時反映されます。
+tRPC API でプロシージャを追加/削除すると、再ビルドなしで CDK コンストラクトに即座に反映されます。
 :::
 
 ### アクセス権限付与
 
-`grantInvokeAccess`メソッドでAPIへのアクセス権限を付与できます。例: Cognito認証ユーザーへのアクセス許可:
+`grantInvokeAccess` メソッドで API へのアクセス権限を付与できます。例: 認証済み Cognito ユーザーに API アクセスを許可:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 ```
 
-## ローカルtRPCサーバー
+## ローカル tRPC サーバー
 
-`serve`ターゲットでローカルサーバーを起動:
+`serve` ターゲットを使用して API のローカルサーバーを実行できます:
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
-ローカルサーバーのエントリポイントは`src/local-server.ts`です。
+ローカルサーバーのエントリポイントは `src/local-server.ts` です。
 
-## tRPC APIの呼び出し
+## tRPC API の呼び出し
 
-型安全なtRPCクライアントを作成できます。別のバックエンドから呼び出す場合:
+型安全な方法で API を呼び出す tRPC クライアントを作成できます。他のバックエンドから API を呼び出す場合、`src/client/index.ts` のクライアントを使用できます:
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -453,8 +460,8 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-Reactウェブサイトから呼び出す場合は、<Link path="guides/api-connection/react-trpc">API接続</Link>ジェネレータを使用してクライアントを設定できます。
+React ウェブサイトから API を呼び出す場合は、クライアント設定のために <Link path="guides/api-connection/react-trpc">API 接続</Link> ジェネレータの使用を検討してください。
 
 ## 詳細情報
 
-tRPCの詳細は[tRPC公式ドキュメント](https://trpc.io/docs)を参照してください。
+tRPC の詳細については [tRPC ドキュメント](https://trpc.io/docs) を参照してください。

--- a/docs/src/content/docs/jp/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/jp/guides/ts-mcp-server.mdx
@@ -12,15 +12,15 @@ import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
-# TypeScript MCP サーバー ジェネレーター
+# TypeScript MCP サーバージェネレーター
 
 大規模言語モデル（LLM）にコンテキストを提供するためのTypeScript [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) サーバーを生成します。
 
 ## MCPとは
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) はAIアシスタントが外部ツールやリソースと連携するためのオープンスタンダードです。LLMが以下を実行するための統一的な方法を提供します：
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) は、AIアシスタントが外部ツールやリソースと相互作用するためのオープンスタンダードです。LLMが以下を行うための一貫した方法を提供します：
 
-- アクション実行や情報取得を行うツール（関数）の実行
+- アクションを実行または情報を取得するツール（関数）の実行
 - コンテキストやデータを提供するリソースへのアクセス
 
 ## 使用方法
@@ -33,7 +33,7 @@ TypeScript MCPサーバーは2つの方法で生成できます：
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## ジェネレーターの出力
 
@@ -42,7 +42,7 @@ TypeScript MCPサーバーは2つの方法で生成できます：
 <FileTree>
   - packages/\<name>/
     - README.md MCPサーバーのドキュメント（使用方法を含む）
-    - project.json Nxプロジェクト設定（build、bundle、devターゲット）
+    - project.json Nxプロジェクト設定（ビルド、バンドル、開発ターゲットを含む）
     - src/
       - index.ts MCPサーバーのエントリーポイント
       - server.ts メインサーバー定義（ツールとリソースの定義）
@@ -52,14 +52,14 @@ TypeScript MCPサーバーは2つの方法で生成できます：
 </FileTree>
 
 :::note
-詳細なジェネレーター出力については<Link path="/guides/typescript-project">TypeScriptプロジェクトジェネレーターのドキュメント</Link>を参照してください。
+ジェネレーター出力の詳細については、<Link path="/guides/typescript-project">TypeScriptプロジェクトジェネレータードキュメント</Link>を参照してください。
 :::
 
 ## MCPサーバーの操作
 
 ### ツールの追加
 
-ツールはAIアシスタントが呼び出せるアクション実行関数です。`server.ts`ファイルに新しいツールを追加できます：
+ツールはAIアシスタントが呼び出せる関数です。`server.ts`ファイルに新しいツールを追加できます：
 
 ```typescript
 server.tool("toolName",
@@ -104,7 +104,7 @@ MCPサーバーをAIアシスタントで使用するには、まずバンドル
 
 ### 設定ファイル
 
-MCPをサポートするAIアシスタントの多くは同様の設定方法を使用します。MCPサーバーの詳細を記載した設定ファイルを作成/更新する必要があります：
+MCPをサポートするほとんどのAIアシスタントは類似した設定方法を使用します。MCPサーバーの詳細を記載した設定ファイルを作成/更新する必要があります：
 
 ```json
 {
@@ -123,12 +123,12 @@ MCPをサポートするAIアシスタントの多くは同様の設定方法を
 `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js`は実際のバンドル済みMCPサーバーのパスに置き換えてください。
 
 :::caution
-サーバー接続時に`ENOENT node`エラーが発生する場合、ターミナルで`which node`を実行して取得したnodeのフルパスを指定する必要があるかもしれません。
+サーバー接続時に`ENOENT node`エラーが発生する場合、ターミナルで`which node`を実行して取得できるnodeの絶対パスを指定する必要があるかもしれません。
 :::
 
 ### アシスタント固有の設定
 
-各AIアシスタントのMCP設定方法については以下を参照してください：
+特定のAIアシスタントでMCPを設定するには、以下のドキュメントを参照してください：
 
 - [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
 - [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
@@ -136,18 +136,18 @@ MCPをサポートするAIアシスタントの多くは同様の設定方法を
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
 
 :::tip
-Amazon Q Developerなど、ワークスペースレベルでMCPサーバー設定を指定できるAIアシスタントもあります。特定プロジェクトに関連するMCPサーバーを定義するのに便利です。
+Amazon Q Developerなど一部のAIアシスタントは、ワークスペースレベルのMCPサーバー設定を指定可能で、特定プロジェクトに関連するMCPサーバーを定義する際に特に有用です。
 :::
 
 ## 開発ワークフロー
 
 ### ビルドターゲット
 
-このジェネレーターは<Link path="/guides/typescript-project">TypeScriptプロジェクトジェネレーター</Link>を基盤としており、そのターゲットを継承するとともに以下の追加ターゲットを提供します：
+このジェネレーターは<Link path="/guides/typescript-project">TypeScriptプロジェクトジェネレーター</Link>を基盤としており、そのターゲットを継承するとともに、以下の追加ターゲットを提供します：
 
 #### バンドル
 
-`bundle`タスクは[esbuild](https://esbuild.github.io/)を使用して、AIアシスタントで使用可能な単一のJavaScriptバンドルファイルを作成します：
+`bundle`タスクは[esbuild](https://esbuild.github.io/)を使用し、AIアシスタントで使用可能な単一のJavaScriptバンドルファイルを作成します：
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
@@ -159,7 +159,7 @@ Amazon Q Developerなど、ワークスペースレベルでMCPサーバー設�
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-開発時には特に有用で、AIアシスタントが常に最新版のMCPサーバーを使用できるようにします。
+開発中に特に有用で、AIアシスタントが常に最新版のMCPサーバーを使用することを保証します。
 
 :::note
 変更を反映するためにMCPサーバーの再起動を必要とするAIアシスタントもあります。

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -10,46 +10,45 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
-[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) は、コードでクラウドインフラストラクチャを定義し、AWS CloudFormation を通じてプロビジョニングするためのフレームワークです。
+[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) はクラウドインフラストラクチャをコードで定義し、AWS CloudFormation を通じてプロビジョニングするフレームワークです。
 
-TypeScript インフラストラクチャジェネレーターは、TypeScript で記述された AWS CDK インフラストラクチャアプリケーションを作成します。生成されたアプリケーションには [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html) チェックによるセキュリティベストプラクティスが含まれています。
+TypeScript インフラストラクチャジェネレータは、TypeScript で記述された AWS CDK インフラストラクチャアプリケーションを作成します。生成されたアプリケーションには [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html) チェックによるセキュリティベストプラクティスが含まれます。
 
 ## 使用方法
 
 ### インフラストラクチャプロジェクトの生成
 
-新しいインフラストラクチャプロジェクトは2つの方法で生成できます：
+新しいインフラストラクチャプロジェクトは2つの方法で生成できます:
 
 <RunGenerator generator="ts#infra" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
-## ジェネレーターの出力
+## ジェネレータの出力結果
 
-ジェネレーターは `<directory>/<name>` ディレクトリに以下のプロジェクト構造を作成します：
+ジェネレータは `<directory>/<name>` ディレクトリに以下のプロジェクト構造を作成します:
 
 <FileTree>
 
   - src
-    - main.ts CDKスタックをインスタンス化してデプロイするアプリケーションエントリーポイント
-    - stacks CDKスタック定義
+    - main.ts CDK スタックをインスタンス化してデプロイするアプリケーションエントリポイント
+    - stacks CDK スタック定義
       - application-stack.ts メインアプリケーションスタック
-  - cdk.json CDK設定ファイル
+  - cdk.json CDK 設定ファイル
   - project.json プロジェクト設定とビルドターゲット
 
 </FileTree>
 
 :::tip
-インフラストラクチャはTypeScriptプロジェクトです。一般的な使用方法の詳細については <Link path="guides/typescript-project">TypeScriptプロジェクトドキュメント</Link> を参照してください。
+インフラストラクチャは TypeScript プロジェクトですので、一般的な使用方法の詳細については <Link path="guides/typescript-project">TypeScript プロジェクトドキュメント</Link> を参照してください。
 :::
 
-## CDKインフラストラクチャの実装
+## CDK インフラストラクチャの実装
 
-`src/stacks/application-stack.ts` 内でCDKインフラストラクチャの実装を開始できます。例：
+`src/stacks/application-stack.ts` 内で CDK インフラストラクチャの記述を開始できます。例:
 
 ```ts title="src/stacks/application-stack.ts" {9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -66,11 +65,11 @@ export class ApplicationStack extends cdk.Stack {
 }
 ```
 
-### APIインフラストラクチャ
+### API インフラストラクチャ
 
-<Link path="guides/trpc">tRPC API</Link> または <Link path="guides/fastapi">FastAPI</Link> ジェネレーターを使用してAPIを作成した場合、`packages/common/constructs` にデプロイ用のコンストラクトが既に存在することに気付くでしょう。
+<Link path="guides/trpc">tRPC API</Link> または <Link path="guides/fastapi">FastAPI</Link> ジェネレータを使用して API を作成した場合、`packages/common/constructs` にそれらをデプロイするためのコンストラクトが既に存在します。
 
-例えば `my-api` という名前のtRPC APIを作成した場合、コンストラクトをインポートしてインスタンス化するだけで必要なインフラストラクチャを追加できます：
+例えば `my-api` という名前の tRPC API を作成した場合、コンストラクトをインポートしてインスタンス化するだけで必要なインフラストラクチャを追加できます:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -81,7 +80,7 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // API用のインフラストラクチャを追加
+    // API のインフラストラクチャを追加
     new MyApi(this, 'MyApi');
   }
 }
@@ -89,7 +88,7 @@ export class ApplicationStack extends cdk.Stack {
 
 ### ウェブサイトインフラストラクチャ
 
-<Link path="guides/cloudscape-website">CloudScapeウェブサイト</Link> ジェネレーターを使用した場合、`packages/common/constructs` にデプロイ用のコンストラクトが既に存在します。例：
+<Link path="guides/cloudscape-website">CloudScape ウェブサイト</Link> ジェネレータを使用した場合、`packages/common/constructs` にデプロイ用のコンストラクトが存在します。例:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -100,66 +99,66 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // ウェブサイト用のインフラストラクチャを追加
+    // ウェブサイトのインフラストラクチャを追加
     new MyWebsite(this, 'MyWebsite');
   }
 }
 ```
 
 :::warning
-ウェブサイトの <Link path="guides/cloudscape-website#runtime-configuration">ランタイム設定</Link> にすべてのAPI設定を含めるためには、APIコンストラクトの「後」にウェブサイトを宣言することが重要です。
+ウェブサイトの <Link path="guides/cloudscape-website#runtime-configuration">ランタイム設定</Link> にすべての API 設定を含めるためには、API コンストラクトの「後」にウェブサイトを宣言することが重要です。
 :::
 
 ## インフラストラクチャの合成
 
-`build` ターゲットの一環として、<Link path="guides/typescript-project#building">デフォルトのコンパイル、リンター、テストターゲット</Link> を実行するのに加え、インフラストラクチャプロジェクトをCloudFormationに合成します。これは `synth` ターゲットを実行することで単体でも実行できます：
+`build` ターゲットの一部として、<Link path="guides/typescript-project#building">デフォルトのコンパイル、リンター、テストターゲット</Link> を実行するのに加え、インフラストラクチャプロジェクトを CloudFormation に「合成」します。これは `synth` ターゲットを実行することで単独でも実行可能です:
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
 合成されたクラウドアセンブリはルートの `dist` フォルダ内の `dist/packages/<my-infra-project>/cdk.out` に配置されます。
 
-## AWSアカウントのブートストラップ
+## AWS アカウントのブートストラップ
 
-AWSアカウントに初めてCDKアプリケーションをデプロイする場合、事前にブートストラップが必要です。
+AWS アカウントに初めて CDK アプリケーションをデプロイする場合、事前にブートストラップが必要です。
 
-まず [AWSアカウントの認証情報を設定](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) してください。
+まず [AWS アカウントの認証情報を設定](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) してください。
 
-次に `cdk bootstrap` コマンドを使用します：
+次に `cdk bootstrap` コマンドを使用します:
 
 ```bash
 npx cdk bootstrap aws://<account-id>/<region>
 ```
 
-詳細については [CDKドキュメント](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html) を参照してください。
+詳細は [CDK ドキュメント](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html) を参照してください。
 
-## AWSへのデプロイ
+## AWS へのデプロイ
 
-ビルド後、`deploy` ターゲットを使用してインフラストラクチャをAWSにデプロイできます：
+ビルド後、`deploy` ターゲットを使用してインフラストラクチャを AWS にデプロイできます。
 
 :::caution
-CI/CDパイプラインでのデプロイには `deploy-ci` ターゲットを使用してください。詳細は後述します。
+CI/CD パイプラインでのデプロイには `deploy-ci` ターゲットを使用してください。詳細は後述します。
 :::
 
-まず [AWSアカウントの認証情報を設定](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) してください。
+まず [AWS アカウントの認証情報を設定](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) してください。
 
-次にデプロイターゲットを実行します：
+次にデプロイターゲットを実行します:
 
 <NxCommands commands={['run <my-infra>:deploy --all']} />
 
 :::tip
-上記のコマンドは `main.ts` で定義されたすべてのスタックをデプロイします。特にアプリケーションの複数ステージを設定している場合、個別のスタックを指定できます：
+上記のコマンドは `main.ts` で定義されたすべてのスタックをデプロイします。特にアプリケーションの複数ステージを構成している場合など、個別のスタックを対象にしたい場合があります:
 
 <NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
 :::
 
-## CI/CDパイプラインでのAWSデプロイ
+## CI/CD パイプラインでの AWS デプロイ
 
-CI/CDパイプラインの一環としてAWSにデプロイする場合は `deploy-ci` ターゲットを使用してください：
+CI/CD パイプラインの一部として AWS にデプロイする場合は `deploy-ci` ターゲットを使用します。
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-このターゲットは通常の `deploy` ターゲットと異なり、事前合成されたクラウドアセンブリを使用してデプロイします。これによりパッケージバージョンの変更に伴う非決定性の問題を回避し、すべてのパイプラインステージで同一のクラウドアセンブリを使用してデプロイできます。
+このターゲットは通常の `deploy` ターゲットと異なり、事前に合成されたクラウドアセンブリをデプロイすることを保証します。これによりパッケージバージョンの変更に伴う非決定性の問題を回避し、すべてのパイプラインステージで同じクラウドアセンブリを使用してデプロイできます。
 
 ## 追加情報
 
-CDKの詳細については [CDK開発者ガイド](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) と [APIリファレンス](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html) を参照してください。
+CDK の詳細については [CDK 開発者ガイド](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) と [API リファレンス](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html) を参照してください。

--- a/docs/src/content/docs/jp/guides/typescript-project.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-project.mdx
@@ -10,21 +10,20 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
-TypeScriptプロジェクトジェネレータは、[ECMAScript Modules（ESM）](https://www.typescriptlang.org/docs/handbook/modules/reference.html)、TypeScriptの[プロジェクト参照](https://www.typescriptlang.org/docs/handbook/project-references.html)、テスト実行用の[Vitest](https://vitest.dev/)、静的解析用の[ESLint](https://eslint.org/)など、ベストプラクティスで構成されたモダンな[TypeScript](https://www.typescriptlang.org/)ライブラリやアプリケーションを作成するために使用できます。
+TypeScriptプロジェクトジェネレータは、[ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html)、TypeScript [プロジェクトリファレンス](https://www.typescriptlang.org/docs/handbook/project-references.html)、テスト実行用の[Vitest](https://vitest.dev/)、静的解析用の[ESLint](https://eslint.org/)など、ベストプラクティスで構成されたモダンな[TypeScript](https://www.typescriptlang.org/)ライブラリやアプリケーションの作成に使用できます。
 
 ## 使用方法
 
 ### TypeScriptプロジェクトの生成
 
-新しいTypeScriptプロジェクトを2つの方法で生成できます：
+新しいTypeScriptプロジェクトは2つの方法で生成できます：
 
 <RunGenerator generator="ts#project" />
 
 ### オプション
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## ジェネレータの出力
 
@@ -32,59 +31,59 @@ TypeScriptプロジェクトジェネレータは、[ECMAScript Modules（ESM）
 
 <FileTree>
 
-  - src TypeScriptのソースコード
+  - src TypeScriptソースコード
     - index.ts
   - project.json プロジェクト設定とビルドターゲット
-  - tsconfig.json このプロジェクト用の基本TypeScript設定（ワークスペースルートのtsconfig.base.jsonを継承）
-  - tsconfig.lib.json ライブラリ用TypeScript設定（ランタイムまたはパッケージ化されたソース）
+  - tsconfig.json プロジェクトの基本TypeScript設定（ワークスペースルートのtsconfig.base.jsonを継承）
+  - tsconfig.lib.json ライブラリ用TypeScript設定（ランタイムまたはパッケージ化ソース）
   - tsconfig.spec.json テスト用TypeScript設定
-  - vite.config.ts Vitestの設定
-  - eslint.config.mjs ESLintの設定
+  - vite.config.ts Vitest設定
+  - eslint.config.mjs ESLint設定
 
 </FileTree>
 
 :::tip
-`package.json`ファイルが作成されないことに注意してください！理由は[後述](#dependencies)で説明します。
+`package.json`ファイルが作成されていないことに注目してください！理由は[後述](#dependencies)で説明します。
 :::
 
 ワークスペースルートの以下のファイルにも変更が加えられます：
 
 <FileTree>
 
-  - nx.json Nx設定が更新され、プロジェクトに@nx/js/typescriptプラグインが構成されます
-  - tsconfig.base.json ワークスペース内の他のプロジェクトからインポート可能にするため、プロジェクトのTypeScriptエイリアスが設定されます
-  - tsconfig.json プロジェクトのTypeScriptプロジェクト参照が追加されます
+  - nx.json @nx/js/typescriptプラグインの設定が更新されます
+  - tsconfig.base.json ワークスペース内の他プロジェクトからインポート可能にするTypeScriptエイリアスが設定されます
+  - tsconfig.json プロジェクトリファレンスが追加されます
 
 </FileTree>
 
-## TypeScriptソースコードの記述
+## TypeScriptソースコードの作成
 
 TypeScriptコードは`src`ディレクトリに追加します。
 
 ### ESMインポート構文
 
-TypeScriptプロジェクトはESモジュールであるため、インポート文ではファイル拡張子を明示的に指定する必要があります：
+TypeScriptプロジェクトはESモジュールであるため、ファイル拡張子を明示的に指定した正しいESM構文でインポート文を作成してください：
 
 ```ts title="index.ts" ".js"
 import { sayHello } from './hello.js';
 ```
 
 :::note
-TypeScriptを使用していても、`sayHello`が`hello.ts`で定義されている場合、インポートでは`.js`ファイル拡張子を使用します。詳細は[こちら](https://www.typescriptlang.org/docs/handbook/modules/reference.html)をご覧ください。
+TypeScriptを使用していても、`sayHello`が`hello.ts`で定義されている場合、インポートでは`.js`ファイル拡張子を使用します。詳細は[こちら](https://www.typescriptlang.org/docs/handbook/modules/reference.html)で確認できます。
 :::
 
-### 他のTypeScriptプロジェクト向けのエクスポート
+### 他TypeScriptプロジェクト向けのエクスポート
 
-TypeScriptプロジェクトのエントリポイントは`src/index.ts`です。他のプロジェクトからインポート可能にする要素はここでエクスポートできます：
+TypeScriptプロジェクトのエントリポイントは`src/index.ts`です。他プロジェクトからインポート可能にする要素はここでエクスポートできます：
 
 ```ts title="src/index.ts"
 export { sayHello } from './hello.js';
 export * from './algorithms/index.js';
 ```
 
-### 他のプロジェクトでのライブラリコードのインポート
+### 他プロジェクトでのライブラリコードのインポート
 
-ワークスペースの`tsconfig.base.json`で設定された[TypeScriptエイリアス](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths)により、他のTypeScriptプロジェクトからプロジェクトを参照できます：
+ワークスペースの`tsconfig.base.json`で設定されたTypeScriptエイリアスを使用して、他TypeScriptプロジェクトから参照できます：
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
@@ -94,7 +93,7 @@ import { sayHello } from ':my-scope/my-library';
 TypeScriptプロジェクトのエイリアスは従来の`@`ではなく`:`で始まります。これにより、ワークスペース内のローカルパッケージと[NPM](https://www.npmjs.com/)のリモートパッケージ間での名前衝突を防ぎます。
 :::
 
-ワークスペースで新しいプロジェクトのインポート文を初めて追加する際、以下のようなエラーがIDEに表示される場合があります：
+ワークスペース内の新しいプロジェクトを初めてインポートする場合、以下のようなIDEエラーが表示される可能性があります：
 
 <details>
 <summary>インポートエラー</summary>
@@ -108,16 +107,16 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 </details>
 
-これは[プロジェクト参照](https://www.typescriptlang.org/docs/handbook/project-references.html)が設定されていないためです。
+これは[プロジェクトリファレンス](https://www.typescriptlang.org/docs/handbook/project-references.html)が設定されていないためです。
 
-Nx TypeScript Syncジェネレータがデフォルトで構成されているため、手動での設定は不要です。以下のコマンドを実行すると必要な構成が追加されます：
+Nx TypeScript Syncジェネレータが自動的に設定を行うため、手動での設定は不要です。以下のコマンドを実行してください：
 
 <NxCommands commands={['sync']} />
 
-これによりIDEのエラーが解消され、ライブラリを使用できるようになります。
+これによりIDEエラーが解消され、ライブラリを使用できるようになります。
 
 :::tip
-プロジェクトをビルドするだけで、以下のようなメッセージが表示される場合もあります：
+プロジェクトをビルドする際、以下のようなメッセージが表示される場合もあります：
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -129,22 +128,22 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-`Yes`を選択するとNxがプロジェクト参照を更新します。
+`Yes`を選択するとNxがプロジェクトリファレンスを更新します。
 :::
 
 ### 依存関係
 
-TypeScriptプロジェクトに`package.json`ファイルが存在しないことに気付くかもしれません。これは従来のTypeScriptモノレポとは異なる点です。
+TypeScriptプロジェクトに`package.json`ファイルが存在しない点に驚かれるかもしれません。これは従来のTypeScriptモノレポとは異なる仕様です。
 
-モノレポ内のTypeScriptパッケージに依存関係を追加するには、ワークスペースルートの`package.json`に依存関係を追加します。パッケージマネージャのコマンドラインから追加できます：
+依存関係を追加するには、ワークスペースルートの`package.json`に追加します。パッケージマネージャのコマンドラインを使用できます：
 
 <InstallCommand pkg="some-npm-package" />
 
-これにより、ワークスペース内のすべてのTypeScriptプロジェクトで依存関係が利用可能になります。
+これにより、ワークスペース内の全TypeScriptプロジェクトで依存関係が利用可能になります。
 
 #### ランタイムコード
 
-TypeScriptプロジェクトをランタイムコード（例：AWS Lambda関数のハンドラ）として使用する場合、[`esbuild`](https://esbuild.github.io/)のようなツールを使用してプロジェクトをバンドルすることを推奨します。これにより[ツリーシェイキング](https://esbuild.github.io/api/#tree-shaking)が行われ、実際に参照されている依存関係のみが含まれます。
+TypeScriptプロジェクトをランタイムコード（例：AWS Lambda関数のハンドラ）として使用する場合、[`esbuild`](https://esbuild.github.io/)などのツールでバンドルすることを推奨します。これにより[ツリーシェイキング](https://esbuild.github.io/api/#tree-shaking)が行われ、実際に使用される依存関係のみが含まれます。
 
 `project.json`ファイルに以下のようなターゲットを追加できます：
 
@@ -171,9 +170,9 @@ TypeScriptプロジェクトをランタイムコード（例：AWS Lambda関数
 
 #### NPMへの公開
 
-TypeScriptプロジェクトをNPMに公開する場合、`package.json`ファイルを作成する必要があります。
+TypeScriptプロジェクトをNPMに公開する場合は、`package.json`ファイルを作成する必要があります。
 
-このファイルにはプロジェクトが参照する依存関係を宣言する必要があります。ビルド時にはワークスペースルートの`package.json`経由で依存関係が解決されるため、[Nx Dependency Checks ESLint Plugin](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks)を設定し、公開するプロジェクトの`package.json`にすべての依存関係が含まれるようにすることを推奨します。
+このファイルにはプロジェクトが参照する依存関係を宣言する必要があります。ビルド時にワークスペースルートの`package.json`から依存関係が解決されるため、[Nx Dependency Checks ESLint Plugin](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks)を設定し、公開用`package.json`に必要な依存関係がすべて含まれるようにすることを推奨します。
 
 ### ビルド
 
@@ -183,17 +182,17 @@ TypeScriptプロジェクトには`build`ターゲット（`project.json`で定�
 
 `<project-name>`はプロジェクトの完全修飾名です。
 
-`build`ターゲットはプロジェクトのコンパイル、リント、テストを実行します。
+`build`ターゲットはプロジェクトのコンパイル、リンティング、テストを実行します。
 
 ビルド出力はワークスペースルートの`dist`フォルダ内（例：`dist/packages/<my-library>/tsc`）に生成されます。
 
 ## テスト
 
-[Vitest](https://vitest.dev/)がプロジェクトのテスト用に設定されています。
+[Vitest](https://vitest.dev/)がテスト実行用に設定されています。
 
-### テストの記述
+### テストの作成
 
-テストは`.spec.ts`または`.test.ts`ファイルに記述し、プロジェクトの`src`フォルダに配置します。
+テストは`.spec.ts`または`.test.ts`ファイルに記述し、プロジェクトの`src`ディレクトリに配置します。
 
 例：
 
@@ -203,7 +202,7 @@ TypeScriptプロジェクトには`build`ターゲット（`project.json`で定�
     - hello.spec.ts hello.tsのテスト
 </FileTree>
 
-Vitestは`describe`、`it`、`test`、`expect`などのJest風の構文を提供します。
+Vitestは`describe`、`it`、`test`、`expect`など、Jest風の構文を提供します。
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
@@ -215,13 +214,14 @@ describe('sayHello', () => {
   });
 
 });
+
 ```
 
-テストの記述方法やモックの作成など詳細は[Vitestドキュメント](https://vitest.dev/guide/#writing-tests)を参照してください。
+テストの作成方法やモック機能などの詳細は[Vitestドキュメント](https://vitest.dev/guide/#writing-tests)を参照してください。
 
 ### テストの実行
 
-テストはプロジェクトの`build`ターゲットの一部として実行されますが、`test`ターゲットを個別に実行することもできます：
+テストは`build`ターゲットの一部として実行されますが、`test`ターゲットで個別に実行することも可能です：
 
 <NxCommands commands={['run <project-name>:test']} />
 
@@ -230,26 +230,26 @@ describe('sayHello', () => {
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-VSCodeユーザーには[Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)拡張機能のインストールを推奨します。IDEからテストの実行・監視・デバッグが可能になります。
+VSCodeユーザーには、テストの実行・監視・デバッグが可能な[Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)拡張機能のインストールを推奨します。
 :::
 
 ## リンティング
 
 TypeScriptプロジェクトではリンティングに[ESLint](https://eslint.org/)、フォーマットに[Prettier](https://prettier.io/)を使用します。
 
-ワークスペースルートの`eslint.config.mjs`ファイルでESLintを構成することを推奨します。これにより変更がすべてのTypeScriptプロジェクトに適用され、一貫性が保たれます。
+ESLintの設定はワークスペースルートの`eslint.config.mjs`ファイルで行うことを推奨します。これによりワークスペース内の全TypeScriptプロジェクトに設定が適用され、一貫性が保たれます。
 
-同様に、Prettierはルートの`.prettierrc`ファイルで構成できます。
+Prettierの設定もルートの`.prettierrc`ファイルで行えます。
 
 ### リンターの実行
 
-プロジェクトのリンティングチェックを行うには`lint`ターゲットを実行します：
+プロジェクトのリンティングチェックは`lint`ターゲットで実行できます：
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
 ### リント問題の修正
 
-ほとんどのリンティングやフォーマットの問題は自動修正可能です。`--configuration=fix`引数を付けてESLintを実行します：
+ほとんどのリンティングやフォーマットの問題は自動修正可能です。`--configuration=fix`引数を付けて実行します：
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 

--- a/docs/src/content/docs/ko/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/api-connection/react-fastapi.mdx
@@ -11,16 +11,15 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-`api-connection` 제너레이터는 React 웹사이트와 FastAPI 백엔드의 통합을 빠르게 설정할 수 있는 방법을 제공합니다. 타입 안전성을 보장하는 방식으로 FastAPI 백엔드 연결에 필요한 모든 구성을 설정하며, 클라이언트 및 [TanStack Query](https://tanstack.com/query/v5) 훅 생성, AWS IAM 인증 지원, 적절한 오류 처리 등을 포함합니다.
+`api-connection` 제너레이터는 React 웹사이트와 FastAPI 백엔드의 통합을 빠르게 설정할 수 있는 방법을 제공합니다. 타입 세이프 방식의 클라이언트 및 [TanStack Query](https://tanstack.com/query/v5) 훅 생성, AWS IAM 인증 지원, 적절한 오류 처리를 포함해 FastAPI 백엔드 연결에 필요한 모든 구성을 설정합니다.
 
-## 사전 요구사항
+## 필수 조건
 
 이 제너레이터를 사용하기 전에 React 애플리케이션이 다음을 갖추었는지 확인하세요:
 
 1. 애플리케이션을 렌더링하는 `main.tsx` 파일
-2. 작동 중인 FastAPI 백엔드 (FastAPI 제너레이터로 생성된 것)
+2. 작동하는 FastAPI 백엔드(FastAPI 제너레이터로 생성된 것)
 
 <details>
 <summary>필요한 `main.tsx` 구조 예시</summary>
@@ -50,21 +49,21 @@ root.render(
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## 제너레이터 출력
 
-제너레이터는 FastAPI 프로젝트의 다음 파일들을 변경합니다:
+제너레이터는 FastAPI 프로젝트의 다음 파일들을 수정합니다:
 
 <FileTree>
 
 - scripts
-  - generate_open_api.py API용 OpenAPI 명세를 생성하는 스크립트 추가
-- project.json 위 생성 스크립트를 호출하는 새로운 빌드 타겟 추가
+  - generate_open_api.py API의 OpenAPI 명세를 생성하는 스크립트 추가
+- project.json 위 생성 스크립트를 호출하는 새 빌드 타겟 추가
 
 </FileTree>
 
-제너레이터는 React 애플리케이션의 다음 파일들을 변경합니다:
+제너레이터는 React 애플리케이션의 다음 파일들을 수정합니다:
 
 <FileTree>
 
@@ -74,10 +73,10 @@ root.render(
     - QueryClientProvider.tsx TanStack React Query 클라이언트 제공자
   - hooks
     - use\<ApiName>.tsx TanStack Query로 상태 관리되는 API 호출 훅 추가
-    - use\<ApiName>Client.tsx 기본 API 클라이언트 인스턴스화 훅 추가
+    - use\<ApiName>Client.tsx 기본 API 클라이언트 인스턴스 생성 훅 추가
     - useSigV4.tsx IAM 인증 선택 시 SigV4로 HTTP 요청 서명 훅 추가
-- project.json 타입 안전 클라이언트 생성하는 새로운 빌드 타겟 추가
-- .gitignore 기본적으로 생성된 클라이언트 파일 버전 관리 제외
+- project.json 타입 세이프 클라이언트 생성 새 빌드 타겟 추가
+- .gitignore 기본적으로 생성된 클라이언트 파일 무시
 
 </FileTree>
 
@@ -85,26 +84,26 @@ root.render(
 
 ### 코드 생성
 
-빌드 시점에 FastAPI의 OpenAPI 명세로부터 타입 안전 클라이언트가 생성됩니다. 이는 React 애플리케이션에 세 개의 새 파일을 추가합니다:
+빌드 시 FastAPI의 OpenAPI 명세에서 타입 세이프 클라이언트가 생성됩니다. 이는 React 애플리케이션에 세 개의 새 파일을 추가합니다:
 
 <FileTree>
 
 - src
   - generated
     - \<ApiName>
-      - types.gen.ts FastAPI에 정의된 pydantic 모델에서 생성된 타입
-      - client.gen.ts API 호출용 타입 안전 클라이언트
+      - types.gen.ts FastAPI의 pydantic 모델에서 생성된 타입
+      - client.gen.ts API 호출용 타입 세이프 클라이언트
       - options-proxy.gen.ts TanStack Query 훅 옵션 생성 메서드 제공
 
 </FileTree>
 
 :::tip
-기본적으로 생성된 클라이언트는 버전 관리에서 제외됩니다. 버전 관리를 원한다면 React 애플리케이션의 `.gitignore`에서 해당 항목을 제거할 수 있지만, `.gen.ts` 파일을 수동으로 수정하면 프로젝트 빌드 시 덮어쓰여질 수 있습니다.
+기본적으로 생성된 클라이언트는 버전 관리에서 제외됩니다. 버전 관리를 원한다면 React 애플리케이션의 `.gitignore`에서 해당 항목을 제거할 수 있지만, `.gen.ts` 파일을 수동으로 수정하면 프로젝트 빌드 시 덮어쓰여집니다.
 :::
 
 ## 생성된 코드 사용
 
-생성된 타입 안전 클라이언트를 사용하여 React 애플리케이션에서 FastAPI를 호출할 수 있습니다. TanStack Query 훅을 통해 클라이언트를 사용하는 것이 권장되지만, 기본 클라이언트를 직접 사용할 수도 있습니다.
+생성된 타입 세이프 클라이언트로 React 애플리케이션에서 FastAPI를 호출할 수 있습니다. TanStack Query 훅을 통해 클라이언트를 사용하는 것이 권장되지만, 기본 클라이언트도 직접 사용 가능합니다.
 
 :::note
 FastAPI를 변경할 때마다 생성된 클라이언트에 반영하려면 프로젝트를 재빌드해야 합니다. 예시:
@@ -113,7 +112,7 @@ FastAPI를 변경할 때마다 생성된 클라이언트에 반영하려면 프�
 :::
 
 :::tip
-React 애플리케이션과 FastAPI를 동시에 개발 중이라면 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch)를 사용하여 API 변경 시마다 클라이언트를 재생성할 수 있습니다:
+React 애플리케이션과 FastAPI를 동시에 개발 중이라면 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch)를 사용해 API 변경 시마다 클라이언트를 재생성할 수 있습니다:
 
 <NxCommands
   commands={[
@@ -125,11 +124,11 @@ React 애플리케이션과 FastAPI를 동시에 개발 중이라면 [`nx watch`
 
 ### API 훅 사용
 
-제너레이터는 TanStack Query로 API를 호출할 수 있는 `use<ApiName>` 훅을 제공합니다.
+제너레이터는 TanStack Query로 API를 호출하는 `use<ApiName>` 훅을 제공합니다.
 
 ### 쿼리
 
-`queryOptions` 메서드를 사용하여 TanStack Query의 `useQuery` 훅에 필요한 옵션을 검색할 수 있습니다:
+`queryOptions` 메서드를 사용해 TanStack Query의 `useQuery` 훅에 필요한 옵션을 검색할 수 있습니다:
 
 ```tsx {7}
 import { useQuery } from '@tanstack/react-query';
@@ -147,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="기본 API 클라이언트 직접 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
+<Drawer title="기본 클라이언트 직접 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -182,7 +181,7 @@ function MyComponent() {
 
 ### 뮤테이션
 
-생성된 훅은 TanStack Query의 `useMutation` 훅을 사용한 뮤테이션 처리를 지원합니다. 로딩 상태, 오류 처리, 낙관적 업데이트를 포함한 생성, 업데이트, 삭제 작업을 깔끔하게 처리할 수 있습니다.
+생성된 훅은 TanStack Query의 `useMutation` 훅을 사용한 뮤테이션 지원을 포함합니다. 로딩 상태, 오류 처리, 낙관적 업데이트로 생성, 업데이트, 삭제 작업을 처리하는 깔끔한 방법을 제공합니다.
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -205,18 +204,18 @@ function CreateItemForm() {
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Creating...' : 'Create Item'}
+        {createItem.isPending ? '생성 중...' : '아이템 생성'}
       </button>
 
       {createItem.isSuccess && (
         <div className="success">
-          Item created with ID: {createItem.data.id}
+          생성된 아이템 ID: {createItem.data.id}
         </div>
       )}
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          오류: {createItem.error.message}
         </div>
       )}
     </form>
@@ -230,19 +229,24 @@ function CreateItemForm() {
 const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
-    console.log('Item created:', data);
+    // 뮤테이션 성공 시 실행
+    console.log('생성된 아이템:', data);
+    // 새 아이템 페이지로 이동
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
-    console.error('Failed to create item:', error);
+    // 뮤테이션 실패 시 실행
+    console.error('아이템 생성 실패:', error);
   },
   onSettled: () => {
+    // 뮤테이션 완료 시 실행(성공/실패 모두)
+    // 영향 받을 수 있는 쿼리 무효화
     queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
   }
 });
 ```
 
-<Drawer title="기본 클라이언트로 뮤테이션 처리" trigger="기본 클라이언트 직접 사용 예시 보기">
+<Drawer title="기본 클라이언트로 뮤테이션 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
 ```tsx
 import { useState } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -264,9 +268,11 @@ function CreateItemForm() {
         description: 'A new item'
       });
       setCreatedItem(newItem);
+      // 새 아이템 페이지로 이동
+      // navigate(`/items/${newItem.id}`);
     } catch (err) {
       setError(err);
-      console.error('Failed to create item:', err);
+      console.error('아이템 생성 실패:', err);
     } finally {
       setIsLoading(false);
     }
@@ -279,18 +285,18 @@ function CreateItemForm() {
         type="submit"
         disabled={isLoading}
       >
-        {isLoading ? 'Creating...' : 'Create Item'}
+        {isLoading ? '생성 중...' : '아이템 생성'}
       </button>
 
       {createdItem && (
         <div className="success">
-          Item created with ID: {createdItem.id}
+          생성된 아이템 ID: {createdItem.id}
         </div>
       )}
 
       {error && (
         <div className="error">
-          Error: {error.message}
+          오류: {error.message}
         </div>
       )}
     </form>
@@ -299,9 +305,9 @@ function CreateItemForm() {
 ```
 </Drawer>
 
-### 무한 쿼리 페이징
+### 무한 쿼리 페이지네이션
 
-`cursor` 파라미터를 입력으로 받는 엔드포인트의 경우, TanStack Query의 `useInfiniteQuery` 훅을 사용한 무한 쿼리 지원이 제공됩니다. "더 보기"나 무한 스크롤 기능 구현이 용이합니다.
+`cursor` 파라미터를 입력으로 받는 엔드포인트의 경우, TanStack Query의 `useInfiniteQuery` 훅을 사용한 무한 쿼리 지원을 제공합니다. "더 보기"나 무한 스크롤 기능 구현이 용이합니다.
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -311,8 +317,9 @@ function ItemList() {
   const api = useMyApi();
   const items = useInfiniteQuery({
     ...api.listItems.infiniteQueryOptions({
-      limit: 10,
+      limit: 10, // 페이지당 아이템 수
     }, {
+      // 다음 페이지 파라미터 반환 함수 정의
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor || undefined
       }),
@@ -328,6 +335,7 @@ function ItemList() {
 
   return (
     <div>
+      {/* 모든 아이템 렌더링을 위해 페이지 배열 평탄화 */}
       <ul>
         {items.data.pages.flatMap(page =>
           page.items.map(item => (
@@ -341,23 +349,23 @@ function ItemList() {
         disabled={!items.hasNextPage || items.isFetchingNextPage}
       >
         {items.isFetchingNextPage
-          ? 'Loading more...'
+          ? '더 불러오는 중...'
           : items.hasNextPage
-          ? 'Load More'
-          : 'No more items'}
+          ? '더 보기'
+          : '더 이상 없음'}
       </button>
     </div>
   );
 }
 ```
 
-생성된 훅은 API가 커서 기반 페이징을 지원할 경우 자동으로 처리합니다. `nextCursor` 값이 응답에서 추출되어 다음 페이지 호출에 사용됩니다.
+생성된 훅은 API가 커서 기반 페이지네이션을 지원하면 자동으로 처리합니다. 응답에서 `nextCursor` 값을 추출해 다음 페이지 호출에 사용합니다.
 
 :::tip
-페이징 파라미터 이름이 `cursor`가 아닌 경우 [`x-cursor` OpenAPI 벤더 확장](#custom-pagination-cursor)으로 커스터마이징 가능합니다.
+`cursor` 이외의 이름으로 페이지네이션 파라미터를 사용하는 경우 [`x-cursor` OpenAPI 벤더 확장으로 커스터마이즈](#custom-pagination-cursor) 가능합니다.
 :::
 
-<Drawer title="기본 클라이언트로 페이징 처리" trigger="기본 클라이언트 직접 사용 예시 보기">
+<Drawer title="기본 클라이언트로 페이지네이션 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -370,6 +378,7 @@ function ItemList() {
   const [nextCursor, setNextCursor] = useState(null);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
+  // 초기 데이터 로드
   useEffect(() => {
     const fetchItems = async () => {
       try {
@@ -387,6 +396,7 @@ function ItemList() {
     fetchItems();
   }, [api]);
 
+  // 더보기 함수
   const loadMore = async () => {
     if (!nextCursor) return;
 
@@ -406,8 +416,13 @@ function ItemList() {
     }
   };
 
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <ErrorMessage message={error.message} />;
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error.message} />;
+  }
 
   return (
     <div>
@@ -422,10 +437,10 @@ function ItemList() {
         disabled={!nextCursor || isFetchingMore}
       >
         {isFetchingMore
-          ? 'Loading more...'
+          ? '더 불러오는 중...'
           : nextCursor
-          ? 'Load More'
-          : 'No more items'}
+          ? '더 보기'
+          : '더 이상 없음'}
       </button>
     </div>
   );
@@ -435,7 +450,7 @@ function ItemList() {
 
 ### 오류 처리
 
-통합에는 타입이 지정된 오류 응답 처리 기능이 내장되어 있습니다. OpenAPI 명세에 정의된 가능한 오류 응답을 캡슐화하는 `<operation-name>Error` 타입이 생성됩니다. 각 오류는 `status`와 `error` 속성을 가지며, `status` 값을 확인하여 특정 오류 유형을 구분할 수 있습니다.
+통합에는 타입이 지정된 오류 응답이 포함됩니다. OpenAPI 명세에 정의된 가능한 오류 응답을 캡슐화하는 `<operation-name>Error` 타입이 생성됩니다. 각 오류는 `status`와 `error` 속성을 가지며, `status` 값을 확인해 특정 오류 유형으로 좁힐 수 있습니다.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -451,9 +466,10 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
+        // error.error는 CreateItem400Response 타입
         return (
           <div>
-            <h2>Invalid input:</h2>
+            <h2>잘못된 입력:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
               {createItem.error.error.validationErrors.map((err) => (
@@ -463,25 +479,27 @@ function MyComponent() {
           </div>
         );
       case 403:
+        // error.error는 CreateItem403Response 타입
         return (
           <div>
-            <h2>Not authorized:</h2>
+            <h2>권한 없음:</h2>
             <p>{createItem.error.error.reason}</p>
           </div>
         );
       case 500:
       case 502:
+        // error.error는 CreateItem5XXResponse 타입
         return (
           <div>
-            <h2>Server error:</h2>
+            <h2>서버 오류:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
+            <p>추적 ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
   }
 
-  return <button onClick={handleClick}>Create Item</button>;
+  return <button onClick={handleClick}>아이템 생성</button>;
 }
 ```
 
@@ -503,9 +521,10 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
+        // error.error는 CreateItem400Response 타입
         return (
           <div>
-            <h2>Invalid input:</h2>
+            <h2>잘못된 입력:</h2>
             <p>{error.error.message}</p>
             <ul>
               {error.error.validationErrors.map((err) => (
@@ -515,32 +534,34 @@ function MyComponent() {
           </div>
         );
       case 403:
+        // error.error는 CreateItem403Response 타입
         return (
           <div>
-            <h2>Not authorized:</h2>
+            <h2>권한 없음:</h2>
             <p>{error.error.reason}</p>
           </div>
         );
       case 500:
       case 502:
+        // error.error는 CreateItem5XXResponse 타입
         return (
           <div>
-            <h2>Server error:</h2>
+            <h2>서버 오류:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
+            <p>추적 ID: {error.error.traceId}</p>
           </div>
         );
     }
   }
 
-  return <button onClick={handleClick}>Create Item</button>;
+  return <button onClick={handleClick}>아이템 생성</button>;
 }
 ```
 </Drawer>
 
 ### 스트림 소비
 
-FastAPI 응답 스트리밍을 <Link path="guides/fastapi#streaming">구성한 경우</Link>, `useQuery` 훅은 새로운 스트림 청크가 도착할 때마다 데이터를 자동으로 업데이트합니다.
+<Link path="guides/fastapi#streaming">스트림 응답을 위한 FastAPI 설정</Link> 시, `useQuery` 훅은 새 스트림 청크 도착 시 자동으로 데이터를 업데이트합니다.
 
 예시:
 
@@ -561,39 +582,44 @@ function MyStreamingComponent() {
 }
 ```
 
-스트림 상태 확인을 위해 `isLoading` 및 `fetchStatus` 속성을 사용할 수 있습니다. 스트림 생명주기:
+스트림 상태 확인을 위해 `isLoading`과 `fetchStatus` 속성 사용 가능. 스트림 생명주기:
 
 <Steps>
-  1. 스트리밍 시작 HTTP 요청 전송
+  1. 스트림 시작 HTTP 요청 전송
+
       - `isLoading`: `true`
       - `fetchStatus`: `'fetching'`
       - `data`: `undefined`
 
   2. 첫 번째 청크 수신
+
       - `isLoading`: `false`
       - `fetchStatus`: `'fetching'`
       - `data`: 첫 번째 청크 포함 배열
 
   3. 후속 청크 수신
+
       - `isLoading`: `false`
       - `fetchStatus`: `'fetching'`
       - `data`: 수신 즉시 업데이트
 
   4. 스트림 완료
+
       - `isLoading`: `false`
       - `fetchStatus`: `'idle'`
       - `data`: 모든 청크 배열
 </Steps>
 
-<Drawer title="기본 클라이언트로 스트리밍 처리" trigger="기본 클라이언트 직접 사용 예시 보기">
+<Drawer title="기본 클라이언트로 스트리밍 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
 
-FastAPI 스트리밍 응답을 <Link path="guides/fastapi#streaming">구성한 경우</Link>>, 생성된 클라이언트는 `for await` 구문을 사용한 스트림 청크 비동기 반복 메서드를 포함합니다.
+<Link path="guides/fastapi#streaming">스트림 응답을 위한 FastAPI 설정</Link> 시, 생성된 클라이언트는 `for await` 구문으로 스트림 청크를 비동기 반복하는 타입 세이프 메서드를 포함합니다.
 
 예시:
 
 ```tsx {8}
 function MyStreamingComponent() {
   const api = useMyApiClient();
+
   const [chunks, setChunks] = useState<Chunk[]>([]);
 
   useEffect(() => {
@@ -619,16 +645,14 @@ function MyStreamingComponent() {
 </Drawer>
 
 :::note
-`cursor` 파라미터를 받는 스트리밍 API 사용 시 `useInfiniteQuery` 훅은 각 페이지가 스트림 완료될 때까지 기다립니다.
+`cursor` 파라미터를 받는 스트리밍 API의 경우, `useInfiniteQuery` 훅 사용 시 각 페이지는 스트림 완료 후 로드됩니다.
 :::
 
 ## 생성 코드 커스터마이징
 
-### 쿼리 및 뮤테이션
+### 쿼리와 뮤테이션
 
-기본적으로 `PUT`, `POST`, `PATCH`, `DELETE` HTTP 메서드를 사용하는 FastAPI 작업은 뮤테이션으로, 나머지는 쿼리로 간주됩니다.
-
-`x-query` 및 `x-mutation`으로 이 동작을 변경할 수 있습니다.
+기본적으로 FastAPI의 `PUT`, `POST`, `PATCH`, `DELETE` HTTP 메서드는 뮤테이션으로, 나머지는 쿼리로 간주됩니다. `x-query`와 `x-mutation`으로 이 동작을 변경할 수 있습니다.
 
 #### x-query
 
@@ -643,7 +667,7 @@ def list_items():
     # ...
 ```
 
-`POST` 메서드 사용에도 `queryOptions` 제공:
+`POST` 메서드임에도 `queryOptions` 제공:
 
 ```tsx
 const items = useQuery(api.listItems.queryOptions());
@@ -662,20 +686,21 @@ def start_processing():
     # ...
 ```
 
-`GET` 메서드 사용에도 `mutationOptions` 제공:
+`GET` 메서드임에도 `mutationOptions` 제공:
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
 ```
 
-### 커스텀 페이징 커서
+### 커스텀 페이지네이션 커서
 
-기본 커서 파라미터 이름 `cursor`를 `x-cursor` 확장으로 커스터마이징:
+기본 커서 파라미터명 `cursor`를 `x-cursor` 확장으로 커스터마이즈:
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
+        # 다른 파라미터명 지정
         "x-cursor": "page_token"
     }
 )
@@ -683,16 +708,17 @@ def list_items(page_token: str = None, limit: int = 10):
     # ...
     return {
         "items": items,
-        "page_token": next_page_token
+        "page_token": next_page_token  # 응답에 동일한 이름으로 커서 포함
     }
 ```
 
-`infiniteQueryOptions` 생성을 원하지 않을 경우 `x-cursor`를 `False`로 설정:
+`infiniteQueryOptions` 생성을 원치 않을 경우 `x-cursor`를 `False`로 설정:
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
+        # 이 엔드포인트에 커서 기반 페이지네이션 비활성화
         "x-cursor": False
     }
 )
@@ -708,7 +734,7 @@ def list_items(page: int = 1, limit: int = 10):
 
 ### 작업 그룹화
 
-생성된 훅과 클라이언트 메서드는 FastAPI 엔드포인트의 OpenAPI 태그 기반으로 자동 조직화됩니다. 관련 작업을 쉽게 찾고 관리할 수 있도록 도와줍니다.
+생성된 훅과 클라이언트 메서드는 FastAPI 엔드포인트의 OpenAPI 태그 기반으로 자동 조직화됩니다. 관련 작업을 쉽게 찾고 API 호출을 체계화하는 데 도움이 됩니다.
 
 예시:
 
@@ -746,22 +772,29 @@ import { useMyApi } from './hooks/useMyApi';
 function ItemsAndUsers() {
   const api = useMyApi();
 
+  // items 태그 작업은 api.items 아래 그룹화
   const items = useQuery(api.items.list.queryOptions());
   const createItem = useMutation(api.items.create.mutationOptions());
 
+  // users 태그 작업은 api.users 아래 그룹화
   const users = useQuery(api.users.list.queryOptions());
+
+  // 사용 예시
+  const handleCreateItem = () => {
+    createItem.mutate({ name: 'New Item' });
+  };
 
   return (
     <div>
-      <h2>Items</h2>
+      <h2>아이템</h2>
       <ul>
         {items.data?.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-      <button onClick={() => createItem.mutate({ name: 'New Item' })}>Add Item</button>
+      <button onClick={handleCreateItem}>아이템 추가</button>
 
-      <h2>Users</h2>
+      <h2>사용자</h2>
       <ul>
         {users.data?.map(user => (
           <li key={user.id}>{user.name}</li>
@@ -772,7 +805,9 @@ function ItemsAndUsers() {
 }
 ```
 
-<Drawer title="기본 클라이언트로 그룹화 작업 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
+이 그룹화는 API 호출 조직화와 IDE의 코드 완성 기능 개선에 도움이 됩니다.
+
+<Drawer title="기본 클라이언트로 그룹화된 작업 사용" trigger="기본 클라이언트 직접 사용 예시 보기">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -783,16 +818,21 @@ function ItemsAndUsers() {
   const [users, setUsers] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  // 데이터 로드
   useEffect(() => {
     const fetchData = async () => {
       try {
         setIsLoading(true);
+
+        // items 그룹 메서드 사용
         const itemsData = await api.items.list();
         setItems(itemsData);
+
+        // users 그룹 메서드 사용
         const usersData = await api.users.list();
         setUsers(usersData);
       } catch (error) {
-        console.error('Error fetching data:', error);
+        console.error('데이터 가져오기 오류:', error);
       } finally {
         setIsLoading(false);
       }
@@ -803,26 +843,29 @@ function ItemsAndUsers() {
 
   const handleCreateItem = async () => {
     try {
+      // items 그룹 메서드로 아이템 생성
       const newItem = await api.items.create({ name: 'New Item' });
       setItems(prevItems => [...prevItems, newItem]);
     } catch (error) {
-      console.error('Error creating item:', error);
+      console.error('아이템 생성 오류:', error);
     }
   };
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
 
   return (
     <div>
-      <h2>Items</h2>
+      <h2>아이템</h2>
       <ul>
         {items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-      <button onClick={handleCreateItem}>Add Item</button>
+      <button onClick={handleCreateItem}>아이템 추가</button>
 
-      <h2>Users</h2>
+      <h2>사용자</h2>
       <ul>
         {users.map(user => (
           <li key={user.id}>{user.name}</li>
@@ -835,12 +878,12 @@ function ItemsAndUsers() {
 </Drawer>
 
 :::tip
-다중 `router` 사용으로 API 분할 가능. 자세한 내용은 [FastAPI 문서](https://fastapi.tiangolo.com/tutorial/bigger-applications/) 참조.
+다중 `router`로 API를 분할할 수도 있습니다. 자세한 내용은 [FastAPI 문서](https://fastapi.tiangolo.com/tutorial/bigger-applications/) 참조.
 :::
 
 ### 오류
 
-FastAPI에서 커스텀 예외 클래스, 예외 핸들러, 응답 모델을 정의하여 오류 응답을 커스터마이징할 수 있습니다. 생성된 클라이언트는 자동으로 이들 커스텀 오류 유형을 처리합니다.
+커스텀 예외 클래스, 예외 핸들러, 오류 상태 코드별 응답 모델 정의로 오류 응답을 커스터마이즈할 수 있습니다. 생성된 클라이언트는 자동으로 이 커스텀 오류 타입을 처리합니다.
 
 #### 커스텀 오류 모델 정의
 
@@ -859,7 +902,7 @@ class ValidationError(BaseModel):
 
 #### 커스텀 예외 생성
 
-다른 오류 시나리오용 예외 클래스 생성:
+다양한 오류 시나리오용 예외 클래스 생성:
 
 ```python title="exceptions.py"
 class NotFoundException(Exception):
@@ -873,7 +916,7 @@ class ValidationException(Exception):
 
 #### 예외 핸들러 추가
 
-예외를 HTTP 응답으로 변환:
+예외를 HTTP 응답으로 변환하는 핸들러 등록:
 
 ```python title="main.py"
 from fastapi import Request
@@ -934,9 +977,9 @@ def create_item(item: Item) -> Item:
     return save_item(item)
 ```
 
-#### React에서 커스텀 오류 유형 사용
+#### React에서 커스텀 오류 타입 사용
 
-생성된 클라이언트는 이들 커스텀 오류 유형을 자동 처리:
+생성된 클라이언트는 이 커스텀 오류 타입을 자동 처리해 타입 검사 및 다양한 오류 응답 처리가 가능합니다:
 
 ```tsx
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -944,34 +987,43 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
+  // 타입 지정된 오류 처리 쿼리
   const getItem = useQuery({
     ...api.getItem.queryOptions({ itemId: '123' }),
     onError: (error) => {
+      // FastAPI 응답 기반 오류 타입
       switch (error.status) {
         case 404:
-          console.error('Not found:', error.error);
+          // error.error는 응답에 지정된 문자열
+          console.error('찾을 수 없음:', error.error);
           break;
         case 500:
-          console.error('Server error:', error.error.message);
+          // error.error는 ErrorDetails 타입
+          console.error('서버 오류:', error.error.message);
           break;
       }
     }
   });
 
+  // 타입 지정된 오류 처리 뮤테이션
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
       switch (error.status) {
         case 400:
-          console.error('Validation error:', error.error.message);
+          // error.error는 ValidationError 타입
+          console.error('유효성 오류:', error.error.message);
+          console.error('필드 오류:', error.error.field_errors);
           break;
         case 403:
-          console.error('Forbidden:', error.error);
+          // error.error는 응답에 지정된 문자열
+          console.error('접근 거부:', error.error);
           break;
       }
     }
   });
 
+  // 오류 처리 렌더링
   if (getItem.isError) {
     if (getItem.error.status === 404) {
       return <NotFoundMessage message={getItem.error.error} />;
@@ -998,6 +1050,7 @@ function ItemComponent() {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  // 오류 처리 포함 아이템 가져오기
   useEffect(() => {
     const fetchItem = async () => {
       try {
@@ -1005,14 +1058,18 @@ function ItemComponent() {
         const data = await api.getItem({ itemId: '123' });
         setItem(data);
       } catch (e) {
+        // FastAPI 응답 기반 오류 타입
         const err = e as GetItemError;
         setError(err);
+
         switch (err.status) {
           case 404:
-            console.error('Not found:', err.error);
+            // err.error는 응답에 지정된 문자열
+            console.error('찾을 수 없음:', err.error);
             break;
           case 500:
-            console.error('Server error:', err.error.message);
+            // err.error는 ErrorDetails 타입
+            console.error('서버 오류:', err.error.message);
             break;
         }
       } finally {
@@ -1023,23 +1080,31 @@ function ItemComponent() {
     fetchItem();
   }, [api]);
 
+  // 오류 처리 포함 아이템 생성
   const handleCreateItem = async (data) => {
     try {
       await api.createItem(data);
     } catch (e) {
       const err = e as CreateItemError;
+
       switch (err.status) {
         case 400:
-          console.error('Validation error:', err.error.message);
+          // err.error는 ValidationError 타입
+          console.error('유효성 오류:', err.error.message);
+          console.error('필드 오류:', err.error.field_errors);
           break;
         case 403:
-          console.error('Forbidden:', err.error);
+          // err.error는 응답에 지정된 문자열
+          console.error('접근 거부:', err.error);
           break;
       }
     }
   };
 
-  if (loading) return <LoadingSpinner />;
+  // 오류 처리 렌더링
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
 
   if (error) {
     if (error.status === 404) {
@@ -1059,7 +1124,7 @@ function ItemComponent() {
 </Drawer>
 
 :::tip
-FastAPI에서 오류 응답 정의 시 항상 `responses` 파라미터를 사용하여 상태 코드별 모델을 지정하세요. 이는 클라이언트의 타입 정보 정확성을 보장합니다.
+FastAPI에서 오류 응답 정의 시 항상 `responses` 파라미터로 상태 코드별 모델을 지정하세요. 이렇게 하면 생성된 클라이언트가 오류 처리에 적절한 타입 정보를 갖게 됩니다.
 :::
 
 ## 모범 사례
@@ -1075,23 +1140,27 @@ function ItemList() {
   const api = useMyApi();
   const items = useQuery(api.listItems.queryOptions());
 
-  if (items.isLoading) return <LoadingSpinner />;
+  if (items.isLoading) {
+    return <LoadingSpinner />;
+  }
 
   if (items.isError) {
     const err = items.error;
     switch (err.status) {
       case 403:
+        // err.error는 ListItems403Response 타입
         return <ErrorMessage message={err.error.reason} />;
       case 500:
       case 502:
+        // err.error는 ListItems5XXResponse 타입
         return (
           <ErrorMessage
             message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
+            details={`추적 ID: ${err.error.traceId}`}
           />
         );
       default:
-        return <ErrorMessage message="An unknown error occurred" />;
+        return <ErrorMessage message="알 수 없는 오류 발생" />;
     }
   }
 
@@ -1127,23 +1196,27 @@ function ItemList() {
     fetchItems();
   }, [api]);
 
-  if (loading) return <LoadingSpinner />;
+  if (loading) {
+    return <LoadingSpinner />;
+  }
 
   if (error) {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
+        // err.error는 ListItems403Response 타입
         return <ErrorMessage message={err.error.reason} />;
       case 500:
       case 502:
+        // err.error는 ListItems5XXResponse 타입
         return (
           <ErrorMessage
             message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
+            details={`추적 ID: ${err.error.traceId}`}
           />
         );
       default:
-        return <ErrorMessage message="An unknown error occurred" />;
+        return <ErrorMessage message="알 수 없는 오류 발생" />;
     }
   }
 
@@ -1160,7 +1233,7 @@ function ItemList() {
 
 ### 낙관적 업데이트
 
-사용자 경험 개선을 위한 낙관적 업데이트 구현:
+더 나은 사용자 경험을 위한 낙관적 업데이트 구현:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -1169,30 +1242,46 @@ function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
+  // 아이템 가져오기 쿼리
   const itemsQuery = useQuery(api.listItems.queryOptions());
 
+  // 낙관적 업데이트 포함 삭제 뮤테이션
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
     onMutate: async (itemId) => {
+      // 진행 중인 리페치 취소
       await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+
+      // 이전 값 스냅샷
       const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+
+      // 낙관적 업데이트
       queryClient.setQueryData(
         api.listItems.queryKey(),
         (old) => old.filter((item) => item.id !== itemId)
       );
+
+      // 스냅샷이 포함된 컨텍스트 객체 반환
       return { previousItems };
     },
     onError: (err, itemId, context) => {
+      // 뮤테이션 실패 시 onMutate의 컨텍스트로 롤백
       queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-      console.error('Failed to delete item:', err);
+      console.error('아이템 삭제 실패:', err);
     },
     onSettled: () => {
+      // 오류/성공 후 항상 리페치로 데이터 동기화 보장
       queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
     },
   });
 
-  if (itemsQuery.isLoading) return <LoadingSpinner />;
-  if (itemsQuery.isError) return <ErrorMessage message="Failed to load items" />;
+  if (itemsQuery.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (itemsQuery.isError) {
+    return <ErrorMessage message="아이템 불러오기 실패" />;
+  }
 
   return (
     <ul>
@@ -1203,7 +1292,7 @@ function ItemList() {
             onClick={() => deleteMutation.mutate(item.id)}
             disabled={deleteMutation.isPending}
           >
-            {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+            {deleteMutation.isPending ? '삭제 중...' : '삭제'}
           </button>
         </li>
       ))}
@@ -1219,14 +1308,16 @@ function ItemList() {
   const [items, setItems] = useState([]);
 
   const handleDelete = async (itemId) => {
+    // 낙관적 삭제
     const previousItems = items;
     setItems(items.filter((item) => item.id !== itemId));
 
     try {
       await api.deleteItem(itemId);
     } catch (error) {
+      // 오류 시 이전 아이템 복원
       setItems(previousItems);
-      console.error('Failed to delete item:', error);
+      console.error('아이템 삭제 실패:', error);
     }
   };
 
@@ -1235,7 +1326,7 @@ function ItemList() {
       {items.map((item) => (
         <li key={item.id}>
           {item.name}
-          <button onClick={() => handleDelete(item.id)}>Delete</button>
+          <button onClick={() => handleDelete(item.id)}>삭제</button>
         </li>
       ))}
     </ul>
@@ -1246,7 +1337,7 @@ function ItemList() {
 
 ## 타입 안전성
 
-통합은 완전한 엔드투엔드 타입 안전성을 제공합니다. IDE는 모든 API 호출에 대한 자동 완성 및 타입 검사를 지원합니다:
+통합은 완전한 엔드투엔드 타입 안전성을 제공합니다. IDE는 모든 API 호출에 대한 자동 완성과 타입 검사를 지원합니다:
 
 ```tsx
 import { useMutation } from '@tanstack/react-query';
@@ -1254,30 +1345,38 @@ import { useMutation } from '@tanstack/react-query';
 function ItemForm() {
   const api = useMyApi();
 
+  // 타입 세이프 아이템 생성 뮤테이션
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
+    // ✅ 응답 타입 미처리 시 타입 오류
     onSuccess: (data) => {
-      console.log(`Item created with ID: ${data.id}`);
+      // data는 API 응답 스키마 기반 타입
+      console.log(`생성된 아이템 ID: ${data.id}`);
     },
   });
 
   const handleSubmit = (data: CreateItemInput) => {
+    // ✅ 입력이 스키마와 불일치 시 타입 오류
     createItem.mutate(data);
   };
 
+  // 오류 UI에서 타입 좁히기 사용
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
       case 400:
+        // error.error는 CreateItem400Response 타입
         return (
           <FormError
-            message="Invalid input"
+            message="잘못된 입력"
             errors={error.error.validationErrors}
           />
         );
       case 403:
+        // error.error는 CreateItem403Response 타입
         return <AuthError reason={error.error.reason} />;
       default:
+        // error.error는 500, 502 등에 대해 CreateItem5XXResponse 타입
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1287,18 +1386,19 @@ function ItemForm() {
       e.preventDefault();
       handleSubmit({ name: 'New Item' });
     }}>
+      {/* 폼 필드 */}
       <button
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Creating...' : 'Create Item'}
+        {createItem.isPending ? '생성 중...' : '아이템 생성'}
       </button>
     </form>
   );
 }
 ```
 
-<Drawer title="기본 클라이언트 타입 안전성" trigger="기본 클라이언트 직접 사용 예시 보기">
+<Drawer title="기본 클라이언트로 타입 안전성" trigger="기본 클라이언트 직접 사용 예시 보기">
 ```tsx
 function ItemForm() {
   const api = useMyApiClient();
@@ -1306,22 +1406,27 @@ function ItemForm() {
 
   const handleSubmit = async (data: CreateItemInput) => {
     try {
+      // ✅ 입력이 스키마와 불일치 시 타입 오류
       await api.createItem(data);
     } catch (e) {
+      // ✅ 가능한 모든 오류 응답 포함 타입
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error는 CreateItem400Response 타입
+          console.error('유효성 오류:', err.error.validationErrors);
           break;
         case 403:
-          console.error('Not authorized:', err.error.reason);
+          // err.error는 CreateItem403Response 타입
+          console.error('권한 없음:', err.error.reason);
           break;
         case 500:
         case 502:
+          // err.error는 CreateItem5XXResponse 타입
           console.error(
-            'Server error:',
+            '서버 오류:',
             err.error.message,
-            'Trace:',
+            '추적:',
             err.error.traceId,
           );
           break;
@@ -1330,12 +1435,13 @@ function ItemForm() {
     }
   };
 
+  // 오류 UI에서 타입 좁히기 사용
   if (error) {
     switch (error.status) {
       case 400:
         return (
           <FormError
-            message="Invalid input"
+            message="잘못된 입력"
             errors={error.error.validationErrors}
           />
         );
@@ -1351,4 +1457,4 @@ function ItemForm() {
 ```
 </Drawer>
 
-타입은 FastAPI의 OpenAPI 스키마에서 자동 생성되며, API 변경 사항은 빌드 후 프론트엔드 코드에 반영됩니다.
+타입은 FastAPI의 OpenAPI 스키마에서 자동 생성되므로 API 변경 사항은 빌드 후 프론트엔드 코드에 반영됩니다.

--- a/docs/src/content/docs/ko/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/ko/guides/api-connection/react-trpc.mdx
@@ -9,17 +9,16 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Nx용 AWS 플러그인은 <Link path="guides/trpc">tRPC API</Link>를 React 웹사이트와 빠르게 통합할 수 있는 생성기를 제공합니다. AWS IAM 인증 지원과 적절한 오류 처리를 포함하여 tRPC 백엔드 연결에 필요한 모든 구성을 설정합니다. 이 통합은 프론트엔드와 tRPC 백엔드 간의 완전한 엔드투엔드 타입 안전성을 보장합니다.
+Nx용 AWS 플러그인은 React 웹사이트와 <Link path="guides/trpc">tRPC API</Link>를 빠르게 통합할 수 있는 생성기를 제공합니다. AWS IAM 인증 지원과 적절한 오류 처리를 포함하여 tRPC 백엔드 연결에 필요한 모든 구성을 설정합니다. 이 통합은 프론트엔드와 tRPC 백엔드 간의 완전한 엔드투엔드 타입 안전성을 보장합니다.
 
 ## 필수 조건
 
-이 생성기를 사용하기 전에 React 애플리케이션이 다음을 갖추었는지 확인하세요:
+이 생성기를 사용하기 전에 React 애플리케이션이 다음을 충족하는지 확인하세요:
 
-1. 애플리케이션을 렌더링하는 `main.tsx` 파일
-2. tRPC 프로바이더가 자동으로 주입될 `<App/>` JSX 엘리먼트
-3. tRPC 백엔드 생성기로 생성된 작동 중인 tRPC 백엔드
+1. 애플리케이션을 렌더링하는 `main.tsx` 파일 존재
+2. tRPC 프로바이더가 자동으로 주입될 `<App/>` JSX 요소 포함
+3. tRPC 백엔드 생성기로 생성된 작업 중인 tRPC 백엔드
 
 <details>
 <summary>필요한 `main.tsx` 구조 예시</summary>
@@ -49,9 +48,9 @@ root.render(
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
-## 생성기 출력
+## 생성기 출력 결과
 
 생성기는 React 애플리케이션에 다음 구조를 생성합니다:
 
@@ -67,7 +66,7 @@ root.render(
     - QueryClientProvider.tsx TanStack React Query 클라이언트 프로바이더
   - hooks
     - useSigV4.tsx SigV4로 HTTP 요청 서명을 위한 훅 (IAM 전용)
-    - use\<ApiName>.tsx 특정 백엔드 API용 훅. ApiName은 API 이름으로 해석됨
+    - use\<ApiName>.tsx 특정 백엔드 API용 훅. ApiName은 API 이름으로 해석
 
 </FileTree>
 
@@ -82,7 +81,7 @@ root.render(
 
 ### tRPC 훅 사용
 
-생성기는 타입 안전한 tRPC 클라이언트에 접근할 수 있는 `use<ApiName>` 훅을 제공합니다:
+생성된 `use<ApiName>` 훅을 통해 타입 안전적인 tRPC 클라이언트에 접근할 수 있습니다:
 
 ```tsx {5,8,11}
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -118,7 +117,7 @@ function MyComponent() {
 
 ### 오류 처리
 
-통합에는 tRPC 오류를 적절히 처리하는 내장 오류 처리 기능이 포함되어 있습니다:
+통합된 오류 처리 기능이 tRPC 오류를 적절히 처리합니다:
 
 ```tsx {4, 6}
 function MyComponent() {
@@ -129,9 +128,9 @@ function MyComponent() {
   if (error) {
     return (
       <div>
-        <h2>오류 발생:</h2>
+        <h2>Error occurred:</h2>
         <p>{error.message}</p>
-        {error.data?.code && <p>코드: {error.data.code}</p>}
+        {error.data?.code && <p>Code: {error.data.code}</p>}
       </div>
     );
   }
@@ -150,7 +149,7 @@ function MyComponent() {
 
 ### 로딩 상태 처리
 
-더 나은 사용자 경험을 위해 로딩 및 오류 상태를 항상 처리하세요:
+더 나은 사용자 경험을 위해 로딩 및 오류 상태를 처리하세요:
 
 ```tsx {6}
 function UserList() {
@@ -178,7 +177,7 @@ function UserList() {
 
 ### 낙관적 업데이트
 
-더 나은 사용자 경험을 위해 낙관적 업데이트를 사용하세요:
+사용자 경험 개선을 위해 낙관적 업데이트를 사용하세요:
 
 ```tsx {15-17,20-22,28-31}
 import { useQueryClient, useQuery, useMutation } from '@tanstack/react-query';
@@ -199,7 +198,7 @@ function UserList() {
           trpc.users.list.queryKey(),
         );
 
-        // 낙관적으로 사용자 삭제
+        // 낙관적으로 사용자 제거
         queryClient.setQueryData(trpc.users.list.queryKey(), (old) =>
           old?.filter((user) => user.id !== userId),
         );
@@ -221,7 +220,7 @@ function UserList() {
       {users.map((user) => (
         <li key={user.id}>
           {user.name}
-          <button onClick={() => deleteMutation.mutate(user.id)}>삭제</button>
+          <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
         </li>
       ))}
     </ul>
@@ -231,7 +230,7 @@ function UserList() {
 
 ### 데이터 프리페칭
 
-성능 향상을 위해 데이터를 미리 가져오세요:
+성능 개선을 위해 데이터를 미리 가져오세요:
 
 ```tsx {8}
 function UserList() {
@@ -239,7 +238,7 @@ function UserList() {
   const users = useQuery(trpc.users.list.queryOptions());
   const queryClient = useQueryClient();
 
-  // 호버 시 사용자 상세 정보 미리 가져오기
+  // 호버 시 사용자 상세 정보 프리페치
   const prefetchUser = async (userId: string) => {
     await queryClient.prefetchQuery(trpc.users.getById.queryOptions(userId));
   };
@@ -282,7 +281,7 @@ function UserList() {
 
       {hasNextPage && (
         <button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
-          {isFetchingNextPage ? '불러오는 중...' : '더 보기'}
+          {isFetchingNextPage ? 'Loading...' : 'Load More'}
         </button>
       )}
     </div>
@@ -290,21 +289,21 @@ function UserList() {
 }
 ```
 
-무한 쿼리는 입력에 `cursor` 프로퍼티가 있는 프로시저에만 사용할 수 있습니다.
+무한 쿼리는 입력에 `cursor` 속성이 있는 프로시저에서만 사용할 수 있습니다.
 
 ## 타입 안전성
 
-이 통합은 완전한 엔드투엔드 타입 안전성을 제공합니다. IDE는 모든 API 호출에 대한 자동 완성과 타입 검사를 지원합니다:
+이 통합은 완전한 엔드투엔드 타입 안전성을 제공합니다. IDE에서 모든 API 호출에 대한 자동 완성과 타입 검사를 지원합니다:
 
 ```tsx
 function UserForm() {
   const trpc = useMyApi();
 
-  // ✅ 입력이 완전히 타입화됨
+  // ✅ 입력은 완전한 타입 검사 적용
   const createUser = trpc.users.create.useMutation();
 
   const handleSubmit = (data: CreateUserInput) => {
-    // ✅ 스키마와 일치하지 않을 경우 타입 오류
+    // ✅ 스키마와 불일치 시 타입 오류 발생
     createUser.mutate(data);
   };
 
@@ -312,10 +311,10 @@ function UserForm() {
 }
 ```
 
-타입은 백엔드의 라우터 및 스키마 정의에서 자동으로 유추되며, API 변경 사항이 즉시 프론트엔드 코드에 반영되어 빌드 없이도 적용됩니다.
+타입은 백엔드의 라우터와 스키마 정의에서 자동으로 유추되며, 빌드 없이도 API 변경 사항이 프론트엔드 코드에 즉시 반영됩니다.
 
 ## 추가 정보
 
 자세한 내용은 [tRPC TanStack React Query 문서](https://trpc.io/docs/client/tanstack-react-query/usage)를 참조하세요.
 
-[TanStack Query 공식 문서](https://tanstack.com/query/v5)도 직접 참조할 수 있습니다.
+직접 [TanStack Query 문서](https://tanstack.com/query/v5)를 참조할 수도 있습니다.

--- a/docs/src/content/docs/ko/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/cloudscape-website-auth.mdx
@@ -10,15 +10,14 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
-CloudScape 웹사이트 인증 생성기는 [Amazon Cognito](https://aws.amazon.com/cognito/)를 사용하여 CloudScape 웹사이트에 인증 기능을 추가합니다.
+CloudScape 웹사이트 인증 생성기는 [Amazon Cognito](https://aws.amazon.com/cognito/)를 사용해 CloudScape 웹사이트에 인증 기능을 추가합니다.
 
-이 생성기는 Cognito 사용자 풀 및 관련 Identity Pool 생성, 사용자 로그인 흐름 처리를 위한 호스팅 UI 구성, 그리고 CloudScape 웹사이트와의 통합을 위한 CDK 인프라를 설정합니다.
+이 생성기는 Cognito 사용자 풀과 연관된 Identity Pool, 사용자 로그인 흐름을 처리하는 호스팅 UI, 그리고 CloudScape 웹사이트와의 통합을 위한 CDK 인프라스트럭처를 구성합니다.
 
 ## 사용 방법
 
-### CloudScape 웹사이트에 인증 추가
+### CloudScape 웹사이트에 인증 추가하기
 
 다음 두 가지 방법으로 CloudScape 웹사이트에 인증을 추가할 수 있습니다:
 
@@ -26,9 +25,9 @@ CloudScape 웹사이트 인증 생성기는 [Amazon Cognito](https://aws.amazon.
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
-## 생성기 출력
+## 생성기 출력 결과
 
 React 웹사이트에 다음과 같은 변경 사항이 적용됩니다:
 
@@ -37,7 +36,7 @@ React 웹사이트에 다음과 같은 변경 사항이 적용됩니다:
     - components
       - CognitoAuth
         - index.tsx 주요 인증 컴포넌트
-    - main.tsx CognitoAuth 컴포넌트 통합을 위해 업데이트됨
+    - main.tsx CognitoAuth 컴포넌트를 적용하도록 업데이트됨
 </FileTree>
 
 또한 `packages/common/constructs` 경로에 다음 인프라 코드가 생성됩니다:
@@ -50,7 +49,7 @@ React 웹사이트에 다음과 같은 변경 사항이 적용됩니다:
 
 ## 인프라 사용 방법
 
-웹사이트 Construct _이전에_ `UserIdentity` Construct를 스택에 추가해야 합니다:
+스택에 `UserIdentity` 구성을 추가해야 하며, 웹사이트 Construct **이전에** 선언해야 합니다:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
 import { Stack } from 'aws-cdk-lib';
@@ -68,11 +67,11 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-`UserIdentity` Construct는 웹사이트가 인증을 위해 올바른 Cognito 사용자 풀을 가리킬 수 있도록 <Link path="guides/cloudscape-website#runtime-configuration">런타임 구성</Link>을 자동으로 추가합니다.
+`UserIdentity` Construct는 웹사이트가 인증을 위해 올바른 Cognito 사용자 풀을 가리킬 수 있도록 필요한 <Link path="guides/cloudscape-website#runtime-configuration">런타임 구성</Link>을 자동으로 추가합니다.
 
 ### 인증된 사용자 접근 권한 부여
 
-API 호출 권한과 같은 특정 작업 수행을 위해 인증된 사용자에게 접근 권한을 부여하려면 Identity Pool의 인증된 역할에 IAM 정책 문구를 추가할 수 있습니다:
+API 호출 권한과 같은 특정 작업 수행을 위해 인증된 사용자에게 접근 권한을 부여하려면 Identity Pool 인증 역할에 IAM 정책 문장을 추가할 수 있습니다:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/ko/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/ko/guides/cloudscape-website.mdx
@@ -10,27 +10,26 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
-이 생성기는 [React](https://react.dev/) 웹사이트를 새로 생성하며 [CloudScape](http://cloudscape.design/)가 구성된 상태와 AWS CDK 인프라를 함께 제공합니다. 이를 통해 정적 웹사이트를 [S3](https://aws.amazon.com/s3/)에 호스팅하고 [CloudFront](https://aws.amazon.com/cloudfront/)로 서비스하며 [WAF](https://aws.amazon.com/waf/)로 보호하는 클라우드 배포가 가능합니다.
+이 생성기는 [CloudScape](http://cloudscape.design/)이 구성된 새로운 [React](https://react.dev/) 웹사이트와 [S3](https://aws.amazon.com/s3/)에 호스팅된 정적 웹사이트를 [CloudFront](https://aws.amazon.com/cloudfront/)로 서비스하고 [WAF](https://aws.amazon.com/waf/)로 보호하는 AWS CDK 인프라 코드를 함께 생성합니다.
 
 생성된 애플리케이션은 빌드 도구 및 번들러로 [Vite](https://vite.dev/)를 사용합니다. 타입 안전 라우팅을 위해 [TanStack Router](https://tanstack.com/router/v1)를 사용합니다.
 
 :::note
-이 생성기는 CloudScape로 초기 설정을 제공하지만, 근본적으로 React 프로젝트 생성기입니다. 원하는 경우 다른 디자인 시스템이나 컴포넌트 라이브러리로 전환하도록 코드를 수정할 수 있습니다.
+이 생성기는 CloudScape를 기본으로 설정하지만, 근본적으로 React 프로젝트 생성기입니다. 원하는 경우 다른 디자인 시스템이나 컴포넌트 라이브러리로 변경할 수 있습니다.
 :::
 
 ## 사용 방법
 
 ### CloudScape 웹사이트 생성
 
-다음 두 가지 방법으로 새 CloudScape 웹사이트를 생성할 수 있습니다:
+다음 두 가지 방법으로 새로운 CloudScape 웹사이트를 생성할 수 있습니다:
 
 <RunGenerator generator="ts#cloudscape-website" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
 ## 생성기 출력 결과
 
@@ -41,11 +40,11 @@ import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/
   - public 정적 에셋
   - src
     - main.tsx React 설정이 포함된 애플리케이션 진입점
-    - config.ts 로고 등 애플리케이션 설정 파일
+    - config.ts 애플리케이션 설정 (예: 로고)
     - components
       - AppLayout CloudScape 레이아웃 및 네비게이션 바 관련 컴포넌트
     - hooks
-      - useAppLayout.tsx 중첩 컴포넌트에서 AppLayout 조정을 위한 훅
+      - useAppLayout.tsx 중첩 컴포넌트에서 AppLayout을 조정하기 위한 훅
     - routes
       - welcome
         - index.tsx @tanstack/react-router용 예제 라우트(페이지)
@@ -56,36 +55,36 @@ import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/
   - tsconfig.spec.json 테스트용 TypeScript 설정
 </FileTree>
 
-또한 생성기는 `packages/common/constructs` 디렉토리에 웹사이트 배포를 위한 CDK 인프라 코드를 생성합니다:
+생성기는 또한 `packages/common/constructs` 디렉토리에 웹사이트 배포를 위한 CDK 인프라 코드를 생성합니다:
 
 <FileTree>
   - src
     - app
       - static-websites
-        - \<name>.ts 웹사이트 전용 인프라 코드
+        - \<name>.ts 웹사이트 전용 인프라
     - core
-      - static-website.ts 일반 StaticWebsite Construct
+      - static-website.ts 일반적인 StaticWebsite 구문
 </FileTree>
 
 ## CloudScape 웹사이트 구현
 
-[React 문서](https://react.dev/learn)에서 React 기초 학습을 시작할 수 있습니다. [CloudScape 문서](https://cloudscape.design/components/)에서 사용 가능한 컴포넌트와 사용 방법을 확인할 수 있습니다.
+[React 문서](https://react.dev/learn)는 React 기반 개발을 시작하기 좋은 자료입니다. [CloudScape 문서](https://cloudscape.design/components/)에서 사용 가능한 컴포넌트와 사용 방법을 확인할 수 있습니다.
 
 ### 라우트
 
 #### 라우트/페이지 생성
 
-생성된 CloudScape 웹사이트는 [TanStack Router](https://tanstack.com/router/v1)가 구성된 상태로 제공됩니다. 새 라우트 추가가 간편합니다:
+CloudScape 웹사이트는 [TanStack Router](https://tanstack.com/router/v1)가 미리 구성되어 있습니다. 새로운 라우트를 쉽게 추가할 수 있습니다:
 
 <Steps>
   1. [로컬 개발 서버 실행](#local-development-server)
   2. `src/routes`에 새 `<page-name>.tsx` 파일 생성 (파일 트리 위치가 경로를 나타냄)
-  3. 자동 생성된 `Route` 및 `RouteComponent`를 확인하고 페이지 제작 시작!
+  3. 자동 생성된 `Route` 및 `RouteComponent`를 확인하고 페이지 개발 시작!
 </Steps>
 
-#### 페이지 간 이동
+#### 페이지 간 네비게이션
 
-`Link` 컴포넌트나 `useNavigate` 훅을 사용하여 페이지 간 이동 가능:
+`Link` 컴포넌트나 `useNavigate` 훅을 사용하여 페이지 간 이동할 수 있습니다:
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -108,17 +107,17 @@ export const MyComponent = () => {
 };
 ```
 
-자세한 내용은 [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) 문서 참조.
+자세한 내용은 [TanStack Router 문서](https://tanstack.com/router/latest/docs/framework/react/overview)를 참조하세요.
 
 ## 런타임 설정
 
-AWS CDK 인프라의 설정값은 런타임 설정을 통해 웹사이트에 제공됩니다. 이를 통해 배포 시점에야 알 수 있는 API URL 등의 정보에 접근 가능합니다.
+AWS CDK 인프라의 설정은 런타임 설정을 통해 웹사이트에 제공됩니다. 이를 통해 배포 시점에만 알 수 있는 API URL 등의 정보에 접근할 수 있습니다.
 
 ### 인프라
 
-`RuntimeConfig` CDK Construct를 사용하여 인프라 코드에서 설정값을 추가/조회할 수 있습니다. `@aws/nx-plugin`으로 생성된 CDK Construct(예: <Link path="guides/trpc">tRPC API</Link> 및 <Link path="guides/fastapi">FastAPI</Link>)는 자동으로 적절한 값을 `RuntimeConfig`에 추가합니다.
+`RuntimeConfig` CDK 구문을 사용하여 인프라에서 설정을 추가하고 조회할 수 있습니다. `@aws/nx-plugin`으로 생성된 CDK 구문(예: <Link path="guides/trpc">tRPC API</Link> 및 <Link path="guides/fastapi">FastAPI</Link>)은 자동으로 `RuntimeConfig`에 적절한 값을 추가합니다.
 
-웹사이트 CDK Construct는 런타임 설정을 S3 버킷 루트에 `runtime-config.json` 파일로 배포합니다.
+웹사이트 CDK 구문은 런타임 설정을 S3 버킷 루트에 `runtime-config.json` 파일로 배포합니다.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {9-10,12-13}
 import { Stack } from 'aws-cdk-lib';
@@ -129,22 +128,22 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // RuntimeConfig에 값을 자동으로 추가
+    // RuntimeConfig에 자동으로 값 추가
     new MyApi(this, 'MyApi');
 
-    // runtime-config.json에 런타임 설정 자동 배포
+    // runtime-config.json으로 런타임 설정 자동 배포
     new MyWebsite(this, 'MyWebsite');
   }
 }
 ```
 
 :::warning
-`runtime-config.json` 파일에서 설정값이 누락되지 않도록 웹사이트를 다른 Construct들 _이후_에 선언해야 합니다.
+`runtime-config.json` 파일에서 설정값이 누락되지 않도록 웹사이트를 다른 구문들 _이후에_ 선언해야 합니다.
 :::
 
 ### 웹사이트 코드
 
-웹사이트 코드에서는 `useRuntimeConfig` 훅을 사용하여 런타임 설정값을 조회할 수 있습니다:
+웹사이트에서는 `useRuntimeConfig` 훅을 사용하여 런타임 설정 값을 조회할 수 있습니다:
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -152,52 +151,52 @@ import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
 const MyComponent = () => {
   const runtimeConfig = useRuntimeConfig();
 
-  // 런타임 설정값 접근 예시
+  // 런타임 설정 값 접근 예시
   const apiUrl = runtimeConfig.httpApis.MyApi;
 };
 ```
 
 ### 로컬 런타임 설정
 
-[로컬 개발 서버](#local-development-server) 실행 시 백엔드 URL, 인증 설정 등을 알기 위해 `public` 디렉토리에 `runtime-config.json` 파일이 필요합니다.
+[로컬 개발 서버](#local-development-server) 실행 시, 백엔드 URL 및 인증 설정 등을 알기 위해 `public` 디렉토리에 `runtime-config.json` 파일이 필요합니다.
 
 웹사이트 프로젝트는 배포된 애플리케이션에서 `runtime-config.json` 파일을 가져오는 `load:runtime-config` 타겟으로 구성되어 있습니다:
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-인프라 프로젝트의 `src/main.ts`에서 스택 이름을 변경한 경우, 웹사이트의 `project.json` 파일 내 `load:runtime-config` 타겟을 해당 스택 이름으로 업데이트해야 합니다.
+인프라 프로젝트의 `src/main.ts`에서 스택 이름을 변경한 경우, 웹사이트의 `project.json` 파일에서 `load:runtime-config` 타겟의 스택 이름을 업데이트해야 합니다.
 :::
 
 ## 로컬 개발 서버
 
-로컬 개발 서버 실행 전 인프라 배포 완료 및 [로컬 런타임 설정 로드](#local-runtime-config)가 필요합니다.
+로컬 개발 서버 실행 전 인프라를 배포하고 [로컬 런타임 설정을 로드](#local-runtime-config)했는지 확인하세요.
 
-다음 명령어로 `serve` 타겟 실행:
+다음 명령어로 `serve` 타겟을 실행할 수 있습니다:
 
 <NxCommands commands={['run <my-website>:serve']} />
 
 ## 빌드
 
-`build` 타겟으로 웹사이트 빌드 가능. Vite를 사용하여 루트 `dist/packages/<my-website>/bundle` 디렉토리에 프로덕션 번들 생성 및 타입 체크, 컴파일, 린트 수행:
+`build` 타겟을 사용하여 웹사이트를 빌드할 수 있습니다. 이는 Vite를 사용해 루트 `dist/packages/<my-website>/bundle` 디렉토리에 프로덕션 번들을 생성하며, 타입 체크, 컴파일, 린팅을 수행합니다.
 
 <NxCommands commands={['run <my-website>:build']} />
 
 ## 테스트
 
-테스트 작성은 일반 TypeScript 프로젝트와 유사하므로 <Link path="guides/typescript-project#testing">TypeScript 프로젝트 가이드</Link> 참조.
+테스트 작성은 일반 TypeScript 프로젝트와 유사하므로 <Link path="guides/typescript-project#testing">TypeScript 프로젝트 가이드</Link>를 참조하세요.
 
-React 전용 테스트를 위해 React Testing Library가 미리 설치되어 있습니다. 사용법은 [React Testing Library 문서](https://testing-library.com/docs/react-testing-library/example-intro) 참조.
+React 전용 테스트를 위해 React Testing Library가 미리 설치되어 있습니다. 사용법은 [React Testing Library 문서](https://testing-library.com/docs/react-testing-library/example-intro)를 참조하세요.
 
-`test` 타겟으로 테스트 실행:
+`test` 타겟으로 테스트를 실행할 수 있습니다:
 
 <NxCommands commands={['run <my-website>:test']} />
 
 ## 웹사이트 배포
 
-<Link path="guides/typescript-infrastructure">TypeScript 인프라 생성기</Link>를 사용하여 CDK 애플리케이션 생성 권장.
+웹사이트 배포에는 <Link path="guides/typescript-infrastructure">TypeScript 인프라 생성기</Link>를 사용해 CDK 애플리케이션을 생성하는 것을 권장합니다.
 
-`packages/common/constructs`에 생성된 CDK Construct를 사용하여 웹사이트 배포 가능:
+`packages/common/constructs`에 생성된 CDK 구문을 사용하여 웹사이트를 배포할 수 있습니다.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/ko/guides/fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/fastapi.mdx
@@ -11,34 +11,33 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
 [FastAPI](https://fastapi.tiangolo.com/)는 Python으로 API를 구축하기 위한 프레임워크입니다.
 
-이 FastAPI 생성기는 AWS CDK 인프라 설정이 포함된 새로운 FastAPI를 생성합니다. 생성된 백엔드는 서버리스 배포를 위해 AWS Lambda를 사용하며 AWS API Gateway API를 통해 노출됩니다. 로깅, AWS X-Ray 추적, Cloudwatch 메트릭을 포함한 관측 가능성을 위해 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)를 설정합니다.
+FastAPI 생성자는 AWS CDK 인프라 설정이 포함된 새로운 FastAPI를 생성합니다. 생성된 백엔드는 서버리스 배포를 위해 AWS Lambda를 사용하며 AWS API Gateway API를 통해 노출됩니다. 로깅, AWS X-Ray 추적, Cloudwatch 메트릭을 포함한 관측 가능성을 위해 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)를 설정합니다.
 
 ## 사용 방법
 
-### FastAPI 생성하기
+### FastAPI 생성
 
-새로운 FastAPI를 두 가지 방법으로 생성할 수 있습니다:
+다음 두 가지 방법으로 새로운 FastAPI를 생성할 수 있습니다:
 
 <RunGenerator generator="py#fast-api" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
-## 생성기 출력
+## 생성자 출력 결과
 
-생성기는 `<directory>/<api-name>` 디렉토리에 다음 프로젝트 구조를 생성합니다:
+생성자는 `<directory>/<api-name>` 디렉토리에 다음 프로젝트 구조를 생성합니다:
 
 <FileTree>
 
-- project.json 프로젝트 설정 및 빌드 대상
-- pyproject.toml Python 프로젝트 설정 및 의존성
+- project.json 프로젝트 구성 및 빌드 대상
+- pyproject.toml Python 프로젝트 구성 및 의존성
 - \<module_name>
   - \_\_init\_\_.py 모듈 초기화
   - init.py FastAPI 앱 설정 및 powertools 미들웨어 구성
@@ -48,9 +47,9 @@ import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.
 
 </FileTree>
 
-생성기는 또한 API 배포에 사용할 수 있는 CDK 구성을 `packages/common/constructs` 디렉토리에 생성합니다.
+생성자는 또한 API 배포에 사용할 수 있는 CDK 구성을 `packages/common/constructs` 디렉토리에 생성합니다.
 
-## FastAPI 구현하기
+## FastAPI 구현
 
 주요 API 구현은 `main.py`에 있습니다. 여기서 API 경로와 구현을 정의합니다. 예시:
 
@@ -70,7 +69,7 @@ def create_item(item: Item):
     return ...
 ```
 
-생성기는 자동으로 다음 기능들을 설정합니다:
+생성자는 다음 기능들을 자동으로 설정합니다:
 
 1. 관측 가능성을 위한 AWS Lambda Powertools 통합
 2. 오류 처리 미들웨어
@@ -82,14 +81,14 @@ def create_item(item: Item):
 
 #### 로깅
 
-생성기는 AWS Lambda Powertools를 사용해 구조화된 로깅을 구성합니다. 라우트 핸들러에서 로거에 접근할 수 있습니다:
+생성자는 AWS Lambda Powertools를 사용한 구조화된 로깅을 구성합니다. 라우트 핸들러에서 로거에 접근할 수 있습니다:
 
 ```python
 from .init import app, logger
 
 @app.get("/items/{item_id}")
 def read_item(item_id: int):
-    logger.info("아이템 조회 중", extra={"item_id": item_id})
+    logger.info("Fetching item", extra={"item_id": item_id})
     return {"item_id": item_id}
 ```
 
@@ -139,7 +138,7 @@ def read_item(item_id: int):
 
 ### 오류 처리
 
-생성기는 포괄적인 오류 처리를 포함합니다:
+생성자는 포괄적인 오류 처리를 포함합니다:
 
 ```python
 from fastapi import HTTPException
@@ -147,28 +146,28 @@ from fastapi import HTTPException
 @app.get("/items/{item_id}")
 def read_item(item_id: int):
     if item_id < 0:
-        raise HTTPException(status_code=400, detail="Item ID는 양수여야 합니다")
+        raise HTTPException(status_code=400, detail="Item ID must be positive")
     return {"item_id": item_id}
 ```
 
-처리되지 않은 예외는 미들웨어에서 포착되어:
+처리되지 않은 예외는 미들웨어에 의해 포착되어:
 
-1. 스택 트레이스와 함께 전체 예외 기록
+1. 전체 예외와 스택 트레이스 기록
 2. 실패 메트릭 기록
 3. 클라이언트에 안전한 500 응답 반환
 4. 상관 ID 유지
 
 :::tip
-`api-connection` 생성기를 사용할 경우 더 나은 코드 생성을 위해 API 작업에 대한 응답 모델을 명시하는 것이 좋습니다. <Link path="guides/api-connection/react-fastapi#errors">자세한 내용 참조</Link>.
+`api-connection` 생성자를 사용하는 경우 더 나은 코드 생성을 위해 API 작업에 대한 응답 모델을 명시하는 것이 좋습니다. <Link path="guides/api-connection/react-fastapi#errors">자세한 내용 참조</Link>.
 :::
 
 ### 스트리밍
 
-FastAPI를 사용하면 [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) 응답 타입으로 호출자에게 스트리밍 응답을 보낼 수 있습니다.
+FastAPI에서는 [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) 응답 타입을 사용하여 호출자에게 스트리밍 응답을 전송할 수 있습니다.
 
-#### 인프라 변경
+#### 인프라 변경 사항
 
-AWS API Gateway는 스트리밍 응답을 지원하지 않으므로, 이를 지원하는 플랫폼에 FastAPI를 배포해야 합니다. 가장 간단한 옵션은 AWS Lambda Function URL을 사용하는 것입니다. 이를 위해 생성된 `common/constructs/src/app/apis/<name>-api.ts` 구성을 Function URL을 배포하는 것으로 교체할 수 있습니다.
+AWS API Gateway는 스트리밍 응답을 지원하지 않으므로 FastAPI를 이를 지원하는 플랫폼에 배포해야 합니다. 가장 간단한 옵션은 AWS Lambda Function URL을 사용하는 것입니다. 이를 위해 생성된 `common/constructs/src/app/apis/<name>-api.ts` 구성을 Function URL을 배포하는 구성으로 교체할 수 있습니다.
 
 <details>
 <summary>스트리밍 FunctionURL 구성 예시</summary>
@@ -241,7 +240,7 @@ export class MyApi extends Construct {
 
     new CfnOutput(this, 'MyApiUrl', { value: functionUrl.url });
 
-    // 클라이언트 디스커버리를 위해 런타임 설정에 API URL 등록
+    // 클라이언트 탐색을 위해 런타임 구성에 API URL 등록
     RuntimeConfig.ensure(this).config.apis = {
       ...RuntimeConfig.ensure(this).config.apis!,
       MyApi: functionUrl.url,
@@ -267,7 +266,7 @@ export class MyApi extends Construct {
 </details>
 
 :::note
-종단간 예시는 <Link path="/get_started/tutorials/dungeon-game/overview">던전 어드벤처 튜토리얼</Link> 참조
+종단간 예시는 <Link path="/get_started/tutorials/dungeon-game/overview">던전 어드벤처 튜토리얼</Link>을 참조하세요.
 :::
 
 #### 구현
@@ -276,9 +275,9 @@ export class MyApi extends Construct {
 
 - [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) 반환
 - 각 응답 청크의 반환 타입 선언
-- <Link path="guides/api-connection/react-fastapi">API 연결</Link> 사용을 계획 중인 경우 OpenAPI 벤더 확장 `x-streaming: true` 추가
+- <Link path="guides/api-connection/react-fastapi">API 연결</Link> 사용 시 OpenAPI 벤더 확장 `x-streaming: true` 추가
 
-예를 들어 API에서 JSON 객체 스트림을 보내려면 다음과 같이 구현할 수 있습니다:
+예를 들어 API에서 JSON 객체 스트림을 전송하려면 다음과 같이 구현할 수 있습니다:
 
 ```py /return (StreamingResponse)/ /openapi_extra[^)]*/ /-> (Chunk)/
 from pydantic import BaseModel
@@ -299,11 +298,11 @@ def my_stream() -> Chunk:
 
 #### 소비
 
-스트리밍 응답을 소비하려면 <Link path="guides/api-connection/react-fastapi#consuming-a-stream">API 연결 생성기</Link>를 사용하여 스트리밍 청크를 반복 처리할 수 있는 타입 안전 메소드를 활용할 수 있습니다.
+스트리밍 응답을 소비하려면 <Link path="guides/api-connection/react-fastapi#consuming-a-stream">API 연결 생성자</Link>를 사용하여 타입 안전한 방식으로 스트림 청크를 반복 처리할 수 있습니다.
 
 ## FastAPI 배포
 
-FastAPI 생성기는 `common/constructs` 폴더에 API 배포를 위한 CDK 구성을 생성합니다. CDK 애플리케이션에서 이를 사용할 수 있습니다:
+FastAPI 생성자는 `common/constructs` 폴더에 API 배포를 위한 CDK 구성을 생성합니다. CDK 애플리케이션에서 이를 사용할 수 있습니다:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs';
@@ -321,10 +320,10 @@ export class ExampleStack extends Stack {
 이 설정은 다음을 구성합니다:
 
 1. FastAPI 애플리케이션의 각 작업에 대한 AWS Lambda 함수
-2. 함수 트리거로서의 API Gateway HTTP/REST API
+2. 함수 트리거로 API Gateway HTTP/REST API
 3. IAM 역할 및 권한
 4. CloudWatch 로그 그룹
-5. X-Ray 추적 설정
+5. X-Ray 추적 구성
 6. CloudWatch 메트릭 네임스페이스
 
 ### 타입 안전 통합
@@ -333,9 +332,9 @@ export class ExampleStack extends Stack {
 
 #### 코드 생성
 
-FastAPI의 작업이 Python으로 정의되고 인프라가 TypeScript로 정의되므로, 통합을 위한 타입 안전 인터페이스를 제공하기 위해 CDK 구성에 메타데이터를 제공하는 코드 생성을 계측합니다.
+FastAPI의 작업은 Python으로 정의되고 인프라는 TypeScript로 정의되므로, 통합을 위한 타입 안전 인터페이스를 제공하기 위해 CDK 구성에 메타데이터를 제공하는 코드 생성을 구현합니다.
 
-공통 구성의 `project.json`에 `generate:<ApiName>-metadata` 대상이 추가되어 `packages/common/constructs/src/generated/my-api/metadata.gen.ts`와 같은 파일을 생성합니다. 이는 빌드 시 생성되므로 버전 관리에서 제외됩니다.
+공통 구성의 `project.json`에 `generate:<ApiName>-metadata` 대상이 추가되어 `packages/common/constructs/src/generated/my-api/metadata.gen.ts`와 같은 파일을 생성합니다. 이 파일은 빌드 시 생성되므로 버전 관리에서 제외됩니다.
 
 :::note
 API를 변경할 때마다 CDK 구성에서 사용되는 타입이 최신 상태인지 확인하기 위해 빌드를 실행해야 합니다.
@@ -344,7 +343,7 @@ API를 변경할 때마다 CDK 구성에서 사용되는 타입이 최신 상태
 :::
 
 :::tip
-CDK 인프라와 FastAPI를 동시에 작업 중인 경우 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch)를 사용하여 API 변경 시마다 타입을 재생성할 수 있습니다:
+CDK 인프라와 FastAPI를 동시에 작업하는 경우 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch)를 사용하여 API 변경 시마다 타입을 재생성할 수 있습니다:
 
 <NxCommands
   commands={[
@@ -364,16 +363,16 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## 로컬 개발
 
-생성기는 다음 명령으로 실행할 수 있는 로컬 개발 서버를 구성합니다:
+생성자는 다음 명령어로 실행할 수 있는 로컬 개발 서버를 구성합니다:
 
 <NxCommands commands={['run my-api:serve']} />
 
-이 서버는 다음 기능으로 FastAPI 개발 서버를 시작합니다:
+이 서버는 다음 기능을 제공합니다:
 
-- 코드 변경 시 자동 리로드
+- 코드 변경 시 자동 재시작
 - `/docs` 또는 `/redoc`에서 대화형 API 문서
-- `/openapi.json`에서 OpenAPI 스키마 제공
+- `/openapi.json`에서 OpenAPI 스키마
 
-## FastAPI 호출하기
+## FastAPI 호출
 
-React 웹사이트에서 API를 호출하려면 <Link path="guides/api-connection/react-fastapi">`api-connection`</Link> 생성기를 사용할 수 있습니다.
+React 웹사이트에서 API를 호출하려면 <Link path="guides/api-connection/react-fastapi">`api-connection`</Link> 생성자를 사용할 수 있습니다.

--- a/docs/src/content/docs/ko/guides/license.mdx
+++ b/docs/src/content/docs/ko/guides/license.mdx
@@ -8,11 +8,10 @@ description: "라이선스 생성기에 대한 참조 문서"
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
-워크스페이스의 `LICENSE` 파일과 소스 코드 헤더를 자동으로 관리합니다.
+작업 공간에서 `LICENSE` 파일 및 소스 코드 헤더를 자동으로 관리합니다.
 
-이 생성기는 [동기화 생성기](https://nx.dev/concepts/sync-generators)를 등록하여 `lint` 대상의 일부로 실행되도록 합니다. 이를 통해 소스 파일이 원하는 라이선스 내용과 형식을 준수하는지, 프로젝트의 `LICENSE` 파일이 올바른지, 관련 프로젝트 파일(`package.json`, `pyproject.toml`)에 라이선스 정보가 포함되었는지 확인합니다.
+이 생성기는 [sync generator](https://nx.dev/concepts/sync-generators)를 등록하여 `lint` 대상의 일부로 실행되며, 소스 파일이 원하는 라이선스 내용 및 형식을 준수하는지, 프로젝트의 `LICENSE` 파일이 정확한지, 관련 프로젝트 파일(`package.json`, `pyproject.toml`)에 라이선스 정보가 포함되어 있는지 확인합니다.
 
 ## 사용 방법
 
@@ -22,7 +21,7 @@ import schema from '../../../../../../packages/nx-plugin/src/license/schema.json
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## 생성기 출력
 
@@ -30,14 +29,14 @@ import schema from '../../../../../../packages/nx-plugin/src/license/schema.json
 
 <FileTree>
   - nx.json lint 대상이 라이선스 동기화 생성기를 실행하도록 구성됨
-  - aws-nx-plugin.config.mts 라이선스 동기화 생성기 설정 파일
+  - aws-nx-plugin.config.mts 라이선스 동기화 생성기 구성
 </FileTree>
 
-일부 기본 라이선스 헤더 내용 및 형식 설정이 `aws-nx-plugin.config.mts`에 추가되어 여러 파일 유형에 적합한 헤더를 작성합니다. 추가 사용자 지정이 필요하면 아래 [설정 섹션](#configuration)을 참조하세요.
+일부 파일 유형에 적합한 헤더를 작성하기 위해 기본 라이선스 헤더 내용 및 형식 구성이 `aws-nx-plugin.config.mts`에 추가됩니다. 추가 사용자 정의가 필요한 경우 아래 [구성 섹션](#구성)을 참조하세요.
 
-## 워크플로
+## 워크플로우
 
-프로젝트를 빌드할 때마다(`lint` 대상이 실행될 때) 라이선스 동기화 생성기가 프로젝트의 라이선스가 설정과 일치하는지 확인합니다(아래 [라이선스 동기화 동작](#license-sync-behaviour) 참조). 동기화되지 않은 부분이 발견되면 다음과 같은 메시지가 표시됩니다:
+프로젝트를 빌드할 때마다(`lint` 대상 실행 시) 라이선스 동기화 생성기는 프로젝트의 라이선스가 구성과 일치하는지 확인합니다([아래 라이선스 동기화 동작 참조](#라이선스-동기화-동작)). 동기화되지 않은 항목이 발견되면 다음과 같은 메시지가 표시됩니다:
 
 ```bash
   NX   The workspace is out of sync
@@ -67,7 +66,7 @@ No, run the tasks without syncing the changes
 변경 사항을 동기화하려면 `Yes`를 선택하세요.
 
 :::note
-지속적 통합 빌드 작업이 라이선스 동기화 실패로 인해 중단되지 않도록, 라이선스 동기화 생성기가 변경한 내용을 버전 관리 시스템에 반드시 커밋하세요.
+지속적 통합 빌드 작업이 라이선스 동기화 실패로 인해 중단되지 않도록, 라이선스 동기화 생성기가 수행한 변경 사항을 버전 관리 시스템에 반드시 커밋하세요.
 :::
 
 ## 라이선스 동기화 동작
@@ -76,29 +75,29 @@ No, run the tasks without syncing the changes
 
 ### 1. 소스 파일 라이선스 헤더 동기화
 
-동기화 생성기가 실행되면 설정에 따라 워크스페이스의 모든 소스 코드 파일에 적절한 라이선스 헤더가 포함되도록 합니다. 헤더는 파일의 첫 번째 블록 주석 또는 연속된 라인 주석으로 작성됩니다(shebang/hashbang이 있는 경우 제외).
+동기화 생성기 실행 시 구성에 따라 작업 공간의 모든 소스 코드 파일에 적절한 라이선스 헤더가 포함되도록 합니다. 헤더는 파일의 첫 번째 블록 주석 또는 연속된 라인 주석으로 작성됩니다(파일에 shebang/hashbang이 있는 경우 제외).
 
-언제든지 설정을 업데이트하여 포함/제외할 파일을 변경하거나 다양한 파일 유형별 라이선스 헤더 내용 및 형식을 수정할 수 있습니다. 자세한 내용은 아래 [설정 섹션](#configuration)을 참조하세요.
+구성을 업데이트하여 포함/제외할 파일 범위를 변경하거나 다양한 파일 유형별 라이선스 헤더 내용 및 형식을 수정할 수 있습니다. 자세한 내용은 [구성 섹션](#구성)을 참조하세요.
 
 ### 2. LICENSE 파일 동기화
 
-동기화 생성기가 실행되면 루트 `LICENSE` 파일이 구성된 라이선스와 일치하는지 확인하고, 워크스페이스의 모든 하위 프로젝트도 올바른 `LICENSE` 파일을 포함하도록 합니다.
+동기화 생성기 실행 시 루트 `LICENSE` 파일이 구성된 라이선스와 일치하는지 확인하고, 작업 공간의 모든 하위 프로젝트에도 올바른 `LICENSE` 파일이 포함되도록 합니다.
 
-필요한 경우 설정에서 프로젝트를 제외할 수 있습니다. 자세한 내용은 아래 [설정 섹션](#configuration)을 참조하세요.
+필요한 경우 구성에서 프로젝트를 제외할 수 있습니다. 자세한 내용은 [구성 섹션](#구성)을 참조하세요.
 
-### 3. 프로젝트 파일 라이선스 정보 동기화
+### 3. 프로젝트 파일 내 라이선스 정보 동기화
 
-동기화 생성기가 실행되면 `package.json` 및 `pyproject.toml` 파일의 `license` 필드가 구성된 라이선스로 설정됩니다.
+동기화 생성기 실행 시 `package.json` 및 `pyproject.toml` 파일의 `license` 필드가 구성된 라이선스로 설정되도록 합니다.
 
-필요한 경우 설정에서 프로젝트를 제외할 수 있습니다. 자세한 내용은 아래 [설정 섹션](#configuration)을 참조하세요.
+필요한 경우 구성에서 프로젝트를 제외할 수 있습니다. 자세한 내용은 [구성 섹션](#구성)을 참조하세요.
 
-## 설정
+## 구성
 
-설정은 워크스페이스 루트의 `aws-nx-plugin.config.mts` 파일에서 정의됩니다.
+구성은 작업 공간 루트의 `aws-nx-plugin.config.mts` 파일에서 정의됩니다.
 
 ### SPDX 및 저작권 소유자
 
-선택한 라이선스는 `spdx` 설정 속성을 통해 언제든지 업데이트할 수 있습니다:
+라이선스는 `spdx` 구성 속성을 통해 언제든지 업데이트할 수 있습니다:
 
 ```typescript title="aws-nx-plugin.config.mts" {3}
 export default {
@@ -108,9 +107,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-동기화 생성기가 실행되면 모든 `LICENSE` 파일, `package.json` 및 `pyproject.toml` 파일이 구성된 라이선스에 맞게 업데이트됩니다.
+동기화 생성기 실행 시 모든 `LICENSE` 파일, `package.json` 및 `pyproject.toml` 파일이 구성된 라이선스에 맞게 업데이트됩니다.
 
-추가로 일부 `LICENSE` 파일에 포함될 저작권 소유자와 연도를 설정할 수 있습니다:
+일부 `LICENSE` 파일에 포함될 저작권 소유자 및 연도도 구성할 수 있습니다:
 
 ```typescript title="aws-nx-plugin.config.mts" {4,5}
 export default {
@@ -126,7 +125,7 @@ export default {
 
 #### 내용
 
-라이선스 헤더 내용은 두 가지 방식으로 구성할 수 있습니다:
+라이선스 헤더 내용은 두 가지 방식으로 구성 가능:
 
 1. 인라인 내용 사용:
 
@@ -154,7 +153,7 @@ export default {
   license: {
     header: {
       content: {
-        filePath: 'license-header.txt'; // 워크스페이스 루트 기준 상대 경로
+        filePath: 'license-header.txt'; // 작업 공간 루트 기준 상대 경로
       }
       // ... 형식 구성
     }
@@ -164,7 +163,7 @@ export default {
 
 #### 형식
 
-글로브 패턴을 사용하여 다양한 파일 유형별 라이선스 헤더 형식을 지정할 수 있습니다. 형식 구성은 라인 주석, 블록 주석 또는 둘의 조합을 지원합니다:
+글로브 패턴을 사용하여 다양한 파일 유형별 라이선스 헤더 형식을 지정할 수 있습니다. 형식 구성은 라인 주석, 블록 주석 또는 둘 다의 조합을 지원합니다:
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
@@ -189,7 +188,7 @@ export default {
           lineStart: ' * ',
           blockEnd: ' */',
         },
-        // 머리글/바닥글이 있는 라인 주석
+        // 헤더/푸터가 있는 라인 주석
         '**/*.py': {
           blockStart: '# ------------',
           lineStart: '# ',
@@ -201,8 +200,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-형식 구성은 다음을 지원합니다:
-
+형식 구성 지원 항목:
 - `blockStart`: 라이선스 내용 전에 작성될 텍스트 (예: 블록 주석 시작)
 - `lineStart`: 라이선스 내용 각 줄 앞에 추가될 텍스트
 - `lineEnd`: 라이선스 내용 각 줄 뒤에 추가될 텍스트
@@ -210,7 +208,7 @@ export default {
 
 #### 사용자 정의 주석 구문
 
-기본적으로 지원되지 않는 파일 유형의 경우, 사용자 정의 주석 구문을 지정하여 동기화 생성기가 기존 라이선스 헤더를 식별하도록 할 수 있습니다.
+기본 지원되지 않는 파일 유형의 경우, 사용자 정의 주석 구문을 지정하여 동기화 생성기가 기존 라이선스 헤더를 식별하도록 할 수 있습니다.
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
@@ -243,7 +241,7 @@ export default {
 
 #### 파일 제외
 
-기본적으로 git 저장소에서는 버전 관리되는 파일만 동기화되도록 모든 `.gitignore` 파일이 적용됩니다. git이 아닌 저장소에서는 구성에서 명시적으로 제외하지 않는 한 모든 파일이 처리됩니다.
+기본적으로 git 저장소에서는 버전 관리 대상 파일만 동기화되도록 모든 `.gitignore` 파일이 적용됩니다. 비 git 저장소에서는 구성에서 명시적으로 제외하지 않는 한 모든 파일이 처리됩니다.
 
 글로브 패턴을 사용하여 라이선스 헤더 동기화에서 추가 파일을 제외할 수 있습니다:
 
@@ -276,9 +274,9 @@ export default {
   license: {
     files: {
       exclude: [
-        // LICENSE 파일, package.json, pyproject.toml 동기화 안 함
+        // LICENSE 파일, package.json, pyproject.toml 동기화 제외
         'packages/excluded-project',
-        // LICENSE 파일은 동기화 안 하지만 package.json 및 pyproject.toml은 동기화
+        // LICENSE 파일 동기화 제외 (package.json/pyproject.toml은 동기화 유지)
         'apps/internal/LICENSE',
       ];
     }
@@ -290,7 +288,7 @@ export default {
 
 라이선스 동기화 생성기를 비활성화하려면:
 
-1. `aws-nx-plugin.config.mts` 설정에서 `license` 섹션 제거 (또는 파일 삭제)
+1. `aws-nx-plugin.config.mts` 구성에서 `license` 섹션 제거(또는 파일 자체 삭제)
 2. `targetDefaults.lint.syncGenerators`에서 `@aws/nx-plugin:license#sync` 생성기 제거
 
-다시 활성화하려면 `license` 생성기를 다시 실행하세요.
+라이선스 동기화를 다시 활성화하려면 `license` 생성기를 다시 실행하세요.

--- a/docs/src/content/docs/ko/guides/nx-generator.mdx
+++ b/docs/src/content/docs/ko/guides/nx-generator.mdx
@@ -11,54 +11,53 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
 TypeScript 프로젝트에 [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators)를 추가하여 컴포넌트 스캐폴딩이나 특정 프로젝트 구조 강제화와 같은 반복 작업을 자동화할 수 있습니다.
 
-## 사용법
+## 사용 방법
 
-### 생성기 생성
+### Generator 생성하기
 
-다음 두 가지 방법으로 생성기를 만들 수 있습니다:
+두 가지 방법으로 Generator를 생성할 수 있습니다:
 
 <RunGenerator generator="ts#nx-generator" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
-## 생성기 출력
+## Generator 출력 결과
 
-생성기는 주어진 `pluginProject` 내에 다음 프로젝트 파일들을 생성합니다:
+Generator는 주어진 `pluginProject` 내에 다음 프로젝트 파일들을 생성합니다:
 
 <FileTree>
   - src/\<name>/
-    - schema.json 생성기 입력을 위한 스키마
-    - schema.d.ts 스키마의 TypeScript 타입
-    - generator.ts 생성기 구현 스텁
-    - generator.spec.ts 생성기 테스트
-  - generators.json 생성기 정의를 위한 Nx 설정
-  - package.json "generators" 항목이 추가되거나 업데이트됨
+    - schema.json Generator 입력을 위한 스키마
+    - schema.d.ts 스키마의 TypeScript 타입 정의
+    - generator.ts Generator 구현 스텁
+    - generator.spec.ts Generator 테스트
+  - generators.json Generator 정의를 위한 Nx 설정
+  - package.json 생성되거나 "generators" 항목이 추가됨
   - tsconfig.json CommonJS 사용으로 업데이트됨
 </FileTree>
 
 :::warning
-이 생성기는 현재 Nx Generator가 CommonJS만 지원하기 때문에 선택한 `pluginProject`를 CommonJS 사용으로 업데이트합니다 ([ESM 지원 관련 GitHub 이슈 참조](https://github.com/nrwl/nx/issues/15682)).
+이 Generator는 현재 Nx Generator가 CommonJS만 지원하기 때문에 선택한 `pluginProject`를 CommonJS 사용으로 업데이트합니다 ([ESM 지원 관련 GitHub 이슈 참조](https://github.com/nrwl/nx/issues/15682)).
 :::
 
-## 로컬 생성기
+## 로컬 Generators
 
 :::tip
-먼저 `ts#project` 생성기를 사용하여 모든 생성기를 위한 전용 TypeScript 프로젝트를 생성할 것을 권장합니다. 예시:
+먼저 `ts#project` Generator를 사용하여 모든 Generator를 위한 전용 TypeScript 프로젝트를 생성할 것을 권장합니다. 예시:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-`ts#nx-generator` 생성기를 실행할 때 로컬 `nx-plugin` 프로젝트를 선택하고 이름, 선택적 디렉토리 및 설명을 지정하세요.
+`ts#nx-generator` Generator를 실행할 때 로컬 `nx-plugin` 프로젝트를 선택하고 이름, 선택적 디렉토리 및 설명을 지정하세요.
 
-### 스키마 정의
+### 스키마 정의하기
 
-`schema.json` 파일은 생성기가 수락하는 옵션을 정의합니다. 이 파일은 [JSON Schema](https://json-schema.org/) 형식과 [Nx 전용 확장](https://nx.dev/extending-nx/recipes/generator-options)을 따릅니다.
+`schema.json` 파일은 Generator가 허용하는 옵션들을 정의합니다. [JSON Schema](https://json-schema.org/) 형식에 [Nx 확장 기능](https://nx.dev/extending-nx/recipes/generator-options)을 추가하여 작성됩니다.
 
 #### 기본 구조
 
@@ -72,15 +71,15 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // 생성기 옵션 작성 위치
+    // Generator 옵션들
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
 ```
 
-#### 간단한 예제
+#### 간단한 예시
 
-기본 옵션을 포함한 간단한 예제:
+기본 옵션들을 포함한 간단한 예시:
 
 ```json
 {
@@ -112,7 +111,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 대화형 프롬프트 (CLI)
 
-`x-prompt` 속성을 추가하여 CLI에서 생성기 실행 시 표시되는 프롬프트를 커스터마이즈할 수 있습니다:
+`x-prompt` 속성을 추가하여 CLI에서 Generator 실행 시 표시되는 프롬프트를 커스터마이즈할 수 있습니다:
 
 ```json
 "name": {
@@ -122,7 +121,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-불리언 옵션의 경우 예/아니오 프롬프트 사용:
+불리언 옵션의 경우 yes/no 프롬프트 사용 가능:
 
 ```json
 "withTests": {
@@ -132,9 +131,9 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-#### 드롭다운 선택
+#### 드롭다운 선택지
 
-고정된 선택지가 있는 옵션의 경우 `enum`을 사용하여 옵션 중 하나를 선택할 수 있게 합니다:
+고정된 선택지 세트가 있는 옵션의 경우 `enum`을 사용하여 옵션 중 하나를 선택할 수 있게 합니다:
 
 ```json
 "style": {
@@ -147,7 +146,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 프로젝트 선택 드롭다운
 
-워크스페이스의 기존 프로젝트에서 선택할 수 있도록 하는 일반적인 패턴:
+워크스페이스의 기존 프로젝트 중에서 선택할 수 있도록 하는 일반적인 패턴:
 
 ```json
 "project": {
@@ -162,7 +161,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 위치 인수
 
-명령줄에서 생성기를 실행할 때 위치 인수로 전달될 옵션을 구성할 수 있습니다:
+명령줄에서 Generator를 실행할 때 위치 인수로 전달되도록 옵션을 구성할 수 있습니다:
 
 ```json
 "name": {
@@ -176,7 +175,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-이를 통해 사용자는 `nx g your-generator --name=my-component` 대신 `nx g your-generator my-component`처럼 생성기를 실행할 수 있습니다.
+이를 통해 사용자는 `nx g your-generator --name=my-component` 대신 `nx g your-generator my-component`처럼 실행할 수 있습니다.
 
 #### 우선순위 설정
 
@@ -190,7 +189,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-옵션은 `"important"` 또는 `"internal"` 우선순위를 가질 수 있습니다. 이는 Nx VSCode 확장과 Nx CLI에서 속성 순서를 지정하는 데 도움이 됩니다.
+옵션은 `"important"` 또는 `"internal"` 우선순위를 가질 수 있습니다. 이는 Nx VSCode 확장과 Nx CLI에서 속성 순서를 조정하는 데 도움이 됩니다.
 
 #### 기본값
 
@@ -206,11 +205,11 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 추가 정보
 
-스키마에 대한 자세한 내용은 [Nx Generator Options 문서](https://nx.dev/extending-nx/recipes/generator-options)를 참조하세요.
+스키마에 대한 자세한 내용은 [Nx Generator 옵션 문서](https://nx.dev/extending-nx/recipes/generator-options)를 참조하세요.
 
-#### schema.d.ts를 이용한 TypeScript 타입
+#### schema.d.ts를 통한 TypeScript 타입
 
-`schema.json`과 함께 생성기는 생성기 옵션에 대한 TypeScript 타입을 제공하는 `schema.d.ts` 파일을 생성합니다:
+`schema.json`과 함께 Generator는 Generator 옵션에 대한 TypeScript 타입을 제공하는 `schema.d.ts` 파일을 생성합니다:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -220,7 +219,7 @@ export interface YourGeneratorSchema {
 }
 ```
 
-이 인터페이스는 타입 안전성과 코드 완성을 위해 생성기 구현에서 사용됩니다:
+이 인터페이스는 타입 안전성과 코드 완성을 위해 Generator 구현에서 사용됩니다:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
@@ -237,18 +236,18 @@ export default async function (tree: Tree, options: YourGeneratorSchema) {
 
 - 속성 추가/제거
 - 속성 타입 변경
-- 속성 필수/선택 설정 (선택적 속성에는 `?` 접미사 사용)
+- 속성 필수/선택 설정 (선택 속성에는 `?` 접미사 사용)
 
 TypeScript 인터페이스는 JSON 스키마에 정의된 구조를 정확히 반영해야 합니다.
 :::
 
-### 생성기 구현
+### Generator 구현하기
 
-위와 같이 새 생성기를 생성한 후 `generator.ts`에서 구현을 작성할 수 있습니다.
+위와 같이 새 Generator를 생성한 후 `generator.ts`에서 구현을 작성할 수 있습니다.
 
-생성기는 가상 파일 시스템(`Tree`)을 변형하는 함수로, 원하는 변경 사항을 만들기 위해 파일을 읽고 씁니다. `Tree`의 변경 사항은 "dry-run" 모드가 아닌 경우 생성기 실행이 완료된 후에만 디스크에 기록됩니다.
+Generator는 가상 파일 시스템(`Tree`)을 변형하는 함수로, 원하는 변경 사항을 만들기 위해 파일을 읽고 씁니다. `Tree`의 변경 사항은 "드라이런" 모드가 아닌 경우 Generator 실행이 완료된 후에만 디스크에 기록됩니다.
 
-생성기에서 수행할 수 있는 일반적인 작업들:
+Generator에서 수행할 수 있는 일반적인 작업들:
 
 #### 파일 읽기/쓰기
 
@@ -276,7 +275,7 @@ generateFiles(
   joinPathFragments(__dirname, 'files'), // 템플릿 디렉토리
   'path/to/output', // 출력 디렉토리
   {
-    // 템플릿에서 치환될 변수
+    // 템플릿에서 치환할 변수들
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
@@ -285,7 +284,7 @@ generateFiles(
 );
 ```
 
-#### TypeScript AST (추상 구문 트리) 조작
+#### TypeScript AST 조작
 
 AST 조작을 위해 [TSQuery](https://github.com/phenomnomnominal/tsquery) 설치를 권장합니다.
 
@@ -298,7 +297,7 @@ import * as ts from 'typescript';
 // 파일 내용을 TypeScript AST로 파싱
 const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
 
-// 셀렉터에 매칭되는 노드 찾기
+// 셀렉터와 일치하는 노드 찾기
 const nodes = tsquery.query(
   sourceFile,
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
@@ -308,7 +307,7 @@ if (nodes.length > 0) {
   // 숫자 리터럴 노드 가져오기
   const numericNode = nodes[0] as ts.NumericLiteral;
 
-  // 현재 버전 번호 가져와 증가
+  // 현재 버전 번호 가져와서 증가
   const currentVersion = Number(numericNode.text);
   const newVersion = currentVersion + 1;
 
@@ -353,12 +352,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-package.json에 의존성을 추가한 경우 생성기 콜백의 일부로 사용자를 위해 설치할 수 있습니다:
+package.json에 의존성을 추가한 경우 사용자를 위해 설치 작업을 Generator 콜백의 일부로 실행할 수 있습니다:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// 생성기는 의존성 설치와 같은 생성 후 작업을 실행할 수 있는 콜백 반환
+// Generator는 의존성 설치와 같은 생성 후 작업을 실행할 수 있는 콜백 반환
 return () => {
   installPackagesTask(tree);
 };
@@ -374,7 +373,7 @@ import { formatFiles } from '@nx/devkit';
 await formatFiles(tree);
 ```
 
-#### JSON 파일 읽기 및 업데이트
+#### JSON 파일 읽기/업데이트
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
@@ -392,21 +391,21 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
-### 생성기 실행
+### Generator 실행하기
 
-두 가지 방법으로 생성기를 실행할 수 있습니다:
+두 가지 방법으로 Generator를 실행할 수 있습니다:
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-VSCode 플러그인 UI에서 생성기가 보이지 않으면 다음 명령으로 Nx 워크스페이스를 새로 고침하세요:
+VSCode 플러그인 UI에 Generator가 표시되지 않으면 Nx Workspace를 새로 고침할 수 있습니다:
 
 <NxCommands commands={['reset']} />
 :::
 
-### 생성기 테스트
+### Generator 테스트하기
 
-생성기의 단위 테스트는 간단하게 구현할 수 있습니다. 일반적인 패턴:
+Generator의 단위 테스트는 간단하게 구현할 수 있습니다. 일반적인 패턴:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -432,10 +431,10 @@ describe('your generator', () => {
   });
 
   it('should generate expected files', async () => {
-    // 생성기 실행
+    // Generator 실행
     await yourGenerator(tree, {
       name: 'test',
-      // 기타 필수 옵션 추가
+      // 다른 필수 옵션 추가
     });
 
     // 파일 생성 확인
@@ -450,10 +449,10 @@ describe('your generator', () => {
   });
 
   it('should update existing files', async () => {
-    // 생성기 실행
+    // Generator 실행
     await yourGenerator(tree, {
       name: 'test',
-      // 기타 필수 옵션 추가
+      // 다른 필수 옵션 추가
     });
 
     // 기존 파일 업데이트 확인
@@ -462,44 +461,44 @@ describe('your generator', () => {
   });
 
   it('should handle errors', async () => {
-    // 특정 조건에서 생성기가 오류를 발생시킬 것으로 예상
+    // 특정 조건에서 Generator가 에러를 발생시키는지 확인
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
-        // 오류를 유발할 옵션 추가
+        // 에러를 유발하는 옵션 추가
       }),
     ).rejects.toThrow('Expected error message');
   });
 });
 ```
 
-생성기 테스트의 주요 포인트:
+Generator 테스트 핵심 포인트:
 
-- `createTreeWithEmptyWorkspace()`로 가상 파일 시스템 생성
-- 생성기 실행 전 필수 파일 설정
+- 가상 파일 시스템 생성에 `createTreeWithEmptyWorkspace()` 사용
+- Generator 실행 전 필수 파일 설정
 - 새 파일 생성과 기존 파일 업데이트 모두 테스트
 - 복잡한 파일 내용에 스냅샷 사용
-- 생성기가 정상적으로 실패하는지 확인하기 위한 오류 조건 테스트
+- Generator가 우아하게 실패하는지 에러 조건 테스트
 
-## @aws/nx-plugin에 생성기 기여하기
+## @aws/nx-plugin에 Generator 기여하기
 
-`ts#nx-generator`를 사용하여 `@aws/nx-plugin` 내부에 생성기를 스캐폴딩할 수도 있습니다.
+`ts#nx-generator`를 사용하여 `@aws/nx-plugin` 내부에 Generator 스캐폴딩을 할 수 있습니다.
 
-이 생성기를 우리 저장소에서 실행하면 다음 파일들이 생성됩니다:
+이 Generator를 저장소에서 실행하면 다음 파일들이 생성됩니다:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json 생성기 입력을 위한 스키마
+    - schema.json Generator 입력 스키마
     - schema.d.ts 스키마의 TypeScript 타입
-    - generator.ts 생성기 구현
-    - generator.spec.ts 생성기 테스트
+    - generator.ts Generator 구현
+    - generator.spec.ts Generator 테스트
   - docs/src/content/docs/guides/
-    - \<name>.mdx 생성기 문서 페이지
-  - packages/nx-plugin/generators.json 생성기가 포함되도록 업데이트됨
+    - \<name>.mdx Generator 문서 페이지
+  - packages/nx-plugin/generators.json Generator 포함하도록 업데이트됨
 </FileTree>
 
-이제 생성기 구현을 시작할 수 있습니다.
+이제 Generator 구현을 시작할 수 있습니다.
 
 :::tip
-AWS용 Nx Plugin에 기여하는 방법에 대한 자세한 가이드는 <Link path="get_started/tutorials/contribute-generator">여기 튜토리얼</Link>을 참조하세요.
+AWS용 Nx Plugin에 기여하는 방법에 대한 더 자세한 가이드는 <Link path="get_started/tutorials/contribute-generator">이 튜토리얼</Link>을 참조하세요.
 :::

--- a/docs/src/content/docs/ko/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/ko/guides/python-lambda-function.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Python 람다 함수"
-description: "Python 람다 함수에 대한 참조 문서"
+title: "파이썬 람다 함수"
+description: "파이썬 람다 함수에 대한 참조 문서"
 ---
 
 
@@ -9,27 +9,26 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
-Python Lambda Function 제너레이터는 기존 Python 프로젝트에 람다 함수를 추가할 수 있는 기능을 제공합니다.
+Python Lambda Function 생성기는 기존 파이썬 프로젝트에 람다 함수를 추가할 수 있는 기능을 제공합니다.
 
-이 제너레이터는 AWS CDK 인프라 설정이 포함된 새로운 Python 람다 핸들러를 생성합니다. 생성된 백엔드는 서버리스 배포를 위해 AWS Lambda를 사용하며, [AWS Lambda Powertools의 Parser](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)를 활용한 선택적 타입 안전성을 제공합니다. 또한 로깅, AWS X-Ray 추적, Cloudwatch 메트릭을 포함한 관측 가능성을 위해 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)를 설정합니다.
+이 생성기는 AWS CDK 인프라 설정과 함께 새로운 파이썬 람다 핸들러를 생성합니다. 생성된 백엔드는 서버리스 배포를 위해 AWS Lambda를 사용하며, [AWS Lambda Powertools의 Parser](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)를 이용한 타입 안전성을 옵션으로 제공합니다. 로깅, AWS X-Ray 추적, Cloudwatch 메트릭을 포함한 관측 가능성을 위해 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/)를 설정합니다.
 
 ## 사용 방법
 
-### 람다 함수 생성하기
+### Lambda Function 생성
 
-다음 두 가지 방법으로 새 람다 함수를 생성할 수 있습니다:
+다음 두 가지 방법으로 새로운 Lambda Function을 생성할 수 있습니다:
 
 <RunGenerator generator="py#lambda-function" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
-## 제너레이터 출력 결과
+## 생성기 출력
 
-제너레이터는 프로젝트에 다음 파일들을 추가합니다:
+생성기는 프로젝트에 다음 파일들을 추가합니다:
 
 <FileTree>
 
@@ -38,9 +37,9 @@ Python Lambda Function 제너레이터는 기존 Python 프로젝트에 람다 �
 
 </FileTree>
 
-제너레이터는 또한 함수 배포에 사용할 수 있는 CDK 구문을 `packages/common/constructs` 디렉토리에 생성합니다.
+생성기는 또한 `packages/common/constructs` 디렉토리에 배포용 CDK 구문을 생성합니다.
 
-`functionPath` 옵션이 제공된 경우, 제너레이터는 지정된 경로에 필요한 파일들을 추가합니다:
+`functionPath` 옵션이 제공된 경우, 생성기는 지정된 경로에 필요한 파일들을 추가합니다:
 
 <FileTree>
 
@@ -50,7 +49,7 @@ Python Lambda Function 제너레이터는 기존 Python 프로젝트에 람다 �
 
 </FileTree>
 
-## 함수 구현하기
+## 함수 구현
 
 주요 함수 구현체는 `<function-name>.py`에 위치합니다. 예시:
 
@@ -80,24 +79,24 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     try:
         # TODO: 구현 필요
         metrics.add_metric(name="SuccessCount", unit=MetricUnit.Count, value=1)
-        # TODO: 필요 시 성공 응답 구현
+        # TODO: 성공 응답 구현 필요 (필요시)
     except Exception as e:
         logger.exception(e)
         metrics.add_metric(name="ErrorCount", unit=MetricUnit.Count, value=1)
-        # TODO: 필요 시 오류 응답 구현
+        # TODO: 에러 응답 구현 필요 (필요시)
 ```
 
-제너레이터는 자동으로 다음 기능들을 설정합니다:
+생성기는 자동으로 다음 기능들을 설정합니다:
 
 1. 관측 가능성을 위한 AWS Lambda Powertools 통합
 2. 메트릭 수집
 3. `@event_parser`를 이용한 타입 안전성
 
-### AWS Lambda Powertools를 활용한 관측 가능성
+### AWS Lambda Powertools를 이용한 관측 가능성
 
 #### 로깅
 
-제너레이터는 AWS Lambda Powertools를 사용해 구조화된 로깅을 구성합니다.
+생성기는 AWS Lambda Powertools를 사용한 구조화된 로깅을 구성합니다.
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -105,21 +104,21 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 ```
 
 :::tip
-디버깅과 모니터링을 용이하게 하기 위해 모든 고유 요청에 상관 ID(correlation id)를 설정하는 것을 권장합니다. 상관 ID 모범 사례는 [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) 문서를 참조하세요.
+디버깅과 모니터링을 용이하게 하기 위해 모든 고유 요청에 correlation id를 설정할 것을 권장합니다. 상세 사항은 [AWS Powertools 로거 문서](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id)를 참조하세요.
 :::
 
 로거는 자동으로 다음을 포함합니다:
 - 이벤트 요청
-- 람다 컨텍스트 정보
+- Lambda 컨텍스트 정보
 - 콜드 스타트 표시기
 
 #### 추적
 
-AWS X-Ray 추적이 자동으로 구성됩니다. 추적에 커스텀 하위 세그먼트를 추가할 수 있습니다:
+AWS X-Ray 추적이 자동으로 구성됩니다. 커스텀 서브세그먼트를 추가할 수 있습니다:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
-    # 새로운 하위 세그먼트 생성
+    # 새로운 서브세그먼트 생성
     with tracer.provider.in_subsegment("function-subsegment"):
         # 로직 구현
         return ....
@@ -142,25 +141,25 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 #### 타입 안전성
 
-람다 함수 생성 시 `eventSource`를 선택한 경우, 함수는 [AWS Lambda Powertools의 `@event_parser`](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)로 계측됩니다. 예시:
+람다 함수 생성 시 `eventSource`를 선택한 경우, [AWS Lambda Powertools의 `@event_parser`](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)가 함수에 적용됩니다. 예시:
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
-    event.detail_type # <- IDE 자동 완성 지원되는 타입 안전 코드
+    event.detail_type # <- IDE 자동완성 지원되는 타입 안전 접근
 ```
 
-이를 통해 <Link path="guides/fastapi">Fast API</Link> 작업과 유사한 방식으로 [Pydantic](https://docs.pydantic.dev/latest/)을 사용해 데이터 모델을 정의할 수 있습니다.
+이를 통해 <Link path="guides/fastapi">Fast API</Link> 작업과 유사하게 [Pydantic](https://docs.pydantic.dev/latest/)을 이용한 데이터 모델 정의가 가능합니다.
 
 :::tip
-DynamoDB 스트림이나 EventBridge 이벤트와 같이 이벤트 내에 중첩된 커스텀 데이터가 있는 경우, [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes)를 사용해 해당 데이터에 대한 타입 안전성을 제공할 수 있습니다.
+DynamoDB 스트림이나 EventBridge 이벤트와 같이 이벤트 내에 중첩된 커스텀 데이터가 있는 경우, [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes)를 사용하여 타입 안전성을 확보할 수 있습니다.
 :::
 
-이벤트 타입을 지정하지 않으려면 `eventSource` 옵션에서 `Any`를 선택하면 됩니다.
+이벤트 타입을 지정하지 않으려면 `eventSource`로 `Any`를 선택하면 됩니다.
 
-## 함수 배포하기
+## 함수 배포
 
-Python Lambda Function 제너레이터는 `common/constructs` 폴더에 함수 배포를 위한 CDK 구문을 생성합니다. CDK 애플리케이션에서 다음과 같이 사용 가능:
+Python Lambda Function 생성기는 `common/constructs` 폴더에 배포용 CDK 구문을 생성합니다. CDK 애플리케이션에서 다음과 같이 사용 가능:
 
 ```ts
 import { MyProjectMyFunction } from ':my-scope/common-constructs';
@@ -176,7 +175,7 @@ export class ExampleStack extends Stack {
 이 구문은 다음을 설정합니다:
 1. AWS Lambda 함수
 2. CloudWatch 로그 그룹
-3. X-Ray 추적 구성
+3. X-Ray 추적 설정
 4. CloudWatch 메트릭 네임스페이스
 
 이 함수는 모든 람다 [이벤트 소스](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/)의 대상으로 사용 가능합니다:
@@ -185,7 +184,7 @@ export class ExampleStack extends Stack {
 이벤트가 핸들러 함수 내에서 적절히 처리되도록 선택한 `eventSource` 옵션과 이벤트 소스가 일치하는지 확인하세요.
 :::
 
-다음 예제는 Event Bridge를 사용해 일정에 따라 람다 함수를 호출하는 CDK 코드를 보여줍니다:
+다음 예제는 Event Bridge를 이용한 스케줄 기반 람다 함수 호출을 위한 CDK 코드를 보여줍니다:
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';

--- a/docs/src/content/docs/ko/guides/python-project.mdx
+++ b/docs/src/content/docs/ko/guides/python-project.mdx
@@ -9,23 +9,22 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
-파이썬 프로젝트 생성기는 현대적인 [Python](https://www.python.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있습니다. 이 생성기는 [UV](https://docs.astral.sh/uv/)로 관리되는 단일 락파일과 [UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/) 내 가상 환경, 테스트 실행을 위한 [pytest](https://docs.pytest.org/en/stable/), 정적 분석을 위한 [Ruff](https://docs.astral.sh/ruff/)가 포함된 모범 사례 기반 구성으로 설정됩니다.
+Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [UV](https://docs.astral.sh/uv/)로 관리되는 단일 lockfile과 [UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/) 내의 가상 환경, 테스트 실행을 위한 [pytest](https://docs.pytest.org/en/stable/), 정적 분석을 위한 [Ruff](https://docs.astral.sh/ruff/)가 포함된 모범 사례 구성이 제공됩니다.
 
-## 사용 방법
+## 사용법
 
-### 파이썬 프로젝트 생성
+### Python 프로젝트 생성
 
-새 파이썬 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
+새 Python 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="py#project" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
-## 생성기 출력 결과
+## 생성기 출력
 
 생성기는 `<directory>/<name>` 디렉토리에 다음 프로젝트 구조를 생성합니다:
 
@@ -33,52 +32,52 @@ import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.j
 
   - \<module-name>
     - \_\_init\_\_.py 모듈 초기화
-    - hello.py 예제 파이썬 소스 파일
+    - hello.py 예제 Python 소스 파일
   - tests
     - \_\_init\_\_.py 모듈 초기화
-    - conftest.py 테스트 설정
+    - conftest.py 테스트 구성
     - test_hello.py 예제 테스트
-  - project.json 프로젝트 설정 및 빌드 타겟
-  - pyproject.toml UV용 패키징 설정 파일
-  - .python-version 프로젝트 파이썬 버전 정보
+  - project.json 프로젝트 구성 및 빌드 타겟
+  - pyproject.toml UV용 패키징 구성 파일
+  - .python-version 프로젝트의 Python 버전 포함
 
 </FileTree>
 
-워크스페이스 루트에는 다음 파일들이 생성/업데이트됩니다:
+워크스페이스 루트에 다음 파일들이 생성/업데이트된 것도 확인할 수 있습니다:
 
 <FileTree>
 
-  - pyproject.toml UV용 워크스페이스 레벨 패키징 설정
-  - .python-version 워크스페이스 파이썬 버전 정보
-  - uv.lock 파이썬 의존성 락파일
+  - pyproject.toml UV용 워크스페이스 수준 패키징 구성
+  - .python-version 워크스페이스 Python 버전 포함
+  - uv.lock Python 종속성 lockfile
 
 </FileTree>
 
-## 파이썬 소스 코드 작성
+## Python 소스 코드 작성
 
-`<module-name>` 디렉토리에 파이썬 소스 코드를 추가하세요.
+Python 소스 코드는 `<module-name>` 디렉토리에 추가하세요.
 
 ### 다른 프로젝트에서 라이브러리 코드 임포트
 
-[UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/)가 설정되어 있으므로, 워크스페이스 내 다른 파이썬 프로젝트에서 현재 프로젝트를 참조할 수 있습니다:
+[UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/)가 구성되어 있으므로, 워크스페이스 내 다른 Python 프로젝트에서 Python 프로젝트를 참조할 수 있습니다:
 
 ```python title="packages/my_other_project/my_other_project/main.py"
 from "my_library.hello" import say_hello
 ```
 
-위 예시에서 `my_library`는 모듈 이름, `hello`는 `hello.py` 파일, `say_hello`는 `hello.py`에 정의된 메서드입니다.
+위 예시에서 `my_library`는 모듈 이름, `hello`는 Python 소스 파일 `hello.py`에 해당하며, `say_hello`는 `hello.py`에 정의된 메서드입니다.
 
-### 의존성 관리
+### 종속성 관리
 
-프로젝트에 의존성을 추가하려면 파이썬 프로젝트에서 `add` 타겟을 실행하세요:
+프로젝트에 종속성을 추가하려면 Python 프로젝트에서 `add` 타겟을 실행할 수 있습니다:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-이 명령은 프로젝트의 `pyproject.toml` 파일에 의존성을 추가하고 루트 `uv.lock`을 업데이트합니다.
+이 명령은 프로젝트의 `pyproject.toml` 파일에 종속성을 추가하고 루트 `uv.lock`을 업데이트합니다.
 
-#### 런타임 코드 번들링
+#### 런타임 코드
 
-파이썬 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사용할 경우 소스 코드와 의존성을 번들로 만들어야 합니다. `project.json` 파일에 다음 타겟을 추가하여 구현할 수 있습니다:
+Python 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사용할 경우, 소스 코드와 모든 종속성을 번들로 만들어야 합니다. `project.json` 파일에 다음 타겟을 추가하여 이를 구현할 수 있습니다:
 
 ```json title="project.json"
 {
@@ -104,21 +103,23 @@ from "my_library.hello" import say_hello
 
 ### 빌드
 
-`project.json`에 정의된 `build` 타겟을 실행하여 프로젝트를 빌드할 수 있습니다:
+Python 프로젝트는 `build` 타겟(`project.json`에 정의됨)으로 구성되며 다음 명령으로 실행할 수 있습니다:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-`<project-name>`은 프로젝트의 전체 정규화된 이름입니다.
+여기서 `<project-name>`은 프로젝트의 완전한 이름입니다.
 
-`build` 타겟은 컴파일, 린트, 테스트를 수행합니다. 빌드 결과물은 워크스페이스 루트의 `dist` 폴더 내에 저장됩니다 (예: `dist/packages/<my-library>/build`).
+`build` 타겟은 컴파일, 린트 및 테스트를 수행합니다.
+
+빌드 출력은 워크스페이스 루트의 `dist` 폴더 내 패키지 및 타겟별 디렉토리(예: `dist/packages/<my-library>/build`)에서 확인할 수 있습니다.
 
 ## 테스트
 
-[pytest](https://docs.pytest.org/en/stable/)가 프로젝트 테스트를 위해 설정되어 있습니다.
+[pytest](https://docs.pytest.org/en/stable/)가 프로젝트 테스트를 위해 구성되어 있습니다.
 
 ### 테스트 작성
 
-테스트는 프로젝트 내 `test` 디렉토리의 `test_` 접두사가 붙은 파이썬 파일에 작성해야 합니다:
+테스트는 프로젝트 내 `test` 디렉토리의 `test_` 접두사가 붙은 Python 파일에 작성해야 합니다:
 
 <FileTree>
   - my_library
@@ -127,7 +128,7 @@ from "my_library.hello" import say_hello
     - test_hello.py hello.py 테스트
 </FileTree>
 
-테스트 메서드는 `test_`로 시작하며 단언문으로 기대값을 검증합니다:
+테스트는 `test_`로 시작하는 메서드로 작성하며, 예상 결과를 검증하기 위해 assertion을 사용합니다:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -140,30 +141,30 @@ def test_say_hello():
 
 ### 테스트 실행
 
-테스트는 `build` 타겟 실행 시 자동으로 수행되지만, 별도로 `test` 타겟을 실행할 수도 있습니다:
+테스트는 프로젝트의 `build` 타겟 실행 시 함께 수행되지만, `test` 타겟을 별도로 실행할 수도 있습니다:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-`-k` 플래그로 특정 테스트 파일이나 메서드를 지정하여 실행할 수 있습니다:
+`-k` 플래그를 사용하여 특정 테스트 파일이나 메서드를 지정해 개별 테스트를 실행할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
 ## 린팅
 
-파이썬 프로젝트는 [Ruff](https://docs.astral.sh/ruff/)를 사용하여 린트를 수행합니다.
+Python 프로젝트는 [Ruff](https://docs.astral.sh/ruff/)를 사용해 린팅을 수행합니다.
 
 ### 린터 실행
 
-프로젝트 린트 검사를 위해 `lint` 타겟을 실행하세요:
+프로젝트 린트 검사를 수행하려면 `lint` 타겟을 실행하세요:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
 ### 린트 문제 수정
 
-대부분의 린트/포맷팅 문제는 자동으로 수정 가능합니다. `--configuration=fix` 인자와 함께 실행하여 수정하세요:
+대부분의 린트 또는 포맷팅 문제는 자동으로 수정할 수 있습니다. `--configuration=fix` 인자를 추가해 Ruff가 문제를 수정하도록 할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-워크스페이스 전체 패키지의 린트 문제를 일괄 수정하려면 다음 명령을 사용하세요:
+워크스페이스 내 모든 패키지의 린트 문제를 한 번에 수정하려면 다음 명령을 실행하세요:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -11,11 +11,10 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/)는 엔드투엔드 타입 안전성을 갖춘 TypeScript API 구축 프레임워크입니다. tRPC를 사용하면 API 작업의 입력 및 출력 변경사항이 클라이언트 코드에 즉시 반영되며, 프로젝트 재빌드 없이도 IDE에서 바로 확인할 수 있습니다.
+[tRPC](https://trpc.io/)는 엔드투엔드 타입 안전성을 갖춘 TypeScript API 구축 프레임워크입니다. tRPC를 사용하면 API 작업의 입력 및 출력 변경사항이 클라이언트 코드에 즉시 반영되며, 프로젝트 재빌드 없이 IDE에서 바로 확인할 수 있습니다.
 
-tRPC API 생성기는 AWS CDK 인프라 설정이 완료된 새로운 tRPC API를 생성합니다. 생성된 백엔드는 서버리스 배포를 위해 AWS Lambda를 사용하며 [Zod](https://zod.dev/)를 통한 스키마 검증을 포함합니다. 또한 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/)를 설정하여 로깅, AWS X-Ray 추적, Cloudwatch 메트릭을 포함한 관측 기능을 제공합니다.
+tRPC API 생성기는 AWS CDK 인프라 설정이 포함된 새로운 tRPC API를 생성합니다. 생성된 백엔드는 서버리스 배포를 위해 AWS Lambda를 사용하며 [Zod](https://zod.dev/)를 통한 스키마 검증을 포함합니다. 또한 로깅, AWS X-Ray 추적, Cloudwatch 메트릭을 위한 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/)를 설정합니다.
 
 ## 사용 방법
 
@@ -27,11 +26,11 @@ tRPC API 생성기는 AWS CDK 인프라 설정이 완료된 새로운 tRPC API�
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
-## 생성기 출력
+## 생성기 출력 결과
 
 생성기는 `<directory>/<api-name>` 디렉토리에 다음 프로젝트 구조를 생성합니다:
 
@@ -40,14 +39,14 @@ tRPC API 생성기는 AWS CDK 인프라 설정이 완료된 새로운 tRPC API�
     - src
       - index.ts 스키마 진입점
       - procedures
-        - echo.ts "echo" 프로시저용 공유 Zod 스키마 정의
+        - echo.ts "echo" 프로시저용 공유 스키마 정의(Zod 사용)
     - tsconfig.json TypeScript 설정
-    - project.json 프로젝트 설정 및 빌드 대상
+    - project.json 프로젝트 설정 및 빌드 타겟
   - backend
     - src
       - init.ts 백엔드 tRPC 초기화
       - router.ts tRPC 라우터 정의 (Lambda 핸들러 API 진입점)
-      - procedures API에서 노출하는 프로시저(작업)
+      - procedures API가 노출하는 프로시저(또는 작업)
         - echo.ts 예제 프로시저
       - middleware
         - error.ts 오류 처리 미들웨어
@@ -58,22 +57,22 @@ tRPC API 생성기는 AWS CDK 인프라 설정이 완료된 새로운 tRPC API�
       - client
         - index.ts 기계 간 API 호출용 타입 안전 클라이언트
     - tsconfig.json TypeScript 설정
-    - project.json 프로젝트 설정 및 빌드 대상
+    - project.json 프로젝트 설정 및 빌드 타겟
 </FileTree>
 
-생성기는 또한 API 배포에 사용할 수 있는 CDK 구성을 `packages/common/constructs` 디렉토리에 생성합니다.
+생성기는 또한 API 배포에 사용할 수 있는 CDK 구문을 `packages/common/constructs` 디렉토리에 생성합니다.
 
 ## tRPC API 구현
 
-위에서 볼 수 있듯이 tRPC API는 [`schema`](#schema)와 [`backend`](#backend) 두 가지 주요 컴포넌트로 구성되며, 워크스페이스에서 개별 패키지로 정의됩니다.
+위에서 볼 수 있듯이 tRPC API는 [`schema`](#schema)와 [`backend`](#backend) 두 가지 주요 구성 요소로 이루어져 있으며, 워크스페이스에서 개별 패키지로 정의됩니다.
 
 :::tip
-`schema`와 `backend`는 모두 TypeScript 프로젝트이므로 일반적인 사용법에 대해서는 <Link path="guides/typescript-project">TypeScript 프로젝트 문서</Link>를 참조할 수 있습니다.
+`schema`와 `backend`는 모두 TypeScript 프로젝트이므로 일반적인 사용법에 대한 자세한 내용은 <Link path="guides/typescript-project">TypeScript 프로젝트 문서</Link>를 참조하세요.
 :::
 
 ### 스키마
 
-스키마 패키지는 클라이언트와 서버 코드 간에 공유되는 타입을 정의합니다. 여기서는 TypeScript 우선 스키마 선언 및 검증 라이브러리인 [Zod](https://zod.dev/)를 사용하여 이러한 타입을 정의합니다.
+스키마 패키지는 클라이언트와 서버 코드 간에 공유되는 타입을 정의합니다. 이 패키지에서는 TypeScript 우선 스키마 선언 및 검증 라이브러리인 [Zod](https://zod.dev/)를 사용하여 이러한 타입을 정의합니다.
 
 예시 스키마는 다음과 같을 수 있습니다:
 
@@ -105,13 +104,13 @@ interface User {
 
 스키마는 런타임에 tRPC API에 의해 자동으로 검증되므로 백엔드에서 수동으로 검증 로직을 작성할 필요가 없습니다.
 
-Zod는 `.merge`, `.pick`, `.omit` 등 스키마를 결합하거나 파생시키는 강력한 유틸리티를 제공합니다. 자세한 내용은 [Zod 문서 사이트](https://zod.dev/?id=basic-usage)에서 확인할 수 있습니다.
+Zod는 `.merge`, `.pick`, `.omit` 등과 같은 강력한 스키마 결합 및 파생 유틸리티를 제공합니다. 자세한 내용은 [Zod 문서 사이트](https://zod.dev/?id=basic-usage)에서 확인할 수 있습니다.
 
 ### 백엔드
 
-중첩된 `backend` 폴더에는 API 작업의 입력, 출력, 구현을 정의하는 API 구현이 포함되어 있습니다.
+중첩된 `backend` 폴더에는 API 작업의 입력, 출력 및 구현을 정의하는 API 구현이 포함되어 있습니다.
 
-`src/router.ts`에서 API의 진입점을 찾을 수 있습니다. 이 파일은 호출되는 작업을 기반으로 요청을 "프로시저"로 라우팅하는 Lambda 핸들러를 포함합니다. 각 프로시저는 예상 입력, 출력 및 구현을 정의합니다.
+API의 진입점은 `src/router.ts`에서 찾을 수 있습니다. 이 파일은 호출되는 작업을 기반으로 요청을 "프로시저"로 라우팅하는 Lambda 핸들러를 포함합니다. 각 프로시저는 예상 입력, 출력 및 구현을 정의합니다.
 
 생성된 샘플 라우터에는 `echo`라는 단일 작업이 있습니다:
 
@@ -123,7 +122,7 @@ export const appRouter = router({
 });
 ```
 
-예제 `echo` 프로시저는 `src/procedures/echo.ts`에 생성됩니다:
+예시 `echo` 프로시저는 `src/procedures/echo.ts`에 생성됩니다:
 
 ```ts
 export const echo = publicProcedure
@@ -132,22 +131,22 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-위 코드를 분석하면:
+위 코드를 분석하면 다음과 같습니다:
 
-- `publicProcedure`는 `src/middleware`에 설정된 미들웨어를 포함하여 API의 공개 메서드를 정의합니다. 이 미들웨어에는 로깅, 추적, 메트릭을 위한 AWS Lambda Powertools 통합이 포함됩니다.
+- `publicProcedure`는 `src/middleware`에 설정된 미들웨어를 포함하여 API의 공개 메서드를 정의합니다. 이 미들웨어에는 로깅, 추적 및 메트릭을 위한 AWS Lambda Powertools 통합이 포함됩니다.
 - `input`은 작업에 대한 예상 입력을 정의하는 Zod 스키마를 받습니다. 이 작업에 전송된 요청은 자동으로 이 스키마에 대해 검증됩니다.
 - `output`은 작업에 대한 예상 출력을 정의하는 Zod 스키마를 받습니다. 스키마를 준수하지 않는 출력을 반환하면 구현에서 타입 오류가 발생합니다.
-- `query`는 API 구현을 정의하는 함수를 받습니다. 이 구현은 작업에 전달된 `input`과 `opts.ctx`에서 사용 가능한 미들웨어에 의해 설정된 기타 컨텍스트를 포함하는 `opts`를 받습니다. `query`에 전달된 함수는 `output` 스키마를 준수하는 출력을 반환해야 합니다.
+- `query`는 API 구현을 정의하는 함수를 받습니다. 이 구현은 `opts`를 수신하며, 여기에는 작업에 전달된 `input`과 미들웨어에서 설정된 다른 컨텍스트(`opts.ctx`에서 사용 가능)가 포함됩니다. `query`에 전달된 함수는 `output` 스키마를 준수하는 출력을 반환해야 합니다.
 
-구현 정의에 `query`를 사용하는 것은 작업이 비변경적임을 나타냅니다. 데이터 검색 메서드를 정의할 때 사용합니다. 변경 작업을 구현하려면 대신 `mutation` 메서드를 사용하세요.
+구현 정의에 `query`를 사용하는 것은 작업이 변경 사항을 유발하지 않음을 나타냅니다. 데이터 검색 메서드를 정의할 때 사용합니다. 변경 작업을 구현하려면 대신 `mutation` 메서드를 사용하세요.
 
-새 작업을 추가할 경우 `src/router.ts`의 라우터에 등록해야 합니다.
+새 작업을 추가할 때는 `src/router.ts`의 라우터에 등록해야 합니다.
 
 ## tRPC API 맞춤 설정
 
 ### 오류 처리
 
-구현에서 `TRPCError`를 발생시켜 클라이언트에 오류 응답을 반환할 수 있습니다. 이러한 오류는 오류 유형을 나타내는 `code`를 받습니다. 예시:
+구현에서 `TRPCError`를 발생시켜 클라이언트에 오류 응답을 반환할 수 있습니다. 이때 오류 유형을 나타내는 `code`를 전달합니다:
 
 ```ts
 throw new TRPCError({
@@ -158,9 +157,9 @@ throw new TRPCError({
 
 ### 작업 구성
 
-API가 확장됨에 따라 관련 작업을 그룹화하고 싶을 수 있습니다.
+API가 커짐에 따라 관련 작업을 그룹화하고 싶을 수 있습니다.
 
-중첩 라우터를 사용하여 작업을 그룹화할 수 있습니다. 예시:
+중첩 라우터를 사용하여 관련 작업을 그룹화할 수 있습니다:
 
 ```ts
 import { getUser } from './procedures/users/get.js';
@@ -175,7 +174,7 @@ const appRouter = router({
 })
 ```
 
-클라이언트는 이 작업 그룹화를 받게 됩니다. 예를 들어 `listUsers` 작업 호출은 다음과 같이 표시될 수 있습니다:
+클라이언트는 이 그룹화된 작업을 받으며, 예를 들어 `listUsers` 작업을 호출하는 것은 다음과 같습니다:
 
 ```ts
 client.users.list.query();
@@ -183,24 +182,24 @@ client.users.list.query();
 
 ### 로깅
 
-AWS Lambda Powertools 로거는 `src/middleware/logger.ts`에 구성되며 `opts.ctx.logger`를 통해 API 구현에서 액세스할 수 있습니다. 이를 사용하여 CloudWatch Logs에 로깅하거나 모든 구조화된 로그 메시지에 포함할 추가 값을 제어할 수 있습니다. 예시:
+AWS Lambda Powertools 로거는 `src/middleware/logger.ts`에 구성되며, API 구현에서 `opts.ctx.logger`를 통해 접근할 수 있습니다. 이를 사용하여 CloudWatch Logs에 로깅하거나 모든 구조화된 로그 메시지에 포함할 추가 값을 제어할 수 있습니다. 예시:
 
 ```ts {5}
 export const echo = publicProcedure
    .input(...)
    .output(...)
    .query(async (opts) => {
-      opts.ctx.logger.info('작업이 입력으로 호출됨', opts.input);
+      opts.ctx.logger.info('작업이 입력과 함께 호출됨', opts.input);
 
       return ...;
    });
 ```
 
-로거에 대한 자세한 내용은 [AWS Lambda Powertools Logger 문서](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/)를 참조하세요.
+로거에 대한 자세한 내용은 [AWS Lambda Powertools 로거 문서](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/)를 참조하세요.
 
 ### 메트릭 기록
 
-AWS Lambda Powertools 메트릭은 `src/middleware/metrics.ts`에 구성되며 `opts.ctx.metrics`를 통해 API 구현에서 액세스할 수 있습니다. 이를 사용하여 AWS SDK를 가져오거나 사용하지 않고도 CloudWatch에 메트릭을 기록할 수 있습니다. 예시:
+AWS Lambda Powertools 메트릭은 `src/middleware/metrics.ts`에 구성되며, API 구현에서 `opts.ctx.metrics`를 통해 접근할 수 있습니다. 이를 사용하여 AWS SDK를 가져오거나 사용하지 않고도 CloudWatch에 메트릭을 기록할 수 있습니다. 예시:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -213,11 +212,11 @@ export const echo = publicProcedure
    });
 ```
 
-자세한 내용은 [AWS Lambda Powertools Metrics 문서](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/)를 참조하세요.
+자세한 내용은 [AWS Lambda Powertools 메트릭 문서](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/)를 참조하세요.
 
 ### X-Ray 추적 미세 조정
 
-AWS Lambda Powertools 트레이서는 `src/middleware/tracer.ts`에 구성되며 `opts.ctx.tracer`를 통해 API 구현에서 액세스할 수 있습니다. 이를 사용하여 API 요청의 성능 및 흐름에 대한 자세한 통찰력을 제공하는 AWS X-Ray 추적을 추가할 수 있습니다. 예시:
+AWS Lambda Powertools 추적기는 `src/middleware/tracer.ts`에 구성되며, API 구현에서 `opts.ctx.tracer`를 통해 접근할 수 있습니다. 이를 사용하여 API 요청의 성능 및 흐름에 대한 자세한 통찰력을 제공하는 AWS X-Ray 추적을 추가할 수 있습니다. 예시:
 
 ```ts {5-7}
 export const echo = publicProcedure
@@ -232,13 +231,13 @@ export const echo = publicProcedure
    });
 ```
 
-자세한 내용은 [AWS Lambda Powertools Tracer 문서](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/)를 참조하세요.
+자세한 내용은 [AWS Lambda Powertools 추적기 문서](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/)를 참조하세요.
 
 ### 커스텀 미들웨어 구현
 
 미들웨어를 구현하여 프로시저에 제공되는 컨텍스트에 추가 값을 추가할 수 있습니다.
 
-예를 들어 `src/middleware/identity.ts`에서 API 호출 사용자에 대한 세부 정보를 추출하는 미들웨어를 구현해 보겠습니다.
+예를 들어, `src/middleware/identity.ts`에서 API 호출 사용자에 대한 세부 정보를 추출하는 미들웨어를 구현해 보겠습니다.
 
 먼저 컨텍스트에 추가할 내용을 정의합니다:
 
@@ -270,7 +269,7 @@ export const createIdentityPlugin = () => {
 };
 ```
 
-이 예제에서는 API Gateway 이벤트에서 호출 Cognito 사용자의 세부 정보를 추출하려 합니다. REST API 또는 HTTP API에 의해 함수에 제공된 이벤트 여부에 따라 구현이 약간 다릅니다:
+이 예제에서는 Cognito 사용자의 주체 ID("sub")를 API Gateway 이벤트에서 추출하고 Cognito에서 사용자 세부 정보를 검색하려고 합니다. 구현은 REST API 또는 HTTP API에 의해 함수에 이벤트가 제공되는지에 따라 약간 다릅니다:
 
 <Tabs>
 <TabItem label="REST">
@@ -318,11 +317,11 @@ export const createIdentityPlugin = () => {
     if (!Users || Users.length !== 1) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `주제 ID ${sub}에 해당하는 사용자를 찾을 수 없음`,
+        message: `주체 ID ${sub}에 해당하는 사용자를 찾을 수 없음`,
       });
     }
 
-    // 다른 프로시저에 컨텍스트로 신원 제공
+    // 컨텍스트에 신원 정보 제공
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -387,11 +386,11 @@ export const createIdentityPlugin = () => {
     if (!Users || Users.length !== 1) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `주제 ID ${sub}에 해당하는 사용자를 찾을 수 없음`,
+        message: `주체 ID ${sub}에 해당하는 사용자를 찾을 수 없음`,
       });
     }
 
-    // 다른 프로시저에 컨텍스트로 신원 제공
+    // 컨텍스트에 신원 정보 제공
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -409,7 +408,7 @@ export const createIdentityPlugin = () => {
 
 ## tRPC API 배포
 
-tRPC 백엔드 생성기는 `common/constructs` 폴더에 API 배포용 CDK 구성을 생성합니다. CDK 애플리케이션에서 이를 사용할 수 있습니다. 예시:
+tRPC 백엔드 생성기는 `common/constructs` 폴더에 API 배포를 위한 CDK 구문을 생성합니다. CDK 애플리케이션에서 이를 사용할 수 있습니다:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
@@ -431,7 +430,7 @@ export class ExampleStack extends Stack {
 <Snippet name="api/type-safe-api-integrations" />
 
 :::tip
-tRPC API에서 프로시저를 추가하거나 제거할 때 재빌드 없이도 이러한 변경사항이 CDK 구성에 즉시 반영됩니다.
+tRPC API에서 프로시저를 추가하거나 제거할 때, 이러한 변경 사항은 재빌드 없이 즉시 CDK 구문에 반영됩니다.
 :::
 
 ### 접근 권한 부여
@@ -444,7 +443,7 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## 로컬 tRPC 서버
 
-`serve` 대상을 사용하여 API용 로컬 서버를 실행할 수 있습니다. 예시:
+`serve` 타겟을 사용하여 API용 로컬 서버를 실행할 수 있습니다:
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
@@ -452,7 +451,7 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## tRPC API 호출
 
-타입 안전 방식으로 API를 호출하기 위해 tRPC 클라이언트를 생성할 수 있습니다. 다른 백엔드에서 tRPC API를 호출하는 경우 `src/client/index.ts`의 클라이언트를 사용할 수 있습니다. 예시:
+타입 안전 방식으로 API를 호출하기 위해 tRPC 클라이언트를 생성할 수 있습니다. 다른 백엔드에서 tRPC API를 호출하는 경우 `src/client/index.ts`의 클라이언트를 사용할 수 있습니다:
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -462,7 +461,7 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-React 웹사이트에서 API를 호출하는 경우 <Link path="guides/api-connection/react-trpc">API 연결</Link> 생성기를 사용하여 클라이언트를 구성하는 것을 고려해 보세요.
+React 웹사이트에서 API를 호출하는 경우 <Link path="guides/api-connection/react-trpc">API 연결</Link> 생성기를 사용하여 클라이언트를 구성하는 것을 고려하세요.
 
 ## 추가 정보
 

--- a/docs/src/content/docs/ko/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/ko/guides/ts-mcp-server.mdx
@@ -14,26 +14,26 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 # TypeScript MCP 서버 생성기
 
-대형 언어 모델(LLM)에 컨텍스트를 제공하기 위한 TypeScript [모델 컨텍스트 프로토콜(MCP)](https://modelcontextprotocol.io/) 서버를 생성합니다.
+대규모 언어 모델(LLM)에 컨텍스트를 제공하기 위한 TypeScript [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 서버를 생성합니다.
 
 ## MCP란?
 
-[모델 컨텍스트 프로토콜(MCP)](https://modelcontextprotocol.io/)은 AI 어시스턴트가 외부 도구 및 리소스와 상호 작용할 수 있도록 하는 개방형 표준입니다. LLM이 다음을 일관된 방식으로 수행할 수 있도록 지원합니다:
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/)는 AI 어시스턴트가 외부 도구 및 리소스와 상호작용할 수 있도록 하는 개방형 표준입니다. LLM이 다음을 수행할 수 있는 일관된 방식을 제공합니다:
 
 - 작업 수행 또는 정보 검색을 위한 도구(함수) 실행
-- 컨텍스트 또는 데이터를 제공하는 리소스 접근
+- 컨텍스트 또는 데이터 제공 리소스 접근
 
 ## 사용 방법
 
 ### MCP 서버 생성
 
-TypeScript MCP 서버를 두 가지 방법으로 생성할 수 있습니다:
+TypeScript MCP 서버를 두 가지 방식으로 생성할 수 있습니다:
 
 <RunGenerator generator="ts#mcp-server" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## 생성기 출력 결과
 
@@ -41,11 +41,11 @@ TypeScript MCP 서버를 두 가지 방법으로 생성할 수 있습니다:
 
 <FileTree>
   - packages/\<name>/
-    - README.md MCP 서버 사용 설명서
-    - project.json 빌드, 번들 및 개발 타겟을 포함한 Nx 프로젝트 설정
+    - README.md 사용 방법 설명이 포함된 MCP 서버 문서
+    - project.json 빌드, 번들 및 개발 타겟을 포함한 Nx 프로젝트 구성
     - src/
       - index.ts MCP 서버 진입점
-      - server.ts 도구 및 리소스를 정의하는 메인 서버
+      - server.ts 도구와 리소스를 정의하는 메인 서버 파일
       - global.d.ts 마크다운 파일 임포트를 위한 TypeScript 타입 선언
       - resources/
         - example-context.md MCP 서버 리소스로 사용되는 예시 마크다운 파일
@@ -55,17 +55,17 @@ TypeScript MCP 서버를 두 가지 방법으로 생성할 수 있습니다:
 생성기 출력에 대한 자세한 내용은 <Link path="/guides/typescript-project">TypeScript 프로젝트 생성기 문서</Link>를 참조하세요.
 :::
 
-## MCP 서버 작업 방법
+## MCP 서버 작업하기
 
 ### 도구 추가
 
-도구는 AI 어시스턴트가 호출할 수 있는 동작 수행 함수입니다. `server.ts` 파일에 새 도구를 추가할 수 있습니다:
+도구는 AI 어시스턴트가 작업을 수행하기 위해 호출할 수 있는 함수입니다. `server.ts` 파일에 새 도구를 추가할 수 있습니다:
 
 ```typescript
 server.tool("toolName",
   { param1: z.string(), param2: z.number() }, // Zod를 사용한 입력 스키마
   async ({ param1, param2 }) => {
-    // 도구 구현
+    // 도구 구현 로직
     return {
       content: [{ type: "text", text: "Result" }]
     };
@@ -85,7 +85,7 @@ server.resource('resource-name', 'example://resource', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
-// 동적 리소스
+// 동적 리소스 생성
 server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
   const data = await fetchSomeData();
   return {
@@ -100,11 +100,11 @@ MCP 서버를 AI 어시스턴트와 사용하려면 먼저 번들링해야 합�
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-이렇게 하면 `dist/packages/your-mcp-server/bundle/index.js` 경로에 번들 버전이 생성됩니다(디렉토리 설정에 따라 경로가 다를 수 있음).
+이 명령은 `dist/packages/your-mcp-server/bundle/index.js` 경로에 번들된 버전을 생성합니다 (디렉토리 설정에 따라 경로가 다를 수 있음).
 
 ### 설정 파일
 
-MCP를 지원하는 대부분의 AI 어시스턴트는 유사한 설정 방식을 사용합니다. MCP 서버 세부 정보가 포함된 설정 파일을 생성하거나 업데이트해야 합니다:
+MCP를 지원하는 대부분의 AI 어시스턴트는 유사한 설정 방식을 사용합니다. MCP 서버 정보로 설정 파일을 생성하거나 업데이트해야 합니다:
 
 ```json
 {
@@ -120,10 +120,10 @@ MCP를 지원하는 대부분의 AI 어시스턴트는 유사한 설정 방식�
 }
 ```
 
-`/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js`를 실제 번들링된 MCP 서버 경로로 교체하세요.
+`/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js`를 실제 번들 경로로 교체하세요.
 
 :::caution
-서버 연결 시 `ENOENT node` 오류가 발생하면 터미널에서 `which node`를 실행하여 얻은 전체 node 경로를 지정해야 할 수 있습니다.
+서버 연결 시 `ENOENT node` 오류가 발생하면 터미널에서 `which node` 명령으로 확인한 node의 전체 경로를 지정해야 할 수 있습니다.
 :::
 
 ### 어시스턴트별 설정
@@ -136,22 +136,22 @@ MCP를 지원하는 대부분의 AI 어시스턴트는 유사한 설정 방식�
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
 
 :::tip
-Amazon Q Developer와 같은 일부 AI 어시스턴트는 워크스페이스 수준 MCP 서버 설정을 지원하여 특정 프로젝트와 관련된 MCP 서버를 정의하는 데 유용합니다.
+Amazon Q Developer와 같은 일부 AI 어시스턴트는 워크스페이스 수준의 MCP 서버 설정을 지원하여 특정 프로젝트와 관련된 MCP 서버를 정의하는 데 유용합니다.
 :::
 
 ## 개발 워크플로우
 
 ### 빌드 타겟
 
-이 생성기는 <Link path="/guides/typescript-project">TypeScript 프로젝트 생성기</Link>를 기반으로 하며 해당 타겟을 상속받으며 다음과 같은 추가 타겟을 제공합니다:
+이 생성기는 <Link path="/guides/typescript-project">TypeScript 프로젝트 생성기</Link>를 기반으로 하며 기본 타겟을 상속받으며 다음과 같은 추가 타겟을 포함합니다:
 
 #### 번들
 
-`bundle` 타겟은 [esbuild](https://esbuild.github.io/)를 사용하여 AI 어시스턴트와 함께 사용할 수 있는 단일 JavaScript 번들 파일을 생성합니다:
+`bundle` 타겟은 [esbuild](https://esbuild.github.io/)를 사용하여 AI 어시스턴트와 함께 사용 가능한 단일 JavaScript 번들 파일을 생성합니다:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-이렇게 하면 `dist/packages/your-mcp-server/bundle/index.js` 경로에 번들 버전이 생성됩니다(디렉토리 설정에 따라 경로가 다를 수 있음).
+이 명령은 `dist/packages/your-mcp-server/bundle/index.js` 경로에 번들된 버전을 생성합니다 (디렉토리 설정에 따라 경로가 다를 수 있음).
 
 #### 개발
 
@@ -159,7 +159,7 @@ Amazon Q Developer와 같은 일부 AI 어시스턴트는 워크스페이스 수
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-개발 중에 사용하면 AI 어시스턴트가 최신 MCP 서버 버전을 사용하도록 보장합니다.
+이 기능은 개발 중에 AI 어시스턴트가 최신 MCP 서버 버전을 사용하도록 보장해주어 특히 유용합니다.
 
 :::note
 일부 AI 어시스턴트는 변경 사항 적용을 위해 MCP 서버 재시작이 필요할 수 있습니다.

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -10,32 +10,31 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
-[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html)는 AWS CloudFormation을 통해 클라우드 인프라를 코드로 정의하고 프로비저닝하기 위한 프레임워크입니다.
+[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html)는 클라우드 인프라를 코드로 정의하고 AWS CloudFormation을 통해 프로비저닝하는 프레임워크입니다.
 
 TypeScript 인프라 생성기는 TypeScript로 작성된 AWS CDK 인프라 애플리케이션을 생성합니다. 생성된 애플리케이션은 [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html) 검사를 통해 보안 모범 사례를 포함합니다.
 
 ## 사용 방법
 
-### 인프라 프로젝트 생성
+### 인프라 프로젝트 생성하기
 
-다음 두 가지 방법으로 새 인프라 프로젝트를 생성할 수 있습니다:
+새 인프라 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="ts#infra" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
-## 생성기 출력
+## 생성기 출력 결과
 
 생성기는 `<directory>/<name>` 디렉토리에 다음 프로젝트 구조를 생성합니다:
 
 <FileTree>
 
   - src
-    - main.ts CDK 스택을 인스턴스화하는 애플리케이션 진입점
+    - main.ts 배포할 CDK 스택을 인스턴스화하는 애플리케이션 진입점
     - stacks CDK 스택 정의
       - application-stack.ts 메인 애플리케이션 스택
   - cdk.json CDK 구성
@@ -44,10 +43,10 @@ TypeScript 인프라 생성기는 TypeScript로 작성된 AWS CDK 인프라 애�
 </FileTree>
 
 :::tip
-인프라는 TypeScript 프로젝트이므로 일반적인 사용법에 대해서는 <Link path="guides/typescript-project">TypeScript 프로젝트 문서</Link>를 참조할 수 있습니다.
+인프라는 TypeScript 프로젝트이므로 일반적인 사용법에 대한 자세한 내용은 <Link path="guides/typescript-project">TypeScript 프로젝트 문서</Link>를 참조하세요.
 :::
 
-## CDK 인프라 구현
+## CDK 인프라 구현하기
 
 `src/stacks/application-stack.ts` 파일 내에서 CDK 인프라 작성을 시작할 수 있습니다. 예시:
 
@@ -60,7 +59,7 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // 인프라 리소스 선언
+    // 여기에 인프라를 정의하세요
     new Bucket(this, 'MyBucket');
   }
 }
@@ -68,9 +67,9 @@ export class ApplicationStack extends cdk.Stack {
 
 ### API 인프라
 
-<Link path="guides/trpc">tRPC API</Link> 또는 <Link path="guides/fastapi">FastAPI</Link> 생성기를 사용하여 API를 생성한 경우, `packages/common/constructs`에 배포를 위한 컨스트럭트가 이미 존재합니다.
+<Link path="guides/trpc">tRPC API</Link> 또는 <Link path="guides/fastapi">FastAPI</Link> 생성기를 사용하여 API를 생성한 경우, `packages/common/constructs`에 배포를 위한 구문(Construct)이 이미 존재하는 것을 확인할 수 있습니다.
 
-예를 들어 `my-api`라는 tRPC API를 생성한 경우, 컨스트럭트를 임포트하고 인스턴스화하여 모든 필요한 인프라를 추가할 수 있습니다:
+예를 들어 `my-api`라는 tRPC API를 생성한 경우, 간단히 구문을 임포트하고 인스턴스화하여 필요한 모든 인프라를 추가할 수 있습니다:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -89,7 +88,7 @@ export class ApplicationStack extends cdk.Stack {
 
 ### 웹사이트 인프라
 
-<Link path="guides/cloudscape-website">CloudScape 웹사이트</Link> 생성기를 사용한 경우 `packages/common/constructs`에 배포용 컨스트럭트가 존재합니다. 예시:
+<Link path="guides/cloudscape-website">CloudScape 웹사이트</Link> 생성기를 사용한 경우, `packages/common/constructs`에 배포를 위한 구문이 이미 존재합니다. 예시:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -107,24 +106,24 @@ export class ApplicationStack extends cdk.Stack {
 ```
 
 :::warning
-웹사이트 <Link path="guides/cloudscape-website#runtime-configuration">런타임 구성</Link>에 모든 API 설정이 포함되도록 하려면 API 컨스트럭트 _이후_에 웹사이트를 선언해야 합니다.
+웹사이트 <Link path="guides/cloudscape-website#runtime-configuration">런타임 구성</Link>에 모든 API 설정이 포함되도록 하려면, 웹사이트 구문을 모든 API 구문 _이후에_ 선언해야 합니다.
 :::
 
-## 인프라 신서사이즈
+## 인프라 합성하기
 
-`build` 타겟의 일부로 <Link path="guides/typescript-project#building">기본 컴파일, 린트 및 테스트 타겟</Link>을 실행하는 동시에 인프라 프로젝트를 CloudFormation으로 _신서사이즈_합니다. 이는 `synth` 타겟을 실행하여 독립적으로 수행할 수도 있습니다:
+`build` 타겟의 일부로 <Link path="guides/typescript-project#building">기본 컴파일, 린트 및 테스트 타겟</Link>을 실행하는 동시에 인프라 프로젝트를 CloudFormation으로 _합성_합니다. 이는 `synth` 타겟을 실행하여 독립적으로 수행할 수도 있습니다:
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
-신서사이즈된 클라우드 어셈블리는 루트 `dist` 폴더의 `dist/packages/<my-infra-project>/cdk.out`에서 확인할 수 있습니다.
+합성된 클라우드 어셈블리는 루트 `dist` 폴더의 `dist/packages/<my-infra-project>/cdk.out`에서 확인할 수 있습니다.
 
 ## AWS 계정 부트스트랩
 
-CDK 애플리케이션을 AWS 계정에 처음 배포할 경우 부트스트랩이 필요합니다.
+AWS 계정에 CDK 애플리케이션을 처음 배포하는 경우 먼저 부트스트랩이 필요합니다.
 
 먼저 [AWS 계정 자격 증명을 구성](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)했는지 확인하세요.
 
-다음으로 `cdk bootstrap` 명령을 사용합니다:
+다음으로 `cdk bootstrap` 명령을 사용할 수 있습니다:
 
 ```bash
 npx cdk bootstrap aws://<account-id>/<region>
@@ -132,12 +131,12 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 자세한 내용은 [CDK 문서](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html)를 참조하세요.
 
-## AWS 배포
+## AWS에 배포하기
 
 빌드 후 `deploy` 타겟을 사용하여 인프라를 AWS에 배포할 수 있습니다.
 
 :::caution
-CI/CD 파이프라인에서 배포할 경우 `deploy-ci` 타겟을 사용하세요. 자세한 내용은 아래를 참조하세요.
+CI/CD 파이프라인에서 배포하는 경우 `deploy-ci` 타겟을 사용하세요. 자세한 내용은 아래를 참조하세요.
 :::
 
 먼저 [AWS 계정 자격 증명을 구성](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)했는지 확인하세요.
@@ -147,19 +146,19 @@ CI/CD 파이프라인에서 배포할 경우 `deploy-ci` 타겟을 사용하세�
 <NxCommands commands={['run <my-infra>:deploy --all']} />
 
 :::tip
-위 명령어는 `main.ts`에 정의된 _모든_ 스택을 배포합니다. 특히 애플리케이션의 여러 단계를 구성한 경우 개별 스택을 타겟팅할 수 있습니다:
+위 명령어는 `main.ts`에 정의된 _모든_ 스택을 배포합니다. 특히 샌드박스 환경 등 애플리케이션의 여러 단계를 구성한 경우 개별 스택을 대상으로 지정할 수 있습니다:
 
 <NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
 :::
 
-## CI/CD 파이프라인에서 AWS 배포
+## CI/CD 파이프라인에서 AWS에 배포하기
 
-CI/CD 파이프라인의 일부로 AWS에 배포할 경우 `deploy-ci` 타겟을 사용하세요.
+CI/CD 파이프라인의 일부로 AWS에 배포하는 경우 `deploy-ci` 타겟을 사용하세요.
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-이 타겟은 일반 `deploy` 타겟과 달리 사전 신서사이즈된 클라우드 어셈블리를 사용하여 배포합니다. 이는 패키지 버전 변경으로 인한 비결정적 문제를 방지하고 모든 파이프라인 단계에서 동일한 클라우드 어셈블리를 사용하도록 합니다.
+이 타겟은 일반 `deploy` 타겟과 달리 사전 합성된 클라우드 어셈블리를 배포하도록 보장합니다. 이는 패키지 버전 변경으로 인한 비결정성 문제를 방지하여 모든 파이프라인 단계가 동일한 클라우드 어셈블리를 사용하도록 합니다.
 
 ## 추가 정보
 
-CDK에 대한 자세한 내용은 [CDK 개발자 가이드](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) 및 [API 레퍼런스](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html)를 참조하세요.
+CDK에 대한 자세한 내용은 [CDK 개발자 가이드](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) 및 [API 참조 문서](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html)를 참조하세요.

--- a/docs/src/content/docs/ko/guides/typescript-project.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-project.mdx
@@ -10,21 +10,20 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
-TypeScript 프로젝트 생성기는 현대적인 [TypeScript](https://www.typescriptlang.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), TypeScript [프로젝트 참조](https://www.typescriptlang.org/docs/handbook/project-references.html), 테스트 실행을 위한 [Vitest](https://vitest.dev/), 정적 분석을 위한 [ESLint](https://eslint.org/) 등 모범 사례가 구성되어 있습니다.
+TypeScript 프로젝트 생성기는 모던 [TypeScript](https://www.typescriptlang.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), TypeScript [프로젝트 참조](https://www.typescriptlang.org/docs/handbook/project-references.html), 테스트 실행을 위한 [Vitest](https://vitest.dev/), 정적 분석을 위한 [ESLint](https://eslint.org/) 등 모범 사례가 구성된 상태로 설정됩니다.
 
 ## 사용 방법
 
-### TypeScript 프로젝트 생성하기
+### TypeScript 프로젝트 생성
 
-다음 두 가지 방법으로 새로운 TypeScript 프로젝트를 생성할 수 있습니다:
+새 TypeScript 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="ts#project" />
 
 ### 옵션
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## 생성기 출력 결과
 
@@ -34,46 +33,46 @@ TypeScript 프로젝트 생성기는 현대적인 [TypeScript](https://www.types
 
   - src TypeScript 소스 코드
     - index.ts
-  - project.json 프로젝트 구성 및 빌드 대상
-  - tsconfig.json 프로젝트 기본 TypeScript 구성 (작업 공간 루트 tsconfig.base.json 확장)
-  - tsconfig.lib.json 라이브러리 런타임/패키지 소스용 TypeScript 구성
+  - project.json 프로젝트 구성 및 빌드 타겟
+  - tsconfig.json 이 프로젝트의 기본 TypeScript 구성 (워크스페이스 루트 tsconfig.base.json 상속)
+  - tsconfig.lib.json 라이브러리용 TypeScript 구성 (런타임 또는 패키지된 소스)
   - tsconfig.spec.json 테스트용 TypeScript 구성
-  - vite.config.ts Vitest 구성 파일
-  - eslint.config.mjs ESLint 구성 파일
+  - vite.config.ts Vitest 구성
+  - eslint.config.mjs ESLint 구성
 
 </FileTree>
 
 :::tip
-`package.json` 파일이 생성되지 않음을 확인하세요! 이에 대한 이유는 [아래](#dependencies)에서 확인할 수 있습니다.
+`package.json` 파일이 생성되지 않는다는 점에 주목하세요! 이유는 [아래](#dependencies)에서 확인할 수 있습니다.
 :::
 
-작업 공간 루트의 다음 파일들에도 변경 사항이 적용됩니다:
+워크스페이스 루트의 다음 파일들에도 일부 변경 사항이 적용됩니다:
 
 <FileTree>
 
   - nx.json Nx 구성이 업데이트되어 프로젝트에 @nx/js/typescript 플러그인이 구성됨
-  - tsconfig.base.json 작업 공간 내 다른 프로젝트에서 현재 프로젝트를 임포트할 수 있도록 TypeScript 별칭 설정
-  - tsconfig.json 프로젝트 참조가 추가됨
+  - tsconfig.base.json 워크스페이스 내 다른 프로젝트에서 이 프로젝트를 임포트할 수 있도록 TypeScript 별칭이 설정됨
+  - tsconfig.json 프로젝트에 대한 TypeScript 프로젝트 참조가 추가됨
 
 </FileTree>
 
 ## TypeScript 소스 코드 작성
 
-`src` 디렉토리에 TypeScript 코드를 추가하세요.
+TypeScript 코드는 `src` 디렉토리에 추가하세요.
 
-### ESM 임포트 구문
+### ESM 임포트 문법
 
-TypeScript 프로젝트가 ES 모듈이므로 파일 확장자를 명시적으로 포함한 ESM 구문으로 임포트문을 작성해야 합니다:
+TypeScript 프로젝트가 ES 모듈이므로, 파일 확장자를 명시적으로 참조하는 ESM 문법으로 임포트 문을 작성해야 합니다:
 
 ```ts title="index.ts" ".js"
 import { sayHello } from './hello.js';
 ```
 
 :::note
-TypeScript를 사용하고 `sayHello`가 `hello.ts`에 정의되어 있더라도 임포트 시 `.js` 확장자를 사용합니다. 자세한 내용은 [여기](https://www.typescriptlang.org/docs/handbook/modules/reference.html)에서 확인할 수 있습니다.
+TypeScript를 사용하고 `sayHello`가 `hello.ts`에 정의되어 있더라도, 임포트 시 `.js` 파일 확장자를 사용합니다. 자세한 내용은 [여기](https://www.typescriptlang.org/docs/handbook/modules/reference.html)에서 확인할 수 있습니다.
 :::
 
-### 다른 TypeScript 프로젝트에서 사용할 내보내기
+### 다른 TypeScript 프로젝트를 위한 내보내기
 
 TypeScript 프로젝트의 진입점은 `src/index.ts`입니다. 다른 프로젝트에서 임포트할 수 있도록 여기에 내보내기를 추가할 수 있습니다:
 
@@ -82,19 +81,19 @@ export { sayHello } from './hello.js';
 export * from './algorithms/index.js';
 ```
 
-### 다른 프로젝트에서 라이브러리 코드 임포트하기
+### 다른 프로젝트에서 라이브러리 코드 임포트
 
-작업 공간 `tsconfig.base.json`에 구성된 [TypeScript 별칭](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths)을 통해 다른 TypeScript 프로젝트에서 현재 프로젝트를 참조할 수 있습니다:
+워크스페이스 `tsconfig.base.json`에 구성된 [TypeScript 별칭](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths)을 통해 다른 TypeScript 프로젝트에서 이 프로젝트를 참조할 수 있습니다:
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
 ```
 
 :::note
-TypeScript 프로젝트 별칭은 전통적인 `@` 대신 `:`로 시작합니다. 이는 작업 공간의 로컬 패키지와 [NPM](https://www.npmjs.com/)의 원격 패키지 간 이름 충돌 가능성을 방지합니다.
+TypeScript 프로젝트의 별칭은 전통적인 `@` 대신 `:`로 시작합니다. 이는 워크스페이스의 로컬 패키지와 [NPM](https://www.npmjs.com/)의 원격 패키지 간 이름 충돌 가능성을 방지하기 위함입니다.
 :::
 
-작업 공간에서 새 프로젝트에 대한 임포트문을 처음 추가할 경우 다음과 유사한 IDE 오류가 발생할 수 있습니다:
+워크스페이스에서 새 프로젝트에 대한 임포트 문을 처음 추가할 때 다음과 유사한 IDE 오류가 발생할 수 있습니다:
 
 <details>
 <summary>임포트 오류</summary>
@@ -110,14 +109,14 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 이는 [프로젝트 참조](https://www.typescriptlang.org/docs/handbook/project-references.html)가 아직 설정되지 않았기 때문입니다.
 
-Nx TypeScript Sync 생성기가 기본적으로 구성되어 있어 수동 구성 없이 다음 명령어 실행으로 필요한 구성을 추가할 수 있습니다:
+TypeScript 프로젝트는 Nx TypeSync 생성기를 통해 기본적으로 구성되어 수동으로 프로젝트 참조를 구성할 필요가 없습니다. 다음 명령을 실행하면 Nx가 필요한 구성을 추가합니다:
 
 <NxCommands commands={['sync']} />
 
-이후 IDE 오류가 사라지고 라이브러리를 사용할 수 있게 됩니다.
+이후 IDE의 오류가 사라지고 라이브러리를 사용할 준비가 완료됩니다.
 
 :::tip
-프로젝트를 빌드하면 다음과 같은 메시지가 표시될 수 있습니다:
+프로젝트를 빌드하면 다음과 같은 메시지가 표시될 수도 있습니다:
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -134,19 +133,19 @@ No, run the tasks without syncing the changes
 
 ### 의존성 관리
 
-전통적인 TypeScript 모노레포와 달리 TypeScript 프로젝트에 `package.json` 파일이 없을 수 있습니다.
+TypeScript 프로젝트에 `package.json` 파일이 없다는 점이 전통적인 TypeScript 모노레포에 익숙한 경우 예상과 다를 수 있습니다.
 
-모노레포 내 TypeScript 패키지에 의존성을 추가하려면 작업 공간 루트의 `package.json`에 의존성을 추가하면 됩니다. 패키지 매니저 명령어를 통해 추가할 수 있습니다:
+모노레포 내 TypeScript 패키지에 대한 의존성을 추가하려면 워크스페이스 루트의 `package.json`에 의존성을 추가하면 됩니다. 패키지 관리자 명령줄을 통해 이를 수행할 수 있습니다:
 
 <InstallCommand pkg="some-npm-package" />
 
-이렇게 추가된 의존성은 작업 공간 내 모든 TypeScript 프로젝트에서 사용 가능합니다.
+이렇게 추가된 의존성은 워크스페이스 내 모든 TypeScript 프로젝트에서 사용 가능합니다.
 
-#### 런타임 코드 사용 시
+#### 런타임 코드
 
-AWS Lambda 함수 핸들러와 같이 런타임 코드로 TypeScript 프로젝트를 사용할 경우, [트리 셰이킹](https://esbuild.github.io/api/#tree-shaking)을 통해 실제 사용되는 의존성만 포함되도록 [`esbuild`](https://esbuild.github.io/) 같은 도구를 사용하는 것이 좋습니다.
+TypeScript 프로젝트를 런타임 코드(예: AWS Lambda 함수 핸들러)로 사용할 때는 [`esbuild`](https://esbuild.github.io/)와 같은 도구를 사용하여 프로젝트를 번들링하는 것이 좋습니다. 이는 [트리 셰이킹](https://esbuild.github.io/api/#tree-shaking)을 통해 실제로 참조되는 의존성만 포함되도록 보장합니다.
 
-`project.json` 파일에 다음 예시와 같은 대상을 추가하여 구현할 수 있습니다:
+`project.json` 파일에 다음과 같은 타겟을 추가하여 이를 구현할 수 있습니다:
 
 ```json
 {
@@ -166,44 +165,44 @@ AWS Lambda 함수 핸들러와 같이 런타임 코드로 TypeScript 프로젝�
 ```
 
 :::note
-위 예시에서 번들 진입점으로 `src/index.ts`를 사용했으므로 이 파일에서 내보낸 코드와 모든 의존성이 번들에 포함됩니다.
+위 타겟에서 `src/index.ts`를 번들 진입점으로 선택했으므로, 이 파일에서 내보낸 코드와 모든 의존성이 번들에 포함됩니다.
 :::
 
-#### NPM 배포 시
+#### NPM에 배포
 
-TypeScript 프로젝트를 NPM에 배포할 경우 `package.json` 파일을 생성해야 합니다.
+TypeScript 프로젝트를 NPM에 배포할 경우 반드시 `package.json` 파일을 생성해야 합니다.
 
-이 파일은 프로젝트가 참조하는 모든 의존성을 선언해야 합니다. 빌드 시 작업 공간 루트 `package.json`의 의존성을 사용하므로, [Nx Dependency Checks ESLint 플러그인](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks)을 구성하여 배포용 `package.json`에 모든 사용 의존성이 포함되도록 하는 것이 좋습니다.
+이 파일은 프로젝트가 참조하는 모든 의존성을 선언해야 합니다. 빌드 시 프로젝트가 워크스페이스 루트 `package.json`을 통해 설치된 의존성을 확인하므로, [Nx Dependency Checks ESLint Plugin](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks)을 구성하여 배포용 프로젝트의 `package.json`이 프로젝트에서 사용하는 모든 의존성을 포함하도록 권장합니다.
 
 ### 빌드
 
-프로젝트 `project.json`에 정의된 `build` 대상으로 빌드를 실행할 수 있습니다:
+TypeScript 프로젝트는 `build` 타겟(`project.json`에 정의됨)으로 구성되며 다음 명령으로 실행할 수 있습니다:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 `<project-name>`은 프로젝트의 전체 이름입니다.
 
-`build` 대상은 컴파일, 린트, 테스트를 수행합니다. 
+`build` 타겟은 프로젝트를 컴파일, 린트, 테스트합니다.
 
-빌드 결과물은 작업 공간 루트 `dist` 폴더 내 `dist/packages/<my-library>/tsc`와 같은 경로에서 확인할 수 있습니다.
+빌드 출력은 워크스페이스 루트 `dist` 폴더 내 패키지 및 타겟별 디렉토리(예: `dist/packages/<my-library>/tsc`)에서 확인할 수 있습니다.
 
 ## 테스트
 
-[Vitest](https://vitest.dev/)가 테스트 실행을 위해 구성되어 있습니다.
+[Vitest](https://vitest.dev/)가 프로젝트 테스트를 위해 구성됩니다.
 
-### 테스트 작성하기
+### 테스트 작성
 
-`.spec.ts` 또는 `.test.ts` 파일에 테스트를 작성하고 프로젝트 `src` 폴더에 함께 배치하세요.
+테스트는 프로젝트의 `src` 폴더 내 `.spec.ts` 또는 `.test.ts` 파일에 함께 위치시켜 작성해야 합니다.
 
 예시:
 
 <FileTree>
   - src
     - hello.ts 라이브러리 소스 코드
-    - hello.spec.ts hello.ts 테스트 코드
+    - hello.spec.ts hello.ts 테스트
 </FileTree>
 
-Vitest는 `describe`, `it`, `test`, `expect` 등 Jest 스타일의 테스트 구문을 제공합니다.
+Vitest는 `describe`, `it`, `test`, `expect`와 같은 Jest 스타일 문법을 제공합니다.
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
@@ -219,40 +218,40 @@ describe('sayHello', () => {
 
 테스트 작성 방법 및 의존성 모킹과 같은 기능에 대한 자세한 내용은 [Vitest 문서](https://vitest.dev/guide/#writing-tests)를 참조하세요.
 
-### 테스트 실행하기
+### 테스트 실행
 
-테스트는 프로젝트 `build` 대상 실행 시 함께 실행되지만, `test` 대상으로 개별 실행도 가능합니다:
+테스트는 프로젝트의 `build` 타겟 실행 시 함께 실행되지만, `test` 타겟을 통해 별도로 실행할 수도 있습니다:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-`-t` 플래그로 특정 테스트를 실행할 수 있습니다:
+`-t` 플래그를 사용하여 개별 테스트 또는 테스트 스위트를 실행할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-VSCode 사용자는 [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) 확장을 설치하여 IDE에서 테스트를 실행/관찰/디버깅할 수 있습니다.
+VSCode 사용자는 [실제로 동작하는 Vitest Runner for VSCode](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) 확장을 설치하여 IDE에서 테스트를 실행, 감시, 디버그할 수 있습니다.
 :::
 
 ## 린팅
 
 TypeScript 프로젝트는 린팅을 위해 [ESLint](https://eslint.org/), 포맷팅을 위해 [Prettier](https://prettier.io/)를 사용합니다.
 
-작업 공간 루트 `eslint.config.mjs` 파일에서 ESLint를 구성하여 모든 TypeScript 프로젝트에 일관된 설정이 적용되도록 하는 것이 좋습니다.
+워크스페이스 루트 `eslint.config.mjs` 파일에서 ESLint를 구성하는 것을 권장합니다. 이 파일의 변경 사항은 워크스페이스 내 모든 TypeScript 프로젝트에 적용되어 일관성을 유지합니다.
 
-Prettier는 루트 `.prettierrc` 파일에서 구성할 수 있습니다.
+마찬가지로 Prettier는 루트 `.prettierrc` 파일에서 구성할 수 있습니다.
 
-### 린터 실행하기
+### 린터 실행
 
-프로젝트 린트 검사를 실행하려면 `lint` 대상을 실행하세요:
+프로젝트 린트 검사를 실행하려면 `lint` 타겟을 실행하세요:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### 린트 문제 수정하기
+### 린트 문제 수정
 
-대부분의 린트/포맷팅 문제는 자동으로 수정 가능합니다. `--configuration=fix` 인자로 ESLint를 실행하여 수정할 수 있습니다:
+대부분의 린트 또는 포맷팅 문제는 자동으로 수정할 수 있습니다. `--configuration=fix` 인자를 사용하여 ESLint가 린트 문제를 수정하도록 할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-작업 공간 전체 패키지의 린트 문제를 수정하려면 다음 명령어를 사용하세요:
+워크스페이스 내 모든 패키지의 린트 문제를 수정하려면 다음을 실행하세요:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/pt/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/api-connection/react-fastapi.mdx
@@ -11,9 +11,8 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-O gerador `api-connection` fornece uma maneira rápida de integrar seu site React com seu backend FastAPI. Ele configura toda a configuração necessária para conectar-se a backends FastAPI de forma tipada, incluindo geração de clientes e hooks do [TanStack Query](https://tanstack.com/query/v5), suporte a autenticação AWS IAM e tratamento adequado de erros.
+O gerador `api-connection` fornece uma maneira rápida de integrar seu site React com seu backend FastAPI. Ele configura todas as configurações necessárias para conectar-se aos backends FastAPI de forma type-safe, incluindo geração de clientes e hooks do [TanStack Query](https://tanstack.com/query/v5), suporte a autenticação AWS IAM e tratamento adequado de erros.
 
 ## Pré-requisitos
 
@@ -50,7 +49,7 @@ root.render(
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## Saída do Gerador
 
@@ -60,7 +59,7 @@ O gerador fará alterações nos seguintes arquivos do seu projeto FastAPI:
 
 - scripts
   - generate_open_api.py Adiciona um script que gera uma especificação OpenAPI para sua API
-- project.json Um novo target é adicionado ao build para invocar o script de geração acima
+- project.json Um novo target é adicionado ao build que invoca o script de geração acima
 
 </FileTree>
 
@@ -76,7 +75,7 @@ O gerador fará alterações nos seguintes arquivos da sua aplicação React:
     - use\<ApiName>.tsx Adiciona um hook para chamar sua API com estado gerenciado pelo TanStack Query
     - use\<ApiName>Client.tsx Adiciona um hook para instanciar o cliente vanilla que pode chamar sua API
     - useSigV4.tsx Adiciona um hook para assinar requisições HTTP com SigV4 (se selecionou autenticação IAM)
-- project.json Um novo target é adicionado ao build para gerar um cliente tipado
+- project.json Um novo target é adicionado ao build que gera um cliente type-safe
 - .gitignore Os arquivos do cliente gerado são ignorados por padrão
 
 </FileTree>
@@ -85,7 +84,7 @@ O gerador também adicionará Runtime Config à infraestrutura do seu site se ai
 
 ### Geração de Código
 
-Durante o build, um cliente tipado é gerado a partir da especificação OpenAPI do seu FastAPI. Isso adicionará três novos arquivos à sua aplicação React:
+No momento do build, um cliente type-safe é gerado a partir da especificação OpenAPI do seu FastAPI. Isso adicionará três novos arquivos à sua aplicação React:
 
 <FileTree>
 
@@ -93,27 +92,27 @@ Durante o build, um cliente tipado é gerado a partir da especificação OpenAPI
   - generated
     - \<ApiName>
       - types.gen.ts Tipos gerados dos modelos pydantic definidos no seu FastAPI
-      - client.gen.ts Cliente tipado para chamar sua API
-      - options-proxy.gen.ts Fornece métodos para criar opções de hooks do TanStack Query para interagir com sua API
+      - client.gen.ts Cliente type-safe para chamar sua API
+      - options-proxy.gen.ts Fornece métodos para criar opções de hooks do TanStack Query para interagir com sua API usando TanStack Query
 
 </FileTree>
 
-:::tip[Dica]
-Por padrão, o cliente gerado é ignorado no controle de versão. Se preferir incluí-lo, você pode remover a entrada do arquivo `.gitignore` da sua aplicação React, mas note que quaisquer alterações manuais nos arquivos `.gen.ts` serão sobrescritas quando o projeto for construído.
+:::tip
+Por padrão, o cliente gerado é ignorado do controle de versão. Se preferir incluí-lo, você pode remover a entrada do arquivo `.gitignore` da sua aplicação React, mas note que quaisquer alterações manuais nos arquivos `.gen.ts` serão sobrescritas quando o projeto for buildado.
 :::
 
 ## Usando o Código Gerado
 
-O cliente tipado gerado pode ser usado para chamar seu FastAPI a partir da aplicação React. Recomenda-se usar os hooks do TanStack Query, mas você pode usar o cliente vanilla se preferir.
+O cliente type-safe gerado pode ser usado para chamar seu FastAPI a partir da aplicação React. Recomenda-se usar o cliente através dos hooks do TanStack Query, mas você pode usar o cliente vanilla se preferir.
 
-:::note[Nota]
-Sempre que fizer alterações no seu FastAPI, você precisa reconstruir seu projeto para que essas mudanças sejam refletidas no cliente gerado. Por exemplo:
+:::note
+Sempre que fizer alterações no seu FastAPI, você precisa rebuildar seu projeto para que essas mudanças sejam refletidas no cliente gerado. Por exemplo:
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
-:::tip[Dica]
-Se estiver trabalhando simultaneamente na aplicação React e no FastAPI, você pode usar [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar o cliente sempre que fizer mudanças na API:
+:::tip
+Se estiver trabalhando ativamente tanto na aplicação React quanto no FastAPI, você pode usar [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar o cliente sempre que fizer mudanças na API:
 
 <NxCommands
   commands={[
@@ -147,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="Usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
+<Drawer title="Usar o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -182,7 +181,7 @@ function MyComponent() {
 
 ### Mutations
 
-Os hooks gerados incluem suporte para mutations usando o hook `useMutation` do TanStack Query. Isso fornece uma maneira limpa de lidar com operações de criação, atualização e exclusão com estados de carregamento, tratamento de erros e atualizações otimistas.
+Os hooks gerados incluem suporte para mutations usando o hook `useMutation` do TanStack Query. Isso fornece uma maneira limpa de lidar com operações de criação, atualização e exclusão com estados de loading, tratamento de erros e atualizações otimistas.
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -190,7 +189,7 @@ import { useMyApi } from './hooks/useMyApi';
 
 function CreateItemForm() {
   const api = useMyApi();
-  // Cria uma mutation usando as opções geradas
+  // Cria uma mutation usando as opções de mutation geradas
   const createItem = useMutation(api.createItem.mutationOptions());
 
   const handleSubmit = (e) => {
@@ -205,18 +204,18 @@ function CreateItemForm() {
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Criando...' : 'Criar Item'}
+        {createItem.isPending ? 'Creating...' : 'Create Item'}
       </button>
 
       {createItem.isSuccess && (
         <div className="success">
-          Item criado com ID: {createItem.data.id}
+          Item created with ID: {createItem.data.id}
         </div>
       )}
 
       {createItem.isError && (
         <div className="error">
-          Erro: {createItem.error.message}
+          Error: {createItem.error.message}
         </div>
       )}
     </form>
@@ -231,13 +230,13 @@ const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
     // Executa quando a mutation tem sucesso
-    console.log('Item criado:', data);
+    console.log('Item created:', data);
     // Você pode navegar para o novo item
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
     // Executa quando a mutation falha
-    console.error('Falha ao criar item:', error);
+    console.error('Failed to create item:', error);
   },
   onSettled: () => {
     // Executa quando a mutation é concluída (sucesso ou erro)
@@ -273,7 +272,7 @@ function CreateItemForm() {
       // navigate(`/items/${newItem.id}`);
     } catch (err) {
       setError(err);
-      console.error('Falha ao criar item:', err);
+      console.error('Failed to create item:', err);
     } finally {
       setIsLoading(false);
     }
@@ -286,18 +285,18 @@ function CreateItemForm() {
         type="submit"
         disabled={isLoading}
       >
-        {isLoading ? 'Criando...' : 'Criar Item'}
+        {isLoading ? 'Creating...' : 'Create Item'}
       </button>
 
       {createdItem && (
         <div className="success">
-          Item criado com ID: {createdItem.id}
+          Item created with ID: {createdItem.id}
         </div>
       )}
 
       {error && (
         <div className="error">
-          Erro: {error.message}
+          Error: {error.message}
         </div>
       )}
     </form>
@@ -308,7 +307,7 @@ function CreateItemForm() {
 
 ### Paginação com Infinite Queries
 
-Para endpoints que aceitam um parâmetro `cursor` como entrada, os hooks gerados fornecem suporte para infinite queries usando o hook `useInfiniteQuery` do TanStack Query. Isso facilita a implementação de funcionalidades "carregar mais" ou scroll infinito.
+Para endpoints que aceitam um parâmetro `cursor` como entrada, os hooks gerados fornecem suporte para infinite queries usando o hook `useInfiniteQuery` do TanStack Query. Isso facilita a implementação de funcionalidades "load more" ou scroll infinito.
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -351,20 +350,20 @@ function ItemList() {
         disabled={!items.hasNextPage || items.isFetchingNextPage}
       >
         {items.isFetchingNextPage
-          ? 'Carregando mais...'
+          ? 'Loading more...'
           : items.hasNextPage
-          ? 'Carregar Mais'
-          : 'Sem mais itens'}
+          ? 'Load More'
+          : 'No more items'}
       </button>
     </div>
   );
 }
 ```
 
-Os hooks gerados lidam automaticamente com paginação baseada em cursor se sua API suportar. O valor `nextCursor` é extraído da resposta e usado para buscar a próxima página.
+Os hooks gerados lidam automaticamente com a paginação baseada em cursor se sua API suportar isso. O valor `nextCursor` é extraído da resposta e usado para buscar a próxima página.
 
-:::tip[Dica]
-Se você tiver uma API paginada cujo parâmetro de paginação tenha um nome diferente de `cursor`, você pode [personalizá-lo usando a extensão OpenAPI `x-cursor`](#custom-pagination-cursor).
+:::tip
+Se você tiver uma API paginada cujo parâmetro de paginação tem um nome diferente de `cursor`, você pode [personalizá-lo usando a extensão OpenAPI `x-cursor`](#custom-pagination-cursor).
 :::
 
 <Drawer title="Paginação usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente diretamente.">
@@ -439,10 +438,10 @@ function ItemList() {
         disabled={!nextCursor || isFetchingMore}
       >
         {isFetchingMore
-          ? 'Carregando mais...'
+          ? 'Loading more...'
           : nextCursor
-          ? 'Carregar Mais'
-          : 'Sem mais itens'}
+          ? 'Load More'
+          : 'No more items'}
       </button>
     </div>
   );
@@ -452,7 +451,7 @@ function ItemList() {
 
 ### Tratamento de Erros
 
-A integração inclui tratamento de erros embutido com respostas de erro tipadas. Um tipo `<operation-name>Error` é gerado, encapsulando as possíveis respostas de erro definidas na especificação OpenAPI. Cada erro possui uma propriedade `status` e `error`, e ao verificar o valor de `status` você pode tratar tipos específicos de erros.
+A integração inclui tratamento de erros embutido com respostas de erro tipadas. Um tipo `<operation-name>Error` é gerado, encapsulando as possíveis respostas de erro definidas na especificação OpenAPI. Cada erro possui uma propriedade `status` e `error`, e ao verificar o valor de `status` você pode identificar um tipo específico de erro.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,7 +470,7 @@ function MyComponent() {
         // error.error é tipado como CreateItem400Response
         return (
           <div>
-            <h2>Entrada inválida:</h2>
+            <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
               {createItem.error.error.validationErrors.map((err) => (
@@ -484,7 +483,7 @@ function MyComponent() {
         // error.error é tipado como CreateItem403Response
         return (
           <div>
-            <h2>Não autorizado:</h2>
+            <h2>Not authorized:</h2>
             <p>{createItem.error.error.reason}</p>
           </div>
         );
@@ -493,7 +492,7 @@ function MyComponent() {
         // error.error é tipado como CreateItem5XXResponse
         return (
           <div>
-            <h2>Erro do servidor:</h2>
+            <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
             <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
@@ -501,7 +500,7 @@ function MyComponent() {
     }
   }
 
-  return <button onClick={handleClick}>Criar Item</button>;
+  return <button onClick={handleClick}>Create Item</button>;
 }
 ```
 
@@ -526,7 +525,7 @@ function MyComponent() {
         // error.error é tipado como CreateItem400Response
         return (
           <div>
-            <h2>Entrada inválida:</h2>
+            <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
               {error.error.validationErrors.map((err) => (
@@ -539,7 +538,7 @@ function MyComponent() {
         // error.error é tipado como CreateItem403Response
         return (
           <div>
-            <h2>Não autorizado:</h2>
+            <h2>Not authorized:</h2>
             <p>{error.error.reason}</p>
           </div>
         );
@@ -548,7 +547,7 @@ function MyComponent() {
         // error.error é tipado como CreateItem5XXResponse
         return (
           <div>
-            <h2>Erro do servidor:</h2>
+            <h2>Server error:</h2>
             <p>{error.error.message}</p>
             <p>Trace ID: {error.error.traceId}</p>
           </div>
@@ -556,14 +555,14 @@ function MyComponent() {
     }
   }
 
-  return <button onClick={handleClick}>Criar Item</button>;
+  return <button onClick={handleClick}>Create Item</button>;
 }
 ```
 </Drawer>
 
 ### Consumindo um Stream
 
-Se você <Link path="guides/fastapi#streaming">configurou seu FastAPI para transmitir respostas</Link>, seu hook `useQuery` atualizará automaticamente os dados conforme novos chunks do stream chegam.
+Se você <Link path="guides/fastapi#streaming">configurou seu FastAPI para stream de respostas</Link>, seu hook `useQuery` atualizará automaticamente seus dados conforme novos chunks do stream chegam.
 
 Por exemplo:
 
@@ -595,26 +594,26 @@ Você pode usar as propriedades `isLoading` e `fetchStatus` para determinar o es
 
   2. O primeiro chunk do stream é recebido
 
-      - `isLoading` torna-se `false`
+      - `isLoading` se torna `false`
       - `fetchStatus` permanece `'fetching'`
-      - `data` torna-se um array contendo o primeiro chunk
+      - `data` se torna um array contendo o primeiro chunk
 
   3. Chunks subsequentes são recebidos
 
       - `isLoading` permanece `false`
       - `fetchStatus` permanece `'fetching'`
-      - `data` é atualizado com cada novo chunk assim que recebido
+      - `data` é atualizado com cada chunk subsequente assim que é recebido
 
   4. O stream é concluído
 
       - `isLoading` permanece `false`
-      - `fetchStatus` torna-se `'idle'`
+      - `fetchStatus` se torna `'idle'`
       - `data` é um array de todos os chunks recebidos
 </Steps>
 
-<Drawer title="Streaming usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
+<Drawer title="Stream usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
 
-Se você <Link path="guides/fastapi#streaming">configurou seu FastAPI para transmitir respostas</Link>, o cliente gerado incluirá métodos tipados para iterar assincronamente sobre chunks do stream usando sintaxe `for await`.
+Se você <Link path="guides/fastapi#streaming">configurou seu FastAPI para stream de respostas</Link>, o cliente gerado incluirá métodos type-safe para iterar assincronamente sobre chunks do stream usando sintaxe `for await`.
 
 Por exemplo:
 
@@ -646,7 +645,7 @@ function MyStreamingComponent() {
 ```
 </Drawer>
 
-:::note[Nota]
+:::note
 Se você tem uma API de streaming que aceita um parâmetro `cursor`, ao usar o hook `useInfiniteQuery`, cada página aguardará o stream terminar antes de ser carregada.
 :::
 
@@ -654,7 +653,7 @@ Se você tem uma API de streaming que aceita um parâmetro `cursor`, ao usar o h
 
 ### Consultas e Mutations
 
-Por padrão, operações no seu FastAPI que usam os métodos HTTP `PUT`, `POST`, `PATCH` e `DELETE` são consideradas mutations, e as demais são consultas.
+Por padrão, operações no seu FastAPI que usam os métodos HTTP `PUT`, `POST`, `PATCH` e `DELETE` são consideradas mutations, e todas as outras são consideradas queries.
 
 Você pode alterar este comportamento usando `x-query` e `x-mutation`.
 
@@ -699,7 +698,7 @@ const startProcessing = useMutation(api.startProcessing.mutationOptions());
 
 ### Cursor de Paginação Personalizado
 
-Por padrão, os hooks gerados assumem paginação por cursor com um parâmetro chamado `cursor`. Você pode personalizar isso usando a extensão `x-cursor`:
+Por padrão, os hooks gerados assumem paginação baseada em cursor com um parâmetro chamado `cursor`. Você pode personalizar este comportamento usando a extensão `x-cursor`:
 
 ```python
 @app.get(
@@ -717,13 +716,13 @@ def list_items(page_token: str = None, limit: int = 10):
     }
 ```
 
-Se não quiser gerar `infiniteQueryOptions` para uma operação, defina `x-cursor` como `False`:
+Se você não deseja gerar `infiniteQueryOptions` para uma operação, pode definir `x-cursor` como `False`:
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
-        # Desabilita paginação por cursor para este endpoint
+        # Desativa paginação baseada em cursor para este endpoint
         "x-cursor": False
     }
 )
@@ -777,11 +776,11 @@ import { useMyApi } from './hooks/useMyApi';
 function ItemsAndUsers() {
   const api = useMyApi();
 
-  // Operações de Items são agrupadas sob api.items
+  // Operações de items são agrupadas sob api.items
   const items = useQuery(api.items.list.queryOptions());
   const createItem = useMutation(api.items.create.mutationOptions());
 
-  // Operações de Users são agrupadas sob api.users
+  // Operações de users são agrupadas sob api.users
   const users = useQuery(api.users.list.queryOptions());
 
   // Exemplo de uso
@@ -797,7 +796,7 @@ function ItemsAndUsers() {
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-      <button onClick={handleCreateItem}>Adicionar Item</button>
+      <button onClick={handleCreateItem}>Add Item</button>
 
       <h2>Users</h2>
       <ul>
@@ -812,7 +811,7 @@ function ItemsAndUsers() {
 
 Este agrupamento facilita a organização das chamadas de API e fornece melhor autocompletar na sua IDE.
 
-<Drawer title="Operações agrupadas usando o cliente diretamente" trigger="Clique aqui para ver um exemplo usando o cliente diretamente.">
+<Drawer title="Operações agrupadas usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente diretamente.">
 ```tsx
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -829,15 +828,15 @@ function ItemsAndUsers() {
       try {
         setIsLoading(true);
 
-        // Operações de Items são agrupadas sob api.items
+        // Operações de items são agrupadas sob api.items
         const itemsData = await api.items.list();
         setItems(itemsData);
 
-        // Operações de Users são agrupadas sob api.users
+        // Operações de users são agrupadas sob api.users
         const usersData = await api.users.list();
         setUsers(usersData);
       } catch (error) {
-        console.error('Erro ao buscar dados:', error);
+        console.error('Error fetching data:', error);
       } finally {
         setIsLoading(false);
       }
@@ -852,12 +851,12 @@ function ItemsAndUsers() {
       const newItem = await api.items.create({ name: 'New Item' });
       setItems(prevItems => [...prevItems, newItem]);
     } catch (error) {
-      console.error('Erro ao criar item:', error);
+      console.error('Error creating item:', error);
     }
   };
 
   if (isLoading) {
-    return <div>Carregando...</div>;
+    return <div>Loading...</div>;
   }
 
   return (
@@ -868,7 +867,7 @@ function ItemsAndUsers() {
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-      <button onClick={handleCreateItem}>Adicionar Item</button>
+      <button onClick={handleCreateItem}>Add Item</button>
 
       <h2>Users</h2>
       <ul>
@@ -882,13 +881,13 @@ function ItemsAndUsers() {
 ```
 </Drawer>
 
-:::tip[Dica]
+:::tip
 Você também pode dividir sua API usando múltiplos `routers`. Consulte a [Documentação do FastAPI](https://fastapi.tiangolo.com/tutorial/bigger-applications/) para mais detalhes.
 :::
 
 ### Erros
 
-Você pode personalizar respostas de erro no seu FastAPI definindo classes de exceção personalizadas, handlers de exceção e especificando modelos de resposta para diferentes códigos de status. O cliente gerado lidará automaticamente com esses tipos de erro personalizados.
+Você pode personalizar respostas de erro no seu FastAPI definindo classes de exceção customizadas, handlers de exceção e especificando modelos de resposta para diferentes códigos de status. O cliente gerado lidará automaticamente com esses tipos de erro personalizados.
 
 #### Definindo Modelos de Erro Personalizados
 
@@ -907,7 +906,7 @@ class ValidationError(BaseModel):
 
 #### Criando Exceções Personalizadas
 
-Depois crie classes de exceção para diferentes cenários de erro:
+Em seguida, crie classes de exceção para diferentes cenários de erro:
 
 ```python title="exceptions.py"
 class NotFoundException(Exception):
@@ -942,7 +941,7 @@ async def validation_error_handler(request: Request, exc: ValidationException):
     )
 ```
 
-:::tip[Dica]
+:::tip
 O `JSONResponse` aceita um dicionário, então usamos o método `model_dump` do nosso modelo Pydantic.
 :::
 
@@ -961,7 +960,7 @@ Finalmente, especifique os modelos de resposta para diferentes códigos de statu
 def get_item(item_id: str) -> Item:
     item = find_item(item_id)
     if not item:
-        raise NotFoundException(message=f"Item com ID {item_id} não encontrado")
+        raise NotFoundException(message=f"Item with ID {item_id} not found")
     return item
 
 @app.post(
@@ -975,8 +974,8 @@ def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
             ValidationError(
-                message="Dados do item inválidos",
-                field_errors=["nome é obrigatório"]
+                message="Invalid item data",
+                field_errors=["name is required"]
             )
         )
     return save_item(item)
@@ -984,7 +983,7 @@ def create_item(item: Item) -> Item:
 
 #### Usando Tipos de Erro Personalizados no React
 
-O cliente gerado lidará automaticamente com esses tipos de erro personalizados, permitindo verificação de tipos e tratamento de diferentes respostas de erro:
+O cliente gerado lidará automaticamente com esses tipos de erro personalizados, permitindo que você verifique tipos e trate diferentes respostas de erro:
 
 ```tsx
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -992,7 +991,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Consulta com tratamento de erros tipado
+  // Query com tratamento de erro tipado
   const getItem = useQuery({
     ...api.getItem.queryOptions({ itemId: '123' }),
     onError: (error) => {
@@ -1000,35 +999,35 @@ function ItemComponent() {
       switch (error.status) {
         case 404:
           // error.error é uma string conforme especificado nas respostas
-          console.error('Não encontrado:', error.error);
+          console.error('Not found:', error.error);
           break;
         case 500:
           // error.error é tipado como ErrorDetails
-          console.error('Erro do servidor:', error.error.message);
+          console.error('Server error:', error.error.message);
           break;
       }
     }
   });
 
-  // Mutation com tratamento de erros tipado
+  // Mutation com tratamento de erro tipado
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
       switch (error.status) {
         case 400:
           // error.error é tipado como ValidationError
-          console.error('Erro de validação:', error.error.message);
-          console.error('Erros de campo:', error.error.field_errors);
+          console.error('Validation error:', error.error.message);
+          console.error('Field errors:', error.error.field_errors);
           break;
         case 403:
           // error.error é uma string conforme especificado nas respostas
-          console.error('Proibido:', error.error);
+          console.error('Forbidden:', error.error);
           break;
       }
     }
   });
 
-  // Renderização do componente com tratamento de erros
+  // Renderização do componente com tratamento de erro
   if (getItem.isError) {
     if (getItem.error.status === 404) {
       return <NotFoundMessage message={getItem.error.error} />;
@@ -1055,7 +1054,7 @@ function ItemComponent() {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // Busca item com tratamento de erros
+  // Busca item com tratamento de erro
   useEffect(() => {
     const fetchItem = async () => {
       try {
@@ -1070,11 +1069,11 @@ function ItemComponent() {
         switch (err.status) {
           case 404:
             // err.error é uma string conforme especificado nas respostas
-            console.error('Não encontrado:', err.error);
+            console.error('Not found:', err.error);
             break;
           case 500:
             // err.error é tipado como ErrorDetails
-            console.error('Erro do servidor:', err.error.message);
+            console.error('Server error:', err.error.message);
             break;
         }
       } finally {
@@ -1085,7 +1084,7 @@ function ItemComponent() {
     fetchItem();
   }, [api]);
 
-  // Cria item com tratamento de erros
+  // Cria item com tratamento de erro
   const handleCreateItem = async (data) => {
     try {
       await api.createItem(data);
@@ -1095,18 +1094,18 @@ function ItemComponent() {
       switch (err.status) {
         case 400:
           // err.error é tipado como ValidationError
-          console.error('Erro de validação:', err.error.message);
-          console.error('Erros de campo:', err.error.field_errors);
+          console.error('Validation error:', err.error.message);
+          console.error('Field errors:', err.error.field_errors);
           break;
         case 403:
           // err.error é uma string conforme especificado nas respostas
-          console.error('Proibido:', err.error);
+          console.error('Forbidden:', err.error);
           break;
       }
     }
   };
 
-  // Renderização do componente com tratamento de erros
+  // Renderização do componente com tratamento de erro
   if (loading) {
     return <LoadingSpinner />;
   }
@@ -1128,15 +1127,15 @@ function ItemComponent() {
 ```
 </Drawer>
 
-:::tip[Dica]
+:::tip
 Ao definir respostas de erro no FastAPI, sempre use o parâmetro `responses` para especificar o modelo para cada código de status. Isso garante que o cliente gerado terá informações de tipo adequadas para tratamento de erros.
 :::
 
 ## Melhores Práticas
 
-### Lidando com Estados de Carregamento
+### Lidar com Estados de Loading
 
-Sempre trate estados de carregamento e erro para uma melhor experiência do usuário:
+Sempre trate estados de loading e erro para uma melhor experiência do usuário:
 
 ```tsx
 import { useQuery } from '@tanstack/react-query';
@@ -1165,7 +1164,7 @@ function ItemList() {
           />
         );
       default:
-        return <ErrorMessage message="Ocorreu um erro desconhecido" />;
+        return <ErrorMessage message="An unknown error occurred" />;
     }
   }
 
@@ -1179,7 +1178,7 @@ function ItemList() {
 }
 ```
 
-<Drawer title="Lidando com estados de carregamento usando o cliente diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
+<Drawer title="Lidar com estados de loading usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
@@ -1221,7 +1220,7 @@ function ItemList() {
           />
         );
       default:
-        return <ErrorMessage message="Ocorreu um erro desconhecido" />;
+        return <ErrorMessage message="An unknown error occurred" />;
     }
   }
 
@@ -1247,14 +1246,14 @@ function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
-  // Consulta para buscar items
+  // Query para buscar items
   const itemsQuery = useQuery(api.listItems.queryOptions());
 
-  // Mutation para excluir items com atualizações otimistas
+  // Mutation para deletar items com atualizações otimistas
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
     onMutate: async (itemId) => {
-      // Cancela qualquer refetch em andamento
+      // Cancela quaisquer refetches em andamento
       await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
 
       // Captura o valor anterior
@@ -1270,12 +1269,12 @@ function ItemList() {
       return { previousItems };
     },
     onError: (err, itemId, context) => {
-      // Se a mutation falhar, usa o contexto do onMutate para reverter
+      // Se a mutation falhar, usa o contexto retornado de onMutate para reverter
       queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-      console.error('Falha ao excluir item:', err);
+      console.error('Failed to delete item:', err);
     },
     onSettled: () => {
-      // Sempre refetch após erro ou sucesso para sincronizar dados
+      // Sempre refetch após erro ou sucesso para garantir sincronização com o servidor
       queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
     },
   });
@@ -1285,7 +1284,7 @@ function ItemList() {
   }
 
   if (itemsQuery.isError) {
-    return <ErrorMessage message="Falha ao carregar items" />;
+    return <ErrorMessage message="Failed to load items" />;
   }
 
   return (
@@ -1297,7 +1296,7 @@ function ItemList() {
             onClick={() => deleteMutation.mutate(item.id)}
             disabled={deleteMutation.isPending}
           >
-            {deleteMutation.isPending ? 'Excluindo...' : 'Excluir'}
+            {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
           </button>
         </li>
       ))}
@@ -1306,7 +1305,7 @@ function ItemList() {
 }
 ```
 
-<Drawer title="Atualizações otimistas usando o cliente diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
+<Drawer title="Atualizações otimistas usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
 ```tsx
 function ItemList() {
   const api = useMyApiClient();
@@ -1322,7 +1321,7 @@ function ItemList() {
     } catch (error) {
       // Restaura os items anteriores em caso de erro
       setItems(previousItems);
-      console.error('Falha ao excluir item:', error);
+      console.error('Failed to delete item:', error);
     }
   };
 
@@ -1331,7 +1330,7 @@ function ItemList() {
       {items.map((item) => (
         <li key={item.id}>
           {item.name}
-          <button onClick={() => handleDelete(item.id)}>Excluir</button>
+          <button onClick={() => handleDelete(item.id)}>Delete</button>
         </li>
       ))}
     </ul>
@@ -1340,9 +1339,9 @@ function ItemList() {
 ```
 </Drawer>
 
-## Segurança de Tipos
+## Type Safety
 
-A integração fornece segurança de tipos completa de ponta a ponta. Sua IDE fornecerá autocompletar e verificação de tipos para todas as chamadas de API:
+A integração fornece type safety completo de ponta a ponta. Sua IDE fornecerá autocompletar e verificação de tipos para todas as chamadas de API:
 
 ```tsx
 import { useMutation } from '@tanstack/react-query';
@@ -1350,22 +1349,22 @@ import { useMutation } from '@tanstack/react-query';
 function ItemForm() {
   const api = useMyApi();
 
-  // Mutation tipada para criar items
+  // Mutation type-safe para criar items
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     // ✅ Erro de tipo se o callback onSuccess não lidar com o tipo de resposta correto
     onSuccess: (data) => {
-      // data é totalmente tipado com base no schema de resposta da API
-      console.log(`Item criado com ID: ${data.id}`);
+      // data é totalmente tipado com base no schema de resposta da sua API
+      console.log(`Item created with ID: ${data.id}`);
     },
   });
 
   const handleSubmit = (data: CreateItemInput) => {
-    // ✅ Erro de tipo se a entrada não corresponder ao schema
+    // ✅ Erro de tipo se o input não corresponder ao schema
     createItem.mutate(data);
   };
 
-  // UI de erro pode usar narrowing de tipos para lidar com diferentes erros
+  // UI de erro pode usar type narrowing para lidar com diferentes tipos de erro
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
@@ -1373,7 +1372,7 @@ function ItemForm() {
         // error.error é tipado como CreateItem400Response
         return (
           <FormError
-            message="Entrada inválida"
+            message="Invalid input"
             errors={error.error.validationErrors}
           />
         );
@@ -1396,14 +1395,14 @@ function ItemForm() {
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Criando...' : 'Criar Item'}
+        {createItem.isPending ? 'Creating...' : 'Create Item'}
       </button>
     </form>
   );
 }
 ```
 
-<Drawer title="Segurança de tipos usando o cliente diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
+<Drawer title="Type safety usando o cliente da API diretamente" trigger="Clique aqui para ver um exemplo usando o cliente vanilla diretamente.">
 ```tsx
 function ItemForm() {
   const api = useMyApiClient();
@@ -1411,7 +1410,7 @@ function ItemForm() {
 
   const handleSubmit = async (data: CreateItemInput) => {
     try {
-      // ✅ Erro de tipo se a entrada não corresponder ao schema
+      // ✅ Erro de tipo se o input não corresponder ao schema
       await api.createItem(data);
     } catch (e) {
       // ✅ Tipo de erro inclui todas as possíveis respostas de erro
@@ -1419,17 +1418,17 @@ function ItemForm() {
       switch (err.status) {
         case 400:
           // err.error é tipado como CreateItem400Response
-          console.error('Erros de validação:', err.error.validationErrors);
+          console.error('Validation errors:', err.error.validationErrors);
           break;
         case 403:
           // err.error é tipado como CreateItem403Response
-          console.error('Não autorizado:', err.error.reason);
+          console.error('Not authorized:', err.error.reason);
           break;
         case 500:
         case 502:
           // err.error é tipado como CreateItem5XXResponse
           console.error(
-            'Erro do servidor:',
+            'Server error:',
             err.error.message,
             'Trace:',
             err.error.traceId,
@@ -1440,13 +1439,13 @@ function ItemForm() {
     }
   };
 
-  // UI de erro pode usar narrowing de tipos para lidar com diferentes erros
+  // UI de erro pode usar type narrowing para lidar com diferentes tipos de erro
   if (error) {
     switch (error.status) {
       case 400:
         return (
           <FormError
-            message="Entrada inválida"
+            message="Invalid input"
             errors={error.error.validationErrors}
           />
         );
@@ -1462,4 +1461,4 @@ function ItemForm() {
 ```
 </Drawer>
 
-Os tipos são gerados automaticamente a partir do schema OpenAPI do seu FastAPI, garantindo que quaisquer alterações na sua API sejam refletidas no código frontend após um build.
+Os tipos são gerados automaticamente a partir do schema OpenAPI do seu FastAPI, garantindo que quaisquer alterações na sua API sejam refletidas no código do frontend após um build.

--- a/docs/src/content/docs/pt/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/pt/guides/api-connection/react-trpc.mdx
@@ -9,9 +9,8 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-O AWS Plugin para Nx fornece um gerador para integrar rapidamente sua <Link path="guides/trpc">API tRPC</Link> com um site React. Ele configura toda a infraestrutura necessária para conexão com seus backends tRPC, incluindo suporte a autenticação IAM da AWS e tratamento adequado de erros. A integração oferece segurança de tipos completa de ponta a ponta entre seu frontend e backend(s) tRPC.
+O Plugin AWS para Nx fornece um gerador para integrar rapidamente sua <Link path="guides/trpc">API tRPC</Link> com um site React. Ele configura toda a infraestrutura necessária para conexão com seus backends tRPC, incluindo suporte a autenticação IAM da AWS e tratamento adequado de erros. A integração oferece segurança de tipos completa entre seu frontend e backend(s) tRPC.
 
 ## Pré-requisitos
 
@@ -41,7 +40,7 @@ root.render(
 
 </details>
 
-## Utilização
+## Uso
 
 ### Executar o Gerador
 
@@ -49,7 +48,7 @@ root.render(
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## Saída do Gerador
 
@@ -63,11 +62,11 @@ O gerador cria a seguinte estrutura em sua aplicação React:
       - index.tsx
       - TrpcProvider.tsx Provider reutilizável para múltiplas APIs tRPC
       - TrpcApis.tsx Objeto contendo todas as conexões de API tRPC
-      - TrpcClientProviders.tsx Configura os clientes tRPC e vinculações aos schemas do backend
-    - QueryClientProvider.tsx Provider do cliente TanStack React Query
+      - TrpcClientProviders.tsx Configura os clients tRPC e vinculações aos schemas do backend
+    - QueryClientProvider.tsx Provider do client TanStack React Query
   - hooks
-    - useSigV4.tsx Hook para assinar requisições HTTP com SigV4 (apenas IAM)
-    - use\<ApiName>.tsx Hook específico para a API do backend. ApiName será resolvido para o nome da API
+    - useSigV4.tsx Hook para assinar requisições HTTP com SigV4 (somente IAM)
+    - use\<ApiName>.tsx Hook para a API backend específica. ApiName será resolvido para o nome da API
 
 </FileTree>
 
@@ -82,7 +81,7 @@ Adicionalmente, instala as dependências necessárias:
 
 ### Usando o Hook tRPC
 
-O gerador fornece um hook `use<ApiName>` que dá acesso ao cliente tRPC com segurança de tipos:
+O gerador fornece um hook `use<ApiName>` que dá acesso ao client tRPC com segurança de tipos:
 
 ```tsx {5,8,11}
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -91,10 +90,10 @@ import { useMyApi } from './hooks/useMyApi';
 function MyComponent() {
   const trpc = useMyApi();
 
-  // Exemplo de consulta
+  // Exemplo de query
   const { data, isLoading, error } = useQuery(trpc.users.list.queryOptions());
 
-  // Exemplo de mutação
+  // Exemplo de mutation
   const mutation = useMutation(trpc.users.create.mutationOptions());
 
   const handleCreate = () => {
@@ -104,7 +103,7 @@ function MyComponent() {
     });
   };
 
-  if (isLoading) return <div>Carregando...</div>;
+  if (isLoading) return <div>Loading...</div>;
 
   return (
     <ul>
@@ -199,7 +198,7 @@ function UserList() {
           trpc.users.list.queryKey(),
         );
 
-        // Remove otimistamente o usuário
+        // Remove otimisticamente o usuário
         queryClient.setQueryData(trpc.users.list.queryKey(), (old) =>
           old?.filter((user) => user.id !== userId),
         );
@@ -231,7 +230,7 @@ function UserList() {
 
 ### Pré-busca de Dados
 
-Pré-busque dados para melhor performance:
+Faça pré-busca de dados para melhor performance:
 
 ```tsx {8}
 function UserList() {
@@ -294,7 +293,7 @@ function UserList() {
 
 ## Segurança de Tipos
 
-A integração fornece segurança de tipos completa de ponta a ponta. Sua IDE oferecerá autocompletar e verificação de tipos para todas chamadas de API:
+A integração fornece segurança de tipos completa de ponta a ponta. Sua IDE oferecerá autocompletar e verificação de tipos para todas as chamadas de API:
 
 ```tsx
 function UserForm() {
@@ -304,7 +303,7 @@ function UserForm() {
   const createUser = trpc.users.create.useMutation();
 
   const handleSubmit = (data: CreateUserInput) => {
-    // ✅ Erro de tipo se input não corresponder ao schema
+    // ✅ Erro de tipo se o input não corresponder ao schema
     createUser.mutate(data);
   };
 
@@ -312,7 +311,7 @@ function UserForm() {
 }
 ```
 
-Os tipos são inferidos automaticamente das definições do router e schema do seu backend, garantindo que quaisquer mudanças na API sejam imediatamente refletidas no código frontend sem necessidade de build.
+Os tipos são inferidos automaticamente do router e definições de schema do seu backend, garantindo que quaisquer alterações na API sejam imediatamente refletidas no código frontend sem necessidade de build.
 
 ## Mais Informações
 

--- a/docs/src/content/docs/pt/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/cloudscape-website-auth.mdx
@@ -10,15 +10,14 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
-O gerador de Autenticação para Site CloudScape adiciona autenticação ao seu site CloudScape utilizando [Amazon Cognito](https://aws.amazon.com/cognito/).
+O gerador de Autenticação para Website CloudScape adiciona autenticação ao seu site CloudScape utilizando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
-Este gerador configura a infraestrutura CDK para criar um Cognito User Pool e um Identity Pool associado, além de uma interface hospedada para fluxos de login de usuários e sua integração com seu site CloudScape.
+Este gerador configura a infraestrutura CDK para criar um User Pool do Cognito e um Identity Pool associado, além de uma interface hospedada para gerenciar fluxos de login de usuários e sua integração com seu site CloudScape.
 
-## Uso
+## Utilização
 
-### Adicionar autenticação ao seu site CloudScape
+### Adicionar Autenticação ao seu Site CloudScape
 
 Você pode adicionar autenticação ao seu site CloudScape de duas formas:
 
@@ -26,11 +25,11 @@ Você pode adicionar autenticação ao seu site CloudScape de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
 ## Saída do Gerador
 
-Você encontrará as seguintes alterações em seu site React:
+Você encontrará as seguintes alterações no seu site React:
 
 <FileTree>
   - src
@@ -45,12 +44,12 @@ Você também encontrará o seguinte código de infraestrutura gerado em `packag
 <FileTree>
   - src
     - core
-      - user-identity.ts Construct que define o user pool e o identity pool
+      - user-identity.ts Construct que define o user pool e identity pool
 </FileTree>
 
 ## Uso da Infraestrutura
 
-Você precisará adicionar o construct `UserIdentity` à sua stack, declarando-o _antes_ do construct do site:
+Você precisará adicionar o construct `UserIdentity` à sua stack, declarando-o _antes_ do construct do website:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
 import { Stack } from 'aws-cdk-lib';
@@ -68,11 +67,11 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-O construct `UserIdentity` adiciona automaticamente a <Link path="guides/cloudscape-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu site possa apontar para o Cognito User Pool correto para autenticação.
+O construct `UserIdentity` adiciona automaticamente a <Link path="guides/cloudscape-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu site possa apontar para o User Pool do Cognito correto para autenticação.
 
-### Concedendo acesso a usuários autenticados
+### Concedendo Acesso a Usuários Autenticados
 
-Para conceder a usuários autenticados acesso para realizar determinadas ações, como conceder permissões para invocar uma API, você pode adicionar políticas IAM à função autenticada do identity pool:
+Para conceder acesso a usuários autenticados para realizar determinadas ações, como conceder permissões para invocar uma API, você pode adicionar políticas IAM à função autenticada do identity pool:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/pt/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/pt/guides/cloudscape-website.mdx
@@ -10,27 +10,26 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
-Este gerador cria um novo website [React](https://react.dev/) com [CloudScape](http://cloudscape.design/) configurado, junto com a infraestrutura AWS CDK para implantar seu website na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
+Este gerador cria um novo site em [React](https://react.dev/) com [CloudScape](http://cloudscape.design/) configurado, juntamente com a infraestrutura AWS CDK para implantar seu site na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
 
-A aplicação gerada utiliza [Vite](https://vite.dev/) como ferramenta de build e bundler. Ela usa [TanStack Router](https://tanstack.com/router/v1) para roteamento type-safe.
+A aplicação gerada utiliza [Vite](https://vite.dev/) como ferramenta de build e bundler. Ela emprega [TanStack Router](https://tanstack.com/router/v1) para roteamento type-safe.
 
-:::nota
-Embora este gerador configure o CloudScape, ele é fundamentalmente um gerador de projetos React, e você pode modificar seu código para migrar para um sistema de design ou biblioteca de componentes alternativo, se desejar.
+:::note
+Embora este gerador configure o CloudScape, ele é fundamentalmente um gerador de projetos React. Você pode modificar seu código para migrar para um sistema de design ou biblioteca de componentes alternativo, se desejar.
 :::
 
-## Uso
+## Utilização
 
-### Gerar um Website CloudScape
+### Gerar um Site CloudScape
 
-Você pode gerar um novo Website CloudScape de duas formas:
+Você pode gerar um novo Site CloudScape de duas formas:
 
 <RunGenerator generator="ts#cloudscape-website" />
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
 ## Saída do Gerador
 
@@ -48,44 +47,44 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
       - useAppLayout.tsx Hook para ajustar o AppLayout a partir de componentes aninhados
     - routes
       - welcome
-        - index.tsx Rota (ou página) de exemplo para @tanstack/react-router
+        - index.tsx Rota de exemplo (ou página) para @tanstack/react-router
     - styles.css Estilos globais
   - vite.config.ts Configuração do Vite e Vitest
-  - tsconfig.json Configuração TypeScript base para código e testes
-  - tsconfig.app.json Configuração TypeScript para código fonte  
+  - tsconfig.json Configuração base do TypeScript para código fonte e testes
+  - tsconfig.app.json Configuração TypeScript para código fonte
   - tsconfig.spec.json Configuração TypeScript para testes
 </FileTree>
 
-O gerador também criará código de infraestrutura CDK para implantar seu website no diretório `packages/common/constructs`:
+O gerador também criará código de infraestrutura CDK para implantar seu site no diretório `packages/common/constructs`:
 
 <FileTree>
   - src
     - app
       - static-websites
-        - \<name>.ts Infraestrutura específica do seu website
+        - \<name>.ts Infraestrutura específica do seu site
     - core
       - static-website.ts Construct genérico StaticWebsite
 </FileTree>
 
-## Implementando seu Website CloudScape
+## Implementando seu Site CloudScape
 
-A [documentação do React](https://react.dev/learn) é um bom ponto de partida para aprender o básico de desenvolvimento com React. Você pode consultar a [documentação do CloudScape](https://cloudscape.design/components/) para detalhes sobre os componentes disponíveis e como usá-los.
+A [documentação do React](https://react.dev/learn) é um bom ponto de partida para aprender os fundamentos de desenvolvimento com React. Consulte a [documentação do CloudScape](https://cloudscape.design/components/) para detalhes sobre os componentes disponíveis e seu uso.
 
 ### Rotas
 
 #### Criando uma Rota/Página
 
-Seu website CloudScape vem com [TanStack Router](https://tanstack.com/router/v1) configurado. Isso facilita a adição de novas rotas:
+Seu site CloudScape vem com [TanStack Router](https://tanstack.com/router/v1) configurado. Isso facilita a adição de novas rotas:
 
 <Steps>
-  1. [Execute o Servidor de Desenvolvimento Local](#servidor-de-desenvolvimento-local)
-  2. Crie um novo arquivo `<nome-da-pagina>.tsx` em `src/routes`, onde a posição na estrutura de arquivos representa o caminho
-  3. Observe que um `Route` e `RouteComponent` são gerados automaticamente. Você pode começar a construir sua página aqui!
+  1. [Execute o Servidor de Desenvolvimento Local](#local-development-server)
+  2. Crie um novo arquivo `<page-name>.tsx` em `src/routes`, onde a posição na estrutura de arquivos representa o caminho
+  3. Observe que um `Route` e `RouteComponent` são gerados automaticamente. Comece a construir sua página aqui!
 </Steps>
 
 #### Navegação Entre Páginas
 
-Você pode usar o componente `Link` ou o hook `useNavigate` para navegar entre páginas:
+Use o componente `Link` ou o hook `useNavigate` para navegar entre páginas:
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -95,7 +94,7 @@ export const MyComponent = () => {
 
   const submit = async () => {
     const id = await ...
-    // Use `navigate` para redirecionar após uma ação assíncrona
+    // Use `navigate` para redirecionar após ação assíncrona
     navigate({ to: '/products/$id', { params: { id }} });
   };
 
@@ -112,13 +111,13 @@ Para mais detalhes, consulte a [documentação do TanStack Router](https://tanst
 
 ## Configuração de Runtime
 
-Configurações da sua infraestrutura AWS CDK são fornecidas ao seu website via Configuração de Runtime. Isso permite que seu website acesse detalhes como URLs de API que só são conhecidos após a implantação.
+A configuração da infraestrutura AWS CDK é fornecida ao seu site via Runtime Configuration. Isso permite que seu site acesse detalhes como URLs de API que só são conhecidos após a implantação.
 
 ### Infraestrutura
 
-O construct CDK `RuntimeConfig` pode ser usado para adicionar e recuperar configurações na sua infraestrutura CDK. Os constructs CDK gerados por `@aws/nx-plugin` (como <Link path="guides/trpc">APIs tRPC</Link> e <Link path="guides/fastapi">FastAPIs</Link>) adicionarão automaticamente valores apropriados ao `RuntimeConfig`.
+O construct CDK `RuntimeConfig` pode ser usado para adicionar e recuperar configuração na infraestrutura CDK. Os constructs CDK gerados por `@aws/nx-plugin` (como <Link path="guides/trpc">APIs tRPC</Link> e <Link path="guides/fastapi">FastAPIs</Link>) adicionarão automaticamente valores apropriados ao `RuntimeConfig`.
 
-Seu construct de website CDK implantará a configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
+Seu construct de site CDK implantará a configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {9-10,12-13}
 import { Stack } from 'aws-cdk-lib';
@@ -139,12 +138,12 @@ export class ApplicationStack extends Stack {
 ```
 
 :::warning
-Você deve declarar seu website _após_ quaisquer constructs que adicionem ao `RuntimeConfig`, caso contrário eles estarão faltando no arquivo `runtime-config.json`.
+Garanta que seu site seja declarado _após_ quaisquer constructs que adicionem valores ao `RuntimeConfig`, caso contrário eles estarão ausentes no arquivo `runtime-config.json`.
 :::
 
-### Código do Website
+### Código do Site
 
-No seu website, você pode usar o hook `useRuntimeConfig` para recuperar valores da configuração de runtime:
+No seu site, use o hook `useRuntimeConfig` para recuperar valores da configuração de runtime:
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -152,52 +151,52 @@ import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
 const MyComponent = () => {
   const runtimeConfig = useRuntimeConfig();
 
-  // Acesse valores da configuração de runtime aqui
+  // Acesse valores da configuração aqui
   const apiUrl = runtimeConfig.httpApis.MyApi;
 };
 ```
 
 ### Configuração de Runtime Local
 
-Ao executar o [servidor de desenvolvimento local](#servidor-de-desenvolvimento-local), você precisará de um arquivo `runtime-config.json` no diretório `public` para que seu website local conheça URLs de backend, configuração de identidade, etc.
+Ao executar o [servidor de desenvolvimento local](#local-development-server), você precisará de um arquivo `runtime-config.json` no diretório `public` para que seu site local conheça URLs de backend, configuração de identidade etc.
 
-Seu projeto de website está configurado com um target `load:runtime-config` que você pode usar para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
+Seu projeto de site está configurado com um target `load:runtime-config` que pode ser usado para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-Se você alterar o nome do seu stack no `src/main.ts` do projeto de infraestrutura, precisará atualizar o target `load:runtime-config` no arquivo `project.json` do seu website com o nome do stack a ser carregado.
+Se alterar o nome do stack no `src/main.ts` do projeto de infraestrutura, atualize o target `load:runtime-config` no arquivo `project.json` do seu site com o nome do stack a ser carregado.
 :::
 
 ## Servidor de Desenvolvimento Local
 
-Antes de executar o servidor de desenvolvimento local, certifique-se de ter implantado sua infraestrutura e [carregado a configuração de runtime local](#configuração-de-runtime-local).
+Antes de executar o servidor local, certifique-se de ter implantado a infraestrutura e [carregado a configuração de runtime local](#local-runtime-config).
 
-Você pode então executar o target `serve`:
+Execute então o target `serve`:
 
 <NxCommands commands={['run <my-website>:serve']} />
 
 ## Build
 
-Você pode construir seu website usando o target `build`. Isso usa o Vite para criar um bundle de produção no diretório `dist/packages/<my-website>/bundle`, além de verificar tipos, compilar e lintar seu website.
+Execute o build do site usando o target `build`. Isso usa o Vite para criar um bundle de produção no diretório `dist/packages/<my-website>/bundle`, além de type-checking, compilação e linting.
 
 <NxCommands commands={['run <my-website>:build']} />
 
 ## Testes
 
-Testar seu website é similar a escrever testes em um projeto TypeScript padrão. Consulte o <Link path="guides/typescript-project#testing">guia de projetos TypeScript</Link> para detalhes.
+Testar seu site é similar a escrever testes em projetos TypeScript padrão. Consulte o <Link path="guides/typescript-project#testing">guia de projetos TypeScript</Link> para detalhes.
 
-Para testes específicos de React, o React Testing Library já está instalado e disponível para escrever testes. Para detalhes de uso, consulte a [documentação do React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
+Para testes específicos de React, o React Testing Library já está instalado e disponível. Para detalhes de uso, consulte a [documentação do React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
-Você pode executar seus testes usando o target `test`:
+Execute testes usando o target `test`:
 
 <NxCommands commands={['run <my-website>:test']} />
 
-## Implantando Seu Website
+## Implantando seu Site
 
-Para implantar seu website, recomendamos usar o <Link path="guides/typescript-infrastructure">Gerador de Infraestrutura TypeScript</Link> para criar uma aplicação CDK.
+Para implantar, recomendamos usar o <Link path="guides/typescript-infrastructure">Gerador de Infraestrutura TypeScript</Link> para criar uma aplicação CDK.
 
-Você pode usar o construct CDK gerado em `packages/common/constructs` para implantar seu website.
+Use o construct CDK gerado em `packages/common/constructs` para implantar seu site:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/pt/guides/fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/fastapi.mdx
@@ -11,23 +11,22 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
-O [FastAPI](https://fastapi.tiangolo.com/) é um framework para construção de APIs em Python.
+[FastAPI](https://fastapi.tiangolo.com/) é um framework para construção de APIs em Python.
 
-O gerador FastAPI cria uma nova aplicação FastAPI com configuração de infraestrutura AWS CDK. O backend gerado utiliza AWS Lambda para implantação serverless, exposto via AWS API Gateway. Configura o [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidade, incluindo logging, rastreamento com AWS X-Ray e métricas no Cloudwatch.
+O gerador FastAPI cria uma nova aplicação FastAPI com configuração de infraestrutura AWS CDK. O backend gerado utiliza AWS Lambda para implantação serverless, exposto via AWS API Gateway. Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidade, incluindo logging, rastreamento com AWS X-Ray e métricas no CloudWatch.
 
 ## Utilização
 
-### Gerar uma aplicação FastAPI
+### Gerar uma API FastAPI
 
-Você pode gerar uma nova aplicação FastAPI de duas formas:
+Você pode gerar uma nova API FastAPI de duas formas:
 
 <RunGenerator generator="py#fast-api" />
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -41,10 +40,10 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<ap
 - pyproject.toml Configuração do projeto Python e dependências
 - \<module_name>
   - \_\_init\_\_.py Inicialização do módulo
-  - init.py Configura a aplicação FastAPI e middleware do powertools
+  - init.py Configura o app FastAPI e middleware do powertools
   - main.py Implementação da API
 - scripts
-  - generate_open_api.py Script para gerar schema OpenAPI a partir da aplicação FastAPI
+  - generate_open_api.py Script para gerar schema OpenAPI a partir do app FastAPI
 
 </FileTree>
 
@@ -74,7 +73,7 @@ O gerador configura automaticamente:
 
 1. Integração com AWS Lambda Powertools para observabilidade
 2. Middleware de tratamento de erros
-3. Correlação request/response
+3. Correlação de requisições/respostas
 4. Coleta de métricas
 5. Handler AWS Lambda usando Mangum
 
@@ -82,7 +81,7 @@ O gerador configura automaticamente:
 
 #### Logging
 
-Configura logging estruturado usando AWS Lambda Powertools. Acesso ao logger nos handlers:
+Configura logging estruturado com AWS Lambda Powertools. Acesso ao logger em handlers:
 
 ```python
 from .init import app, logger
@@ -96,13 +95,13 @@ def read_item(item_id: int):
 O logger inclui automaticamente:
 
 - IDs de correlação para rastreamento
-- Caminho e método da requisição
+- Path e método da requisição
 - Informações de contexto Lambda
 - Indicadores de cold start
 
-#### Tracing
+#### Rastreamento
 
-Rastreamento AWS X-Ray configurado automaticamente. Adicione subsegmentos personalizados:
+Rastreamento com AWS X-Ray configurado automaticamente. Adicione subsegmentos personalizados:
 
 ```python
 from .init import app, tracer
@@ -116,7 +115,7 @@ def read_item(item_id: int):
 
 #### Métricas
 
-Métricas CloudWatch coletadas automaticamente. Adicione métricas personalizadas:
+Métricas no CloudWatch coletadas automaticamente. Adicione métricas personalizadas:
 
 ```python
 from .init import app, metrics
@@ -137,7 +136,7 @@ Métricas padrão incluem:
 
 ### Tratamento de Erros
 
-O gerador inclui tratamento abrangente de erros:
+Tratamento abrangente de erros:
 
 ```python
 from fastapi import HTTPException
@@ -145,31 +144,31 @@ from fastapi import HTTPException
 @app.get("/items/{item_id}")
 def read_item(item_id: int):
     if item_id < 0:
-        raise HTTPException(status_code=400, detail="Item ID deve ser positivo")
+        raise HTTPException(status_code=400, detail="Item ID must be positive")
     return {"item_id": item_id}
 ```
 
 Exceções não tratadas são capturadas pelo middleware e:
 
-1. Registram a exceção completa com stack trace
+1. Registram exceção completa com stack trace
 2. Gravam métrica de falha
 3. Retornam resposta 500 segura
-4. Preservam o ID de correlação
+4. Preservam ID de correlação
 
 :::tip
-Recomenda-se definir modelos de resposta para melhor geração de código ao usar o gerador `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Detalhes aqui</Link>.
+Recomenda-se especificar modelos de resposta para melhor geração de código com `api-connection`. <Link path="guides/api-connection/react-fastapi#errors">Detalhes aqui</Link>.
 :::
 
 ### Streaming
 
-Com FastAPI, você pode streamar respostas usando [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse).
+Com FastAPI, você pode transmitir respostas usando [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse).
 
 #### Alterações de Infraestrutura
 
-Como API Gateway não suporta streaming, você precisará implantar em uma plataforma compatível como AWS Lambda Function URL. Substitua o constructo gerado `common/constructs/src/app/apis/<name>-api.ts` por um que use Function URL.
+Como API Gateway não suporta streaming, você precisará implantar em outra plataforma. Uma opção é usar AWS Lambda Function URL. Substitua o construct gerado `common/constructs/src/app/apis/<name>-api.ts` por um que use Function URL.
 
 <details>
-<summary>Exemplo de Construct FunctionURL para Streaming</summary>
+<summary>Exemplo de Construct com FunctionURL para Streaming</summary>
 
 ```ts
 import { Duration, Stack, CfnOutput } from 'aws-cdk-lib';
@@ -258,24 +257,17 @@ export class MyApi extends Construct {
     });
   }
 }
-
 ```
 
 </details>
 
 :::note
-Para um exemplo completo, consulte o <Link path="/get_started/tutorials/dungeon-game/overview">Tutorial Dungeon Adventure</Link>
+Para exemplo completo, consulte o <Link path="/get_started/tutorials/dungeon-game/overview">Tutorial Dungeon Adventure</Link>
 :::
 
 #### Implementação
 
 Após atualizar a infraestrutura, implemente streaming no FastAPI:
-
-- Retorne um [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)
-- Declare o tipo de cada chunk
-- Adicione a extensão OpenAPI `x-streaming: true` para uso com <Link path="guides/api-connection/react-fastapi">API Connection</Link>.
-
-Exemplo para stream de objetos JSON:
 
 ```py /return (StreamingResponse)/ /openapi_extra[^)]*/ /-> (Chunk)/
 from pydantic import BaseModel
@@ -296,7 +288,7 @@ def my_stream() -> Chunk:
 
 #### Consumo
 
-Para consumir streams, utilize o <Link path="guides/api-connection/react-fastapi#consuming-a-stream">Gerador API Connection</Link> para iteração tipada.
+Para consumir streams, use o <Link path="guides/api-connection/react-fastapi#consuming-a-stream">API Connection Generator</Link>.
 
 ## Implantando sua API FastAPI
 
@@ -319,9 +311,9 @@ Isso configura:
 1. Função Lambda para cada operação
 2. API Gateway HTTP/REST como trigger
 3. Roles e permissões IAM
-4. Log group CloudWatch
-5. Configuração X-Ray
-6. Namespace de métricas CloudWatch
+4. Log group no CloudWatch
+5. Configuração de rastreamento X-Ray
+6. Namespace de métricas no CloudWatch
 
 ### Integrações Type-Safe
 
@@ -329,16 +321,16 @@ Isso configura:
 
 #### Geração de Código
 
-Um target `generate:<ApiName>-metadata` é adicionado ao `project.json` para gerar metadados tipados. O arquivo gerado `packages/common/constructs/src/generated/my-api/metadata.gen.ts` é ignorado no versionamento.
+O target `generate:<ApiName>-metadata` em `project.json` gera metadados para integração type-safe. O arquivo gerado `packages/common/constructs/src/generated/my-api/metadata.gen.ts` é ignorado no versionamento.
 
 :::note
-Execute um build após alterações na API para atualizar os tipos:
+Execute build após alterações na API para atualizar tipos:
 
 <NxCommands commands={["run-many --target build --all"]} />
 :::
 
 :::tip
-Use [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar tipos durante o desenvolvimento:
+Use [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar tipos automaticamente:
 
 <NxCommands
   commands={[
@@ -350,7 +342,7 @@ Use [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) para regenerar tipos 
 
 ### Concedendo Acesso
 
-Use `grantInvokeAccess` para conceder acesso à API:
+Use `grantInvokeAccess` para conceder acesso:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -362,10 +354,10 @@ Execute o servidor local com:
 
 <NxCommands commands={['run my-api:serve']} />
 
-Isso inicia um servidor FastAPI com:
+Isso inicia um servidor com:
 
-- Recarga automática
-- Documentação interativa em `/docs` ou `/redoc`
+- Recarregamento automático
+- Documentação interativa em `/docs` e `/redoc`
 - Schema OpenAPI em `/openapi.json`
 
 ## Invocando sua API

--- a/docs/src/content/docs/pt/guides/license.mdx
+++ b/docs/src/content/docs/pt/guides/license.mdx
@@ -8,54 +8,53 @@ description: "Documentação de referência para o gerador de Licença"
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
-Gerencie automaticamente arquivos `LICENSE` e cabeçalhos de código-fonte em seu workspace.
+Gerencie automaticamente arquivos `LICENSE` e cabeçalhos de código fonte em seu workspace.
 
-Este gerador registra um [gerador de sincronização](https://nx.dev/concepts/sync-generators) para executar como parte de seus targets `lint`, garantindo que seus arquivos fonte estejam em conformidade com o conteúdo e formato desejados da licença, além de assegurar que os arquivos `LICENSE` de seus projetos estejam corretos e que as informações de licenciamento estejam incluídas em arquivos de projeto relevantes (`package.json`, `pyproject.toml`).
+Este gerador registra um [sync generator](https://nx.dev/concepts/sync-generators) para executar como parte dos seus targets `lint`, garantindo que seus arquivos fonte estejam em conformidade com o conteúdo e formato desejado da licença, além de assegurar que os arquivos `LICENSE` do seu projeto estejam corretos e que as informações de licenciamento estejam incluídas em arquivos relevantes do projeto (`package.json`, `pyproject.toml`).
 
-## Uso
+## Utilização
 
-### Executar o gerador
+### Executar o Gerador
 
 <RunGenerator generator="license" />
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
-## Saída do gerador
+## Saída do Gerador
 
 O gerador criará ou atualizará os seguintes arquivos:
 
 <FileTree>
-  - nx.json O target lint é configurado para executar o gerador de sincronização de licença
-  - aws-nx-plugin.config.mts Configuração do gerador de sincronização de licença
+  - nx.json O target lint é configurado para executar o sync generator de licença
+  - aws-nx-plugin.config.mts Configuração para o sync generator de licença
 </FileTree>
 
-Uma configuração padrão para conteúdo e formato de cabeçalhos de licença é adicionada ao `aws-nx-plugin.config.mts` para escrever cabeçalhos apropriados para vários tipos de arquivo. Você pode personalizar isso posteriormente; consulte a [seção de configuração](#configuration) abaixo.
+Uma configuração padrão para conteúdo e formato de cabeçalhos de licença é adicionada ao `aws-nx-plugin.config.mts` para escrever cabeçalhos apropriados para vários tipos de arquivo. Você pode personalizar isso posteriormente; consulte a [seção de configuração](#configuração) abaixo.
 
-## Fluxo de trabalho
+## Fluxo de Trabalho
 
-Sempre que você construir seus projetos (e um target `lint` for executado), o gerador de sincronização de licença garantirá que o licenciamento em seu projeto corresponda à sua configuração (veja [comportamento de sincronização de licença abaixo](#license-sync-behaviour)). Se detectar que algo está desatualizado, você receberá uma mensagem como:
+Sempre que você construir seus projetos (e um target `lint` for executado), o sync generator de licença garantirá que o licenciamento em seu projeto corresponda à sua configuração (veja [comportamento de sincronização de licença abaixo](#comportamento-de-sincronização-de-licença)). Se detectar que algo está desatualizado, você receberá uma mensagem como:
 
 ```bash
-  NX   The workspace is out of sync
+  NX   O workspace está desatualizado
 
 [@aws/nx-plugin:license#sync]: Arquivos LICENSE do projeto estão desatualizados:
 - LICENSE
-- packages/<my-project>LICENSE
+- packages/<meu-projeto>LICENSE
 
 Arquivos package.json do projeto estão desatualizados:
 - package.json
 
 Arquivos pyproject.toml do projeto estão desatualizados:
 - pyproject.toml
-- packages/<my-python-project>/pyproject.toml
+- packages/<meu-projeto-python>/pyproject.toml
 
 Cabeçalhos de licença estão desatualizados nos seguintes arquivos fonte:
-- packages/<my-project>/src/index.ts
-- packages/<my-python-project>/main.py
+- packages/<meu-projeto>/src/index.ts
+- packages/<meu-projeto-python>/main.py
 
 Isso resultará em um erro no CI.
 
@@ -67,38 +66,38 @@ Não, executar as tasks sem sincronizar as alterações
 Selecione `Sim` para sincronizar as alterações.
 
 :::note
-Verifique as alterações feitas pelo gerador de sincronização de licença no controle de versão para garantir que as tasks de construção de integração contínua não falhem devido a licenças desatualizadas.
+Verifique as alterações feitas pelo sync generator de licença no controle de versão para garantir que as tasks de construção em integração contínua não falhem devido a licenças desatualizadas.
 :::
 
 ## Comportamento de Sincronização de Licença
 
-O gerador de sincronização de licença executa três tarefas principais:
+O sync generator de licença executa três tarefas principais:
 
-### 1. Sincronizar cabeçalhos de licença em arquivos fonte
+### 1. Sincronizar Cabeçalhos de Licença em Arquivos Fonte
 
-Quando executado, o gerador garantirá que todos os arquivos fonte do workspace (com base em sua configuração) contenham o cabeçalho de licença apropriado. O cabeçalho é escrito como o primeiro bloco de comentário ou série consecutiva de comentários de linha no arquivo (além do shebang/hashbang, se presente).
+Quando executado, o sync generator garantirá que todos os arquivos fonte do workspace (baseado em sua configuração) contenham o cabeçalho de licença apropriado. O cabeçalho é escrito como o primeiro bloco de comentário ou série consecutiva de comentários de linha no arquivo (além do shebang/hashbang, se presente).
 
-Você pode atualizar a configuração a qualquer momento para alterar quais arquivos devem ser incluídos/excluídos, bem como o conteúdo ou formato dos cabeçalhos para diferentes tipos de arquivo. Para detalhes, consulte a [seção de configuração](#configuration) abaixo.
+Você pode atualizar a configuração a qualquer momento para alterar quais arquivos devem ser incluídos/excluídos, bem como o conteúdo ou formato dos cabeçalhos para diferentes tipos de arquivo. Para detalhes, consulte a [seção de configuração](#configuração).
 
-### 2. Sincronizar arquivos LICENSE
+### 2. Sincronizar Arquivos LICENSE
 
-Quando executado, o gerador garantirá que o arquivo raiz `LICENSE` corresponda à licença configurada, além de verificar que todos os subprojetos no workspace contenham o arquivo `LICENSE` correto.
+Quando executado, o sync generator garantirá que o arquivo raiz `LICENSE` corresponda à licença configurada, além de verificar que todos os subprojetos no workspace contenham o arquivo `LICENSE` correto.
 
-Você pode excluir projetos na configuração se necessário. Consulte a [seção de configuração](#configuration) abaixo.
+Você pode excluir projetos na configuração se necessário. Para detalhes, consulte a [seção de configuração](#configuração).
 
-### 3. Sincronizar informações de licença em arquivos de projeto
+### 3. Sincronizar Informações de Licença em Arquivos de Projeto
 
-Quando executado, o gerador garantirá que os campos `license` em arquivos `package.json` e `pyproject.toml` estejam definidos conforme sua licença configurada.
+Quando executado, o sync generator garantirá que os campos `license` em arquivos `package.json` e `pyproject.toml` estejam definidos conforme sua licença configurada.
 
-Você pode excluir projetos na configuração se necessário. Consulte a [seção de configuração](#configuration) abaixo.
+Você pode excluir projetos na configuração se necessário. Para detalhes, consulte a [seção de configuração](#configuração).
 
 ## Configuração
 
 A configuração é definida no arquivo `aws-nx-plugin.config.mts` na raiz do workspace.
 
-### SPDX e detentor dos direitos autorais
+### SPDX e Detentor dos Direitos Autorais
 
-Sua licença escolhida pode ser atualizada a qualquer momento via propriedade `spdx`:
+Sua licença pode ser atualizada a qualquer momento via propriedade `spdx`:
 
 ```typescript title="aws-nx-plugin.config.mts" {3}
 export default {
@@ -108,9 +107,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-Quando o gerador é executado, todos os arquivos `LICENSE`, `package.json` e `pyproject.toml` serão atualizados para refletir a licença configurada.
+Quando o sync generator é executado, todos os arquivos `LICENSE`, `package.json` e `pyproject.toml` serão atualizados para refletir a licença configurada.
 
-Você pode adicionalmente configurar o detentor dos direitos autorais e o ano de copyright, incluídos em alguns arquivos `LICENSE`:
+Você pode configurar adicionalmente o detentor dos direitos autorais e o ano, que são incluídos em alguns arquivos `LICENSE`:
 
 ```typescript title="aws-nx-plugin.config.mts" {4,5}
 export default {
@@ -122,7 +121,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-### Cabeçalhos de licença
+### Cabeçalhos de Licença
 
 #### Conteúdo
 
@@ -164,7 +163,7 @@ export default {
 
 #### Formato
 
-Você pode especificar como os cabeçalhos devem ser formatados para diferentes tipos de arquivo usando padrões glob. A configuração suporta comentários de linha, bloco ou combinação de ambos:
+Você pode especificar como os cabeçalhos são formatados para diferentes tipos de arquivo usando padrões glob. A configuração suporta comentários de linha, bloco ou combinação de ambos:
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
@@ -183,7 +182,7 @@ export default {
           blockStart: '/*',
           blockEnd: '*/',
         },
-        // Comentários de bloco com prefixos de linha
+        // Comentários de bloco com prefixos
         '**/*.java': {
           blockStart: '/*',
           lineStart: ' * ',
@@ -203,14 +202,14 @@ export default {
 
 A configuração de formato suporta:
 
-- `blockStart`: Texto escrito antes do conteúdo da licença (ex: para iniciar um bloco de comentário)
-- `lineStart`: Texto prefixado em cada linha do conteúdo
-- `lineEnd`: Texto sufixado em cada linha do conteúdo
-- `blockEnd`: Texto escrito após o conteúdo da licença (ex: para encerrar um bloco de comentário)
+- `blockStart`: Texto antes do conteúdo da licença (ex: iniciar bloco de comentário)
+- `lineStart`: Texto pré-pendido em cada linha
+- `lineEnd`: Texto pós-pendido em cada linha
+- `blockEnd`: Texto após o conteúdo da licença (ex: finalizar bloco de comentário)
 
-#### Sintaxe de comentário personalizada
+#### Sintaxe de Comentário Personalizada
 
-Para tipos de arquivo não suportados nativamente, você pode especificar sintaxes personalizadas para identificar cabeçalhos existentes:
+Para tipos de arquivo não suportados nativamente, você pode especificar sintaxe personalizada para identificar cabeçalhos existentes:
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
@@ -241,7 +240,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-#### Excluir arquivos
+#### Excluir Arquivos
 
 Por padrão, em repositórios git, todos os arquivos `.gitignore` são respeitados. Em repositórios não-git, todos os arquivos são considerados a menos que explicitamente excluídos na configuração.
 
@@ -265,7 +264,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-### Excluir arquivos de projeto da sincronização
+### Excluir Arquivos de Projeto da Sincronização
 
 Todos os arquivos `LICENSE`, `package.json` e `pyproject.toml` são sincronizados por padrão.
 
@@ -276,9 +275,9 @@ export default {
   license: {
     files: {
       exclude: [
-        // não sincronizar LICENSE, package.json ou pyproject.toml
+        // não sincroniza LICENSE, package.json ou pyproject.toml
         'packages/excluded-project',
-        // não sincronizar LICENSE, mas sincronizar package.json/pyproject.toml
+        // não sincroniza LICENSE, mas sincroniza package.json/pyproject.toml
         'apps/internal/LICENSE',
       ];
     }
@@ -286,11 +285,11 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-## Desativar sincronização de licença
+## Desativar Sincronização de Licença
 
-Para desativar o gerador:
+Para desativar o sync generator de licença:
 
 1. Remova a seção `license` do `aws-nx-plugin.config.mts` (ou remova o arquivo)
 2. Remova o gerador `@aws/nx-plugin:license#sync` de `targetDefaults.lint.syncGenerators`
 
-Para reativar, execute o gerador `license` novamente.
+Para reativar, execute novamente o gerador `license`.

--- a/docs/src/content/docs/pt/guides/nx-generator.mdx
+++ b/docs/src/content/docs/pt/guides/nx-generator.mdx
@@ -11,11 +11,10 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
 Adiciona um [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a um projeto TypeScript para ajudar a automatizar tarefas repetitivas como criação de componentes ou imposição de estruturas de projeto específicas.
 
-## Uso
+## Utilização
 
 ### Gerar um Generator
 
@@ -25,36 +24,36 @@ Você pode gerar um generator de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
 ## Saída do Generator
 
-O generator criará os seguintes arquivos no `pluginProject` selecionado:
+O generator criará os seguintes arquivos no projeto `pluginProject` selecionado:
 
 <FileTree>
   - src/\<name>/
     - schema.json Esquema para entrada do generator
-    - schema.d.ts Tipos TypeScript para seu esquema
-    - generator.ts Implementação inicial do generator
-    - generator.spec.ts Testes para seu generator
+    - schema.d.ts Tipos TypeScript para o esquema
+    - generator.ts Implementação base do generator
+    - generator.spec.ts Testes para o generator
   - generators.json Configuração Nx para definir seus generators
-  - package.json Criado ou atualizado para adicionar entrada "generators"
+  - package.json Criado ou atualizado com entrada "generators"
   - tsconfig.json Atualizado para usar CommonJS
 </FileTree>
 
 :::warning
-Este generator atualizará o `pluginProject` selecionado para usar CommonJS, pois os Nx Generators atualmente só suportam CommonJS ([consulte este problema no GitHub para suporte a ESM](https://github.com/nrwl/nx/issues/15682)).
+Este generator atualizará o `pluginProject` selecionado para usar CommonJS, pois os Nx Generators atualmente só suportam CommonJS ([consulte esta issue do GitHub sobre suporte a ESM](https://github.com/nrwl/nx/issues/15682)).
 :::
 
 ## Generators Locais
 
 :::tip
-Recomendamos gerar um projeto TypeScript dedicado para todos seus generators usando o generator `ts#project` primeiro. Por exemplo:
+Recomendamos gerar um projeto TypeScript dedicado para seus generators usando o generator `ts#project` primeiro. Por exemplo:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-Selecione seu projeto local `nx-plugin` ao executar o generator `ts#nx-generator`, e especifique um nome com diretório e descrição opcionais.
+Selecione seu projeto local `nx-plugin` ao executar o generator `ts#nx-generator`, e especifique um nome, diretório opcional e descrição.
 
 ### Definindo o Esquema
 
@@ -72,7 +71,7 @@ Um arquivo schema.json possui a seguinte estrutura básica:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // Your generator options go here
+    // Suas opções do generator aqui
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
@@ -118,7 +117,7 @@ Você pode personalizar os prompts exibidos ao executar seu generator via CLI ad
 "name": {
   "type": "string",
   "description": "Component name",
-  "x-prompt": "Qual é o nome do seu componente?"
+  "x-prompt": "What is the name of your component?"
 }
 ```
 
@@ -128,13 +127,13 @@ Para opções booleanas, use um prompt sim/não:
 "withTests": {
   "type": "boolean",
   "description": "Whether to generate test files",
-  "x-prompt": "Deseja gerar arquivos de teste?"
+  "x-prompt": "Would you like to generate test files?"
 }
 ```
 
 #### Seleções em Dropdown
 
-Para opções com um conjunto fixo de escolhas, use `enum` para permitir que usuários selecionem uma das opções:
+Para opções com um conjunto fixo de escolhas, use `enum` para permitir seleção entre as opções:
 
 ```json
 "style": {
@@ -147,13 +146,13 @@ Para opções com um conjunto fixo de escolhas, use `enum` para permitir que usu
 
 #### Dropdown de Seleção de Projeto
 
-Um padrão comum é permitir que usuários selecionem entre projetos existentes no workspace:
+Um padrão comum é permitir seleção entre projetos existentes no workspace:
 
 ```json
 "project": {
   "type": "string",
   "description": "The project to add the component to",
-  "x-prompt": "Em qual projeto você deseja adicionar o componente?",
+  "x-prompt": "Which project would you like to add the component to?",
   "x-dropdown": "projects"
 }
 ```
@@ -162,7 +161,7 @@ A propriedade `x-dropdown: "projects"` instrui o Nx a preencher o dropdown com t
 
 #### Argumentos Posicionais
 
-Você pode configurar opções para serem passadas como argumentos posicionais ao executar o generator pela linha de comando:
+Configure opções para serem passadas como argumentos posicionais na linha de comando:
 
 ```json
 "name": {
@@ -176,11 +175,11 @@ Você pode configurar opções para serem passadas como argumentos posicionais a
 }
 ```
 
-Isso permite que usuários executem seu generator como `nx g your-generator meu-componente` em vez de `nx g your-generator --name=meu-componente`.
+Isso permite executar o generator como `nx g your-generator my-component` em vez de `nx g your-generator --name=my-component`.
 
 #### Definindo Prioridades
 
-Use a propriedade `x-priority` para indicar quais opções são mais importantes:
+Use a propriedade `x-priority` para indicar opções mais importantes:
 
 ```json
 "name": {
@@ -190,11 +189,11 @@ Use a propriedade `x-priority` para indicar quais opções são mais importantes
 }
 ```
 
-Opções podem ter prioridades `"important"` ou `"internal"`. Isso ajuda o Nx a ordenar propriedades na extensão VSCode do NX e na CLI do Nx.
+Opções podem ter prioridades `"important"` ou `"internal"`. Isso ajuda o Nx a ordenar propriedades na extensão VSCode e CLI.
 
 #### Valores Padrão
 
-Você pode fornecer valores padrão para opções:
+Forneça valores padrão para opções:
 
 ```json
 "directory": {
@@ -206,11 +205,11 @@ Você pode fornecer valores padrão para opções:
 
 #### Mais Informações
 
-Para mais detalhes sobre esquemas, consulte a [documentação de Opções do Generator Nx](https://nx.dev/extending-nx/recipes/generator-options).
+Para detalhes sobre esquemas, consulte a [documentação de Opções do Nx Generator](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Tipos TypeScript com schema.d.ts
 
-Junto com `schema.json`, o generator cria um arquivo `schema.d.ts` que fornece tipos TypeScript para as opções do generator:
+Junto com `schema.json`, o generator cria um arquivo `schema.d.ts` com tipos TypeScript para as opções:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -220,46 +219,45 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Esta interface é usada na implementação do generator para fornecer segurança de tipos e autocompletar:
+Esta interface é usada na implementação do generator para segurança de tipos e autocompletar:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // TypeScript conhece os tipos de todas suas opções
+  // TypeScript conhece os tipos de todas as opções
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-Sempre que modificar o `schema.json`, você deve atualizar o `schema.d.ts` para corresponder. Isso inclui:
-
-- Adicionar ou remover propriedades
+Sempre que modificar `schema.json`, atualize `schema.d.ts` para corresponder. Isso inclui:
+- Adicionar/remover propriedades
 - Alterar tipos de propriedades
-- Tornar propriedades obrigatórias ou opcionais (use o sufixo `?` para propriedades opcionais)
+- Tornar propriedades obrigatórias ou opcionais (use `?` para opcionais)
 
-A interface TypeScript deve refletir com precisão a estrutura definida em seu schema JSON.
+A interface TypeScript deve refletir fielmente a estrutura definida no schema JSON.
 :::
 
 ### Implementando um Generator
 
-Após criar o novo generator como acima, você pode escrever sua implementação em `generator.ts`.
+Após criar o generator como acima, você pode escrever sua implementação em `generator.ts`.
 
-Um generator é uma função que modifica um sistema de arquivos virtual (a `Tree`), lendo e escrevendo arquivos para fazer as alterações desejadas. As mudanças na `Tree` só são escritas no disco quando o generator termina de executar, a menos que seja executado em modo "dry-run".
+Um generator é uma função que modula um sistema de arquivos virtual (`Tree`), lendo e escrevendo arquivos para fazer mudanças. As alterações só são escritas no disco após a execução do generator, exceto em modo "dry-run".
 
-Aqui estão algumas operações comuns que você pode querer realizar em seu generator:
+Aqui estão operações comuns que você pode realizar:
 
 #### Lendo e Escrevendo Arquivos
 
 ```typescript
-// Ler um arquivo
+// Ler arquivo
 const content = tree.read('path/to/file.ts', 'utf-8');
 
-// Escrever um arquivo
+// Escrever arquivo
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
-// Verificar se um arquivo existe
+// Verificar existência
 if (tree.exists('path/to/file.ts')) {
   // Fazer algo
 }
@@ -273,53 +271,52 @@ import { generateFiles, joinPathFragments } from '@nx/devkit';
 // Gerar arquivos de templates
 generateFiles(
   tree,
-  joinPathFragments(__dirname, 'files'), // Diretório do template
+  joinPathFragments(__dirname, 'files'), // Diretório template
   'path/to/output', // Diretório de saída
   {
-    // Variáveis para substituir nos templates
+    // Variáveis para substituição
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
-    // Adicione mais variáveis conforme necessário
   },
 );
 ```
 
-#### Manipulação de AST (Abstract Syntax Tree) TypeScript
+#### Manipulação de AST TypeScript
 
-Recomendamos instalar [TSQuery](https://github.com/phenomnomnominal/tsquery) para ajudar na manipulação de AST.
+Recomendamos instalar [TSQuery](https://github.com/phenomnomnominal/tsquery) para manipulação de AST.
 
 ```typescript
 import { tsquery } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
 
-// Exemplo: Incrementar número de versão em um arquivo
+// Exemplo: Incrementar versão em arquivo
 
-// Parsear o conteúdo do arquivo em uma AST TypeScript
+// Parsear conteúdo em AST
 const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
 
-// Encontrar nós correspondentes ao seletor
+// Encontrar nós correspondentes
 const nodes = tsquery.query(
   sourceFile,
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
 );
 
 if (nodes.length > 0) {
-  // Obter o nó do literal numérico
+  // Obter nó numérico
   const numericNode = nodes[0] as ts.NumericLiteral;
 
-  // Obter o número da versão atual e incrementá-lo
+  // Incrementar versão
   const currentVersion = Number(numericNode.text);
   const newVersion = currentVersion + 1;
 
-  // Substituir o nó na AST
+  // Substituir nó na AST
   const result = tsquery.replace(
     sourceFile,
     'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
     () => ts.factory.createNumericLiteral(newVersion),
   );
 
-  // Escrever o conteúdo atualizado de volta na tree
+  // Escrever conteúdo atualizado
   tree.write(
     'path/to/version.ts',
     ts
@@ -332,7 +329,7 @@ if (nodes.length > 0) {
 ```
 
 :::tip
-Você pode testar seletores online no [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
+Teste seletores online no [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
 :::
 
 #### Adicionando Dependências
@@ -353,12 +350,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-Se você adicionar dependências a um package.json, pode instalá-las para o usuário como parte do callback do generator:
+Se adicionar dependências, você pode instalá-las para o usuário via callback:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// Generators retornam um callback que pode executar tarefas pós-geração, como instalar dependências
+// Generators retornam callback para tarefas pós-geração
 return () => {
   installPackagesTask(tree);
 };
@@ -370,19 +367,19 @@ return () => {
 ```typescript
 import { formatFiles } from '@nx/devkit';
 
-// Formatando todos os arquivos modificados
+// Formatar arquivos modificados
 await formatFiles(tree);
 ```
 
-#### Lendo e Atualizando Arquivos JSON
+#### Lendo e Atualizando JSON
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// Ler um arquivo JSON
+// Ler JSON
 const packageJson = readJson(tree, 'package.json');
 
-// Atualizar um arquivo JSON
+// Atualizar JSON
 updateJson(tree, 'tsconfig.json', (json) => {
   json.compilerOptions = {
     ...json.compilerOptions,
@@ -399,27 +396,27 @@ Você pode executar seu generator de duas formas:
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-Se você não visualizar seu generator na UI do plugin VSCode, pode atualizar seu Nx Workspace com:
+Se não visualizar seu generator na UI do plugin VSCode, atualize seu Nx Workspace com:
 
 <NxCommands commands={['reset']} />
 :::
 
 ### Testando Seu Generator
 
-Testes unitários para generators são simples de implementar. Aqui está um padrão típico:
+Testes unitários para generators são simples de implementar. Padrão típico:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { yourGenerator } from './generator';
 
-describe('seu generator', () => {
+describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
-    // Criar uma workspace tree vazia
+    // Criar workspace vazio
     tree = createTreeWithEmptyWorkspace();
 
-    // Adicionar arquivos que devem existir previamente na tree
+    // Adicionar arquivos pré-existentes
     tree.write(
       'project.json',
       JSON.stringify({
@@ -431,75 +428,69 @@ describe('seu generator', () => {
     tree.write('src/existing-file.ts', 'export const existing = true;');
   });
 
-  it('deve gerar os arquivos esperados', async () => {
-    // Executar o generator
+  it('should generate expected files', async () => {
+    // Executar generator
     await yourGenerator(tree, {
       name: 'test',
-      // Adicionar outras opções requeridas
     });
 
-    // Verificar se arquivos foram criados
+    // Verificar arquivos gerados
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
 
-    // Verificar conteúdo do arquivo
+    // Verificar conteúdo
     const content = tree.read('src/test/file.ts', 'utf-8');
     expect(content).toContain('export const test');
 
-    // Você também pode usar snapshots
+    // Snapshots
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
-  it('deve atualizar arquivos existentes', async () => {
-    // Executar o generator
+  it('should update existing files', async () => {
     await yourGenerator(tree, {
       name: 'test',
-      // Adicionar outras opções requeridas
     });
 
-    // Verificar se arquivos existentes foram atualizados
     const content = tree.read('src/existing-file.ts', 'utf-8');
     expect(content).toContain('import { test } from');
   });
 
-  it('deve lidar com erros', async () => {
-    // Esperar que o generator lance um erro em certas condições
+  it('should handle errors', async () => {
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
-        // Adicionar opções que devem causar um erro
       }),
-    ).rejects.toThrow('Mensagem de erro esperada');
+    ).rejects.toThrow('Expected error message');
   });
 });
 ```
 
-Pontos-chave para testar generators:
+Pontos-chave para testes:
 
-- Use `createTreeWithEmptyWorkspace()` para criar um sistema de arquivos virtual
-- Configure quaisquer arquivos pré-requisitos antes de executar o generator
-- Teste tanto a criação de novos arquivos quanto atualizações em arquivos existentes
-- Use snapshots para conteúdo de arquivo complexo
-- Teste condições de erro para garantir falha graciosa
+- Use `createTreeWithEmptyWorkspace()` para sistema de arquivos virtual
+- Configure arquivos pré-requisitos
+- Teste criação e atualização de arquivos
+- Use snapshots para conteúdo complexo
+- Teste condições de erro
 
-## Contribuindo com Generators para o @aws/nx-plugin
+## Contribuindo com Generators para @aws/nx-plugin
 
-Você também pode usar `ts#nx-generator` para criar um generator dentro do `@aws/nx-plugin`.
+Você também pode usar `ts#nx-generator` para criar generators dentro de `@aws/nx-plugin`.
 
-Quando este generator é executado em nosso repositório, ele gerará os seguintes arquivos para você:
+Quando executado em nosso repositório, este generator criará:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Esquema para entrada do generator
-    - schema.d.ts Tipos TypeScript para seu esquema
-    - generator.ts Implementação do generator
-    - generator.spec.ts Testes para seu generator
+    - schema.json Esquema do generator
+    - schema.d.ts Tipos TypeScript
+    - generator.ts Implementação
+    - generator.spec.ts Testes
   - docs/src/content/docs/guides/
-    - \<name>.mdx Página de documentação para seu generator
-  - packages/nx-plugin/generators.json Atualizado para incluir seu generator
+    - \<name>.mdx Documentação
+  - packages/nx-plugin/generators.json Atualizado com seu generator
 </FileTree>
 
-Você pode então começar a implementar seu generator.
+Você pode então implementar seu generator.
 
 :::tip
-Para um guia mais detalhado sobre como contribuir para o Nx Plugin para AWS, consulte o <Link path="get_started/tutorials/contribute-generator">tutorial aqui</Link>.
+Para um guia detalhado sobre contribuição para o Nx Plugin da AWS, consulte o <Link path="get_started/tutorials/contribute-generator">tutorial aqui</Link>.
 :::

--- a/docs/src/content/docs/pt/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/pt/guides/python-lambda-function.mdx
@@ -9,11 +9,10 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
-O gerador de Função Lambda em Python permite adicionar uma função lambda a um projeto Python existente.
+O gerador de Função Lambda Python permite adicionar uma função lambda a um projeto Python existente.
 
-Este gerador cria um novo handler de lambda Python com configuração de infraestrutura AWS CDK. O backend gerado utiliza AWS Lambda para implantação serverless, com tipagem opcional usando o [Parser do AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Ele configura o [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidade, incluindo logging, rastreamento com AWS X-Ray e métricas no CloudWatch.
+Este gerador cria um novo handler de lambda Python com configuração de infraestrutura AWS CDK. O backend gerado utiliza AWS Lambda para implantação serverless, com verificação de tipos opcional usando o [Parser do AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Ele configura o [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) para observabilidade, incluindo logging, rastreamento com AWS X-Ray e métricas no CloudWatch.
 
 ## Uso
 
@@ -25,7 +24,7 @@ Você pode gerar uma nova Função Lambda de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
 ## Saída do Gerador
 
@@ -38,9 +37,9 @@ O gerador adicionará os seguintes arquivos ao seu projeto:
 
 </FileTree>
 
-O gerador também cria construtos CDK para implantação da função, que residem no diretório `packages/common/constructs`.
+O gerador também criará construtos CDK para implantar sua função, que residem no diretório `packages/common/constructs`.
 
-Se a opção `functionPath` for fornecida, o gerador adicionará os arquivos no caminho especificado:
+Se a opção `functionPath` for fornecida, o gerador adicionará os arquivos necessários no caminho especificado:
 
 <FileTree>
 
@@ -52,7 +51,7 @@ Se a opção `functionPath` for fornecida, o gerador adicionará os arquivos no 
 
 ## Implementando sua Função
 
-A implementação principal está em `<function-name>.py`. Veja um exemplo:
+A implementação principal da função está em `<function-name>.py`. Aqui está um exemplo:
 
 ```python
 import os
@@ -78,20 +77,20 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     metrics.add_metric(name="InvocationCount", unit=MetricUnit.Count, value=1)
 
     try:
-        # TODO: Implement
+        # TODO: Implementar
         metrics.add_metric(name="SuccessCount", unit=MetricUnit.Count, value=1)
-        # TODO: Implement success response if required
+        # TODO: Implementar resposta de sucesso se necessário
     except Exception as e:
         logger.exception(e)
         metrics.add_metric(name="ErrorCount", unit=MetricUnit.Count, value=1)
-        # TODO: Implement error response if required
+        # TODO: Implementar resposta de erro se necessário
 ```
 
 O gerador configura automaticamente vários recursos:
 
 1. Integração com AWS Lambda Powertools para observabilidade
 2. Coleta de métricas
-3. Tipagem segura usando `@event_parser`
+3. Verificação de tipos usando `@event_parser`
 
 ### Observabilidade com AWS Lambda Powertools
 
@@ -105,7 +104,7 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 ```
 
 :::tip
-Recomenda-se definir um correlation id para requisições únicas para facilitar depuração e monitoramento. Consulte a documentação do [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) para melhores práticas.
+Recomenda-se definir um correlation id para todas as requisições únicas para facilitar depuração e monitoramento. Consulte a documentação do [aws powertools logger](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) para melhores práticas.
 :::
 
 O logger inclui automaticamente:
@@ -128,7 +127,7 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 
 #### Métricas
 
-Métricas do CloudWatch são coletadas automaticamente. Você pode adicionar métricas personalizadas:
+Métricas do CloudWatch são coletadas automaticamente para cada requisição. Você pode adicionar métricas personalizadas:
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -142,27 +141,27 @@ Métricas padrão incluem:
 - Contagem de sucessos/falhas
 - Métricas de cold start
 
-#### Tipagem Segura
+#### Verificação de Tipos
 
-Se você escolheu um `eventSource` ao gerar sua função, ela será instrumentada com [`@event_parser` do AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Exemplo:
+Se você escolheu um `eventSource` ao gerar sua função lambda, ela será instrumentada com [`@event_parser` do AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/). Por exemplo:
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
-    event.detail_type # <- tipagem segura com autocompletar na IDE
+    event.detail_type # <- tipagem segura com autocompletar da IDE
 ```
 
-Isso permite definir modelos de dados usando [Pydantic](https://docs.pydantic.dev/latest/), similar ao funcionamento com <Link path="guides/fastapi">FastAPI</Link>.
+Isso permite definir modelos de dados usando [Pydantic](https://docs.pydantic.dev/latest/), de forma similar ao trabalho com <Link path="guides/fastapi">Fast API</Link>.
 
 :::tip
-Para dados personalizados aninhados em eventos (ex: streams DynamoDB ou eventos EventBridge), você pode usar [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) para garantir tipagem segura.
+Se você possui dados personalizados aninhados em um evento, como um stream do DynamoDB ou evento do EventBridge, pode ser útil usar [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) para garantir tipagem segura.
 :::
 
-Se não desejar tipar seu evento, selecione `Any` para o `eventSource`.
+Se não desejar tipar seu evento, você pode selecionar `Any` como `eventSource`.
 
 ## Implantando sua Função
 
-O gerador cria um construto CDK para implantação no diretório `common/constructs`. Use em uma aplicação CDK:
+O gerador cria um construto CDK para implantação no diretório `common/constructs`. Você pode usá-lo em uma aplicação CDK:
 
 ```ts
 import { MyProjectMyFunction } from ':my-scope/common-constructs';
@@ -182,13 +181,13 @@ Isso configura:
 3. Configuração de rastreamento X-Ray
 4. Namespace de métricas no CloudWatch
 
-A função pode ser usada como alvo para qualquer [event source](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) do Lambda:
+Esta função pode ser usada como alvo para qualquer [fonte de evento lambda](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/):
 
 :::note
-Garanta que o event source corresponda à opção `eventSource` selecionada para tratamento adequado do evento.
+Garanta que a fonte de evento corresponda à opção `eventSource` selecionada para garantir o tratamento adequado do evento.
 :::
 
-O exemplo abaixo demonstra código CDK para invocar sua função em um agendamento usando Event Bridge:
+O exemplo abaixo demonstra o código CDK para invocar sua função lambda em um agendamento usando Event Bridge:
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';

--- a/docs/src/content/docs/pt/guides/python-project.mdx
+++ b/docs/src/content/docs/pt/guides/python-project.mdx
@@ -9,11 +9,10 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
-O gerador de projetos Python pode ser usado para criar uma biblioteca ou aplicação moderna em [Python](https://www.python.org/) configurada com melhores práticas, gerenciada com [UV](https://docs.astral.sh/uv/), um único arquivo de lock e ambiente virtual em um [UV workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para execução de testes e [Ruff](https://docs.astral.sh/ruff/) para análise estática.
+O gerador de projetos Python pode ser usado para criar uma biblioteca ou aplicação moderna em [Python](https://www.python.org/) configurada com melhores práticas, gerenciada com [UV](https://docs.astral.sh/uv/), utilizando um único arquivo de lock e ambiente virtual em um [espaço de trabalho UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para execução de testes e [Ruff](https://docs.astral.sh/ruff/) para análise estática.
 
-## Utilização
+## Uso
 
 ### Gerar um Projeto Python
 
@@ -23,7 +22,7 @@ Você pode gerar um novo projeto Python de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
 ## Saída do Gerador
 
@@ -33,11 +32,11 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
 
   - \<module-name>
     - \_\_init\_\_.py Inicialização do módulo
-    - hello.py Exemplo de arquivo fonte Python
+    - hello.py Arquivo de exemplo em Python
   - tests
     - \_\_init\_\_.py Inicialização do módulo
     - conftest.py Configuração de testes
-    - test_hello.py Exemplo de testes
+    - test_hello.py Testes de exemplo
   - project.json Configuração do projeto e targets de build
   - pyproject.toml Arquivo de configuração de empacotamento usado pelo UV
   - .python-version Contém a versão do Python do projeto
@@ -54,13 +53,13 @@ Você também pode notar os seguintes arquivos criados/atualizados na raiz do wo
 
 </FileTree>
 
-## Escrevendo Código Fonte Python
+## Escrevendo Código Python
 
-Adicione seu código fonte Python no diretório `<module-name>`.
+Adicione seu código-fonte Python no diretório `<module-name>`.
 
-### Importando Código da Sua Biblioteca em Outros Projetos
+### Importando Código da Biblioteca em Outros Projetos
 
-Como os [UV workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) estão configurados para você, é possível referenciar seu projeto Python de qualquer outro projeto Python no seu workspace:
+Como os [espaços de trabalho UV](https://docs.astral.sh/uv/concepts/projects/workspaces/) estão configurados, você pode referenciar seu projeto Python de qualquer outro projeto Python no workspace:
 
 ```python title="packages/my_other_project/my_other_project/main.py"
 from "my_library.hello" import say_hello
@@ -78,7 +77,7 @@ Isso adicionará a dependência ao arquivo `pyproject.toml` do seu projeto e atu
 
 #### Código de Runtime
 
-Quando você usa seu projeto Python como código de runtime (por exemplo como handler de uma função AWS Lambda), será necessário criar um bundle do código fonte e todas suas dependências. Você pode fazer isso adicionando um target como o seguinte ao seu arquivo `project.json`:
+Ao usar seu projeto Python como código de runtime (por exemplo, como handler de uma função AWS Lambda), você precisará criar um bundle do código-fonte e todas suas dependências. Isso pode ser alcançado adicionando um target como o seguinte ao seu arquivo `project.json`:
 
 ```json title="project.json"
 {
@@ -110,9 +109,9 @@ Seu projeto Python está configurado com um target `build` (definido em `project
 
 Onde `<project-name>` é o nome totalmente qualificado do seu projeto.
 
-O target `build` irá compilar, verificar lint e testar seu projeto.
+O target `build` irá compilar, lintar e testar seu projeto.
 
-A saída do build pode ser encontrada na pasta `dist` raiz do seu workspace, dentro de um diretório para seu pacote e target, por exemplo `dist/packages/<my-library>/build`
+A saída do build pode ser encontrada na pasta `dist` raiz do workspace, dentro de um diretório para seu pacote e target, por exemplo `dist/packages/<my-library>/build`
 
 ## Testes
 
@@ -142,11 +141,11 @@ Para mais detalhes sobre como escrever testes, consulte a [documentação do pyt
 
 ### Executando Testes
 
-Os testes serão executados como parte do target `build` do seu projeto, mas você também pode executá-los separadamente usando o target `test`:
+Os testes serão executados como parte do target `build` do projeto, mas também podem ser executados separadamente usando o target `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Você pode executar um teste individual ou um conjunto de testes usando o flag `-k`, especificando o nome do arquivo de teste ou método:
+Você pode executar um teste individual ou suite de testes usando a flag `-k`, especificando o nome do arquivo de teste ou método:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -156,16 +155,16 @@ Projetos Python usam [Ruff](https://docs.astral.sh/ruff/) para linting.
 
 ### Executando o Linter
 
-Para invocar o linter e verificar seu projeto, você pode executar o target `lint`:
+Para invocar o linter e verificar seu projeto, execute o target `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corrigindo Problemas de Lint
+### Corrigindo Problemas de Linting
 
-A maioria dos problemas de linting ou formatação podem ser corrigidos automaticamente. Você pode instruir o Ruff a corrigir problemas de lint executando com o argumento `--configuration=fix`:
+A maioria dos problemas de linting ou formatação pode ser corrigida automaticamente. Você pode pedir ao Ruff para corrigir problemas usando o argumento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Da mesma forma, se desejar corrigir todos os problemas de lint em todos os pacotes do seu workspace, você pode executar:
+Similarmente, para corrigir todos os problemas de linting em todos os pacotes do workspace, execute:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -11,11 +11,10 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/) é um framework para construção de APIs em TypeScript com segurança de tipos end-to-end. Usando tRPC, atualizações nas entradas e saídas das operações da API são refletidas imediatamente no código do cliente e visíveis em sua IDE sem necessidade de reconstruir o projeto.
+[tRPC](https://trpc.io/) é um framework para construção de APIs em TypeScript com segurança de tipos end-to-end. Usando tRPC, atualizações nas entradas e saídas das operações da API são refletidas imediatamente no código do cliente e visíveis na sua IDE sem necessidade de reconstruir o projeto.
 
-O gerador de API tRPC cria uma nova API tRPC com configuração de infraestrutura AWS CDK. O backend gerado utiliza AWS Lambda para deploy serverless e inclui validação de esquema usando [Zod](https://zod.dev/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) para observabilidade, incluindo logging, rastreamento com AWS X-Ray e métricas no Cloudwatch.
+O gerador de API tRPC cria uma nova API tRPC com configuração de infraestrutura AWS CDK. O backend gerado utiliza AWS Lambda para implantação serverless e inclui validação de schema usando [Zod](https://zod.dev/). Configura [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) para observabilidade, incluindo logging, rastreamento com AWS X-Ray e métricas no Cloudwatch.
 
 ## Utilização
 
@@ -27,7 +26,7 @@ Você pode gerar uma nova API tRPC de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -52,30 +51,31 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<ap
       - middleware
         - error.ts Middleware para tratamento de erros
         - logger.ts middleware para configurar AWS Powertools para logging em Lambda
-        - tracer.ts middleware para configurar AWS Powertools para rastreamento em Lambda  
+        - tracer.ts middleware para configurar AWS Powertools para rastreamento em Lambda
         - metrics.ts middleware para configurar AWS Powertools para métricas em Lambda
       - local-server.ts Ponto de entrada do adaptador standalone tRPC para servidor de desenvolvimento local
       - client
-        - index.ts Cliente type-safe para chamadas máquina-a-máquina
+        - index.ts Cliente type-safe para chamadas máquina-a-máquina à API
     - tsconfig.json Configuração TypeScript
     - project.json Configuração do projeto e targets de build
+
 </FileTree>
 
-O gerador também criará constructs CDK para deploy da API, localizados em `packages/common/constructs`.
+O gerador também criará constructs CDK que podem ser usados para implantar sua API, residindo no diretório `packages/common/constructs`.
 
 ## Implementando sua API tRPC
 
-Como visto acima, existem dois componentes principais: [`schema`](#schema) e [`backend`](#backend), definidos como pacotes individuais no workspace.
+Como visto acima, existem dois componentes principais em uma API tRPC: [`schema`](#schema) e [`backend`](#backend), definidos como projetos individuais no seu workspace.
 
 :::tip
-`schema` e `backend` são projetos TypeScript. Consulte a <Link path="guides/typescript-project">documentação de projetos TypeScript</Link> para detalhes gerais.
+Tanto `schema` quanto `backend` são projetos TypeScript, então você pode consultar a <Link path="guides/typescript-project">documentação de projeto TypeScript</Link> para mais detalhes sobre uso geral.
 :::
 
 ### Schema
 
-O pacote schema define tipos compartilhados entre client e server. Esses tipos são definidos usando [Zod](https://zod.dev/), uma biblioteca TypeScript-first para declaração e validação de schemas.
+O pacote schema define os tipos compartilhados entre seu código cliente e servidor. Neste pacote, esses tipos são definidos usando [Zod](https://zod.dev/), uma biblioteca TypeScript-first para declaração e validação de schemas.
 
-Um exemplo de schema:
+Um exemplo de schema pode ser:
 
 ```ts
 import { z } from 'zod';
@@ -91,7 +91,7 @@ export const UserSchema = z.object({
 export type User = z.TypeOf<typeof UserSchema>;
 ```
 
-O tipo `User` é equivalente a:
+Dado o schema acima, o tipo `User` é equivalente ao seguinte TypeScript:
 
 ```ts
 interface User {
@@ -101,19 +101,19 @@ interface User {
 }
 ```
 
-Schemas são compartilhados entre client e server, permitindo atualizações centralizadas nas estruturas da API.
+Schemas são compartilhados por código cliente e servidor, proporcionando um único local para atualizações quando mudanças são feitas nas estruturas usadas na API.
 
-A validação automática de schemas no runtime elimina a necessidade de lógica de validação manual no backend.
+Schemas são validados automaticamente pela sua API tRPC em runtime, eliminando a necessidade de criar lógica de validação manualmente no backend.
 
-Zod fornece utilitários poderosos como `.merge`, `.pick`, `.omit` e outros. Saiba mais na [documentação do Zod](https://zod.dev/?id=basic-usage).
+Zod fornece utilitários poderosos para combinar ou derivar schemas como `.merge`, `.pick`, `.omit` e outros. Mais informações podem ser encontradas no [site de documentação do Zod](https://zod.dev/?id=basic-usage).
 
 ### Backend
 
-A pasta `backend` contém a implementação da API, onde são definidas operações, entradas, saídas e implementações.
+A pasta aninhada `backend` contém sua implementação da API, onde você define as operações da API e suas entradas, saídas e implementações.
 
-O ponto de entrada está em `src/router.ts`, que contém o handler Lambda para rotear requisições aos procedimentos. Cada procedimento define input, output e implementação.
+O ponto de entrada da API está em `src/router.ts`. Este arquivo contém o handler Lambda que roteia requisições para "procedures" baseado na operação invocada. Cada procedure define a entrada esperada, saída e implementação.
 
-O roteador de exemplo possui uma operação `echo`:
+O roteador de exemplo gerado possui uma única operação chamada `echo`:
 
 ```ts
 import { echo } from './procedures/echo.js';
@@ -123,7 +123,7 @@ export const appRouter = router({
 });
 ```
 
-O procedimento `echo` em `src/procedures/echo.ts`:
+O procedimento `echo` de exemplo é gerado em `src/procedures/echo.ts`:
 
 ```ts
 export const echo = publicProcedure
@@ -132,31 +132,35 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-Explicação:
+Analisando o código acima:
 
-- `publicProcedure` define um método público com middleware configurado em `src/middleware` (incluindo AWS Lambda Powertools)
-- `input` aceita um schema Zod para validar entradas automaticamente
-- `output` define o schema de saída, causando erros de tipo se não conformado
-- `query` define a implementação para operações não mutáveis. Use `mutation` para operações mutáveis
+- `publicProcedure` define um método público na API, incluindo o middleware configurado em `src/middleware`. Este middleware inclui integração com AWS Lambda Powertools para logging, tracing e métricas.
+- `input` aceita um schema Zod que define a entrada esperada para a operação. Requisições para esta operação são validadas automaticamente contra este schema.
+- `output` aceita um schema Zod que define a saída esperada. Você verá erros de tipo na implementação se não retornar uma saída que conforme com o schema.
+- `query` aceita uma função que define a implementação da sua API. Esta implementação recebe `opts`, que contém o `input` passado para a operação, além de outros contextos configurados por middleware, disponíveis em `opts.ctx`. A função passada para `query` deve retornar uma saída que conforme com o schema de `output`.
 
-Novas operações devem ser registradas em `src/router.ts`.
+O uso de `query` para definir a implementação indica que a operação não é mutativa. Use isto para definir métodos de recuperação de dados. Para operações mutativas, use o método `mutation` ao invés.
+
+Se adicionar uma nova operação, certifique-se de registrá-la adicionando-a ao roteador em `src/router.ts`.
 
 ## Personalizando sua API tRPC
 
 ### Erros
 
-Retorne erros lançando `TRPCError`:
+Na sua implementação, você pode retornar erros para clientes lançando um `TRPCError`. Estes aceitam um `code` que indica o tipo de erro, por exemplo:
 
 ```ts
 throw new TRPCError({
   code: 'NOT_FOUND',
-  message: 'Recurso não encontrado',
+  message: 'O recurso solicitado não pôde ser encontrado',
 });
 ```
 
-### Organizando Operações
+### Organizando suas Operações
 
-Agrupe operações relacionadas com roteadores aninhados:
+Conforme sua API cresce, você pode querer agrupar operações relacionadas.
+
+Você pode agrupar operações usando roteadores aninhados, por exemplo:
 
 ```ts
 import { getUser } from './procedures/users/get.js';
@@ -171,7 +175,7 @@ const appRouter = router({
 })
 ```
 
-Chamadas no cliente refletem o agrupamento:
+Clientes então recebem este agrupamento, por exemplo invocar a operação `listUsers` seria:
 
 ```ts
 client.users.list.query();
@@ -179,7 +183,7 @@ client.users.list.query();
 
 ### Logging
 
-O logger AWS Powertools está acessível via `opts.ctx.logger`:
+O logger AWS Lambda Powertools é configurado em `src/middleware/logger.ts`, e pode ser acessado numa implementação via `opts.ctx.logger`. Você pode usar isto para registrar logs no CloudWatch Logs e/ou controlar valores adicionais a incluir em cada mensagem de log estruturada. Por exemplo:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -187,15 +191,16 @@ export const echo = publicProcedure
    .output(...)
    .query(async (opts) => {
       opts.ctx.logger.info('Operação chamada com input', opts.input);
+
       return ...;
    });
 ```
 
-Consulte a [documentação do Logger](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/).
+Para mais informações sobre o logger, consulte a [documentação do AWS Lambda Powertools Logger](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/).
 
-### Métricas
+### Registrando Métricas
 
-Métricas AWS Powertools via `opts.ctx.metrics`:
+As métricas do AWS Lambda Powertools são configuradas em `src/middleware/metrics.ts`, e podem ser acessadas via `opts.ctx.metrics`. Use isto para registrar métricas no CloudWatch sem necessidade de usar o SDK da AWS, por exemplo:
 
 ```ts {5}
 export const echo = publicProcedure
@@ -203,15 +208,16 @@ export const echo = publicProcedure
    .output(...)
    .query(async (opts) => {
       opts.ctx.metrics.addMetric('Invocations', 'Count', 1);
+
       return ...;
    });
 ```
 
-Veja [documentação de Métricas](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/).
+Para mais informações, consulte a [documentação do AWS Lambda Powertools Metrics](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/).
 
-### Rastreamento com X-Ray
+### Ajuste Fino de Tracing com X-Ray
 
-Tracer AWS Powertools via `opts.ctx.tracer`:
+O tracer AWS Lambda Powertools é configurado em `src/middleware/tracer.ts`, e pode ser acessado via `opts.ctx.tracer`. Use isto para adicionar traces com AWS X-Ray e obter insights detalhados sobre performance e fluxo de requisições. Por exemplo:
 
 ```ts {5-7}
 export const echo = publicProcedure
@@ -219,19 +225,22 @@ export const echo = publicProcedure
    .output(...)
    .query(async (opts) => {
       const subSegment = opts.ctx.tracer.getSegment()!.addNewSubsegment('MyAlgorithm');
-      // ... lógica do algoritmo
+      // ... lógica do algoritmo para capturar
       subSegment.close();
+
       return ...;
    });
 ```
 
-Documentação do [Tracer](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/).
+Para mais informações, consulte a [documentação do AWS Lambda Powertools Tracer](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/).
 
-### Middleware Customizado
+### Implementando Middleware Customizado
 
-Adicione valores ao contexto implementando middleware. Exemplo em `src/middleware/identity.ts`:
+Você pode adicionar valores adicionais ao contexto fornecido para procedures implementando middleware.
 
-Defina a interface de contexto:
+Como exemplo, vamos implementar um middleware para extrair detalhes do usuário chamador da API em `src/middleware/identity.ts`.
+
+Primeiro definimos o que será adicionado ao contexto:
 
 ```ts
 export interface IIdentityContext {
@@ -242,24 +251,26 @@ export interface IIdentityContext {
 }
 ```
 
-Implemente o middleware:
+Note que definimos uma propriedade opcional adicional ao contexto. O tRPC gerencia a garantia de que isto está definido em procedures que configuraram corretamente este middleware.
+
+Em seguida, implementamos o middleware com a seguinte estrutura:
 
 ```ts
 export const createIdentityPlugin = () => {
    const t = initTRPC.context<...>().create();
    return t.procedure.use(async (opts) => {
-      // Lógica pré-procedimento
+      // Adicione lógica aqui para executar antes da procedure
 
       const response = await opts.next(...);
 
-      // Lógica pós-procedimento
+      // Adicione lógica aqui para executar após a procedure
 
       return response;
    });
 };
 ```
 
-Exemplo de implementação para REST e HTTP APIs:
+No nosso caso, queremos extrair detalhes do usuário Cognito. Faremos isso extraindo o ID de assunto (sub) do usuário do evento API Gateway e recuperando detalhes do Cognito. A implementação varia dependendo se o evento veio de uma API REST ou HTTP:
 
 <Tabs>
 <TabItem label="REST">
@@ -269,7 +280,12 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
 import { APIGatewayProxyEvent } from 'aws-lambda';
 
-// ... interface IIdentityContext
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
 
 export const createIdentityPlugin = () => {
   const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
@@ -277,11 +293,43 @@ export const createIdentityPlugin = () => {
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    // ... lógica de extração de sub e usuário
+    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+    let sub: string | undefined = undefined;
+    if (cognitoAuthenticationProvider) {
+      const providerParts = cognitoAuthenticationProvider.split(':');
+      sub = providerParts[providerParts.length - 1];
+    }
+
+    if (!sub) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Não foi possível determinar o usuário chamador`,
+      });
+    }
+
+    const { Users } = await cognito.listUsers({
+      // Assume que o ID do user pool está configurado no ambiente lambda
+      UserPoolId: process.env.USER_POOL_ID!,
+      Limit: 1,
+      Filter: `sub="${sub}"`,
+    });
+
+    if (!Users || Users.length !== 1) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Nenhum usuário encontrado com subjectId ${sub}`,
+      });
+    }
+
+    // Fornece a identidade para outras procedures no contexto
     return await opts.next({
       ctx: {
         ...opts.ctx,
-        identity: { sub, username: Users[0].Username! },
+        identity: {
+          sub,
+          username: Users[0].Username!,
+        },
       },
     });
   });
@@ -295,7 +343,12 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
 import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
-// ... interface IIdentityContext
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
 
 export const createIdentityPlugin = () => {
   const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
@@ -303,11 +356,49 @@ export const createIdentityPlugin = () => {
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    // ... lógica de extração de sub e usuário
+    const cognitoIdentity = opts.ctx.event.requestContext?.authorizer?.iam
+      ?.cognitoIdentity as unknown as
+      | {
+          amr: string[];
+        }
+      | undefined;
+
+    const sub = (cognitoIdentity?.amr ?? [])
+      .flatMap((s) => (s.includes(':CognitoSignIn:') ? [s] : []))
+      .map((s) => {
+        const parts = s.split(':');
+        return parts[parts.length - 1];
+      })?.[0];
+
+    if (!sub) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Não foi possível determinar o usuário chamador`,
+      });
+    }
+
+    const { Users } = await cognito.listUsers({
+      // Assume que o ID do user pool está configurado no ambiente lambda
+      UserPoolId: process.env.USER_POOL_ID!,
+      Limit: 1,
+      Filter: `sub="${sub}"`,
+    });
+
+    if (!Users || Users.length !== 1) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `Nenhum usuário encontrado com subjectId ${sub}`,
+      });
+    }
+
+    // Fornece a identidade para outras procedures no contexto
     return await opts.next({
       ctx: {
         ...opts.ctx,
-        identity: { sub, username: Users[0].Username! },
+        identity: {
+          sub,
+          username: Users[0].Username!,
+        },
       },
     });
   });
@@ -316,15 +407,16 @@ export const createIdentityPlugin = () => {
 </TabItem>
 </Tabs>
 
-## Deploy da API tRPC
+## Implantando sua API tRPC
 
-O gerador cria um construct CDK em `common/constructs`. Consumo em aplicação CDK:
+O gerador de backend tRPC cria um construct CDK para implantação na pasta `common/constructs`. Você pode consumir isto em uma aplicação CDK, por exemplo:
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
 
 export class ExampleStack extends Stack {
    constructor(scope: Construct, id: string) {
+      // Adiciona a API à stack
       const api = new MyApi(this, 'MyApi', {
         integrations: MyApi.defaultIntegrations(this).build(),
       });
@@ -332,35 +424,35 @@ export class ExampleStack extends Stack {
 }
 ```
 
-Isso configura infraestrutura com API Gateway, Lambda e autenticação IAM.
+Isto configura a infraestrutura da API, incluindo AWS API Gateway REST/HTTP API, funções Lambda para lógica de negócio e autenticação IAM.
 
 ### Integrações Type-Safe
 
 <Snippet name="api/type-safe-api-integrations" />
 
 :::tip
-Alterações nos procedimentos são refletidas no construct CDK sem rebuild.
+Quando você adiciona ou remove uma procedure na sua API tRPC, estas mudanças são refletidas imediatamente no construct CDK sem necessidade de rebuild.
 :::
 
 ### Concedendo Acesso
 
-Use `grantInvokeAccess` para conceder acesso:
+Você pode usar o método `grantInvokeAccess` para conceder acesso à API. Por exemplo, para conceder acesso a usuários Cognito autenticados:
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 ```
 
-## Servidor Local tRPC
+## Servidor tRPC Local
 
-Execute servidor local com:
+Você pode usar o target `serve` para executar um servidor local da API:
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
-Ponto de entrada em `src/local-server.ts`.
+O ponto de entrada do servidor local está em `src/local-server.ts`.
 
-## Invocando a API tRPC
+## Invocando sua API tRPC
 
-Crie um cliente type-safe usando `src/client/index.ts`:
+Você pode criar um cliente tRPC para invocar sua API de forma type-safe. Para chamadas de outro backend, use o cliente em `src/client/index.ts`:
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -370,8 +462,8 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-Para React, use o gerador <Link path="guides/api-connection/react-trpc">API Connection</Link>.
+Para chamar a API de um site React, considere usar o gerador <Link path="guides/api-connection/react-trpc">API Connection</Link> para configurar o cliente.
 
 ## Mais Informações
 
-Consulte a [documentação do tRPC](https://trpc.io/docs).
+Para mais informações sobre tRPC, consulte a [documentação do tRPC](https://trpc.io/docs).

--- a/docs/src/content/docs/pt/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/pt/guides/ts-mcp-server.mdx
@@ -14,16 +14,16 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 # Gerador de Servidor MCP em TypeScript
 
-Gere um servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) em TypeScript para fornecer contexto a Modelos de Linguagem de Grande Porte (LLMs).
+Gere um servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) em TypeScript para fornecer contexto a Large Language Models (LLMs).
 
-## O que é MCP?
+## O que é o MCP?
 
 O [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) é um padrão aberto que permite assistentes de IA interagirem com ferramentas e recursos externos. Ele fornece uma maneira consistente para LLMs:
 
-- Executarem ferramentas (funções) que realizam ações ou recuperam informações
-- Acessarem recursos que fornecem contexto ou dados
+- Executar ferramentas (funções) que realizam ações ou recuperam informações
+- Acessar recursos que fornecem contexto ou dados
 
-## Utilização
+## Uso
 
 ### Gerar um Servidor MCP
 
@@ -33,11 +33,11 @@ Você pode gerar um servidor MCP em TypeScript de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## Saída do Gerador
 
-O gerador criará os seguintes arquivos do projeto:
+O gerador criará os seguintes arquivos de projeto:
 
 <FileTree>
   - packages/\<nome>/
@@ -45,7 +45,7 @@ O gerador criará os seguintes arquivos do projeto:
     - project.json Configuração do projeto Nx com targets de build, bundle e dev
     - src/
       - index.ts Ponto de entrada do servidor MCP
-      - server.ts Definição principal do servidor, declarando ferramentas e recursos
+      - server.ts Definição principal do servidor, definindo ferramentas e recursos
       - global.d.ts Declarações de tipos TypeScript para importar arquivos markdown
       - resources/
         - example-context.md Arquivo markdown de exemplo usado como recurso pelo servidor MCP
@@ -59,15 +59,15 @@ Consulte a <Link path="/guides/typescript-project">documentação do gerador de 
 
 ### Adicionando Ferramentas
 
-Ferramentas são funções que o assistente de IA pode chamar para realizar ações. Você pode adicionar novas ferramentas no arquivo `server.ts`:
+Ferramentas são funções que o assistente de IA pode chamar para executar ações. Você pode adicionar novas ferramentas no arquivo `server.ts`:
 
 ```typescript
-server.tool("toolName",
+server.tool("nomeDaFerramenta",
   { param1: z.string(), param2: z.number() }, // Esquema de entrada usando Zod
   async ({ param1, param2 }) => {
     // Implementação da ferramenta
     return {
-      content: [{ type: "text", text: "Result" }]
+      content: [{ type: "text", text: "Resultado" }]
     };
   }
 );
@@ -81,12 +81,12 @@ Recursos fornecem contexto ao assistente de IA. Você pode adicionar recursos es
 // Recurso estático de um arquivo
 import exampleContext from './resources/example-context.md';
 
-server.resource('resource-name', 'example://resource', async (uri) => ({
+server.resource('nome-do-recurso', 'example://recurso', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
 // Recurso dinâmico
-server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
+server.resource('recurso-dinamico', 'dynamic://recurso', async (uri) => {
   const data = await fetchSomeData();
   return {
     contents: [{ uri: uri.href, text: data }],
@@ -96,11 +96,11 @@ server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
 
 ## Configuração com Assistentes de IA
 
-Para usar seu servidor MCP com assistentes de IA, você precisa gerar o bundle primeiro:
+Para usar seu servidor MCP com assistentes de IA, você precisa empacotá-lo primeiro:
 
-<NxCommands commands={['run your-mcp-server:bundle']} />
+<NxCommands commands={['run seu-servidor-mcp:bundle']} />
 
-Isso cria uma versão empacotada em `dist/packages/your-mcp-server/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
+Isso cria uma versão empacotada em `dist/packages/seu-servidor-mcp/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
 
 ### Arquivos de Configuração
 
@@ -109,10 +109,10 @@ A maioria dos assistentes de IA que suportam MCP usa uma abordagem de configura�
 ```json
 {
   "mcpServers": {
-    "your-mcp-server": {
+    "seu-servidor-mcp": {
       "command": "node",
       "args": [
-        "/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js"
+        "/caminho/para/workspace/dist/packages/seu-servidor-mcp/bundle/index.js"
       ],
       "transportType": "stdio"
     }
@@ -120,13 +120,13 @@ A maioria dos assistentes de IA que suportam MCP usa uma abordagem de configura�
 }
 ```
 
-Substitua `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` pelo caminho real para o bundle do seu servidor MCP.
+Substitua `/caminho/para/workspace/dist/packages/seu-servidor-mcp/bundle/index.js` pelo caminho real para seu servidor MCP empacotado.
 
 :::caution
 Se receber um erro como `ENOENT node` ao conectar ao servidor, talvez seja necessário especificar o caminho completo para o `node`, que pode ser obtido executando `which node` no terminal.
 :::
 
-### Configurações Específicas por Assistente
+### Configuração Específica por Assistente
 
 Consulte a documentação a seguir para configurar o MCP com assistentes específicos:
 
@@ -149,15 +149,15 @@ O gerador é baseado no <Link path="/guides/typescript-project">gerador de proje
 
 O target `bundle` usa [esbuild](https://esbuild.github.io/) para criar um único arquivo JavaScript empacotado que pode ser usado com assistentes de IA:
 
-<NxCommands commands={['run your-mcp-server:bundle']} />
+<NxCommands commands={['run seu-servidor-mcp:bundle']} />
 
-Isso cria uma versão empacotada em `dist/packages/your-mcp-server/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
+Isso cria uma versão empacotada em `dist/packages/seu-servidor-mcp/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
 
 #### Dev
 
 O target `dev` monitora alterações no seu projeto e reconstrói o bundle automaticamente:
 
-<NxCommands commands={['run your-mcp-server:dev']} />
+<NxCommands commands={['run seu-servidor-mcp:dev']} />
 
 Isso é particularmente útil durante o desenvolvimento, garantindo que seu assistente de IA utilize a versão mais recente do servidor MCP.
 

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -10,13 +10,12 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
 O [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) é um framework para definir infraestrutura em nuvem como código e provisioná-la através do AWS CloudFormation.
 
 O gerador de infraestrutura TypeScript cria uma aplicação de infraestrutura AWS CDK escrita em TypeScript. A aplicação gerada inclui práticas recomendadas de segurança através de verificações com [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html).
 
-## Utilização
+## Uso
 
 ### Gerar um Projeto de Infraestrutura
 
@@ -26,7 +25,7 @@ Você pode gerar um novo projeto de infraestrutura de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
 ## Saída do Gerador
 
@@ -44,12 +43,12 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
 </FileTree>
 
 :::tip
-Sua infraestrutura é um projeto TypeScript, portanto você pode consultar a <Link path="guides/typescript-project">documentação de projetos TypeScript</Link> para detalhes gerais de utilização.
+Sua infraestrutura é um projeto TypeScript, portanto você pode consultar a <Link path="guides/typescript-project">documentação de projetos TypeScript</Link> para mais detalhes sobre uso geral.
 :::
 
 ## Implementando sua Infraestrutura CDK
 
-Você pode começar a escrever sua infraestrutura CDK no arquivo `src/stacks/application-stack.ts`, por exemplo:
+Você pode começar a escrever sua infraestrutura CDK dentro de `src/stacks/application-stack.ts`, por exemplo:
 
 ```ts title="src/stacks/application-stack.ts" {9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -68,9 +67,9 @@ export class ApplicationStack extends cdk.Stack {
 
 ### Infraestrutura de API
 
-Se você usou os geradores <Link path="guides/trpc">tRPC API</Link> ou <Link path="guides/fastapi">FastAPI</Link> para criar APIs, notará que já existem alguns constructs disponíveis em `packages/common/constructs` para implantá-las.
+Se você usou os geradores <Link path="guides/trpc">tRPC API</Link> ou <Link path="guides/fastapi">FastAPI</Link> para criar APIs, notará que já tem alguns constructs disponíveis em `packages/common/constructs` para implantá-los.
 
-Por exemplo, se você criou uma API tRPC chamada `my-api`, basta importar e instanciar o construct para adicionar toda a infraestrutura necessária:
+Se, por exemplo, você criou uma API tRPC chamada `my-api`, basta importar e instanciar o construct para adicionar toda a infraestrutura necessária:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -89,7 +88,7 @@ export class ApplicationStack extends cdk.Stack {
 
 ### Infraestrutura de Website
 
-Se você usou o gerador <Link path="guides/cloudscape-website">CloudScape website</Link>, notará que já existe um construct em `packages/common/constructs` para implantá-lo. Por exemplo:
+Se você usou o gerador <Link path="guides/cloudscape-website">CloudScape website</Link>, notará que já tem um construct em `packages/common/constructs` para implantá-lo. Por exemplo:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -107,20 +106,20 @@ export class ApplicationStack extends cdk.Stack {
 ```
 
 :::warning
-É importante garantir que o website seja declarado _após_ quaisquer constructs de API para que a <Link path="guides/cloudscape-website#runtime-configuration">Configuração de Runtime</Link> do website inclua todas as configurações de API.
+É importante garantir que o website seja declarado _após_ quaisquer constructs de API para que o <Link path="guides/cloudscape-website#runtime-configuration">Runtime Config</Link> do website inclua todas as configurações da API.
 :::
 
 ## Sintetizando sua Infraestrutura
 
-Como parte do target `build`, além de executar os <Link path="guides/typescript-project#building">targets padrão de compilação, lint e testes</Link>, seu projeto de infraestrutura é _sintetizado_ para CloudFormation. Isso também pode ser executado isoladamente através do target `synth`:
+Como parte do target `build`, além de executar os <Link path="guides/typescript-project#building">targets padrão de compilação, lint e teste</Link>, seu projeto de infraestrutura é _sintetizado_ para CloudFormation. Isso também pode ser executado separadamente através do target `synth`:
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
 Você encontrará sua cloud assembly sintetizada na pasta raiz `dist`, em `dist/packages/<my-infra-project>/cdk.out`.
 
-## Bootstrapping da sua Conta AWS
+## Bootstrapping da Sua Conta AWS
 
-Se você está implantando uma aplicação CDK em uma conta AWS pela primeira vez, é necessário fazer o bootstrap primeiro.
+Se você está implantando uma aplicação CDK em uma conta AWS pela primeira vez, será necessário fazer bootstrap primeiro.
 
 Primeiro, certifique-se de ter [configurado credenciais para sua conta AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
@@ -137,17 +136,17 @@ Para mais detalhes, consulte a [documentação do CDK](https://docs.aws.amazon.c
 Após um build, você pode implantar sua infraestrutura na AWS usando o target `deploy`.
 
 :::caution
-Use o target `deploy-ci` para implantações em pipelines CI/CD. Veja detalhes abaixo.
+Use o target `deploy-ci` para implantações em pipelines CI/CD. Veja abaixo para detalhes.
 :::
 
 Primeiro, certifique-se de ter [configurado credenciais para sua conta AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html).
 
-Em seguida, execute o target deploy:
+Em seguida, execute o target de deploy:
 
 <NxCommands commands={['run <my-infra>:deploy --all']} />
 
 :::tip
-O comando acima implanta _todas_ as stacks definidas em `main.ts`. Você pode optar por implantar uma stack específica, especialmente se tiver configurados múltiplos estágios de uma aplicação:
+O comando acima implanta _todas_ as stacks definidas em `main.ts`. Você pode querer direcionar uma stack individual, especialmente se tiver configurado múltiplos estágios de uma aplicação:
 
 <NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
 :::
@@ -158,8 +157,8 @@ Use o target `deploy-ci` para implantações na AWS como parte de um pipeline CI
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-Este target difere do `deploy` regular por garantir a implantação usando uma cloud-assembly pré-sintetizada, evitando problemas de não-determinismo causados por alterações em versões de pacotes. Isso garante que todos os estágios do pipeline usem a mesma cloud-assembly.
+Este target difere ligeiramente do target `deploy` regular por garantir que a cloud-assembly pré-sintetizada seja implantada, em vez de sintetizar durante a execução. Isso ajuda a evitar problemas potenciais de não-determinismo devido a versões de pacotes, garantindo que todos os estágios do pipeline usem a mesma cloud-assembly.
 
 ## Mais Informações
 
-Para mais detalhes sobre o CDK, consulte o [Guia do Desenvolvedor CDK](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) e a [Referência da API](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html).
+Para mais informações sobre CDK, consulte o [Guia do Desenvolvedor CDK](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) e [Referência da API](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html).

--- a/docs/src/content/docs/pt/guides/typescript-project.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-project.mdx
@@ -10,9 +10,8 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
-O gerador de projetos TypeScript pode ser usado para criar bibliotecas ou aplicações modernas em [TypeScript](https://www.typescriptlang.org/) configuradas com melhores práticas como [Módulos ECMAScript (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), [referências de projeto TypeScript](https://www.typescriptlang.org/docs/handbook/project-references.html), [Vitest](https://vitest.dev/) para execução de testes e [ESLint](https://eslint.org/) para análise estática.
+O gerador de projetos TypeScript pode ser usado para criar uma biblioteca ou aplicação moderna em [TypeScript](https://www.typescriptlang.org/) configurada com melhores práticas como [ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html), [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) do TypeScript, [Vitest](https://vitest.dev/) para execução de testes e [ESLint](https://eslint.org/) para análise estática.
 
 ## Uso
 
@@ -24,7 +23,7 @@ Você pode gerar um novo projeto TypeScript de duas formas:
 
 ### Opções
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## Saída do Gerador
 
@@ -32,14 +31,14 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
 
 <FileTree>
 
-  - src Código-fonte TypeScript
+  - src Código fonte TypeScript
     - index.ts
   - project.json Configuração do projeto e targets de build
-  - tsconfig.json Configuração base TypeScript para este projeto (estende o tsconfig.base.json raiz do workspace)
-  - tsconfig.lib.json Configuração TypeScript para sua biblioteca (código de runtime ou empacotado)
-  - tsconfig.spec.json Configuração TypeScript para seus testes
-  - vite.config.ts Configuração para o Vitest
-  - eslint.config.mjs Configuração para o ESLint
+  - tsconfig.json Configuração base do TypeScript para este projeto (estende o tsconfig.base.json da raiz do workspace)
+  - tsconfig.lib.json Configuração do TypeScript para sua biblioteca (código de runtime ou empacotado)
+  - tsconfig.spec.json Configuração do TypeScript para seus testes
+  - vite.config.ts Configuração do Vitest
+  - eslint.config.mjs Configuração do ESLint
 
 </FileTree>
 
@@ -52,7 +51,7 @@ Você também notará alterações nos seguintes arquivos na raiz do workspace:
 <FileTree>
 
   - nx.json A configuração do Nx é atualizada para configurar o plugin @nx/js/typescript para seu projeto
-  - tsconfig.base.json Um alias TypeScript é configurado para seu projeto para permitir importação por outros projetos do workspace
+  - tsconfig.base.json Um alias TypeScript é configurado para seu projeto permitindo importação por outros projetos do workspace
   - tsconfig.json Uma referência de projeto TypeScript é adicionada para seu projeto
 
 </FileTree>
@@ -63,28 +62,28 @@ Adicione seu código TypeScript no diretório `src`.
 
 ### Sintaxe de Importação ESM
 
-Como seu projeto TypeScript é um Módulo ES, certifique-se de escrever suas declarações de importação com a sintaxe ESM correta, referenciando explicitamente a extensão do arquivo:
+Como seu projeto TypeScript é um ES Module, certifique-se de escrever suas instruções de importação com a sintaxe ESM correta, referenciando explicitamente a extensão do arquivo:
 
 ```ts title="index.ts" ".js"
 import { sayHello } from './hello.js';
 ```
 
 :::note
-Apesar de estarmos usando TypeScript, e `sayHello` estar definido em `hello.ts`, usamos a extensão `.js` em nossa importação. Você pode ler mais sobre isso [aqui](https://www.typescriptlang.org/docs/handbook/modules/reference.html).
+Apesar de usarmos TypeScript, e `sayHello` estar definido em `hello.ts`, usamos a extensão `.js` na importação. Você pode ler mais sobre isso [aqui](https://www.typescriptlang.org/docs/handbook/modules/reference.html).
 :::
 
 ### Exportando para Outros Projetos TypeScript
 
-O ponto de entrada do seu projeto TypeScript é `src/index.ts`. Você pode adicionar exports aqui para qualquer coisa que deseje que outros projetos possam importar:
+O ponto de entrada do seu projeto TypeScript é `src/index.ts`. Você pode adicionar exports aqui para qualquer elemento que deseje disponibilizar para outros projetos:
 
 ```ts title="src/index.ts"
 export { sayHello } from './hello.js';
 export * from './algorithms/index.js';
 ```
 
-### Importando seu Código em Outros Projetos
+### Importando Código da Biblioteca em Outros Projetos
 
-[Aliases TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) para seu projeto são configurados no `tsconfig.base.json` do workspace, permitindo que você referencie seu projeto TypeScript de outros projetos:
+[Aliases TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths) para seu projeto são configurados no `tsconfig.base.json` do workspace, permitindo referenciar seu projeto TypeScript de outros projetos:
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
@@ -94,7 +93,7 @@ import { sayHello } from ':my-scope/my-library';
 Aliases para projetos TypeScript começam com `:` ao invés do tradicional `@`, evitando conflitos de nomes entre pacotes locais do workspace e pacotes remotos no [NPM](https://www.npmjs.com/).
 :::
 
-Ao adicionar uma declaração de importação para um novo projeto em seu workspace pela primeira vez, você provavelmente verá um erro em sua IDE similar ao abaixo:
+Ao adicionar uma instrução de importação para um novo projeto em seu workspace pela primeira vez, você provavelmente verá um erro no IDE similar a:
 
 <details>
 <summary>Erro de importação</summary>
@@ -108,16 +107,16 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 </details>
 
-Isso ocorre porque uma [referência de projeto](https://www.typescriptlang.org/docs/handbook/project-references.html) ainda não foi configurada.
+Isso ocorre porque uma [project reference](https://www.typescriptlang.org/docs/handbook/project-references.html) ainda não foi configurada.
 
-Projetos TypeScript são configurados com o gerador Nx TypeScript Sync por padrão, dispensando a necessidade de configuração manual. Basta executar o seguinte comando e o Nx adicionará a configuração necessária:
+Projetos TypeScript são configurados com o gerador Nx TypeScript Sync por padrão, eliminando a necessidade de configurar manualmente as referências. Basta executar o seguinte comando para o Nx adicionar a configuração necessária:
 
 <NxCommands commands={['sync']} />
 
-Após isso, o erro em sua IDE deve desaparecer e você estará pronto para usar sua biblioteca.
+Após isso, o erro no IDE deve desaparecer e você estará pronto para usar sua biblioteca.
 
 :::tip
-Você também pode simplesmente construir seu projeto e será apresentado uma mensagem como:
+Você também pode simplesmente construir seu projeto e será questionado com uma mensagem como:
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -136,17 +135,17 @@ Selecione `Yes` para permitir que o Nx atualize suas referências de projeto.
 
 Você notará que seu projeto TypeScript não possui um arquivo `package.json`, o que pode ser inesperado se você está acostumado com monorepos TypeScript tradicionais.
 
-Para adicionar uma dependência a qualquer pacote TypeScript em seu monorepo, basta adicionar a dependência ao `package.json` na raiz do workspace. Você pode fazer isso via linha de comando do seu gerenciador de pacotes:
+Para adicionar uma dependência a qualquer pacote TypeScript em seu monorepo, basta adicioná-la ao `package.json` na raiz do workspace. Você pode fazer isso via linha de comando do seu gerenciador de pacotes:
 
 <InstallCommand pkg="some-npm-package" />
 
-A dependência então fica disponível para todos os projetos TypeScript em seu workspace.
+A dependência ficará disponível para todos os projetos TypeScript em seu workspace.
 
 #### Código de Runtime
 
-Ao usar seu projeto TypeScript como código de runtime (por exemplo, como handler de uma função AWS Lambda), recomenda-se usar uma ferramenta como [`esbuild`](https://esbuild.github.io/) para empacotar seu projeto, pois isso permite [tree-shake](https://esbuild.github.io/api/#tree-shaking) para incluir apenas as dependências realmente utilizadas.
+Ao usar seu projeto TypeScript como código de runtime (por exemplo como handler de uma função AWS Lambda), recomenda-se usar ferramentas como [`esbuild`](https://esbuild.github.io/) para empacotar o projeto, pois isso permite [tree-shake](https://esbuild.github.io/api/#tree-shaking) para incluir apenas dependências realmente utilizadas.
 
-Você pode configurar isso adicionando um target como o seguinte em seu arquivo `project.json`:
+Você pode configurar isso adicionando um target como o seguinte ao seu arquivo `project.json`:
 
 ```json
 {
@@ -166,30 +165,30 @@ Você pode configurar isso adicionando um target como o seguinte em seu arquivo 
 ```
 
 :::note
-Note que no target acima escolhemos `src/index.ts` como ponto de entrada do bundle, o que significa que o código exportado deste arquivo será incluído no bundle junto com todas suas dependências.
+Note que no target acima escolhemos `src/index.ts` como entrypoint do bundle, significando que o código exportado deste arquivo será incluído junto com todas suas dependências.
 :::
 
 #### Publicação no NPM
 
-Se você está publicando seu projeto TypeScript no NPM, deve criar um arquivo `package.json` para ele.
+Se for publicar seu projeto TypeScript no NPM, você deve criar um arquivo `package.json` para ele.
 
-Este deve declarar todas as dependências utilizadas. Como durante o build o projeto resolve dependências instaladas via `package.json` raiz do workspace, recomenda-se configurar o [ESLint Plugin Nx Dependency Checks](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) para garantir que o `package.json` publicado inclua todas dependências usadas.
+Este deve declarar todas as dependências utilizadas. Como durante o build as dependências são resolvidas via `package.json` da raiz do workspace, recomenda-se configurar o [Nx Dependency Checks ESLint Plugin](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) para garantir que o `package.json` publicado inclua todas dependências usadas.
 
 ### Build
 
-Seu projeto TypeScript é configurado com um target `build` (definido em `project.json`), que pode ser executado via:
+Seu projeto TypeScript possui um target `build` configurado (definido em `project.json`), que pode ser executado via:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 Onde `<project-name>` é o nome completo qualificado do seu projeto.
 
-O target `build` irá compilar, lintar e testar seu projeto.
+O target `build` compilará, fará lint e testará seu projeto.
 
-A saída do build pode ser encontrada na pasta `dist` raiz do workspace, dentro de um diretório para seu pacote e target, por exemplo `dist/packages/<my-library>/tsc`
+A saída do build estará na pasta `dist` da raiz do workspace, dentro de um diretório para seu pacote e target, por exemplo `dist/packages/<my-library>/tsc`
 
 ## Testes
 
-[Vitest](https://vitest.dev/) está configurado para testar seu projeto.
+[Vitest](https://vitest.dev/) está configurado para testes em seu projeto.
 
 ### Escrevendo Testes
 
@@ -203,43 +202,44 @@ Exemplo:
     - hello.spec.ts Testes para hello.ts
 </FileTree>
 
-O Vitest fornece sintaxe estilo Jest para definir testes, com utilitários como `describe`, `it`, `test` e `expect`.
+O Vitest fornece sintaxe similar ao Jest para definir testes, com utilitários como `describe`, `it`, `test` e `expect`.
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
 
 describe('sayHello', () => {
 
-  it('deve cumprimentar o chamador', () => {
-    expect(sayHello('Darth Vader')).toBe('Olá, Darth Vader!');
+  it('should greet the caller', () => {
+    expect(sayHello('Darth Vader')).toBe('Hello, Darth Vader!');
   });
 
 });
+
 ```
 
-Para mais detalhes sobre como escrever testes e recursos como mock de dependências, consulte a [documentação do Vitest](https://vitest.dev/guide/#writing-tests)
+Para detalhes sobre escrita de testes e recursos como mock de dependências, consulte a [documentação do Vitest](https://vitest.dev/guide/#writing-tests)
 
 ### Executando Testes
 
-Testes são executados como parte do target `build`, mas você também pode executá-los separadamente via target `test`:
+Testes são executados como parte do target `build`, mas você pode executá-los separadamente usando o target `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Você pode executar um teste ou suite específica usando a flag `-t`:
+Você pode executar um teste individual ou suite usando a flag `-t`:
 
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-Usuários do VSCode podem instalar a extensão [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) para executar, monitorar ou debugar testes diretamente da IDE.
+Usuários de VSCode podem instalar a extensão [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) para executar, monitorar ou debugar testes diretamente do IDE.
 :::
 
 ## Linting
 
 Projetos TypeScript usam [ESLint](https://eslint.org/) para linting e [Prettier](https://prettier.io/) para formatação.
 
-Recomendamos configurar o ESLint no arquivo `eslint.config.mjs` raiz do workspace, pois alterações aqui se aplicarão a todos projetos TypeScript e garantirão consistência.
+Recomendamos configurar o ESLint no arquivo `eslint.config.mjs` da raiz do workspace, garantindo consistência entre todos projetos.
 
-Da mesma forma, você pode configurar o Prettier no arquivo `.prettierrc` raiz.
+Da mesma forma, você pode configurar o Prettier no arquivo `.prettierrc` da raiz.
 
 ### Executando o Linter
 
@@ -247,12 +247,12 @@ Para verificar seu projeto com o linter, execute o target `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corrigindo Problemas de Linting
+### Corrigindo Problemas de Lint
 
-A maioria dos problemas de linting/formatação pode ser corrigida automaticamente. Você pode pedir ao ESLint para corrigir problemas usando o argumento `--configuration=fix`:
+A maioria dos problemas de linting/formatação podem ser corrigidos automaticamente. Use o argumento `--configuration=fix` para aplicar correções:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Similarmente, para corrigir todos problemas em todos pacotes do workspace:
+Para corrigir todos os problemas em todos pacotes do workspace:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/zh/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/api-connection/react-fastapi.mdx
@@ -3,20 +3,19 @@ title: "React 连接到 FastAPI"
 description: "将 React 网站连接到 Python FastAPI"
 ---
 
-<think>
-
 import { FileTree, Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
+import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-`api-connection` 生成器提供了一种快速将 React 网站与 FastAPI 后端集成的方式。它设置了所有必要的配置，以类型安全的方式连接到 FastAPI 后端，包括客户端和 [TanStack Query](https://tanstack.com/query/v5) 钩子生成、AWS IAM 身份验证支持和正确的错误处理。
+`api-connection` 生成器提供了一种快速将 React 网站与 FastAPI 后端集成的方式。它能以类型安全的方式设置连接 FastAPI 后端所需的所有配置，包括客户端和 [TanStack Query](https://tanstack.com/query/v5) 钩子生成、AWS IAM 身份验证支持和正确的错误处理。
 
-## 先决条件
+## 前提条件
 
-使用此生成器前，请确保您的 React 应用具备：
+使用此生成器前，请确保你的 React 应用具备：
 
 1. 渲染应用的 `main.tsx` 文件
 2. 可运行的 FastAPI 后端（使用 FastAPI 生成器生成）
@@ -41,7 +40,7 @@ root.render(
 
 </details>
 
-## 使用方式
+## 使用方法
 
 ### 运行生成器
 
@@ -58,8 +57,8 @@ root.render(
 <FileTree>
 
 - scripts
-  - generate_open_api.py 添加生成 OpenAPI 规范的脚本
-- project.json 构建时新增调用生成脚本的目标
+  - generate_open_api.py 添加生成 API 的 OpenAPI 规范的脚本
+- project.json 在构建目标中添加调用上述生成脚本的新目标
 
 </FileTree>
 
@@ -72,47 +71,47 @@ root.render(
     - \<ApiName>Provider.tsx API 客户端提供者
     - QueryClientProvider.tsx TanStack React Query 客户端提供者
   - hooks
-    - use\<ApiName>.tsx 添加使用 TanStack Query 管理状态的 API 调用钩子
-    - use\<ApiName>Client.tsx 添加实例化原生 API 客户端的钩子
-    - useSigV4.tsx 添加使用 SigV4 签名 HTTP 请求的钩子（如果选择 IAM 身份验证）
-- project.json 构建时新增生成类型安全客户端的目标
+    - use\<ApiName>.tsx 添加通过 TanStack Query 管理状态调用 API 的钩子
+    - use\<ApiName>Client.tsx 添加实例化普通 API 客户端的钩子
+    - useSigV4.tsx 添加使用 SigV4 签名 HTTP 请求的钩子（如果选择 IAM 认证）
+- project.json 在构建目标中添加生成类型安全客户端的新目标
 - .gitignore 默认忽略生成的客户端文件
 
 </FileTree>
 
-生成器还会在网站基础设施中添加运行时配置（如果尚未存在），确保 FastAPI 的 API URL 在网站中可用，并由 `use<ApiName>.tsx` 钩子自动配置。
+生成器还会在网站基础设施中添加运行时配置（如尚未存在），确保 FastAPI 的 API URL 在网站中可用，并由 `use<ApiName>.tsx` 钩子自动配置。
 
 ### 代码生成
 
-构建时，根据 FastAPI 的 OpenAPI 规范生成类型安全客户端。这将在 React 应用中新增三个文件：
+构建时，将从 FastAPI 的 OpenAPI 规范生成类型安全客户端，这会为 React 应用添加三个新文件：
 
 <FileTree>
 
 - src
   - generated
     - \<ApiName>
-      - types.gen.ts 从 FastAPI 的 pydantic 模型生成类型
+      - types.gen.ts 从 FastAPI 定义的 pydantic 模型生成的类型
       - client.gen.ts 调用 API 的类型安全客户端
       - options-proxy.gen.ts 提供创建 TanStack Query 钩子选项的方法
 
 </FileTree>
 
 :::tip
-默认生成的客户端会被版本控制忽略。如需提交，可从 React 应用的 `.gitignore` 中移除相关条目，但注意手动修改 `.gen.ts` 文件会在项目构建时被覆盖。
+默认生成的客户端会被版本控制忽略。如需提交，可从 React 应用的 `.gitignore` 中移除相关条目，但请注意手动修改 `.gen.ts` 文件会在项目构建时被覆盖。
 :::
 
 ## 使用生成代码
 
-推荐通过 TanStack Query 钩子使用生成的类型安全客户端调用 FastAPI，也可直接使用原生客户端。
+推荐通过 TanStack Query 钩子使用生成的类型安全客户端调用 FastAPI，也可直接使用普通客户端。
 
 :::note
-修改 FastAPI 后需重新构建项目以使更改生效。例如：
+修改 FastAPI 后需重新构建项目以使更改反映到生成的客户端中。例如：
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
 :::tip
-如需同时开发 React 应用和 FastAPI，可使用 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) 在 API 变更时自动生成客户端：
+若同时开发 React 应用和 FastAPI，可使用 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) 在 API 变更时自动重新生成客户端：
 
 <NxCommands
   commands={[
@@ -124,7 +123,7 @@ root.render(
 
 ### 使用 API 钩子
 
-生成器提供 `use<ApiName>` 钩子，用于通过 TanStack Query 调用 API。
+生成器提供 `use<ApiName>` 钩子用于通过 TanStack Query 调用 API。
 
 ### 查询
 
@@ -146,7 +145,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="直接使用 API 客户端" trigger="点击查看直接使用原生客户端的示例。">
+<Drawer title="直接使用 API 客户端" trigger="点击查看直接使用普通客户端的示例。">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -181,7 +180,7 @@ function MyComponent() {
 
 ### 变更
 
-生成的钩子支持使用 TanStack Query 的 `useMutation` 处理创建、更新和删除操作，提供加载状态、错误处理和乐观更新。
+生成的钩子支持使用 TanStack Query 的 `useMutation` 处理变更操作，提供加载状态、错误处理和乐观更新。
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -189,6 +188,7 @@ import { useMyApi } from './hooks/useMyApi';
 
 function CreateItemForm() {
   const api = useMyApi();
+  // 使用生成的变更选项创建变更
   const createItem = useMutation(api.createItem.mutationOptions());
 
   const handleSubmit = (e) => {
@@ -198,22 +198,23 @@ function CreateItemForm() {
 
   return (
     <form onSubmit={handleSubmit}>
+      {/* 表单字段 */}
       <button
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? 'Creating...' : 'Create Item'}
+        {createItem.isPending ? '创建中...' : '创建项目'}
       </button>
 
       {createItem.isSuccess && (
         <div className="success">
-          Item created with ID: {createItem.data.id}
+          创建项目 ID: {createItem.data.id}
         </div>
       )}
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          错误: {createItem.error.message}
         </div>
       )}
     </form>
@@ -227,19 +228,24 @@ function CreateItemForm() {
 const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
-    console.log('Item created:', data);
+    // 变更成功时执行
+    console.log('项目已创建:', data);
+    // 可导航至新项目
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
-    console.error('Failed to create item:', error);
+    // 变更失败时执行
+    console.error('创建项目失败:', error);
   },
   onSettled: () => {
+    // 变更完成时执行（成功或失败）
+    // 适合刷新可能受影响的查询
     queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
   }
 });
 ```
 
-<Drawer title="直接使用客户端进行变更" trigger="点击查看直接使用客户端的示例。">
+<Drawer title="直接使用客户端处理变更" trigger="点击查看直接使用客户端的示例。">
 ```tsx
 import { useState } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -261,8 +267,11 @@ function CreateItemForm() {
         description: 'A new item'
       });
       setCreatedItem(newItem);
+      // 可导航至新项目
+      // navigate(`/items/${newItem.id}`);
     } catch (err) {
       setError(err);
+      console.error('创建项目失败:', err);
     } finally {
       setIsLoading(false);
     }
@@ -270,22 +279,23 @@ function CreateItemForm() {
 
   return (
     <form onSubmit={handleSubmit}>
+      {/* 表单字段 */}
       <button
         type="submit"
         disabled={isLoading}
       >
-        {isLoading ? 'Creating...' : 'Create Item'}
+        {isLoading ? '创建中...' : '创建项目'}
       </button>
 
       {createdItem && (
         <div className="success">
-          Item created with ID: {createdItem.id}
+          创建项目 ID: {createdItem.id}
         </div>
       )}
 
       {error && (
         <div className="error">
-          Error: {error.message}
+          错误: {error.message}
         </div>
       )}
     </form>
@@ -294,9 +304,9 @@ function CreateItemForm() {
 ```
 </Drawer>
 
-### 无限滚动分页
+### 无限查询分页
 
-对于支持 `cursor` 参数的端点，生成的钩子支持使用 `useInfiniteQuery` 实现"加载更多"或无限滚动功能。
+对于接收 `cursor` 参数的端点，生成的钩子支持使用 TanStack Query 的 `useInfiniteQuery` 实现无限滚动或"加载更多"功能。
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -306,15 +316,25 @@ function ItemList() {
   const api = useMyApi();
   const items = useInfiniteQuery({
     ...api.listItems.infiniteQueryOptions({
-      limit: 10,
+      limit: 10, // 每页项目数
     }, {
+      // 确保定义 getNextPageParam 函数返回下一页的 cursor 参数
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor || undefined
       }),
   });
 
+  if (items.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (items.isError) {
+    return <ErrorMessage message={items.error.message} />;
+  }
+
   return (
     <div>
+      {/* 平铺页面数组渲染所有项目 */}
       <ul>
         {items.data.pages.flatMap(page =>
           page.items.map(item => (
@@ -328,15 +348,21 @@ function ItemList() {
         disabled={!items.hasNextPage || items.isFetchingNextPage}
       >
         {items.isFetchingNextPage
-          ? 'Loading more...'
+          ? '正在加载更多...'
           : items.hasNextPage
-          ? 'Load More'
-          : 'No more items'}
+          ? '加载更多'
+          : '没有更多项目'}
       </button>
     </div>
   );
 }
 ```
+
+生成的钩子会自动处理基于 cursor 的分页。`nextCursor` 值从响应中提取用于获取下一页。
+
+:::tip
+如果 API 的分页参数名不是 `cursor`，可通过 [`x-cursor` OpenAPI 扩展](#custom-pagination-cursor)自定义。
+:::
 
 <Drawer title="直接使用客户端分页" trigger="点击查看直接使用客户端的示例。">
 ```tsx
@@ -346,22 +372,56 @@ import { useMyApiClient } from './hooks/useMyApiClient';
 function ItemList() {
   const api = useMyApiClient();
   const [items, setItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [nextCursor, setNextCursor] = useState(null);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
+  // 获取初始数据
+  useEffect(() => {
+    const fetchItems = async () => {
+      try {
+        setIsLoading(true);
+        const response = await api.listItems({ limit: 10 });
+        setItems(response.items);
+        setNextCursor(response.nextCursor);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchItems();
+  }, [api]);
+
+  // 加载更多函数
   const loadMore = async () => {
+    if (!nextCursor) return;
+
     try {
       setIsFetchingMore(true);
       const response = await api.listItems({
         limit: 10,
         cursor: nextCursor
       });
-      setItems(prev => [...prev, ...response.items]);
+
+      setItems(prevItems => [...prevItems, ...response.items]);
       setNextCursor(response.nextCursor);
+    } catch (err) {
+      setError(err);
     } finally {
       setIsFetchingMore(false);
     }
   };
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error.message} />;
+  }
 
   return (
     <div>
@@ -370,11 +430,16 @@ function ItemList() {
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
+
       <button
         onClick={loadMore}
         disabled={!nextCursor || isFetchingMore}
       >
-        {isFetchingMore ? 'Loading...' : 'Load More'}
+        {isFetchingMore
+          ? '正在加载更多...'
+          : nextCursor
+          ? '加载更多'
+          : '没有更多项目'}
       </button>
     </div>
   );
@@ -384,7 +449,7 @@ function ItemList() {
 
 ### 错误处理
 
-集成包含类型化错误响应，通过检查 `status` 可处理特定错误类型。
+集成包含内置类型化错误处理。生成 `<operation-name>Error` 类型封装 OpenAPI 规范中可能的错误响应。通过检查 `status` 可定位具体错误类型。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -393,12 +458,17 @@ function MyComponent() {
   const api = useMyApi();
   const createItem = useMutation(api.createItem.mutationOptions());
 
+  const handleClick = () => {
+    createItem.mutate({ name: 'New Item' });
+  };
+
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
+        // error.error 类型为 CreateItem400Response
         return (
           <div>
-            <h2>Invalid input:</h2>
+            <h2>无效输入:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
               {createItem.error.error.validationErrors.map((err) => (
@@ -408,28 +478,31 @@ function MyComponent() {
           </div>
         );
       case 403:
+        // error.error 类型为 CreateItem403Response
         return (
           <div>
-            <h2>Not authorized:</h2>
+            <h2>未授权:</h2>
             <p>{createItem.error.error.reason}</p>
           </div>
         );
       case 500:
       case 502:
+        // error.error 类型为 CreateItem5XXResponse
         return (
           <div>
-            <h2>Server error:</h2>
+            <h2>服务器错误:</h2>
             <p>{createItem.error.error.message}</p>
+            <p>追踪 ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
   }
 
-  return <button onClick={() => createItem.mutate()}>Create Item</button>;
+  return <button onClick={handleClick}>创建项目</button>;
 }
 ```
 
-<Drawer title="直接处理客户端错误" trigger="点击查看直接使用客户端的示例。">
+<Drawer title="直接使用客户端处理错误" trigger="点击查看直接使用客户端的示例。">
 ```tsx {9,15}
 function MyComponent() {
   const api = useMyApiClient();
@@ -447,30 +520,49 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
+        // error.error 类型为 CreateItem400Response
         return (
           <div>
-            <h2>Invalid input:</h2>
+            <h2>无效输入:</h2>
             <p>{error.error.message}</p>
+            <ul>
+              {error.error.validationErrors.map((err) => (
+                <li key={err.field}>{err.message}</li>
+              ))}
+            </ul>
           </div>
         );
       case 403:
+        // error.error 类型为 CreateItem403Response
         return (
           <div>
-            <h2>Not authorized:</h2>
+            <h2>未授权:</h2>
             <p>{error.error.reason}</p>
+          </div>
+        );
+      case 500:
+      case 502:
+        // error.error 类型为 CreateItem5XXResponse
+        return (
+          <div>
+            <h2>服务器错误:</h2>
+            <p>{error.error.message}</p>
+            <p>追踪 ID: {error.error.traceId}</p>
           </div>
         );
     }
   }
 
-  return <button onClick={handleClick}>Create Item</button>;
+  return <button onClick={handleClick}>创建项目</button>;
 }
 ```
 </Drawer>
 
-### 流式响应
+### 使用流
 
-如果 FastAPI 配置了流式响应，`useQuery` 钩子会在新数据块到达时自动更新。
+如果已 <Link path="guides/fastapi#streaming">配置 FastAPI 流式响应</Link>，`useQuery` 钩子会在新数据块到达时自动更新数据。
+
+例如：
 
 ```tsx {3}
 function MyStreamingComponent() {
@@ -489,30 +581,44 @@ function MyStreamingComponent() {
 }
 ```
 
-流式生命周期阶段：
+可使用 `isLoading` 和 `fetchStatus` 属性确定流的当前状态。流的生命周期如下：
 
 <Steps>
-  1. 发送 HTTP 请求
+  1. 发送启动流的 HTTP 请求
+
       - `isLoading` 为 `true`
       - `fetchStatus` 为 `'fetching'`
       - `data` 为 `undefined`
 
-  2. 接收首个数据块
+  2. 接收到流的首个数据块
+
       - `isLoading` 变为 `false`
       - `fetchStatus` 保持 `'fetching'`
-      - `data` 更新为首个数据块
+      - `data` 变为包含首个数据块的数组
 
-  3. 接收后续数据块
-      - `data` 持续更新
+  3. 接收到后续数据块
 
-  4. 流式结束
+      - `isLoading` 保持 `false`
+      - `fetchStatus` 保持 `'fetching'`
+      - `data` 随每个新数据块立即更新
+
+  4. 流完成
+
+      - `isLoading` 保持 `false`
       - `fetchStatus` 变为 `'idle'`
+      - `data` 包含所有接收的数据块
 </Steps>
 
-<Drawer title="直接处理流式响应" trigger="点击查看直接使用客户端的示例。">
+<Drawer title="直接使用客户端处理流" trigger="点击查看直接使用客户端的示例。">
+
+如果已 <Link path="guides/fastapi#streaming">配置 FastAPI 流式响应</Link>，生成的客户端将包含使用 `for await` 语法异步迭代流数据块的类型安全方法。
+
+例如：
+
 ```tsx {8}
 function MyStreamingComponent() {
   const api = useMyApiClient();
+
   const [chunks, setChunks] = useState<Chunk[]>([]);
 
   useEffect(() => {
@@ -537,11 +643,15 @@ function MyStreamingComponent() {
 ```
 </Drawer>
 
+:::note
+如果流式 API 接收 `cursor` 参数，使用 `useInfiniteQuery` 钩子时，每页将等待流完成后再加载。
+:::
+
 ## 自定义生成代码
 
 ### 查询与变更
 
-默认将 `PUT`、`POST`、`PATCH` 和 `DELETE` 方法视为变更，其他视为查询。可通过 `x-query` 和 `x-mutation` 修改此行为。
+默认情况下，FastAPI 中使用 `PUT`、`POST`、`PATCH` 和 `DELETE` HTTP 方法的路由被视为变更操作，其他视为查询。可通过 `x-query` 和 `x-mutation` 调整此行为。
 
 #### x-query
 
@@ -554,6 +664,12 @@ function MyStreamingComponent() {
 )
 def list_items():
     # ...
+```
+
+生成的钩子将提供 `queryOptions`，即使使用 `POST` 方法：
+
+```tsx
+const items = useQuery(api.listItems.queryOptions());
 ```
 
 #### x-mutation
@@ -569,67 +685,266 @@ def start_processing():
     # ...
 ```
 
+生成的钩子将提供 `mutationOptions`，即使使用 `GET` 方法：
+
+```tsx
+const startProcessing = useMutation(api.startProcessing.mutationOptions());
+```
+
 ### 自定义分页游标
 
-通过 `x-cursor` 扩展自定义分页参数：
+默认生成的钩子假设分页参数名为 `cursor`。可通过 `x-cursor` 扩展自定义：
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
+        # 指定不同的游标参数名
         "x-cursor": "page_token"
     }
 )
 def list_items(page_token: str = None, limit: int = 10):
     # ...
+    return {
+        "items": items,
+        "page_token": next_page_token  # 响应需包含同名游标
+    }
 ```
 
-禁用分页生成：
+若不想为某个操作生成 `infiniteQueryOptions`，可将 `x-cursor` 设为 `False`：
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
+        # 禁用此端点的游标分页
         "x-cursor": False
     }
 )
 def list_items(page: int = 1, limit: int = 10):
     # ...
+    return {
+        "items": items,
+        "total": total_count,
+        "page": page,
+        "pages": total_pages
+    }
 ```
 
 ### 操作分组
 
-根据 OpenAPI 标签自动分组操作：
+生成的钩子和客户端方法根据 FastAPI 端点的 OpenAPI 标签自动组织，便于查找相关操作。
 
-```python
-@app.get("/items", tags=["items"])
+例如：
+
+```python title="items.py"
+@app.get(
+    "/items",
+    tags=["items"],
+)
 def list():
     # ...
 
-@app.post("/items", tags=["items"])
+@app.post(
+    "/items",
+    tags=["items"],
+)
 def create(item: Item):
     # ...
 ```
 
-分组后使用示例：
-
-```tsx
-const items = useQuery(api.items.list.queryOptions());
-const createItem = useMutation(api.items.create.mutationOptions());
+```python title="users.py"
+@app.get(
+    "/users",
+    tags=["users"],
+)
+def list():
+    # ...
 ```
 
-<Drawer title="直接使用分组客户端" trigger="点击查看直接使用客户端的示例。">
+生成的钩子将按标签分组：
+
 ```tsx
-const itemsData = await api.items.list();
-const usersData = await api.users.list();
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function ItemsAndUsers() {
+  const api = useMyApi();
+
+  // items 操作分组在 api.items 下
+  const items = useQuery(api.items.list.queryOptions());
+  const createItem = useMutation(api.items.create.mutationOptions());
+
+  // users 操作分组在 api.users 下
+  const users = useQuery(api.users.list.queryOptions());
+
+  // 使用示例
+  const handleCreateItem = () => {
+    createItem.mutate({ name: 'New Item' });
+  };
+
+  return (
+    <div>
+      <h2>项目</h2>
+      <ul>
+        {items.data?.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+      <button onClick={handleCreateItem}>添加项目</button>
+
+      <h2>用户</h2>
+      <ul>
+        {users.data?.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+分组机制便于组织 API 调用，并在 IDE 中提供更好的代码补全。
+
+<Drawer title="直接使用分组的客户端操作" trigger="点击查看直接使用客户端的示例。">
+```tsx
+import { useState, useEffect } from 'react';
+import { useMyApiClient } from './hooks/useMyApiClient';
+
+function ItemsAndUsers() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 加载数据
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+
+        // items 操作分组在 api.items 下
+        const itemsData = await api.items.list();
+        setItems(itemsData);
+
+        // users 操作分组在 api.users 下
+        const usersData = await api.users.list();
+        setUsers(usersData);
+      } catch (error) {
+        console.error('获取数据错误:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [api]);
+
+  const handleCreateItem = async () => {
+    try {
+      // 使用分组方法创建项目
+      const newItem = await api.items.create({ name: 'New Item' });
+      setItems(prevItems => [...prevItems, newItem]);
+    } catch (error) {
+      console.error('创建项目错误:', error);
+    }
+  };
+
+  if (isLoading) {
+    return <div>加载中...</div>;
+  }
+
+  return (
+    <div>
+      <h2>项目</h2>
+      <ul>
+        {items.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+      <button onClick={handleCreateItem}>添加项目</button>
+
+      <h2>用户</h2>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 ```
 </Drawer>
 
-### 错误处理
+:::tip
+也可使用多个 `routers` 拆分 API。详见 [FastAPI 文档](https://fastapi.tiangolo.com/tutorial/bigger-applications/)。
+:::
 
-通过自定义异常和响应模型实现类型化错误处理：
+### 错误
 
-```python
+可通过定义自定义异常类、异常处理程序并为不同状态码指定响应模型来自定义错误响应。生成的客户端会自动处理这些自定义错误类型。
+
+#### 定义自定义错误模型
+
+首先使用 Pydantic 定义错误模型：
+
+```python title="models.py"
+from pydantic import BaseModel
+
+class ErrorDetails(BaseModel):
+    message: str
+
+class ValidationError(BaseModel):
+    message: str
+    field_errors: list[str]
+```
+
+#### 创建自定义异常
+
+为不同错误场景创建异常类：
+
+```python title="exceptions.py"
+class NotFoundException(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+class ValidationException(Exception):
+    def __init__(self, details: ValidationError):
+        self.details = details
+```
+
+#### 添加异常处理程序
+
+注册异常处理程序将异常转换为 HTTP 响应：
+
+```python title="main.py"
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+@app.exception_handler(NotFoundException)
+async def not_found_handler(request: Request, exc: NotFoundException):
+    return JSONResponse(
+        status_code=404,
+        content=exc.message,
+    )
+
+@app.exception_handler(ValidationException)
+async def validation_error_handler(request: Request, exc: ValidationException):
+    return JSONResponse(
+        status_code=400,
+        content=exc.details.model_dump(),
+    )
+```
+
+:::tip
+`JSONResponse` 接受字典，因此我们使用 Pydantic 模型的 `model_dump` 方法。
+:::
+
+#### 指定响应模型
+
+在端点定义中为不同状态码指定响应模型：
+
+```python title="main.py"
 @app.get(
     "/items/{item_id}",
     responses={
@@ -638,32 +953,178 @@ const usersData = await api.users.list();
     }
 )
 def get_item(item_id: str) -> Item:
-    # ...
+    item = find_item(item_id)
+    if not item:
+        raise NotFoundException(message=f"Item with ID {item_id} not found")
+    return item
+
+@app.post(
+    "/items",
+    responses={
+        400: {"model": ValidationError},
+        403: {"model": str}
+    }
+)
+def create_item(item: Item) -> Item:
+    if not is_valid(item):
+        raise ValidationException(
+            ValidationError(
+                message="Invalid item data",
+                field_errors=["name is required"]
+            )
+        )
+    return save_item(item)
 ```
 
-React 中使用类型化错误：
+#### 在 React 中使用自定义错误类型
+
+生成的客户端会自动处理这些自定义错误类型，允许进行类型检查和错误响应处理：
 
 ```tsx
-switch (error.status) {
-  case 404:
-    console.error('Not found:', error.error);
-    break;
-  case 500:
-    console.error('Server error:', error.error.message);
-    break;
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+function ItemComponent() {
+  const api = useMyApi();
+
+  // 带类型错误处理的查询
+  const getItem = useQuery({
+    ...api.getItem.queryOptions({ itemId: '123' }),
+    onError: (error) => {
+      // 根据 FastAPI 的响应定义错误类型
+      switch (error.status) {
+        case 404:
+          // error.error 是 responses 中指定的字符串
+          console.error('未找到:', error.error);
+          break;
+        case 500:
+          // error.error 类型为 ErrorDetails
+          console.error('服务器错误:', error.error.message);
+          break;
+      }
+    }
+  });
+
+  // 带类型错误处理的变更
+  const createItem = useMutation({
+    ...api.createItem.mutationOptions(),
+    onError: (error) => {
+      switch (error.status) {
+        case 400:
+          // error.error 类型为 ValidationError
+          console.error('验证错误:', error.error.message);
+          console.error('字段错误:', error.error.field_errors);
+          break;
+        case 403:
+          // error.error 是 responses 中指定的字符串
+          console.error('禁止访问:', error.error);
+          break;
+      }
+    }
+  });
+
+  // 组件渲染与错误处理
+  if (getItem.isError) {
+    if (getItem.error.status === 404) {
+      return <NotFoundMessage message={getItem.error.error} />;
+    } else {
+      return <ErrorMessage message={getItem.error.error.message} />;
+    }
+  }
+
+  return (
+    <div>
+      {/* 组件内容 */}
+    </div>
+  );
 }
 ```
 
 <Drawer title="直接处理自定义错误" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-const err = e as GetItemError;
-switch (err.status) {
-  case 404:
-    // 处理 404 错误
-    break;
+import { useState, useEffect } from 'react';
+
+function ItemComponent() {
+  const api = useMyApiClient();
+  const [item, setItem] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // 带错误处理的数据获取
+  useEffect(() => {
+    const fetchItem = async () => {
+      try {
+        setLoading(true);
+        const data = await api.getItem({ itemId: '123' });
+        setItem(data);
+      } catch (e) {
+        // 根据 FastAPI 的响应定义错误类型
+        const err = e as GetItemError;
+        setError(err);
+
+        switch (err.status) {
+          case 404:
+            // err.error 是 responses 中指定的字符串
+            console.error('未找到:', err.error);
+            break;
+          case 500:
+            // err.error 类型为 ErrorDetails
+            console.error('服务器错误:', err.error.message);
+            break;
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItem();
+  }, [api]);
+
+  // 带错误处理的创建项目
+  const handleCreateItem = async (data) => {
+    try {
+      await api.createItem(data);
+    } catch (e) {
+      const err = e as CreateItemError;
+
+      switch (err.status) {
+        case 400:
+          // err.error 类型为 ValidationError
+          console.error('验证错误:', err.error.message);
+          console.error('字段错误:', err.error.field_errors);
+          break;
+        case 403:
+          // err.error 是 responses 中指定的字符串
+          console.error('禁止访问:', err.error);
+          break;
+      }
+    }
+  };
+
+  // 组件渲染与错误处理
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    if (error.status === 404) {
+      return <NotFoundMessage message={error.error} />;
+    } else if (error.status === 500) {
+      return <ErrorMessage message={error.error.message} />;
+    }
+  }
+
+  return (
+    <div>
+      {/* 组件内容 */}
+    </div>
+  );
 }
 ```
 </Drawer>
+
+:::tip
+在 FastAPI 中定义错误响应时，始终使用 `responses` 参数为每个状态码指定模型，确保生成的客户端具有正确的错误类型信息。
+:::
 
 ## 最佳实践
 
@@ -672,84 +1133,327 @@ switch (err.status) {
 始终处理加载和错误状态以提升用户体验：
 
 ```tsx
-if (items.isLoading) {
-  return <LoadingSpinner />;
-}
+import { useQuery } from '@tanstack/react-query';
 
-if (items.isError) {
-  return <ErrorMessage message={items.error.message} />;
+function ItemList() {
+  const api = useMyApi();
+  const items = useQuery(api.listItems.queryOptions());
+
+  if (items.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (items.isError) {
+    const err = items.error;
+    switch (err.status) {
+      case 403:
+        // err.error 类型为 ListItems403Response
+        return <ErrorMessage message={err.error.reason} />;
+      case 500:
+      case 502:
+        // err.error 类型为 ListItems5XXResponse
+        return (
+          <ErrorMessage
+            message={err.error.message}
+            details={`追踪 ID: ${err.error.traceId}`}
+          />
+        );
+      default:
+        return <ErrorMessage message="发生未知错误" />;
+    }
+  }
+
+  return (
+    <ul>
+      {items.data.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 
 <Drawer title="直接处理加载状态" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-if (loading) {
-  return <LoadingSpinner />;
-}
+function ItemList() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-if (error) {
-  return <ErrorMessage message={error.message} />;
+  useEffect(() => {
+    const fetchItems = async () => {
+      try {
+        const data = await api.listItems();
+        setItems(data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchItems();
+  }, [api]);
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    const err = error as ListItemsError;
+    switch (err.status) {
+      case 403:
+        // err.error 类型为 ListItems403Response
+        return <ErrorMessage message={err.error.reason} />;
+      case 500:
+      case 502:
+        // err.error 类型为 ListItems5XXResponse
+        return (
+          <ErrorMessage
+            message={err.error.message}
+            details={`追踪 ID: ${err.error.traceId}`}
+          />
+        );
+      default:
+        return <ErrorMessage message="发生未知错误" />;
+    }
+  }
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 </Drawer>
 
 ### 乐观更新
 
-通过乐观更新提升用户体验：
+实现乐观更新以提升用户体验：
 
 ```tsx
-const deleteMutation = useMutation({
-  ...api.deleteItem.mutationOptions(),
-  onMutate: async (itemId) => {
-    const previousItems = queryClient.getQueryData(api.listItems.queryKey());
-    queryClient.setQueryData(api.listItems.queryKey(), old => old.filter(item => item.id !== itemId));
-    return { previousItems };
-  },
-  onError: (err, itemId, context) => {
-    queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-  },
-});
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+function ItemList() {
+  const api = useMyApi();
+  const queryClient = useQueryClient();
+
+  // 获取项目的查询
+  const itemsQuery = useQuery(api.listItems.queryOptions());
+
+  // 带乐观更新的删除变更
+  const deleteMutation = useMutation({
+    ...api.deleteItem.mutationOptions(),
+    onMutate: async (itemId) => {
+      // 取消正在进行的重新获取
+      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+
+      // 快照旧值
+      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+
+      // 乐观更新新值
+      queryClient.setQueryData(
+        api.listItems.queryKey(),
+        (old) => old.filter((item) => item.id !== itemId)
+      );
+
+      // 返回包含快照的上下文对象
+      return { previousItems };
+    },
+    onError: (err, itemId, context) => {
+      // 变更失败时使用 onMutate 返回的上下文回滚
+      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      console.error('删除项目失败:', err);
+    },
+    onSettled: () => {
+      // 无论成功失败都重新获取数据以确保与服务器同步
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    },
+  });
+
+  if (itemsQuery.isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (itemsQuery.isError) {
+    return <ErrorMessage message="加载项目失败" />;
+  }
+
+  return (
+    <ul>
+      {itemsQuery.data.map((item) => (
+        <li key={item.id}>
+          {item.name}
+          <button
+            onClick={() => deleteMutation.mutate(item.id)}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? '删除中...' : '删除'}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
 ```
 
 <Drawer title="直接实现乐观更新" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-const previousItems = items;
-setItems(items.filter(item => item.id !== itemId));
-try {
-  await api.deleteItem(itemId);
-} catch {
-  setItems(previousItems);
+function ItemList() {
+  const api = useMyApiClient();
+  const [items, setItems] = useState([]);
+
+  const handleDelete = async (itemId) => {
+    // 乐观移除项目
+    const previousItems = items;
+    setItems(items.filter((item) => item.id !== itemId));
+
+    try {
+      await api.deleteItem(itemId);
+    } catch (error) {
+      // 出错时恢复旧项目
+      setItems(previousItems);
+      console.error('删除项目失败:', error);
+    }
+  };
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>
+          {item.name}
+          <button onClick={() => handleDelete(item.id)}>删除</button>
+        </li>
+      ))}
+    </ul>
+  );
 }
 ```
 </Drawer>
 
 ## 类型安全
 
-集成提供端到端类型安全，IDE 会为所有 API 调用提供自动补全和类型检查：
+集成提供完整的端到端类型安全。IDE 将为所有 API 调用提供自动补全和类型检查：
 
 ```tsx
-const createItem = useMutation({
-  ...api.createItem.mutationOptions(),
-  onSuccess: (data) => {
-    // data 类型自动推断
-    console.log(`Item ID: ${data.id}`);
-  },
-});
+import { useMutation } from '@tanstack/react-query';
 
-const handleSubmit = (data: CreateItemInput) => {
-  createItem.mutate(data); // 输入类型校验
-};
+function ItemForm() {
+  const api = useMyApi();
+
+  // 创建项目的类型安全变更
+  const createItem = useMutation({
+    ...api.createItem.mutationOptions(),
+    // ✅ 若 onSuccess 回调未处理正确的响应类型会报类型错误
+    onSuccess: (data) => {
+      // data 根据 API 响应模式完全类型化
+      console.log(`项目创建 ID: ${data.id}`);
+    },
+  });
+
+  const handleSubmit = (data: CreateItemInput) => {
+    // ✅ 若输入不符合模式会报类型错误
+    createItem.mutate(data);
+  };
+
+  // 错误 UI 可使用类型缩窄处理不同错误类型
+  if (createItem.error) {
+    const error = createItem.error;
+    switch (error.status) {
+      case 400:
+        // error.error 类型为 CreateItem400Response
+        return (
+          <FormError
+            message="无效输入"
+            errors={error.error.validationErrors}
+          />
+        );
+      case 403:
+        // error.error 类型为 CreateItem403Response
+        return <AuthError reason={error.error.reason} />;
+      default:
+        // error.error 类型为 CreateItem5XXResponse（500、502 等）
+        return <ServerError message={error.error.message} />;
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault();
+      handleSubmit({ name: 'New Item' });
+    }}>
+      {/* 表单字段 */}
+      <button
+        type="submit"
+        disabled={createItem.isPending}
+      >
+        {createItem.isPending ? '创建中...' : '创建项目'}
+      </button>
+    </form>
+  );
+}
 ```
 
 <Drawer title="直接使用类型安全客户端" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-try {
-  // 输入类型校验
-  await api.createItem(data);
-} catch (e) {
-  const err = e as CreateItemError; // 错误类型推断
+function ItemForm() {
+  const api = useMyApiClient();
+  const [error, setError] = useState<CreateItemError | null>(null);
+
+  const handleSubmit = async (data: CreateItemInput) => {
+    try {
+      // ✅ 若输入不符合模式会报类型错误
+      await api.createItem(data);
+    } catch (e) {
+      // ✅ 错误类型包含所有可能的错误响应
+      const err = e as CreateItemError;
+      switch (err.status) {
+        case 400:
+          // err.error 类型为 CreateItem400Response
+          console.error('验证错误:', err.error.validationErrors);
+          break;
+        case 403:
+          // err.error 类型为 CreateItem403Response
+          console.error('未授权:', err.error.reason);
+          break;
+        case 500:
+        case 502:
+          // err.error 类型为 CreateItem5XXResponse
+          console.error(
+            '服务器错误:',
+            err.error.message,
+            '追踪:',
+            err.error.traceId,
+          );
+          break;
+      }
+      setError(err);
+    }
+  };
+
+  // 错误 UI 可使用类型缩窄处理不同错误类型
+  if (error) {
+    switch (error.status) {
+      case 400:
+        return (
+          <FormError
+            message="无效输入"
+            errors={error.error.validationErrors}
+          />
+        );
+      case 403:
+        return <AuthError reason={error.error.reason} />;
+      default:
+        return <ServerError message={error.error.message} />;
+    }
+  }
+
+  return <form onSubmit={handleSubmit}>{/* ... */}</form>;
 }
 ```
 </Drawer>
 
-所有类型均从 FastAPI 的 OpenAPI 模式生成，确保前端代码与 API 变更保持同步。
+类型从 FastAPI 的 OpenAPI 模式自动生成，确保 API 变更在构建后能反映到前端代码中。

--- a/docs/src/content/docs/zh/guides/api-connection/react-fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/api-connection/react-fastapi.mdx
@@ -3,19 +3,20 @@ title: "React 连接到 FastAPI"
 description: "将 React 网站连接到 Python FastAPI"
 ---
 
+<think>
+
 import { FileTree, Steps } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-`api-connection` 生成器提供了一种快速将 React 网站与 FastAPI 后端集成的方式。它能以类型安全的方式设置连接 FastAPI 后端所需的所有配置，包括客户端和 [TanStack Query](https://tanstack.com/query/v5) 钩子生成、AWS IAM 身份验证支持和正确的错误处理。
+`api-connection` 生成器提供了一种快速将 React 网站与 FastAPI 后端集成的方式。它设置了所有必要的配置，以类型安全的方式连接到 FastAPI 后端，包括客户端和 [TanStack Query](https://tanstack.com/query/v5) 钩子生成、AWS IAM 身份验证支持和正确的错误处理。
 
-## 前提条件
+## 先决条件
 
-使用此生成器前，请确保你的 React 应用具备：
+使用此生成器前，请确保您的 React 应用具备：
 
 1. 渲染应用的 `main.tsx` 文件
 2. 可运行的 FastAPI 后端（使用 FastAPI 生成器生成）
@@ -40,7 +41,7 @@ root.render(
 
 </details>
 
-## 使用方法
+## 使用方式
 
 ### 运行生成器
 
@@ -48,7 +49,7 @@ root.render(
 
 ### 选项
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## 生成器输出
 
@@ -57,8 +58,8 @@ root.render(
 <FileTree>
 
 - scripts
-  - generate_open_api.py 添加生成 API 的 OpenAPI 规范的脚本
-- project.json 在构建目标中添加调用上述生成脚本的新目标
+  - generate_open_api.py 添加生成 OpenAPI 规范的脚本
+- project.json 构建时新增调用生成脚本的目标
 
 </FileTree>
 
@@ -71,47 +72,47 @@ root.render(
     - \<ApiName>Provider.tsx API 客户端提供者
     - QueryClientProvider.tsx TanStack React Query 客户端提供者
   - hooks
-    - use\<ApiName>.tsx 添加通过 TanStack Query 管理状态调用 API 的钩子
-    - use\<ApiName>Client.tsx 添加实例化普通 API 客户端的钩子
-    - useSigV4.tsx 添加使用 SigV4 签名 HTTP 请求的钩子（如果选择 IAM 认证）
-- project.json 在构建目标中添加生成类型安全客户端的新目标
+    - use\<ApiName>.tsx 添加使用 TanStack Query 管理状态的 API 调用钩子
+    - use\<ApiName>Client.tsx 添加实例化原生 API 客户端的钩子
+    - useSigV4.tsx 添加使用 SigV4 签名 HTTP 请求的钩子（如果选择 IAM 身份验证）
+- project.json 构建时新增生成类型安全客户端的目标
 - .gitignore 默认忽略生成的客户端文件
 
 </FileTree>
 
-生成器还会在网站基础设施中添加运行时配置（如尚未存在），确保 FastAPI 的 API URL 在网站中可用，并由 `use<ApiName>.tsx` 钩子自动配置。
+生成器还会在网站基础设施中添加运行时配置（如果尚未存在），确保 FastAPI 的 API URL 在网站中可用，并由 `use<ApiName>.tsx` 钩子自动配置。
 
 ### 代码生成
 
-构建时，将从 FastAPI 的 OpenAPI 规范生成类型安全客户端，这会为 React 应用添加三个新文件：
+构建时，根据 FastAPI 的 OpenAPI 规范生成类型安全客户端。这将在 React 应用中新增三个文件：
 
 <FileTree>
 
 - src
   - generated
     - \<ApiName>
-      - types.gen.ts 从 FastAPI 定义的 pydantic 模型生成的类型
+      - types.gen.ts 从 FastAPI 的 pydantic 模型生成类型
       - client.gen.ts 调用 API 的类型安全客户端
       - options-proxy.gen.ts 提供创建 TanStack Query 钩子选项的方法
 
 </FileTree>
 
 :::tip
-默认生成的客户端会被版本控制忽略。如需提交，可从 React 应用的 `.gitignore` 中移除相关条目，但请注意手动修改 `.gen.ts` 文件会在项目构建时被覆盖。
+默认生成的客户端会被版本控制忽略。如需提交，可从 React 应用的 `.gitignore` 中移除相关条目，但注意手动修改 `.gen.ts` 文件会在项目构建时被覆盖。
 :::
 
 ## 使用生成代码
 
-推荐通过 TanStack Query 钩子使用生成的类型安全客户端调用 FastAPI，也可直接使用普通客户端。
+推荐通过 TanStack Query 钩子使用生成的类型安全客户端调用 FastAPI，也可直接使用原生客户端。
 
 :::note
-修改 FastAPI 后需重新构建项目以使更改反映到生成的客户端中。例如：
+修改 FastAPI 后需重新构建项目以使更改生效。例如：
 
 <NxCommands commands={['run-many --target build --all']} />
 :::
 
 :::tip
-若同时开发 React 应用和 FastAPI，可使用 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) 在 API 变更时自动重新生成客户端：
+如需同时开发 React 应用和 FastAPI，可使用 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) 在 API 变更时自动生成客户端：
 
 <NxCommands
   commands={[
@@ -123,7 +124,7 @@ root.render(
 
 ### 使用 API 钩子
 
-生成器提供 `use<ApiName>` 钩子用于通过 TanStack Query 调用 API。
+生成器提供 `use<ApiName>` 钩子，用于通过 TanStack Query 调用 API。
 
 ### 查询
 
@@ -145,7 +146,7 @@ function MyComponent() {
 }
 ```
 
-<Drawer title="直接使用 API 客户端" trigger="点击查看直接使用普通客户端的示例。">
+<Drawer title="直接使用 API 客户端" trigger="点击查看直接使用原生客户端的示例。">
 ```tsx {5,13}
 import { useState, useEffect } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -180,7 +181,7 @@ function MyComponent() {
 
 ### 变更
 
-生成的钩子支持使用 TanStack Query 的 `useMutation` 处理变更操作，提供加载状态、错误处理和乐观更新。
+生成的钩子支持使用 TanStack Query 的 `useMutation` 处理创建、更新和删除操作，提供加载状态、错误处理和乐观更新。
 
 ```tsx {5-7,11}
 import { useMutation } from '@tanstack/react-query';
@@ -188,7 +189,6 @@ import { useMyApi } from './hooks/useMyApi';
 
 function CreateItemForm() {
   const api = useMyApi();
-  // 使用生成的变更选项创建变更
   const createItem = useMutation(api.createItem.mutationOptions());
 
   const handleSubmit = (e) => {
@@ -198,23 +198,22 @@ function CreateItemForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      {/* 表单字段 */}
       <button
         type="submit"
         disabled={createItem.isPending}
       >
-        {createItem.isPending ? '创建中...' : '创建项目'}
+        {createItem.isPending ? 'Creating...' : 'Create Item'}
       </button>
 
       {createItem.isSuccess && (
         <div className="success">
-          创建项目 ID: {createItem.data.id}
+          Item created with ID: {createItem.data.id}
         </div>
       )}
 
       {createItem.isError && (
         <div className="error">
-          错误: {createItem.error.message}
+          Error: {createItem.error.message}
         </div>
       )}
     </form>
@@ -228,24 +227,19 @@ function CreateItemForm() {
 const createItem = useMutation({
   ...api.createItem.mutationOptions(),
   onSuccess: (data) => {
-    // 变更成功时执行
-    console.log('项目已创建:', data);
-    // 可导航至新项目
+    console.log('Item created:', data);
     navigate(`/items/${data.id}`);
   },
   onError: (error) => {
-    // 变更失败时执行
-    console.error('创建项目失败:', error);
+    console.error('Failed to create item:', error);
   },
   onSettled: () => {
-    // 变更完成时执行（成功或失败）
-    // 适合刷新可能受影响的查询
     queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
   }
 });
 ```
 
-<Drawer title="直接使用客户端处理变更" trigger="点击查看直接使用客户端的示例。">
+<Drawer title="直接使用客户端进行变更" trigger="点击查看直接使用客户端的示例。">
 ```tsx
 import { useState } from 'react';
 import { useMyApiClient } from './hooks/useMyApiClient';
@@ -267,11 +261,8 @@ function CreateItemForm() {
         description: 'A new item'
       });
       setCreatedItem(newItem);
-      // 可导航至新项目
-      // navigate(`/items/${newItem.id}`);
     } catch (err) {
       setError(err);
-      console.error('创建项目失败:', err);
     } finally {
       setIsLoading(false);
     }
@@ -279,23 +270,22 @@ function CreateItemForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      {/* 表单字段 */}
       <button
         type="submit"
         disabled={isLoading}
       >
-        {isLoading ? '创建中...' : '创建项目'}
+        {isLoading ? 'Creating...' : 'Create Item'}
       </button>
 
       {createdItem && (
         <div className="success">
-          创建项目 ID: {createdItem.id}
+          Item created with ID: {createdItem.id}
         </div>
       )}
 
       {error && (
         <div className="error">
-          错误: {error.message}
+          Error: {error.message}
         </div>
       )}
     </form>
@@ -304,9 +294,9 @@ function CreateItemForm() {
 ```
 </Drawer>
 
-### 无限查询分页
+### 无限滚动分页
 
-对于接收 `cursor` 参数的端点，生成的钩子支持使用 TanStack Query 的 `useInfiniteQuery` 实现无限滚动或"加载更多"功能。
+对于支持 `cursor` 参数的端点，生成的钩子支持使用 `useInfiniteQuery` 实现"加载更多"或无限滚动功能。
 
 ```tsx {5-14,24-26}
 import { useInfiniteQuery } from '@tanstack/react-query';
@@ -316,25 +306,15 @@ function ItemList() {
   const api = useMyApi();
   const items = useInfiniteQuery({
     ...api.listItems.infiniteQueryOptions({
-      limit: 10, // 每页项目数
+      limit: 10,
     }, {
-      // 确保定义 getNextPageParam 函数返回下一页的 cursor 参数
       getNextPageParam: (lastPage) =>
         lastPage.nextCursor || undefined
       }),
   });
 
-  if (items.isLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
-  }
-
   return (
     <div>
-      {/* 平铺页面数组渲染所有项目 */}
       <ul>
         {items.data.pages.flatMap(page =>
           page.items.map(item => (
@@ -348,21 +328,15 @@ function ItemList() {
         disabled={!items.hasNextPage || items.isFetchingNextPage}
       >
         {items.isFetchingNextPage
-          ? '正在加载更多...'
+          ? 'Loading more...'
           : items.hasNextPage
-          ? '加载更多'
-          : '没有更多项目'}
+          ? 'Load More'
+          : 'No more items'}
       </button>
     </div>
   );
 }
 ```
-
-生成的钩子会自动处理基于 cursor 的分页。`nextCursor` 值从响应中提取用于获取下一页。
-
-:::tip
-如果 API 的分页参数名不是 `cursor`，可通过 [`x-cursor` OpenAPI 扩展](#custom-pagination-cursor)自定义。
-:::
 
 <Drawer title="直接使用客户端分页" trigger="点击查看直接使用客户端的示例。">
 ```tsx
@@ -372,56 +346,22 @@ import { useMyApiClient } from './hooks/useMyApiClient';
 function ItemList() {
   const api = useMyApiClient();
   const [items, setItems] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [nextCursor, setNextCursor] = useState(null);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
-  // 获取初始数据
-  useEffect(() => {
-    const fetchItems = async () => {
-      try {
-        setIsLoading(true);
-        const response = await api.listItems({ limit: 10 });
-        setItems(response.items);
-        setNextCursor(response.nextCursor);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchItems();
-  }, [api]);
-
-  // 加载更多函数
   const loadMore = async () => {
-    if (!nextCursor) return;
-
     try {
       setIsFetchingMore(true);
       const response = await api.listItems({
         limit: 10,
         cursor: nextCursor
       });
-
-      setItems(prevItems => [...prevItems, ...response.items]);
+      setItems(prev => [...prev, ...response.items]);
       setNextCursor(response.nextCursor);
-    } catch (err) {
-      setError(err);
     } finally {
       setIsFetchingMore(false);
     }
   };
-
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (error) {
-    return <ErrorMessage message={error.message} />;
-  }
 
   return (
     <div>
@@ -430,16 +370,11 @@ function ItemList() {
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
-
       <button
         onClick={loadMore}
         disabled={!nextCursor || isFetchingMore}
       >
-        {isFetchingMore
-          ? '正在加载更多...'
-          : nextCursor
-          ? '加载更多'
-          : '没有更多项目'}
+        {isFetchingMore ? 'Loading...' : 'Load More'}
       </button>
     </div>
   );
@@ -449,7 +384,7 @@ function ItemList() {
 
 ### 错误处理
 
-集成包含内置类型化错误处理。生成 `<operation-name>Error` 类型封装 OpenAPI 规范中可能的错误响应。通过检查 `status` 可定位具体错误类型。
+集成包含类型化错误响应，通过检查 `status` 可处理特定错误类型。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -458,17 +393,12 @@ function MyComponent() {
   const api = useMyApi();
   const createItem = useMutation(api.createItem.mutationOptions());
 
-  const handleClick = () => {
-    createItem.mutate({ name: 'New Item' });
-  };
-
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error 类型为 CreateItem400Response
         return (
           <div>
-            <h2>无效输入:</h2>
+            <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
               {createItem.error.error.validationErrors.map((err) => (
@@ -478,31 +408,28 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error 类型为 CreateItem403Response
         return (
           <div>
-            <h2>未授权:</h2>
+            <h2>Not authorized:</h2>
             <p>{createItem.error.error.reason}</p>
           </div>
         );
       case 500:
       case 502:
-        // error.error 类型为 CreateItem5XXResponse
         return (
           <div>
-            <h2>服务器错误:</h2>
+            <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>追踪 ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
   }
 
-  return <button onClick={handleClick}>创建项目</button>;
+  return <button onClick={() => createItem.mutate()}>Create Item</button>;
 }
 ```
 
-<Drawer title="直接使用客户端处理错误" trigger="点击查看直接使用客户端的示例。">
+<Drawer title="直接处理客户端错误" trigger="点击查看直接使用客户端的示例。">
 ```tsx {9,15}
 function MyComponent() {
   const api = useMyApiClient();
@@ -520,49 +447,30 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error 类型为 CreateItem400Response
         return (
           <div>
-            <h2>无效输入:</h2>
+            <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
-            <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
-              ))}
-            </ul>
           </div>
         );
       case 403:
-        // error.error 类型为 CreateItem403Response
         return (
           <div>
-            <h2>未授权:</h2>
+            <h2>Not authorized:</h2>
             <p>{error.error.reason}</p>
-          </div>
-        );
-      case 500:
-      case 502:
-        // error.error 类型为 CreateItem5XXResponse
-        return (
-          <div>
-            <h2>服务器错误:</h2>
-            <p>{error.error.message}</p>
-            <p>追踪 ID: {error.error.traceId}</p>
           </div>
         );
     }
   }
 
-  return <button onClick={handleClick}>创建项目</button>;
+  return <button onClick={handleClick}>Create Item</button>;
 }
 ```
 </Drawer>
 
-### 使用流
+### 流式响应
 
-如果已 <Link path="guides/fastapi#streaming">配置 FastAPI 流式响应</Link>，`useQuery` 钩子会在新数据块到达时自动更新数据。
-
-例如：
+如果 FastAPI 配置了流式响应，`useQuery` 钩子会在新数据块到达时自动更新。
 
 ```tsx {3}
 function MyStreamingComponent() {
@@ -581,44 +489,30 @@ function MyStreamingComponent() {
 }
 ```
 
-可使用 `isLoading` 和 `fetchStatus` 属性确定流的当前状态。流的生命周期如下：
+流式生命周期阶段：
 
 <Steps>
-  1. 发送启动流的 HTTP 请求
-
+  1. 发送 HTTP 请求
       - `isLoading` 为 `true`
       - `fetchStatus` 为 `'fetching'`
       - `data` 为 `undefined`
 
-  2. 接收到流的首个数据块
-
+  2. 接收首个数据块
       - `isLoading` 变为 `false`
       - `fetchStatus` 保持 `'fetching'`
-      - `data` 变为包含首个数据块的数组
+      - `data` 更新为首个数据块
 
-  3. 接收到后续数据块
+  3. 接收后续数据块
+      - `data` 持续更新
 
-      - `isLoading` 保持 `false`
-      - `fetchStatus` 保持 `'fetching'`
-      - `data` 随每个新数据块立即更新
-
-  4. 流完成
-
-      - `isLoading` 保持 `false`
+  4. 流式结束
       - `fetchStatus` 变为 `'idle'`
-      - `data` 包含所有接收的数据块
 </Steps>
 
-<Drawer title="直接使用客户端处理流" trigger="点击查看直接使用客户端的示例。">
-
-如果已 <Link path="guides/fastapi#streaming">配置 FastAPI 流式响应</Link>，生成的客户端将包含使用 `for await` 语法异步迭代流数据块的类型安全方法。
-
-例如：
-
+<Drawer title="直接处理流式响应" trigger="点击查看直接使用客户端的示例。">
 ```tsx {8}
 function MyStreamingComponent() {
   const api = useMyApiClient();
-
   const [chunks, setChunks] = useState<Chunk[]>([]);
 
   useEffect(() => {
@@ -643,15 +537,11 @@ function MyStreamingComponent() {
 ```
 </Drawer>
 
-:::note
-如果流式 API 接收 `cursor` 参数，使用 `useInfiniteQuery` 钩子时，每页将等待流完成后再加载。
-:::
-
 ## 自定义生成代码
 
 ### 查询与变更
 
-默认情况下，FastAPI 中使用 `PUT`、`POST`、`PATCH` 和 `DELETE` HTTP 方法的路由被视为变更操作，其他视为查询。可通过 `x-query` 和 `x-mutation` 调整此行为。
+默认将 `PUT`、`POST`、`PATCH` 和 `DELETE` 方法视为变更，其他视为查询。可通过 `x-query` 和 `x-mutation` 修改此行为。
 
 #### x-query
 
@@ -664,12 +554,6 @@ function MyStreamingComponent() {
 )
 def list_items():
     # ...
-```
-
-生成的钩子将提供 `queryOptions`，即使使用 `POST` 方法：
-
-```tsx
-const items = useQuery(api.listItems.queryOptions());
 ```
 
 #### x-mutation
@@ -685,266 +569,67 @@ def start_processing():
     # ...
 ```
 
-生成的钩子将提供 `mutationOptions`，即使使用 `GET` 方法：
-
-```tsx
-const startProcessing = useMutation(api.startProcessing.mutationOptions());
-```
-
 ### 自定义分页游标
 
-默认生成的钩子假设分页参数名为 `cursor`。可通过 `x-cursor` 扩展自定义：
+通过 `x-cursor` 扩展自定义分页参数：
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
-        # 指定不同的游标参数名
         "x-cursor": "page_token"
     }
 )
 def list_items(page_token: str = None, limit: int = 10):
     # ...
-    return {
-        "items": items,
-        "page_token": next_page_token  # 响应需包含同名游标
-    }
 ```
 
-若不想为某个操作生成 `infiniteQueryOptions`，可将 `x-cursor` 设为 `False`：
+禁用分页生成：
 
 ```python
 @app.get(
     "/items",
     openapi_extra={
-        # 禁用此端点的游标分页
         "x-cursor": False
     }
 )
 def list_items(page: int = 1, limit: int = 10):
     # ...
-    return {
-        "items": items,
-        "total": total_count,
-        "page": page,
-        "pages": total_pages
-    }
 ```
 
 ### 操作分组
 
-生成的钩子和客户端方法根据 FastAPI 端点的 OpenAPI 标签自动组织，便于查找相关操作。
+根据 OpenAPI 标签自动分组操作：
 
-例如：
-
-```python title="items.py"
-@app.get(
-    "/items",
-    tags=["items"],
-)
+```python
+@app.get("/items", tags=["items"])
 def list():
     # ...
 
-@app.post(
-    "/items",
-    tags=["items"],
-)
+@app.post("/items", tags=["items"])
 def create(item: Item):
     # ...
 ```
 
-```python title="users.py"
-@app.get(
-    "/users",
-    tags=["users"],
-)
-def list():
-    # ...
-```
-
-生成的钩子将按标签分组：
+分组后使用示例：
 
 ```tsx
-import { useQuery, useMutation } from '@tanstack/react-query';
-import { useMyApi } from './hooks/useMyApi';
-
-function ItemsAndUsers() {
-  const api = useMyApi();
-
-  // items 操作分组在 api.items 下
-  const items = useQuery(api.items.list.queryOptions());
-  const createItem = useMutation(api.items.create.mutationOptions());
-
-  // users 操作分组在 api.users 下
-  const users = useQuery(api.users.list.queryOptions());
-
-  // 使用示例
-  const handleCreateItem = () => {
-    createItem.mutate({ name: 'New Item' });
-  };
-
-  return (
-    <div>
-      <h2>项目</h2>
-      <ul>
-        {items.data?.map(item => (
-          <li key={item.id}>{item.name}</li>
-        ))}
-      </ul>
-      <button onClick={handleCreateItem}>添加项目</button>
-
-      <h2>用户</h2>
-      <ul>
-        {users.data?.map(user => (
-          <li key={user.id}>{user.name}</li>
-        ))}
-      </ul>
-    </div>
-  );
-}
+const items = useQuery(api.items.list.queryOptions());
+const createItem = useMutation(api.items.create.mutationOptions());
 ```
 
-分组机制便于组织 API 调用，并在 IDE 中提供更好的代码补全。
-
-<Drawer title="直接使用分组的客户端操作" trigger="点击查看直接使用客户端的示例。">
+<Drawer title="直接使用分组客户端" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-import { useState, useEffect } from 'react';
-import { useMyApiClient } from './hooks/useMyApiClient';
-
-function ItemsAndUsers() {
-  const api = useMyApiClient();
-  const [items, setItems] = useState([]);
-  const [users, setUsers] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  // 加载数据
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setIsLoading(true);
-
-        // items 操作分组在 api.items 下
-        const itemsData = await api.items.list();
-        setItems(itemsData);
-
-        // users 操作分组在 api.users 下
-        const usersData = await api.users.list();
-        setUsers(usersData);
-      } catch (error) {
-        console.error('获取数据错误:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [api]);
-
-  const handleCreateItem = async () => {
-    try {
-      // 使用分组方法创建项目
-      const newItem = await api.items.create({ name: 'New Item' });
-      setItems(prevItems => [...prevItems, newItem]);
-    } catch (error) {
-      console.error('创建项目错误:', error);
-    }
-  };
-
-  if (isLoading) {
-    return <div>加载中...</div>;
-  }
-
-  return (
-    <div>
-      <h2>项目</h2>
-      <ul>
-        {items.map(item => (
-          <li key={item.id}>{item.name}</li>
-        ))}
-      </ul>
-      <button onClick={handleCreateItem}>添加项目</button>
-
-      <h2>用户</h2>
-      <ul>
-        {users.map(user => (
-          <li key={user.id}>{user.name}</li>
-        ))}
-      </ul>
-    </div>
-  );
-}
+const itemsData = await api.items.list();
+const usersData = await api.users.list();
 ```
 </Drawer>
 
-:::tip
-也可使用多个 `routers` 拆分 API。详见 [FastAPI 文档](https://fastapi.tiangolo.com/tutorial/bigger-applications/)。
-:::
+### 错误处理
 
-### 错误
+通过自定义异常和响应模型实现类型化错误处理：
 
-可通过定义自定义异常类、异常处理程序并为不同状态码指定响应模型来自定义错误响应。生成的客户端会自动处理这些自定义错误类型。
-
-#### 定义自定义错误模型
-
-首先使用 Pydantic 定义错误模型：
-
-```python title="models.py"
-from pydantic import BaseModel
-
-class ErrorDetails(BaseModel):
-    message: str
-
-class ValidationError(BaseModel):
-    message: str
-    field_errors: list[str]
-```
-
-#### 创建自定义异常
-
-为不同错误场景创建异常类：
-
-```python title="exceptions.py"
-class NotFoundException(Exception):
-    def __init__(self, message: str):
-        self.message = message
-
-class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
-        self.details = details
-```
-
-#### 添加异常处理程序
-
-注册异常处理程序将异常转换为 HTTP 响应：
-
-```python title="main.py"
-from fastapi import Request
-from fastapi.responses import JSONResponse
-
-@app.exception_handler(NotFoundException)
-async def not_found_handler(request: Request, exc: NotFoundException):
-    return JSONResponse(
-        status_code=404,
-        content=exc.message,
-    )
-
-@app.exception_handler(ValidationException)
-async def validation_error_handler(request: Request, exc: ValidationException):
-    return JSONResponse(
-        status_code=400,
-        content=exc.details.model_dump(),
-    )
-```
-
-:::tip
-`JSONResponse` 接受字典，因此我们使用 Pydantic 模型的 `model_dump` 方法。
-:::
-
-#### 指定响应模型
-
-在端点定义中为不同状态码指定响应模型：
-
-```python title="main.py"
+```python
 @app.get(
     "/items/{item_id}",
     responses={
@@ -953,178 +638,32 @@ async def validation_error_handler(request: Request, exc: ValidationException):
     }
 )
 def get_item(item_id: str) -> Item:
-    item = find_item(item_id)
-    if not item:
-        raise NotFoundException(message=f"Item with ID {item_id} not found")
-    return item
-
-@app.post(
-    "/items",
-    responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
-    }
-)
-def create_item(item: Item) -> Item:
-    if not is_valid(item):
-        raise ValidationException(
-            ValidationError(
-                message="Invalid item data",
-                field_errors=["name is required"]
-            )
-        )
-    return save_item(item)
+    # ...
 ```
 
-#### 在 React 中使用自定义错误类型
-
-生成的客户端会自动处理这些自定义错误类型，允许进行类型检查和错误响应处理：
+React 中使用类型化错误：
 
 ```tsx
-import { useMutation, useQuery } from '@tanstack/react-query';
-
-function ItemComponent() {
-  const api = useMyApi();
-
-  // 带类型错误处理的查询
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // 根据 FastAPI 的响应定义错误类型
-      switch (error.status) {
-        case 404:
-          // error.error 是 responses 中指定的字符串
-          console.error('未找到:', error.error);
-          break;
-        case 500:
-          // error.error 类型为 ErrorDetails
-          console.error('服务器错误:', error.error.message);
-          break;
-      }
-    }
-  });
-
-  // 带类型错误处理的变更
-  const createItem = useMutation({
-    ...api.createItem.mutationOptions(),
-    onError: (error) => {
-      switch (error.status) {
-        case 400:
-          // error.error 类型为 ValidationError
-          console.error('验证错误:', error.error.message);
-          console.error('字段错误:', error.error.field_errors);
-          break;
-        case 403:
-          // error.error 是 responses 中指定的字符串
-          console.error('禁止访问:', error.error);
-          break;
-      }
-    }
-  });
-
-  // 组件渲染与错误处理
-  if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
-    }
-  }
-
-  return (
-    <div>
-      {/* 组件内容 */}
-    </div>
-  );
+switch (error.status) {
+  case 404:
+    console.error('Not found:', error.error);
+    break;
+  case 500:
+    console.error('Server error:', error.error.message);
+    break;
 }
 ```
 
 <Drawer title="直接处理自定义错误" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-import { useState, useEffect } from 'react';
-
-function ItemComponent() {
-  const api = useMyApiClient();
-  const [item, setItem] = useState(null);
-  const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(true);
-
-  // 带错误处理的数据获取
-  useEffect(() => {
-    const fetchItem = async () => {
-      try {
-        setLoading(true);
-        const data = await api.getItem({ itemId: '123' });
-        setItem(data);
-      } catch (e) {
-        // 根据 FastAPI 的响应定义错误类型
-        const err = e as GetItemError;
-        setError(err);
-
-        switch (err.status) {
-          case 404:
-            // err.error 是 responses 中指定的字符串
-            console.error('未找到:', err.error);
-            break;
-          case 500:
-            // err.error 类型为 ErrorDetails
-            console.error('服务器错误:', err.error.message);
-            break;
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchItem();
-  }, [api]);
-
-  // 带错误处理的创建项目
-  const handleCreateItem = async (data) => {
-    try {
-      await api.createItem(data);
-    } catch (e) {
-      const err = e as CreateItemError;
-
-      switch (err.status) {
-        case 400:
-          // err.error 类型为 ValidationError
-          console.error('验证错误:', err.error.message);
-          console.error('字段错误:', err.error.field_errors);
-          break;
-        case 403:
-          // err.error 是 responses 中指定的字符串
-          console.error('禁止访问:', err.error);
-          break;
-      }
-    }
-  };
-
-  // 组件渲染与错误处理
-  if (loading) {
-    return <LoadingSpinner />;
-  }
-
-  if (error) {
-    if (error.status === 404) {
-      return <NotFoundMessage message={error.error} />;
-    } else if (error.status === 500) {
-      return <ErrorMessage message={error.error.message} />;
-    }
-  }
-
-  return (
-    <div>
-      {/* 组件内容 */}
-    </div>
-  );
+const err = e as GetItemError;
+switch (err.status) {
+  case 404:
+    // 处理 404 错误
+    break;
 }
 ```
 </Drawer>
-
-:::tip
-在 FastAPI 中定义错误响应时，始终使用 `responses` 参数为每个状态码指定模型，确保生成的客户端具有正确的错误类型信息。
-:::
 
 ## 最佳实践
 
@@ -1133,327 +672,84 @@ function ItemComponent() {
 始终处理加载和错误状态以提升用户体验：
 
 ```tsx
-import { useQuery } from '@tanstack/react-query';
+if (items.isLoading) {
+  return <LoadingSpinner />;
+}
 
-function ItemList() {
-  const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
-
-  if (items.isLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (items.isError) {
-    const err = items.error;
-    switch (err.status) {
-      case 403:
-        // err.error 类型为 ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
-      case 500:
-      case 502:
-        // err.error 类型为 ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`追踪 ID: ${err.error.traceId}`}
-          />
-        );
-      default:
-        return <ErrorMessage message="发生未知错误" />;
-    }
-  }
-
-  return (
-    <ul>
-      {items.data.map((item) => (
-        <li key={item.id}>{item.name}</li>
-      ))}
-    </ul>
-  );
+if (items.isError) {
+  return <ErrorMessage message={items.error.message} />;
 }
 ```
 
 <Drawer title="直接处理加载状态" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-function ItemList() {
-  const api = useMyApiClient();
-  const [items, setItems] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+if (loading) {
+  return <LoadingSpinner />;
+}
 
-  useEffect(() => {
-    const fetchItems = async () => {
-      try {
-        const data = await api.listItems();
-        setItems(data);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchItems();
-  }, [api]);
-
-  if (loading) {
-    return <LoadingSpinner />;
-  }
-
-  if (error) {
-    const err = error as ListItemsError;
-    switch (err.status) {
-      case 403:
-        // err.error 类型为 ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
-      case 500:
-      case 502:
-        // err.error 类型为 ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`追踪 ID: ${err.error.traceId}`}
-          />
-        );
-      default:
-        return <ErrorMessage message="发生未知错误" />;
-    }
-  }
-
-  return (
-    <ul>
-      {items.map((item) => (
-        <li key={item.id}>{item.name}</li>
-      ))}
-    </ul>
-  );
+if (error) {
+  return <ErrorMessage message={error.message} />;
 }
 ```
 </Drawer>
 
 ### 乐观更新
 
-实现乐观更新以提升用户体验：
+通过乐观更新提升用户体验：
 
 ```tsx
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-
-function ItemList() {
-  const api = useMyApi();
-  const queryClient = useQueryClient();
-
-  // 获取项目的查询
-  const itemsQuery = useQuery(api.listItems.queryOptions());
-
-  // 带乐观更新的删除变更
-  const deleteMutation = useMutation({
-    ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
-      // 取消正在进行的重新获取
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
-
-      // 快照旧值
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
-
-      // 乐观更新新值
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
-      );
-
-      // 返回包含快照的上下文对象
-      return { previousItems };
-    },
-    onError: (err, itemId, context) => {
-      // 变更失败时使用 onMutate 返回的上下文回滚
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
-      console.error('删除项目失败:', err);
-    },
-    onSettled: () => {
-      // 无论成功失败都重新获取数据以确保与服务器同步
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
-    },
-  });
-
-  if (itemsQuery.isLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (itemsQuery.isError) {
-    return <ErrorMessage message="加载项目失败" />;
-  }
-
-  return (
-    <ul>
-      {itemsQuery.data.map((item) => (
-        <li key={item.id}>
-          {item.name}
-          <button
-            onClick={() => deleteMutation.mutate(item.id)}
-            disabled={deleteMutation.isPending}
-          >
-            {deleteMutation.isPending ? '删除中...' : '删除'}
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
-}
+const deleteMutation = useMutation({
+  ...api.deleteItem.mutationOptions(),
+  onMutate: async (itemId) => {
+    const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+    queryClient.setQueryData(api.listItems.queryKey(), old => old.filter(item => item.id !== itemId));
+    return { previousItems };
+  },
+  onError: (err, itemId, context) => {
+    queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+  },
+});
 ```
 
 <Drawer title="直接实现乐观更新" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-function ItemList() {
-  const api = useMyApiClient();
-  const [items, setItems] = useState([]);
-
-  const handleDelete = async (itemId) => {
-    // 乐观移除项目
-    const previousItems = items;
-    setItems(items.filter((item) => item.id !== itemId));
-
-    try {
-      await api.deleteItem(itemId);
-    } catch (error) {
-      // 出错时恢复旧项目
-      setItems(previousItems);
-      console.error('删除项目失败:', error);
-    }
-  };
-
-  return (
-    <ul>
-      {items.map((item) => (
-        <li key={item.id}>
-          {item.name}
-          <button onClick={() => handleDelete(item.id)}>删除</button>
-        </li>
-      ))}
-    </ul>
-  );
+const previousItems = items;
+setItems(items.filter(item => item.id !== itemId));
+try {
+  await api.deleteItem(itemId);
+} catch {
+  setItems(previousItems);
 }
 ```
 </Drawer>
 
 ## 类型安全
 
-集成提供完整的端到端类型安全。IDE 将为所有 API 调用提供自动补全和类型检查：
+集成提供端到端类型安全，IDE 会为所有 API 调用提供自动补全和类型检查：
 
 ```tsx
-import { useMutation } from '@tanstack/react-query';
+const createItem = useMutation({
+  ...api.createItem.mutationOptions(),
+  onSuccess: (data) => {
+    // data 类型自动推断
+    console.log(`Item ID: ${data.id}`);
+  },
+});
 
-function ItemForm() {
-  const api = useMyApi();
-
-  // 创建项目的类型安全变更
-  const createItem = useMutation({
-    ...api.createItem.mutationOptions(),
-    // ✅ 若 onSuccess 回调未处理正确的响应类型会报类型错误
-    onSuccess: (data) => {
-      // data 根据 API 响应模式完全类型化
-      console.log(`项目创建 ID: ${data.id}`);
-    },
-  });
-
-  const handleSubmit = (data: CreateItemInput) => {
-    // ✅ 若输入不符合模式会报类型错误
-    createItem.mutate(data);
-  };
-
-  // 错误 UI 可使用类型缩窄处理不同错误类型
-  if (createItem.error) {
-    const error = createItem.error;
-    switch (error.status) {
-      case 400:
-        // error.error 类型为 CreateItem400Response
-        return (
-          <FormError
-            message="无效输入"
-            errors={error.error.validationErrors}
-          />
-        );
-      case 403:
-        // error.error 类型为 CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error 类型为 CreateItem5XXResponse（500、502 等）
-        return <ServerError message={error.error.message} />;
-    }
-  }
-
-  return (
-    <form onSubmit={(e) => {
-      e.preventDefault();
-      handleSubmit({ name: 'New Item' });
-    }}>
-      {/* 表单字段 */}
-      <button
-        type="submit"
-        disabled={createItem.isPending}
-      >
-        {createItem.isPending ? '创建中...' : '创建项目'}
-      </button>
-    </form>
-  );
-}
+const handleSubmit = (data: CreateItemInput) => {
+  createItem.mutate(data); // 输入类型校验
+};
 ```
 
 <Drawer title="直接使用类型安全客户端" trigger="点击查看直接使用客户端的示例。">
 ```tsx
-function ItemForm() {
-  const api = useMyApiClient();
-  const [error, setError] = useState<CreateItemError | null>(null);
-
-  const handleSubmit = async (data: CreateItemInput) => {
-    try {
-      // ✅ 若输入不符合模式会报类型错误
-      await api.createItem(data);
-    } catch (e) {
-      // ✅ 错误类型包含所有可能的错误响应
-      const err = e as CreateItemError;
-      switch (err.status) {
-        case 400:
-          // err.error 类型为 CreateItem400Response
-          console.error('验证错误:', err.error.validationErrors);
-          break;
-        case 403:
-          // err.error 类型为 CreateItem403Response
-          console.error('未授权:', err.error.reason);
-          break;
-        case 500:
-        case 502:
-          // err.error 类型为 CreateItem5XXResponse
-          console.error(
-            '服务器错误:',
-            err.error.message,
-            '追踪:',
-            err.error.traceId,
-          );
-          break;
-      }
-      setError(err);
-    }
-  };
-
-  // 错误 UI 可使用类型缩窄处理不同错误类型
-  if (error) {
-    switch (error.status) {
-      case 400:
-        return (
-          <FormError
-            message="无效输入"
-            errors={error.error.validationErrors}
-          />
-        );
-      case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
-        return <ServerError message={error.error.message} />;
-    }
-  }
-
-  return <form onSubmit={handleSubmit}>{/* ... */}</form>;
+try {
+  // 输入类型校验
+  await api.createItem(data);
+} catch (e) {
+  const err = e as CreateItemError; // 错误类型推断
 }
 ```
 </Drawer>
 
-类型从 FastAPI 的 OpenAPI 模式自动生成，确保 API 变更在构建后能反映到前端代码中。
+所有类型均从 FastAPI 的 OpenAPI 模式生成，确保前端代码与 API 变更保持同步。

--- a/docs/src/content/docs/zh/guides/api-connection/react-trpc.mdx
+++ b/docs/src/content/docs/zh/guides/api-connection/react-trpc.mdx
@@ -9,17 +9,16 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../../packages/nx-plugin/src/api-connection/schema.json';
 
-Nx 的 AWS 插件提供了一个生成器，可快速将您的 <Link path="guides/trpc">tRPC API</Link> 与 React 网站集成。它会配置所有必要的后端连接设置，包括 AWS IAM 身份验证支持和正确的错误处理。该集成可在前端与 tRPC 后端之间提供完整的端到端类型安全。
+Nx 的 AWS 插件提供了一个生成器，可快速将您的 <Link path="guides/trpc">tRPC API</Link> 与 React 网站集成。它会自动配置所有必要的后端连接配置，包括 AWS IAM 身份验证支持和正确的错误处理。该集成提供前端与 tRPC 后端之间的完整端到端类型安全。
 
 ## 前提条件
 
 使用此生成器前，请确保您的 React 应用具备：
 
 1. 渲染应用的 `main.tsx` 文件
-2. 将自动注入 tRPC 提供程序的 `<App/>` JSX 元素
-3. 可正常运行的 tRPC 后端（需使用 tRPC 后端生成器创建）
+2. 用于自动注入 tRPC provider 的 `<App/>` JSX 元素
+3. 可运行的 tRPC 后端（使用 tRPC 后端生成器生成）
 
 <details>
 <summary>所需 `main.tsx` 结构示例</summary>
@@ -30,7 +29,7 @@ import * as ReactDOM from 'react-dom/client';
 import App from './app/app';
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTTMLHtmlElement,
+  document.getElementById('root') as HTMLElement,
 );
 root.render(
   <StrictMode>
@@ -41,19 +40,19 @@ root.render(
 
 </details>
 
-## 使用说明
+## 使用方式
 
 ### 运行生成器
 
 <RunGenerator generator="api-connection" />
 
-### 选项配置
+### 选项参数
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="api-connection" />
 
 ## 生成器输出
 
-生成器将在您的 React 应用中创建以下结构：
+生成器会在 React 应用中创建以下结构：
 
 <FileTree>
 
@@ -61,28 +60,28 @@ root.render(
   - components
     - TrpcClients
       - index.tsx
-      - TrpcProvider.tsx 可复用多个 tRPC API 的 Provider
+      - TrpcProvider.tsx 用于多个 tRPC API 的复用 Provider
       - TrpcApis.tsx 包含所有 tRPC API 连接的对象
-      - TrpcClientProviders.tsx 配置 tRPC 客户端与后端 schema 的绑定
+      - TrpcClientProviders.tsx 设置 tRPC 客户端并绑定到后端 schema
     - QueryClientProvider.tsx TanStack React Query 客户端 Provider
   - hooks
-    - useSigV4.tsx 使用 SigV4 签名 HTTP 请求的钩子（仅限 IAM）
+    - useSigV4.tsx 用于 SigV4 签名 HTTP 请求的钩子（仅限 IAM）
     - use\<ApiName>.tsx 对应后端 API 的钩子。ApiName 将解析为 API 名称
 
 </FileTree>
 
-同时安装以下依赖项：
+同时会安装以下依赖：
 
   - `@trpc/client`
   - `@trpc/tanstack-react-query`
   - `@tanstack/react-query`
-  - `aws4fetch`（使用 IAM 认证时需要）
+  - `aws4fetch`（如果使用 IAM 认证）
 
 ## 使用生成代码
 
 ### 使用 tRPC 钩子
 
-生成器提供 `use<ApiName>` 钩子用于访问类型安全的 tRPC 客户端：
+生成器提供 `use<ApiName>` 钩子来访问类型安全的 tRPC 客户端：
 
 ```tsx {5,8,11}
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -104,7 +103,7 @@ function MyComponent() {
     });
   };
 
-  if (isLoading) return <div>加载中...</div>;
+  if (isLoading) return <div>Loading...</div>;
 
   return (
     <ul>
@@ -118,7 +117,7 @@ function MyComponent() {
 
 ### 错误处理
 
-集成包含内置错误处理机制，可正确处理 tRPC 错误：
+集成包含内置的错误处理机制：
 
 ```tsx {4, 6}
 function MyComponent() {
@@ -131,7 +130,7 @@ function MyComponent() {
       <div>
         <h2>发生错误：</h2>
         <p>{error.message}</p>
-        {error.data?.code && <p>错误代码：{error.data.code}</p>}
+        {error.data?.code && <p>错误代码: {error.data.code}</p>}
       </div>
     );
   }
@@ -207,7 +206,7 @@ function UserList() {
         return { previousUsers };
       },
       onError: (err, userId, context) => {
-        // 出错时恢复原始数据
+        // 出错时恢复数据
         queryClient.setQueryData(
           trpc.users.list.queryKey(),
           context?.previousUsers,
@@ -231,7 +230,7 @@ function UserList() {
 
 ### 数据预取
 
-预取数据以提升性能：
+通过预取提升性能：
 
 ```tsx {8}
 function UserList() {
@@ -258,7 +257,7 @@ function UserList() {
 
 ### 无限查询
 
-使用无限查询处理分页：
+处理分页数据：
 
 ```tsx {5-12}
 function UserList() {
@@ -290,21 +289,21 @@ function UserList() {
 }
 ```
 
-需注意：无限查询只能用于输入参数包含 `cursor` 的存储过程。
+注意：无限查询仅适用于输入参数包含 `cursor` 属性的流程。
 
 ## 类型安全
 
-该集成提供完整的端到端类型安全。您的 IDE 将为所有 API 调用提供完整的自动补全和类型检查：
+该集成提供完整的端到端类型安全。您的 IDE 将为所有 API 调用提供自动补全和类型检查：
 
 ```tsx
 function UserForm() {
   const trpc = useMyApi();
 
-  // ✅ 输入类型完全校验
+  // ✅ 输入类型完全匹配
   const createUser = trpc.users.create.useMutation();
 
   const handleSubmit = (data: CreateUserInput) => {
-    // ✅ 输入不匹配 schema 时会报类型错误
+    // ✅ 输入不符合 schema 时会产生类型错误
     createUser.mutate(data);
   };
 
@@ -312,7 +311,7 @@ function UserForm() {
 }
 ```
 
-类型会自动从后端路由和 schema 定义中推断，确保 API 的任何变更都能立即反映在前端代码中，无需重新构建。
+类型会自动从后端路由器和 schema 定义中推断，确保 API 的任何变更都能立即反映在前端代码中，无需重新构建。
 
 ## 更多信息
 

--- a/docs/src/content/docs/zh/guides/cloudscape-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/cloudscape-website-auth.mdx
@@ -10,11 +10,10 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.json';
 
-CloudScape 网站认证生成器通过[Amazon Cognito](https://aws.amazon.com/cognito/)为您的 CloudScape 网站添加身份验证功能。
+CloudScape 网站认证生成器使用 [Amazon Cognito](https://aws.amazon.com/cognito/) 为您的 CloudScape 网站添加认证功能。
 
-该生成器会配置 CDK 基础设施，用于创建 Cognito 用户池及关联的身份池、处理用户登录流程的托管 UI，并将其与您的 CloudScape 网站集成。
+该生成器会配置 CDK 基础设施来创建 Cognito 用户池及关联的身份池，同时生成用于处理用户登录流程的托管 UI，并将其集成到您的 CloudScape 网站中。
 
 ## 使用方法
 
@@ -26,11 +25,11 @@ CloudScape 网站认证生成器通过[Amazon Cognito](https://aws.amazon.com/co
 
 ### 配置选项
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website#auth" />
 
 ## 生成器输出
 
-您的 React 网站将产生以下变更：
+您的 React 网站中将出现以下变更：
 
 <FileTree>
   - src
@@ -40,17 +39,17 @@ CloudScape 网站认证生成器通过[Amazon Cognito](https://aws.amazon.com/co
     - main.tsx 更新以集成 CognitoAuth 组件
 </FileTree>
 
-在 `packages/common/constructs` 目录下将生成以下基础设施代码：
+您还将在 `packages/common/constructs` 中看到生成的基础设施代码：
 
 <FileTree>
   - src
     - core
-      - user-identity.ts 定义用户池和身份池的构造
+      - user-identity.ts 定义用户池和身份池的构造体
 </FileTree>
 
 ## 基础设施使用
 
-您需要在堆栈中添加 `UserIdentity` 构造，并确保其声明在网站构造之前：
+您需要在堆栈中添加 `UserIdentity` 构造体，并确保在网站构造体_之前_声明：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
 import { Stack } from 'aws-cdk-lib';
@@ -68,11 +67,11 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-`UserIdentity` 构造会自动添加必要的<Link path="guides/cloudscape-website#runtime-configuration">运行时配置</Link>，确保您的网站能正确指向 Cognito 用户池进行认证。
+`UserIdentity` 构造体会自动添加必要的 <Link path="guides/cloudscape-website#runtime-configuration">运行时配置</Link>，确保您的网站可以指向正确的 Cognito 用户池进行认证。
 
 ### 授予认证用户访问权限
 
-要为认证用户授予特定操作权限（例如允许调用 API），可向身份池的认证角色添加 IAM 策略声明：
+要为认证用户授予执行特定操作的权限（例如允许调用 API），可以向身份池的认证角色添加 IAM 策略声明：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/zh/guides/cloudscape-website.mdx
+++ b/docs/src/content/docs/zh/guides/cloudscape-website.mdx
@@ -10,82 +10,81 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/cloudscape-website/app/schema.json';
 
-此生成器会创建一个预配置了[CloudScape](http://cloudscape.design/)的[React](https://react.dev/)网站，并附带用于将网站部署至云端的AWS CDK基础设施，部署后网站将作为静态站点托管于[S3](https://aws.amazon.com/s3/)，通过[CloudFront](https://aws.amazon.com/cloudfront/)分发，并受[WAF](https://aws.amazon.com/waf/)保护。
+该生成器会创建一个配置了 [CloudScape](http://cloudscape.design/) 的 [React](https://react.dev/) 网站，并生成对应的 AWS CDK 基础设施代码，用于将您的网站作为静态站点部署到云端，托管在 [S3](https://aws.amazon.com/s3/) 上，通过 [CloudFront](https://aws.amazon.com/cloudfront/) 分发，并通过 [WAF](https://aws.amazon.com/waf/) 进行安全防护。
 
-生成的应用程序使用[Vite](https://vite.dev/)作为构建工具和打包器，并采用[TanStack Router](https://tanstack.com/router/v1)实现类型安全的路由功能。
+生成的应用程序使用 [Vite](https://vite.dev/) 作为构建工具和打包器，并采用 [TanStack Router](https://tanstack.com/router/v1) 实现类型安全的路由。
 
 :::note
-虽然此生成器默认集成了CloudScape，但其本质上是一个React项目生成器。如有需要，您可修改代码以切换至其他设计系统或组件库。
+虽然该生成器默认配置了 CloudScape，但它本质上是一个 React 项目生成器，您可以根据需要修改代码以切换至其他设计系统或组件库。
 :::
 
 ## 使用方式
 
-### 生成CloudScape网站
+### 生成 CloudScape 网站
 
-您可通过两种方式生成新的CloudScape网站：
+您可以通过两种方式生成新的 CloudScape 网站：
 
 <RunGenerator generator="ts#cloudscape-website" />
 
-### 选项配置
+### 配置选项
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#cloudscape-website" />
 
 ## 生成器输出
 
-生成器将在`<directory>/<name>`目录下创建如下项目结构：
+生成器会在 `<directory>/<name>` 目录下创建以下项目结构：
 
 <FileTree>
-  - index.html HTML入口文件
+  - index.html HTML 入口文件
   - public 静态资源目录
   - src
-    - main.tsx 应用入口文件（包含React初始化）
-    - config.ts 应用配置（如Logo）
+    - main.tsx 应用入口文件（包含 React 初始化）
+    - config.ts 应用配置（如 logo）
     - components
-      - AppLayout CloudScape整体布局及导航栏组件
+      - AppLayout 全局 CloudScape 布局和导航栏组件
     - hooks
-      - useAppLayout.tsx 用于从嵌套组件调整AppLayout的Hook
+      - useAppLayout.tsx 用于从嵌套组件调整 AppLayout 的钩子
     - routes
       - welcome
-        - index.tsx 示例路由（或页面），基于@tanstack/react-router
+        - index.tsx 示例路由（或页面）用于 @tanstack/react-router
     - styles.css 全局样式
-  - vite.config.ts Vite与Vitest配置
-  - tsconfig.json 基础TypeScript配置（适用于源码及测试）
-  - tsconfig.app.json 源码的TypeScript配置
-  - tsconfig.spec.json 测试的TypeScript配置
+  - vite.config.ts Vite 和 Vitest 配置
+  - tsconfig.json 基础 TypeScript 配置（适用于源码和测试）
+  - tsconfig.app.json 源码 TypeScript 配置
+  - tsconfig.spec.json 测试 TypeScript 配置
 </FileTree>
 
-生成器还会在`packages/common/constructs`目录下创建用于部署网站的CDK基础设施代码：
+生成器还会在 `packages/common/constructs` 目录下创建用于部署网站的 CDK 基础设施代码：
 
 <FileTree>
   - src
     - app
       - static-websites
-        - \<name>.ts 网站专属基础设施
+        - \<name>.ts 网站专属基础设施代码
     - core
-      - static-website.ts 通用的StaticWebsite构造
+      - static-website.ts 通用 StaticWebsite 构造
 </FileTree>
 
-## 开发您的CloudScape网站
+## 开发 CloudScape 网站
 
-建议从[React官方文档](https://react.dev/learn)开始学习React基础知识，并参考[CloudScape组件文档](https://cloudscape.design/components/)了解可用组件及其使用方法。
+[React 文档](https://react.dev/learn) 是学习 React 基础开发的良好起点。您可以参考 [CloudScape 文档](https://cloudscape.design/components/) 了解可用组件及其使用方法。
 
 ### 路由管理
 
 #### 创建路由/页面
 
-生成的CloudScape网站已预装[TanStack Router](https://tanstack.com/router/v1)，添加新路由非常便捷：
+生成的 CloudScape 网站已预配置 [TanStack Router](https://tanstack.com/router/v1)，添加新路由非常简便：
 
 <Steps>
   1. [启动本地开发服务器](#local-development-server)
-  2. 在`src/routes`下创建新`<页面名称>.tsx`文件，文件路径即对应页面路径
-  3. 系统会自动生成`Route`和`RouteComponent`，您可在此开始构建页面
+  2. 在 `src/routes` 目录下创建新文件 `<page-name>.tsx`，文件路径对应路由路径
+  3. 系统会自动生成 `Route` 和 `RouteComponent`，您可以在此开始构建页面！
 </Steps>
 
 #### 页面间导航
 
-使用`Link`组件或`useNavigate`钩子实现页面跳转：
+您可以使用 `Link` 组件或 `useNavigate` 钩子实现页面跳转：
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -95,7 +94,7 @@ export const MyComponent = () => {
 
   const submit = async () => {
     const id = await ...
-    // 异步操作后使用`navigate`进行重定向
+    // 使用 `navigate` 在异步操作后重定向
     navigate({ to: '/products/$id', { params: { id }} });
   };
 
@@ -108,17 +107,17 @@ export const MyComponent = () => {
 };
 ```
 
-更多细节请参阅[TanStack Router文档](https://tanstack.com/router/latest/docs/framework/react/overview)。
+更多细节请参考 [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) 文档。
 
 ## 运行时配置
 
-通过AWS CDK基础设施提供的运行时配置，您的网站可以获取诸如API URL等部署时才能确定的参数。
+AWS CDK 基础设施的配置通过运行时配置提供给网站。这使得网站可以访问部署时才能确定的配置信息（如 API 地址）。
 
-### 基础设施配置
+### 基础设施
 
-在CDK基础设施中，可使用`RuntimeConfig`构造来添加和获取配置。由`@aws/nx-plugin`生成的CDK构造（如<Link path="guides/trpc">tRPC API</Link>和<Link path="guides/fastapi">FastAPI</Link>）会自动向`RuntimeConfig`添加相应值。
+`RuntimeConfig` CDK 构造可用于在基础设施中添加和获取配置。由 `@aws/nx-plugin` 生成的 CDK 构造（如 <Link path="guides/trpc">tRPC API</Link> 和 <Link path="guides/fastapi">FastAPI</Link>）会自动将相关配置值添加到 `RuntimeConfig`。
 
-网站CDK构造会将运行时配置以`runtime-config.json`文件形式部署至S3存储桶根目录。
+网站 CDK 构造会将运行时配置以 `runtime-config.json` 文件形式部署到 S3 存储桶根目录。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {9-10,12-13}
 import { Stack } from 'aws-cdk-lib';
@@ -129,22 +128,22 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // 自动向RuntimeConfig添加值
+    // 自动向 RuntimeConfig 添加值
     new MyApi(this, 'MyApi');
 
-    // 自动将运行时配置部署至runtime-config.json
+    // 自动部署运行时配置到 runtime-config.json
     new MyWebsite(this, 'MyWebsite');
   }
 }
 ```
 
 :::warning
-必须确保在声明网站构造_之后_再声明其他向`RuntimeConfig`添加值的构造，否则这些值将不会出现在`runtime-config.json`中。
+必须确保在声明网站构造 _之前_ 声明所有会向 `RuntimeConfig` 添加值的构造，否则这些配置将不会出现在 `runtime-config.json` 文件中。
 :::
 
 ### 网站代码
 
-在网站代码中，可使用`useRuntimeConfig`钩子获取运行时配置值：
+在网站代码中，可以使用 `useRuntimeConfig` 钩子获取运行时配置值：
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -159,45 +158,45 @@ const MyComponent = () => {
 
 ### 本地运行时配置
 
-运行[本地开发服务器](#local-development-server)时，需在`public`目录下放置`runtime-config.json`文件以便本地网站获取后端URL、身份配置等信息。
+运行 [本地开发服务器](#local-development-server) 时，需要在 `public` 目录下放置 `runtime-config.json` 文件，以便本地网站获取后端地址、身份配置等信息。
 
-网站项目已配置`load:runtime-config`目标，可用于从已部署应用拉取运行时配置文件：
+网站项目已配置 `load:runtime-config` 目标，可用于从已部署应用拉取 `runtime-config.json` 文件：
 
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-若修改了基础设施项目`src/main.ts`中的堆栈名称，需同步更新网站项目`project.json`文件中`load:runtime-config`目标对应的堆栈名称。
+如果修改了基础设施项目 `src/main.ts` 中的堆栈名称，需要同步更新网站项目 `project.json` 文件中 `load:runtime-config` 目标对应的堆栈名称。
 :::
 
 ## 本地开发服务器
 
-启动本地开发服务器前，请确保基础设施已部署且[已加载本地运行时配置](#local-runtime-config)。
+启动本地开发服务器前，请确保已部署基础设施并已 [加载本地运行时配置](#local-runtime-config)。
 
-随后可运行`serve`目标：
+然后可以运行 `serve` 目标：
 
 <NxCommands commands={['run <my-website>:serve']} />
 
-## 构建部署
+## 构建
 
-通过`build`目标构建网站。该命令使用Vite生成生产环境包（存放于根目录`dist/packages/<my-website>/bundle`），同时进行类型检查、编译和代码规范检测：
+使用 `build` 目标进行构建。该操作会使用 Vite 在根目录 `dist/packages/<my-website>/bundle` 下生成生产环境包，同时执行类型检查、编译和代码校验。
 
 <NxCommands commands={['run <my-website>:build']} />
 
-## 测试指南
+## 测试
 
-网站测试与标准TypeScript项目测试类似，详情请参考<Link path="guides/typescript-project#testing">TypeScript项目指南</Link>。
+网站测试与标准 TypeScript 项目测试类似，请参考 <Link path="guides/typescript-project#testing">TypeScript 项目指南</Link> 获取详细信息。
 
-针对React测试，项目已预装React Testing Library。具体使用方法请查阅[React Testing Library文档](https://testing-library.com/docs/react-testing-library/example-intro)。
+针对 React 的专项测试，项目已预装 React Testing Library。具体使用方法请参考 [React Testing Library 文档](https://testing-library.com/docs/react-testing-library/example-intro)。
 
-运行`test`目标执行测试：
+可以使用 `test` 目标运行测试：
 
 <NxCommands commands={['run <my-website>:test']} />
 
-## 网站部署
+## 部署网站
 
-推荐使用<Link path="guides/typescript-infrastructure">TypeScript基础设施生成器</Link>创建CDK应用来部署网站。
+我们推荐使用 <Link path="guides/typescript-infrastructure">TypeScript 基础设施生成器</Link> 创建 CDK 应用来部署网站。
 
-可利用`packages/common/constructs`中生成的CDK构造进行部署：
+可以使用 `packages/common/constructs` 中生成的 CDK 构造来部署网站：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
 import { Stack } from 'aws-cdk-lib';

--- a/docs/src/content/docs/zh/guides/fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/fastapi.mdx
@@ -11,29 +11,28 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/fast-api/schema.json';
 
-[FastAPI](https://fastapi.tiangolo.com/) 是用于构建 Python API 的框架。
+[FastAPI](https://fastapi.tiangolo.com/) 是一个用于构建 Python API 的框架。
 
-FastAPI 生成器可创建带有 AWS CDK 基础设施配置的新 FastAPI 项目。生成的后端使用 AWS Lambda 实现无服务器部署，并通过 AWS API Gateway API 对外暴露。项目内置了 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) 用于可观测性，包含日志记录、AWS X-Ray 追踪和 CloudWatch 指标。
+FastAPI 生成器会创建一个带有 AWS CDK 基础设施配置的新 FastAPI 项目。生成的后端使用 AWS Lambda 进行无服务器部署，通过 AWS API Gateway API 对外暴露。项目默认配置了 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) 用于可观测性，包括日志记录、AWS X-Ray 追踪和 Cloudwatch 指标。
 
 ## 使用方式
 
 ### 生成 FastAPI
 
-可通过两种方式生成新 FastAPI：
+有两种方式可以生成新的 FastAPI 项目：
 
 <RunGenerator generator="py#fast-api" />
 
 ### 选项配置
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#fast-api" />
 
 <Snippet name="api/api-choice-note" />
 
 ## 生成器输出
 
-生成器将在 `<directory>/<api-name>` 目录下创建以下项目结构：
+生成器会在 `<directory>/<api-name>` 目录下创建以下项目结构：
 
 <FileTree>
 
@@ -41,7 +40,7 @@ FastAPI 生成器可创建带有 AWS CDK 基础设施配置的新 FastAPI 项目
 - pyproject.toml Python 项目配置和依赖项
 - \<module_name>
   - \_\_init\_\_.py 模块初始化
-  - init.py 设置 FastAPI 应用并配置 powertools 中间件
+  - init.py 初始化 FastAPI 应用并配置 powertools 中间件
   - main.py API 实现
 - scripts
   - generate_open_api.py 从 FastAPI 应用生成 OpenAPI 模式的脚本
@@ -52,7 +51,7 @@ FastAPI 生成器可创建带有 AWS CDK 基础设施配置的新 FastAPI 项目
 
 ## 实现 FastAPI
 
-API 主实现位于 `main.py` 文件，在此定义 API 路由及其实现。示例如下：
+主要 API 实现位于 `main.py` 文件，用于定义 API 路由及其实现。示例如下：
 
 ```python
 from .init import app, tracer
@@ -76,13 +75,13 @@ def create_item(item: Item):
 2. 错误处理中间件
 3. 请求/响应关联
 4. 指标收集
-5. 使用 Mangum 的 AWS Lambda 处理器
+5. 使用 Mangum 的 AWS Lambda 处理程序
 
-### 通过 AWS Lambda Powertools 实现可观测性
+### 使用 AWS Lambda Powertools 进行可观测
 
 #### 日志记录
 
-生成器配置了使用 AWS Lambda Powertools 的结构化日志记录。可在路由处理器中访问日志记录器：
+生成器使用 AWS Lambda Powertools 配置结构化日志记录。可在路由处理程序中访问日志记录器：
 
 ```python
 from .init import app, logger
@@ -98,11 +97,11 @@ def read_item(item_id: int):
 - 用于请求追踪的关联 ID
 - 请求路径和方法
 - Lambda 上下文信息
-- 冷启动标识
+- 冷启动指示器
 
 #### 追踪
 
-自动配置 AWS X-Ray 追踪。可为追踪添加自定义子分段：
+自动配置 AWS X-Ray 追踪。可为追踪添加自定义子段：
 
 ```python
 from .init import app, tracer
@@ -110,7 +109,7 @@ from .init import app, tracer
 @app.get("/items/{item_id}")
 @tracer.capture_method
 def read_item(item_id: int):
-    # 创建新子分段
+    # 创建新子段
     with tracer.provider.in_subsegment("fetch-item-details"):
         # 业务逻辑
         return {"item_id": item_id}
@@ -130,12 +129,12 @@ def read_item(item_id: int):
     return {"item_id": item_id}
 ```
 
-默认指标包含：
+默认指标包括：
 
 - 请求计数
 - 成功/失败计数
 - 冷启动指标
-- 按路由统计指标
+- 按路由统计的指标
 
 ### 错误处理
 
@@ -151,24 +150,24 @@ def read_item(item_id: int):
     return {"item_id": item_id}
 ```
 
-未处理异常会被中间件捕获并：
+未捕获的异常会被中间件处理：
 
-1. 记录完整异常及堆栈跟踪
+1. 记录完整异常和堆栈跟踪
 2. 记录失败指标
-3. 返回安全的 500 响应给客户端
+3. 向客户端返回安全的 500 响应
 4. 保留关联 ID
 
 :::tip
-若计划使用 `api-connection` 生成器，建议为 API 操作指定响应模型以获得更好的代码生成效果。<Link path="guides/api-connection/react-fastapi#errors">详见此处</Link>。
+建议为 API 操作指定响应模型，以便在使用 `api-connection` 生成器时获得更好的代码生成效果。<Link path="guides/api-connection/react-fastapi#errors">查看详情</Link>。
 :::
 
 ### 流式传输
 
-使用 FastAPI 可以通过 [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) 响应类型实现流式响应。
+使用 FastAPI 可以通过 [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse) 响应类型向调用方流式传输响应。
 
 #### 基础设施变更
 
-由于 AWS API Gateway 不支持流式响应，需要将 FastAPI 部署到支持此功能的平台。最简单的选择是使用 AWS Lambda 函数 URL。为此可替换生成的 `common/constructs/src/app/apis/<name>-api.ts` 构造，改用支持函数 URL 的部署方式。
+由于 AWS API Gateway 不支持流式响应，需要将 FastAPI 部署到支持该功能的平台。最简单的选择是使用 AWS Lambda 函数 URL。为此可以替换生成的 `common/constructs/src/app/apis/<name>-api.ts` 构造。
 
 <details>
 <summary>流式 FunctionURL 构造示例</summary>
@@ -241,7 +240,7 @@ export class MyApi extends Construct {
 
     new CfnOutput(this, 'MyApiUrl', { value: functionUrl.url });
 
-    // 将 API URL 注册到运行时配置以供客户端发现
+    // 在运行时配置中注册 API URL 供客户端发现
     RuntimeConfig.ensure(this).config.apis = {
       ...RuntimeConfig.ensure(this).config.apis!,
       MyApi: functionUrl.url,
@@ -267,18 +266,18 @@ export class MyApi extends Construct {
 </details>
 
 :::note
-完整端到端示例请参考 <Link path="/get_started/tutorials/dungeon-game/overview">地下城冒险教程</Link>
+完整端到端示例请参考 <Link path="/get_started/tutorials/dungeon-game/overview">地牢冒险教程</Link>
 :::
 
 #### 实现
 
-更新基础设施支持流式传输后，可在 FastAPI 中实现流式 API。API 应：
+更新基础设施支持流式传输后，可以在 FastAPI 中实现流式 API。API 应：
 
 - 返回 [`StreamingResponse`](https://fastapi.tiangolo.com/reference/responses/?h=streaming#fastapi.responses.StreamingResponse)
 - 声明每个响应块的返回类型
-- 若计划使用 <Link path="guides/api-connection/react-fastapi">API 连接</Link>，需添加 OpenAPI 扩展 `x-streaming: true`
+- 添加 OpenAPI 供应商扩展 `x-streaming: true`（如果计划使用 <Link path="guides/api-connection/react-fastapi">API 连接</Link>）
 
-例如，若需从 API 流式传输 JSON 对象序列，可如下实现：
+例如，若要从 API 流式传输 JSON 对象序列，可如下实现：
 
 ```py /return (StreamingResponse)/ /openapi_extra[^)]*/ /-> (Chunk)/
 from pydantic import BaseModel
@@ -299,11 +298,11 @@ def my_stream() -> Chunk:
 
 #### 消费
 
-要消费流式响应，可使用 <Link path="guides/api-connection/react-fastapi#consuming-a-stream">API 连接生成器</Link>，其提供类型安全的方法来迭代流式块。
+要消费流式响应，可使用 <Link path="guides/api-connection/react-fastapi#consuming-a-stream">API 连接生成器</Link>，该生成器将提供类型安全的方法来迭代流式数据块。
 
 ## 部署 FastAPI
 
-FastAPI 生成器在 `common/constructs` 目录中创建用于部署 API 的 CDK 构造。可在 CDK 应用中使用：
+FastAPI 生成器在 `common/constructs` 文件夹中创建了用于部署 API 的 CDK 构造。可在 CDK 应用中使用：
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs';
@@ -318,7 +317,7 @@ export class ExampleStack extends Stack {
 }
 ```
 
-此配置包含：
+该配置包含：
 
 1. 为 FastAPI 应用中的每个操作创建 AWS Lambda 函数
 2. 使用 API Gateway HTTP/REST API 作为函数触发器
@@ -335,16 +334,16 @@ export class ExampleStack extends Stack {
 
 由于 FastAPI 操作在 Python 中定义而基础设施在 TypeScript 中定义，我们通过代码生成向 CDK 构造提供元数据，以实现类型安全的集成接口。
 
-在公共构造的 `project.json` 中添加了 `generate:<ApiName>-metadata` 目标来促进此代码生成，该目标生成如 `packages/common/constructs/src/generated/my-api/metadata.gen.ts` 的文件。由于这是在构建时生成的，版本控制中会忽略该文件。
+在公共构造的 `project.json` 中添加了 `generate:<ApiName>-metadata` 目标来促进代码生成，生成如 `packages/common/constructs/src/generated/my-api/metadata.gen.ts` 的文件。由于这是构建时生成的，版本控制中会忽略该文件。
 
 :::note
-更改 API 后需要执行构建以确保 CDK 构造使用的类型保持最新。
+当 API 发生变更时，需要运行构建以确保 CDK 构造使用的类型是最新的。
 
 <NxCommands commands={["run-many --target build --all"]} />
 :::
 
 :::tip
-若同时进行 CDK 基础设施和 FastAPI 开发，可使用 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) 在每次 API 变更时重新生成类型：
+如果同时进行 CDK 基础设施和 FastAPI 开发，可以使用 [`nx watch`](https://nx.dev/nx-api/nx/documents/watch) 在每次 API 变更时重新生成类型：
 
 <NxCommands
   commands={[
@@ -354,9 +353,9 @@ export class ExampleStack extends Stack {
 />
 :::
 
-### 权限授予
+### 授权访问
 
-可通过 `grantInvokeAccess` 方法授予 API 访问权限：
+可使用 `grantInvokeAccess` 方法授予 API 访问权限：
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -364,7 +363,7 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## 本地开发
 
-生成器配置了可通过以下命令运行的本地开发服务器：
+生成器配置了本地开发服务器，可通过以下命令运行：
 
 <NxCommands commands={['run my-api:serve']} />
 

--- a/docs/src/content/docs/zh/guides/license.mdx
+++ b/docs/src/content/docs/zh/guides/license.mdx
@@ -8,11 +8,10 @@ description: "许可证生成器的参考文档"
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/license/schema.json';
 
-自动管理工作区中的 `LICENSE` 文件和源代码头部声明。
+自动管理工作区中的 `LICENSE` 文件和源代码头部。
 
-该生成器注册了[同步生成器](https://nx.dev/concepts/sync-generators)，作为 `lint` 目标的一部分执行，确保源文件符合指定的许可证内容和格式，同时确保项目的 `LICENSE` 文件正确无误，并在相关项目文件（`package.json`、`pyproject.toml`）中包含许可证信息。
+此生成器注册了一个[同步生成器](https://nx.dev/concepts/sync-generators)，作为 `lint` 目标的一部分执行，确保您的源文件符合所需的许可证内容和格式，同时确保项目的 `LICENSE` 文件正确无误，且相关项目文件（`package.json`、`pyproject.toml`）包含许可信息。
 
 ## 使用方式
 
@@ -20,40 +19,40 @@ import schema from '../../../../../../packages/nx-plugin/src/license/schema.json
 
 <RunGenerator generator="license" />
 
-### 选项配置
+### 选项
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="license" />
 
 ## 生成器输出
 
 生成器将创建或更新以下文件：
 
 <FileTree>
-  - nx.json 配置 lint 目标以运行许可证同步生成器
-  - aws-nx-plugin.config.mts 许可证同步生成器的配置文件
+  - nx.json 配置了运行许可证同步生成器的 lint 目标
+  - aws-nx-plugin.config.mts 许可证同步生成器的配置
 </FileTree>
 
-`aws-nx-plugin.config.mts` 中会添加默认的许可证头部内容及格式配置，用于为若干文件类型写入合适的头部声明。您可能需要根据需求自定义此配置，详见下方[配置说明](#configuration)。
+`aws-nx-plugin.config.mts` 中添加了许可证头部内容和格式的默认配置，用于为部分文件类型写入适当的头部。您可能需要进一步自定义；请参阅下方的[配置部分](#configuration)。
 
 ## 工作流程
 
-每当构建项目（运行 `lint` 目标时），许可证同步生成器会确保项目中的许可证信息与配置一致（参见[下方许可证同步行为](#license-sync-behaviour)）。若检测到不同步情况，您将收到如下提示：
+每当构建项目时（`lint` 目标运行），许可证同步生成器会确保项目中的许可信息与配置匹配（参见[下方许可证同步行为](#license-sync-behaviour)）。若检测到不一致，您将收到如下消息：
 
 ```bash
   NX   工作区不同步
 
-[@aws/nx-plugin:license#sync]: 项目 LICENSE 文件不同步:
+[@aws/nx-plugin:license#sync]: 项目 LICENSE 文件不同步：
 - LICENSE
 - packages/<my-project>LICENSE
 
-项目 package.json 文件不同步:
+项目 package.json 文件不同步：
 - package.json
 
-项目 pyproject.toml 文件不同步:
+项目 pyproject.toml 文件不同步：
 - pyproject.toml
 - packages/<my-python-project>/pyproject.toml
 
-以下源代码文件中的许可证头部声明不同步:
+以下源文件中的许可证头部不同步：
 - packages/<my-project>/src/index.ts
 - packages/<my-python-project>/main.py
 
@@ -61,44 +60,44 @@ import schema from '../../../../../../packages/nx-plugin/src/license/schema.json
 
 ? 是否要同步已识别的变更以使工作区保持最新？
 是，同步变更并运行任务
-否，不进行同步直接运行任务
+否，不同步变更直接运行任务
 ```
 
-选择 `是` 进行同步。
+选择 `是` 以同步变更。
 
 :::note
-请确保检查许可证同步生成器所做的变更并提交至版本控制系统，以避免持续集成构建任务因许可证不同步而失败。
+请确保将许可证同步生成器所做的变更提交至版本控制，以避免持续集成构建任务因许可证不同步而失败。
 :::
 
 ## 许可证同步行为
 
 许可证同步生成器执行三项主要任务：
 
-### 1. 同步源代码文件许可证头部声明
+### 1. 同步源文件许可证头部
 
-同步生成器运行时，将确保工作区中所有源代码文件（基于配置）包含正确的许可证头部声明。该头部声明将被写入文件的首个块注释或连续行注释区域（文件若存在 shebang/hashbang 声明则位于其后）。
+同步生成器运行时，将确保工作区中所有源代码文件（基于配置）包含适当的许可证头部。头部以文件的第一个块注释或连续行注释形式写入（文件中的 shebang/hashbang 除外）。
 
-您可随时更新配置以调整需包含/排除的文件范围，或修改不同文件类型的许可证头部内容与格式。详见下方[配置说明](#configuration)。
+您可随时更新配置以更改应包含或排除的文件，以及不同文件类型的许可证头部内容或格式。更多细节请参阅[配置部分](#configuration)。
 
 ### 2. 同步 LICENSE 文件
 
-同步生成器运行时，将确保根目录 `LICENSE` 文件与配置的许可证一致，同时验证所有子项目的 `LICENSE` 文件正确性。
+同步生成器运行时，将确保根 `LICENSE` 文件与配置的许可证一致，并确保所有子项目也包含正确的 `LICENSE` 文件。
 
-必要时可通过配置排除特定项目。详见下方[配置说明](#configuration)。
+必要时可通过配置排除项目。更多细节请参阅[配置部分](#configuration)。
 
-### 3. 同步项目文件中的许可证信息
+### 3. 同步项目文件中的许可信息
 
-同步生成器运行时，将确保 `package.json` 和 `pyproject.toml` 文件中的 `license` 字段与配置的许可证一致。
+同步生成器运行时，将确保 `package.json` 和 `pyproject.toml` 文件中的 `license` 字段设置为配置的许可证。
 
-必要时可通过配置排除特定项目。详见下方[配置说明](#configuration)。
+必要时可通过配置排除项目。更多细节请参阅[配置部分](#configuration)。
 
-## 配置说明
+## 配置
 
-配置定义于工作区根目录的 `aws-nx-plugin.config.mts` 文件中。
+配置定义在工作区根目录的 `aws-nx-plugin.config.mts` 文件中。
 
-### SPDX 与版权方
+### SPDX 与版权持有者
 
-可通过 `spdx` 配置属性随时更新选择的许可证：
+可通过 `spdx` 配置属性随时更新所选许可证：
 
 ```typescript title="aws-nx-plugin.config.mts" {3}
 export default {
@@ -108,9 +107,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-同步生成器运行时，所有 `LICENSE` 文件、`package.json` 和 `pyproject.toml` 文件将根据配置的许可证进行更新。
+同步生成器运行时，所有 `LICENSE` 文件、`package.json` 和 `pyproject.toml` 文件将更新以反映配置的许可证。
 
-您还可配置版权方和版权年份（部分 `LICENSE` 文件包含此信息）：
+可额外配置版权持有者和年份（部分 `LICENSE` 文件包含）：
 
 ```typescript title="aws-nx-plugin.config.mts" {4,5}
 export default {
@@ -122,13 +121,13 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-### 许可证头部声明
+### 许可证头部
 
 #### 内容
 
 许可证头部内容可通过两种方式配置：
 
-1. 使用内联内容：
+1. 内联内容：
 
 ```typescript title="aws-nx-plugin.config.mts" {5-9}
 export default {
@@ -136,9 +135,9 @@ export default {
     header: {
       content: {
         lines: [
-          '版权所有：我的公司',
-          '基于 MIT 协议许可',
-          '保留所有权利',
+          'Copyright: My Company, Incorporated.',
+          'Licensed under the MIT License',
+          'All rights reserved',
         ];
       }
       // ... 格式配置
@@ -164,14 +163,14 @@ export default {
 
 #### 格式
 
-可通过 glob 模式为不同文件类型指定许可证头部的行注释、块注释或组合格式：
+可通过 glob 模式为不同文件类型指定许可证头部格式。格式配置支持行注释、块注释或两者结合：
 
 ```typescript title="aws-nx-plugin.config.mts" {7-29}
 export default {
   license: {
     header: {
       content: {
-        lines: ['此处填写版权声明'],
+        lines: ['Copyright notice here'],
       },
       format: {
         // 行注释
@@ -189,7 +188,7 @@ export default {
           lineStart: ' * ',
           blockEnd: ' */',
         },
-        // 带头尾的行注释
+        // 带头部/尾部的行注释
         '**/*.py': {
           blockStart: '# ------------',
           lineStart: '# ',
@@ -201,23 +200,23 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-格式配置支持以下属性：
+格式配置支持：
 
-- `blockStart`: 许可证内容前的起始文本（如块注释起始符）
-- `lineStart`: 每行许可证内容的前缀文本
-- `lineEnd`: 每行许可证内容的后缀文本
-- `blockEnd`: 许可证内容后的结束文本（如块注释结束符）
+- `blockStart`: 许可证内容前的文本（如开启块注释）
+- `lineStart`: 每行许可证内容前的文本
+- `lineEnd`: 每行许可证内容后的文本
+- `blockEnd`: 许可证内容后的文本（如结束块注释）
 
 #### 自定义注释语法
 
-对于原生不支持的文件类型，可通过指定自定义注释语法来标识现有许可证头部：
+对于原生不支持的文件类型，可指定自定义注释语法以帮助同步生成器识别现有许可证头部：
 
 ```typescript title="aws-nx-plugin.config.mts" {12-22}
 export default {
   license: {
     header: {
       content: {
-        lines: ['我的许可证头部'],
+        lines: ['My license header'],
       },
       format: {
         '**/*.xyz': {
@@ -243,16 +242,16 @@ export default {
 
 #### 排除文件
 
-在 Git 仓库中默认遵循所有 `.gitignore` 文件，确保仅同步受版本控制的文件。非 Git 仓库中默认包含所有文件，除非在配置中显式排除。
+默认在 git 仓库中，所有 `.gitignore` 文件会被遵循以确保仅同步版本控制管理的文件。非 git 仓库中，所有文件均被考虑，除非在配置中显式排除。
 
-可通过 glob 模式排除特定文件：
+可通过 glob 模式排除文件：
 
 ```typescript title="aws-nx-plugin.config.mts" {12-16}
 export default {
   license: {
     header: {
       content: {
-        lines: ['我的许可证头部'],
+        lines: ['My license header'],
       },
       format: {
         '**/*.ts': {
@@ -267,7 +266,7 @@ export default {
 
 ### 排除项目文件同步
 
-默认同步所有 `LICENSE` 文件、`package.json` 文件和 `pyproject.toml` 文件。
+默认同步所有 `LICENSE`、`package.json` 和 `pyproject.toml` 文件。
 
 可通过 glob 模式排除特定项目或文件：
 
@@ -276,9 +275,9 @@ export default {
   license: {
     files: {
       exclude: [
-        // 不同步 LICENSE 文件、package.json 和 pyproject.toml
+        // 不同步 LICENSE、package.json 或 pyproject.toml
         'packages/excluded-project',
-        // 不同步 LICENSE 文件，但同步 package.json 和/或 pyproject.toml
+        // 不同步 LICENSE，但同步 package.json 和/或 pyproject.toml
         'apps/internal/LICENSE',
       ];
     }
@@ -290,7 +289,7 @@ export default {
 
 禁用许可证同步生成器：
 
-1. 从 `aws-nx-plugin.config.mts` 配置中移除 `license` 配置节（或删除 `aws-nx-plugin.config.mts` 文件）
+1. 从 `aws-nx-plugin.config.mts` 配置中移除 `license` 部分（或删除该文件）
 2. 从 `targetDefaults.lint.syncGenerators` 中移除 `@aws/nx-plugin:license#sync` 生成器
 
-重新启用时只需再次运行 `license` 生成器即可。
+重新启用时，只需再次运行 `license` 生成器。

--- a/docs/src/content/docs/zh/guides/nx-generator.mdx
+++ b/docs/src/content/docs/zh/guides/nx-generator.mdx
@@ -11,50 +11,49 @@ import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/schema.json';
 
-为 TypeScript 项目添加一个 [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators)，帮助自动化重复任务，例如组件脚手架或强制特定项目结构。
+为 TypeScript 项目添加 [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators)，帮助自动化重复任务，如组件脚手架或强制特定项目结构。
 
 ## 使用方式
 
 ### 生成生成器
 
-有两种方式可以生成生成器：
+可通过两种方式创建生成器：
 
 <RunGenerator generator="ts#nx-generator" />
 
 ### 选项参数
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#nx-generator" />
 
 ## 生成器输出
 
-生成器将在指定的 `pluginProject` 内创建以下项目文件：
+生成器将在指定的 `pluginProject` 中创建以下项目文件：
 
 <FileTree>
   - src/\<name>/
-    - schema.json 生成器的输入模式定义
-    - schema.d.ts 模式文件的 TypeScript 类型
-    - generator.ts 生成器实现桩代码
+    - schema.json 生成器输入模式定义
+    - schema.d.ts 模式对应的 TypeScript 类型
+    - generator.ts 生成器实现存根
     - generator.spec.ts 生成器测试用例
-  - generators.json 定义生成器的 Nx 配置文件
-  - package.json 创建或更新以添加 "generators" 入口
+  - generators.json Nx 生成器配置
+  - package.json 创建或更新以添加 "generators" 条目
   - tsconfig.json 更新为使用 CommonJS
 </FileTree>
 
 :::warning
-本生成器会将选定的 `pluginProject` 更新为使用 CommonJS，因目前 Nx 生成器仅支持 CommonJS（[关于 ESM 支持请参考此 GitHub issue](https://github.com/nrwl/nx/issues/15682)）。
+本生成器会将选定的 `pluginProject` 更新为使用 CommonJS，因目前 Nx 生成器仅支持 CommonJS（[ESM 支持相关 GitHub 问题](https://github.com/nrwl/nx/issues/15682)）。
 :::
 
 ## 本地生成器
 
 :::tip
-建议先使用 `ts#project` 生成器为所有生成器创建专用的 TypeScript 项目。例如：
+建议先使用 `ts#project` 生成器创建专门用于存放生成器的 TypeScript 项目。例如：
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-运行 `ts#nx-generator` 生成器时选择本地的 `nx-plugin` 项目，并指定名称及可选的目录和描述。
+运行 `ts#nx-generator` 生成器时选择本地 `nx-plugin` 项目，并指定名称、可选目录和描述。
 
 ### 定义模式
 
@@ -62,42 +61,42 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/nx-generator/sch
 
 #### 基础结构
 
-schema.json 文件基本结构如下：
+schema.json 文件基本结构：
 
 ```json
 {
   "$schema": "https://json-schema.org/schema",
   "$id": "YourGeneratorName",
-  "title": "Your Generator Title",
-  "description": "Description of what your generator does",
+  "title": "生成器标题",
+  "description": "生成器功能描述",
   "type": "object",
   "properties": {
-    // 生成器选项在此定义
+    // 生成器选项定义
   },
-  "required": ["requiredOption1", "requiredOption2"]
+  "required": ["必填选项1", "必填选项2"]
 }
 ```
 
 #### 简单示例
 
-基础选项的简单示例：
+基础选项示例：
 
 ```json
 {
   "$schema": "https://json-schema.org/schema",
   "$id": "ComponentGenerator",
-  "title": "Create a Component",
-  "description": "Creates a new React component",
+  "title": "创建组件",
+  "description": "创建新的 React 组件",
   "type": "object",
   "properties": {
     "name": {
       "type": "string",
-      "description": "Component name",
+      "description": "组件名称",
       "x-priority": "important"
     },
     "directory": {
       "type": "string",
-      "description": "组件生成目录",
+      "description": "组件创建目录",
       "default": "src/components"
     },
     "withTests": {
@@ -110,19 +109,19 @@ schema.json 文件基本结构如下：
 }
 ```
 
-#### 交互式提示 (CLI)
+#### 交互式提示（CLI）
 
-通过添加 `x-prompt` 属性自定义 CLI 运行生成器时的提示：
+通过添加 `x-prompt` 属性自定义 CLI 提示：
 
 ```json
 "name": {
   "type": "string",
-  "description": "Component name",
-  "x-prompt": "请输入组件名称？"
+  "description": "组件名称",
+  "x-prompt": "请输入组件名称："
 }
 ```
 
-布尔类型选项可使用 yes/no 提示：
+布尔选项使用是/否提示：
 
 ```json
 "withTests": {
@@ -134,7 +133,7 @@ schema.json 文件基本结构如下：
 
 #### 下拉选择
 
-对于固定选项集合，使用 `enum` 创建下拉选择：
+固定选项使用 `enum` 定义：
 
 ```json
 "style": {
@@ -147,22 +146,22 @@ schema.json 文件基本结构如下：
 
 #### 项目选择下拉
 
-常用模式是让用户从工作区现有项目中选择：
+从工作区现有项目中选择：
 
 ```json
 "project": {
   "type": "string",
-  "description": "目标项目",
+  "description": "添加组件的目标项目",
   "x-prompt": "请选择要添加组件的项目：",
   "x-dropdown": "projects"
 }
 ```
 
-`x-dropdown: "projects"` 属性指示 Nx 用工作区所有项目填充下拉列表。
+`x-dropdown: "projects"` 指示 Nx 用工作区所有项目填充下拉列表。
 
 #### 位置参数
 
-配置选项作为命令行位置参数：
+配置命令行位置参数：
 
 ```json
 "name": {
@@ -176,7 +175,7 @@ schema.json 文件基本结构如下：
 }
 ```
 
-用户可运行 `nx g your-generator my-component` 代替 `nx g your-generator --name=my-component`。
+允许用户通过 `nx g your-generator my-component` 而非 `nx g your-generator --name=my-component` 运行。
 
 #### 设置优先级
 
@@ -199,18 +198,18 @@ schema.json 文件基本结构如下：
 ```json
 "directory": {
   "type": "string",
-  "description": "组件生成目录",
+  "description": "组件创建目录",
   "default": "src/components"
 }
 ```
 
 #### 更多信息
 
-详细模式说明参考 [Nx 生成器选项文档](https://nx.dev/extending-nx/recipes/generator-options)。
+详见 [Nx 生成器选项文档](https://nx.dev/extending-nx/recipes/generator-options)。
 
-#### 通过 schema.d.ts 生成类型
+#### 使用 schema.d.ts 的类型定义
 
-生成器会创建 `schema.d.ts` 文件为选项提供 TypeScript 类型：
+生成器同时创建 `schema.d.ts` 提供类型定义：
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -220,36 +219,33 @@ export interface YourGeneratorSchema {
 }
 ```
 
-该接口用于生成器实现以提供类型安全和代码补全：
+该接口用于生成器实现以提供类型安全：
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // TypeScript 知晓所有选项类型
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-修改 `schema.json` 后必须更新 `schema.d.ts`：
-- 添加/删除属性
+修改 `schema.json` 后必须同步更新 `schema.d.ts`，包括：
+- 增删属性
 - 修改属性类型
-- 设置必选/可选（可选属性使用 `?` 后缀）
+- 设置必填/可选（可选属性使用 `?` 后缀）
 
-TypeScript 接口应准确反映 JSON 模式定义。
+TypeScript 接口需准确反映 JSON 模式结构。
 :::
 
 ### 实现生成器
 
 创建生成器后，可在 `generator.ts` 中编写实现逻辑。
 
-生成器是操作虚拟文件系统 (`Tree`) 的函数，只有在生成器执行完成后才会将变更写入磁盘（"dry-run" 模式除外）。
+生成器函数操作虚拟文件系统 (`Tree`)，仅在执行完成后写入实际文件（"dry-run" 模式除外）。
 
-常用操作示例：
-
-#### 读写文件
+#### 文件读写
 
 ```typescript
 // 读取文件
@@ -275,56 +271,39 @@ generateFiles(
   joinPathFragments(__dirname, 'files'), // 模板目录
   'path/to/output', // 输出目录
   {
-    // 模板变量替换
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
-    // 添加更多变量
   },
 );
 ```
 
 #### TypeScript AST 操作
 
-推荐安装 [TSQuery](https://github.com/phenomnomnominal/tsquery) 辅助 AST 操作：
+推荐安装 [TSQuery](https://github.com/phenomnomnominal/tsquery) 进行 AST 操作：
 
 ```typescript
 import { tsquery } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
 
-// 示例：递增文件版本号
-
-// 将文件内容解析为 AST
+// 示例：递增版本号
 const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// 查找匹配节点
 const nodes = tsquery.query(
   sourceFile,
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
 );
 
 if (nodes.length > 0) {
-  // 获取数值字面量节点
   const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // 递增版本号
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // 替换 AST 节点
+  const newVersion = Number(numericNode.text) + 1;
   const result = tsquery.replace(
     sourceFile,
     'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
     () => ts.factory.createNumericLiteral(newVersion),
   );
-
-  // 将更新内容写回 Tree
   tree.write(
     'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
+    ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
       .printNode(ts.EmitHint.Unspecified, result, sourceFile),
   );
 }
@@ -339,25 +318,19 @@ if (nodes.length > 0) {
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
 
-// 添加 package.json 依赖
 addDependenciesToPackageJson(
   tree,
-  {
-    'new-dependency': '^1.0.0',
-  },
-  {
-    'new-dev-dependency': '^2.0.0',
-  },
+  { 'new-dependency': '^1.0.0' },
+  { 'new-dev-dependency': '^2.0.0' },
 );
 ```
 
 :::note
-添加依赖后可通过回调函数自动安装：
+添加依赖后可通过回调安装：
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// 生成器返回的回调函数可执行安装任务
 return () => {
   installPackagesTask(tree);
 };
@@ -369,26 +342,20 @@ return () => {
 ```typescript
 import { formatFiles } from '@nx/devkit';
 
-// 格式化所有修改过的文件
 await formatFiles(tree);
 ```
 
-#### 读写 JSON 文件
+#### JSON 文件操作
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// 读取 JSON 文件
 const packageJson = readJson(tree, 'package.json');
 
-// 更新 JSON 文件
-updateJson(tree, 'tsconfig.json', (json) => {
-  json.compilerOptions = {
-    ...json.compilerOptions,
-    strict: true,
-  };
-  return json;
-});
+updateJson(tree, 'tsconfig.json', (json) => ({
+  ...json,
+  compilerOptions: { ...json.compilerOptions, strict: true }
+}));
 ```
 
 ### 运行生成器
@@ -398,103 +365,62 @@ updateJson(tree, 'tsconfig.json', (json) => {
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-若在 VSCode 插件中看不到生成器，可通过以下命令刷新 Nx 工作区：
+若 VSCode 插件未显示生成器，可刷新 Nx 工作区：
 
 <NxCommands commands={['reset']} />
 :::
 
 ### 测试生成器
 
-生成器单元测试编写模式示例：
+单元测试示例：
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { yourGenerator } from './generator';
 
-describe('your generator', () => {
+describe('生成器测试', () => {
   let tree;
 
   beforeEach(() => {
-    // 创建空工作区树
     tree = createTreeWithEmptyWorkspace();
-
-    // 添加预置文件
-    tree.write(
-      'project.json',
-      JSON.stringify({
-        name: 'test-project',
-        sourceRoot: 'src',
-      }),
-    );
-
-    tree.write('src/existing-file.ts', 'export const existing = true;');
+    tree.write('project.json', JSON.stringify({ name: 'test-project' }));
   });
 
   it('应生成预期文件', async () => {
-    // 运行生成器
-    await yourGenerator(tree, {
-      name: 'test',
-      // 其他必填参数
-    });
-
-    // 检查文件生成
+    await yourGenerator(tree, { name: 'test' });
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
-
-    // 检查文件内容
-    const content = tree.read('src/test/file.ts', 'utf-8');
-    expect(content).toContain('export const test');
-
-    // 可使用快照测试
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
-  it('应更新已有文件', async () => {
-    await yourGenerator(tree, {
-      name: 'test',
-      // 其他参数
-    });
-
-    const content = tree.read('src/existing-file.ts', 'utf-8');
-    expect(content).toContain('import { test } from');
-  });
-
   it('应处理错误', async () => {
-    await expect(
-      yourGenerator(tree, {
-        name: 'invalid',
-        // 触发错误的参数
-      }),
-    ).rejects.toThrow('预期错误信息');
+    await expect(yourGenerator(tree, { name: 'invalid' }))
+      .rejects.toThrow('预期错误信息');
   });
 });
 ```
 
-测试关键点：
-- 使用 `createTreeWithEmptyWorkspace()` 创建虚拟文件系统
-- 预先设置必要文件
-- 测试新文件生成和已有文件更新
+测试要点：
+- 使用 `createTreeWithEmptyWorkspace` 创建虚拟文件系统
+- 设置前置文件
+- 测试文件创建与更新
 - 使用快照测试复杂内容
-- 测试错误处理逻辑
+- 验证错误处理
 
-## 为 @aws/nx-plugin 贡献生成器
+## 向 @aws/nx-plugin 贡献生成器
 
-可使用 `ts#nx-generator` 在 `@aws/nx-plugin` 中创建生成器框架。
-
-在仓库中运行此生成器将创建以下文件：
+使用 `ts#nx-generator` 在 `@aws/nx-plugin` 中创建生成器时，将生成以下文件：
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json 生成器模式文件
-    - schema.d.ts 类型定义
-    - generator.ts 生成器实现
-    - generator.spec.ts 测试用例
+    - schema.json
+    - schema.d.ts
+    - generator.ts
+    - generator.spec.ts
   - docs/src/content/docs/guides/
-    - \<name>.mdx 生成器文档页
+    - \<name>.mdx
   - packages/nx-plugin/generators.json 更新包含新生成器
 </FileTree>
 
-之后即可开始实现生成器逻辑。
-
 :::tip
-关于如何为 AWS Nx 插件贡献生成器，请参考 <Link path="get_started/tutorials/contribute-generator">贡献指南</Link>。
+有关贡献 AWS Nx 插件的详细指南，请参考<Link path="get_started/tutorials/contribute-generator">此教程</Link>。
 :::

--- a/docs/src/content/docs/zh/guides/python-lambda-function.mdx
+++ b/docs/src/content/docs/zh/guides/python-lambda-function.mdx
@@ -9,23 +9,22 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/lambda-function/schema.json';
 
-Python Lambda Function 生成器支持向现有 Python 项目添加 Lambda 函数。
+Python Lambda 函数生成器支持在现有 Python 项目中添加 Lambda 函数。
 
-该生成器将创建带有 AWS CDK 基础设施配置的新 Python Lambda 处理器。生成的后端使用 AWS Lambda 进行无服务器部署，并可选通过 [AWS Lambda Powertools 的 Parser](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) 实现类型安全。它会配置 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) 用于可观测性，包括日志记录、AWS X-Ray 追踪和 Cloudwatch 指标。
+该生成器会创建一个新的 Python Lambda 处理程序并配置 AWS CDK 基础设施。生成的后端使用 AWS Lambda 进行无服务器部署，并可选使用 [AWS Lambda Powertools 的 Parser](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) 实现类型安全。它通过 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/python/latest/) 配置了可观测性功能，包括日志记录、AWS X-Ray 追踪和 Cloudwatch 指标。
 
-## 使用方式
+## 使用方法
 
 ### 生成 Lambda 函数
 
-可通过两种方式生成新的 Lambda 函数：
+有两种方式可以生成新的 Lambda 函数：
 
 <RunGenerator generator="py#lambda-function" />
 
 ### 选项参数
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#lambda-function" />
 
 ## 生成器输出
 
@@ -34,19 +33,19 @@ Python Lambda Function 生成器支持向现有 Python 项目添加 Lambda 函�
 <FileTree>
 
 - \<模块名称>
-  - \<lambda-function>.py 函数实现文件
+  - \<lambda函数>.py 函数实现
 
 </FileTree>
 
 生成器还会在 `packages/common/constructs` 目录下创建用于部署函数的 CDK 构造。
 
-若提供了 `functionPath` 选项，生成器将在指定路径添加必要文件：
+若提供了 `functionPath` 选项，生成器会将必要文件添加到指定路径：
 
 <FileTree>
 
 - \<模块名称>
   - \<自定义路径>
-    - \<函数名称>.py 函数实现文件
+    - \<函数名称>.py 函数实现
 
 </FileTree>
 
@@ -78,26 +77,26 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     metrics.add_metric(name="InvocationCount", unit=MetricUnit.Count, value=1)
 
     try:
-        # TODO: Implement
+        # TODO: 实现业务逻辑
         metrics.add_metric(name="SuccessCount", unit=MetricUnit.Count, value=1)
-        # TODO: Implement success response if required
+        # TODO: 按需实现成功响应
     except Exception as e:
         logger.exception(e)
         metrics.add_metric(name="ErrorCount", unit=MetricUnit.Count, value=1)
-        # TODO: Implement error response if required
+        # TODO: 按需实现错误响应
 ```
 
-生成器自动配置以下功能：
+生成器自动配置了以下功能：
 
 1. AWS Lambda Powertools 集成实现可观测性
 2. 指标收集
 3. 使用 `@event_parser` 的类型安全
 
-### 通过 AWS Lambda Powertools 实现可观测性
+### 使用 AWS Lambda Powertools 实现可观测性
 
 #### 日志记录
 
-生成器使用 AWS Lambda Powertools 配置结构化日志：
+生成器通过 AWS Lambda Powertools 配置结构化日志：
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
@@ -105,21 +104,22 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
 ```
 
 :::tip
-建议为所有唯一请求设置关联 ID 以便调试和监控，请参考 [AWS Powertools 日志文档](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) 获取最佳实践。
+建议为所有唯一请求设置关联 ID 以便调试和监控。请参考 [AWS Powertools 日志文档](https://docs.powertools.aws.dev/lambda/python/2.22.0/core/logger/#setting-a-correlation-id) 了解关联 ID 最佳实践。
 :::
 
 日志记录器自动包含：
+
 - 事件请求
 - Lambda 上下文信息
 - 冷启动标识
 
 #### 追踪
 
-自动配置 AWS X-Ray 追踪。可为追踪添加自定义子片段：
+自动配置 AWS X-Ray 追踪。可为追踪添加自定义子段：
 
 ```python
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
-    # 创建新子片段
+    # 创建新子段
     with tracer.provider.in_subsegment("function-subsegment"):
         # 业务逻辑
         return ....
@@ -135,32 +135,33 @@ def lambda_handler(event: EventBridgeModel, context: LambdaContext):
     return ...
 ```
 
-默认指标包含：
+默认指标包括：
+
 - 调用次数
 - 成功/失败次数
 - 冷启动指标
 
 #### 类型安全
 
-若生成 Lambda 函数时选择了 `eventSource`，函数将通过 [AWS Lambda Powertools 的 `@event_parser`](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) 实现类型校验。例如：
+若生成 Lambda 函数时选择了 `eventSource`，函数将通过 [AWS Lambda Powertools 的 `@event_parser`](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) 实现类型安全：
 
 ```python {3}
 @event_parser(model=EventBridgeModel)
 def lambda_handler(event: EventBridgeModel, context: LambdaContext):
-    event.detail_type # <- 类型安全且支持 IDE 自动补全
+    event.detail_type # <- 类型安全，支持 IDE 自动补全
 ```
 
-这允许使用 [Pydantic](https://docs.pydantic.dev/latest/) 定义数据模型，类似 <Link path="guides/fastapi">FastAPI</Link> 的工作方式。
+这允许使用 [Pydantic](https://docs.pydantic.dev/latest/) 定义数据模型，类似于 <Link path="guides/fastapi">Fast API</Link> 的工作方式。
 
 :::tip
-如果事件中存在嵌套的自定义数据（如 DynamoDB 流或 EventBridge 事件），建议使用 [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) 为这些数据提供类型安全。
+若事件中包含自定义数据（如 DynamoDB 流或 EventBridge 事件），使用 [Envelopes](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/#envelopes) 可为该数据提供类型安全。
 :::
 
-若不需要事件类型校验，可为 `eventSource` 选择 `Any` 选项。
+若不需要事件类型定义，可在 `eventSource` 选项中选择 `Any`。
 
 ## 部署函数
 
-Python Lambda Function 生成器会在 `common/constructs` 目录创建 CDK 构造。可在 CDK 应用中使用：
+Python Lambda 函数生成器在 `common/constructs` 目录下创建了 CDK 构造。可在 CDK 应用中使用：
 
 ```ts
 import { MyProjectMyFunction } from ':my-scope/common-constructs';
@@ -173,7 +174,8 @@ export class ExampleStack extends Stack {
 }
 ```
 
-该构造将配置：
+该构造配置了：
+
 1. AWS Lambda 函数
 2. CloudWatch 日志组
 3. X-Ray 追踪配置
@@ -182,10 +184,10 @@ export class ExampleStack extends Stack {
 该函数可作为任何 Lambda [事件源](https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/) 的目标：
 
 :::note
-请确保事件源与所选的 `eventSource` 选项匹配，以保证事件在处理器函数中正确处理。
+请确保事件源与所选 `eventSource` 选项匹配，以保证事件在处理器函数中正确处理。
 :::
 
-以下示例展示使用 Event Bridge 定时触发 Lambda 函数的 CDK 代码：
+以下示例演示使用 Event Bridge 定时触发 Lambda 函数的 CDK 代码：
 
 ```ts
 import { EventPattern, Rule, Schedule } from 'aws-cdk-lib/aws-events';
@@ -197,7 +199,7 @@ export class ExampleStack extends Stack {
     // 将函数添加到堆栈
     const fn = new MyProjectMyFunction(this, 'MyFunction');
 
-    // 将函数添加至 EventBridge 任务
+    // 将函数添加到 EventBridge 任务
     const eventRule = new Rule(this, 'MyFunctionScheduleRule', {
       schedule: Schedule.cron({ minute: '15' }),
       targets: [new LambdaFunction(fn)],

--- a/docs/src/content/docs/zh/guides/python-project.mdx
+++ b/docs/src/content/docs/zh/guides/python-project.mdx
@@ -9,21 +9,20 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/py/project/schema.json';
 
-Python 项目生成器可用于创建配置了最佳实践的现代 [Python](https://www.python.org/) 库或应用，使用 [UV](https://docs.astral.sh/uv/) 进行管理，包含单一锁文件和 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)中的虚拟环境，使用 [pytest](https://docs.pytest.org/en/stable/) 运行测试，[Ruff](https://docs.astral.sh/ruff/) 进行静态分析。
+Python 项目生成器可用于创建配置了最佳实践的现代 [Python](https://www.python.org/) 库或应用程序，使用 [UV](https://docs.astral.sh/uv/) 进行管理，包含单一锁文件和位于 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)中的虚拟环境，使用 [pytest](https://docs.pytest.org/en/stable/) 运行测试，以及 [Ruff](https://docs.astral.sh/ruff/) 进行静态分析。
 
-## 使用方法
+## 使用方式
 
 ### 生成 Python 项目
 
-有两种方式可以生成新的 Python 项目：
+您可以通过两种方式生成新的 Python 项目：
 
 <RunGenerator generator="py#project" />
 
 ### 选项
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="py#project" />
 
 ## 生成器输出
 
@@ -33,18 +32,18 @@ Python 项目生成器可用于创建配置了最佳实践的现代 [Python](htt
 
   - \<模块名称>
     - \_\_init\_\_.py 模块初始化文件
-    - hello.py 示例 Python 源码文件
+    - hello.py Python 示例源文件
   - tests
     - \_\_init\_\_.py 模块初始化文件
     - conftest.py 测试配置
-    - test_hello.py 示例测试文件
+    - test_hello.py 示例测试
   - project.json 项目配置和构建目标
   - pyproject.toml UV 使用的包管理配置文件
   - .python-version 包含项目的 Python 版本
 
 </FileTree>
 
-你可能还会注意到工作区根目录下创建/更新了以下文件：
+您可能还会注意到工作区根目录中创建/更新了以下文件：
 
 <FileTree>
 
@@ -54,19 +53,19 @@ Python 项目生成器可用于创建配置了最佳实践的现代 [Python](htt
 
 </FileTree>
 
-## 编写 Python 源码
+## 编写 Python 源代码
 
-在 `<模块名称>` 目录中添加你的 Python 源代码。
+在 `<模块名称>` 目录中添加您的 Python 源代码。
 
 ### 在其他项目中导入库代码
 
-由于已配置 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)，你可以从工作区中的任意 Python 项目引用你的 Python 项目：
+由于已配置 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)，您可以从工作区中的任何其他 Python 项目引用您的 Python 项目：
 
 ```python title="packages/my_other_project/my_other_project/main.py"
 from "my_library.hello" import say_hello
 ```
 
-上述代码中，`my_library` 是模块名称，`hello` 对应 Python 源文件 `hello.py`，`say_hello` 是在 `hello.py` 中定义的方法
+上述代码中，`my_library` 是模块名称，`hello` 对应 Python 源文件 `hello.py`，`say_hello` 是 `hello.py` 中定义的方法
 
 ### 依赖管理
 
@@ -74,11 +73,11 @@ from "my_library.hello" import say_hello
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-这将把依赖添加到项目的 `pyproject.toml` 文件，并更新根目录的 `uv.lock`。
+这会将依赖添加到项目的 `pyproject.toml` 文件，并更新根目录的 `uv.lock`。
 
 #### 运行时代码
 
-当将 Python 项目用作运行时代码时（例如作为 AWS lambda 函数的处理程序），需要将源代码及其所有依赖打包。可以通过在 `project.json` 文件中添加类似以下目标来实现：
+当将 Python 项目作为运行时代码使用时（例如作为 AWS lambda 函数的处理程序），需要将源代码及其所有依赖打包。可以通过在 `project.json` 文件中添加如下目标实现：
 
 ```json title="project.json"
 {
@@ -104,7 +103,7 @@ from "my_library.hello" import say_hello
 
 ### 构建
 
-Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通过以下命令运行：
+Python 项目配置了 `build` 目标（定义于 `project.json`），可通过以下命令运行：
 
 <NxCommands commands={['run <project-name>:build']} />
 
@@ -120,7 +119,7 @@ Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通
 
 ### 编写测试
 
-测试应写在项目内的 `test` 目录中，文件名以 `test_` 开头，例如：
+测试应位于项目的 `test` 目录中，文件名以 `test_` 开头，例如：
 
 <FileTree>
   - my_library
@@ -129,7 +128,7 @@ Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通
     - test_hello.py hello.py 的测试
 </FileTree>
 
-测试方法应以 `test_` 开头并通过断言验证预期结果，例如：
+测试方法应以 `test_` 开头，并通过断言验证预期结果，例如：
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -138,15 +137,15 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-更多测试编写细节请参考 [pytest 文档](https://docs.pytest.org/en/stable/how-to/assert.html#)。
+有关编写测试的更多细节，请参考 [pytest 文档](https://docs.pytest.org/en/stable/how-to/assert.html#)。
 
 ### 运行测试
 
-测试将在项目的 `build` 目标中自动运行，也可单独运行 `test` 目标：
+测试会在项目 `build` 目标中自动运行，但也可单独运行 `test` 目标：
 
 <NxCommands commands={['run <project-name>:test']} />
 
-使用 `-k` 参数可运行指定测试文件或方法：
+可以使用 `-k` 标志运行单个测试或测试套件，指定测试文件或方法名称：
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -154,18 +153,18 @@ def test_say_hello():
 
 Python 项目使用 [Ruff](https://docs.astral.sh/ruff/) 进行代码检查。
 
-### 运行检查
+### 运行检查器
 
-运行 `lint` 目标可检查项目代码：
+要检查项目代码，可运行 `lint` 目标：
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### 修复问题
+### 修复检查问题
 
-大多数检查或格式问题可自动修复。通过添加 `--configuration=fix` 参数让 Ruff 自动修复：
+大多数代码检查或格式问题可以自动修复。通过添加 `--configuration=fix` 参数可让 Ruff 自动修复问题：
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-要修复工作区中所有包的检查问题，可运行：
+若要修复工作区中所有包的检查问题，可运行：
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -11,23 +11,22 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Snippet from '@components/snippet.astro';
-import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema.json';
 
-[tRPC](https://trpc.io/) 是一个用于构建具备端到端类型安全的 TypeScript API 框架。使用 tRPC 时，API 操作输入输出的更新会立即反映在客户端代码中，并能在 IDE 中直接查看，无需重新构建项目。
+[tRPC](https://trpc.io/) 是一个用于在 TypeScript 中构建端到端类型安全 API 的框架。使用 tRPC 时，API 操作输入输出的变更会立即反映在客户端代码中，并可在 IDE 中直接查看，无需重新构建项目。
 
-该 tRPC API 生成器可创建带有 AWS CDK 基础设施配置的全新 tRPC API。生成的后端使用 AWS Lambda 进行无服务器部署，并通过 [Zod](https://zod.dev/) 实现模式验证。同时配置了 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) 以实现可观测性，包括日志记录、AWS X-Ray 追踪和 CloudWatch 指标。
+tRPC API 生成器会创建一个新的 tRPC API 并配置 AWS CDK 基础设施。生成的后端使用 AWS Lambda 进行无服务器部署，并通过 [Zod](https://zod.dev/) 实现模式验证。它配置了 [AWS Lambda Powertools](https://docs.powertools.aws.dev/lambda/typescript/latest/) 用于可观测性，包括日志记录、AWS X-Ray 追踪和 CloudWatch 指标。
 
 ## 使用方式
 
 ### 生成 tRPC API
 
-您可以通过两种方式生成新的 tRPC API：
+可通过两种方式生成新的 tRPC API：
 
 <RunGenerator generator="ts#trpc-api" />
 
-### 选项配置
+### 选项参数
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#trpc-api" />
 
 <Snippet name="api/api-choice-note" />
 
@@ -38,42 +37,42 @@ import schema from '../../../../../../packages/nx-plugin/src/trpc/backend/schema
 <FileTree>
   - schema
     - src
-      - index.ts Schema 入口点
+      - index.ts 模式入口文件
       - procedures
-        - echo.ts 使用 Zod 定义的 "echo" 过程共享模式定义
+        - echo.ts 使用 Zod 的 "echo" 过程共享模式定义
     - tsconfig.json TypeScript 配置
     - project.json 项目配置与构建目标
   - backend
     - src
       - init.ts 后端 tRPC 初始化
-      - router.ts tRPC 路由定义（Lambda 处理器 API 入口点）
+      - router.ts tRPC 路由定义（Lambda 处理程序 API 入口）
       - procedures API 暴露的过程（操作）
         - echo.ts 示例过程
       - middleware
         - error.ts 错误处理中间件
-        - logger.ts 配置 AWS Lambda Powertools 日志记录的中间件
-        - tracer.ts 配置 AWS Lambda Powertools 追踪的中间件
-        - metrics.ts 配置 AWS Lambda Powertools 指标的中间件
-      - local-server.ts 本地开发服务器使用的 tRPC 独立适配器入口点
+        - logger.ts 配置 AWS Powertools Lambda 日志的中间件
+        - tracer.ts 配置 AWS Powertools Lambda 追踪的中间件
+        - metrics.ts 配置 AWS Powertools Lambda 指标的中间件
+      - local-server.ts 本地开发服务器使用的 tRPC 独立适配器入口
       - client
         - index.ts 机器间 API 调用的类型安全客户端
     - tsconfig.json TypeScript 配置
     - project.json 项目配置与构建目标
 </FileTree>
 
-生成器还会在 `packages/common/constructs` 目录下创建用于部署 API 的 CDK 构造体。
+生成器还会在 `packages/common/constructs` 目录中创建用于部署 API 的 CDK 构造。
 
 ## 实现 tRPC API
 
-如上所示，tRPC API 主要由两个组件构成：工作区中定义为独立包的 [`schema`](#schema) 和 [`backend`](#backend)。
+如上所示，tRPC API 包含两个主要组件：[`schema`](#schema) 和 [`backend`](#backend)，在您的工作区中定义为独立项目。
 
 :::tip
-`schema` 和 `backend` 均为 TypeScript 项目，更多通用使用细节可参考 <Link path="guides/typescript-project">TypeScript 项目文档</Link>。
+`schema` 和 `backend` 均为 TypeScript 项目，更多通用用法可参考 <Link path="guides/typescript-project">TypeScript 项目文档</Link>。
 :::
 
 ### 模式定义
 
-模式包定义了客户端与服务端代码共享的类型。这些类型使用 TypeScript 优先的模式声明与验证库 [Zod](https://zod.dev/) 进行定义。
+schema 包定义了客户端与服务端代码共享的类型。这些类型使用 [Zod](https://zod.dev/)（一个 TypeScript 优先的模式声明与验证库）进行定义。
 
 示例模式如下所示：
 
@@ -91,7 +90,7 @@ export const UserSchema = z.object({
 export type User = z.TypeOf<typeof UserSchema>;
 ```
 
-根据以上模式，`User` 类型等效于以下 TypeScript 接口：
+根据上述模式，`User` 类型等效于以下 TypeScript 代码：
 
 ```ts
 interface User {
@@ -101,19 +100,19 @@ interface User {
 }
 ```
 
-模式在服务端和客户端代码间共享，为 API 使用的数据结构变更提供了单一修改点。
+模式由服务端和客户端代码共享，当需要修改 API 使用的数据结构时，只需在此处更新即可。
 
-tRPC API 在运行时自动验证模式，省去了手动编写后端验证逻辑的工作。
+tRPC API 在运行时自动验证模式，无需在后端手动编写验证逻辑。
 
-Zod 提供了强大的模式组合与派生工具，如 `.merge`、`.pick`、`.omit` 等。更多信息请参阅 [Zod 官方文档](https://zod.dev/?id=basic-usage)。
+Zod 提供强大的模式组合与派生工具，如 `.merge`、`.pick`、`.omit` 等。更多信息请参阅 [Zod 文档网站](https://zod.dev/?id=basic-usage)。
 
 ### 后端实现
 
-嵌套的 `backend` 文件夹包含 API 实现，您需要在此定义 API 操作及其输入、输出与实现。
+嵌套的 `backend` 文件夹包含 API 实现，您可在此定义 API 操作及其输入、输出和实现。
 
-API 入口点位于 `src/router.ts`，该文件包含将请求路由到具体过程的 Lambda 处理器。每个过程定义了预期的输入、输出和实现。
+API 入口位于 `src/router.ts`，该文件包含 Lambda 处理程序，根据调用的操作将请求路由至对应"过程"。每个过程定义预期的输入、输出和实现。
 
-生成的示例路由包含名为 `echo` 的单一操作：
+生成的示例路由包含名为 `echo` 的单个操作：
 
 ```ts
 import { echo } from './procedures/echo.js';
@@ -134,31 +133,33 @@ export const echo = publicProcedure
 
 代码解析：
 
-- `publicProcedure` 定义 API 的公共方法，包含 `src/middleware` 中配置的中间件（含 AWS Lambda Powertools 集成）
-- `input` 接受 Zod 模式定义操作的预期输入，请求将自动根据此模式进行验证
-- `output` 接受 Zod 模式定义操作的预期输出，若返回不符合模式将触发类型错误
-- `query` 接受定义操作实现的函数，通过 `opts` 参数获取输入和中间件设置的上下文 (`opts.ctx`)，返回值必须符合 `output` 模式
+- `publicProcedure` 定义 API 的公共方法，包含 `src/middleware` 中配置的中间件。这些中间件包含用于日志、追踪和指标的 AWS Lambda Powertools 集成
+- `input` 接受 Zod 模式，定义操作的预期输入。该操作的请求会自动根据此模式进行验证
+- `output` 接受 Zod 模式，定义操作的预期输出。若实现返回不符合模式的输出，将出现类型错误
+- `query` 接受定义操作实现的函数。该实现接收 `opts` 参数，包含传递给操作的 `input` 以及中间件设置的上下文（通过 `opts.ctx` 访问）。传递给 `query` 的函数必须返回符合 `output` 模式的输出
 
-使用 `query` 定义非变更操作，用于数据检索。实现变更操作时请使用 `mutation` 方法。
+使用 `query` 定义实现表示该操作是非变更性的，用于定义数据检索方法。若要实现变更性操作，请改用 `mutation` 方法。
 
-新增操作时，请确保在 `src/router.ts` 中注册。
+添加新操作后，请确保在 `src/router.ts` 的路由中注册。
 
-## 定制 tRPC API
+## 自定义 tRPC API
 
 ### 错误处理
 
-在实现中可通过抛出 `TRPCError` 返回错误响应，例如：
+在实现中，可通过抛出 `TRPCError` 向客户端返回错误响应。这些错误接受表示错误类型的 `code`，例如：
 
 ```ts
 throw new TRPCError({
   code: 'NOT_FOUND',
-  message: '未找到请求的资源',
+  message: '找不到请求的资源',
 });
 ```
 
-### 操作组织
+### 组织操作
 
-随着 API 扩展，可通过嵌套路由对相关操作进行分组：
+随着 API 扩展，您可能需要对相关操作进行分组。
+
+可使用嵌套路由对操作进行分组，例如：
 
 ```ts
 import { getUser } from './procedures/users/get.js';
@@ -173,7 +174,7 @@ const appRouter = router({
 })
 ```
 
-客户端将按分组调用操作，例如：
+客户端将接收此操作分组，例如调用上述 `listUsers` 操作：
 
 ```ts
 client.users.list.query();
@@ -181,24 +182,24 @@ client.users.list.query();
 
 ### 日志记录
 
-AWS Lambda Powertools 日志记录器配置于 `src/middleware/logger.ts`，可通过 `opts.ctx.logger` 访问，例如：
+AWS Lambda Powertools 日志记录器配置于 `src/middleware/logger.ts`，可通过 `opts.ctx.logger` 在 API 实现中访问。您可用此记录 CloudWatch 日志，或控制每个结构化日志消息的附加内容。例如：
 
 ```ts {5}
 export const echo = publicProcedure
    .input(...)
    .output(...)
    .query(async (opts) => {
-      opts.ctx.logger.info('操作调用参数', opts.input);
+      opts.ctx.logger.info('操作调用输入', opts.input);
 
       return ...;
    });
 ```
 
-更多信息请参阅 [AWS Lambda Powertools 日志文档](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/)。
+更多日志记录器信息请参阅 [AWS Lambda Powertools 日志文档](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/)。
 
-### 指标记录
+### 记录指标
 
-AWS Lambda Powertools 指标配置于 `src/middleware/metrics.ts`，可通过 `opts.ctx.metrics` 访问，例如：
+AWS Lambda Powertools 指标配置于 `src/middleware/metrics.ts`，可通过 `opts.ctx.metrics` 在 API 实现中访问。您可用此在 CloudWatch 中记录指标，无需导入 AWS SDK。例如：
 
 ```ts {5}
 export const echo = publicProcedure
@@ -213,9 +214,9 @@ export const echo = publicProcedure
 
 更多信息请参阅 [AWS Lambda Powertools 指标文档](https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics/)。
 
-### X-Ray 追踪调优
+### 精细化 X-Ray 追踪
 
-AWS Lambda Powertools 追踪器配置于 `src/middleware/tracer.ts`，可通过 `opts.ctx.tracer` 访问，例如：
+AWS Lambda Powertools 追踪器配置于 `src/middleware/tracer.ts`，可通过 `opts.ctx.tracer` 在 API 实现中访问。您可用此添加 AWS X-Ray 追踪以深入了解 API 请求的性能和流程。例如：
 
 ```ts {5-7}
 export const echo = publicProcedure
@@ -223,7 +224,7 @@ export const echo = publicProcedure
    .output(...)
    .query(async (opts) => {
       const subSegment = opts.ctx.tracer.getSegment()!.addNewSubsegment('我的算法');
-      // ... 需捕获的算法逻辑
+      // ... 需要捕获的算法逻辑
       subSegment.close();
 
       return ...;
@@ -232,11 +233,13 @@ export const echo = publicProcedure
 
 更多信息请参阅 [AWS Lambda Powertools 追踪文档](https://docs.powertools.aws.dev/lambda/typescript/latest/core/tracer/)。
 
-### 自定义中间件
+### 实现自定义中间件
 
-通过实现中间件可向过程上下文添加自定义值。以下示例在 `src/middleware/identity.ts` 中实现身份中间件：
+可通过实现中间件为过程上下文添加额外值。
 
-首先定义上下文扩展：
+例如，在 `src/middleware/identity.ts` 中实现中间件来从 API 提取调用用户详情。
+
+首先定义要添加到上下文的内容：
 
 ```ts
 export interface IIdentityContext {
@@ -247,24 +250,26 @@ export interface IIdentityContext {
 }
 ```
 
-然后实现中间件：
+注意我们在上下文中定义了附加的_可选_属性。tRPC 会确保在正确配置此中间件的过程中有此定义。
+
+接下来实现中间件，结构如下：
 
 ```ts
 export const createIdentityPlugin = () => {
    const t = initTRPC.context<...>().create();
    return t.procedure.use(async (opts) => {
-      // 前置逻辑
+      // 在这里添加在过程之前运行的逻辑
 
       const response = await opts.next(...);
 
-      // 后置逻辑
+      // 在这里添加在过程之后运行的逻辑
 
       return response;
    });
 };
 ```
 
-具体实现根据 API 类型有所不同：
+在本例中，我们需要提取调用 Cognito 用户的详情。通过从 API Gateway 事件中提取用户主题 ID（"sub"），并从 Cognito 获取用户详情。具体实现根据事件来自 REST API 或 HTTP API 有所不同：
 
 <Tabs>
 <TabItem label="REST">
@@ -303,6 +308,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
+      // 假设用户池 ID 已配置在 Lambda 环境变量中
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -311,10 +317,11 @@ export const createIdentityPlugin = () => {
     if (!Users || Users.length !== 1) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `未找到 subjectId 为 ${sub} 的用户`,
+        message: `找不到主题 ID ${sub} 对应的用户`,
       });
     }
 
+    // 向其他过程提供身份信息
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -370,6 +377,7 @@ export const createIdentityPlugin = () => {
     }
 
     const { Users } = await cognito.listUsers({
+      // 假设用户池 ID 已配置在 Lambda 环境变量中
       UserPoolId: process.env.USER_POOL_ID!,
       Limit: 1,
       Filter: `sub="${sub}"`,
@@ -378,10 +386,11 @@ export const createIdentityPlugin = () => {
     if (!Users || Users.length !== 1) {
       throw new TRPCError({
         code: 'FORBIDDEN',
-        message: `未找到 subjectId 为 ${sub} 的用户`,
+        message: `找不到主题 ID ${sub} 对应的用户`,
       });
     }
 
+    // 向其他过程提供身份信息
     return await opts.next({
       ctx: {
         ...opts.ctx,
@@ -399,13 +408,14 @@ export const createIdentityPlugin = () => {
 
 ## 部署 tRPC API
 
-生成器在 `common/constructs` 文件夹中创建了部署 API 的 CDK 构造体。在 CDK 应用中使用示例：
+tRPC 后端生成器在 `common/constructs` 文件夹中生成用于部署 API 的 CDK 构造。您可在 CDK 应用程序中使用，例如：
 
 ```ts {6-8}
 import { MyApi } from ':my-scope/common-constructs`;
 
 export class ExampleStack extends Stack {
    constructor(scope: Construct, id: string) {
+      // 将 API 添加到堆栈
       const api = new MyApi(this, 'MyApi', {
         integrations: MyApi.defaultIntegrations(this).build(),
       });
@@ -413,19 +423,19 @@ export class ExampleStack extends Stack {
 }
 ```
 
-该配置包含 AWS API Gateway REST/HTTP API、业务逻辑的 AWS Lambda 函数和 IAM 认证。
+此配置设置 API 基础设施，包括 AWS API Gateway REST/HTTP API、业务逻辑的 AWS Lambda 函数和 IAM 认证。
 
 ### 类型安全集成
 
 <Snippet name="api/type-safe-api-integrations" />
 
 :::tip
-tRPC API 的过程变更将立即反映在 CDK 构造体中，无需重新构建。
+当您在 tRPC API 中添加或删除过程时，这些变更会立即反映在 CDK 构造中，无需重新构建。
 :::
 
-### 权限授予
+### 授权访问
 
-使用 `grantInvokeAccess` 方法授予 API 访问权限，例如授权认证的 Cognito 用户：
+可使用 `grantInvokeAccess` 方法授予 API 访问权限，例如授予认证的 Cognito 用户访问权限：
 
 ```ts
 api.grantInvokeAccess(myIdentityPool.authenticatedRole);
@@ -433,15 +443,15 @@ api.grantInvokeAccess(myIdentityPool.authenticatedRole);
 
 ## 本地 tRPC 服务器
 
-使用 `serve` 目标运行本地 API 服务器：
+使用 `serve` 目标运行 API 本地服务器，例如：
 
 <NxCommands commands={['run @my-scope/my-api-backend:serve']} />
 
-本地服务器入口点为 `src/local-server.ts`。
+本地服务器入口位于 `src/local-server.ts`。
 
 ## 调用 tRPC API
 
-创建类型安全的 tRPC 客户端进行调用。后端间调用示例：
+可创建 tRPC 客户端以类型安全方式调用 API。若从其他后端调用 tRPC API，可使用 `src/client/index.ts` 中的客户端，例如：
 
 ```ts
 import { createMyApiClient } from ':my-scope/my-api-backend';
@@ -451,8 +461,8 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-React 网站调用建议使用 <Link path="guides/api-connection/react-trpc">API 连接</Link> 生成器配置客户端。
+若从 React 网站调用 API，建议使用 <Link path="guides/api-connection/react-trpc">API 连接</Link> 生成器配置客户端。
 
 ## 更多信息
 
-更多 tRPC 细节请参阅 [tRPC 官方文档](https://trpc.io/docs)。
+有关 tRPC 的更多信息，请参阅 [tRPC 文档](https://trpc.io/docs)。

--- a/docs/src/content/docs/zh/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/zh/guides/ts-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ts#mcp-server"
-description: "为大型语言模型提供上下文的生成 TypeScript 模型上下文协议（MCP）服务器"
+title: "ts#mcp-服务器"
+description: "为大型语言模型提供上下文的生成TypeScript模型上下文协议（MCP）服务器"
 ---
 
 
@@ -18,12 +18,12 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 ## 什么是 MCP？
 
-[模型上下文协议（MCP）](https://modelcontextprotocol.io/) 是一个开放标准，允许 AI 助手与外部工具和资源交互。它为 LLMs 提供了统一的方式来：
+[模型上下文协议（MCP）](https://modelcontextprotocol.io/) 是一个开放标准，允许 AI 助手与外部工具和资源交互。它为 LLMs 提供了一致的方式来：
 
-- 执行执行操作或获取信息的工具（函数）
+- 执行执行操作或检索信息的工具（函数）
 - 访问提供上下文或数据的资源
 
-## 使用方法
+## 使用方式
 
 ### 生成 MCP 服务器
 
@@ -31,24 +31,24 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 <RunGenerator generator="ts#mcp-server" />
 
-### 选项配置
+### 选项参数
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#mcp-server" />
 
 ## 生成器输出
 
 生成器将创建以下项目文件：
 
 <FileTree>
-  - packages/\<name>/
-    - README.md MCP 服务器文档，包含使用说明
-    - project.json Nx 项目配置，包含构建、打包和开发目标
+  - packages/\<名称>/
+    - README.md MCP 服务器使用说明文档
+    - project.json 包含构建、打包和开发目标的 Nx 项目配置
     - src/
       - index.ts MCP 服务器入口文件
       - server.ts 主服务器定义文件，声明工具和资源
       - global.d.ts 用于导入 Markdown 文件的 TypeScript 类型声明
       - resources/
-        - example-context.md 示例 Markdown 文件，作为 MCP 服务器的资源
+        - example-context.md 用作 MCP 服务器资源的示例 Markdown 文件
 </FileTree>
 
 :::note
@@ -59,15 +59,15 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 ### 添加工具
 
-工具是 AI 助手可以调用的执行操作的函数。您可以在 `server.ts` 文件中添加新工具：
+工具是 AI 助手可以调用的功能函数。您可以在 `server.ts` 文件中添加新工具：
 
 ```typescript
-server.tool("toolName",
-  { param1: z.string(), param2: z.number() }, // 使用 Zod 的输入模式
-  async ({ param1, param2 }) => {
-    // 工具实现
+server.tool("工具名称",
+  { 参数1: z.string(), 参数2: z.number() }, // 使用 Zod 的输入模式
+  async ({ 参数1, 参数2 }) => {
+    // 工具实现逻辑
     return {
-      content: [{ type: "text", text: "Result" }]
+      content: [{ type: "text", text: "结果" }]
     };
   }
 );
@@ -81,12 +81,12 @@ server.tool("toolName",
 // 从文件导入静态资源
 import exampleContext from './resources/example-context.md';
 
-server.resource('resource-name', 'example://resource', async (uri) => ({
+server.resource('资源名称', 'example://resource', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
 // 动态资源
-server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
+server.resource('动态资源', 'dynamic://resource', async (uri) => {
   const data = await fetchSomeData();
   return {
     contents: [{ uri: uri.href, text: data }],
@@ -96,15 +96,15 @@ server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
 
 ## 配置 AI 助手
 
-要使用您的 MCP 服务器，需要先进行打包：
+要使用 MCP 服务器，需要先进行打包：
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-这将生成打包文件 `dist/packages/your-mcp-server/bundle/index.js`（路径可能因目录设置而异）。
+打包文件将生成在 `dist/packages/your-mcp-server/bundle/index.js`（路径可能因目录设置而异）。
 
 ### 配置文件
 
-大多数支持 MCP 的 AI 助手使用类似的配置方法。您需要创建或更新包含 MCP 服务器详细信息的配置文件：
+大多数支持 MCP 的 AI 助手使用类似的配置方式。您需要创建或更新配置文件来添加 MCP 服务器信息：
 
 ```json
 {
@@ -120,15 +120,15 @@ server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
 }
 ```
 
-将 `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` 替换为实际的打包文件路径。
+请将 `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` 替换为实际的打包文件路径。
 
 :::caution
-如果连接服务器时出现 `ENOENT node` 错误，可能需要通过终端执行 `which node` 获取完整的 node 路径。
+如果连接服务器时出现 `ENOENT node` 错误，可能需要通过终端运行 `which node` 获取 node 的完整路径。
 :::
 
 ### 特定助手配置
 
-请参考以下文档配置具体 AI 助手的 MCP 支持：
+各 AI 助手的 MCP 配置文档参考：
 
 - [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
 - [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
@@ -136,30 +136,30 @@ server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
 
 :::tip
-部分 AI 助手（如 Amazon Q Developer）支持工作区级别的 MCP 服务器配置，这对项目相关的 MCP 服务器定义非常有用。
+部分 AI 助手（如 Amazon Q Developer）支持工作区级别的 MCP 服务器配置，这对定义项目相关 MCP 服务器非常有用。
 :::
 
 ## 开发工作流
 
 ### 构建目标
 
-本生成器基于 <Link path="/guides/typescript-project">TypeScript 项目生成器</Link> 构建，继承了其所有构建目标，并新增了以下目标：
+本生成器基于 <Link path="/guides/typescript-project">TypeScript 项目生成器</Link>，继承了其所有构建目标，并新增以下目标：
 
 #### 打包
 
-`bundle` 任务使用 [esbuild](https://esbuild.github.io/) 生成可供 AI 助手使用的单一 JavaScript 打包文件：
+`bundle` 任务使用 [esbuild](https://esbuild.github.io/) 创建单一 JavaScript 打包文件：
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-输出路径为 `dist/packages/your-mcp-server/bundle/index.js`（可能因目录设置而异）。
+打包文件生成在 `dist/packages/your-mcp-server/bundle/index.js`（路径可能因目录设置而异）。
 
 #### 开发模式
 
-`dev` 任务监控项目变更并自动重新打包：
+`dev` 任务会监控项目变更并自动重新打包：
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-该模式在开发过程中非常实用，可确保 AI 助手始终使用最新的 MCP 服务器版本。
+这在开发过程中非常实用，可确保 AI 助手始终使用最新的 MCP 服务器版本。
 
 :::note
 部分 AI 助手需要重启 MCP 服务器才能使变更生效。

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -10,27 +10,26 @@ import RunGenerator from '@components/run-generator.astro';
 import Link from '@components/link.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/infra/app/schema.json';
 
 [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html) 是一个通过代码定义云基础设施并通过 AWS CloudFormation 进行部署的框架。
 
-TypeScript 基础设施生成器会创建一个用 TypeScript 编写的 AWS CDK 基础设施应用。该应用通过 [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html) 检查集成了安全最佳实践。
+TypeScript 基础设施生成器会创建一个用 TypeScript 编写的 AWS CDK 基础设施应用。生成的应用程序通过 [CFN Guard](https://docs.aws.amazon.com/cfn-guard/latest/ug/what-is-guard.html) 检查集成了安全最佳实践。
 
-## 使用方法
+## 使用方式
 
 ### 生成基础设施项目
 
-有两种方式可以生成新的基础设施项目：
+您可以通过两种方式生成新的基础设施项目：
 
 <RunGenerator generator="ts#infra" />
 
-### 选项配置
+### 选项参数
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#infra" />
 
 ## 生成器输出
 
-生成器会在 `<directory>/<name>` 目录下创建以下项目结构：
+生成器将在 `<directory>/<name>` 目录下创建以下项目结构：
 
 <FileTree>
 
@@ -38,13 +37,13 @@ TypeScript 基础设施生成器会创建一个用 TypeScript 编写的 AWS CDK 
     - main.ts 实例化 CDK 堆栈的应用程序入口点
     - stacks CDK 堆栈定义
       - application-stack.ts 主应用堆栈
-  - cdk.json CDK 配置
-  - project.json 项目配置与构建目标
+  - cdk.json CDK 配置文件
+  - project.json 项目配置和构建目标
 
 </FileTree>
 
 :::tip
-您的基础设施是 TypeScript 项目，可参考 <Link path="guides/typescript-project">TypeScript 项目文档</Link> 了解常规使用细节。
+您的基础设施是 TypeScript 项目，因此可以参考 <Link path="guides/typescript-project">TypeScript 项目文档</Link> 了解其常规用法的更多细节。
 :::
 
 ## 实现 CDK 基础设施
@@ -68,7 +67,9 @@ export class ApplicationStack extends cdk.Stack {
 
 ### API 基础设施
 
-如果使用过 <Link path="guides/trpc">tRPC API</Link> 或 <Link path="guides/fastapi">FastAPI</Link> 生成器创建 API，您会注意到 `packages/common/constructs` 中已有用于部署的构造组件。例如，若您创建了一个名为 `my-api` 的 tRPC API，只需导入并实例化该构造即可添加所有必要的部署基础设施：
+如果您使用过 <Link path="guides/trpc">tRPC API</Link> 或 <Link path="guides/fastapi">FastAPI</Link> 生成器创建 API，会注意到 `packages/common/constructs` 中已有现成的构造用于部署。
+
+例如，如果您创建了一个名为 `my-api` 的 tRPC API，只需导入并实例化该构造即可添加所有必要的部署基础设施：
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -87,7 +88,7 @@ export class ApplicationStack extends cdk.Stack {
 
 ### 网站基础设施
 
-如果使用过 <Link path="guides/cloudscape-website">CloudScape 网站</Link> 生成器，您会注意到 `packages/common/constructs` 中已有部署用的构造组件。例如：
+如果您使用过 <Link path="guides/cloudscape-website">CloudScape 网站</Link> 生成器，会注意到 `packages/common/constructs` 中已有现成的构造用于部署。例如：
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import * as cdk from 'aws-cdk-lib';
@@ -105,59 +106,59 @@ export class ApplicationStack extends cdk.Stack {
 ```
 
 :::warning
-为确保网站 <Link path="guides/cloudscape-website#runtime-configuration">运行时配置</Link> 包含所有 API 配置，请务必将网站构造声明在 API 构造之后。
+为确保网站 <Link path="guides/cloudscape-website#runtime-configuration">运行时配置</Link> 包含所有 API 配置，必须确保在声明任何 API 构造之后声明网站。
 :::
 
 ## 合成基础设施
 
-在 `build` 目标中，除了执行 <Link path="guides/typescript-project#building">默认的编译、检查与测试任务</Link> 外，您的基础设施项目会被_合成_为 CloudFormation 模板。您也可以通过单独运行 `synth` 目标来执行此操作：
+作为 `build` 目标的一部分，除了运行 <Link path="guides/typescript-project#building">默认的编译、代码检查和测试目标</Link> 外，您的基础设施项目会被 _合成_ 为 CloudFormation 模板。也可以通过单独运行 `synth` 目标来执行此操作：
 
 <NxCommands commands={['run <my-infra>:synth']} />
 
-合成后的云组装件将位于根 `dist` 目录下的 `dist/packages/<my-infra-project>/cdk.out` 中。
+合成后的云装配文件将位于根目录的 `dist` 文件夹下，路径为 `dist/packages/<my-infra-project>/cdk.out`。
 
-## 引导 AWS 账户
+## 初始化 AWS 账户
 
-若首次向某 AWS 账户部署 CDK 应用，需先进行账户引导。
+如果是首次向 AWS 账户部署 CDK 应用，需要先进行初始化。
 
-首先，确保已 [配置 AWS 账户凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)。
+首先确保已 [配置 AWS 账户凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)。
 
-随后，使用 `cdk bootstrap` 命令：
+然后使用 `cdk bootstrap` 命令：
 
 ```bash
 npx cdk bootstrap aws://<account-id>/<region>
 ```
 
-详情请参阅 [CDK 文档](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html)。
+更多细节请参考 [CDK 文档](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html)。
 
 ## 部署到 AWS
 
-构建完成后，可通过 `deploy` 目标将基础设施部署到 AWS：
+构建完成后，可以使用 `deploy` 目标将基础设施部署到 AWS。
 
 :::caution
-在 CI/CD 流水线中部署时请使用 `deploy-ci` 目标，详见下文。
+在 CI/CD 流水线中部署时请使用 `deploy-ci` 目标。详见下文说明。
 :::
 
-首先，确保已 [配置 AWS 账户凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)。
+首先确保已 [配置 AWS 账户凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)。
 
-随后运行部署命令：
+然后运行部署目标：
 
 <NxCommands commands={['run <my-infra>:deploy --all']} />
 
 :::tip
-上述命令会部署 `main.ts` 中定义的所有堆栈。若需部署特定堆栈（例如配置了多阶段应用时），可指定目标堆栈：
+上述命令会部署 `main.ts` 中定义的所有堆栈。如果配置了应用的多个阶段，可能需要指定单个堆栈：
 
 <NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
 :::
 
 ## 在 CI/CD 流水线中部署到 AWS
 
-在 CI/CD 流水线中部署时，请使用 `deploy-ci` 目标：
+在 CI/CD 流水线中部署时请使用 `deploy-ci` 目标。
 
 <NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
 
-该目标与常规 `deploy` 目标的区别在于：它确保部署的是预先合成的云组装件，而非实时合成。这有助于避免因依赖版本变更导致的非确定性问题，确保流水线各阶段使用相同的云组装件进行部署。
+该目标与常规 `deploy` 目标的区别在于：它确保部署的是预先合成的云装配文件，而不是实时合成。这有助于避免因软件包版本变化导致的非确定性问题，确保流水线各阶段使用相同的云装配文件进行部署。
 
 ## 更多信息
 
-有关 CDK 的更多信息，请参阅 [CDK 开发者指南](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) 和 [API 参考文档](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html)。
+有关 CDK 的更多信息，请参考 [CDK 开发者指南](https://docs.aws.amazon.com/cdk/v2/guide/core_concepts.html) 和 [API 参考文档](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html)。

--- a/docs/src/content/docs/zh/guides/typescript-project.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-project.mdx
@@ -10,33 +10,32 @@ import RunGenerator from '@components/run-generator.astro';
 import InstallCommand from '@components/install-command.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
-import schema from '../../../../../../packages/nx-plugin/src/ts/lib/schema.json';
 
-TypeScript 项目生成器可用于创建配置了最佳实践的现代化 [TypeScript](https://www.typescriptlang.org/) 库或应用，包括 [ECMAScript Modules (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html)、TypeScript [项目引用](https://www.typescriptlang.org/docs/handbook/project-references.html)、用于运行测试的 [Vitest](https://vitest.dev/) 及用于静态分析的 [ESLint](https://eslint.org/)。
+TypeScript 项目生成器可用于创建配置了最佳实践的现代化 [TypeScript](https://www.typescriptlang.org/) 库或应用，这些最佳实践包括 [ECMAScript 模块 (ESM)](https://www.typescriptlang.org/docs/handbook/modules/reference.html)、TypeScript [项目引用](https://www.typescriptlang.org/docs/handbook/project-references.html)、用于运行测试的 [Vitest](https://vitest.dev/) 以及用于静态分析的 [ESLint](https://eslint.org/)。
 
-## 使用方法
+## 使用方式
 
 ### 生成 TypeScript 项目
 
-有两种方式可生成新的 TypeScript 项目：
+您可以通过两种方式生成新的 TypeScript 项目：
 
 <RunGenerator generator="ts#project" />
 
-### 选项
+### 选项配置
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="ts#project" />
 
 ## 生成器输出
 
-生成器将在 `<directory>/<name>` 目录下创建如下项目结构：
+生成器将在 `<directory>/<name>` 目录中创建以下项目结构：
 
 <FileTree>
 
   - src TypeScript 源代码
     - index.ts
-  - project.json 项目配置及构建目标
-  - tsconfig.json 项目基础 TypeScript 配置（继承自工作区根目录的 tsconfig.base.json）
-  - tsconfig.lib.json 库的 TypeScript 配置（运行时或打包后的源码）
+  - project.json 项目配置和构建目标
+  - tsconfig.json 本项目的基础 TypeScript 配置（继承工作区根目录的 tsconfig.base.json）
+  - tsconfig.lib.json 库的 TypeScript 配置（运行时或打包源码）
   - tsconfig.spec.json 测试的 TypeScript 配置
   - vite.config.ts Vitest 配置
   - eslint.config.mjs ESLint 配置
@@ -44,38 +43,38 @@ TypeScript 项目生成器可用于创建配置了最佳实践的现代化 [Type
 </FileTree>
 
 :::tip
-注意此项目未创建 `package.json` 文件！原因详见[下方说明](#dependencies)。
+注意本项目不会创建 `package.json` 文件！您可以在[下方](#dependencies)了解原因。
 :::
 
-同时，工作区根目录中的以下文件会有所变更：
+您还会发现工作区根目录的以下文件发生了变化：
 
 <FileTree>
 
-  - nx.json Nx 配置更新，为项目配置 @nx/js/typescript 插件
-  - tsconfig.base.json 为项目设置 TypeScript 别名，以便工作区其他项目导入
-  - tsconfig.json 为项目添加 TypeScript 项目引用
+  - nx.json Nx 配置更新，为您的项目配置 @nx/js/typescript 插件
+  - tsconfig.base.json 为您的项目设置了 TypeScript 别名，以便工作区其他项目可以导入
+  - tsconfig.json 为您的项目添加了 TypeScript 项目引用
 
 </FileTree>
 
 ## 编写 TypeScript 源代码
 
-将 TypeScript 代码添加至 `src` 目录。
+在 `src` 目录中添加您的 TypeScript 代码。
 
 ### ESM 导入语法
 
-由于项目采用 ES 模块，需在导入语句中显式指定文件扩展名：
+由于您的 TypeScript 项目是 ES 模块，请确保使用正确的 ESM 语法编写导入语句，显式引用文件扩展名：
 
 ```ts title="index.ts" ".js"
 import { sayHello } from './hello.js';
 ```
 
 :::note
-尽管使用 TypeScript 且 `sayHello` 定义于 `hello.ts`，导入时仍需使用 `.js` 扩展名。详见[此说明](https://www.typescriptlang.org/docs/handbook/modules/reference.html)。
+尽管我们使用 TypeScript，且 `sayHello` 定义在 `hello.ts` 中，但我们在导入时使用 `.js` 扩展名。您可在此[阅读更多信息](https://www.typescriptlang.org/docs/handbook/modules/reference.html)。
 :::
 
 ### 为其他 TypeScript 项目导出
 
-项目入口点为 `src/index.ts`，可在此导出供其他项目使用的内容：
+TypeScript 项目的入口点是 `src/index.ts`。您可以在此处添加希望其他项目能够导入的导出：
 
 ```ts title="src/index.ts"
 export { sayHello } from './hello.js';
@@ -84,20 +83,20 @@ export * from './algorithms/index.js';
 
 ### 在其他项目中导入库代码
 
-工作区 `tsconfig.base.json` 中配置了项目的 [TypeScript 别名](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths)，便于其他 TypeScript 项目引用：
+工作区 `tsconfig.base.json` 中配置了项目的 [TypeScript 别名](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths)，允许您从其他 TypeScript 项目引用本 TypeScript 项目：
 
 ```ts title="packages/my-other-project/src/index.ts"
 import { sayHello } from ':my-scope/my-library';
 ```
 
 :::note
-项目别名以 `:` 开头而非传统 `@`，避免本地包与 [NPM](https://www.npmjs.com/) 远程包命名冲突。
+TypeScript 项目的别名以 `:` 开头而非传统的 `@`，这可以避免工作区本地包与 [NPM](https://www.npmjs.com/) 远程包之间的命名冲突。
 :::
 
-首次导入新项目时，IDE 可能出现类似错误：
+当您首次在工作区中为某个新项目添加导入语句时，IDE 中可能会看到类似以下错误：
 
 <details>
-<summary>导入错误示例</summary>
+<summary>导入错误</summary>
 
 ```bash wrap
 File '/path/to/my/workspace/packages/my-library/src/index.ts' is not under 'rootDir' '/path/to/my/workspace/packages/my-consumer'. 'rootDir' is expected to contain all source files.
@@ -108,16 +107,16 @@ File '/path/to/my/workspace/packages/my-library/src/index.ts' is not listed with
 
 </details>
 
-此因尚未配置[项目引用](https://www.typescriptlang.org/docs/handbook/project-references.html)。
+这是因为尚未设置[项目引用](https://www.typescriptlang.org/docs/handbook/project-references.html)。
 
-TypeScript 项目默认通过 Nx TypeSync 生成器配置，无需手动设置。运行以下命令添加必要配置：
+TypeScript 项目默认配置了 Nx TypeSync 生成器，您无需手动配置项目引用。只需运行以下命令，Nx 将自动添加所需配置：
 
 <NxCommands commands={['sync']} />
 
-完成后错误将消失，可正常使用库。
+此后 IDE 中的错误应会消失，您即可正常使用库。
 
 :::tip
-构建项目时也可能出现提示：
+您也可以直接构建项目，此时会看到如下提示：
 
 ```bash wrap
 [@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
@@ -134,19 +133,19 @@ No, run the tasks without syncing the changes
 
 ### 依赖管理
 
-项目未包含 `package.json` 文件，与传统 TypeScript 单体仓库不同。
+您会注意到 TypeScript 项目没有 `package.json` 文件，这对于习惯传统 TypeScript monorepo 的用户可能有些意外。
 
-要添加依赖，请将其加入工作区根目录的 `package.json` 中。可通过包管理器命令行操作：
+要为 monorepo 中的任何 TypeScript 包添加依赖，只需将依赖添加到工作区根目录的 `package.json`。您可以通过包管理器的命令行操作：
 
 <InstallCommand pkg="some-npm-package" />
 
-依赖将可供工作区所有 TypeScript 项目使用。
+此后该依赖即可供工作区中所有 TypeScript 项目使用。
 
 #### 运行时代码
 
-将项目作为运行时代码（如 AWS Lambda 处理程序）时，建议使用 [`esbuild`](https://esbuild.github.io/) 进行打包，以通过[摇树优化](https://esbuild.github.io/api/#tree-shaking)确保仅包含实际使用的依赖。
+当您将 TypeScript 项目作为运行时代码使用时（例如作为 AWS Lambda 函数的处理程序），建议使用 [`esbuild`](https://esbuild.github.io/) 等工具进行打包，因其支持[摇树优化](https://esbuild.github.io/api/#tree-shaking)以确保仅包含实际引用的依赖。
 
-在 `project.json` 中添加如下构建目标：
+您可以通过在 `project.json` 文件中添加如下构建目标实现：
 
 ```json
 {
@@ -166,30 +165,36 @@ No, run the tasks without syncing the changes
 ```
 
 :::note
-示例中选择 `src/index.ts` 作为打包入口点，导出内容及其依赖将被包含。
+注意上述构建目标中，我们选择 `src/index.ts` 作为打包入口文件，这意味着该文件导出的代码及其所有依赖都将包含在打包结果中。
 :::
 
 #### 发布到 NPM
 
-若需发布到 NPM，必须创建 `package.json`。需声明所有依赖，建议配置 [Nx 依赖检查 ESLint 插件](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks)确保依赖完整性。
+若要将 TypeScript 项目发布到 NPM，必须为其创建 `package.json` 文件。
+
+该文件需声明项目引用的依赖。由于构建时项目会解析通过工作区根目录 `package.json` 安装的依赖，建议配置 [Nx 依赖检查 ESLint 插件](https://nx.dev/nx-api/eslint-plugin/documents/dependency-checks) 以确保发布的 `package.json` 包含项目中使用的所有依赖。
 
 ### 构建
 
-项目配置了 `build` 目标（定义于 `project.json`），可通过以下命令运行：
+TypeScript 项目配置了 `build` 构建目标（定义于 `project.json`），可通过以下命令运行：
 
 <NxCommands commands={['run <project-name>:build']} />
 
-其中 `<project-name>` 为项目全称。
+其中 `<project-name>` 是项目的全限定名称。
 
-`build` 目标将编译、检查及测试项目。构建输出位于工作区根目录 `dist` 文件夹中，例如 `dist/packages/<my-library>/tsc`。
+`build` 目标将执行编译、代码检查及测试。
+
+构建输出位于工作区根目录的 `dist` 文件夹中，具体路径为 `dist/packages/<my-library>/tsc`
 
 ## 测试
 
-使用 [Vitest](https://vitest.dev/) 进行测试。
+项目使用 [Vitest](https://vitest.dev/) 进行测试。
 
 ### 编写测试
 
-测试文件应为 `.spec.ts` 或 `.test.ts` 格式，与源码共存于 `src` 目录。例如：
+测试文件应使用 `.spec.ts` 或 `.test.ts` 扩展名，与源码文件共同存放在 `src` 目录。
+
+例如：
 
 <FileTree>
   - src
@@ -197,7 +202,7 @@ No, run the tasks without syncing the changes
     - hello.spec.ts 测试文件
 </FileTree>
 
-Vitest 提供类似 Jest 的语法，支持 `describe`、`it`、`test` 和 `expect` 等工具。
+Vitest 提供类似 Jest 的测试语法，支持 `describe`、`it`、`test` 和 `expect` 等工具函数。
 
 ```ts title="hello.spec.ts"
 import { sayHello } from './hello.js';
@@ -211,38 +216,42 @@ describe('sayHello', () => {
 });
 ```
 
-更多测试编写技巧及模拟依赖功能，请参阅 [Vitest 文档](https://vitest.dev/guide/#writing-tests)。
+有关测试编写技巧及依赖模拟等功能的详细信息，请参考 [Vitest 文档](https://vitest.dev/guide/#writing-tests)
 
 ### 运行测试
 
-测试随 `build` 目标自动运行，也可单独执行：
+测试将作为项目 `build` 目标的一部分自动运行，您也可以通过 `test` 目标单独运行：
 
 <NxCommands commands={['run <project-name>:test']} />
 
-使用 `-t` 标志运行特定测试套件：
+使用 `-t` 标志可运行单个测试或测试套件：
 
 <NxCommands commands={["run <project-name>:test -t 'sayHello'"]} />
 
 :::tip
-VSCode 用户建议安装 [真正可用的 Vitest 运行器扩展](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)，支持从 IDE 运行、监视或调试测试。
+VSCode 用户建议安装 [真正可用的 Vitest Runner 扩展](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)，支持直接从 IDE 运行、监视或调试测试。
 :::
 
 ## 代码检查
 
-项目使用 [ESLint](https://eslint.org/) 进行代码检查，[Prettier](https://prettier.io/) 进行格式化。建议在工作区根目录的 `eslint.config.mjs` 中配置 ESLint，以确保一致性。Prettier 配置于根目录 `.prettierrc` 文件。
+TypeScript 项目使用 [ESLint](https://eslint.org/) 进行代码检查，配合 [Prettier](https://prettier.io/) 进行代码格式化。
 
-### 运行检查
+建议在工作区根目录的 `eslint.config.mjs` 文件中配置 ESLint，这样修改会应用于工作区所有 TypeScript 项目，确保一致性。
 
-执行 `lint` 目标进行代码检查：
+同理，您可以在根目录的 `.prettierrc` 文件中配置 Prettier。
+
+### 运行检查器
+
+要检查项目的代码规范，可运行 `lint` 目标：
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### 修复问题
+### 修复检查问题
 
-多数检查或格式问题可自动修复。使用 `--configuration=fix` 参数运行 ESLint：
+大多数代码规范和格式问题可自动修复。通过添加 `--configuration=fix` 参数可让 ESLint 自动修复问题：
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-修复整个工作区问题：
+若要修复工作区所有包的检查问题，可运行：
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { getPackageManagerCommand, PackageManager } from '@nx/devkit';
+import { PackageManager } from '@nx/devkit';
 import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';

--- a/packages/nx-plugin/LICENSE-THIRD-PARTY
+++ b/packages/nx-plugin/LICENSE-THIRD-PARTY
@@ -4793,34 +4793,6 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: @nx/devkit (20.6.4)
-This software contains the following license and notice below:
-
-(The MIT License)
-
-Copyright (c) 2017-2025 Narwhal Technologies Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
 The following software may be included in this product: @nx/devkit (21.0.3)
 This software contains the following license and notice below:
 
@@ -5060,7 +5032,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @nxlv/python (20.12.0)
+The following software may be included in this product: @nxlv/python (21.0.0)
 This software contains the following license and notice below:
 
 MIT License

--- a/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
@@ -9,7 +9,6 @@ description: Some description
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/foo-bar/schema.json';
 
 TODO: Add an overview of your generator here.
 
@@ -23,7 +22,7 @@ You can generate a foo#bar in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="foo#bar" />
 
 ## Generator Output
 

--- a/packages/nx-plugin/src/ts/nx-generator/files/nx-plugin-for-aws/docs/__nameKebabCase__.mdx.template
+++ b/packages/nx-plugin/src/ts/nx-generator/files/nx-plugin-for-aws/docs/__nameKebabCase__.mdx.template
@@ -6,7 +6,6 @@ description: <%- description ?? 'TODO - A short description of your generator' %
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
-import schema from '../../../../../../packages/nx-plugin/src/<%- generatorSubDir %>/schema.json';
 
 TODO: Add an overview of your generator here.
 
@@ -20,7 +19,7 @@ You can generate a <%- name %> in two ways:
 
 ### Options
 
-<GeneratorParameters schema={schema} />
+<GeneratorParameters generator="<%- name %>" />
 
 ## Generator Output
 

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -424,7 +424,7 @@ ${section}
     contentType: 'application/json',
     accept: 'application/json',
     body: JSON.stringify({
-      max_tokens: 32768,
+      max_tokens: 32000,
       temperature: 0.7,
       top_p: 0.9,
       prompt: `<｜User｜>${prompt}<｜Assistant｜>`,


### PR DESCRIPTION
### Reason for this change

Avoid users having to specify the path to the schema.

This is also a prerequisite for something else I'm cooking up ;)

### Description of changes

Accept a generator id instead of the schema.

### Description of how you validated changes

Ran the docs server locally

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*