### PR TITLE
feat(aws-nx-mcp): Add an MCP server to uplift usage with AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ pnpm nx g @aws/nx-plugin:ts#infra
 - [Build a Dungeon Adventure Game](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/dungeon-game/overview/) to get an in-depth guided tutorial on how to use the @aws/nx-plugin.
 - [Add @aws/nx-plugin to your existing project](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/existing-project/)
 
+## MCP Server Installation and Setup
+
+This package additionally provides an MCP server to help AI assistants use the Nx Plugin for AWS.
+
+1. Ensure you have `node` and `npm` installed ([see here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm))
+2. Add the server to your MCP client configuration
+
+Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```
+
+If you have issues such as `ENOENT npx`, replace the command with `/full/path/to/npx` (use `which npx` to find this).
+
 ## Documentation Translation
 
 The project supports automatic translation of documentation using AWS Bedrock's Deepseek & Haiku 3.5 models. Documentation is translated from English to multiple languages (currently Japanese, with support for French, Spanish, German, Chinese, and Korean).

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@hey-api/openapi-ts": "0.64.13",
     "@iarna/toml": "^2.2.5",
-    "@smithy/node-http-handler": "^4.0.4",
+    "@modelcontextprotocol/sdk": "^1.11.3",
     "@nx/devkit": "~21.0.3",
     "@nx/eslint": "~21.0.3",
     "@nx/eslint-plugin": "~21.0.3",
@@ -34,6 +34,7 @@
     "@nxlv/python": "^21.0.0",
     "@phenomnomnominal/tsquery": "6.1.3",
     "@quantco/pnpm-licenses": "^2.2.1",
+    "@smithy/node-http-handler": "^4.0.4",
     "@tailwindcss/vite": "^4.0.16",
     "@tanstack/react-query": "^5.74.3",
     "@testing-library/react": "^16.2.0",
@@ -104,7 +105,8 @@
     "typescript": "~5.8.2",
     "verdaccio": "^6.1.0",
     "vite": "^6.2.3",
-    "vitest": "^3.0.9"
+    "vitest": "^3.0.9",
+    "zod": "^3.24.2"
   },
   "pnpm": {
     "overrides": {

--- a/packages/nx-plugin/LICENSE-THIRD-PARTY
+++ b/packages/nx-plugin/LICENSE-THIRD-PARTY
@@ -3556,6 +3556,33 @@ THE SOFTWARE.
 
 ---
 
+The following software may be included in this product: @modelcontextprotocol/sdk (1.11.3)
+This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2024 Anthropic, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 The following software may be included in this product: @modern-js/node-bundle-require (2.65.1)
 This software contains the following license and notice below:
 
@@ -11588,6 +11615,61 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
+The following software may be included in this product: eventsource (3.0.7)
+This software contains the following license and notice below:
+
+The MIT License
+
+Copyright (c) EventSource GitHub organisation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+The following software may be included in this product: eventsource-parser (3.0.2)
+This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2025 Espen Hovlandsdal <espen@hovlandsdal.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 The following software may be included in this product: expand-tilde (2.0.2)
 This software contains the following license and notice below:
 
@@ -11655,6 +11737,32 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+The following software may be included in this product: express-rate-limit (7.5.0)
+This software contains the following license and notice below:
+
+# MIT License
+
+Copyright 2023 Nathan Friedly, Vedant K
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
@@ -18019,6 +18127,33 @@ SOFTWARE.
 
 ---
 
+The following software may be included in this product: pkce-challenge (5.0.0)
+This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2019
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 The following software may be included in this product: pkg-types (1.3.1)
 This software contains the following license and notice below:
 
@@ -18611,6 +18746,34 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ---
 
 The following software may be included in this product: raw-body (2.5.2)
+This software contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---
+
+The following software may be included in this product: raw-body (3.0.0)
 This software contains the following license and notice below:
 
 The MIT License (MIT)
@@ -28352,6 +28515,33 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
+The following software may be included in this product: zod (3.24.2)
+This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 The following software may be included in this product: @ampproject/remapping (2.3.0)
 This software contains the following license and notice below:
 
@@ -35778,6 +35968,27 @@ LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
 OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following software may be included in this product: zod-to-json-schema (3.24.5)
+This software contains the following license and notice below:
+
+ISC License
+
+Copyright (c) 2020, Stefan Terdell
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -100,6 +100,28 @@ pnpm nx g @aws/nx-plugin:ts#infra
 - [Build a Dungeon Adventure Game](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/dungeon-game/overview/) to get an in-depth guided tutorial on how to use the @aws/nx-plugin.
 - [Add @aws/nx-plugin to your existing project](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/existing-project/)
 
+## MCP Server Installation and Setup
+
+This package additionally provides an MCP server to help AI assistants use the Nx Plugin for AWS.
+
+1. Ensure you have `node` and `npm` installed ([see here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm))
+2. Add the server to your MCP client configuration
+
+Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```
+
+If you have issues such as `ENOENT npx`, replace the command with `/full/path/to/npx` (use `which npx` to find this).
+
 ## Documentation Translation
 
 The project supports automatic translation of documentation using AWS Bedrock's Deepseek & Haiku 3.5 models. Documentation is translated from English to multiple languages (currently Japanese, with support for French, Spanish, German, Chinese, and Korean).

--- a/packages/nx-plugin/bin/aws-nx-mcp.ts
+++ b/packages/nx-plugin/bin/aws-nx-mcp.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { startMcpServer } from '../src/mcp-server';
+
+void (async () => {
+  try {
+    await startMcpServer();
+  } catch (e) {
+    console.error(e);
+  }
+})();

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -7,19 +7,22 @@
       "factory": "./src/ts/lib/generator",
       "schema": "./src/ts/lib/schema.json",
       "description": "Generates a TypeScript project",
-      "metric": "g1"
+      "metric": "g1",
+      "guidePages": ["typescript-project"]
     },
     "py#project": {
       "factory": "./src/py/project/generator",
       "schema": "./src/py/project/schema.json",
       "description": "Generates a Python project",
-      "metric": "g2"
+      "metric": "g2",
+      "guidePages": ["python-project"]
     },
     "py#fast-api": {
       "factory": "./src/py/fast-api/generator",
       "schema": "./src/py/fast-api/schema.json",
       "description": "Generates a FastAPI Python project",
-      "metric": "g3"
+      "metric": "g3",
+      "guidePages": ["fastapi"]
     },
     "py#fast-api#react-connection": {
       "factory": "./src/py/fast-api/react/generator",
@@ -32,13 +35,15 @@
       "factory": "./src/cloudscape-website/app/generator",
       "schema": "./src/cloudscape-website/app/schema.json",
       "description": "Generates a React static website based on Cloudscape",
-      "metric": "g5"
+      "metric": "g5",
+      "guidePages": ["cloudscape-website"]
     },
     "ts#cloudscape-website#auth": {
       "factory": "./src/cloudscape-website/cognito-auth/generator",
       "schema": "./src/cloudscape-website/cognito-auth/schema.json",
       "description": "Adds auth to an existing cloudscape website",
-      "metric": "g6"
+      "metric": "g6",
+      "guidePages": ["cloudscape-website-auth"]
     },
     "ts#cloudscape-website#runtime-config": {
       "factory": "./src/cloudscape-website/runtime-config/generator",
@@ -51,13 +56,15 @@
       "factory": "./src/infra/app/generator",
       "schema": "./src/infra/app/schema.json",
       "description": "Generates a cdk application",
-      "metric": "g8"
+      "metric": "g8",
+      "guidePages": ["typescript-infrastructure"]
     },
     "ts#trpc-api": {
       "factory": "./src/trpc/backend/generator",
       "schema": "./src/trpc/backend/schema.json",
       "description": "creates a trpc backend",
-      "metric": "g9"
+      "metric": "g9",
+      "guidePages": ["trpc"]
     },
     "ts#trpc-api#react-connection": {
       "factory": "./src/trpc/react/generator",
@@ -70,7 +77,12 @@
       "factory": "./src/api-connection/generator",
       "schema": "./src/api-connection/schema.json",
       "description": "Integrates a source project with a target API project",
-      "metric": "g11"
+      "metric": "g11",
+      "guidePages": [
+        "api-connection",
+        "api-connection/react-fastapi",
+        "api-connection/react-trpc"
+      ]
     },
     "open-api#ts-client": {
       "factory": "./src/open-api/ts-client/generator",
@@ -103,13 +115,15 @@
       "factory": "./src/py/lambda-function/generator",
       "schema": "./src/py/lambda-function/schema.json",
       "description": "Adds a lambda function to a python project",
-      "metric": "g16"
+      "metric": "g16",
+      "guidePages": ["python-lambda-function"]
     },
     "ts#nx-generator": {
       "factory": "./src/ts/nx-generator/generator",
       "schema": "./src/ts/nx-generator/schema.json",
       "description": "Generator for adding an Nx Generator to an existing TypeScript project",
-      "metric": "g17"
+      "metric": "g17",
+      "guidePages": ["nx-generator"]
     },
     "ts#mcp-server": {
       "factory": "./src/ts/mcp-server/generator",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -14,6 +14,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "bin": {
+    "aws-nx-mcp": "./bin/aws-nx-mcp.js"
+  },
   "generators": "./generators.json",
   "peerDependencies": {
     "prettier": "^3.4.2",
@@ -23,6 +26,7 @@
     "@apidevtools/swagger-parser": "^10.1.1",
     "@hey-api/openapi-ts": "0.64.13",
     "@iarna/toml": "^2.2.5",
+    "@modelcontextprotocol/sdk": "^1.11.3",
     "@nx/devkit": "~21.0.3",
     "@nx/eslint": "~21.0.3",
     "@nx/js": "~21.0.3",
@@ -42,6 +46,7 @@
     "openapi-types": "^12.1.3",
     "typescript": "~5.8.2",
     "vite": "^6.2.3",
-    "vitest": "^3.0.9"
+    "vitest": "^3.0.9",
+    "zod": "^3.24.2"
   }
 }

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -54,8 +54,21 @@
         "cwd": "{projectRoot}"
       }
     },
+    "post-compile": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["chmod +x dist/packages/nx-plugin/bin/aws-nx-mcp.js"]
+      },
+      "dependsOn": ["compile"]
+    },
     "build": {
-      "dependsOn": ["compile", "lint", "test", "generate-3p-license"]
+      "dependsOn": [
+        "compile",
+        "post-compile",
+        "lint",
+        "test",
+        "generate-3p-license"
+      ]
     }
   }
 }

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { NxGeneratorInfo } from '../utils/nx';
+import { postProcessGuide } from './generator-info';
+import fs from 'fs';
+
+describe('postProcessGuide', () => {
+  const generators: NxGeneratorInfo[] = [
+    {
+      id: 'test-generator',
+      description: 'A test generator',
+      resolvedSchemaPath: '/path/to/schema.json',
+      resolvedFactoryPath: '/path/to/factory',
+      metric: 'g1',
+    },
+  ];
+
+  beforeEach(() => {
+    // Mock fs.readFileSync to return a mock schema
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify({
+        properties: {
+          name: {
+            type: 'string',
+            description: 'The name of the project',
+          },
+          directory: {
+            type: 'string',
+            description: 'The directory to create the project in',
+          },
+        },
+        required: ['name'],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should transform NxCommands components to markdown code blocks', () => {
+    const input = `
+# Test Guide
+Here's how to run a command:
+<NxCommands commands={["generate @aws/nx-plugin:ts#project"]} />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a command:
+\`\`\`bash
+nx generate @aws/nx-plugin:ts#project
+\`\`\`
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+  });
+
+  it('should transform NxCommands components with single quotes', () => {
+    const input = `
+# Test Guide
+Here's how to run a command:
+<NxCommands commands={['generate @aws/nx-plugin:ts#project']} />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a command:
+\`\`\`bash
+nx generate @aws/nx-plugin:ts#project
+\`\`\`
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+  });
+
+  it('should transform NxCommands components with multiple commands', () => {
+    const input = `
+# Test Guide
+Here's how to run a command:
+<NxCommands commands={["generate @aws/nx-plugin:ts#project", "sync", 'foo']} />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a command:
+\`\`\`bash
+nx generate @aws/nx-plugin:ts#project
+nx sync
+nx foo
+\`\`\`
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+  });
+
+  it('should transform NxCommands components with package manager prefix', () => {
+    const input = `
+# Test Guide
+Here's how to run a command:
+<NxCommands commands={["generate @aws/nx-plugin:ts#project"]} />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a command:
+\`\`\`bash
+pnpm nx generate @aws/nx-plugin:ts#project
+\`\`\`
+`;
+
+    const result = postProcessGuide(input, generators, 'pnpm');
+    expect(result).toBe(expected);
+  });
+
+  it('should transform RunGenerator components to generator commands', () => {
+    const input = `
+# Test Guide
+Here's how to run a generator:
+<RunGenerator generator="test-generator" />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a generator:
+\`\`\`bash
+nx g @aws/nx-plugin:test-generator --no-interactive --name=<name>
+\`\`\`
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+  });
+
+  it('should transform RunGenerator components with package manager prefix', () => {
+    const input = `
+# Test Guide
+Here's how to run a generator:
+<RunGenerator generator="test-generator" />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a generator:
+\`\`\`bash
+npx nx g @aws/nx-plugin:test-generator --no-interactive --name=<name>
+\`\`\`
+`;
+
+    const result = postProcessGuide(input, generators, 'npm');
+    expect(result).toBe(expected);
+  });
+
+  it('should transform GeneratorParameters components to schema documentation', () => {
+    const input = `
+# Test Guide
+Here are the parameters for the generator:
+<GeneratorParameters generator="test-generator" />
+`;
+
+    const expected = `
+# Test Guide
+Here are the parameters for the generator:
+- name [type: string] (required) The name of the project
+- directory [type: string] The directory to create the project in
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+  });
+
+  it('should leave GeneratorParameters components unchanged if generator is not found', () => {
+    const input = `
+# Test Guide
+Here are the parameters for the generator:
+<GeneratorParameters generator="non-existent-generator" />
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(input);
+  });
+
+  it('should leave GeneratorParameters components unchanged if generator parameter is missing', () => {
+    const input = `
+# Test Guide
+Here are the parameters for the generator:
+<GeneratorParameters somethingElse="value" />
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(input);
+  });
+
+  it('should handle multiple transformations in a single guide', () => {
+    const input = `
+# Test Guide
+Here's how to run a command:
+<NxCommands commands={["generate @aws/nx-plugin:ts#project"]} />
+
+And here's how to run a generator:
+<RunGenerator generator="test-generator" />
+
+Here are the parameters for the generator:
+<GeneratorParameters generator="test-generator" />
+`;
+
+    const expected = `
+# Test Guide
+Here's how to run a command:
+\`\`\`bash
+bunx nx generate @aws/nx-plugin:ts#project
+\`\`\`
+
+And here's how to run a generator:
+\`\`\`bash
+bunx nx g @aws/nx-plugin:test-generator --no-interactive --name=<name>
+\`\`\`
+
+Here are the parameters for the generator:
+- name [type: string] (required) The name of the project
+- directory [type: string] The directory to create the project in
+`;
+
+    const result = postProcessGuide(input, generators, 'bun');
+    expect(result).toBe(expected);
+  });
+
+  it('should handle errors when reading schema file', () => {
+    // Mock fs.readFileSync to throw an error
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('File not found');
+    });
+
+    const input = `
+# Test Guide
+Here's how to run a generator:
+<RunGenerator generator="test-generator" />
+
+Here are the parameters for the generator:
+<GeneratorParameters generator="test-generator" />
+`;
+
+    const result = postProcessGuide(input, generators);
+    expect(result).toBe(input);
+  });
+});

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import kebabCase from 'lodash.kebabcase';
+import { NxGeneratorInfo } from '../utils/nx';
+import fs from 'fs';
+
+/**
+ * Build a command to run nx
+ */
+export const buildNxCommand = (command: string, pm?: string) =>
+  `${
+    pm
+      ? `${
+          {
+            npm: 'npx',
+            bun: 'bunx',
+          }[pm] ?? pm
+        } `
+      : ''
+  }nx ${command}`;
+
+const renderSchema = (schema: any) =>
+  Object.entries(schema.properties)
+    .map(
+      ([parameter, parameterSchema]: [string, any]) =>
+        `- ${parameter} [type: ${parameterSchema.type}]${(schema.required ?? []).includes(parameter) ? ` (required)` : ''} ${parameterSchema.description}`,
+    )
+    .join('\n');
+
+const renderGeneratorCommand = (
+  generatorId: string,
+  schema: any,
+  packageManager?: string,
+) => `\`\`\`bash
+${buildNxCommand(
+  `g @aws/nx-plugin:${generatorId} --no-interactive ${Object.entries(
+    schema.properties,
+  )
+    .filter(([parameter]) => (schema.required ?? []).includes(parameter))
+    .map(([parameter]: [string, any]) => `--${parameter}=<${parameter}>`)
+    .join(' ')}`,
+  packageManager,
+)}
+\`\`\``;
+
+/**
+ * Render summary information about a generator
+ */
+export const renderGeneratorInfo = (
+  packageManager: string,
+  info: NxGeneratorInfo,
+): string => {
+  const schema = JSON.parse(fs.readFileSync(info.resolvedSchemaPath, 'utf-8'));
+
+  return `${info.id}
+
+Description: ${info.description}
+
+Available Parameters:
+${renderSchema(schema)}
+
+Command:
+${renderGeneratorCommand(info.id, schema, packageManager)}
+`;
+};
+
+/**
+ * Retrieve the markdown guide pages for a generator from github.
+ * If the generator has guidePages in generators.json we fetch all of those, otherwise we
+ * try to fetch a guide with the generator name kebab-cased.
+ */
+export const fetchGuidePagesForGenerator = async (
+  info: NxGeneratorInfo,
+  generators: NxGeneratorInfo[],
+  packageManager?: string,
+): Promise<string> => {
+  return await fetchGuidePages(
+    info.guidePages ?? [kebabCase(info.id)],
+    generators,
+    packageManager,
+  );
+};
+
+/**
+ * Fetch markdown guide pages from github
+ */
+export const fetchGuidePages = async (
+  guidePages: string[],
+  generators: NxGeneratorInfo[],
+  packageManager?: string,
+): Promise<string> => {
+  const guides = await Promise.allSettled(
+    guidePages.map(
+      async (guide) =>
+        await (
+          await fetch(
+            `https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/guides/${guide}.mdx`,
+          )
+        ).text(),
+    ),
+  );
+  return guides
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => postProcessGuide(result.value, generators, packageManager))
+    .join('\n\n');
+};
+
+const findGeneratorAndSchema = (
+  generators: NxGeneratorInfo[],
+  generatorId: string,
+) => {
+  const generator = generators.find((info) => info.id === generatorId);
+  if (!generator) {
+    return undefined;
+  }
+
+  try {
+    const schema = JSON.parse(
+      fs.readFileSync(generator.resolvedSchemaPath, 'utf-8'),
+    );
+    return { generator, schema };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Post-process a guide page to "inline" relevant components
+ */
+export const postProcessGuide = (
+  guide: string,
+  generators: NxGeneratorInfo[],
+  packageManager?: string,
+): string => {
+  // Replace <NxCommands /> with markdown code blocks
+  let processedGuide = guide.replace(
+    /<NxCommands\s+commands={([^}]+)}\s*\/>/g,
+    (match, commandsMatch) => {
+      try {
+        const commands = JSON.parse(
+          commandsMatch
+            .replaceAll("\\'", '__ESCAPED_SINGLE_QUOTE__')
+            .replaceAll("'", '"')
+            .replaceAll('__ESCAPED_SINGLE_QUOTE__', "\\'"),
+        );
+        return `\`\`\`bash\n${commands.map((command) => buildNxCommand(command, packageManager)).join('\n')}\n\`\`\``;
+      } catch {
+        return match;
+      }
+    },
+  );
+
+  // Replace <RunGenerator /> with renderGeneratorCommand
+  processedGuide = processedGuide.replace(
+    /<RunGenerator\s+([^/>]+)\s*\/>/g,
+    (match, attributes) => {
+      // Extract generator parameter
+      const generatorMatch = attributes.match(/generator=["']([^"']+)["']/);
+      if (!generatorMatch) {
+        return match; // If no generator parameter, leave as is
+      }
+
+      const generatorId = generatorMatch[1];
+
+      const info = findGeneratorAndSchema(generators, generatorId);
+
+      if (!info) {
+        return match;
+      }
+
+      return renderGeneratorCommand(generatorId, info.schema, packageManager);
+    },
+  );
+
+  // Replace <GeneratorParameters /> with renderSchema
+  processedGuide = processedGuide.replace(
+    /<GeneratorParameters\s+([^/>]+)\s*\/>/g,
+    (match, attributes) => {
+      // Extract generator parameter
+      const generatorMatch = attributes.match(/generator=["']([^"']+)["']/);
+      if (!generatorMatch) {
+        return match; // If no generator parameter, leave as is
+      }
+
+      const generatorId = generatorMatch[1];
+
+      const info = findGeneratorAndSchema(generators, generatorId);
+
+      if (!info) {
+        return match;
+      }
+
+      return renderSchema(info.schema);
+    },
+  );
+
+  return processedGuide;
+};

--- a/packages/nx-plugin/src/mcp-server/index.ts
+++ b/packages/nx-plugin/src/mcp-server/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createServer } from './server';
+
+export const startMcpServer = async () => {
+  const transport = new StdioServerTransport();
+  await createServer().connect(transport);
+  console.error('Nx Plugin for AWS MCP Server listening on STDIO');
+};

--- a/packages/nx-plugin/src/mcp-server/schema.ts
+++ b/packages/nx-plugin/src/mcp-server/schema.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+
+export const PACKAGE_MANAGERS = ['pnpm', 'yarn', 'npm', 'bun'] as const;
+export const PackageManagerSchema = z.enum(PACKAGE_MANAGERS);

--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createServer } from './server';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+describe('MCP Server', () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    // Create a new client instance
+    client = new Client({
+      name: 'test-client',
+      version: '1.0.0',
+    });
+
+    // Create the server
+    server = createServer();
+
+    // Create linked transports for client and server
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    // Connect both client and server
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        text: () => Promise.resolve('Mocked guide content'),
+      }),
+    );
+  });
+
+  it('should initialize with the correct server information', async () => {
+    // Get server info from client
+    const instructions = client.getInstructions();
+    expect(instructions).toContain('Tool Selection Guide');
+  });
+
+  it('should list available tools', async () => {
+    // List tools using client
+    const tools = await client.listTools();
+
+    // Verify tools are registered
+    const toolNames = tools.tools.map((tool) => tool.name);
+    expect(toolNames).toContain('general-guidance');
+    expect(toolNames).toContain('create-workspace-command');
+    expect(toolNames).toContain('list-generators');
+    expect(toolNames).toContain('generator-guide');
+  });
+
+  it('should execute create-workspace-command tool', async () => {
+    // Call the tool using client
+    const result = await client.callTool({
+      name: 'create-workspace-command',
+      arguments: {
+        workspaceName: 'test-workspace',
+        packageManager: 'pnpm',
+      },
+    });
+
+    // Verify result
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('npx create-nx-workspace@');
+    expect(result.content[0].text).toContain('--preset=@aws/nx-plugin');
+  });
+
+  it('should execute list-generators tool', async () => {
+    // Call the tool using client
+    const result = await client.callTool({
+      name: 'list-generators',
+      arguments: {
+        packageManager: 'pnpm',
+      },
+    });
+
+    // Verify result
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Available Generators');
+    expect(result.content[0].text).toContain('ts#project');
+  });
+
+  it('should execute general-guidance tool', async () => {
+    // Call the tool using client
+    const result = await client.callTool({
+      name: 'general-guidance',
+      arguments: {},
+    });
+
+    // Verify result
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Nx Plugin for AWS Guidance');
+    expect(result.content[0].text).toContain('Getting Started');
+    expect(result.content[0].text).toContain('Nx Primer');
+    expect(result.content[0].text).toContain('General Instructions');
+  });
+
+  it('should execute generator-guide tool with valid generator', async () => {
+    // Call the tool using client
+    const result = await client.callTool({
+      name: 'generator-guide',
+      arguments: {
+        packageManager: 'pnpm',
+        generator: 'ts#project',
+      },
+    });
+
+    // Verify result
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Guide');
+    expect(result.content[0].text).toContain('Mocked guide content');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/guides/typescript-project.mdx`,
+    );
+  });
+
+  it('should post process guide pages fetched by the generator-guide tool', async () => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        text: () => Promise.resolve('<NxCommands commands={["foo"]} />'),
+      }),
+    );
+
+    // Call the tool using client
+    const result = await client.callTool({
+      name: 'generator-guide',
+      arguments: {
+        packageManager: 'pnpm',
+        generator: 'ts#project',
+      },
+    });
+
+    // Verify result
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('pnpm nx foo');
+  });
+
+  it('should throw an error when generator-guide is called with an invalid generator', async () => {
+    // Call the tool with an invalid generator ID
+    await expect(
+      client.callTool({
+        name: 'generator-guide',
+        arguments: {
+          packageManager: 'pnpm',
+          generator: 'invalid-generator-id-that-does-not-exist',
+        },
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/nx-plugin/src/mcp-server/server.ts
+++ b/packages/nx-plugin/src/mcp-server/server.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { listGenerators } from '../utils/nx';
+import { addCreateWorkspaceCommandTool } from './tools/create-workspace-command';
+import { addListGeneratorsTool } from './tools/list-generators';
+import { addGeneratorGuideTool } from './tools/generator-guide';
+import {
+  addGeneralGuidanceTool,
+  TOOL_SELECTION_GUIDE,
+} from './tools/general-guidance';
+
+/**
+ * Create the MCP Server
+ */
+export const createServer = () => {
+  const generators = listGenerators();
+
+  const server = new McpServer(
+    {
+      name: 'nx-plugin-for-aws',
+      version: '1.0.0',
+    },
+    {
+      instructions: `# Nx Plugin for AWS MCP Server
+
+This server provides resources and tools for quickly scaffolding AWS projects within an Nx workspace (monorepo), using the Nx Plugin for AWS (@aws/nx-plugin).
+
+The Nx Plugin for AWS provides "generators" to add projects or functionality to your workspace. Use this to build the foundations of any project you are building
+on AWS, if the generators apply to your use case.
+
+${TOOL_SELECTION_GUIDE}
+`,
+    },
+  );
+
+  addGeneralGuidanceTool(server, generators);
+  addCreateWorkspaceCommandTool(server);
+  addListGeneratorsTool(server, generators);
+  addGeneratorGuideTool(server, generators);
+
+  return server;
+};

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { PackageManagerSchema } from '../schema';
+
+/**
+ * Add a tool which tells a model how to create an Nx workspace
+ */
+export const addCreateWorkspaceCommandTool = (server: McpServer) => {
+  server.tool(
+    'create-workspace-command',
+    { workspaceName: z.string(), packageManager: PackageManagerSchema },
+    ({ workspaceName, packageManager }) => ({
+      content: [
+        {
+          type: 'text',
+          text: `Run the following command to create a workspace:
+
+\`\`\`bash
+npx create-nx-workspace@~21.0.3 ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip
+\`\`\`
+
+Note that this will create a workspace in a new directory named ${workspaceName}. If you are already working in the directory
+you would like for your workspace, you can move all the files up one level and delete the empty directory afterwards, eg:
+
+\`\`\`bash
+mv ${workspaceName}/{*,.*} ./ && rm -rf ${workspaceName}
+\`\`\`
+
+(Note that the above command will complain about moving . and .. but that is expected and ok!)
+  `,
+        },
+      ],
+    }),
+  );
+};

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { NxGeneratorInfo } from '../../utils/nx';
+import { PACKAGE_MANAGERS } from '../schema';
+import { buildNxCommand, fetchGuidePages } from '../generator-info';
+
+export const TOOL_SELECTION_GUIDE = `## Tool Selection Guide
+
+- Use the \`general-guidance\` tool for guidance and best practices for working with Nx and the Nx Plugin for AWS.
+- Use the \`create-workspace-command\` tool to discover how to create a workspace to start a new project.
+- Use the \`list-generators\` tool to discover the available generators and how to run them.
+- Use the \`generator-guide\` tool to retrieve detailed information about a specific generator.`;
+
+/**
+ * Add a tool which provides general guidance for using Nx and the Nx Plugin for AWS
+ */
+export const addGeneralGuidanceTool = (
+  server: McpServer,
+  generators: NxGeneratorInfo[],
+) => {
+  server.tool('general-guidance', async () => ({
+    content: [
+      {
+        type: 'text',
+        text: `# Nx Plugin for AWS Guidance
+
+${TOOL_SELECTION_GUIDE}
+
+## Getting Started
+
+- Choose a package manager first. You can choose between ${PACKAGE_MANAGERS.join(' ,')}. It's recommended to use "pnpm" if the user has no preference
+- Next, you must create an Nx workspace. Use the \`create-workspace-command\` tool for more details, and provide it with your chosen package manager
+- After this, you can start scaffolding the main components of your application using generators. Use the \`list-generators\` tool to discover available generators, and the \`generator-guide\` tool for more detailed information about a specific generator
+
+## Nx Primer
+
+- Prefix nx commands with the appropriate prefix for your package manager, for example:
+${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
+- Each project in your workspace has a file named \`project.json\` which contains important project information such as its name, and defines the "targets" which can be run for that project, for example building or testing the project
+- Use the command \`nx reset\` to reset the Nx daemon when unexpected issues arise
+- After adding dependencies between projects, use \`nx sync\` to ensure project references are set up correctly
+
+## General Instructions
+
+- Workspaces contain a single \`package.json\` file at the root which defines the dependencies for all projects. Therefore when installing dependencies, you must add these to the root workspace using the appropriate command for your package manager:
+  - pnpm add -w -D <package>
+  - yarn add -D <package>
+  - npm install --legacy-peer-deps -D <package>
+  - bun install -D <package>
+  - (Omit -D for production dependencies)
+- When specifying project names as arguments to generators, use the _fully qualified_ project name, for example \`@workspace-name/project-name\`. Check the \`project.json\` file for the specific package to find its fully qualified name
+- When no generator exists for a specific framework required, use the base \`ts#project\` and \`py#project\` generators and build on top, unless building a React website in which case use the \`ts#cloudscape-website\` generator and replace CloudScape with your desired UI component library
+
+## Useful Commands
+
+- Fix lint issues with \`nx run-many --target lint --configuration=fix --all --output-style=stream\`
+- Build all projects with \`nx run-many --target build --all --output-style=stream\`
+
+## Best Practices
+
+- Generate all projects into the \`packages/\` directory
+- After making changes to your projects, fix linting issues, then run a full build
+
+## Language Specific Guidance
+
+Please refer to the below documentation for important details regarding working with any TypeScript or Python projects.
+
+${await fetchGuidePages(['typescript-project', 'python-project'], generators)}
+
+    `,
+      },
+    ],
+  }));
+};

--- a/packages/nx-plugin/src/mcp-server/tools/generator-guide.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/generator-guide.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { NxGeneratorInfo } from '../../utils/nx';
+import { z } from 'zod';
+import {
+  renderGeneratorInfo,
+  fetchGuidePagesForGenerator,
+} from '../generator-info';
+import { PackageManagerSchema } from '../schema';
+
+/**
+ * Add a tool which provides a detailed guide for an individual generator
+ */
+export const addGeneratorGuideTool = (
+  server: McpServer,
+  generators: NxGeneratorInfo[],
+) => {
+  server.tool(
+    'generator-guide',
+    {
+      packageManager: PackageManagerSchema,
+      generator: z.custom<string>((v) =>
+        generators.map((g) => g.id).includes(v),
+      ),
+    },
+    async ({ packageManager, generator: generatorId }) => {
+      const generator = generators.find((g) => g.id === generatorId);
+      if (!generator) {
+        throw new Error(
+          `No generator found with id ${generatorId}. Available generators: ${generators.map((g) => g.id).join(' ,')}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `## ${renderGeneratorInfo(packageManager, generator)}
+
+# Guide
+
+${await fetchGuidePagesForGenerator(generator, generators, packageManager)}
+`,
+          },
+        ],
+      };
+    },
+  );
+};

--- a/packages/nx-plugin/src/mcp-server/tools/list-generators.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/list-generators.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { PackageManagerSchema } from '../schema';
+import { renderGeneratorInfo } from '../generator-info';
+import { NxGeneratorInfo } from '../../utils/nx';
+
+/**
+ * Adds a tool which lists details about the available generators
+ */
+export const addListGeneratorsTool = (
+  server: McpServer,
+  generators: NxGeneratorInfo[],
+) => {
+  server.tool(
+    'list-generators',
+    { packageManager: PackageManagerSchema },
+    ({ packageManager }) => ({
+      content: [
+        {
+          type: 'text',
+          text: `## Available Generators
+
+  ${generators.map((g) => `### ${renderGeneratorInfo(packageManager, g)}`).join('\n\n')}
+  `,
+        },
+      ],
+    }),
+  );
+};

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -10,15 +10,38 @@ export interface NxGeneratorInfo {
   readonly id: string;
   readonly metric: string;
   readonly resolvedFactoryPath: string;
+  readonly resolvedSchemaPath: string;
+  readonly hidden?: boolean;
+  readonly description: string;
+  readonly guidePages?: string[];
 }
 
 const GENERATORS: NxGeneratorInfo[] = Object.entries(
   GeneratorsJson.generators,
-).map(([id, { metric, factory }]) => ({
+).map(([id, info]) => ({
   id,
-  metric,
-  resolvedFactoryPath: path.resolve(__dirname, '..', '..', factory),
+  metric: info.metric,
+  resolvedFactoryPath: path.resolve(__dirname, '..', '..', info.factory),
+  resolvedSchemaPath: path.resolve(__dirname, '..', '..', info.schema),
+  description: info.description,
+  ...('hidden' in info && info.hidden
+    ? {
+        hidden: info.hidden,
+      }
+    : {}),
+  ...('guidePages' in info && info.guidePages
+    ? {
+        guidePages: info.guidePages,
+      }
+    : {}),
 }));
+
+/**
+ * List Nx Plugin for AWS generators
+ * @param includeHidden include hidden generators (default false)
+ */
+export const listGenerators = (includeHidden = false): NxGeneratorInfo[] =>
+  GENERATORS.filter((g) => includeHidden || !g.hidden);
 
 /**
  * Return generator information. Call this from a generator method with __filename

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -13,7 +13,7 @@ export const VERSIONS = {
   '@aws-lambda-powertools/tracer': '^2.17.0',
   '@nxlv/python': '^21.0.0',
   '@nx/devkit': '~21.0.3',
-  '@modelcontextprotocol/sdk': '^1.10.2',
+  '@modelcontextprotocol/sdk': '^1.11.3',
   '@tanstack/react-router': '^1.114.27',
   '@tanstack/router-plugin': '^1.114.27',
   '@cloudscape-design/board-components': '^3.0.94',

--- a/packages/nx-plugin/tsconfig.lib.json
+++ b/packages/nx-plugin/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "bin/**/*.ts"],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.11.3
+        version: 1.11.3
       '@nx/devkit':
         specifier: ~21.0.3
         version: 21.0.3(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
@@ -292,6 +295,9 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.13)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
   packages/nx-plugin:
     dependencies:
@@ -304,6 +310,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.11.3
+        version: 1.11.3
       '@nx/devkit':
         specifier: ~21.0.3
         version: 21.0.3(nx@21.0.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@swc/types@0.1.20)(typescript@5.8.2))(@swc/core@1.7.26(@swc/helpers@0.5.15)))
@@ -370,6 +379,9 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.13)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
 packages:
 
@@ -1800,6 +1812,10 @@ packages:
 
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
+
+  '@modelcontextprotocol/sdk@1.11.3':
+    resolution: {integrity: sha512-rmOWVRUbUJD7iSvJugjUbFZshTAuJ48MXoZ80Osx1GM0K/H1w7rSEvmw8m6vdWxNASgtaHIhAgre4H/E9GJiYQ==}
+    engines: {node: '>=18'}
 
   '@modern-js/node-bundle-require@2.65.1':
     resolution: {integrity: sha512-XpEkciVEfDbkkLUI662ZFlI9tXsUQtLXk4NRJDBGosNnk9uL2XszmC8sKsdCSLK8AYuPW2w6MTVWuJsOR0EU8A==}
@@ -4638,6 +4654,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.2:
+    resolution: {integrity: sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -4655,6 +4679,12 @@ packages:
 
   express-rate-limit@5.5.1:
     resolution: {integrity: sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg==}
+
+  express-rate-limit@7.5.0:
+    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: 4.21.2
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -6652,6 +6682,10 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -6796,6 +6830,10 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
   rc9@2.1.2:
@@ -10160,6 +10198,21 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - acorn
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.11.3':
+    dependencies:
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      express: 4.21.2
+      express-rate-limit: 7.5.0(express@4.21.2)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
+    transitivePeerDependencies:
       - supports-color
 
   '@modern-js/node-bundle-require@2.65.1':
@@ -13822,6 +13875,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.2: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.2
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -13843,6 +13902,10 @@ snapshots:
   exponential-backoff@3.1.2: {}
 
   express-rate-limit@5.5.1: {}
+
+  express-rate-limit@7.5.0(express@4.21.2):
+    dependencies:
+      express: 4.21.2
 
   express@4.21.2:
     dependencies:
@@ -16386,6 +16449,8 @@ snapshots:
   pirates@4.0.6:
     optional: true
 
+  pkce-challenge@5.0.0: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -16522,6 +16587,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
       unpipe: 1.0.0
 
   rc9@2.1.2:


### PR DESCRIPTION
### Reason for this change

A first attempt at an MCP server for the Nx Plugin for AWS. This is all subject to change and I am yet to write docs as there are some additional changes to the Nx plugin that would help AI to use it, which I would like to make separately.

This gets the base functionality out and gives us something to iterate on.

### Description of changes

Add an MCP server with several tools which provide information to AI assistants regarding how to use the Nx Plugin for AWS.

- `general-guidance` for guidance and best practices for working with Nx and the Nx Plugin for AWS.
- `create-workspace-command` to discover how to create a workspace to start a new project.
- `list-generators` to discover the available generators and how to run them.
- `generator-guide` to retrieve detailed information about a specific generator.

### Description of how you validated changes

Tested out locally with Cline

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*