### PR TITLE
feat: allow specifying short project names in generator arguments

### DIFF
--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -78,7 +78,7 @@ export const smokeTest = (
         opts,
       );
       await runCLI(
-        `generate @aws/nx-plugin:api-connection --sourceProject=@e2e-test/website --targetProject=e_2_e_test.py_api --no-interactive`,
+        `generate @aws/nx-plugin:api-connection --sourceProject=website --targetProject=py_api --no-interactive`,
         opts,
       );
       await runCLI(

--- a/packages/nx-plugin/src/api-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/api-connection/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { Tree, updateJson } from '@nx/devkit';
 import { apiConnectionGenerator, determineProjectType } from './generator';
 import { createTreeUsingTsSolutionSetup } from '../utils/test';
 import { vi, expect, describe, it, beforeEach } from 'vitest';
@@ -241,6 +241,25 @@ dependencies = ["fastapi"]`,
         'apps/api/project.json',
         JSON.stringify({
           name: 'api',
+          root: 'apps/api',
+          metadata: {
+            apiType: 'trpc',
+          },
+        }),
+      );
+
+      expect(determineProjectType(tree, 'api')).toBe('ts#trpc-api');
+    });
+
+    it('should allow an unqualified project name to be specified', () => {
+      updateJson(tree, 'package.json', (packageJson) => ({
+        ...packageJson,
+        name: '@my-qualified-name/source',
+      }));
+      tree.write(
+        'apps/api/project.json',
+        JSON.stringify({
+          name: '@my-qualified-name/api',
           root: 'apps/api',
           metadata: {
             apiType: 'trpc',

--- a/packages/nx-plugin/src/api-connection/generator.ts
+++ b/packages/nx-plugin/src/api-connection/generator.ts
@@ -2,17 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-  joinPathFragments,
-  ProjectConfiguration,
-  readProjectConfiguration,
-  Tree,
-} from '@nx/devkit';
+import { joinPathFragments, ProjectConfiguration, Tree } from '@nx/devkit';
 import { ApiConnectionSchema } from './schema';
 import trpcReactGenerator from '../trpc/react/generator';
 import { hasExportDeclaration } from '../utils/ast';
 import { readToml } from '../utils/toml';
 import fastApiReactGenerator from '../py/fast-api/react/generator';
+import { readProjectConfigurationUnqualified } from '../utils/nx';
 
 /**
  * List of supported source and target project types for api connections
@@ -105,7 +101,10 @@ export const determineProjectType = (
   tree: Tree,
   projectName: string,
 ): ProjectType | undefined => {
-  const projectConfiguration = readProjectConfiguration(tree, projectName);
+  const projectConfiguration = readProjectConfigurationUnqualified(
+    tree,
+    projectName,
+  );
 
   // NB: if adding new checks, ensure these go from most to least specific
   // eg. react website is more specific than typescript project

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.ts
@@ -6,7 +6,6 @@ import {
   joinPathFragments,
   generateFiles,
   Tree,
-  readProjectConfiguration,
   addDependenciesToPackageJson,
   installPackagesTask,
   OverwriteStrategy,
@@ -29,7 +28,6 @@ import {
   SyntaxKind,
   VariableDeclaration,
   InterfaceDeclaration,
-  SourceFile,
 } from 'typescript';
 import { withVersions } from '../../utils/versions';
 import {
@@ -43,7 +41,11 @@ import {
   query,
 } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  getGeneratorInfo,
+  readProjectConfigurationUnqualified,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const COGNITO_AUTH_GENERATOR_INFO: NxGeneratorInfo =
@@ -53,7 +55,10 @@ export async function cognitoAuthGenerator(
   tree: Tree,
   options: CognitoAuthGeneratorSchema,
 ) {
-  const srcRoot = readProjectConfiguration(tree, options.project).sourceRoot;
+  const srcRoot = readProjectConfigurationUnqualified(
+    tree,
+    options.project,
+  ).sourceRoot;
   if (
     tree.exists(joinPathFragments(srcRoot, 'components/CognitoAuth/index.tsx'))
   ) {

--- a/packages/nx-plugin/src/cloudscape-website/runtime-config/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/runtime-config/generator.ts
@@ -6,7 +6,6 @@ import {
   joinPathFragments,
   generateFiles,
   Tree,
-  readProjectConfiguration,
   OverwriteStrategy,
 } from '@nx/devkit';
 import { RuntimeConfigGeneratorSchema } from './schema';
@@ -15,7 +14,11 @@ import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
 import { formatFilesInSubtree } from '../../utils/format';
 import { prependStatements, query, replaceIfExists } from '../../utils/ast';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  getGeneratorInfo,
+  readProjectConfigurationUnqualified,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const RUNTIME_CONFIG_GENERATOR_INFO: NxGeneratorInfo =
@@ -25,7 +28,10 @@ export async function runtimeConfigGenerator(
   tree: Tree,
   options: RuntimeConfigGeneratorSchema,
 ) {
-  const srcRoot = readProjectConfiguration(tree, options.project).sourceRoot;
+  const srcRoot = readProjectConfigurationUnqualified(
+    tree,
+    options.project,
+  ).sourceRoot;
   const mainTsxPath = joinPathFragments(srcRoot, 'main.tsx');
   if (!tree.exists(mainTsxPath)) {
     throw new Error(

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -51,13 +51,14 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
   - npm install --legacy-peer-deps -D <package>
   - bun install -D <package>
   - (Omit -D for production dependencies)
-- When specifying project names as arguments to generators, use the _fully qualified_ project name, for example \`@workspace-name/project-name\`. Check the \`project.json\` file for the specific package to find its fully qualified name
+- When specifying project names as arguments to generators, prefer the _fully qualified_ project name, for example \`@workspace-name/project-name\`. Check the \`project.json\` file for the specific package to find its fully qualified name
 - When no generator exists for a specific framework required, use the base \`ts#project\` and \`py#project\` generators and build on top, unless building a React website in which case use the \`ts#cloudscape-website\` generator and replace CloudScape with your desired UI component library
 
 ## Useful Commands
 
 - Fix lint issues with \`nx run-many --target lint --configuration=fix --all --output-style=stream\`
 - Build all projects with \`nx run-many --target build --all --output-style=stream\`
+- Prefer importing the CDK constructs vended by generators in \`packages/common/constructs\` over writing your own
 
 ## Best Practices
 

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -9,7 +9,6 @@ import {
   joinPathFragments,
   OverwriteStrategy,
   ProjectConfiguration,
-  readProjectConfiguration,
   Tree,
   updateJson,
   updateProjectConfiguration,
@@ -34,7 +33,11 @@ import { addStarExport } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
 import { getNpmScope } from '../../utils/npm-scope';
 import { sortObjectKeys } from '../../utils/object';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  getGeneratorInfo,
+  readProjectConfigurationUnqualified,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const LAMBDA_FUNCTION_GENERATOR_INFO: NxGeneratorInfo =
@@ -78,7 +81,10 @@ export const lambdaFunctionProjectGenerator = async (
   tree: Tree,
   schema: LambdaFunctionProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
-  const projectConfig = readProjectConfiguration(tree, schema.project);
+  const projectConfig = readProjectConfigurationUnqualified(
+    tree,
+    schema.project,
+  );
 
   const pyProjectPath = joinPathFragments(projectConfig.root, 'pyproject.toml');
 
@@ -96,7 +102,7 @@ export const lambdaFunctionProjectGenerator = async (
   }
 
   const dir = projectConfig.root;
-  const projectNameWithOutScope = schema.project.split('.').pop();
+  const projectNameWithOutScope = projectConfig.name.split('.').pop();
   const normalizedProjectName = toSnakeCase(projectNameWithOutScope);
 
   // Module name is the last part of the source root,

--- a/packages/nx-plugin/src/trpc/react/generator.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.ts
@@ -8,7 +8,6 @@ import {
   installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
-  readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
 import { ReactGeneratorSchema } from './schema';
@@ -39,7 +38,11 @@ import {
 } from '../../utils/ast';
 import { toClassName } from '../../utils/names';
 import { formatFilesInSubtree } from '../../utils/format';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  getGeneratorInfo,
+  readProjectConfigurationUnqualified,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const TRPC_REACT_GENERATOR_INFO: NxGeneratorInfo =
@@ -49,18 +52,18 @@ export async function reactGenerator(
   tree: Tree,
   options: ReactGeneratorSchema,
 ) {
-  const frontendProjectConfig = readProjectConfiguration(
+  const frontendProjectConfig = readProjectConfigurationUnqualified(
     tree,
     options.frontendProjectName,
   );
-  const backendProjectConfig = readProjectConfiguration(
+  const backendProjectConfig = readProjectConfigurationUnqualified(
     tree,
     options.backendProjectName,
   );
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const apiName = (backendProjectConfig.metadata as any)?.apiName;
   const apiNameClassName = toClassName(apiName);
-  const backendProjectAlias = toScopeAlias(options.backendProjectName);
+  const backendProjectAlias = toScopeAlias(backendProjectConfig.name);
 
   generateFiles(
     tree,
@@ -70,7 +73,7 @@ export async function reactGenerator(
       apiName,
       apiNameClassName: toClassName(apiName),
       ...options,
-      backendProjectAlias: toScopeAlias(options.backendProjectName),
+      backendProjectAlias,
     },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
@@ -108,7 +111,7 @@ export async function reactGenerator(
   }
 
   await runtimeConfigGenerator(tree, {
-    project: options.frontendProjectName,
+    project: frontendProjectConfig.name,
   });
 
   // update main.tsx

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -9,7 +9,6 @@ import {
   installPackagesTask,
   joinPathFragments,
   readJson,
-  readProjectConfiguration,
   Tree,
   updateJson,
   writeJson,
@@ -23,7 +22,10 @@ import snakeCase from 'lodash.snakecase';
 import { addStarExport, replace } from '../../utils/ast';
 import { ArrayLiteralExpression, factory } from 'typescript';
 import NxPluginForAwsPackageJson from '../../../package.json';
-import { getGeneratorInfo } from '../../utils/nx';
+import {
+  getGeneratorInfo,
+  readProjectConfigurationUnqualified,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { withVersions } from '../../utils/versions';
 import { formatFilesInSubtree } from '../../utils/format';
@@ -36,7 +38,7 @@ export const nxGeneratorGenerator = async (
 ): Promise<GeneratorCallback | void> => {
   const { name, directory, pluginProject, description } = options;
 
-  const plugin = readProjectConfiguration(tree, pluginProject);
+  const plugin = readProjectConfigurationUnqualified(tree, pluginProject);
   const sourceRoot = plugin.sourceRoot ?? joinPathFragments(plugin.root, 'src');
   const sourceRootParts = sourceRoot.split('/');
   const srcDir = sourceRootParts[sourceRootParts.length - 1];

--- a/packages/nx-plugin/src/utils/nx.spec.ts
+++ b/packages/nx-plugin/src/utils/nx.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from './test';
+import { expect, describe, it, beforeEach } from 'vitest';
+import { readProjectConfigurationUnqualified } from './nx';
+
+describe('readProjectConfigurationUnqualified', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+
+    // Setup package.json with a scope
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        name: '@my-scope/monorepo',
+        version: '1.0.0',
+      }),
+    );
+  });
+
+  it('should find project with direct name', () => {
+    // Create a project with a direct name
+    tree.write(
+      'apps/direct-project/project.json',
+      JSON.stringify({
+        name: 'direct-project',
+        root: 'apps/direct-project',
+      }),
+    );
+
+    const result = readProjectConfigurationUnqualified(tree, 'direct-project');
+
+    expect(result.name).toBe('direct-project');
+    expect(result.root).toBe('apps/direct-project');
+  });
+
+  it('should find project with TypeScript fully qualified name', () => {
+    // Create a project with a TypeScript fully qualified name
+    tree.write(
+      'apps/ts-project/project.json',
+      JSON.stringify({
+        name: '@my-scope/ts-project',
+        root: 'apps/ts-project',
+      }),
+    );
+
+    // Should be able to find it with the unqualified name
+    const result = readProjectConfigurationUnqualified(tree, 'ts-project');
+
+    expect(result.name).toBe('@my-scope/ts-project');
+    expect(result.root).toBe('apps/ts-project');
+  });
+
+  it('should find project with Python fully qualified name', () => {
+    // Create a project with a Python fully qualified name
+    tree.write(
+      'apps/py-project/project.json',
+      JSON.stringify({
+        name: 'my_scope.py-project',
+        root: 'apps/py-project',
+      }),
+    );
+
+    // Should be able to find it with the unqualified name
+    const result = readProjectConfigurationUnqualified(tree, 'py-project');
+
+    expect(result.name).toBe('my_scope.py-project');
+    expect(result.root).toBe('apps/py-project');
+  });
+
+  it('should throw error if project is not found', () => {
+    // Should throw an error for a non-existent project
+    expect(() =>
+      readProjectConfigurationUnqualified(tree, 'non-existent-project'),
+    ).toThrow(/Cannot find configuration for 'non-existent-project'/);
+  });
+});

--- a/packages/nx-plugin/src/utils/paths.ts
+++ b/packages/nx-plugin/src/utils/paths.ts
@@ -2,15 +2,18 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readProjectConfiguration, Tree } from '@nx/devkit';
+import { Tree } from '@nx/devkit';
+import { readProjectConfigurationUnqualified } from './nx';
+
 export const getRelativePathToRoot = (
   tree: Tree,
-  projectName: string
+  projectName: string,
 ): string => {
-  const projectConfig = readProjectConfiguration(tree, projectName);
+  const projectConfig = readProjectConfigurationUnqualified(tree, projectName);
   const projectRoot = projectConfig.root;
   return getRelativePathToRootByDirectory(projectRoot);
 };
+
 export const getRelativePathToRootByDirectory = (directory: string): string => {
   // Count the number of path segments to determine how many '../' we need
   const levels = directory.split('/').filter(Boolean).length;


### PR DESCRIPTION
### Reason for this change

Saves some typing when running generators. Additionally in my MCP server testing I've found that despite the guidance saying to use the fully qualified name, models will often still specify the unqualified name.

### Description of changes

Instead of always needing to specify the fully-qualified project name, we let users specify a short project name.

### Description of how you validated changes

Unit tests and smoke tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*