### PR TITLE
chore(mcp-server): add a custom lint rule to ensure mcp sdk is correctly imported

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+module.exports = {
+  rules: {
+    'require-mcp-js-extension': require('./rules/require-mcp-js-extension'),
+  },
+};

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-local-custom-nx-plugin-for-aws-rules",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/eslint/rules/require-mcp-js-extension.js
+++ b/eslint/rules/require-mcp-js-extension.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ensure that all imports from @modelcontextprotocol end with .js',
+    },
+    fixable: 'code',
+    schema: [], // no options
+    messages: {
+      requireJsExtension:
+        'Imports from @modelcontextprotocol must end with .js extension',
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        // Check if this is an import from @modelcontextprotocol
+        const source = node.source.value;
+        if (
+          typeof source === 'string' &&
+          source.startsWith('@modelcontextprotocol/')
+        ) {
+          // Check if the import already ends with .js
+          if (!source.endsWith('.js')) {
+            context.report({
+              node,
+              messageId: 'requireJsExtension',
+              fix(fixer) {
+                // Add .js extension to the import
+                const newSource = `${source}.js`;
+                return fixer.replaceText(node.source, `'${newSource}'`);
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-cypress": "^4.2.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-local-custom-nx-plugin-for-aws-rules": "file:eslint",
     "eslint-plugin-playwright": "^2.2.0",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/packages/nx-plugin/.eslintrc.json
+++ b/packages/nx-plugin/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["../../.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
+  "plugins": ["local-custom-nx-plugin-for-aws-rules"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -13,7 +14,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "rules": {
+        "local-custom-nx-plugin-for-aws-rules/require-mcp-js-extension": "error"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-local-custom-nx-plugin-for-aws-rules:
+        specifier: file:eslint
+        version: file:eslint
       eslint-plugin-playwright:
         specifier: ^2.2.0
         version: 2.2.0(eslint@9.23.0(jiti@2.4.2))
@@ -4534,6 +4537,9 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-local-custom-nx-plugin-for-aws-rules@file:eslint:
+    resolution: {directory: eslint, type: directory}
 
   eslint-plugin-playwright@2.2.0:
     resolution: {integrity: sha512-qSQpAw7RcSzE3zPp8FMGkthaCWovHZ/BsXtpmnGax9vQLIovlh1bsZHEa2+j2lv9DWhnyeLM/qZmp7ffQZfQvg==}
@@ -13714,6 +13720,8 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-local-custom-nx-plugin-for-aws-rules@file:eslint: {}
 
   eslint-plugin-playwright@2.2.0(eslint@9.23.0(jiti@2.4.2)):
     dependencies:


### PR DESCRIPTION
### Reason for this change

Despite the `@aws/nx-plugin` package being `commonjs`, imports for the mcp sdk must use the esm-style `.js` extensions in order for the dependencies to be resolved correctly at runtime. TypeScript compilation doesn't complain if using the syntax without the extension, and neither does vitest.

### Description of changes

Add a custom eslint rule to defend against accidentally omitting the extension.

### Description of how you validated changes

Intentionally omitted a `.js` extension and observed lint rule pick it up, and add it with `--fix` option.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*