### PR TITLE
fix(py#lambda-function): fix dependency added to common/constructs

### DIFF
--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -228,7 +228,7 @@ describe('lambda-handler project generator', () => {
     );
 
     expect(sharedConstructsConfig.targets.build.dependsOn).toContain(
-      'proj.test_function:build',
+      'test-project:build',
     );
   });
 

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -259,9 +259,9 @@ export const lambdaFunctionProjectGenerator = async (
       }
       config.targets.build.dependsOn = [
         ...(config.targets.build.dependsOn ?? []).filter(
-          (t) => t !== `${fullyQualifiedFunctionName}:build`,
+          (t) => t !== `${projectConfig.name}:build`,
         ),
-        `${fullyQualifiedFunctionName}:build`,
+        `${projectConfig.name}:build`,
       ];
       return config;
     },


### PR DESCRIPTION
### Reason for this change

The dependency wasn't specifying the project, but instead the function name which isn't a target/project to depend on.

### Description of changes

Fix to ensure the python lambda project's build target is depended on by common constructs.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*