### PR TITLE
fix(mcp-server): ensure each tool has a description

### DIFF
--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -57,6 +57,13 @@ describe('MCP Server', () => {
     expect(toolNames).toContain('generator-guide');
   });
 
+  it('should have a description for every tool', async () => {
+    // Amazon Q CLI fails to load tools unless each one has a description
+    for (const tool of (await client.listTools()).tools ?? []) {
+      expect(tool.description).toBeDefined();
+    }
+  });
+
   it('should execute create-workspace-command tool', async () => {
     // Call the tool using client
     const result = await client.callTool({

--- a/packages/nx-plugin/src/mcp-server/server.ts
+++ b/packages/nx-plugin/src/mcp-server/server.ts
@@ -11,6 +11,7 @@ import {
   addGeneralGuidanceTool,
   TOOL_SELECTION_GUIDE,
 } from './tools/general-guidance';
+import PackageJson from '../../package.json';
 
 /**
  * Create the MCP Server
@@ -21,7 +22,7 @@ export const createServer = () => {
   const server = new McpServer(
     {
       name: 'nx-plugin-for-aws',
-      version: '1.0.0',
+      version: PackageJson.version,
     },
     {
       instructions: `# Nx Plugin for AWS MCP Server

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -12,6 +12,7 @@ import { PackageManagerSchema } from '../schema';
 export const addCreateWorkspaceCommandTool = (server: McpServer) => {
   server.tool(
     'create-workspace-command',
+    'Tool to discover how to create a workspace to start a new project.',
     { workspaceName: z.string(), packageManager: PackageManagerSchema },
     ({ workspaceName, packageManager }) => ({
       content: [

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -21,11 +21,14 @@ export const addGeneralGuidanceTool = (
   server: McpServer,
   generators: NxGeneratorInfo[],
 ) => {
-  server.tool('general-guidance', async () => ({
-    content: [
-      {
-        type: 'text',
-        text: `# Nx Plugin for AWS Guidance
+  server.tool(
+    'general-guidance',
+    'Tool for guidance and best practices for working with Nx and the Nx Plugin for AWS',
+    async () => ({
+      content: [
+        {
+          type: 'text',
+          text: `# Nx Plugin for AWS Guidance
 
 ${TOOL_SELECTION_GUIDE}
 
@@ -75,7 +78,8 @@ Please refer to the below documentation for important details regarding working 
 ${await fetchGuidePages(['typescript-project', 'python-project'], generators)}
 
     `,
-      },
-    ],
-  }));
+        },
+      ],
+    }),
+  );
 };

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -41,7 +41,7 @@ ${TOOL_SELECTION_GUIDE}
 ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 - Each project in your workspace has a file named \`project.json\` which contains important project information such as its name, and defines the "targets" which can be run for that project, for example building or testing the project
 - Use the command \`nx reset\` to reset the Nx daemon when unexpected issues arise
-- After adding dependencies between projects, use \`nx sync\` to ensure project references are set up correctly
+- After adding dependencies between TypeScript projects, use \`nx sync\` to ensure project references are set up correctly
 
 ## General Instructions
 
@@ -62,8 +62,11 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 
 ## Best Practices
 
+- After running a generator, use the \`nx show projects\` command to check which projects have been added (if any)
+- Carefully examine the files that have been generated and always refer back to the generator guide when working in a generated project
 - Generate all projects into the \`packages/\` directory
 - After making changes to your projects, fix linting issues, then run a full build
+- When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load:runtime-config target after a deployment to point a local website at a sandbox stack.
 
 ## Language Specific Guidance
 

--- a/packages/nx-plugin/src/mcp-server/tools/generator-guide.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/generator-guide.ts
@@ -20,6 +20,7 @@ export const addGeneratorGuideTool = (
 ) => {
   server.tool(
     'generator-guide',
+    'Tool to retrieve detailed information about a specific generator.',
     {
       packageManager: PackageManagerSchema,
       generator: z.custom<string>((v) =>

--- a/packages/nx-plugin/src/mcp-server/tools/list-generators.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/list-generators.ts
@@ -16,6 +16,7 @@ export const addListGeneratorsTool = (
 ) => {
   server.tool(
     'list-generators',
+    'Tool to discover the available generators and how to run them.',
     { packageManager: PackageManagerSchema },
     ({ packageManager }) => ({
       content: [


### PR DESCRIPTION
### Reason for this change

Amazon Q CLI doesn't load tools unless they have a description!

https://github.com/aws/amazon-q-developer-cli/blob/972adf4c445b0486dfb991b10bfeabc6cb4cc498/crates/chat-cli/src/cli/chat/tool_manager.rs#L1245-L1248

### Description of changes

Add a description to every tool, and enforce it with a test.

Also use the package version for the server version.

### Description of how you validated changes

Pointed Q at local server and observed tools!

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*