### PR TITLE
fix(ts#mcp-server): ensure tool descriptions are included in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ pnpm nx g @aws/nx-plugin:ts#infra
 
 ### Additional resources
 
-- Use [Quick Start](https://awslabs.github.io/nx-plugin-for-aws/get_started/quick-start/) to get a taste of @aws/nx-plugin.
-- [Build a Dungeon Adventure Game](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/dungeon-game/overview/) to get an in-depth guided tutorial on how to use the @aws/nx-plugin.
-- [Add @aws/nx-plugin to your existing project](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/existing-project/)
+- Use [Quick Start](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/quick-start/) to get a taste of @aws/nx-plugin.
+- [Build a Dungeon Adventure Game](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/tutorials/dungeon-game/overview/) to get an in-depth guided tutorial on how to use the @aws/nx-plugin.
+- [Add @aws/nx-plugin to your existing project](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/tutorials/existing-project/)
 
 ## MCP Server Installation and Setup
 
@@ -114,13 +114,15 @@ Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
   "mcpServers": {
     "aws-nx-mcp": {
       "command": "npx",
-      "args": ["-p", "@aws/nx-plugin", "aws-nx-mcp"]
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
     }
   }
 }
 ```
 
 If you have issues such as `ENOENT npx`, replace the command with `/full/path/to/npx` (use `which npx` to find this).
+
+For more details, [take a look at the guide here](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/building-with-ai/)
 
 ## Documentation Translation
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -217,6 +217,19 @@ export default defineConfig({
                 },
               ],
             },
+            {
+              label: 'Building with AI',
+              link: '/get_started/building-with-ai',
+              translations: {
+                jp: 'AIでの構築',
+                ko: 'AI로 구축하기',
+                fr: "Construire avec l'IA",
+                it: "Costruire con l'IA",
+                es: 'Construyendo con IA',
+                pt: 'Construindo com IA',
+                zh: '使用 AI 构建',
+              },
+            },
           ],
         },
         {

--- a/docs/src/content/docs/en/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/en/get_started/building-with-ai.mdx
@@ -1,0 +1,28 @@
+---
+title: Building with AI
+description: Building with AI and the Nx Plugin for AWS MCP Server
+---
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+The Nx Plugin for AWS includes an [MCP Server](https://modelcontextprotocol.io/introduction) which enables AI assistants to work with the Nx Plugin for AWS. By utilizing the MCP Server, you can accelerate your development workflow with AI, while benefitting from your projects being scaffolded in a deterministic fashion, spending less time and less of your context window on setting up the main components.
+
+Use the MCP Server with your AI Assistant of choice, such as Amazon Q Developer, Cline, Claude Code or Cursor.
+
+## MCP Server Configuration
+
+Most AI Assistants will have a JSON file for MCP server configuration. In Amazon Q Developer, this is located in `~/.aws/amazonq/mcp.json`. Add an entry for the Nx Plugin for AWS MCP Server
+
+<Snippet name="mcp/config" />
+
+Please refer to the following documentation for configuring MCP with specific AI Assistants:
+
+<Snippet name="mcp/assistant-docs" />
+
+## Start Vibe Coding
+
+Ask your AI Assistant to build something using the `aws-nx-mcp` MCP Server! Generally AI Assistants will start by creating a workspace, scaffolding with the applicable generators, and then filling in the business logic.
+
+## Build your own MCP Server
+
+Check out the <Link path="/guides/ts-mcp-server">`ts#mcp-server` generator guide</Link> for details about building your own MCP Server.

--- a/docs/src/content/docs/en/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/en/guides/ts-mcp-server.mdx
@@ -7,6 +7,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
@@ -60,7 +61,7 @@ Please refer to the <Link path="/guides/typescript-project">TypeScript project g
 Tools are functions that the AI assistant can call to perform actions. You can add new tools in the `server.ts` file:
 
 ```typescript
-server.tool("toolName",
+server.tool("toolName", "tool description",
   { param1: z.string(), param2: z.number() }, // Input schema using Zod
   async ({ param1, param2 }) => {
     // Tool implementation
@@ -128,10 +129,7 @@ If you receive an error such as `ENOENT node` when connecting to your server, yo
 
 Please refer to the following documentation for configuring MCP with specific AI Assistants:
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
 Some AI Assistants, such as Amazon Q Developer, allow you to specify workspace level MCP server configuration, which is particularly useful for defining the relevant MCP servers for a particular project.

--- a/docs/src/content/docs/en/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/en/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,7 @@
+---
+title: MCP AI Assistant docs
+---
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)

--- a/docs/src/content/docs/en/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/en/snippets/mcp/config.mdx
@@ -1,0 +1,13 @@
+---
+title: MCP Server Configuration
+---
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/en/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/prerequisites.mdx
@@ -1,6 +1,8 @@
 ---
 title: Prerequisites
 ---
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (We recommend using something like [NVM](https://github.com/nvm-sh/nvm) to manage your node versions)
   - verify by running `node --version`
@@ -11,3 +13,7 @@ title: Prerequisites
   2. verify with `uv python list --only-installed`
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account (where your application will be deployed)
 - If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+
+:::tip
+If you use an AI Assistant such as Amazon Q Developer, Cursor, Claude Code or Cline, you may also wish to <Link path="/get_started/building-with-ai">install the Nx Plugin for AWS MCP server.</Link>
+:::

--- a/docs/src/content/docs/es/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/es/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "Construyendo con IA"
+description: "Construyendo con IA y el Plugin de Nx para el Servidor AWS MCP"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+El Plugin Nx para AWS incluye un [Servidor MCP](https://modelcontextprotocol.io/introduction) que permite a los asistentes de IA trabajar con el Plugin Nx para AWS. Al utilizar el Servidor MCP, puedes acelerar tu flujo de trabajo de desarrollo con IA, beneficiándote de proyectos generados de manera determinista, gastando menos tiempo y menos de tu ventana de contexto en configurar los componentes principales.
+
+Utiliza el Servidor MCP con tu asistente de IA preferido, como Amazon Q Developer, Cline, Claude Code o Cursor.
+
+## Configuración del Servidor MCP
+
+La mayoría de los asistentes de IA utilizan un archivo JSON para la configuración del servidor MCP. En Amazon Q Developer, este se encuentra en `~/.aws/amazonq/mcp.json`. Agrega una entrada para el Servidor MCP del Plugin Nx para AWS:
+
+<Snippet name="mcp/config" />
+
+Consulta la siguiente documentación para configurar MCP con asistentes de IA específicos:
+
+<Snippet name="mcp/assistant-docs" />
+
+## Comienza con Vibe Coding
+
+¡Pídele a tu asistente de IA que construya algo usando el servidor MCP `aws-nx-mcp`! Generalmente los asistentes comenzarán creando un workspace, generando componentes con los generadores aplicables, y luego completando la lógica de negocio.
+
+## Construye tu propio Servidor MCP
+
+Revisa la <Link path="/guides/ts-mcp-server">guía del generador `ts#mcp-server`</Link> para detalles sobre cómo construir tu propio Servidor MCP.

--- a/docs/src/content/docs/es/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/es/guides/ts-mcp-server.mdx
@@ -9,16 +9,17 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
-# Generador de Servidor MCP en TypeScript
+# Generador de servidor MCP en TypeScript
 
-Genera un servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript para proporcionar contexto a Modelos de Lenguaje Grandes (LLMs).
+Genera un servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript para proporcionar contexto a Modelos de Lenguaje Grande (LLMs).
 
 ## ¿Qué es MCP?
 
-El [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) es un estándar abierto que permite a los asistentes de IA interactuar con herramientas y recursos externos. Proporciona una forma consistente para que los LLMs puedan:
+El [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) es un estándar abierto que permite a asistentes de IA interactuar con herramientas y recursos externos. Proporciona una forma consistente para que los LLMs puedan:
 
 - Ejecutar herramientas (funciones) que realizan acciones o recuperan información
 - Acceder a recursos que proveen contexto o datos
@@ -35,17 +36,17 @@ Puedes generar un servidor MCP en TypeScript de dos formas:
 
 <GeneratorParameters generator="ts#mcp-server" />
 
-## Salida del Generador
+## Salida del generador
 
 El generador creará los siguientes archivos del proyecto:
 
 <FileTree>
-  - packages/\<nombre>/
+  - packages/\<name>/
     - README.md Documentación del servidor MCP con instrucciones de uso
     - project.json Configuración del proyecto Nx con objetivos de build, bundle y dev
     - src/
       - index.ts Punto de entrada del servidor MCP
-      - server.ts Definición principal del servidor, con herramientas y recursos
+      - server.ts Definición principal del servidor, incluyendo herramientas y recursos
       - global.d.ts Declaraciones de tipos TypeScript para importar archivos markdown
       - resources/
         - example-context.md Archivo markdown de ejemplo usado como recurso para el servidor MCP
@@ -55,56 +56,56 @@ El generador creará los siguientes archivos del proyecto:
 Consulta la <Link path="/guides/typescript-project">documentación del generador de proyectos TypeScript</Link> para más detalles sobre la salida del generador.
 :::
 
-## Trabajando con tu Servidor MCP
+## Trabajando con tu servidor MCP
 
-### Añadiendo Herramientas
+### Añadiendo herramientas
 
-Las herramientas son funciones que el asistente de IA puede ejecutar. Puedes añadir nuevas herramientas en el archivo `server.ts`:
+Las herramientas son funciones que el asistente de IA puede llamar para realizar acciones. Puedes añadir nuevas herramientas en el archivo `server.ts`:
 
 ```typescript
-server.tool("nombreHerramienta",
+server.tool("toolName", "tool description",
   { param1: z.string(), param2: z.number() }, // Esquema de entrada usando Zod
   async ({ param1, param2 }) => {
     // Implementación de la herramienta
     return {
-      content: [{ type: "text", text: "Resultado" }]
+      content: [{ type: "text", text: "Result" }]
     };
   }
 );
 ```
 
-### Añadiendo Recursos
+### Añadiendo recursos
 
 Los recursos proveen contexto al asistente de IA. Puedes añadir recursos estáticos desde archivos o recursos dinámicos:
 
 ```typescript
-// Recurso estático desde archivo
+// Recurso estático desde un archivo
 import exampleContext from './resources/example-context.md';
 
-server.resource('nombre-recurso', 'example://recurso', async (uri) => ({
+server.resource('resource-name', 'example://resource', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
 // Recurso dinámico
-server.resource('recurso-dinamico', 'dynamic://recurso', async (uri) => {
-  const data = await obtenerDatos();
+server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
+  const data = await fetchSomeData();
   return {
     contents: [{ uri: uri.href, text: data }],
   };
 });
 ```
 
-## Configuración con Asistentes de IA
+## Configuración con asistentes de IA
 
 Para usar tu servidor MCP con asistentes de IA, primero debes empaquetarlo:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-Esto crea una versión empaquetada en `dist/packages/your-mcp-server/bundle/index.js` (la ruta puede variar según tu configuración).
+Esto crea una versión empaquetada en `dist/packages/your-mcp-server/bundle/index.js` (la ruta puede variar según tu configuración de directorios).
 
-### Archivos de Configuración
+### Archivos de configuración
 
-La mayoría de asistentes de IA que soportan MCP usan un enfoque similar. Deberás crear/actualizar un archivo de configuración con los detalles de tu servidor:
+La mayoría de asistentes de IA que soportan MCP usan un enfoque de configuración similar. Necesitarás crear o actualizar un archivo de configuración con los detalles de tu servidor MCP:
 
 ```json
 {
@@ -112,7 +113,7 @@ La mayoría de asistentes de IA que soportan MCP usan un enfoque similar. Deber�
     "your-mcp-server": {
       "command": "node",
       "args": [
-        "/ruta/al/workspace/dist/packages/your-mcp-server/bundle/index.js"
+        "/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js"
       ],
       "transportType": "stdio"
     }
@@ -120,47 +121,44 @@ La mayoría de asistentes de IA que soportan MCP usan un enfoque similar. Deber�
 }
 ```
 
-Reemplaza `/ruta/al/workspace/dist/packages/your-mcp-server/bundle/index.js` con la ruta real a tu servidor empaquetado.
+Reemplaza `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` con la ruta real a tu servidor MCP empaquetado.
 
 :::caution
-Si recibes un error como `ENOENT node` al conectar, quizás debes especificar la ruta completa a `node`, que puedes obtener ejecutando `which node` en tu terminal.
+Si recibes un error como `ENOENT node` al conectarte a tu servidor, posiblemente necesites especificar la ruta completa a `node`, que puedes obtener ejecutando `which node` en tu terminal.
 :::
 
-### Configuración Específica por Asistente
+### Configuración específica por asistente
 
-Consulta estas guías para configurar MCP con asistentes específicos:
+Consulta la siguiente documentación para configurar MCP con asistentes de IA específicos:
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
-Algunos asistentes como Amazon Q Developer permiten configuración de servidores MCP a nivel de workspace, útil para definir servidores relevantes a un proyecto.
+Algunos asistentes de IA, como Amazon Q Developer, permiten especificar configuración de servidores MCP a nivel de workspace, lo cual es particularmente útil para definir los servidores MCP relevantes para un proyecto específico.
 :::
 
-## Flujo de Desarrollo
+## Flujo de desarrollo
 
-### Objetivos de Build
+### Objetivos de build
 
-Este generador se basa en el <Link path="/guides/typescript-project">generador de proyectos TypeScript</Link> y hereda sus objetivos, añadiendo estos adicionales:
+El generador está construido sobre el <Link path="/guides/typescript-project">generador de proyectos TypeScript</Link> y por lo tanto hereda sus objetivos, además de añadir los siguientes objetivos adicionales:
 
 #### Bundle
 
-El objetivo `bundle` usa [esbuild](https://esbuild.github.io/) para crear un único archivo JavaScript empaquetado:
+La tarea `bundle` usa [esbuild](https://esbuild.github.io/) para crear un único archivo JavaScript empaquetado que puede usarse con asistentes de IA:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-Esto genera el bundle en `dist/packages/your-mcp-server/bundle/index.js` (ruta puede variar).
+Esto crea una versión empaquetada en `dist/packages/your-mcp-server/bundle/index.js` (la ruta puede variar según tu configuración de directorios).
 
 #### Dev
 
-El objetivo `dev` monitorea cambios y reconstruye automáticamente:
+La tarea `dev` monitorea cambios en tu proyecto y reconstruye automáticamente el bundle:
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-Es útil durante desarrollo para que tu asistente use siempre la última versión.
+Esto es particularmente útil durante el desarrollo, ya que asegura que tu asistente de IA utilice la versión más reciente de tu servidor MCP.
 
 :::note
-Algunos asistentes requieren reiniciar el servidor MCP para aplicar cambios.
+Algunos asistentes de IA requerirán que reinicies el servidor MCP para que los cambios surtan efecto.
 :::

--- a/docs/src/content/docs/es/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/es/snippets/mcp/assistant-docs.mdx
@@ -1,12 +1,7 @@
 ---
 title: "Documentación del Asistente de IA de MCP"
 ---
-
-
-
 - [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
 - [Cline](https://docs.cline.bot/mcp/mcp-overview)
 - [Cursor](https://docs.cursor.com/context/model-context-protocol)
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
-
-<!-- Nota: Todos los enlaces y nombres técnicos se mantienen sin cambios según los requisitos -->

--- a/docs/src/content/docs/es/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/es/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,12 @@
+---
+title: "Documentación del Asistente de IA de MCP"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+
+<!-- Nota: Todos los enlaces y nombres técnicos se mantienen sin cambios según los requisitos -->

--- a/docs/src/content/docs/es/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/es/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "Configuración del Servidor MCP"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/es/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/es/snippets/prerequisites.mdx
@@ -4,13 +4,19 @@ title: "Requisitos previos"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Node >= 22](https://nodejs.org/en/download) (Recomendamos usar herramientas como [NVM](https://github.com/nvm-sh/nvm) para gestionar tus versiones de Node)
+- [Node >= 22](https://nodejs.org/en/download) (Recomendamos usar algo como [NVM](https://github.com/nvm-sh/nvm) para gestionar tus versiones de Node)
   - Verifica ejecutando `node --version`
 - [PNPM >= 10](https://pnpm.io/installation#using-npm) (también puedes usar [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation) o [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) si lo prefieres)
   - Verifica ejecutando `pnpm --version`, `yarn --version`, `bun --version` o `npm --version`
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
   1. Instala Python 3.12 ejecutando: `uv python install 3.12.0`
   2. Verifica con `uv python list --only-installed`
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para tu cuenta de AWS objetivo (donde se desplegará tu aplicación)
-- Si usas [VSCode](https://code.visualstudio.com/), recomendamos instalar el [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+- [Credenciales de AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para tu cuenta de AWS de destino (donde se desplegará tu aplicación)
+- Si usas [VSCode](https://code.visualstudio.com/), recomendamos instalar el [Complemento Nx Console para VSCode](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+
+:::tip
+Si utilizas un Asistente de IA como Amazon Q Developer, Cursor, Claude Code o Cline, también puedes querer <Link path="/get_started/building-with-ai">instalar el complemento de Nx para AWS MCP server.</Link>
+:::

--- a/docs/src/content/docs/fr/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/fr/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "Construire avec l'IA"
+description: "Construire avec l'IA et le Plugin Nx pour le Serveur AWS MCP"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+Le Plugin Nx pour AWS inclut un [serveur MCP](https://modelcontextprotocol.io/introduction) qui permet aux assistants IA de collaborer avec le Plugin Nx pour AWS. En utilisant le serveur MCP, vous pouvez accélérer votre flux de développement avec l'IA, tout en bénéficiant d'une génération déterministe de vos projets, en passant moins de temps et en utilisant moins de contexte pour configurer les composants principaux.
+
+Utilisez le serveur MCP avec l'assistant IA de votre choix comme Amazon Q Developer, Cline, Claude Code ou Cursor.
+
+## Configuration du serveur MCP
+
+La plupart des assistants IA utilisent un fichier JSON pour la configuration du serveur MCP. Dans Amazon Q Developer, ce fichier se trouve dans `~/.aws/amazonq/mcp.json`. Ajoutez une entrée pour le serveur MCP du Plugin Nx pour AWS :
+
+<Snippet name="mcp/config" />
+
+Consultez la documentation suivante pour configurer MCP avec des assistants IA spécifiques :
+
+<Snippet name="mcp/assistant-docs" />
+
+## Commencez le Vibe Coding
+
+Demandez à votre assistant IA de construire quelque chose en utilisant le serveur MCP `aws-nx-mcp` ! Généralement, les assistants IA commenceront par créer un espace de travail, généreront les squelettes avec les générateurs appropriés, puis rempliront la logique métier.
+
+## Construisez votre propre serveur MCP
+
+Consultez le <Link path="/guides/ts-mcp-server">guide du générateur `ts#mcp-server`</Link> pour plus de détails sur la création de votre propre serveur MCP.

--- a/docs/src/content/docs/fr/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/fr/guides/ts-mcp-server.mdx
@@ -9,12 +9,13 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
 # Générateur de serveur MCP TypeScript
 
-Générez un serveur [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript pour fournir du contexte aux Grands Modèles de Langage (LLMs).
+Générez un serveur [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) en TypeScript pour fournir du contexte aux grands modèles de langage (LLMs).
 
 ## Qu'est-ce que le MCP ?
 
@@ -45,14 +46,14 @@ Le générateur créera les fichiers projet suivants :
     - project.json Configuration de projet Nx avec les cibles build, bundle et dev
     - src/
       - index.ts Point d'entrée du serveur MCP
-      - server.ts Définition principale du serveur, décrivant outils et ressources
+      - server.ts Définition principale du serveur, décrivant les outils et ressources
       - global.d.ts Déclarations de types TypeScript pour l'import de fichiers markdown
       - resources/
         - example-context.md Exemple de fichier markdown utilisé comme ressource pour le serveur MCP
 </FileTree>
 
 :::note
-Veuillez consulter la <Link path="/guides/typescript-project">documentation du générateur de projet TypeScript</Link> pour plus de détails concernant le résultat du générateur.
+Veuillez consulter la <Link path="/guides/typescript-project">documentation du générateur de projet TypeScript</Link> pour plus de détails sur le résultat du générateur.
 :::
 
 ## Utilisation de votre serveur MCP
@@ -62,7 +63,7 @@ Veuillez consulter la <Link path="/guides/typescript-project">documentation du g
 Les outils sont des fonctions que l'assistant IA peut appeler pour effectuer des actions. Vous pouvez ajouter de nouveaux outils dans le fichier `server.ts` :
 
 ```typescript
-server.tool("toolName",
+server.tool("toolName", "tool description",
   { param1: z.string(), param2: z.number() }, // Schéma d'entrée utilisant Zod
   async ({ param1, param2 }) => {
     // Implémentation de l'outil
@@ -96,11 +97,11 @@ server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
 
 ## Configuration avec les assistants IA
 
-Pour utiliser votre serveur MCP avec des assistants IA, vous devez d'abord le regrouper :
+Pour utiliser votre serveur MCP avec des assistants IA, vous devez d'abord le bundler :
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-Ceci crée une version regroupée dans `dist/packages/your-mcp-server/bundle/index.js` (le chemin peut varier selon votre configuration).
+Ceci crée une version bundle dans `dist/packages/your-mcp-server/bundle/index.js` (le chemin peut varier selon votre configuration).
 
 ### Fichiers de configuration
 
@@ -120,38 +121,35 @@ La plupart des assistants IA supportant MCP utilisent une approche de configurat
 }
 ```
 
-Remplacez `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` par le chemin réel vers votre serveur MCP regroupé.
+Remplacez `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` par le chemin réel vers votre serveur MCP bundle.
 
 :::caution
-Si vous recevez une erreur telle que `ENOENT node` lors de la connexion à votre serveur, vous devrez peut-être spécifier le chemin complet vers `node`, que vous pouvez obtenir en exécutant `which node` dans votre terminal.
+Si vous recevez une erreur comme `ENOENT node` lors de la connexion à votre serveur, vous devrez peut-être spécifier le chemin complet vers `node`, que vous pouvez obtenir en exécutant `which node` dans votre terminal.
 :::
 
 ### Configuration spécifique aux assistants
 
-Veuillez consulter les documentations suivantes pour configurer MCP avec des assistants IA spécifiques :
+Veuillez consulter la documentation suivante pour configurer MCP avec des assistants IA spécifiques :
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
-Certains assistants IA, comme Amazon Q Developer, permettent de spécifier une configuration MCP au niveau de l'espace de travail, particulièrement utile pour définir les serveurs MCP pertinents pour un projet donné.
+Certains assistants IA, comme Amazon Q Developer, permettent de spécifier une configuration de serveur MCP au niveau du workspace, ce qui est particulièrement utile pour définir les serveurs MCP pertinents pour un projet donné.
 :::
 
 ## Workflow de développement
 
-### Cibles de construction
+### Cibles de build
 
 Le générateur est basé sur le <Link path="/guides/typescript-project">générateur de projet TypeScript</Link> et hérite donc de ses cibles, tout en ajoutant les cibles supplémentaires suivantes :
 
 #### Bundle
 
-La tâche `bundle` utilise [esbuild](https://esbuild.github.io/) pour créer un fichier JavaScript unique regroupé, utilisable avec les assistants IA :
+La tâche `bundle` utilise [esbuild](https://esbuild.github.io/) pour créer un fichier JavaScript unique qui peut être utilisé avec les assistants IA :
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-Ceci crée une version regroupée dans `dist/packages/your-mcp-server/bundle/index.js` (le chemin peut varier selon votre configuration).
+Ceci crée une version bundle dans `dist/packages/your-mcp-server/bundle/index.js` (le chemin peut varier selon votre configuration).
 
 #### Dev
 
@@ -162,5 +160,5 @@ La tâche `dev` surveille les modifications de votre projet et reconstruit autom
 Ceci est particulièrement utile pendant le développement car il garantit que votre assistant IA utilise la dernière version de votre serveur MCP.
 
 :::note
-Certains assistants IA nécessiteront un redémarrage du serveur MCP pour que les modifications prennent effet.
+Certains assistants IA nécessitent un redémarrage du serveur MCP pour que les modifications prennent effet.
 :::

--- a/docs/src/content/docs/fr/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/fr/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,12 @@
+---
+title: "Documentation de l'assistant IA MCP"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+
+*Note: Tous les éléments soumis étaient des noms de produits/projets ou des liens techniques - aucun contenu traduisible n'était présent dans le texte source selon les contraintes données.*

--- a/docs/src/content/docs/fr/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/fr/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "Configuration du serveur MCP"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/fr/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/fr/snippets/prerequisites.mdx
@@ -4,13 +4,19 @@ title: "Prérequis"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (Nous recommandons d'utiliser un outil comme [NVM](https://github.com/nvm-sh/nvm) pour gérer vos versions de Node)
-  - vérifiez avec `node --version`
-- [PNPM >= 10](https://pnpm.io/installation#using-npm) (vous pouvez également utiliser [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation) ou [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) si vous préférez)
-  - vérifiez avec `pnpm --version`, `yarn --version`, `bun --version` ou `npm --version`
+  - vérifier en exécutant `node --version`
+- [PNPM >= 10](https://pnpm.io/installation#using-npm) (vous pouvez aussi utiliser [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation) ou [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) si vous préférez)
+  - vérifier en exécutant `pnpm --version`, `yarn --version`, `bun --version` ou `npm --version`
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
-  1. installez Python 3.12 en exécutant : `uv python install 3.12.0`
-  2. vérifiez avec `uv python list --only-installed`
+  1. installer Python 3.12 en exécutant : `uv python install 3.12.0`
+  2. vérifier avec `uv python list --only-installed`
 - [Identifiants AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurés pour votre compte AWS cible (où votre application sera déployée)
-- Si vous utilisez [VSCode](https://code.visualstudio.com/), nous recommandons d'installer le [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+- Si vous utilisez [VSCode](https://code.visualstudio.com/), nous recommandons d'installer le [Plugin VSCode Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+
+:::tip
+Si vous utilisez un assistant IA comme Amazon Q Developer, Cursor, Claude Code ou Cline, vous pouvez aussi <Link path="/get_started/building-with-ai">installer le plugin Nx pour AWS MCP server.</Link>
+:::

--- a/docs/src/content/docs/it/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/it/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "Costruire con l'IA"
+description: "Costruire con l'IA e il Plugin Nx per AWS MCP Server"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+Il Plugin Nx per AWS include un [MCP Server](https://modelcontextprotocol.io/introduction) che consente agli assistenti AI di lavorare con il Plugin Nx per AWS. Utilizzando il MCP Server, puoi accelerare il tuo flusso di lavoro di sviluppo con l'AI, beneficiando della generazione deterministica dei progetti e risparmiando tempo e risorse del contesto nella configurazione dei componenti principali.
+
+Utilizza il MCP Server con l'assistente AI di tua scelta come Amazon Q Developer, Cline, Claude Code o Cursor.
+
+## Configurazione del MCP Server
+
+La maggior parte degli assistenti AI utilizza un file JSON per la configurazione del MCP Server. In Amazon Q Developer, questo si trova in `~/.aws/amazonq/mcp.json`. Aggiungi una voce per il MCP Server del Plugin Nx per AWS:
+
+<Snippet name="mcp/config" />
+
+Consulta la documentazione specifica per configurare il MCP con il tuo assistente AI:
+
+<Snippet name="mcp/assistant-docs" />
+
+## Inizia il Vibe Coding
+
+Chiedi al tuo assistente AI di costruire qualcosa utilizzando il MCP Server `aws-nx-mcp`! Generalmente gli assistenti inizieranno creando un workspace, generando componenti con i generatori applicabili e poi implementando la logica di business.
+
+## Costruisci il tuo MCP Server
+
+Consulta la <Link path="/guides/ts-mcp-server">guida del generatore `ts#mcp-server`</Link> per dettagli sulla creazione del tuo MCP Server personalizzato.

--- a/docs/src/content/docs/it/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/it/guides/ts-mcp-server.mdx
@@ -9,18 +9,19 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
-# Generatore di Server MCP TypeScript
+# Generatore di Server TypeScript MCP
 
 Genera un server [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) in TypeScript per fornire contesto ai Large Language Model (LLM).
 
 ## Cos'è l'MCP?
 
-Il [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) è uno standard aperto che consente agli assistenti AI di interagire con strumenti e risorse esterne. Fornisce un metodo consistente per i LLM per:
+Il [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) è uno standard aperto che permette agli assistenti AI di interagire con strumenti e risorse esterne. Fornisce un metodo consistente per gli LLM di:
 
-- Eseguire strumenti (funzioni) che compiono azioni o recuperano informazioni  
+- Eseguire strumenti (funzioni) che compiono azioni o recuperano informazioni
 - Accedere a risorse che forniscono contesto o dati
 
 ## Utilizzo
@@ -37,16 +38,16 @@ Puoi generare un server MCP TypeScript in due modi:
 
 ## Output del Generatore
 
-Il generatore creerà i seguenti file di progetto:
+Il generatore creerà i seguenti file del progetto:
 
 <FileTree>
   - packages/\<name>/
-    - README.md Documentazione del server MCP con istruzioni per l'uso
+    - README.md Documentazione del server MCP con istruzioni d'uso
     - project.json Configurazione del progetto Nx con target per build, bundle e dev
     - src/
-      - index.ts Punto di ingresso del server MCP
+      - index.ts Punto d'ingresso del server MCP
       - server.ts Definizione principale del server, con strumenti e risorse
-      - global.d.ts Dichiarazioni di tipo TypeScript per importare file markdown
+      - global.d.ts Dichiarazioni di tipo TypeScript per l'importazione di file markdown
       - resources/
         - example-context.md File markdown di esempio utilizzato come risorsa per il server MCP
 </FileTree>
@@ -55,15 +56,15 @@ Il generatore creerà i seguenti file di progetto:
 Consulta la <Link path="/guides/typescript-project">documentazione del generatore di progetti TypeScript</Link> per ulteriori dettagli sull'output del generatore.
 :::
 
-## Lavorare con il Server MCP
+## Lavorare con il Tuo Server MCP
 
 ### Aggiungere Strumenti
 
 Gli strumenti sono funzioni che l'assistente AI può chiamare per eseguire azioni. Puoi aggiungere nuovi strumenti nel file `server.ts`:
 
 ```typescript
-server.tool("toolName",
-  { param1: z.string(), param2: z.number() }, // Schema di input utilizzando Zod
+server.tool("toolName", "tool description",
+  { param1: z.string(), param2: z.number() }, // Schema di input usando Zod
   async ({ param1, param2 }) => {
     // Implementazione dello strumento
     return {
@@ -78,7 +79,7 @@ server.tool("toolName",
 Le risorse forniscono contesto all'assistente AI. Puoi aggiungere risorse statiche da file o risorse dinamiche:
 
 ```typescript
-// Risorsa statica da un file
+// Risorsa statica da file
 import exampleContext from './resources/example-context.md';
 
 server.resource('resource-name', 'example://resource', async (uri) => ({
@@ -126,28 +127,25 @@ Sostituisci `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` c
 Se ricevi un errore come `ENOENT node` durante la connessione al server, potrebbe essere necessario specificare il percorso completo di `node`, ottenibile eseguendo `which node` nel terminale.
 :::
 
-### Configurazione Specifica per Assistente
+### Configurazione Specifica per Assistante
 
-Consulta la seguente documentazione per configurare MCP con assistenti AI specifici:
+Consulta la seguente documentazione per configurare MCP con assistanti AI specifici:
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
-Alcuni assistenti AI, come Amazon Q Developer, consentono di specificare una configurazione MCP a livello di workspace, particolarmente utile per definire i server MCP rilevanti per un progetto specifico.
+Alcuni assistanti AI, come Amazon Q Developer, permettono di specificare configurazioni MCP a livello di workspace, particolarmente utili per definire i server MCP rilevanti per un progetto specifico.
 :::
 
 ## Flusso di Sviluppo
 
 ### Target di Build
 
-Il generatore è basato sul <Link path="/guides/typescript-project">generatore di progetti TypeScript</Link> e ne eredita i target, aggiungendo inoltre i seguenti target:
+Il generatore è basato sul <Link path="/guides/typescript-project">generatore di progetti TypeScript</Link> e quindi eredita i suoi target, aggiungendo inoltre i seguenti target:
 
 #### Bundle
 
-Il task `bundle` utilizza [esbuild](https://esbuild.github.io/) per creare un singolo file JavaScript che può essere utilizzato con gli assistenti AI:
+Il task `bundle` utilizza [esbuild](https://esbuild.github.io/) per creare un singolo file JavaScript bundled utilizzabile con assistenti AI:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
@@ -159,8 +157,8 @@ Il task `dev` monitora le modifiche nel progetto e ricostruisce automaticamente 
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-Particolarmente utile durante lo sviluppo, garantisce che l'assistente AI utilizzi l'ultima versione del server MCP.
+Questo è particolarmente utile durante lo sviluppo poiché garantisce che l'assistente AI utilizzi l'ultima versione del tuo server MCP.
 
 :::note
-Alcuni assistenti AI richiederanno il riavvio del server MCP per applicare le modifiche.
+Alcuni assistanti AI richiederanno il riavvio del server MCP per applicare le modifiche.
 :::

--- a/docs/src/content/docs/it/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/it/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,17 @@
+---
+title: "Documentazione dell'Assistente AI MCP"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+
+Traduzione italiana:
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html) (Configurazione MCP da riga di comando)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview) (Panoramica su MCP)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol) (Protocollo Model Context)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp) (Configurare il Model Context Protocol - MCP)

--- a/docs/src/content/docs/it/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/it/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "Configurazione del Server MCP"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/it/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/it/snippets/prerequisites.mdx
@@ -4,13 +4,19 @@ title: "Prerequisiti"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (Consigliamo di utilizzare strumenti come [NVM](https://github.com/nvm-sh/nvm) per gestire le versioni di Node)
   - verifica eseguendo `node --version`
-- [PNPM >= 10](https://pnpm.io/installation#using-npm) (puoi usare anche [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation) o [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) se preferisci)
+- [PNPM >= 10](https://pnpm.io/installation#using-npm) (puoi anche usare [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation) o [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) se preferisci)
   - verifica eseguendo `pnpm --version`, `yarn --version`, `bun --version` o `npm --version`
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
   1. installa Python 3.12 eseguendo: `uv python install 3.12.0`
   2. verifica con `uv python list --only-installed`
-- [Credenziali AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurate per il tuo account AWS di destinazione (dove verrà distribuita la tua applicazione)
-- Se utilizzi [VSCode](https://code.visualstudio.com/), consigliamo di installare il [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+- [Credenziali AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurate per il tuo account AWS target (dove verrà distribuita l'applicazione)
+- Se utilizzi [VSCode](https://code.visualstudio.com/), consigliamo di installare l'[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+
+:::tip
+Se usi un Assistente AI come Amazon Q Developer, Cursor, Claude Code o Cline, potresti voler <Link path="/get_started/building-with-ai">installare il Plugin Nx per AWS MCP server.</Link>
+:::

--- a/docs/src/content/docs/jp/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/jp/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "AIを活用した構築"
+description: "AWS MCP サーバー用のNxプラグインを使用したAIによる構築"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+Nx Plugin for AWSには[Model Context Protocol（MCP）サーバー](https://modelcontextprotocol.io/introduction)が含まれており、AIアシスタントがNx Plugin for AWSと連携できるようになります。MCPサーバーを活用することで、AIによる開発ワークフローの加速が可能となり、プロジェクトの主要コンポーネント設定に費やす時間とコンテキストウィンドウを削減しつつ、決定論的な方法でプロジェクトをスキャフォールディングできます。
+
+Amazon Q Developer、Cline、Claude Code、Cursorなど、お好みのAIアシスタントでMCPサーバーをご利用いただけます。
+
+## MCPサーバーの設定
+
+ほとんどのAIアシスタントでは、MCPサーバー設定用のJSONファイルが用意されています。Amazon Q Developerの場合、`~/.aws/amazonq/mcp.json`に配置されます。Nx Plugin for AWSのMCPサーバー用エントリを追加してください。
+
+<Snippet name="mcp/config" />
+
+特定のAIアシスタントでのMCP設定方法については、以下のドキュメントを参照してください：
+
+<Snippet name="mcp/assistant-docs" />
+
+## Vibe Codingの開始
+
+AIアシスタントに`aws-nx-mcp` MCPサーバーを使用した構築を指示しましょう！一般的にAIアシスタントは、ワークスペースの作成から適用可能なジェネレーターによるスキャフォールディング、ビジネスロジックの実装という流れで作業を進めます。
+
+## 独自MCPサーバーの構築
+
+独自のMCPサーバー構築に関する詳細は、<Link path="/guides/ts-mcp-server">`ts#mcp-server`ジェネレーターガイド</Link>をご覧ください。

--- a/docs/src/content/docs/jp/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/jp/guides/ts-mcp-server.mdx
@@ -9,23 +9,24 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
 # TypeScript MCP サーバージェネレーター
 
-大規模言語モデル（LLM）にコンテキストを提供するためのTypeScript [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) サーバーを生成します。
+大規模言語モデル（LLM）にコンテキストを提供するためのTypeScript [Model Context Protocol（MCP）](https://modelcontextprotocol.io/) サーバーを生成します。
 
 ## MCPとは
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) は、AIアシスタントが外部ツールやリソースと相互作用するためのオープンスタンダードです。LLMが以下を行うための一貫した方法を提供します：
+[Model Context Protocol（MCP）](https://modelcontextprotocol.io/) は、AIアシスタントが外部ツールやリソースと連携するためのオープンスタンダードです。LLMが以下を行うための統一的な方法を提供します：
 
-- アクションを実行または情報を取得するツール（関数）の実行
+- アクション実行や情報取得を行うツール（関数）の実行
 - コンテキストやデータを提供するリソースへのアクセス
 
 ## 使用方法
 
-### MCPサーバーの生成
+### MCPサーバーの生成方法
 
 TypeScript MCPサーバーは2つの方法で生成できます：
 
@@ -41,33 +42,33 @@ TypeScript MCPサーバーは2つの方法で生成できます：
 
 <FileTree>
   - packages/\<name>/
-    - README.md MCPサーバーのドキュメント（使用方法を含む）
-    - project.json Nxプロジェクト設定（ビルド、バンドル、開発ターゲットを含む）
+    - README.md MCPサーバーの使用説明書
+    - project.json ビルド、バンドル、開発ターゲットを含むNxプロジェクト設定
     - src/
       - index.ts MCPサーバーのエントリーポイント
-      - server.ts メインサーバー定義（ツールとリソースの定義）
+      - server.ts ツールとリソースを定義するメインサーバー
       - global.d.ts マークダウンファイルインポート用TypeScript型宣言
       - resources/
-        - example-context.md MCPサーバー用リソースとして使用するマークダウンファイルの例
+        - example-context.md MCPサーバー用リソースとして使用されるマークダウンファイルの例
 </FileTree>
 
 :::note
-ジェネレーター出力の詳細については、<Link path="/guides/typescript-project">TypeScriptプロジェクトジェネレータードキュメント</Link>を参照してください。
+詳細については、<Link path="/guides/typescript-project">TypeScriptプロジェクトジェネレーターのドキュメント</Link>を参照してください。
 :::
 
 ## MCPサーバーの操作
 
 ### ツールの追加
 
-ツールはAIアシスタントが呼び出せる関数です。`server.ts`ファイルに新しいツールを追加できます：
+ツールはAIアシスタントが呼び出せるアクション実行関数です。`server.ts`ファイルに新しいツールを追加できます：
 
 ```typescript
-server.tool("toolName",
+server.tool("toolName", "ツールの説明",
   { param1: z.string(), param2: z.number() }, // Zodを使用した入力スキーマ
   async ({ param1, param2 }) => {
     // ツールの実装
     return {
-      content: [{ type: "text", text: "Result" }]
+      content: [{ type: "text", text: "結果" }]
     };
   }
 );
@@ -75,7 +76,7 @@ server.tool("toolName",
 
 ### リソースの追加
 
-リソースはAIアシスタントにコンテキストを提供します。ファイルからの静的リソースまたは動的リソースを追加できます：
+リソースはAIアシスタントにコンテキストを提供します。ファイルからの静的リソースや動的リソースを追加できます：
 
 ```typescript
 // ファイルからの静的リソース
@@ -96,15 +97,15 @@ server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
 
 ## AIアシスタントとの連携設定
 
-MCPサーバーをAIアシスタントで使用するには、まずバンドルする必要があります：
+MCPサーバーをAIアシスタントで使用するには、まずバンドルが必要です：
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-これにより`dist/packages/your-mcp-server/bundle/index.js`にバンドル版が作成されます（ディレクトリ設定によりパスは異なる場合があります）。
+これにより`dist/packages/your-mcp-server/bundle/index.js`にバンドル版が生成されます（ディレクトリ設定によりパスは異なる場合があります）。
 
 ### 設定ファイル
 
-MCPをサポートするほとんどのAIアシスタントは類似した設定方法を使用します。MCPサーバーの詳細を記載した設定ファイルを作成/更新する必要があります：
+MCPをサポートするAIアシスタントの多くは類似した設定方法を使用します。MCPサーバーの詳細を設定ファイルに記述する必要があります：
 
 ```json
 {
@@ -123,20 +124,17 @@ MCPをサポートするほとんどのAIアシスタントは類似した設定
 `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js`は実際のバンドル済みMCPサーバーのパスに置き換えてください。
 
 :::caution
-サーバー接続時に`ENOENT node`エラーが発生する場合、ターミナルで`which node`を実行して取得できるnodeの絶対パスを指定する必要があるかもしれません。
+`ENOENT node`のようなエラーが発生した場合、ターミナルで`which node`を実行して取得できるnodeの絶対パスを指定する必要があるかもしれません。
 :::
 
 ### アシスタント固有の設定
 
-特定のAIアシスタントでMCPを設定するには、以下のドキュメントを参照してください：
+各AIアシスタントのMCP連携設定については、以下のドキュメントを参照してください：
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
-Amazon Q Developerなど一部のAIアシスタントは、ワークスペースレベルのMCPサーバー設定を指定可能で、特定プロジェクトに関連するMCPサーバーを定義する際に特に有用です。
+Amazon Q Developerなど一部のAIアシスタントでは、ワークスペースレベルのMCPサーバー設定が可能で、特定プロジェクトに関連するMCPサーバーを定義するのに便利です。
 :::
 
 ## 開発ワークフロー
@@ -147,11 +145,11 @@ Amazon Q Developerなど一部のAIアシスタントは、ワークスペース
 
 #### バンドル
 
-`bundle`タスクは[esbuild](https://esbuild.github.io/)を使用し、AIアシスタントで使用可能な単一のJavaScriptバンドルファイルを作成します：
+`bundle`タスクは[esbuild](https://esbuild.github.io/)を使用して、AIアシスタントで使用可能な単一のJavaScriptファイルを生成します：
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-これにより`dist/packages/your-mcp-server/bundle/index.js`にバンドル版が作成されます（ディレクトリ設定によりパスは異なる場合があります）。
+これにより`dist/packages/your-mcp-server/bundle/index.js`にバンドル版が生成されます（ディレクトリ設定によりパスは異なる場合があります）。
 
 #### 開発
 
@@ -159,8 +157,8 @@ Amazon Q Developerなど一部のAIアシスタントは、ワークスペース
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-開発中に特に有用で、AIアシスタントが常に最新版のMCPサーバーを使用することを保証します。
+開発中に使用すると、AIアシスタントが常に最新のMCPサーバーバージョンを使用するようになります。
 
 :::note
-変更を反映するためにMCPサーバーの再起動を必要とするAIアシスタントもあります。
+一部のAIアシスタントでは、変更を反映するためにMCPサーバーの再起動が必要です。
 :::

--- a/docs/src/content/docs/jp/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/jp/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,10 @@
+---
+title: "MCPのAIアシスタントドキュメント"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)

--- a/docs/src/content/docs/jp/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/jp/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "MCPサーバー設定"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/jp/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/jp/snippets/prerequisites.mdx
@@ -4,13 +4,19 @@ title: "前提条件"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download)（Nodeバージョン管理には[NVM](https://github.com/nvm-sh/nvm)の使用を推奨）
-  - インストール確認: `node --version`
-- [PNPM >= 10](https://pnpm.io/installation#using-npm)（代替として[Yarn >= 4](https://yarnpkg.com/getting-started/install)、[Bun >= 1](https://bun.sh/docs/installation)、[NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager)も使用可）
-  - インストール確認: `pnpm --version`、`yarn --version`、`bun --version` または `npm --version`
+  - `node --version` を実行して確認
+- [PNPM >= 10](https://pnpm.io/installation#using-npm)（代替として[Yarn >= 4](https://yarnpkg.com/getting-started/install)、[Bun >= 1](https://bun.sh/docs/installation)、[NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager)も使用可能）
+  - `pnpm --version`、`yarn --version`、`bun --version` または `npm --version` で確認
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
-  1. Python 3.12のインストール: `uv python install 3.12.0`
-  2. 確認コマンド: `uv python list --only-installed`
+  1. Python 3.12をインストール: `uv python install 3.12.0`
+  2. `uv python list --only-installed` で確認
 - デプロイ先AWSアカウント用に設定された[AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)
-- [VSCode](https://code.visualstudio.com/)利用者向けに[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)のインストールを推奨
+- [VSCode](https://code.visualstudio.com/)を使用する場合、[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)のインストールを推奨
+
+:::tip
+Amazon Q Developer、Cursor、Claude Code、ClineなどのAIアシスタントを使用する場合は、<Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP serverのインストール</Link>も推奨します。
+:::

--- a/docs/src/content/docs/ko/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/ko/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "AI로 구축하기"
+description: "AWS MCP 서버용 Nx 플러그인을 사용한 AI 구축"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+Nx Plugin for AWS는 [MCP Server](https://modelcontextprotocol.io/introduction)를 포함하고 있어 AI 어시스턴트가 Nx Plugin for AWS와 협업할 수 있도록 합니다. MCP Server를 활용하면 AI를 통해 개발 워크플로를 가속화할 수 있으며, 프로젝트가 결정론적인 방식으로 구성되어 주요 컴포넌트 설정에 소요되는 시간과 컨텍스트 윈도우를 절약할 수 있습니다.
+
+Amazon Q Developer, Cline, Claude Code 또는 Cursor와 같은 선호하는 AI 어시스턴트와 함께 MCP Server를 사용하세요.
+
+## MCP 서버 구성
+
+대부분의 AI 어시스턴트는 MCP 서버 구성을 위한 JSON 파일을 사용합니다. Amazon Q Developer에서는 이 파일이 `~/.aws/amazonq/mcp.json`에 위치합니다. Nx Plugin for AWS MCP Server에 대한 항목을 추가하세요.
+
+<Snippet name="mcp/config" />
+
+특정 AI 어시스턴트와의 MCP 구성 방법은 다음 문서를 참조하세요:
+
+<Snippet name="mcp/assistant-docs" />
+
+## Vibe Coding 시작하기
+
+AI 어시스턴트에게 `aws-nx-mcp` MCP Server를 사용하여 무언가를 구축하도록 요청하세요! 일반적으로 AI 어시스턴트는 작업 공간 생성, 적절한 제너레이터를 통한 스캐폴딩, 비즈니스 로직 채우기 순서로 진행합니다.
+
+## 커스텀 MCP 서버 구축
+
+자체 MCP 서버 구축에 대한 자세한 내용은 <Link path="/guides/ts-mcp-server">`ts#mcp-server` 제너레이터 가이드</Link>를 확인하세요.

--- a/docs/src/content/docs/ko/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/ko/guides/ts-mcp-server.mdx
@@ -9,25 +9,26 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
 # TypeScript MCP 서버 생성기
 
-대규모 언어 모델(LLM)에 컨텍스트를 제공하기 위한 TypeScript [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 서버를 생성합니다.
+대규모 언어 모델(LLM)에 컨텍스트를 제공하기 위한 TypeScript [모델 컨텍스트 프로토콜(MCP)](https://modelcontextprotocol.io/) 서버를 생성합니다.
 
 ## MCP란?
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/)는 AI 어시스턴트가 외부 도구 및 리소스와 상호작용할 수 있도록 하는 개방형 표준입니다. LLM이 다음을 수행할 수 있는 일관된 방식을 제공합니다:
+[모델 컨텍스트 프로토콜(MCP)](https://modelcontextprotocol.io/)은 AI 어시스턴트가 외부 도구 및 리소스와 상호작용할 수 있도록 하는 개방형 표준입니다. LLM이 다음을 수행할 수 있는 일관된 방법을 제공합니다:
 
 - 작업 수행 또는 정보 검색을 위한 도구(함수) 실행
-- 컨텍스트 또는 데이터 제공 리소스 접근
+- 컨텍스트 또는 데이터를 제공하는 리소스 접근
 
 ## 사용 방법
 
 ### MCP 서버 생성
 
-TypeScript MCP 서버를 두 가지 방식으로 생성할 수 있습니다:
+TypeScript MCP 서버를 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="ts#mcp-server" />
 
@@ -41,14 +42,14 @@ TypeScript MCP 서버를 두 가지 방식으로 생성할 수 있습니다:
 
 <FileTree>
   - packages/\<name>/
-    - README.md 사용 방법 설명이 포함된 MCP 서버 문서
-    - project.json 빌드, 번들 및 개발 타겟을 포함한 Nx 프로젝트 구성
+    - README.md MCP 서버 사용 설명서
+    - project.json 빌드, 번들 및 개발 타겟을 포함한 Nx 프로젝트 설정
     - src/
       - index.ts MCP 서버 진입점
-      - server.ts 도구와 리소스를 정의하는 메인 서버 파일
+      - server.ts 도구 및 리소스를 정의하는 메인 서버 정의
       - global.d.ts 마크다운 파일 임포트를 위한 TypeScript 타입 선언
       - resources/
-        - example-context.md MCP 서버 리소스로 사용되는 예시 마크다운 파일
+        - example-context.md MCP 서버용 예시 리소스 마크다운 파일
 </FileTree>
 
 :::note
@@ -57,15 +58,15 @@ TypeScript MCP 서버를 두 가지 방식으로 생성할 수 있습니다:
 
 ## MCP 서버 작업하기
 
-### 도구 추가
+### 도구 추가하기
 
-도구는 AI 어시스턴트가 작업을 수행하기 위해 호출할 수 있는 함수입니다. `server.ts` 파일에 새 도구를 추가할 수 있습니다:
+도구는 AI 어시스턴트가 호출할 수 있는 동작 수행 함수입니다. `server.ts` 파일에 새 도구를 추가할 수 있습니다:
 
 ```typescript
-server.tool("toolName",
+server.tool("toolName", "tool description",
   { param1: z.string(), param2: z.number() }, // Zod를 사용한 입력 스키마
   async ({ param1, param2 }) => {
-    // 도구 구현 로직
+    // 도구 구현
     return {
       content: [{ type: "text", text: "Result" }]
     };
@@ -73,9 +74,9 @@ server.tool("toolName",
 );
 ```
 
-### 리소스 추가
+### 리소스 추가하기
 
-리소스는 AI 어시스턴트에 컨텍스트를 제공합니다. 파일에서 정적 리소스를 추가하거나 동적 리소스를 생성할 수 있습니다:
+리소스는 AI 어시스턴트에 컨텍스트를 제공합니다. 파일에서 정적 리소스나 동적 리소스를 추가할 수 있습니다:
 
 ```typescript
 // 파일에서 정적 리소스 임포트
@@ -85,7 +86,7 @@ server.resource('resource-name', 'example://resource', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
-// 동적 리소스 생성
+// 동적 리소스
 server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
   const data = await fetchSomeData();
   return {
@@ -100,7 +101,7 @@ MCP 서버를 AI 어시스턴트와 사용하려면 먼저 번들링해야 합�
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-이 명령은 `dist/packages/your-mcp-server/bundle/index.js` 경로에 번들된 버전을 생성합니다 (디렉토리 설정에 따라 경로가 다를 수 있음).
+이 명령은 `dist/packages/your-mcp-server/bundle/index.js`에 번들 버전을 생성합니다(디렉토리 설정에 따라 경로가 다를 수 있음).
 
 ### 설정 파일
 
@@ -120,38 +121,35 @@ MCP를 지원하는 대부분의 AI 어시스턴트는 유사한 설정 방식�
 }
 ```
 
-`/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js`를 실제 번들 경로로 교체하세요.
+`/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js`를 실제 번들된 MCP 서버 경로로 변경하세요.
 
 :::caution
-서버 연결 시 `ENOENT node` 오류가 발생하면 터미널에서 `which node` 명령으로 확인한 node의 전체 경로를 지정해야 할 수 있습니다.
+서버 연결 시 `ENOENT node` 오류가 발생하면 터미널에서 `which node`를 실행하여 얻은 전체 node 경로를 지정해야 할 수 있습니다.
 :::
 
 ### 어시스턴트별 설정
 
 특정 AI 어시스턴트와의 MCP 연동 설정은 다음 문서를 참조하세요:
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
-Amazon Q Developer와 같은 일부 AI 어시스턴트는 워크스페이스 수준의 MCP 서버 설정을 지원하여 특정 프로젝트와 관련된 MCP 서버를 정의하는 데 유용합니다.
+Amazon Q Developer와 같은 일부 AI 어시스턴트는 워크스페이스 수준 MCP 서버 설정을 지원하며, 특정 프로젝트와 관련된 MCP 서버를 정의하는 데 유용합니다.
 :::
 
 ## 개발 워크플로우
 
 ### 빌드 타겟
 
-이 생성기는 <Link path="/guides/typescript-project">TypeScript 프로젝트 생성기</Link>를 기반으로 하며 기본 타겟을 상속받으며 다음과 같은 추가 타겟을 포함합니다:
+이 생성기는 <Link path="/guides/typescript-project">TypeScript 프로젝트 생성기</Link>를 기반으로 하며 해당 타겟을 상속받고 다음과 같은 추가 타겟을 포함합니다:
 
 #### 번들
 
-`bundle` 타겟은 [esbuild](https://esbuild.github.io/)를 사용하여 AI 어시스턴트와 함께 사용 가능한 단일 JavaScript 번들 파일을 생성합니다:
+`bundle` 타겟은 [esbuild](https://esbuild.github.io/)를 사용하여 AI 어시스턴트와 함께 사용할 수 있는 단일 JavaScript 번들 파일을 생성합니다:
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-이 명령은 `dist/packages/your-mcp-server/bundle/index.js` 경로에 번들된 버전을 생성합니다 (디렉토리 설정에 따라 경로가 다를 수 있음).
+이 명령은 `dist/packages/your-mcp-server/bundle/index.js`에 번들 버전을 생성합니다(디렉토리 설정에 따라 경로가 다를 수 있음).
 
 #### 개발
 
@@ -159,7 +157,7 @@ Amazon Q Developer와 같은 일부 AI 어시스턴트는 워크스페이스 수
 
 <NxCommands commands={['run your-mcp-server:dev']} />
 
-이 기능은 개발 중에 AI 어시스턴트가 최신 MCP 서버 버전을 사용하도록 보장해주어 특히 유용합니다.
+이 기능은 개발 중에 AI 어시스턴트가 최신 MCP 서버 버전을 사용하도록 보장해주므로 특히 유용합니다.
 
 :::note
 일부 AI 어시스턴트는 변경 사항 적용을 위해 MCP 서버 재시작이 필요할 수 있습니다.

--- a/docs/src/content/docs/ko/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/ko/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,10 @@
+---
+title: "MCP AI 어시스턴트 문서"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)

--- a/docs/src/content/docs/ko/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/ko/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "MCP 서버 구성"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/ko/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/ko/snippets/prerequisites.mdx
@@ -4,13 +4,19 @@ title: "필수 조건"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) ([NVM](https://github.com/nvm-sh/nvm)과 같은 도구로 Node 버전 관리 권장)
-  - `node --version` 명령어로 버전 확인
-- [PNPM >= 10](https://pnpm.io/installation#using-npm) (선호한다면 [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) 사용 가능)
-  - `pnpm --version`, `yarn --version`, `bun --version`, `npm --version` 명령어로 각각 버전 확인
+  - `node --version` 실행으로 버전 확인
+- [PNPM >= 10](https://pnpm.io/installation#using-npm) ([Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), 또는 [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) 사용 가능)
+  - `pnpm --version`, `yarn --version`, `bun --version` 또는 `npm --version` 실행으로 버전 확인
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
-  1. `uv python install 3.12.0` 명령어로 Python 3.12 설치
-  2. `uv python list --only-installed` 명령어로 설치 확인
-- 애플리케이션을 배포할 대상 AWS 계정에 설정된 [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)
+  1. `uv python install 3.12.0` 실행으로 Python 3.12 설치
+  2. `uv python list --only-installed` 실행으로 설치 확인
+- 애플리케이션을 배포할 대상 AWS 계정에 구성된 [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)
 - [VSCode](https://code.visualstudio.com/) 사용 시 [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) 설치 권장
+
+:::tip
+Amazon Q Developer, Cursor, Claude Code, Cline과 같은 AI 도우미를 사용하는 경우 <Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP server 설치</Link>를 고려해 보세요.
+:::

--- a/docs/src/content/docs/pt/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/pt/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "Construindo com IA"
+description: "Construindo com IA e o Plugin Nx para Servidor AWS MCP"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+O Plugin Nx para AWS inclui um [Servidor MCP](https://modelcontextprotocol.io/introduction) que permite que assistentes de IA trabalhem com o Plugin Nx para AWS. Ao utilizar o Servidor MCP, você pode acelerar seu fluxo de desenvolvimento com IA, aproveitando projetos gerados de forma determinística, gastando menos tempo e menos do seu contexto na configuração dos componentes principais.
+
+Use o Servidor MCP com seu Assistente de IA preferido, como Amazon Q Developer, Cline, Claude Code ou Cursor.
+
+## Configuração do Servidor MCP
+
+A maioria dos Assistentes de IA possui um arquivo JSON para configuração do servidor MCP. No Amazon Q Developer, este arquivo está localizado em `~/.aws/amazonq/mcp.json`. Adicione uma entrada para o Servidor MCP do Plugin Nx para AWS:
+
+<Snippet name="mcp/config" />
+
+Consulte a documentação específica para configurar o MCP com seu Assistente de IA:
+
+<Snippet name="mcp/assistant-docs" />
+
+## Iniciar Vibe Coding
+
+Peça ao seu Assistente de IA para construir algo usando o servidor MCP `aws-nx-mcp`! Geralmente, os Assistentes de IA começarão criando um workspace, gerando componentes com os generators aplicáveis e depois preenchendo a lógica de negócios.
+
+## Construa seu próprio Servidor MCP
+
+Confira o <Link path="/guides/ts-mcp-server">guia do generator `ts#mcp-server`</Link> para detalhes sobre como construir seu próprio Servidor MCP.

--- a/docs/src/content/docs/pt/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/pt/guides/ts-mcp-server.mdx
@@ -9,6 +9,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
@@ -18,7 +19,7 @@ Gere um servidor [Model Context Protocol (MCP)](https://modelcontextprotocol.io/
 
 ## O que é o MCP?
 
-O [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) é um padrão aberto que permite assistentes de IA interagirem com ferramentas e recursos externos. Ele fornece uma maneira consistente para LLMs:
+O [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) é um padrão aberto que permite a assistentes de IA interagirem com ferramentas e recursos externos. Ele fornece uma maneira consistente para LLMs:
 
 - Executar ferramentas (funções) que realizam ações ou recuperam informações
 - Acessar recursos que fornecem contexto ou dados
@@ -37,7 +38,7 @@ Você pode gerar um servidor MCP em TypeScript de duas formas:
 
 ## Saída do Gerador
 
-O gerador criará os seguintes arquivos de projeto:
+O gerador criará os seguintes arquivos do projeto:
 
 <FileTree>
   - packages/\<nome>/
@@ -52,7 +53,7 @@ O gerador criará os seguintes arquivos de projeto:
 </FileTree>
 
 :::note
-Consulte a <Link path="/guides/typescript-project">documentação do gerador de projetos TypeScript</Link> para detalhes adicionais sobre a saída do gerador.
+Consulte a <Link path="/guides/typescript-project">documentação do gerador de projetos TypeScript</Link> para mais detalhes sobre a saída do gerador.
 :::
 
 ## Trabalhando com Seu Servidor MCP
@@ -62,12 +63,12 @@ Consulte a <Link path="/guides/typescript-project">documentação do gerador de 
 Ferramentas são funções que o assistente de IA pode chamar para executar ações. Você pode adicionar novas ferramentas no arquivo `server.ts`:
 
 ```typescript
-server.tool("nomeDaFerramenta",
+server.tool("toolName", "tool description",
   { param1: z.string(), param2: z.number() }, // Esquema de entrada usando Zod
   async ({ param1, param2 }) => {
     // Implementação da ferramenta
     return {
-      content: [{ type: "text", text: "Resultado" }]
+      content: [{ type: "text", text: "Result" }]
     };
   }
 );
@@ -81,12 +82,12 @@ Recursos fornecem contexto ao assistente de IA. Você pode adicionar recursos es
 // Recurso estático de um arquivo
 import exampleContext from './resources/example-context.md';
 
-server.resource('nome-do-recurso', 'example://recurso', async (uri) => ({
+server.resource('resource-name', 'example://resource', async (uri) => ({
   contents: [{ uri: uri.href, text: exampleContext }],
 }));
 
 // Recurso dinâmico
-server.resource('recurso-dinamico', 'dynamic://recurso', async (uri) => {
+server.resource('dynamic-resource', 'dynamic://resource', async (uri) => {
   const data = await fetchSomeData();
   return {
     contents: [{ uri: uri.href, text: data }],
@@ -94,13 +95,13 @@ server.resource('recurso-dinamico', 'dynamic://recurso', async (uri) => {
 });
 ```
 
-## Configuração com Assistentes de IA
+## Configurando com Assistentes de IA
 
-Para usar seu servidor MCP com assistentes de IA, você precisa empacotá-lo primeiro:
+Para usar seu servidor MCP com assistentes de IA, você precisa compilá-lo primeiro:
 
-<NxCommands commands={['run seu-servidor-mcp:bundle']} />
+<NxCommands commands={['run your-mcp-server:bundle']} />
 
-Isso cria uma versão empacotada em `dist/packages/seu-servidor-mcp/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
+Isso cria uma versão compilada em `dist/packages/your-mcp-server/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
 
 ### Arquivos de Configuração
 
@@ -109,10 +110,10 @@ A maioria dos assistentes de IA que suportam MCP usa uma abordagem de configura�
 ```json
 {
   "mcpServers": {
-    "seu-servidor-mcp": {
+    "your-mcp-server": {
       "command": "node",
       "args": [
-        "/caminho/para/workspace/dist/packages/seu-servidor-mcp/bundle/index.js"
+        "/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js"
       ],
       "transportType": "stdio"
     }
@@ -120,44 +121,41 @@ A maioria dos assistentes de IA que suportam MCP usa uma abordagem de configura�
 }
 ```
 
-Substitua `/caminho/para/workspace/dist/packages/seu-servidor-mcp/bundle/index.js` pelo caminho real para seu servidor MCP empacotado.
+Substitua `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` pelo caminho real para seu servidor MCP compilado.
 
 :::caution
-Se receber um erro como `ENOENT node` ao conectar ao servidor, talvez seja necessário especificar o caminho completo para o `node`, que pode ser obtido executando `which node` no terminal.
+Se receber um erro como `ENOENT node` ao conectar ao seu servidor, talvez seja necessário especificar o caminho completo para o `node`, que pode ser obtido executando `which node` no terminal.
 :::
 
 ### Configuração Específica por Assistente
 
-Consulte a documentação a seguir para configurar o MCP com assistentes específicos:
+Consulte a documentação abaixo para configurar o MCP com assistentes específicos:
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
-Alguns assistentes, como o Amazon Q Developer, permitem especificar configurações de servidor MCP no nível do workspace, o que é particularmente útil para definir os servidores MCP relevantes para um projeto específico.
+Alguns assistentes de IA, como o Amazon Q Developer, permitem especificar configurações de servidor MCP no nível do workspace, o que é particularmente útil para definir os servidores MCP relevantes para um projeto específico.
 :::
 
 ## Fluxo de Desenvolvimento
 
 ### Targets de Build
 
-O gerador é baseado no <Link path="/guides/typescript-project">gerador de projetos TypeScript</Link> e herda seus targets, além de adicionar os seguintes targets:
+O gerador é baseado no <Link path="/guides/typescript-project">gerador de projetos TypeScript</Link> e herda seus targets, além de adicionar os seguintes targets adicionais:
 
 #### Bundle
 
-O target `bundle` usa [esbuild](https://esbuild.github.io/) para criar um único arquivo JavaScript empacotado que pode ser usado com assistentes de IA:
+O target `bundle` usa [esbuild](https://esbuild.github.io/) para criar um único arquivo JavaScript que pode ser usado com assistentes de IA:
 
-<NxCommands commands={['run seu-servidor-mcp:bundle']} />
+<NxCommands commands={['run your-mcp-server:bundle']} />
 
-Isso cria uma versão empacotada em `dist/packages/seu-servidor-mcp/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
+Isso cria uma versão compilada em `dist/packages/your-mcp-server/bundle/index.js` (o caminho pode variar conforme suas configurações de diretório).
 
 #### Dev
 
-O target `dev` monitora alterações no seu projeto e reconstrói o bundle automaticamente:
+O target `dev` monitora mudanças em seu projeto e recompila automaticamente o bundle:
 
-<NxCommands commands={['run seu-servidor-mcp:dev']} />
+<NxCommands commands={['run your-mcp-server:dev']} />
 
 Isso é particularmente útil durante o desenvolvimento, garantindo que seu assistente de IA utilize a versão mais recente do servidor MCP.
 

--- a/docs/src/content/docs/pt/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/pt/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,13 @@
+---
+title: "Documentação do Assistente de IA MCP"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+
+**Nota de implementação:**  
+Como solicitado, todos os nomes de produtos, URLs e elementos técnicos foram mantidos em seu formato original. A estrutura MDX e a formatação permanecem idênticas ao conteúdo original em inglês.

--- a/docs/src/content/docs/pt/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/pt/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "Configuração do Servidor MCP"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/pt/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/pt/snippets/prerequisites.mdx
@@ -4,6 +4,8 @@ title: "Pré-requisitos"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (Recomendamos usar algo como [NVM](https://github.com/nvm-sh/nvm) para gerenciar versões do Node)
   - verifique executando `node --version`
@@ -12,5 +14,9 @@ title: "Pré-requisitos"
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
   1. instale Python 3.12 executando: `uv python install 3.12.0`
   2. verifique com `uv python list --only-installed`
-- [Credenciais da AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para a sua conta AWS de destino (onde sua aplicação será implantada)
-- Se estiver usando [VSCode](https://code.visualstudio.com/), recomendamos instalar o [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+- [Credenciais AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para sua conta AWS de destino (onde seu aplicativo será implantado)
+- Se usar [VSCode](https://code.visualstudio.com/), recomendamos instalar o [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+
+:::tip
+Se você usa um Assistente de IA como Amazon Q Developer, Cursor, Claude Code ou Cline, pode querer também <Link path="/get_started/building-with-ai">instalar o Nx Plugin para AWS MCP server.</Link>
+:::

--- a/docs/src/content/docs/zh/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/zh/get_started/building-with-ai.mdx
@@ -1,0 +1,31 @@
+---
+title: "使用 AI 构建"
+description: "使用 AI 和 AWS MCP 服务器的 Nx 插件进行构建"
+---
+
+
+
+import Link from '@components/link.astro'
+import Snippet from '@components/snippet.astro'
+
+Nx AWS 插件包含一个 [MCP Server](https://modelcontextprotocol.io/introduction)，使 AI 助手能够与 Nx AWS 插件协同工作。通过使用 MCP 服务器，您可以通过 AI 加速开发流程，同时确保项目以确定性的方式生成，减少在设置主要组件时消耗的时间和上下文窗口。
+
+您可以选择与任意 AI 助手配合使用 MCP 服务器，例如 Amazon Q Developer、Cline、Claude Code 或 Cursor。
+
+## MCP 服务器配置
+
+大多数 AI 助手都会通过 JSON 文件进行 MCP 服务器配置。在 Amazon Q Developer 中，该文件位于 `~/.aws/amazonq/mcp.json`。请为 Nx AWS 插件的 MCP 服务器添加配置项：
+
+<Snippet name="mcp/config" />
+
+具体 AI 助手的 MCP 配置文档请参考：
+
+<Snippet name="mcp/assistant-docs" />
+
+## 开始智能编码
+
+让您的 AI 助手使用 `aws-nx-mcp` MCP 服务器进行构建！通常 AI 助手会先创建工作区，使用适用的生成器搭建框架，然后填充业务逻辑。
+
+## 构建自定义 MCP 服务器
+
+查看 <Link path="/guides/ts-mcp-server">`ts#mcp-server` 生成器指南</Link> 了解如何构建自定义 MCP 服务器的详细信息。

--- a/docs/src/content/docs/zh/guides/ts-mcp-server.mdx
+++ b/docs/src/content/docs/zh/guides/ts-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ts#mcp-服务器"
-description: "为大型语言模型提供上下文的生成TypeScript模型上下文协议（MCP）服务器"
+title: "ts#mcp-server"
+description: "为大型语言模型提供上下文的生成 TypeScript 模型上下文协议（MCP）服务器"
 ---
 
 
@@ -9,16 +9,17 @@ import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Link from '@components/link.astro';
+import Snippet from '@components/snippet.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schema.json';
 
 # TypeScript MCP 服务器生成器
 
-生成用于为大型语言模型（LLMs）提供上下文的 TypeScript [模型上下文协议（MCP）](https://modelcontextprotocol.io/) 服务器。
+生成用于为大型语言模型（LLM）提供上下文的 TypeScript [模型上下文协议（MCP）](https://modelcontextprotocol.io/) 服务器。
 
 ## 什么是 MCP？
 
-[模型上下文协议（MCP）](https://modelcontextprotocol.io/) 是一个开放标准，允许 AI 助手与外部工具和资源交互。它为 LLMs 提供了一致的方式来：
+[模型上下文协议（MCP）](https://modelcontextprotocol.io/) 是一个开放标准，允许 AI 助手与外部工具和资源交互。它为 LLM 提供了一致的方式来：
 
 - 执行执行操作或检索信息的工具（函数）
 - 访问提供上下文或数据的资源
@@ -31,7 +32,7 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 
 <RunGenerator generator="ts#mcp-server" />
 
-### 选项参数
+### 选项配置
 
 <GeneratorParameters generator="ts#mcp-server" />
 
@@ -62,7 +63,7 @@ import schema from '../../../../../../packages/nx-plugin/src/ts/mcp-server/schem
 工具是 AI 助手可以调用的功能函数。您可以在 `server.ts` 文件中添加新工具：
 
 ```typescript
-server.tool("工具名称",
+server.tool("工具名称", "工具描述",
   { 参数1: z.string(), 参数2: z.number() }, // 使用 Zod 的输入模式
   async ({ 参数1, 参数2 }) => {
     // 工具实现逻辑
@@ -75,7 +76,7 @@ server.tool("工具名称",
 
 ### 添加资源
 
-资源为 AI 助手提供上下文。您可以添加来自文件的静态资源或动态资源：
+资源为 AI 助手提供上下文。您可以添加静态文件资源或动态资源：
 
 ```typescript
 // 从文件导入静态资源
@@ -104,7 +105,7 @@ server.resource('动态资源', 'dynamic://resource', async (uri) => {
 
 ### 配置文件
 
-大多数支持 MCP 的 AI 助手使用类似的配置方式。您需要创建或更新配置文件来添加 MCP 服务器信息：
+支持 MCP 的 AI 助手通常使用类似的配置方式。需要创建或更新配置文件添加 MCP 服务器信息：
 
 ```json
 {
@@ -120,20 +121,17 @@ server.resource('动态资源', 'dynamic://resource', async (uri) => {
 }
 ```
 
-请将 `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` 替换为实际的打包文件路径。
+将 `/path/to/workspace/dist/packages/your-mcp-server/bundle/index.js` 替换为实际的打包文件路径。
 
 :::caution
-如果连接服务器时出现 `ENOENT node` 错误，可能需要通过终端运行 `which node` 获取 node 的完整路径。
+如果连接时出现 `ENOENT node` 错误，可能需要通过终端运行 `which node` 获取 node 的完整路径。
 :::
 
 ### 特定助手配置
 
-各 AI 助手的 MCP 配置文档参考：
+各 AI 助手的详细配置请参考：
 
-- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
-- [Cline](https://docs.cline.bot/mcp-servers/configuring-mcp-servers)
-- [Cursor](https://docs.cursor.com/context/model-context-protocol)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)
+<Snippet name="mcp/assistant-docs" />
 
 :::tip
 部分 AI 助手（如 Amazon Q Developer）支持工作区级别的 MCP 服务器配置，这对定义项目相关 MCP 服务器非常有用。
@@ -143,7 +141,7 @@ server.resource('动态资源', 'dynamic://resource', async (uri) => {
 
 ### 构建目标
 
-本生成器基于 <Link path="/guides/typescript-project">TypeScript 项目生成器</Link>，继承了其所有构建目标，并新增以下目标：
+本生成器基于 <Link path="/guides/typescript-project">TypeScript 项目生成器</Link>，继承了其构建目标，并新增了以下目标：
 
 #### 打包
 
@@ -151,7 +149,7 @@ server.resource('动态资源', 'dynamic://resource', async (uri) => {
 
 <NxCommands commands={['run your-mcp-server:bundle']} />
 
-打包文件生成在 `dist/packages/your-mcp-server/bundle/index.js`（路径可能因目录设置而异）。
+打包文件生成于 `dist/packages/your-mcp-server/bundle/index.js`（路径可能因目录设置而异）。
 
 #### 开发模式
 

--- a/docs/src/content/docs/zh/snippets/mcp/assistant-docs.mdx
+++ b/docs/src/content/docs/zh/snippets/mcp/assistant-docs.mdx
@@ -1,0 +1,10 @@
+---
+title: "MCP AI 助手文档"
+---
+
+
+
+- [Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-configuration.html)
+- [Cline](https://docs.cline.bot/mcp/mcp-overview)
+- [Cursor](https://docs.cursor.com/context/model-context-protocol)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp)

--- a/docs/src/content/docs/zh/snippets/mcp/config.mdx
+++ b/docs/src/content/docs/zh/snippets/mcp/config.mdx
@@ -1,0 +1,16 @@
+---
+title: "MCP服务器配置"
+---
+
+
+
+```json {3-6}
+{
+  "mcpServers": {
+    "aws-nx-mcp": {
+      "command": "npx",
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/zh/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/zh/snippets/prerequisites.mdx
@@ -4,13 +4,19 @@ title: "先决条件"
 
 
 
+import Link from '@components/link.astro';
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Node >= 22](https://nodejs.org/en/download)（推荐使用 [NVM](https://github.com/nvm-sh/nvm) 管理 Node 版本）
-  - 通过 `node --version` 验证版本
-- [PNPM >= 10](https://pnpm.io/installation#using-npm)（也可选择 [Yarn >= 4](https://yarnpkg.com/getting-started/install)、[Bun >= 1](https://bun.sh/docs/installation) 或 [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager)）
-  - 通过 `pnpm --version`、`yarn --version`、`bun --version` 或 `npm --version` 验证版本
+- [Node >= 22](https://nodejs.org/en/download) (建议使用 [NVM](https://github.com/nvm-sh/nvm) 等工具管理 Node 版本)
+  - 通过运行 `node --version` 验证版本
+- [PNPM >= 10](https://pnpm.io/installation#using-npm) (也可选择 [Yarn >= 4](https://yarnpkg.com/getting-started/install)、[Bun >= 1](https://bun.sh/docs/installation) 或 [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager))
+  - 通过运行 `pnpm --version`、`yarn --version`、`bun --version` 或 `npm --version` 验证版本
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
   1. 安装 Python 3.12：`uv python install 3.12.0`
-  2. 通过 `uv python list --only-installed` 验证安装
-- [AWS 凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)需配置至目标 AWS 账户（应用部署环境）
-- 使用 [VSCode](https://code.visualstudio.com/) 时推荐安装 [Nx Console VSCode 插件](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)
+  2. 验证安装：`uv python list --only-installed`
+- 已配置指向目标 AWS 账户的 [AWS 凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)（应用将部署至该账户）
+- 使用 [VSCode](https://code.visualstudio.com/) 时，建议安装 [Nx Console VSCode 插件](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)
+
+:::tip
+如果使用 Amazon Q Developer、Cursor、Claude Code 或 Cline 等 AI 助手，可考虑<Link path="/get_started/building-with-ai">安装适用于 AWS MCP 服务器的 Nx 插件</Link>
+:::

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -96,9 +96,9 @@ pnpm nx g @aws/nx-plugin:ts#infra
 
 ### Additional resources
 
-- Use [Quick Start](https://awslabs.github.io/nx-plugin-for-aws/get_started/quick-start/) to get a taste of @aws/nx-plugin.
-- [Build a Dungeon Adventure Game](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/dungeon-game/overview/) to get an in-depth guided tutorial on how to use the @aws/nx-plugin.
-- [Add @aws/nx-plugin to your existing project](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/existing-project/)
+- Use [Quick Start](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/quick-start/) to get a taste of @aws/nx-plugin.
+- [Build a Dungeon Adventure Game](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/tutorials/dungeon-game/overview/) to get an in-depth guided tutorial on how to use the @aws/nx-plugin.
+- [Add @aws/nx-plugin to your existing project](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/tutorials/existing-project/)
 
 ## MCP Server Installation and Setup
 
@@ -114,13 +114,15 @@ Example configuration for Amazon Q CLI MCP (`~/.aws/amazonq/mcp.json`):
   "mcpServers": {
     "aws-nx-mcp": {
       "command": "npx",
-      "args": ["-p", "@aws/nx-plugin", "aws-nx-mcp"]
+      "args": ["-y", "-p", "@aws/nx-plugin", "aws-nx-mcp"]
     }
   }
 }
 ```
 
 If you have issues such as `ENOENT npx`, replace the command with `/full/path/to/npx` (use `which npx` to find this).
+
+For more details, [take a look at the guide here](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/building-with-ai/)
 
 ## Documentation Translation
 

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -207,9 +207,14 @@ export const createServer = () => {
   });
 
   // Add an addition tool
-  server.tool('add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
-    content: [{ type: 'text', text: String(a + b) }],
-  }));
+  server.tool(
+    'add',
+    'adds two numbers',
+    { a: z.number(), b: z.number() },
+    async ({ a, b }) => ({
+      content: [{ type: 'text', text: String(a + b) }],
+    }),
+  );
 
   // Add a resource which provides context from a markdown file
   server.resource('example-context', 'example://context', async (uri) => ({

--- a/packages/nx-plugin/src/ts/mcp-server/files/src/server.ts.template
+++ b/packages/nx-plugin/src/ts/mcp-server/files/src/server.ts.template
@@ -12,7 +12,7 @@ export const createServer = () => {
   });
 
   // Add an addition tool
-  server.tool("add",
+  server.tool("add", "adds two numbers",
     { a: z.number(), b: z.number() },
     async ({ a, b }) => ({
       content: [{ type: "text", text: String(a + b) }]


### PR DESCRIPTION
Since Q requires tool descriptions, it's helpful if we vend sample code that defines them!

Additionally added some brief docs on using the MCP Server.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*