### PR TITLE
feat(sdk): expose sdk for extending generators

### DIFF
--- a/docs/src/content/docs/en/guides/nx-generator.mdx
+++ b/docs/src/content/docs/en/guides/nx-generator.mdx
@@ -264,6 +264,8 @@ if (tree.exists('path/to/file.ts')) {
 
 #### Generating Files from Templates
 
+You can generate files with the `generateFiles` utility from `@nx/devkit`. This allows you to define templates in [EJS](https://ejs.co/) syntax, and substitute variables.
+
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 
@@ -284,48 +286,19 @@ generateFiles(
 
 #### TypeScript AST (Abstract Syntax Tree) Manipulation
 
-We recommend installing [TSQuery](https://github.com/phenomnomnominal/tsquery) to help with AST manipulation.
+You can use the `tsAstReplace` method exposed by the Nx Plugin for AWS to replace parts of a TypeScript abstract syntax tree.
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
 // Example: Increment version number in a file
-
-// Parse the file content into a TypeScript AST
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// Find nodes matching the selector
-const nodes = tsquery.query(
-  sourceFile,
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // Get the numeric literal node
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // Get the current version number and increment it
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // Replace the node in the AST
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // Write the updated content back to the tree
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
 :::tip
@@ -365,10 +338,10 @@ return () => {
 #### Formatting Generated Files
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
 // Format all files that were modified
-await formatFiles(tree);
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
 #### Reading and Updating JSON Files
@@ -388,6 +361,68 @@ updateJson(tree, 'tsconfig.json', (json) => {
   return json;
 });
 ```
+
+#### Extending a Generator from the Nx Plugin for AWS
+
+You can import generators from the Nx Plugin for AWS, and extend or compose them as you wish, for example you might wish to create a generator which builds on top of a TypeScript project:
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // Extend the TypeScript project generator here
+
+  // Return the callback to ensure dependencies are installed.
+  // You can wrap the callback if you wish to perform additional operations in the generator callback.
+  return callback;
+};
+```
+
+#### OpenAPI Generators
+
+You can use and extend the generators we use for TypeScript clients and hooks in a similar way to the above:
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // Add additional files here
+};
+```
+
+We also expose a method which allows you to build a data structure that can be used to iterate over operations in an OpenAPI specification and therefore instrument your own code generation, for example:
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'), // Template directory
+    'path/to/output', // Output directory
+    data,
+  );
+};
+```
+
+Which then allows you to write templates such as:
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+Refer to the [codebase on GitHub](https://github.com/awslabs/nx-plugin-for-aws/) for more complex example templates.
 
 ### Running Your Generator
 

--- a/docs/src/content/docs/es/guides/nx-generator.mdx
+++ b/docs/src/content/docs/es/guides/nx-generator.mdx
@@ -12,13 +12,13 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
 
-Agrega un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a un proyecto TypeScript para ayudarte a automatizar tareas repetitivas como la creación de componentes o la aplicación de estructuras de proyecto específicas.
+Agrega un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a un proyecto TypeScript, para ayudarte a automatizar tareas repetitivas como la creación de componentes o la aplicación de estructuras de proyecto específicas.
 
 ## Uso
 
-### Generar un generador
+### Generar un Generator
 
-Puedes generar un generador de dos formas:
+Puedes generar un generator de dos formas:
 
 <RunGenerator generator="ts#nx-generator" />
 
@@ -26,40 +26,40 @@ Puedes generar un generador de dos formas:
 
 <GeneratorParameters generator="ts#nx-generator" />
 
-## Salida del generador
+## Salida del Generator
 
-El generador creará los siguientes archivos en el `pluginProject` seleccionado:
+El generator creará los siguientes archivos en el proyecto `pluginProject` seleccionado:
 
 <FileTree>
   - src/\<name>/
-    - schema.json Esquema para la entrada del generador
+    - schema.json Esquema para la entrada del generator
     - schema.d.ts Tipos TypeScript para el esquema
-    - generator.ts Implementación base del generador
-    - generator.spec.ts Pruebas para el generador
-  - generators.json Configuración de Nx para definir tus generadores
+    - generator.ts Implementación base del generator
+    - generator.spec.ts Pruebas para el generator
+  - generators.json Configuración de Nx para definir tus generators
   - package.json Creado o actualizado para agregar entrada "generators"
   - tsconfig.json Actualizado para usar CommonJS
 </FileTree>
 
 :::warning
-Este generador actualizará el `pluginProject` seleccionado para usar CommonJS, ya que los generadores de Nx solo admiten CommonJS actualmente ([consulta este issue de GitHub para soporte de ESM](https://github.com/nrwl/nx/issues/15682)).
+Este generator actualizará el `pluginProject` seleccionado para usar CommonJS, ya que Nx Generators actualmente solo soporta CommonJS ([consulta este issue de GitHub para soporte ESM](https://github.com/nrwl/nx/issues/15682)).
 :::
 
-## Generadores locales
+## Generadores Locales
 
 :::tip
-Recomendamos generar primero un proyecto TypeScript dedicado para todos tus generadores usando el generador `ts#project`. Por ejemplo:
+Recomendamos generar primero un proyecto TypeScript dedicado para todos tus generators usando el generator `ts#project`. Por ejemplo:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-Selecciona tu proyecto local `nx-plugin` al ejecutar el generador `ts#nx-generator`, y especifica un nombre junto con un directorio y descripción opcionales.
+Selecciona tu proyecto local `nx-plugin` al ejecutar el generator `ts#nx-generator`, y especifica un nombre junto con un directorio y descripción opcionales.
 
-### Definiendo el esquema
+### Definiendo el Esquema
 
-El archivo `schema.json` define las opciones que acepta tu generador. Sigue el formato [JSON Schema](https://json-schema.org/) con [extensiones específicas de Nx](https://nx.dev/extending-nx/recipes/generator-options).
+El archivo `schema.json` define las opciones que acepta tu generator. Sigue el formato [JSON Schema](https://json-schema.org/) con [extensiones específicas de Nx](https://nx.dev/extending-nx/recipes/generator-options).
 
-#### Estructura básica
+#### Estructura Básica
 
 Un archivo schema.json tiene la siguiente estructura básica:
 
@@ -71,13 +71,13 @@ Un archivo schema.json tiene la siguiente estructura básica:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // Your generator options go here
+    // Tus opciones del generator van aquí
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
 ```
 
-#### Ejemplo simple
+#### Ejemplo Simple
 
 Aquí un ejemplo simple con algunas opciones básicas:
 
@@ -109,9 +109,9 @@ Aquí un ejemplo simple con algunas opciones básicas:
 }
 ```
 
-#### Prompts interactivos (CLI)
+#### Prompts Interactivos (CLI)
 
-Puedes personalizar los prompts mostrados al ejecutar tu generador vía CLI agregando la propiedad `x-prompt`:
+Puedes personalizar los prompts mostrados al ejecutar tu generator desde la CLI agregando la propiedad `x-prompt`:
 
 ```json
 "name": {
@@ -131,9 +131,9 @@ Para opciones booleanas, puedes usar un prompt sí/no:
 }
 ```
 
-#### Selecciones desplegables
+#### Selecciones en Dropdown
 
-Para opciones con un conjunto fijo de opciones, usa `enum` para que los usuarios puedan seleccionar una:
+Para opciones con un conjunto fijo de opciones, usa `enum` para que los usuarios puedan seleccionar:
 
 ```json
 "style": {
@@ -144,9 +144,9 @@ Para opciones con un conjunto fijo de opciones, usa `enum` para que los usuarios
 }
 ```
 
-#### Desplegable de selección de proyecto
+#### Dropdown de Selección de Proyecto
 
-Un patrón común es permitir a los usuarios seleccionar entre proyectos existentes en el workspace:
+Un patrón común es permitir a los usuarios seleccionar entre proyectos existentes:
 
 ```json
 "project": {
@@ -157,11 +157,11 @@ Un patrón común es permitir a los usuarios seleccionar entre proyectos existen
 }
 ```
 
-La propiedad `x-dropdown: "projects"` indica a Nx que llene el desplegable con todos los proyectos del workspace.
+La propiedad `x-dropdown: "projects"` indica a Nx que llene el dropdown con todos los proyectos del workspace.
 
-#### Argumentos posicionales
+#### Argumentos Posicionales
 
-Puedes configurar opciones para que se pasen como argumentos posicionales al ejecutar el generador desde la línea de comandos:
+Puedes configurar opciones para pasarse como argumentos posicionales al ejecutar el generator desde CLI:
 
 ```json
 "name": {
@@ -175,11 +175,11 @@ Puedes configurar opciones para que se pasen como argumentos posicionales al eje
 }
 ```
 
-Esto permite a los usuarios ejecutar tu generador como `nx g your-generator my-component` en lugar de `nx g your-generator --name=my-component`.
+Esto permite ejecutar el generator como `nx g your-generator my-component` en lugar de `nx g your-generator --name=my-component`.
 
-#### Estableciendo prioridades
+#### Estableciendo Prioridades
 
-Usa la propiedad `x-priority` para indicar qué opciones son más importantes:
+Usa la propiedad `x-priority` para indicar opciones importantes:
 
 ```json
 "name": {
@@ -189,11 +189,11 @@ Usa la propiedad `x-priority` para indicar qué opciones son más importantes:
 }
 ```
 
-Las opciones pueden tener prioridades de `"important"` o `"internal"`. Esto ayuda a Nx a ordenar propiedades en la extensión VSCode de Nx y en la CLI.
+Las prioridades pueden ser `"important"` o `"internal"`. Esto ayuda a Nx a ordenar propiedades en la extensión VSCode y CLI.
 
-#### Valores predeterminados
+#### Valores Predeterminados
 
-Puedes proveer valores predeterminados para las opciones:
+Puedes proveer valores predeterminados:
 
 ```json
 "directory": {
@@ -203,13 +203,13 @@ Puedes proveer valores predeterminados para las opciones:
 }
 ```
 
-#### Más información
+#### Más Información
 
-Para más detalles sobre esquemas, consulta la [documentación de Opciones de Generadores de Nx](https://nx.dev/extending-nx/recipes/generator-options).
+Para más detalles sobre esquemas, consulta la [documentación de Nx Generator Options](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Tipos TypeScript con schema.d.ts
 
-Junto con `schema.json`, el generador crea un archivo `schema.d.ts` que provee tipos TypeScript para las opciones:
+Junto con `schema.json`, el generator crea un archivo `schema.d.ts` con tipos TypeScript para las opciones:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -219,52 +219,53 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Esta interfaz se usa en la implementación del generador para proveer seguridad de tipos y autocompletado:
+Esta interfaz se usa en la implementación del generator para seguridad de tipos:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // TypeScript conoce los tipos de todas tus opciones
+  // TypeScript conoce los tipos de las opciones
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-Cada vez que modifiques `schema.json`, debes actualizar `schema.d.ts` para que coincida. Esto incluye:
-
-- Agregar o eliminar propiedades
+Al modificar `schema.json`, debes actualizar `schema.d.ts` para que coincidan:
+- Agregar/eliminar propiedades
 - Cambiar tipos de propiedades
-- Hacer propiedades requeridas u opcionales (usa el sufijo `?` para propiedades opcionales)
+- Hacer propiedades requeridas/opcionales (usa `?` para opcionales)
 
-La interfaz TypeScript debe reflejar fielmente la estructura definida en tu esquema JSON.
+La interfaz TypeScript debe reflejar fielmente el esquema JSON.
 :::
 
-### Implementando un generador
+### Implementando un Generator
 
-Después de crear el nuevo generador como arriba, puedes escribir tu implementación en `generator.ts`.
+Tras crear el generator, puedes escribir su implementación en `generator.ts`.
 
-Un generador es una función que muta un sistema de archivos virtual (`Tree`), leyendo y escribiendo archivos para realizar los cambios deseados. Los cambios del `Tree` solo se escriben en disco cuando el generador termina de ejecutarse, a menos que se ejecute en modo "dry-run".
+Un generator es una función que modifica un sistema de archivos virtual (`Tree`), leyendo y escribiendo archivos. Los cambios se escriben al disco solo al finalizar, a menos que se ejecute en modo "dry-run".
 
-Aquí hay algunas operaciones comunes que podrías realizar en tu generador:
+Operaciones comunes en un generator:
 
-#### Leer y escribir archivos
+#### Lectura y Escritura de Archivos
 
 ```typescript
-// Leer un archivo
+// Leer archivo
 const content = tree.read('path/to/file.ts', 'utf-8');
 
-// Escribir un archivo
+// Escribir archivo
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
-// Verificar si un archivo existe
+// Verificar existencia
 if (tree.exists('path/to/file.ts')) {
   // Hacer algo
 }
 ```
 
-#### Generar archivos desde plantillas
+#### Generar Archivos desde Plantillas
+
+Puedes generar archivos con `generateFiles` de `@nx/devkit`, usando plantillas [EJS](https://ejs.co/):
 
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
@@ -275,66 +276,36 @@ generateFiles(
   joinPathFragments(__dirname, 'files'), // Directorio de plantillas
   'path/to/output', // Directorio de salida
   {
-    // Variables para reemplazar en plantillas
+    // Variables para sustituir
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
-    // Agrega más variables según sea necesario
   },
 );
 ```
 
-#### Manipulación de AST (Abstract Syntax Tree) de TypeScript
+#### Manipulación de AST TypeScript
 
-Recomendamos instalar [TSQuery](https://github.com/phenomnomnominal/tsquery) para ayudar con la manipulación de AST.
+Puedes usar `tsAstReplace` del Nx Plugin para AWS para modificar ASTs:
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
-// Ejemplo: Incrementar número de versión en un archivo
-
-// Parsear el contenido del archivo en un AST de TypeScript
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// Encontrar nodos que coincidan con el selector
-const nodes = tsquery.query(
-  sourceFile,
+// Ejemplo: Incrementar versión
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // Obtener el nodo del literal numérico
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // Obtener el número de versión actual e incrementarlo
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // Reemplazar el nodo en el AST
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // Escribir el contenido actualizado de vuelta al tree
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
 :::tip
-Puedes probar selectores en línea en el [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
+Puedes probar selectores en el [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
 :::
 
-#### Agregar dependencias
+#### Agregar Dependencias
 
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
@@ -352,36 +323,36 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-Si agregas dependencias a un package.json, puedes instalarlas para el usuario como parte del callback del generador:
+Si agregas dependencias, puedes instalarlas automáticamente:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// Los generadores retornan un callback que puede ejecutar tareas post-generación, como instalar dependencias
+// Los generators pueden devolver un callback para tareas post-generación
 return () => {
   installPackagesTask(tree);
 };
 ```
 :::
 
-#### Formatear archivos generados
+#### Formatear Archivos Generados
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
-// Formatear todos los archivos modificados
-await formatFiles(tree);
+// Formatear archivos modificados
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
-#### Leer y actualizar archivos JSON
+#### Leer y Actualizar JSON
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// Leer un archivo JSON
+// Leer JSON
 const packageJson = readJson(tree, 'package.json');
 
-// Actualizar un archivo JSON
+// Actualizar JSON
 updateJson(tree, 'tsconfig.json', (json) => {
   json.compilerOptions = {
     ...json.compilerOptions,
@@ -391,21 +362,81 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
-### Ejecutar tu generador
+#### Extender Generators del Nx Plugin para AWS
 
-Puedes ejecutar tu generador de dos formas:
+Puedes importar y extender generators existentes:
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // Extender el generator de proyecto TypeScript aquí
+
+  return callback;
+};
+```
+
+#### Generadores OpenAPI
+
+Puedes usar generators para clientes TypeScript:
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // Agregar archivos adicionales
+};
+```
+
+También puedes generar datos para iterar sobre operaciones OpenAPI:
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'),
+    'path/to/output',
+    data,
+  );
+};
+```
+
+Ejemplo de plantilla EJS:
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+Consulta el [repositorio en GitHub](https://github.com/awslabs/nx-plugin-for-aws/) para ejemplos más complejos.
+
+### Ejecutar tu Generator
+
+Puedes ejecutar tu generator de dos formas:
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-Si no ves tu generador en la UI del plugin de VSCode, puedes refrescar tu workspace de Nx con:
+Si no ves tu generator en la UI de VSCode, actualiza tu workspace Nx con:
 
 <NxCommands commands={['reset']} />
 :::
 
-### Probar tu generador
+### Probar tu Generator
 
-Las pruebas unitarias para generadores son sencillas de implementar. Aquí un patrón típico:
+Las pruebas unitarias para generators son sencillas:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -415,90 +446,50 @@ describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
-    // Crear un workspace tree vacío
     tree = createTreeWithEmptyWorkspace();
-
-    // Agregar archivos que deban existir previamente
-    tree.write(
-      'project.json',
-      JSON.stringify({
-        name: 'test-project',
-        sourceRoot: 'src',
-      }),
-    );
-
     tree.write('src/existing-file.ts', 'export const existing = true;');
   });
 
   it('should generate expected files', async () => {
-    // Ejecutar el generador
-    await yourGenerator(tree, {
-      name: 'test',
-      // Agregar otras opciones requeridas
-    });
+    await yourGenerator(tree, { name: 'test' });
 
-    // Verificar creación de archivos
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
-
-    // Verificar contenido del archivo
     const content = tree.read('src/test/file.ts', 'utf-8');
     expect(content).toContain('export const test');
-
-    // También puedes usar snapshots
-    expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should update existing files', async () => {
-    // Ejecutar el generador
-    await yourGenerator(tree, {
-      name: 'test',
-      // Agregar otras opciones requeridas
-    });
-
-    // Verificar actualización de archivos existentes
-    const content = tree.read('src/existing-file.ts', 'utf-8');
-    expect(content).toContain('import { test } from');
   });
 
   it('should handle errors', async () => {
-    // Esperar que el generador lance un error en ciertas condiciones
     await expect(
-      yourGenerator(tree, {
-        name: 'invalid',
-        // Agregar opciones que causen error
-      }),
+      yourGenerator(tree, { name: 'invalid' })
     ).rejects.toThrow('Expected error message');
   });
 });
 ```
 
-Puntos clave para probar generadores:
+Puntos clave para pruebas:
+- Usar `createTreeWithEmptyWorkspace()`
+- Configurar archivos preexistentes
+- Verificar creación y modificación de archivos
+- Usar snapshots para contenido complejo
+- Probar condiciones de error
 
-- Usa `createTreeWithEmptyWorkspace()` para crear un sistema de archivos virtual
-- Configura archivos prerrequisitos antes de ejecutar el generador
-- Prueba creación de nuevos archivos y actualización de existentes
-- Usa snapshots para contenido complejo
-- Prueba condiciones de error para asegurar fallos controlados
+## Contribuir Generators a @aws/nx-plugin
 
-## Contribuir generadores a @aws/nx-plugin
+Puedes usar `ts#nx-generator` para crear generators dentro de `@aws/nx-plugin`.
 
-También puedes usar `ts#nx-generator` para crear un generador dentro de `@aws/nx-plugin`.
-
-Cuando este generador se ejecuta en nuestro repositorio, generará los siguientes archivos:
+Al ejecutarlo en nuestro repositorio, generará:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Esquema para la entrada del generador
-    - schema.d.ts Tipos TypeScript para el esquema
-    - generator.ts Implementación del generador
-    - generator.spec.ts Pruebas para tu generador
+    - schema.json
+    - schema.d.ts
+    - generator.ts
+    - generator.spec.ts
   - docs/src/content/docs/guides/
-    - \<name>.mdx Página de documentación para tu generador
-  - packages/nx-plugin/generators.json Actualizado para incluir tu generador
+    - \<name>.mdx
+  - packages/nx-plugin/generators.json Actualizado
 </FileTree>
 
-Luego puedes comenzar a implementar tu generador.
-
 :::tip
-Para una guía más detallada sobre cómo contribuir al Nx Plugin para AWS, consulta el <Link path="get_started/tutorials/contribute-generator">tutorial aquí</Link>.
+Para una guía detallada sobre contribuir al Nx Plugin para AWS, consulta el <Link path="get_started/tutorials/contribute-generator">tutorial aquí</Link>.
 :::

--- a/docs/src/content/docs/fr/guides/nx-generator.mdx
+++ b/docs/src/content/docs/fr/guides/nx-generator.mdx
@@ -12,7 +12,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
 
-Ajoute un [Générateur Nx](https://nx.dev/extending-nx/recipes/local-generators) à un projet TypeScript pour automatiser des tâches répétitives comme la création de composants ou l'application de structures de projet spécifiques.
+Ajoute un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) à un projet TypeScript pour vous aider à automatiser des tâches répétitives comme la création de composants ou l'application de structures de projet spécifiques.
 
 ## Utilisation
 
@@ -32,7 +32,7 @@ Le générateur créera les fichiers suivants dans le `pluginProject` spécifié
 
 <FileTree>
   - src/\<name>/
-    - schema.json Schéma des entrées pour votre générateur
+    - schema.json Schéma pour les entrées de votre générateur
     - schema.d.ts Types TypeScript pour votre schéma
     - generator.ts Implémentation de base du générateur
     - generator.spec.ts Tests pour votre générateur
@@ -144,9 +144,9 @@ Pour les options avec un ensemble fixe de choix, utilisez `enum` pour permettre 
 }
 ```
 
-#### Menu déroulant de sélection de projet
+#### Liste déroulante de sélection de projet
 
-Un pattern courant est de permettre aux utilisateurs de sélectionner parmi les projets existants :
+Un modèle courant consiste à laisser les utilisateurs sélectionner parmi les projets existants :
 
 ```json
 "project": {
@@ -157,11 +157,11 @@ Un pattern courant est de permettre aux utilisateurs de sélectionner parmi les 
 }
 ```
 
-La propriété `x-dropdown: "projects"` indique à Nx de peupler le menu déroulant avec tous les projets du workspace.
+La propriété `x-dropdown: "projects"` indique à Nx de peupler la liste avec tous les projets de l'espace de travail.
 
 #### Arguments positionnels
 
-Vous pouvez configurer des options pour qu'elles soient passées comme arguments positionnels via la ligne de commande :
+Vous pouvez configurer des options à passer comme arguments positionnels via la ligne de commande :
 
 ```json
 "name": {
@@ -175,7 +175,7 @@ Vous pouvez configurer des options pour qu'elles soient passées comme arguments
 }
 ```
 
-Cela permet d'exécuter le générateur via `nx g your-generator my-component` au lieu de `nx g your-generator --name=my-component`.
+Cela permet d'exécuter le générateur comme `nx g your-generator my-component` au lieu de `nx g your-generator --name=my-component`.
 
 #### Définition des priorités
 
@@ -189,7 +189,7 @@ Utilisez la propriété `x-priority` pour indiquer les options les plus importan
 }
 ```
 
-Les priorités possibles sont `"important"` ou `"internal"`. Cela aide Nx à ordonner les propriétés dans l'extension VSCode et la CLI.
+Les priorités peuvent être `"important"` ou `"internal"`. Cela aide Nx à ordonner les propriétés dans l'extension VSCode et la CLI.
 
 #### Valeurs par défaut
 
@@ -205,11 +205,11 @@ Vous pouvez fournir des valeurs par défaut :
 
 #### Plus d'informations
 
-Pour plus de détails sur les schémas, consultez la [documentation Nx sur les options des générateurs](https://nx.dev/extending-nx/recipes/generator-options).
+Pour plus de détails sur les schémas, consultez la [documentation Nx sur les options de générateur](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Types TypeScript avec schema.d.ts
 
-Avec `schema.json`, le générateur crée un fichier `schema.d.ts` fournissant les types TypeScript pour les options :
+En plus de `schema.json`, le générateur crée un fichier `schema.d.ts` fournissant des types TypeScript pour vos options :
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -219,37 +219,37 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Cette interface est utilisée dans l'implémentation pour la sécurité des types et l'autocomplétion :
+Cette interface est utilisée dans votre implémentation pour la sécurité des types et l'autocomplétion :
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // TypeScript connaît les types de toutes les options
+  // TypeScript connaît les types de toutes vos options
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-Toute modification de `schema.json` nécessite une mise à jour de `schema.d.ts` correspondante, incluant :
+À chaque modification de `schema.json`, vous devez mettre à jour `schema.d.ts` en conséquence. Cela inclut :
 
 - Ajout/suppression de propriétés
-- Modification des types
-- Définition de propriétés requises/optionnelles (utilisez `?` pour les optionnelles)
+- Modification des types de propriétés
+- Rendre des propriétés obligatoires ou optionnelles (utilisez `?` pour les propriétés optionnelles)
 
-L'interface TypeScript doit refléter fidèlement le schéma JSON.
+L'interface TypeScript doit refléter fidèlement la structure définie dans votre schéma JSON.
 :::
 
 ### Implémentation d'un générateur
 
 Après avoir créé le générateur, vous pouvez écrire son implémentation dans `generator.ts`.
 
-Un générateur est une fonction qui modifie un système de fichiers virtuel (`Tree`), lisant et écrivant des fichiers. Les modifications ne sont écrites sur le disque qu'après l'exécution complète, sauf en mode "dry-run".
+Un générateur est une fonction qui modifie un système de fichiers virtuel (`Tree`), lisant et écrivant des fichiers pour effectuer les changements. Les modifications ne sont écrites sur le disque qu'après l'exécution du générateur, sauf en mode "dry-run".
 
-Opérations courantes dans un générateur :
+Voici des opérations courantes dans un générateur :
 
-#### Lecture/Écriture de fichiers
+#### Lecture et écriture de fichiers
 
 ```typescript
 // Lire un fichier
@@ -264,18 +264,20 @@ if (tree.exists('path/to/file.ts')) {
 }
 ```
 
-#### Génération de fichiers depuis des templates
+#### Génération de fichiers à partir de modèles
+
+Utilisez `generateFiles` de `@nx/devkit` pour générer des fichiers avec des modèles [EJS](https://ejs.co/).
 
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 
-// Générer des fichiers depuis des templates
+// Générer des fichiers à partir de modèles
 generateFiles(
   tree,
-  joinPathFragments(__dirname, 'files'), // Répertoire des templates
+  joinPathFragments(__dirname, 'files'), // Répertoire des modèles
   'path/to/output', // Répertoire de sortie
   {
-    // Variables de remplacement
+    // Variables de substitution
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
@@ -285,48 +287,19 @@ generateFiles(
 
 #### Manipulation d'AST TypeScript
 
-Nous recommandons d'installer [TSQuery](https://github.com/phenomnomnominal/tsquery) pour manipuler l'AST.
+Utilisez `tsAstReplace` du plugin Nx pour AWS pour modifier l'AST TypeScript :
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
 // Exemple : Incrémenter un numéro de version
-
-// Parser le contenu en AST
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// Trouver les nodes correspondants
-const nodes = tsquery.query(
-  sourceFile,
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // Récupérer la node numérique
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // Incrémenter la version
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // Remplacer la node
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // Écrire le contenu modifié
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
 :::tip
@@ -351,12 +324,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-Si vous ajoutez des dépendances, vous pouvez les installer via une tâche :
+Si vous ajoutez des dépendances, vous pouvez les installer via une tâche post-génération :
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// Retourner une callback pour installer les dépendances
+// Les générateurs peuvent retourner une callback pour exécuter des tâches post-génération
 return () => {
   installPackagesTask(tree);
 };
@@ -366,21 +339,21 @@ return () => {
 #### Formatage des fichiers générés
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
 // Formater tous les fichiers modifiés
-await formatFiles(tree);
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
-#### Lecture/Mise à jour de fichiers JSON
+#### Lecture et mise à jour de fichiers JSON
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// Lire un JSON
+// Lire un fichier JSON
 const packageJson = readJson(tree, 'package.json');
 
-// Mettre à jour un JSON
+// Mettre à jour un fichier JSON
 updateJson(tree, 'tsconfig.json', (json) => {
   json.compilerOptions = {
     ...json.compilerOptions,
@@ -390,21 +363,81 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
-### Exécution du générateur
+#### Extension d'un générateur du plugin Nx pour AWS
+
+Vous pouvez importer et étendre des générateurs existants :
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // Étendre le générateur de projet TypeScript ici
+
+  return callback;
+};
+```
+
+#### Générateurs OpenAPI
+
+Vous pouvez utiliser les générateurs pour les clients TypeScript et les hooks :
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // Ajouter des fichiers supplémentaires ici
+};
+```
+
+Nous exposons aussi une méthode pour générer des structures de données à partir de spécifications OpenAPI :
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'),
+    'path/to/output',
+    data,
+  );
+};
+```
+
+Exemple de template EJS :
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+Consultez le [dépôt GitHub](https://github.com/awslabs/nx-plugin-for-aws/) pour des exemples complexes.
+
+### Exécution de votre générateur
 
 Deux méthodes pour exécuter votre générateur :
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-Si le générateur n'apparaît pas dans l'UI VSCode, rafraîchissez le workspace Nx :
+Si votre générateur n'apparaît pas dans l'interface VSCode, rafraîchissez l'espace de travail Nx avec :
 
 <NxCommands commands={['reset']} />
 :::
 
-### Tests du générateur
+### Tests de votre générateur
 
-Les tests unitaires pour les générateurs sont simples à implémenter :
+Les tests unitaires suivent ce modèle :
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -414,74 +447,39 @@ describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
-    // Créer un workspace vide
     tree = createTreeWithEmptyWorkspace();
-
-    // Ajouter des fichiers existants
-    tree.write(
-      'project.json',
-      JSON.stringify({
-        name: 'test-project',
-        sourceRoot: 'src',
-      }),
-    );
-
     tree.write('src/existing-file.ts', 'export const existing = true;');
   });
 
   it('should generate expected files', async () => {
-    // Exécuter le générateur
-    await yourGenerator(tree, {
-      name: 'test',
-    });
-
-    // Vérifier les fichiers générés
+    await yourGenerator(tree, { name: 'test' });
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
-
-    // Vérifier le contenu
-    const content = tree.read('src/test/file.ts', 'utf-8');
-    expect(content).toContain('export const test');
-
-    // Utiliser des snapshots
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
-  it('should update existing files', async () => {
-    await yourGenerator(tree, {
-      name: 'test',
-    });
-
-    const content = tree.read('src/existing-file.ts', 'utf-8');
-    expect(content).toContain('import { test } from');
-  });
-
   it('should handle errors', async () => {
-    await expect(
-      yourGenerator(tree, {
-        name: 'invalid',
-      }),
-    ).rejects.toThrow('Expected error message');
+    await expect(yourGenerator(tree, { name: 'invalid' }))
+      .rejects.toThrow('Expected error message');
   });
 });
 ```
 
 Points clés pour les tests :
 
-- Utiliser `createTreeWithEmptyWorkspace()`
-- Configurer les fichiers prérequis
-- Tester création et modification de fichiers
-- Utiliser des snapshots pour le contenu complexe
-- Tester les cas d'erreur
+- Utilisez `createTreeWithEmptyWorkspace()` pour un système de fichiers virtuel
+- Testez la création de fichiers et les mises à jour
+- Utilisez des snapshots pour le contenu complexe
+- Testez les cas d'erreur
 
 ## Contribution de générateurs à @aws/nx-plugin
 
 Le générateur `ts#nx-generator` peut aussi scaffold un générateur dans `@aws/nx-plugin`.
 
-Dans notre dépôt, il générera :
+Dans notre dépôt, il génèrera :
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Schéma des entrées
+    - schema.json Schéma d'entrée
     - schema.d.ts Types TypeScript
     - generator.ts Implémentation
     - generator.spec.ts Tests
@@ -490,8 +488,6 @@ Dans notre dépôt, il générera :
   - packages/nx-plugin/generators.json Mis à jour
 </FileTree>
 
-Vous pouvez ensuite implémenter votre générateur.
-
 :::tip
-Pour un guide détaillé sur la contribution au plugin Nx pour AWS, consultez le <Link path="get_started/tutorials/contribute-generator">tutoriel ici</Link>.
+Pour un guide détaillé sur la contribution, consultez le <Link path="get_started/tutorials/contribute-generator">tutoriel ici</Link>.
 :::

--- a/docs/src/content/docs/it/guides/nx-generator.mdx
+++ b/docs/src/content/docs/it/guides/nx-generator.mdx
@@ -12,11 +12,11 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
 
-Aggiunge un [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a un progetto TypeScript, per aiutarti ad automatizzare task ripetitivi come la creazione di componenti o l'imposizione di strutture di progetto specifiche.
+Aggiunge un [Generatore Nx](https://nx.dev/extending-nx/recipes/local-generators) a un progetto TypeScript, per aiutarti ad automatizzare attività ripetitive come lo scaffolding di componenti o l'imposizione di strutture di progetto specifiche.
 
 ## Utilizzo
 
-### Genera un Generatore
+### Generare un Generatore
 
 Puoi generare un generatore in due modi:
 
@@ -38,22 +38,22 @@ Il generatore creerà i seguenti file all'interno del `pluginProject` specificat
     - generator.spec.ts Test per il generatore
   - generators.json Configurazione Nx per definire i generatori
   - package.json Creato o aggiornato con una voce "generators"
-  - tsconfig.json Aggiornato per utilizzare CommonJS
+  - tsconfig.json Aggiornato per usare CommonJS
 </FileTree>
 
-:::warning
-Questo generatore aggiornerà il `pluginProject` selezionato per utilizzare CommonJS, poiché attualmente i generatori Nx supportano solo CommonJS ([fai riferimento a questa issue GitHub per il supporto ESM](https://github.com/nrwl/nx/issues/15682)).
+:::avvertimento
+Questo generatore aggiornerà il `pluginProject` selezionato per utilizzare CommonJS, poiché i generatori Nx supportano attualmente solo CommonJS ([fai riferimento a questa issue GitHub per il supporto ESM](https://github.com/nrwl/nx/issues/15682)).
 :::
 
 ## Generator Locali
 
-:::tip
+:::suggerimento
 Consigliamo di generare prima un progetto TypeScript dedicato per tutti i tuoi generatori utilizzando il generatore `ts#project`. Ad esempio:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-Seleziona il tuo progetto locale `nx-plugin` quando esegui il generatore `ts#nx-generator`, e specifica un nome, una directory opzionale e una descrizione.
+Seleziona il tuo progetto locale `nx-plugin` quando esegui il generatore `ts#nx-generator`, e specifica un nome con directory e descrizione opzionali.
 
 ### Definizione dello Schema
 
@@ -67,8 +67,8 @@ Un file schema.json ha la seguente struttura base:
 {
   "$schema": "https://json-schema.org/schema",
   "$id": "YourGeneratorName",
-  "title": "Titolo del Generatore",
-  "description": "Descrizione delle funzionalità del generatore",
+  "title": "Your Generator Title",
+  "description": "Description of what your generator does",
   "type": "object",
   "properties": {
     // Le opzioni del generatore vanno qui
@@ -79,29 +79,29 @@ Un file schema.json ha la seguente struttura base:
 
 #### Esempio Semplice
 
-Ecco un esempio semplice con alcune opzioni base:
+Ecco un esempio semplice con alcune opzioni di base:
 
 ```json
 {
   "$schema": "https://json-schema.org/schema",
   "$id": "ComponentGenerator",
-  "title": "Crea un Componente",
-  "description": "Crea un nuovo componente React",
+  "title": "Create a Component",
+  "description": "Creates a new React component",
   "type": "object",
   "properties": {
     "name": {
       "type": "string",
-      "description": "Nome del componente",
+      "description": "Component name",
       "x-priority": "important"
     },
     "directory": {
       "type": "string",
-      "description": "Directory in cui verrà creato il componente",
+      "description": "Directory where the component will be created",
       "default": "src/components"
     },
     "withTests": {
       "type": "boolean",
-      "description": "Generare i file di test",
+      "description": "Whether to generate test files",
       "default": true
     }
   },
@@ -116,8 +116,8 @@ Puoi personalizzare i prompt visualizzati durante l'esecuzione del generatore vi
 ```json
 "name": {
   "type": "string",
-  "description": "Nome del componente",
-  "x-prompt": "Qual è il nome del componente?"
+  "description": "Component name",
+  "x-prompt": "What is the name of your component?"
 }
 ```
 
@@ -126,8 +126,8 @@ Per opzioni booleane, puoi usare un prompt sì/no:
 ```json
 "withTests": {
   "type": "boolean",
-  "description": "Generare i file di test",
-  "x-prompt": "Desideri generare i file di test?"
+  "description": "Whether to generate test files",
+  "x-prompt": "Would you like to generate test files?"
 }
 ```
 
@@ -138,21 +138,21 @@ Per opzioni con un set fisso di scelte, usa `enum` per permettere agli utenti di
 ```json
 "style": {
   "type": "string",
-  "description": "Approccio di stile da utilizzare",
+  "description": "The styling approach to use",
   "enum": ["css", "scss", "styled-components", "none"],
   "default": "css"
 }
 ```
 
-#### Selezione Progetto da Tendina
+#### Selezione Progetto a Tendina
 
-Un pattern comune è permettere agli utenti di selezionare tra progetti esistenti nel workspace:
+Un pattern comune è permettere agli utenti di selezionare da progetti esistenti nel workspace:
 
 ```json
 "project": {
   "type": "string",
-  "description": "Progetto a cui aggiungere il componente",
-  "x-prompt": "A quale progetto vuoi aggiungere il componente?",
+  "description": "The project to add the component to",
+  "x-prompt": "Which project would you like to add the component to?",
   "x-dropdown": "projects"
 }
 ```
@@ -166,7 +166,7 @@ Puoi configurare opzioni da passare come argomenti posizionali quando si esegue 
 ```json
 "name": {
   "type": "string",
-  "description": "Nome del componente",
+  "description": "Component name",
   "x-priority": "important",
   "$default": {
     "$source": "argv",
@@ -175,7 +175,7 @@ Puoi configurare opzioni da passare come argomenti posizionali quando si esegue 
 }
 ```
 
-Ciò consente agli utenti di eseguire il generatore come `nx g your-generator my-component` invece di `nx g your-generator --name=my-component`.
+Questo permette agli utenti di eseguire il generatore come `nx g your-generator my-component` invece di `nx g your-generator --name=my-component`.
 
 #### Impostazione Priorità
 
@@ -184,12 +184,12 @@ Usa la proprietà `x-priority` per indicare le opzioni più importanti:
 ```json
 "name": {
   "type": "string",
-  "description": "Nome del componente",
+  "description": "Component name",
   "x-priority": "important"
 }
 ```
 
-Le opzioni possono avere priorità `"important"` o `"internal"`. Questo aiuta Nx a ordinare le proprietà nell'estensione VSCode di Nx e nella CLI.
+Le opzioni possono avere priorità `"important"` o `"internal"`. Questo aiuta Nx a ordinare le proprietà nell'estensione VSCode di Nx e nella CLI Nx.
 
 #### Valori Predefiniti
 
@@ -198,18 +198,18 @@ Puoi fornire valori predefiniti per le opzioni:
 ```json
 "directory": {
   "type": "string",
-  "description": "Directory in cui verrà creato il componente",
+  "description": "Directory where the component will be created",
   "default": "src/components"
 }
 ```
 
 #### Ulteriori Informazioni
 
-Per maggiori dettagli sugli schemi, consulta la [documentazione di Nx Generator Options](https://nx.dev/extending-nx/recipes/generator-options).
+Per maggiori dettagli sugli schemi, consulta la [documentazione Nx Generator Options](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Tipi TypeScript con schema.d.ts
 
-Insieme a `schema.json`, il generatore crea un file `schema.d.ts` che fornisce tipi TypeScript per le opzioni:
+Insieme a `schema.json`, il generatore crea un file `schema.d.ts` che fornisce tipi TypeScript per le opzioni del generatore:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -219,7 +219,7 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Questa interfaccia viene utilizzata nell'implementazione del generatore per type safety e completamento del codice:
+Questa interfaccia è usata nell'implementazione del generatore per garantire type safety e completamento del codice:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
@@ -231,19 +231,19 @@ export default async function (tree: Tree, options: YourGeneratorSchema) {
 }
 ```
 
-:::caution
-Ogni volta che modifichi `schema.json`, devi aggiornare `schema.d.ts` per corrispondere. Ciò include:
+:::attenzione
+Ogni volta che modifichi `schema.json`, devi aggiornare `schema.d.ts` per corrispondere. Questo include:
 
 - Aggiungere o rimuovere proprietà
 - Cambiare i tipi delle proprietà
 - Rendere proprietà obbligatorie o opzionali (usa il suffisso `?` per proprietà opzionali)
 
-L'interfaccia TypeScript deve riflettere accuratamente la struttura definita nello schema JSON.
+L'interfaccia TypeScript deve riflettere accuratamente la struttura definita nel tuo JSON schema.
 :::
 
 ### Implementazione di un Generatore
 
-Dopo aver creato il nuovo generatore come sopra, puoi scrivere l'implementazione in `generator.ts`.
+Dopo aver creato il nuovo generatore come sopra, puoi scrivere la tua implementazione in `generator.ts`.
 
 Un generatore è una funzione che modifica un filesystem virtuale (`Tree`), leggendo e scrivendo file per apportare le modifiche desiderate. Le modifiche dal `Tree` vengono scritte su disco solo al termine dell'esecuzione del generatore, a meno che non sia eseguito in modalità "dry-run".
 
@@ -252,10 +252,10 @@ Ecco alcune operazioni comuni che potresti voler eseguire nel generatore:
 #### Lettura e Scrittura di File
 
 ```typescript
-// Legge un file
+// Leggi un file
 const content = tree.read('path/to/file.ts', 'utf-8');
 
-// Scrive un file
+// Scrivi un file
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
 // Verifica se un file esiste
@@ -265,6 +265,8 @@ if (tree.exists('path/to/file.ts')) {
 ```
 
 #### Generazione File da Template
+
+Puoi generare file con l'utility `generateFiles` da `@nx/devkit`. Questo permette di definire template in sintassi [EJS](https://ejs.co/) e sostituire variabili.
 
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
@@ -286,51 +288,22 @@ generateFiles(
 
 #### Manipolazione AST (Abstract Syntax Tree) TypeScript
 
-Consigliamo di installare [TSQuery](https://github.com/phenomnomnominal/tsquery) per aiutare con la manipolazione AST.
+Puoi usare il metodo `tsAstReplace` esposto dal Nx Plugin for AWS per sostituire parti di un abstract syntax tree TypeScript.
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
 // Esempio: Incrementa numero di versione in un file
-
-// Analizza il contenuto del file in un AST TypeScript
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// Trova nodi corrispondenti al selettore
-const nodes = tsquery.query(
-  sourceFile,
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // Ottieni il nodo del letterale numerico
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // Ottieni la versione corrente e incrementala
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // Sostituisci il nodo nell'AST
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // Scrivi il contenuto aggiornato nel tree
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
-:::tip
+:::suggerimento
 Puoi testare i selettori online nel [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
 :::
 
@@ -339,7 +312,7 @@ Puoi testare i selettori online nel [TSQuery Playground](https://tsquery-playgro
 ```typescript
 import { addDependenciesToPackageJson } from '@nx/devkit';
 
-// Aggiunge dipendenze a package.json
+// Aggiungi dipendenze a package.json
 addDependenciesToPackageJson(
   tree,
   {
@@ -351,13 +324,13 @@ addDependenciesToPackageJson(
 );
 ```
 
-:::note
-Se aggiungi dipendenze a un package.json, puoi installarle per l'utente come parte della callback del generatore:
+:::nota
+Se aggiungi dipendenze a un package.json, puoi installarle per l'utente come parte del callback del generatore:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// I generatori restituiscono una callback che può eseguire task post-generazione, come l'installazione di dipendenze
+// I generatori restituiscono un callback che può eseguire task post-generazione, come installare dipendenze
 return () => {
   installPackagesTask(tree);
 };
@@ -367,10 +340,10 @@ return () => {
 #### Formattazione File Generati
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
 // Formatta tutti i file modificati
-await formatFiles(tree);
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
 #### Lettura e Aggiornamento File JSON
@@ -378,7 +351,7 @@ await formatFiles(tree);
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// Legge un file JSON
+// Leggi un file JSON
 const packageJson = readJson(tree, 'package.json');
 
 // Aggiorna un file JSON
@@ -391,14 +364,76 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
+#### Estensione di un Generatore dal Nx Plugin for AWS
+
+Puoi importare generatori dal Nx Plugin for AWS ed estenderli o combinarli come desideri. Ad esempio, potresti creare un generatore che si basa su un progetto TypeScript:
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // Estendi qui il generatore di progetto TypeScript
+
+  // Restituisci il callback per assicurare l'installazione delle dipendenze.
+  // Puoi wrappare il callback se desideri eseguire operazioni aggiuntive nel callback del generatore.
+  return callback;
+};
+```
+
+#### Generator OpenAPI
+
+Puoi usare ed estendere i generatori che utilizziamo per client e hook TypeScript in modo simile a quanto sopra:
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // Aggiungi file aggiuntivi qui
+};
+```
+
+Esponiamo anche un metodo che ti permette di costruire una struttura dati utilizzabile per iterare sulle operazioni in una specifica OpenAPI e quindi strumentare la tua generazione di codice, ad esempio:
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'), // Directory template
+    'path/to/output', // Directory di output
+    data,
+  );
+};
+```
+
+Il che ti permette di scrivere template come:
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+Fai riferimento al [codice sorgente su GitHub](https://github.com/awslabs/nx-plugin-for-aws/) per esempi di template più complessi.
+
 ### Esecuzione del Generatore
 
 Puoi eseguire il generatore in due modi:
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
-:::note
-Se non vedi il generatore nell'interfaccia UI del plugin VSCode, puoi aggiornare il tuo Nx Workspace con:
+:::nota
+Se non vedi il tuo generatore nell'interfaccia UI del plugin VSCode, puoi aggiornare il tuo Nx Workspace con:
 
 <NxCommands commands={['reset']} />
 :::
@@ -411,14 +446,14 @@ I test unitari per i generatori sono semplici da implementare. Ecco un pattern t
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { yourGenerator } from './generator';
 
-describe('tuo generatore', () => {
+describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
     // Crea un workspace tree vuoto
     tree = createTreeWithEmptyWorkspace();
 
-    // Aggiungi eventuali file che dovrebbero già esistere
+    // Aggiungi file che devono esistere nel tree
     tree.write(
       'project.json',
       JSON.stringify({
@@ -475,14 +510,14 @@ describe('tuo generatore', () => {
 Punti chiave per testare i generatori:
 
 - Usa `createTreeWithEmptyWorkspace()` per creare un filesystem virtuale
-- Configura eventuali file prerequisiti prima di eseguire il generatore
-- Testa sia la creazione di nuovi file che gli aggiornamenti a file esistenti
+- Imposta file prerequisiti prima di eseguire il generatore
+- Testa sia la creazione di nuovi file che l'aggiornamento di file esistenti
 - Usa snapshot per contenuti di file complessi
-- Testa condizioni di errore per garantire un fallimento controllato
+- Testa condizioni di errore per assicurarti che il generatore fallisca correttamente
 
 ## Contribuire ai Generatori per @aws/nx-plugin
 
-Puoi anche usare `ts#nx-generator` per scaffoldare un generatore all'interno di `@aws/nx-plugin`.
+Puoi usare `ts#nx-generator` anche per scaffoldare un generatore all'interno di `@aws/nx-plugin`.
 
 Quando questo generatore viene eseguito nel nostro repository, genererà i seguenti file:
 
@@ -499,6 +534,6 @@ Quando questo generatore viene eseguito nel nostro repository, genererà i segue
 
 Potrai quindi iniziare a implementare il tuo generatore.
 
-:::tip
-Per una guida più approfondita su come contribuire all'Nx Plugin per AWS, consulta il <Link path="get_started/tutorials/contribute-generator">tutorial qui</Link>.
+:::suggerimento
+Per una guida più approfondita su come contribuire al Nx Plugin for AWS, consulta il <Link path="get_started/tutorials/contribute-generator">tutorial qui</Link>.
 :::

--- a/docs/src/content/docs/jp/guides/nx-generator.mdx
+++ b/docs/src/content/docs/jp/guides/nx-generator.mdx
@@ -32,32 +32,32 @@ TypeScriptプロジェクトに[Nx Generator](https://nx.dev/extending-nx/recipe
 
 <FileTree>
   - src/\<name>/
-    - schema.json ジェネレータ入力用スキーマ
+    - schema.json ジェネレータの入力スキーマ
     - schema.d.ts スキーマのTypeScript型定義
     - generator.ts ジェネレータ実装のスタブ
     - generator.spec.ts ジェネレータのテスト
-  - generators.json ジェネレータ定義用Nx設定
+  - generators.json ジェネレータ定義用のNx設定
   - package.json 「generators」エントリが追加または更新
   - tsconfig.json CommonJS使用に更新
 </FileTree>
 
-:::warning
-現在NxジェネレータはCommonJSのみをサポートしているため、このジェネレータは選択した`pluginProject`をCommonJS使用に更新します（[ESMサポートに関するGitHubイシュー](https://github.com/nrwl/nx/issues/15682)）。
+:::警告
+このジェネレータは選択した`pluginProject`をCommonJS使用に更新します。現時点ではNxジェネレータがCommonJSのみをサポートしているためです（[ESMサポートに関するGitHubイシュー](https://github.com/nrwl/nx/issues/15682)）。
 :::
 
 ## ローカルジェネレータ
 
-:::tip
-ジェネレータ用に専用のTypeScriptプロジェクトを`ts#project`ジェネレータで先に生成することを推奨します。例:
+:::ヒント
+まず`ts#project`ジェネレータを使用して、すべてのジェネレータ用の専用TypeScriptプロジェクトを生成することを推奨します。例:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-`ts#nx-generator`ジェネレータ実行時にローカルの`nx-plugin`プロジェクトを選択し、名前とオプションのディレクトリ、説明を指定します。
+`ts#nx-generator`ジェネレータを実行する際にローカルの`nx-plugin`プロジェクトを選択し、名前、オプションのディレクトリ、説明を指定します。
 
 ### スキーマの定義
 
-`schema.json`ファイルはジェネレータが受け入れるオプションを定義します。[JSON Schema](https://json-schema.org/)形式に[Nx固有の拡張](https://nx.dev/extending-nx/recipes/generator-options)を加えた形式です。
+`schema.json`ファイルはジェネレータが受け入れるオプションを定義します。[JSON Schema](https://json-schema.org/)形式と[Nx拡張仕様](https://nx.dev/extending-nx/recipes/generator-options)に従います。
 
 #### 基本構造
 
@@ -71,7 +71,7 @@ schema.jsonファイルの基本構造:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // ジェネレータオプション
+    // Your generator options go here
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
@@ -117,17 +117,17 @@ schema.jsonファイルの基本構造:
 "name": {
   "type": "string",
   "description": "Component name",
-  "x-prompt": "What is the name of your component?"
+  "x-prompt": "コンポーネントの名前を入力してください"
 }
 ```
 
-booleanオプションではyes/noプロンプトを使用:
+真偽値オプションにはYes/Noプロンプト:
 
 ```json
 "withTests": {
   "type": "boolean",
   "description": "Whether to generate test files",
-  "x-prompt": "Would you like to generate test files?"
+  "x-prompt": "テストファイルを生成しますか？"
 }
 ```
 
@@ -138,7 +138,7 @@ booleanオプションではyes/noプロンプトを使用:
 ```json
 "style": {
   "type": "string",
-  "description": "The styling approach to use",
+  "description": "使用するスタイリング手法",
   "enum": ["css", "scss", "styled-components", "none"],
   "default": "css"
 }
@@ -151,17 +151,17 @@ booleanオプションではyes/noプロンプトを使用:
 ```json
 "project": {
   "type": "string",
-  "description": "The project to add the component to",
-  "x-prompt": "Which project would you like to add the component to?",
+  "description": "コンポーネントを追加するプロジェクト",
+  "x-prompt": "コンポーネントを追加するプロジェクトを選択してください",
   "x-dropdown": "projects"
 }
 ```
 
-`x-dropdown: "projects"`プロパティはNxにワークスペースの全プロジェクトをドロップダウン表示させます。
+`x-dropdown: "projects"`プロパティは、Nxにワークスペース内の全プロジェクトをドロップダウンに表示するよう指示します。
 
 #### 位置引数
 
-コマンドライン実行時に位置引数としてオプションを渡す設定:
+コマンドライン実行時の位置引数としてオプションを設定:
 
 ```json
 "name": {
@@ -175,11 +175,11 @@ booleanオプションではyes/noプロンプトを使用:
 }
 ```
 
-これにより`nx g your-generator my-component`のように実行可能になります。
+これにより`nx g your-generator my-component`のように実行可能になります（`--name=my-component`不要）。
 
-#### 優先度設定
+#### 優先度の設定
 
-`x-priority`プロパティで重要オプションを表示:
+`x-priority`プロパティで重要なオプションを指定:
 
 ```json
 "name": {
@@ -189,7 +189,7 @@ booleanオプションではyes/noプロンプトを使用:
 }
 ```
 
-`"important"`または`"internal"`優先度を設定可能。Nx VSCode拡張とCLIでのプロパティ順序制御に役立ちます。
+`"important"`または`"internal"`を指定可能。Nx VSCode拡張やCLIでのプロパティ表示順序に影響します。
 
 #### デフォルト値
 
@@ -198,7 +198,7 @@ booleanオプションではyes/noプロンプトを使用:
 ```json
 "directory": {
   "type": "string",
-  "description": "Directory where the component will be created",
+  "description": "コンポーネント生成ディレクトリ",
   "default": "src/components"
 }
 ```
@@ -207,7 +207,7 @@ booleanオプションではyes/noプロンプトを使用:
 
 スキーマの詳細は[Nx Generator Optionsドキュメント](https://nx.dev/extending-nx/recipes/generator-options)を参照。
 
-#### schema.d.tsのTypeScript型
+#### schema.d.tsによるTypeScript型
 
 `schema.json`と共に生成される`schema.d.ts`はジェネレータオプションのTypeScript型を提供:
 
@@ -219,43 +219,43 @@ export interface YourGeneratorSchema {
 }
 ```
 
-このインターフェースは型安全性とコード補完のために実装で使用:
+このインターフェースは型安全性とコード補完のためにジェネレータ実装で使用:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // オプションの型が認識される
+  // オプションの型がTypeScriptで認識される
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-`schema.json`を変更する際は、必ず`schema.d.ts`も更新してください。変更内容には以下が含まれます:
+`schema.json`を変更する際は、必ず`schema.d.ts`も更新してください。具体的には:
 
 - プロパティの追加/削除
 - プロパティ型の変更
-- 必須/オプションの変更（オプションは`?`接尾辞）
+- 必須/オプションの変更（オプションには`?`接尾辞を使用）
 
 TypeScriptインターフェースはJSONスキーマの構造を正確に反映する必要があります。
 :::
 
 ### ジェネレータの実装
 
-上記でジェネレータを作成後、`generator.ts`に実装を記述します。
+上記の方法でジェネレータを作成後、`generator.ts`に実装を記述します。
 
-ジェネレータは仮想ファイルシステム（`Tree`）を操作し、変更をディスクに書き込みます（「dry-run」モードでない場合）。
+ジェネレータは仮想ファイルシステム（`Tree`）を操作する関数です。変更はジェネレータ終了時（dry-runモードでない場合）に実際のファイルシステムに反映されます。
 
 一般的な操作例:
 
 #### ファイルの読み書き
 
 ```typescript
-// ファイル読み込み
+// ファイル読み取り
 const content = tree.read('path/to/file.ts', 'utf-8');
 
-// ファイル書き込み
+// 新規ファイル作成
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
 // ファイル存在確認
@@ -265,6 +265,8 @@ if (tree.exists('path/to/file.ts')) {
 ```
 
 #### テンプレートからのファイル生成
+
+`@nx/devkit`の`generateFiles`ユーティリティで[EJS](https://ejs.co/)テンプレートを使用:
 
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
@@ -285,52 +287,23 @@ generateFiles(
 
 #### TypeScript AST操作
 
-[TSQuery](https://github.com/phenomnomnominal/tsquery)の使用を推奨:
+AWS向けNxプラグインの`tsAstReplace`メソッドでASTを操作:
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
-// 例: バージョン番号の更新
-
-// ファイル内容をASTに解析
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// セレクタに一致するノードを検索
-const nodes = tsquery.query(
-  sourceFile,
+// バージョン番号更新例
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // 数値リテラルノード取得
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // バージョン番号をインクリメント
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // ASTノード置換
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // 更新内容をtreeに書き込み
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
-:::tip
-セレクタは[TSQuery Playground](https://tsquery-playground.firebaseapp.com/)でテスト可能です。
+:::ヒント
+セレクタのテストは[TSQuery Playground](https://tsquery-playground.firebaseapp.com/)で実施可能です。
 :::
 
 #### 依存関係の追加
@@ -351,12 +324,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-依存関係を追加後、インストールタスクをコールバックで実行:
+依存関係追加後、ジェネレータコールバックでインストールを実行:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// ジェネレータが依存関係インストールタスクを返す
+// 依存関係インストール用コールバックを返す
 return () => {
   installPackagesTask(tree);
 };
@@ -366,10 +339,10 @@ return () => {
 #### 生成ファイルのフォーマット
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
-// 変更ファイルをフォーマット
-await formatFiles(tree);
+// 変更ファイルのフォーマット
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
 #### JSONファイルの操作
@@ -377,7 +350,7 @@ await formatFiles(tree);
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// JSONファイル読み込み
+// JSONファイル読み取り
 const packageJson = readJson(tree, 'package.json');
 
 // JSONファイル更新
@@ -389,6 +362,67 @@ updateJson(tree, 'tsconfig.json', (json) => {
   return json;
 });
 ```
+
+#### AWS向けNxプラグインのジェネレータ拡張
+
+AWS向けNxプラグインのジェネレータをインポートして拡張可能:
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // TypeScriptプロジェクトジェネレータを拡張
+
+  // 依存関係インストール用コールバックを返す
+  return callback;
+};
+```
+
+#### OpenAPIジェネレータ
+
+TypeScriptクライアント生成用ジェネレータを同様に拡張:
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // 追加ファイル生成
+};
+```
+
+OpenAPI仕様の操作反復用データ構造構築メソッド:
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'), // テンプレートディレクトリ
+    'path/to/output', // 出力ディレクトリ
+    data,
+  );
+};
+```
+
+テンプレート例:
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+複雑な例は[GitHubリポジトリ](https://github.com/awslabs/nx-plugin-for-aws/)を参照。
 
 ### ジェネレータの実行
 
@@ -417,7 +451,7 @@ describe('your generator', () => {
     // 空のワークスペース作成
     tree = createTreeWithEmptyWorkspace();
 
-    // 既存ファイルの追加
+    // 事前に存在するファイルを追加
     tree.write(
       'project.json',
       JSON.stringify({
@@ -429,11 +463,11 @@ describe('your generator', () => {
     tree.write('src/existing-file.ts', 'export const existing = true;');
   });
 
-  it('should generate expected files', async () => {
+  it('期待するファイルを生成する', async () => {
     // ジェネレータ実行
     await yourGenerator(tree, {
       name: 'test',
-      // 必須オプション
+      // その他必須オプション
     });
 
     // ファイル生成確認
@@ -447,57 +481,57 @@ describe('your generator', () => {
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
-  it('should update existing files', async () => {
+  it('既存ファイルを更新する', async () => {
     // ジェネレータ実行
     await yourGenerator(tree, {
       name: 'test',
-      // 必須オプション
+      // その他必須オプション
     });
 
-    // 既存ファイル更新確認
+    // 既存ファイルの更新確認
     const content = tree.read('src/existing-file.ts', 'utf-8');
     expect(content).toContain('import { test } from');
   });
 
-  it('should handle errors', async () => {
+  it('エラーを適切に処理する', async () => {
     // エラー発生条件のテスト
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
         // エラーを引き起こすオプション
       }),
-    ).rejects.toThrow('Expected error message');
+    ).rejects.toThrow('想定されるエラーメッセージ');
   });
 });
 ```
 
-テストの要点:
+テストの主要ポイント:
 
-- `createTreeWithEmptyWorkspace()`で仮想ファイルシステムを作成
-- 事前に必要なファイルをセットアップ
-- 新規ファイル生成と既存ファイル更新をテスト
-- 複雑なファイル内容にはスナップショットを使用
-- エラー条件をテストして適切なエラーハンドリングを確認
+- `createTreeWithEmptyWorkspace()`で仮想ファイルシステム作成
+- ジェネレータ実行前の前提条件ファイルをセットアップ
+- 新規ファイル生成と既存ファイル更新の両方をテスト
+- 複雑なファイル内容にはスナップショットテストを使用
+- エラー条件のテストで適切なエラーハンドリングを確認
 
 ## @aws/nx-pluginへのジェネレータ提供
 
-`ts#nx-generator`を使用して`@aws/nx-plugin`内にジェネレータをスキャフォールドできます。
+`ts#nx-generator`を使用して`@aws/nx-plugin`内にジェネレータをスキャフォールディング可能です。
 
-当リポジトリで実行すると、以下のファイルが生成されます:
+当リポジトリで実行時、以下のファイルが生成されます:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json ジェネレータ入力用スキーマ
-    - schema.d.ts スキーマのTypeScript型定義
+    - schema.json ジェネレータ入力スキーマ
+    - schema.d.ts TypeScript型定義
     - generator.ts ジェネレータ実装
     - generator.spec.ts テスト
   - docs/src/content/docs/guides/
-    - \<name>.mdx ジェネレータのドキュメントページ
+    - \<name>.mdx ジェネレータドキュメント
   - packages/nx-plugin/generators.json ジェネレータ定義を更新
 </FileTree>
 
 実装を開始できます。
 
-:::tip
+:::ヒント
 AWS向けNxプラグインへの貢献に関する詳細ガイドは<Link path="get_started/tutorials/contribute-generator">こちらのチュートリアル</Link>を参照してください。
 :::

--- a/docs/src/content/docs/ko/guides/nx-generator.mdx
+++ b/docs/src/content/docs/ko/guides/nx-generator.mdx
@@ -16,9 +16,9 @@ TypeScript 프로젝트에 [Nx Generator](https://nx.dev/extending-nx/recipes/lo
 
 ## 사용 방법
 
-### Generator 생성하기
+### 생성기 생성
 
-두 가지 방법으로 Generator를 생성할 수 있습니다:
+생성기는 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="ts#nx-generator" />
 
@@ -26,38 +26,38 @@ TypeScript 프로젝트에 [Nx Generator](https://nx.dev/extending-nx/recipes/lo
 
 <GeneratorParameters generator="ts#nx-generator" />
 
-## Generator 출력 결과
+## 생성기 출력
 
-Generator는 주어진 `pluginProject` 내에 다음 프로젝트 파일들을 생성합니다:
+생성기는 주어진 `pluginProject` 내에 다음 프로젝트 파일들을 생성합니다:
 
 <FileTree>
   - src/\<name>/
-    - schema.json Generator 입력을 위한 스키마
-    - schema.d.ts 스키마의 TypeScript 타입 정의
-    - generator.ts Generator 구현 스텁
-    - generator.spec.ts Generator 테스트
-  - generators.json Generator 정의를 위한 Nx 설정
+    - schema.json 생성자 입력을 위한 스키마
+    - schema.d.ts 스키마의 TypeScript 타입
+    - generator.ts 생성자 구현 스텁
+    - generator.spec.ts 생성자 테스트
+  - generators.json 생성자 정의를 위한 Nx 설정
   - package.json 생성되거나 "generators" 항목이 추가됨
   - tsconfig.json CommonJS 사용으로 업데이트됨
 </FileTree>
 
 :::warning
-이 Generator는 현재 Nx Generator가 CommonJS만 지원하기 때문에 선택한 `pluginProject`를 CommonJS 사용으로 업데이트합니다 ([ESM 지원 관련 GitHub 이슈 참조](https://github.com/nrwl/nx/issues/15682)).
+이 생성기는 현재 Nx Generator가 CommonJS만 지원하기 때문에 선택한 `pluginProject`를 CommonJS 사용으로 업데이트합니다([ESM 지원 관련 GitHub 이슈 참조](https://github.com/nrwl/nx/issues/15682)).
 :::
 
-## 로컬 Generators
+## 로컬 생성기
 
 :::tip
-먼저 `ts#project` Generator를 사용하여 모든 Generator를 위한 전용 TypeScript 프로젝트를 생성할 것을 권장합니다. 예시:
+먼저 `ts#project` 생성기를 사용하여 모든 생성기를 위한 전용 TypeScript 프로젝트를 생성하는 것을 권장합니다. 예시:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-`ts#nx-generator` Generator를 실행할 때 로컬 `nx-plugin` 프로젝트를 선택하고 이름, 선택적 디렉토리 및 설명을 지정하세요.
+`ts#nx-generator` 생성기를 실행할 때 로컬 `nx-plugin` 프로젝트를 선택하고 이름, 선택적 디렉토리 및 설명을 지정하세요.
 
-### 스키마 정의하기
+### 스키마 정의
 
-`schema.json` 파일은 Generator가 허용하는 옵션들을 정의합니다. [JSON Schema](https://json-schema.org/) 형식에 [Nx 확장 기능](https://nx.dev/extending-nx/recipes/generator-options)을 추가하여 작성됩니다.
+`schema.json` 파일은 생성자가 허용하는 옵션들을 정의합니다. [JSON Schema](https://json-schema.org/) 형식과 [Nx 확장 기능](https://nx.dev/extending-nx/recipes/generator-options)을 따릅니다.
 
 #### 기본 구조
 
@@ -71,7 +71,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // Generator 옵션들
+    // Your generator options go here
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
@@ -79,7 +79,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 간단한 예시
 
-기본 옵션들을 포함한 간단한 예시:
+기본 옵션을 포함한 간단한 예시:
 
 ```json
 {
@@ -111,7 +111,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 대화형 프롬프트 (CLI)
 
-`x-prompt` 속성을 추가하여 CLI에서 Generator 실행 시 표시되는 프롬프트를 커스터마이즈할 수 있습니다:
+CLI에서 생성기를 실행할 때 표시되는 프롬프트를 사용자 정의하려면 `x-prompt` 속성을 추가하세요:
 
 ```json
 "name": {
@@ -121,7 +121,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-불리언 옵션의 경우 yes/no 프롬프트 사용 가능:
+불리언 옵션의 경우 yes/no 프롬프트 사용:
 
 ```json
 "withTests": {
@@ -131,9 +131,9 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-#### 드롭다운 선택지
+#### 드롭다운 선택
 
-고정된 선택지 세트가 있는 옵션의 경우 `enum`을 사용하여 옵션 중 하나를 선택할 수 있게 합니다:
+고정된 선택지가 있는 옵션의 경우 `enum`을 사용하여 사용자가 옵션 중 하나를 선택할 수 있게 합니다:
 
 ```json
 "style": {
@@ -146,7 +146,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 프로젝트 선택 드롭다운
 
-워크스페이스의 기존 프로젝트 중에서 선택할 수 있도록 하는 일반적인 패턴:
+작업 공간의 기존 프로젝트 중에서 선택하도록 하는 일반적인 패턴:
 
 ```json
 "project": {
@@ -157,11 +157,11 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-`x-dropdown: "projects"` 속성은 Nx에게 드롭다운을 워크스페이스의 모든 프로젝트로 채우도록 지시합니다.
+`x-dropdown: "projects"` 속성은 Nx에게 드롭다운을 작업 공간의 모든 프로젝트로 채우도록 지시합니다.
 
 #### 위치 인수
 
-명령줄에서 Generator를 실행할 때 위치 인수로 전달되도록 옵션을 구성할 수 있습니다:
+명령줄에서 생성기를 실행할 때 위치 인수로 전달되도록 옵션을 구성할 수 있습니다:
 
 ```json
 "name": {
@@ -179,7 +179,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 우선순위 설정
 
-`x-priority` 속성을 사용하여 중요한 옵션을 표시합니다:
+`x-priority` 속성을 사용하여 가장 중요한 옵션을 표시합니다:
 
 ```json
 "name": {
@@ -189,7 +189,7 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 }
 ```
 
-옵션은 `"important"` 또는 `"internal"` 우선순위를 가질 수 있습니다. 이는 Nx VSCode 확장과 Nx CLI에서 속성 순서를 조정하는 데 도움이 됩니다.
+옵션은 `"important"` 또는 `"internal"` 우선순위를 가질 수 있습니다. 이는 Nx VSCode 확장과 Nx CLI에서 속성 순서를 지정하는 데 도움이 됩니다.
 
 #### 기본값
 
@@ -205,11 +205,11 @@ schema.json 파일의 기본 구조는 다음과 같습니다:
 
 #### 추가 정보
 
-스키마에 대한 자세한 내용은 [Nx Generator 옵션 문서](https://nx.dev/extending-nx/recipes/generator-options)를 참조하세요.
+스키마에 대한 자세한 내용은 [Nx Generator Options 문서](https://nx.dev/extending-nx/recipes/generator-options)를 참조하세요.
 
 #### schema.d.ts를 통한 TypeScript 타입
 
-`schema.json`과 함께 Generator는 Generator 옵션에 대한 TypeScript 타입을 제공하는 `schema.d.ts` 파일을 생성합니다:
+`schema.json`과 함께 생성되는 `schema.d.ts` 파일은 생성자 옵션에 대한 TypeScript 타입을 제공합니다:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -219,37 +219,37 @@ export interface YourGeneratorSchema {
 }
 ```
 
-이 인터페이스는 타입 안전성과 코드 완성을 위해 Generator 구현에서 사용됩니다:
+이 인터페이스는 타입 안전성과 코드 완성을 위해 생성자 구현에서 사용됩니다:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: YourGeneratorSchema) {
-  // TypeScript가 모든 옵션의 타입을 알고 있음
+  // TypeScript는 모든 옵션의 타입을 알고 있음
   const { name, directory = 'src/components', withTests = true } = options;
   // ...
 }
 ```
 
 :::caution
-`schema.json`을 수정할 때마다 `schema.d.ts`를 일치하도록 업데이트해야 합니다. 다음 사항이 포함됩니다:
+`schema.json`을 수정할 때마다 `schema.d.ts`를 일치하도록 업데이트해야 합니다. 다음을 포함합니다:
 
-- 속성 추가/제거
+- 속성 추가 또는 제거
 - 속성 타입 변경
 - 속성 필수/선택 설정 (선택 속성에는 `?` 접미사 사용)
 
 TypeScript 인터페이스는 JSON 스키마에 정의된 구조를 정확히 반영해야 합니다.
 :::
 
-### Generator 구현하기
+### 생성자 구현
 
-위와 같이 새 Generator를 생성한 후 `generator.ts`에서 구현을 작성할 수 있습니다.
+위와 같이 새 생성자를 생성한 후 `generator.ts`에 구현을 작성할 수 있습니다.
 
-Generator는 가상 파일 시스템(`Tree`)을 변형하는 함수로, 원하는 변경 사항을 만들기 위해 파일을 읽고 씁니다. `Tree`의 변경 사항은 "드라이런" 모드가 아닌 경우 Generator 실행이 완료된 후에만 디스크에 기록됩니다.
+생성자는 가상 파일 시스템(`Tree`)을 변형하는 함수로, 원하는 변경 사항을 만들기 위해 파일을 읽고 씁니다. `Tree`의 변경 사항은 "dry-run" 모드가 아닌 한 생성자 실행이 완료된 후에만 디스크에 기록됩니다.
 
-Generator에서 수행할 수 있는 일반적인 작업들:
+생성자에서 수행할 수 있는 일반적인 작업 예시:
 
-#### 파일 읽기/쓰기
+#### 파일 읽기 및 쓰기
 
 ```typescript
 // 파일 읽기
@@ -266,6 +266,8 @@ if (tree.exists('path/to/file.ts')) {
 
 #### 템플릿에서 파일 생성
 
+`@nx/devkit`의 `generateFiles` 유틸리티를 사용하여 [EJS](https://ejs.co/) 구문의 템플릿으로 파일을 생성하고 변수를 대체할 수 있습니다.
+
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 
@@ -275,7 +277,7 @@ generateFiles(
   joinPathFragments(__dirname, 'files'), // 템플릿 디렉토리
   'path/to/output', // 출력 디렉토리
   {
-    // 템플릿에서 치환할 변수들
+    // 템플릿에서 대체할 변수
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
@@ -284,50 +286,21 @@ generateFiles(
 );
 ```
 
-#### TypeScript AST 조작
+#### TypeScript AST(추상 구문 트리) 조작
 
-AST 조작을 위해 [TSQuery](https://github.com/phenomnomnominal/tsquery) 설치를 권장합니다.
+AWS용 Nx 플러그인에서 제공하는 `tsAstReplace` 메서드를 사용하여 TypeScript 추상 구문 트리의 일부를 교체할 수 있습니다.
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
 // 예시: 파일 내 버전 번호 증가
-
-// 파일 내용을 TypeScript AST로 파싱
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// 셀렉터와 일치하는 노드 찾기
-const nodes = tsquery.query(
-  sourceFile,
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // 숫자 리터럴 노드 가져오기
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // 현재 버전 번호 가져와서 증가
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // AST에서 노드 교체
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // 업데이트된 내용을 트리에 다시 쓰기
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
 :::tip
@@ -352,12 +325,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-package.json에 의존성을 추가한 경우 사용자를 위해 설치 작업을 Generator 콜백의 일부로 실행할 수 있습니다:
+package.json에 의존성을 추가한 경우 생성자 콜백의 일부로 사용자를 위해 설치할 수 있습니다:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// Generator는 의존성 설치와 같은 생성 후 작업을 실행할 수 있는 콜백 반환
+// 생성자는 의존성 설치와 같은 생성 후 작업을 실행할 수 있는 콜백 반환
 return () => {
   installPackagesTask(tree);
 };
@@ -367,13 +340,13 @@ return () => {
 #### 생성된 파일 포맷팅
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
 // 수정된 모든 파일 포맷팅
-await formatFiles(tree);
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
-#### JSON 파일 읽기/업데이트
+#### JSON 파일 읽기 및 업데이트
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
@@ -391,21 +364,83 @@ updateJson(tree, 'tsconfig.json', (json) => {
 });
 ```
 
-### Generator 실행하기
+#### AWS용 Nx 플러그인에서 생성자 확장
 
-두 가지 방법으로 Generator를 실행할 수 있습니다:
+AWS용 Nx 플러그인에서 생성자를 가져와 확장하거나 조합할 수 있습니다. 예를 들어 TypeScript 프로젝트를 기반으로 생성자를 만들 수 있습니다:
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // TypeScript 프로젝트 생성자 확장
+
+  // 의존성 설치를 보장하기 위해 콜백 반환
+  // 추가 작업을 수행하려면 콜백을 래핑할 수 있음
+  return callback;
+};
+```
+
+#### OpenAPI 생성자
+
+TypeScript 클라이언트 및 훅에 사용하는 생성자를 유사한 방식으로 사용하고 확장할 수 있습니다:
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // 여기에 추가 파일 생성
+};
+```
+
+또한 OpenAPI 사양의 작업을 반복하는 데 사용할 수 있는 데이터 구조를 구축하는 메서드를 제공하여 자체 코드 생성을 구현할 수 있습니다:
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'), // 템플릿 디렉토리
+    'path/to/output', // 출력 디렉토리
+    data,
+  );
+};
+```
+
+이를 통해 다음과 같은 템플릿을 작성할 수 있습니다:
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+더 복잡한 예제 템플릿은 [GitHub의 코드베이스](https://github.com/awslabs/nx-plugin-for-aws/)를 참조하세요.
+
+### 생성자 실행
+
+생성자는 두 가지 방법으로 실행할 수 있습니다:
 
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-VSCode 플러그인 UI에 Generator가 표시되지 않으면 Nx Workspace를 새로 고침할 수 있습니다:
+VSCode 플러그인 UI에 생성자가 표시되지 않으면 Nx 작업 공간을 새로 고침하세요:
 
 <NxCommands commands={['reset']} />
 :::
 
-### Generator 테스트하기
+### 생성자 테스트
 
-Generator의 단위 테스트는 간단하게 구현할 수 있습니다. 일반적인 패턴:
+생성자의 단위 테스트는 간단하게 구현할 수 있습니다. 일반적인 패턴 예시:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -415,10 +450,10 @@ describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
-    // 빈 워크스페이스 트리 생성
+    // 빈 작업 공간 트리 생성
     tree = createTreeWithEmptyWorkspace();
 
-    // 트리에 미리 존재해야 하는 파일 추가
+    // 트리에 이미 존재해야 하는 파일 추가
     tree.write(
       'project.json',
       JSON.stringify({
@@ -431,7 +466,7 @@ describe('your generator', () => {
   });
 
   it('should generate expected files', async () => {
-    // Generator 실행
+    // 생성자 실행
     await yourGenerator(tree, {
       name: 'test',
       // 다른 필수 옵션 추가
@@ -449,7 +484,7 @@ describe('your generator', () => {
   });
 
   it('should update existing files', async () => {
-    // Generator 실행
+    // 생성자 실행
     await yourGenerator(tree, {
       name: 'test',
       // 다른 필수 옵션 추가
@@ -461,44 +496,44 @@ describe('your generator', () => {
   });
 
   it('should handle errors', async () => {
-    // 특정 조건에서 Generator가 에러를 발생시키는지 확인
+    // 특정 조건에서 생성자가 오류를 발생시키는지 확인
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
-        // 에러를 유발하는 옵션 추가
+        // 오류를 유발하는 옵션 추가
       }),
     ).rejects.toThrow('Expected error message');
   });
 });
 ```
 
-Generator 테스트 핵심 포인트:
+생성자 테스트의 주요 포인트:
 
 - 가상 파일 시스템 생성에 `createTreeWithEmptyWorkspace()` 사용
-- Generator 실행 전 필수 파일 설정
+- 생성자 실행 전 필수 파일 설정
 - 새 파일 생성과 기존 파일 업데이트 모두 테스트
 - 복잡한 파일 내용에 스냅샷 사용
-- Generator가 우아하게 실패하는지 에러 조건 테스트
+- 생성자가 우아하게 실패하는지 확인하기 위해 오류 조건 테스트
 
-## @aws/nx-plugin에 Generator 기여하기
+## @aws/nx-plugin에 생성자 기여
 
-`ts#nx-generator`를 사용하여 `@aws/nx-plugin` 내부에 Generator 스캐폴딩을 할 수 있습니다.
+`ts#nx-generator`를 사용하여 `@aws/nx-plugin` 내부에 생성자 스캐폴딩을 할 수도 있습니다.
 
-이 Generator를 저장소에서 실행하면 다음 파일들이 생성됩니다:
+이 생성자를 우리 저장소에서 실행하면 다음 파일들이 생성됩니다:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Generator 입력 스키마
+    - schema.json 생성자 입력을 위한 스키마
     - schema.d.ts 스키마의 TypeScript 타입
-    - generator.ts Generator 구현
-    - generator.spec.ts Generator 테스트
+    - generator.ts 생성자 구현
+    - generator.spec.ts 생성자 테스트
   - docs/src/content/docs/guides/
-    - \<name>.mdx Generator 문서 페이지
-  - packages/nx-plugin/generators.json Generator 포함하도록 업데이트됨
+    - \<name>.mdx 생성자 문서 페이지
+  - packages/nx-plugin/generators.json 생성자 포함하도록 업데이트됨
 </FileTree>
 
-이제 Generator 구현을 시작할 수 있습니다.
+이제 생성자 구현을 시작할 수 있습니다.
 
 :::tip
-AWS용 Nx Plugin에 기여하는 방법에 대한 더 자세한 가이드는 <Link path="get_started/tutorials/contribute-generator">이 튜토리얼</Link>을 참조하세요.
+AWS용 Nx 플러그인에 기여하는 방법에 대한 자세한 가이드는 <Link path="get_started/tutorials/contribute-generator">여기 튜토리얼</Link>을 참조하세요.
 :::

--- a/docs/src/content/docs/pt/guides/nx-generator.mdx
+++ b/docs/src/content/docs/pt/guides/nx-generator.mdx
@@ -12,7 +12,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import Link from '@components/link.astro';
 
-Adiciona um [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a um projeto TypeScript para ajudar a automatizar tarefas repetitivas como criação de componentes ou imposição de estruturas de projeto específicas.
+Adiciona um [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators) a um projeto TypeScript para ajudar a automatizar tarefas repetitivas como scaffolding de componentes ou imposição de estruturas de projeto específicas.
 
 ## Utilização
 
@@ -28,13 +28,13 @@ Você pode gerar um generator de duas formas:
 
 ## Saída do Generator
 
-O generator criará os seguintes arquivos no projeto `pluginProject` selecionado:
+O generator criará os seguintes arquivos no projeto `pluginProject` especificado:
 
 <FileTree>
   - src/\<name>/
     - schema.json Esquema para entrada do generator
     - schema.d.ts Tipos TypeScript para o esquema
-    - generator.ts Implementação base do generator
+    - generator.ts Implementação inicial do generator
     - generator.spec.ts Testes para o generator
   - generators.json Configuração Nx para definir seus generators
   - package.json Criado ou atualizado com entrada "generators"
@@ -48,7 +48,7 @@ Este generator atualizará o `pluginProject` selecionado para usar CommonJS, poi
 ## Generators Locais
 
 :::tip
-Recomendamos gerar um projeto TypeScript dedicado para seus generators usando o generator `ts#project` primeiro. Por exemplo:
+Recomendamos gerar um projeto TypeScript dedicado para todos seus generators usando o generator `ts#project` primeiro. Por exemplo:
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
@@ -57,7 +57,7 @@ Selecione seu projeto local `nx-plugin` ao executar o generator `ts#nx-generator
 
 ### Definindo o Esquema
 
-O arquivo `schema.json` define as opções que seu generator aceita. Ele segue o formato [JSON Schema](https://json-schema.org/) com [extensões específicas do Nx](https://nx.dev/extending-nx/recipes/generator-options).
+O arquivo `schema.json` define as opções aceitas pelo seu generator. Ele segue o formato [JSON Schema](https://json-schema.org/) com [extensões específicas do Nx](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Estrutura Básica
 
@@ -71,7 +71,7 @@ Um arquivo schema.json possui a seguinte estrutura básica:
   "description": "Description of what your generator does",
   "type": "object",
   "properties": {
-    // Suas opções do generator aqui
+    // Your generator options go here
   },
   "required": ["requiredOption1", "requiredOption2"]
 }
@@ -131,7 +131,7 @@ Para opções booleanas, use um prompt sim/não:
 }
 ```
 
-#### Seleções em Dropdown
+#### Seleções Dropdown
 
 Para opções com um conjunto fixo de escolhas, use `enum` para permitir seleção entre as opções:
 
@@ -161,7 +161,7 @@ A propriedade `x-dropdown: "projects"` instrui o Nx a preencher o dropdown com t
 
 #### Argumentos Posicionais
 
-Configure opções para serem passadas como argumentos posicionais na linha de comando:
+Você pode configurar opções para serem passadas como argumentos posicionais ao executar o generator via linha de comando:
 
 ```json
 "name": {
@@ -175,7 +175,7 @@ Configure opções para serem passadas como argumentos posicionais na linha de c
 }
 ```
 
-Isso permite executar o generator como `nx g your-generator my-component` em vez de `nx g your-generator --name=my-component`.
+Isso permite executar o generator como `nx g your-generator my-component` ao invés de `nx g your-generator --name=my-component`.
 
 #### Definindo Prioridades
 
@@ -189,11 +189,11 @@ Use a propriedade `x-priority` para indicar opções mais importantes:
 }
 ```
 
-Opções podem ter prioridades `"important"` ou `"internal"`. Isso ajuda o Nx a ordenar propriedades na extensão VSCode e CLI.
+Opções podem ter prioridades `"important"` ou `"internal"`. Isso ajuda o Nx a ordenar propriedades na extensão VSCode e CLI do Nx.
 
 #### Valores Padrão
 
-Forneça valores padrão para opções:
+Você pode fornecer valores padrão para opções:
 
 ```json
 "directory": {
@@ -205,11 +205,11 @@ Forneça valores padrão para opções:
 
 #### Mais Informações
 
-Para detalhes sobre esquemas, consulte a [documentação de Opções do Nx Generator](https://nx.dev/extending-nx/recipes/generator-options).
+Para mais detalhes sobre esquemas, consulte a [documentação de Opções do Nx Generator](https://nx.dev/extending-nx/recipes/generator-options).
 
 #### Tipos TypeScript com schema.d.ts
 
-Junto com `schema.json`, o generator cria um arquivo `schema.d.ts` com tipos TypeScript para as opções:
+Junto com `schema.json`, o generator cria um arquivo `schema.d.ts` que fornece tipos TypeScript para as opções:
 
 ```typescript
 export interface YourGeneratorSchema {
@@ -219,7 +219,7 @@ export interface YourGeneratorSchema {
 }
 ```
 
-Esta interface é usada na implementação do generator para segurança de tipos e autocompletar:
+Esta interface é usada na implementação do generator para fornecer segurança de tipos e autocompletar:
 
 ```typescript
 import { YourGeneratorSchema } from './schema';
@@ -232,32 +232,33 @@ export default async function (tree: Tree, options: YourGeneratorSchema) {
 ```
 
 :::caution
-Sempre que modificar `schema.json`, atualize `schema.d.ts` para corresponder. Isso inclui:
-- Adicionar/remover propriedades
-- Alterar tipos de propriedades
-- Tornar propriedades obrigatórias ou opcionais (use `?` para opcionais)
+Sempre que modificar `schema.json`, você deve atualizar `schema.d.ts` correspondente. Isso inclui:
 
-A interface TypeScript deve refletir fielmente a estrutura definida no schema JSON.
+- Adicionar ou remover propriedades
+- Alterar tipos de propriedades
+- Tornar propriedades obrigatórias ou opcionais (use sufixo `?` para opcionais)
+
+A interface TypeScript deve refletir com precisão a estrutura definida no schema JSON.
 :::
 
 ### Implementando um Generator
 
 Após criar o generator como acima, você pode escrever sua implementação em `generator.ts`.
 
-Um generator é uma função que modula um sistema de arquivos virtual (`Tree`), lendo e escrevendo arquivos para fazer mudanças. As alterações só são escritas no disco após a execução do generator, exceto em modo "dry-run".
+Um generator é uma função que modula um sistema de arquivos virtual (`Tree`), lendo e escrevendo arquivos para fazer as alterações desejadas. As mudanças no `Tree` só são escritas em disco quando o generator termina, exceto em modo "dry-run".
 
-Aqui estão operações comuns que você pode realizar:
+Aqui estão operações comuns que você pode realizar no generator:
 
 #### Lendo e Escrevendo Arquivos
 
 ```typescript
-// Ler arquivo
+// Ler um arquivo
 const content = tree.read('path/to/file.ts', 'utf-8');
 
-// Escrever arquivo
+// Escrever um arquivo
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
-// Verificar existência
+// Verificar se um arquivo existe
 if (tree.exists('path/to/file.ts')) {
   // Fazer algo
 }
@@ -265,71 +266,45 @@ if (tree.exists('path/to/file.ts')) {
 
 #### Gerando Arquivos de Templates
 
+Você pode gerar arquivos com o utilitário `generateFiles` do `@nx/devkit`. Isso permite definir templates em sintaxe [EJS](https://ejs.co/) e substituir variáveis.
+
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 
 // Gerar arquivos de templates
 generateFiles(
   tree,
-  joinPathFragments(__dirname, 'files'), // Diretório template
+  joinPathFragments(__dirname, 'files'), // Diretório do template
   'path/to/output', // Diretório de saída
   {
-    // Variáveis para substituição
+    // Variáveis para substituir nos templates
     name: options.name,
     nameCamelCase: camelCase(options.name),
     nameKebabCase: kebabCase(options.name),
+    // Adicione mais variáveis conforme necessário
   },
 );
 ```
 
-#### Manipulação de AST TypeScript
+#### Manipulação de AST (Abstract Syntax Tree) TypeScript
 
-Recomendamos instalar [TSQuery](https://github.com/phenomnomnominal/tsquery) para manipulação de AST.
+Você pode usar o método `tsAstReplace` exposto pelo Nx Plugin for AWS para substituir partes de uma AST TypeScript.
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
-// Exemplo: Incrementar versão em arquivo
-
-// Parsear conteúdo em AST
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-
-// Encontrar nós correspondentes
-const nodes = tsquery.query(
-  sourceFile,
+// Exemplo: Incrementar número de versão em um arquivo
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  // Obter nó numérico
-  const numericNode = nodes[0] as ts.NumericLiteral;
-
-  // Incrementar versão
-  const currentVersion = Number(numericNode.text);
-  const newVersion = currentVersion + 1;
-
-  // Substituir nó na AST
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-
-  // Escrever conteúdo atualizado
-  tree.write(
-    'path/to/version.ts',
-    ts
-      .createPrinter({
-        newLine: ts.NewLineKind.LineFeed,
-      })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
 :::tip
-Teste seletores online no [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
+Você pode testar seletores online no [TSQuery Playground](https://tsquery-playground.firebaseapp.com/).
 :::
 
 #### Adicionando Dependências
@@ -350,12 +325,12 @@ addDependenciesToPackageJson(
 ```
 
 :::note
-Se adicionar dependências, você pode instalá-las para o usuário via callback:
+Se adicionar dependências a um package.json, você pode instalá-las para o usuário como parte do callback do generator:
 
 ```ts
 import { installPackagesTask } from '@nx/devkit';
 
-// Generators retornam callback para tarefas pós-geração
+// Generators retornam um callback que pode executar tarefas pós-geração, como instalar dependências
 return () => {
   installPackagesTask(tree);
 };
@@ -365,21 +340,21 @@ return () => {
 #### Formatando Arquivos Gerados
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
-// Formatar arquivos modificados
-await formatFiles(tree);
+// Formatar todos os arquivos modificados
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
-#### Lendo e Atualizando JSON
+#### Lendo e Atualizando Arquivos JSON
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
-// Ler JSON
+// Ler um arquivo JSON
 const packageJson = readJson(tree, 'package.json');
 
-// Atualizar JSON
+// Atualizar um arquivo JSON
 updateJson(tree, 'tsconfig.json', (json) => {
   json.compilerOptions = {
     ...json.compilerOptions,
@@ -388,6 +363,68 @@ updateJson(tree, 'tsconfig.json', (json) => {
   return json;
 });
 ```
+
+#### Estendendo um Generator do Nx Plugin for AWS
+
+Você pode importar generators do Nx Plugin for AWS e estendê-los ou compô-los conforme desejar. Por exemplo, criar um generator que estende um projeto TypeScript:
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+
+  // Estenda o generator de projeto TypeScript aqui
+
+  // Retorne o callback para garantir instalação de dependências
+  // Você pode encapsular o callback para operações adicionais
+  return callback;
+};
+```
+
+#### Generators OpenAPI
+
+Você pode usar e estender os generators que usamos para clients e hooks TypeScript de forma similar:
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+
+  // Adicione arquivos adicionais aqui
+};
+```
+
+Também expomos um método para construir estruturas de dados que permitem iterar sobre operações em especificações OpenAPI e instrumentar sua própria geração de código:
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'), // Diretório de templates
+    'path/to/output', // Diretório de saída
+    data,
+  );
+};
+```
+
+Isso permite escrever templates como:
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+Consulte o [repositório no GitHub](https://github.com/awslabs/nx-plugin-for-aws/) para exemplos mais complexos.
 
 ### Executando Seu Generator
 
@@ -403,7 +440,7 @@ Se não visualizar seu generator na UI do plugin VSCode, atualize seu Nx Workspa
 
 ### Testando Seu Generator
 
-Testes unitários para generators são simples de implementar. Padrão típico:
+Testes unitários para generators são simples de implementar. Aqui está um padrão típico:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -429,25 +466,27 @@ describe('your generator', () => {
   });
 
   it('should generate expected files', async () => {
-    // Executar generator
+    // Executar o generator
     await yourGenerator(tree, {
       name: 'test',
+      // Adicionar outras opções necessárias
     });
 
-    // Verificar arquivos gerados
+    // Verificar criação de arquivos
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
 
     // Verificar conteúdo
     const content = tree.read('src/test/file.ts', 'utf-8');
     expect(content).toContain('export const test');
 
-    // Snapshots
+    // Snapshots também podem ser usados
     expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should update existing files', async () => {
     await yourGenerator(tree, {
       name: 'test',
+      // Adicionar outras opções necessárias
     });
 
     const content = tree.read('src/existing-file.ts', 'utf-8');
@@ -458,39 +497,40 @@ describe('your generator', () => {
     await expect(
       yourGenerator(tree, {
         name: 'invalid',
+        // Opções que devem causar erro
       }),
-    ).rejects.toThrow('Expected error message');
+    ).rejects.toThrow('Mensagem de erro esperada');
   });
 });
 ```
 
-Pontos-chave para testes:
+Pontos-chave para testar generators:
 
-- Use `createTreeWithEmptyWorkspace()` para sistema de arquivos virtual
-- Configure arquivos pré-requisitos
-- Teste criação e atualização de arquivos
+- Use `createTreeWithEmptyWorkspace()` para criar sistema de arquivos virtual
+- Configure arquivos pré-requisitos antes de executar o generator
+- Teste criação de novos arquivos e atualizações de existentes
 - Use snapshots para conteúdo complexo
-- Teste condições de erro
+- Teste condições de erro para garantir falha controlada
 
 ## Contribuindo com Generators para @aws/nx-plugin
 
-Você também pode usar `ts#nx-generator` para criar generators dentro de `@aws/nx-plugin`.
+Você também pode usar `ts#nx-generator` para estruturar um generator dentro de `@aws/nx-plugin`.
 
-Quando executado em nosso repositório, este generator criará:
+Quando executado em nosso repositório, este generator criará os seguintes arquivos:
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json Esquema do generator
-    - schema.d.ts Tipos TypeScript
-    - generator.ts Implementação
-    - generator.spec.ts Testes
+    - schema.json Esquema para entrada do generator
+    - schema.d.ts Tipos TypeScript para o esquema
+    - generator.ts Implementação do generator
+    - generator.spec.ts Testes para o generator
   - docs/src/content/docs/guides/
-    - \<name>.mdx Documentação
-  - packages/nx-plugin/generators.json Atualizado com seu generator
+    - \<name>.mdx Página de documentação do generator
+  - packages/nx-plugin/generators.json Atualizado para incluir seu generator
 </FileTree>
 
-Você pode então implementar seu generator.
+Você pode então começar a implementar seu generator.
 
 :::tip
-Para um guia detalhado sobre contribuição para o Nx Plugin da AWS, consulte o <Link path="get_started/tutorials/contribute-generator">tutorial aqui</Link>.
+Para um guia mais detalhado sobre contribuição para o Nx Plugin for AWS, consulte o <Link path="get_started/tutorials/contribute-generator">tutorial aqui</Link>.
 :::

--- a/docs/src/content/docs/zh/guides/nx-generator.mdx
+++ b/docs/src/content/docs/zh/guides/nx-generator.mdx
@@ -14,15 +14,15 @@ import Link from '@components/link.astro';
 
 为 TypeScript 项目添加 [Nx Generator](https://nx.dev/extending-nx/recipes/local-generators)，帮助自动化重复任务，如组件脚手架或强制特定项目结构。
 
-## 使用方式
+## 使用方法
 
 ### 生成生成器
 
-可通过两种方式创建生成器：
+有两种方式生成生成器：
 
 <RunGenerator generator="ts#nx-generator" />
 
-### 选项参数
+### 选项
 
 <GeneratorParameters generator="ts#nx-generator" />
 
@@ -32,34 +32,34 @@ import Link from '@components/link.astro';
 
 <FileTree>
   - src/\<name>/
-    - schema.json 生成器输入模式定义
-    - schema.d.ts 模式对应的 TypeScript 类型
+    - schema.json 生成器输入模式
+    - schema.d.ts 模式的 TypeScript 类型定义
     - generator.ts 生成器实现存根
-    - generator.spec.ts 生成器测试用例
+    - generator.spec.ts 生成器测试
   - generators.json Nx 生成器配置
   - package.json 创建或更新以添加 "generators" 条目
   - tsconfig.json 更新为使用 CommonJS
 </FileTree>
 
 :::warning
-本生成器会将选定的 `pluginProject` 更新为使用 CommonJS，因目前 Nx 生成器仅支持 CommonJS（[ESM 支持相关 GitHub 问题](https://github.com/nrwl/nx/issues/15682)）。
+本生成器会将选定的 `pluginProject` 更新为使用 CommonJS，因为目前 Nx 生成器仅支持 CommonJS（[ESM 支持参考此 GitHub 问题](https://github.com/nrwl/nx/issues/15682)）。
 :::
 
 ## 本地生成器
 
 :::tip
-建议先使用 `ts#project` 生成器创建专门用于存放生成器的 TypeScript 项目。例如：
+建议先使用 `ts#project` 生成器创建专门用于生成器的 TypeScript 项目。例如：
 
 <RunGenerator generator="ts#project" requiredParameters={{ name: 'nx-plugin', directory: 'tools' }} />
 :::
 
-运行 `ts#nx-generator` 生成器时选择本地 `nx-plugin` 项目，并指定名称、可选目录和描述。
+运行 `ts#nx-generator` 时选择本地 `nx-plugin` 项目，并指定名称、可选目录和描述。
 
 ### 定义模式
 
-`schema.json` 文件定义生成器接受的选项，遵循 [JSON Schema](https://json-schema.org/) 格式并包含 [Nx 扩展](https://nx.dev/extending-nx/recipes/generator-options)。
+`schema.json` 文件定义生成器接受的选项，遵循 [JSON Schema](https://json-schema.org/) 格式和 [Nx 扩展](https://nx.dev/extending-nx/recipes/generator-options)。
 
-#### 基础结构
+#### 基本结构
 
 schema.json 文件基本结构：
 
@@ -71,7 +71,7 @@ schema.json 文件基本结构：
   "description": "生成器功能描述",
   "type": "object",
   "properties": {
-    // 生成器选项定义
+    // 生成器选项
   },
   "required": ["必填选项1", "必填选项2"]
 }
@@ -86,7 +86,7 @@ schema.json 文件基本结构：
   "$schema": "https://json-schema.org/schema",
   "$id": "ComponentGenerator",
   "title": "创建组件",
-  "description": "创建新的 React 组件",
+  "description": "创建新 React 组件",
   "type": "object",
   "properties": {
     "name": {
@@ -109,7 +109,7 @@ schema.json 文件基本结构：
 }
 ```
 
-#### 交互式提示（CLI）
+#### 交互式提示 (CLI)
 
 通过添加 `x-prompt` 属性自定义 CLI 提示：
 
@@ -133,7 +133,7 @@ schema.json 文件基本结构：
 
 #### 下拉选择
 
-固定选项使用 `enum` 定义：
+固定选项使用 `enum`：
 
 ```json
 "style": {
@@ -146,18 +146,18 @@ schema.json 文件基本结构：
 
 #### 项目选择下拉
 
-从工作区现有项目中选择：
+从工作区项目中选择：
 
 ```json
 "project": {
   "type": "string",
   "description": "添加组件的目标项目",
-  "x-prompt": "请选择要添加组件的项目：",
+  "x-prompt": "请选择目标项目：",
   "x-dropdown": "projects"
 }
 ```
 
-`x-dropdown: "projects"` 指示 Nx 用工作区所有项目填充下拉列表。
+`x-dropdown: "projects"` 属性使 Nx 填充工作区所有项目。
 
 #### 位置参数
 
@@ -175,7 +175,7 @@ schema.json 文件基本结构：
 }
 ```
 
-允许用户通过 `nx g your-generator my-component` 而非 `nx g your-generator --name=my-component` 运行。
+允许通过 `nx g your-generator my-component` 而非 `nx g your-generator --name=my-component` 运行。
 
 #### 设置优先级
 
@@ -189,7 +189,7 @@ schema.json 文件基本结构：
 }
 ```
 
-优先级可为 `"important"` 或 `"internal"`，帮助 Nx 在 VSCode 插件和 CLI 中排序属性。
+优先级可为 `"important"` 或 `"internal"`，帮助 Nx 在 VSCode 插件和 CLI 中排序。
 
 #### 默认值
 
@@ -205,9 +205,9 @@ schema.json 文件基本结构：
 
 #### 更多信息
 
-详见 [Nx 生成器选项文档](https://nx.dev/extending-nx/recipes/generator-options)。
+详细模式说明参考 [Nx 生成器选项文档](https://nx.dev/extending-nx/recipes/generator-options)。
 
-#### 使用 schema.d.ts 的类型定义
+#### 使用 schema.d.ts 的 TypeScript 类型
 
 生成器同时创建 `schema.d.ts` 提供类型定义：
 
@@ -233,19 +233,21 @@ export default async function (tree: Tree, options: YourGeneratorSchema) {
 :::caution
 修改 `schema.json` 后必须同步更新 `schema.d.ts`，包括：
 - 增删属性
-- 修改属性类型
-- 设置必填/可选（可选属性使用 `?` 后缀）
+- 修改类型
+- 必选/可选状态（可选属性使用 `?` 后缀）
 
 TypeScript 接口需准确反映 JSON 模式结构。
 :::
 
 ### 实现生成器
 
-创建生成器后，可在 `generator.ts` 中编写实现逻辑。
+创建生成器后，可在 `generator.ts` 中编写实现。
 
-生成器函数操作虚拟文件系统 (`Tree`)，仅在执行完成后写入实际文件（"dry-run" 模式除外）。
+生成器函数操作虚拟文件系统 (`Tree`)，仅在执行完成后写入磁盘（"dry-run" 模式除外）。
 
-#### 文件读写
+常见操作示例：
+
+#### 读写文件
 
 ```typescript
 // 读取文件
@@ -254,18 +256,19 @@ const content = tree.read('path/to/file.ts', 'utf-8');
 // 写入文件
 tree.write('path/to/new-file.ts', 'export const hello = "world";');
 
-// 检查文件存在性
+// 检查文件存在
 if (tree.exists('path/to/file.ts')) {
-  // 执行操作
+  // 操作
 }
 ```
 
-#### 模板文件生成
+#### 模板生成文件
+
+使用 `@nx/devkit` 的 `generateFiles` 工具，通过 [EJS](https://ejs.co/) 模板生成文件：
 
 ```typescript
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 
-// 从模板生成文件
 generateFiles(
   tree,
   joinPathFragments(__dirname, 'files'), // 模板目录
@@ -280,37 +283,23 @@ generateFiles(
 
 #### TypeScript AST 操作
 
-推荐安装 [TSQuery](https://github.com/phenomnomnominal/tsquery) 进行 AST 操作：
+使用 Nx Plugin for AWS 的 `tsAstReplace` 方法修改 AST：
 
 ```typescript
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsAstReplace } from '@aws/nx-plugin/sdk/utils/ast';
 import * as ts from 'typescript';
 
 // 示例：递增版本号
-const sourceFile = tsquery.ast(tree.read('path/to/version.ts', 'utf-8'));
-const nodes = tsquery.query(
-  sourceFile,
+tsAstReplace(
+  tree,
+  'path/to/version.ts',
   'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-);
-
-if (nodes.length > 0) {
-  const numericNode = nodes[0] as ts.NumericLiteral;
-  const newVersion = Number(numericNode.text) + 1;
-  const result = tsquery.replace(
-    sourceFile,
-    'VariableDeclaration:has(Identifier[name="VERSION"]) NumericLiteral',
-    () => ts.factory.createNumericLiteral(newVersion),
-  );
-  tree.write(
-    'path/to/version.ts',
-    ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
-      .printNode(ts.EmitHint.Unspecified, result, sourceFile),
-  );
-}
+  (node: ts.NumericLiteral) =>
+    ts.factory.createNumericLiteral(Number(node.text) + 1));
 ```
 
 :::tip
-可在 [TSQuery Playground](https://tsquery-playground.firebaseapp.com/) 在线测试选择器。
+可在 [TSQuery Playground](https://tsquery-playground.firebaseapp.com/) 测试选择器。
 :::
 
 #### 添加依赖
@@ -340,23 +329,76 @@ return () => {
 #### 格式化文件
 
 ```typescript
-import { formatFiles } from '@nx/devkit';
+import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 
-await formatFiles(tree);
+await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
-#### JSON 文件操作
+#### 读写 JSON 文件
 
 ```typescript
 import { readJson, updateJson } from '@nx/devkit';
 
+// 读取 JSON
 const packageJson = readJson(tree, 'package.json');
 
-updateJson(tree, 'tsconfig.json', (json) => ({
-  ...json,
-  compilerOptions: { ...json.compilerOptions, strict: true }
-}));
+// 更新 JSON
+updateJson(tree, 'tsconfig.json', (json) => {
+  json.compilerOptions.strict = true;
+  return json;
+});
 ```
+
+#### 扩展 Nx Plugin for AWS 生成器
+
+可导入并扩展生成器：
+
+```ts
+import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const callback = await tsProjectGenerator(tree, { ... });
+  // 扩展逻辑
+  return callback;
+};
+```
+
+#### OpenAPI 生成器
+
+可扩展 TypeScript 客户端生成器：
+
+```ts
+import { openApiTsClientGenerator } from '@aws/nx-plugin/sdk/open-api';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  await openApiTsClientGenerator(tree, { ... });
+  // 添加文件
+};
+```
+
+构建 OpenAPI 操作数据结构：
+
+```ts
+import { buildOpenApiCodeGenerationData } from '@aws/nx-plugin/sdk/open-api.js';
+
+export const myGenerator = async (tree: Tree, schema: MyGeneratorSchema) => {
+  const data = await buildOpenApiCodeGenerationData(tree, 'path/to/spec.json');
+  generateFiles(tree, __dirname, 'output', data);
+};
+```
+
+模板示例：
+
+```ejs
+// files/my-operations.ts.template
+export const myOperationNames = [
+<%_ allOperations.forEach((op) => { _%>
+  '<%- op.name %>',
+<%_ }); _%>
+];
+```
+
+参考 [GitHub 代码库](https://github.com/awslabs/nx-plugin-for-aws/) 获取复杂模板示例。
 
 ### 运行生成器
 
@@ -365,7 +407,7 @@ updateJson(tree, 'tsconfig.json', (json) => ({
 <RunGenerator namespace="@my-project/nx-plugin" generator="my-generator" />
 
 :::note
-若 VSCode 插件未显示生成器，可刷新 Nx 工作区：
+若 VSCode 插件未显示生成器，可通过以下命令刷新工作区：
 
 <NxCommands commands={['reset']} />
 :::
@@ -378,7 +420,7 @@ updateJson(tree, 'tsconfig.json', (json) => ({
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { yourGenerator } from './generator';
 
-describe('生成器测试', () => {
+describe('your generator', () => {
   let tree;
 
   beforeEach(() => {
@@ -386,13 +428,18 @@ describe('生成器测试', () => {
     tree.write('project.json', JSON.stringify({ name: 'test-project' }));
   });
 
-  it('应生成预期文件', async () => {
+  it('生成预期文件', async () => {
     await yourGenerator(tree, { name: 'test' });
     expect(tree.exists('src/test/file.ts')).toBeTruthy();
-    expect(tree.read('src/test/file.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('src/test/file.ts')).toMatchSnapshot();
   });
 
-  it('应处理错误', async () => {
+  it('更新现有文件', async () => {
+    await yourGenerator(tree, { name: 'test' });
+    expect(tree.read('src/existing-file.ts')).toContain('import { test }');
+  });
+
+  it('错误处理', async () => {
     await expect(yourGenerator(tree, { name: 'invalid' }))
       .rejects.toThrow('预期错误信息');
   });
@@ -400,15 +447,15 @@ describe('生成器测试', () => {
 ```
 
 测试要点：
-- 使用 `createTreeWithEmptyWorkspace` 创建虚拟文件系统
+- 使用 `createTreeWithEmptyWorkspace()` 创建虚拟文件系统
 - 设置前置文件
 - 测试文件创建与更新
 - 使用快照测试复杂内容
-- 验证错误处理
+- 测试错误条件
 
 ## 向 @aws/nx-plugin 贡献生成器
 
-使用 `ts#nx-generator` 在 `@aws/nx-plugin` 中创建生成器时，将生成以下文件：
+在仓库内使用 `ts#nx-generator` 生成以下文件：
 
 <FileTree>
   - packages/nx-plugin/src/\<name>/
@@ -418,9 +465,9 @@ describe('生成器测试', () => {
     - generator.spec.ts
   - docs/src/content/docs/guides/
     - \<name>.mdx
-  - packages/nx-plugin/generators.json 更新包含新生成器
+  - packages/nx-plugin/generators.json 更新包含生成器
 </FileTree>
 
 :::tip
-有关贡献 AWS Nx 插件的详细指南，请参考<Link path="get_started/tutorials/contribute-generator">此教程</Link>。
+贡献指南详见 <Link path="get_started/tutorials/contribute-generator">本教程</Link>。
 :::

--- a/packages/nx-plugin/sdk/api-connection.ts
+++ b/packages/nx-plugin/sdk/api-connection.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { apiConnectionGenerator } from '../src/api-connection/generator';
+export type { ApiConnectionGeneratorSchema } from '../src/api-connection/schema';

--- a/packages/nx-plugin/sdk/open-api.ts
+++ b/packages/nx-plugin/sdk/open-api.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  openApiTsClientGenerator,
+  buildOpenApiCodeGenerationData,
+} from '../src/open-api/ts-client/generator';
+export type { OpenApiTsClientGeneratorSchema } from '../src/open-api/ts-client/schema';
+
+export { openApiTsHooksGenerator } from '../src/open-api/ts-hooks/generator';
+export type { OpenApiTsHooksGeneratorSchema } from '../src/open-api/ts-hooks/schema';
+
+export { openApiTsMetadataGenerator } from '../src/open-api/ts-metadata/generator';
+export type { OpenApiTsMetadataGeneratorSchema } from '../src/open-api/ts-metadata/schema';

--- a/packages/nx-plugin/sdk/py.ts
+++ b/packages/nx-plugin/sdk/py.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { pyProjectGenerator } from '../src/py/project/generator';
+export { PyProjectGeneratorSchema } from '../src/py/project/schema';
+
+export { pyFastApiProjectGenerator } from '../src/py/fast-api/generator';
+export { PyFastApiProjectGeneratorSchema } from '../src/py/fast-api/schema';
+
+export { pyLambdaFunctionGenerator } from '../src/py/lambda-function/generator';
+export { PyLambdaFunctionGeneratorSchema } from '../src/py/lambda-function/schema';

--- a/packages/nx-plugin/sdk/ts.ts
+++ b/packages/nx-plugin/sdk/ts.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// TypeScript Project Generator
+export { tsProjectGenerator } from '../src/ts/lib/generator';
+export type { TsProjectGeneratorSchema } from '../src/ts/lib/schema';
+
+// TypeScript Infrastructure
+export { tsInfraGenerator } from '../src/infra/app/generator';
+export type { TsInfraGeneratorSchema } from '../src/infra/app/schema';
+
+// TypeScript MCP Server Generator
+export { tsMcpServerGenerator } from '../src/ts/mcp-server/generator';
+export type { TsMcpServerGeneratorSchema } from '../src/ts/mcp-server/schema';
+
+// TypeScript Nx Generator Generator
+export { tsNxGeneratorGenerator } from '../src/ts/nx-generator/generator';
+export type { TsNxGeneratorGeneratorSchema } from '../src/ts/nx-generator/schema';
+
+// TypeScript CloudScape Website Generator
+export { tsCloudScapeWebsiteGenerator } from '../src/cloudscape-website/app/generator';
+export type { TsCloudScapeWebsiteGeneratorSchema } from '../src/cloudscape-website/app/schema';
+
+// TypeScript CloudScape Website Auth Generator
+export { tsCloudScapeWebsiteAuthGenerator } from '../src/cloudscape-website/cognito-auth/generator';
+export type { TsCloudScapeWebsiteAuthGeneratorSchema } from '../src/cloudscape-website/cognito-auth/schema';
+
+// Runtime Config
+export { runtimeConfigGenerator } from '../src/cloudscape-website/runtime-config/generator';
+export type { RuntimeConfigGeneratorSchema } from '../src/cloudscape-website/runtime-config/schema';
+
+// TypeScript tRPC API
+export { tsTrpcApiGenerator } from '../src/trpc/backend/generator';
+export type { TsTrpcApiGeneratorSchema } from '../src/trpc/backend/schema';
+
+// Shared Constructs
+export { sharedConstructsGenerator } from '../src/utils/shared-constructs';

--- a/packages/nx-plugin/sdk/utils/ast.ts
+++ b/packages/nx-plugin/sdk/utils/ast.ts
@@ -2,8 +2,4 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-export interface OpenApiTsClientGeneratorSchema {
-  openApiSpecPath: string;
-  outputPath: string;
-}
+export { replace as tsAstReplace } from '../../src/utils/ast';

--- a/packages/nx-plugin/sdk/utils/format.ts
+++ b/packages/nx-plugin/sdk/utils/format.ts
@@ -3,7 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface OpenApiTsClientGeneratorSchema {
-  openApiSpecPath: string;
-  outputPath: string;
-}
+export { formatFilesInSubtree } from '../../src/utils/format';

--- a/packages/nx-plugin/sdk/utils/test.ts
+++ b/packages/nx-plugin/sdk/utils/test.ts
@@ -3,7 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface OpenApiTsClientGeneratorSchema {
-  openApiSpecPath: string;
-  outputPath: string;
-}
+export { createTreeUsingTsSolutionSetup } from '../../src/utils/test';

--- a/packages/nx-plugin/src/api-connection/generator.ts
+++ b/packages/nx-plugin/src/api-connection/generator.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { joinPathFragments, ProjectConfiguration, Tree } from '@nx/devkit';
-import { ApiConnectionSchema } from './schema';
+import { ApiConnectionGeneratorSchema } from './schema';
 import trpcReactGenerator from '../trpc/react/generator';
 import { hasExportDeclaration } from '../utils/ast';
 import { readToml } from '../utils/toml';
@@ -55,7 +55,7 @@ const CONNECTION_GENERATORS = {
     }),
 } satisfies Record<
   ConnectionKey,
-  (tree: Tree, options: ApiConnectionSchema) => Promise<any>
+  (tree: Tree, options: ApiConnectionGeneratorSchema) => Promise<any>
 >;
 
 /**
@@ -63,7 +63,7 @@ const CONNECTION_GENERATORS = {
  */
 export const apiConnectionGenerator = async (
   tree: Tree,
-  options: ApiConnectionSchema,
+  options: ApiConnectionGeneratorSchema,
 ) => {
   const sourceType = determineProjectType(tree, options.sourceProject);
   const targetType = determineProjectType(tree, options.targetProject);

--- a/packages/nx-plugin/src/api-connection/schema.d.ts
+++ b/packages/nx-plugin/src/api-connection/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface ApiConnectionSchema {
+export interface ApiConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   auth: 'IAM' | 'None';

--- a/packages/nx-plugin/src/cloudscape-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.spec.ts
@@ -5,16 +5,16 @@
 import { Tree } from '@nx/devkit';
 import {
   CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO,
-  appGenerator,
+  tsCloudScapeWebsiteGenerator,
 } from './generator';
-import { AppGeneratorSchema } from './schema';
+import { TsCloudScapeWebsiteGeneratorSchema } from './schema';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 
 describe('cloudscape-website generator', () => {
   let tree: Tree;
 
-  const options: AppGeneratorSchema = {
+  const options: TsCloudScapeWebsiteGeneratorSchema = {
     name: 'test-app',
   };
 
@@ -23,7 +23,7 @@ describe('cloudscape-website generator', () => {
   });
 
   it('should generate base files and structure', async () => {
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
     // Check main application files
     expect(tree.exists('test-app/src/main.tsx')).toBeTruthy();
     expect(tree.exists('test-app/src/config.ts')).toBeTruthy();
@@ -54,14 +54,14 @@ describe('cloudscape-website generator', () => {
   });
 
   it('should configure vite correctly', async () => {
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
     const viteConfig = tree.read('test-app/vite.config.ts')?.toString();
     expect(viteConfig).toBeDefined();
     expect(viteConfig).toMatchSnapshot('vite.config.ts');
   });
 
   it('should generate shared constructs', async () => {
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
     // Check shared constructs files
     expect(
       tree.exists(
@@ -101,7 +101,7 @@ describe('cloudscape-website generator', () => {
   });
 
   it('should update package.json with required dependencies', async () => {
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
     const packageJson = JSON.parse(tree.read('package.json').toString());
     // Check for website dependencies
     expect(packageJson.dependencies).toMatchObject({
@@ -117,14 +117,14 @@ describe('cloudscape-website generator', () => {
   });
 
   it('should configure TypeScript correctly', async () => {
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
     const tsConfig = JSON.parse(tree.read('test-app/tsconfig.json').toString());
     expect(tsConfig.compilerOptions.moduleResolution).toBe('Bundler');
     expect(tsConfig).toMatchSnapshot('tsconfig.json');
   });
 
   it('should handle custom directory option', async () => {
-    await appGenerator(tree, {
+    await tsCloudScapeWebsiteGenerator(tree, {
       ...options,
       directory: 'custom-dir',
     });
@@ -143,14 +143,14 @@ describe('cloudscape-website generator', () => {
         version: '0.0.0',
       }),
     );
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
     const packageJson = JSON.parse(tree.read('package.json').toString());
     expect(packageJson.dependencies).toMatchSnapshot('scoped-dependencies');
   });
 
   it('should add generator metric to app.ts', async () => {
     // Call the generator function
-    await appGenerator(tree, options);
+    await tsCloudScapeWebsiteGenerator(tree, options);
 
     // Verify the metric was added to app.ts
     expectHasMetricTags(tree, CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO.metric);

--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -22,7 +22,7 @@ import {
   isPropertyAssignment,
   ArrayLiteralExpression,
 } from 'typescript';
-import { AppGeneratorSchema } from './schema';
+import { TsCloudScapeWebsiteGeneratorSchema } from './schema';
 import { applicationGenerator } from '@nx/react';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import {
@@ -50,7 +50,10 @@ import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 export const CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
 
-export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
+export async function tsCloudScapeWebsiteGenerator(
+  tree: Tree,
+  schema: TsCloudScapeWebsiteGeneratorSchema,
+) {
   const npmScopePrefix = getNpmScopePrefix(tree);
   const websiteNameClassName = toClassName(schema.name);
   const websiteNameKebabCase = toKebabCase(schema.name);
@@ -447,4 +450,4 @@ export async function appGenerator(tree: Tree, schema: AppGeneratorSchema) {
     }
   };
 }
-export default appGenerator;
+export default tsCloudScapeWebsiteGenerator;

--- a/packages/nx-plugin/src/cloudscape-website/app/schema.d.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/schema.d.ts
@@ -4,7 +4,7 @@
  */
 import { SupportedStyles } from '@nx/react';
 
-export interface AppGeneratorSchema {
+export interface TsCloudScapeWebsiteGeneratorSchema {
   name: string;
   directory?: string;
   skipInstall?: boolean;

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.spec.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Tree, updateJson } from '@nx/devkit';
-import { COGNITO_AUTH_GENERATOR_INFO, cognitoAuthGenerator } from './generator';
-import { CognitoAuthGeneratorSchema } from './schema';
+import {
+  COGNITO_AUTH_GENERATOR_INFO,
+  tsCloudScapeWebsiteAuthGenerator,
+} from './generator';
+import { TsCloudScapeWebsiteAuthGeneratorSchema } from './schema';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
@@ -12,7 +15,7 @@ import { expectHasMetricTags } from '../../utils/metrics.spec';
 describe('cognito-auth generator', () => {
   let tree: Tree;
 
-  const options: CognitoAuthGeneratorSchema = {
+  const options: TsCloudScapeWebsiteAuthGeneratorSchema = {
     project: 'test-project',
     cognitoDomain: 'test',
     allowSignup: true,
@@ -48,7 +51,7 @@ describe('cognito-auth generator', () => {
     `,
     );
 
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
 
     // Verify component files are generated
     expect(
@@ -97,7 +100,7 @@ describe('cognito-auth generator', () => {
     `,
     );
 
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
 
     const mainTsxContent = tree
       .read('packages/test-project/src/main.tsx')
@@ -126,13 +129,13 @@ describe('cognito-auth generator', () => {
     `,
     );
     await expect(
-      async () => await cognitoAuthGenerator(tree, options),
+      async () => await tsCloudScapeWebsiteAuthGenerator(tree, options),
     ).rejects.toThrowError();
   });
 
   it('should handle missing main.tsx', async () => {
     await expect(
-      async () => await cognitoAuthGenerator(tree, options),
+      async () => await tsCloudScapeWebsiteAuthGenerator(tree, options),
     ).rejects.toThrowError();
   });
 
@@ -158,7 +161,7 @@ describe('cognito-auth generator', () => {
       'packages/common/constructs/src/index.ts',
       'export const dummy = true;',
     );
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
     const indexContent = tree
       .read('packages/common/constructs/src/core/index.ts')
       .toString();
@@ -185,7 +188,7 @@ describe('cognito-auth generator', () => {
       }
     `,
     );
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
     // Read package.json
     const packageJson = JSON.parse(tree.read('package.json').toString());
     // Verify dependencies are added
@@ -216,10 +219,10 @@ describe('cognito-auth generator', () => {
     `,
     );
     // First run to create files
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
     // Run generator again
     await expect(
-      async () => await cognitoAuthGenerator(tree, options),
+      async () => await tsCloudScapeWebsiteAuthGenerator(tree, options),
     ).rejects.toThrowErrorMatchingSnapshot();
   });
 
@@ -399,7 +402,7 @@ export default AppLayout;
     `,
     );
 
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
 
     const appLayoutContent = tree
       .read('packages/test-project/src/components/AppLayout/index.tsx')
@@ -465,7 +468,7 @@ export default AppLayout;
       }),
     );
 
-    await cognitoAuthGenerator(tree, {
+    await tsCloudScapeWebsiteAuthGenerator(tree, {
       ...options,
       project: 'test-project', // unqualified
     });
@@ -493,7 +496,7 @@ export default AppLayout;
     );
 
     // Call the generator function
-    await cognitoAuthGenerator(tree, options);
+    await tsCloudScapeWebsiteAuthGenerator(tree, options);
 
     // Verify the metric was added to app.ts
     expectHasMetricTags(tree, COGNITO_AUTH_GENERATOR_INFO.metric);

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.ts
@@ -16,7 +16,7 @@ import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
 } from '../../utils/shared-constructs-constants';
-import { CognitoAuthGeneratorSchema as CognitoAuthGeneratorSchema } from './schema';
+import { TsCloudScapeWebsiteAuthGeneratorSchema as TsCloudScapeWebsiteAuthGeneratorSchema } from './schema';
 import { runtimeConfigGenerator } from '../runtime-config/generator';
 import {
   ArrowFunction,
@@ -51,9 +51,9 @@ import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 export const COGNITO_AUTH_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
 
-export async function cognitoAuthGenerator(
+export async function tsCloudScapeWebsiteAuthGenerator(
   tree: Tree,
-  options: CognitoAuthGeneratorSchema,
+  options: TsCloudScapeWebsiteAuthGeneratorSchema,
 ) {
   const srcRoot = readProjectConfigurationUnqualified(
     tree,
@@ -510,4 +510,4 @@ export async function cognitoAuthGenerator(
     installPackagesTask(tree);
   };
 }
-export default cognitoAuthGenerator;
+export default tsCloudScapeWebsiteAuthGenerator;

--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.d.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export interface CognitoAuthGeneratorSchema {
+export interface TsCloudScapeWebsiteAuthGeneratorSchema {
   project: string;
   allowSignup: boolean;
   cognitoDomain: string;

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Tree, readProjectConfiguration } from '@nx/devkit';
-import { INFRA_APP_GENERATOR_INFO, infraGenerator } from './generator';
-import { InfraGeneratorSchema } from './schema';
+import { INFRA_APP_GENERATOR_INFO, tsInfraGenerator } from './generator';
+import { TsInfraGeneratorSchema } from './schema';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 
 describe('infra generator', () => {
   let tree: Tree;
 
-  const options: InfraGeneratorSchema = {
+  const options: TsInfraGeneratorSchema = {
     name: 'test',
     ruleSet: 'aws_prototyping',
     directory: 'packages',
@@ -23,7 +23,7 @@ describe('infra generator', () => {
   });
 
   it('should generate files with correct content', async () => {
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
     const config = readProjectConfiguration(tree, '@proj/test');
     expect(config.projectType).toEqual('application');
     // Verify files are generated
@@ -55,7 +55,7 @@ describe('infra generator', () => {
   });
 
   it('should configure project.json with correct targets', async () => {
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
     const config = readProjectConfiguration(tree, '@proj/test');
     // Snapshot entire project configuration
     expect(config).toMatchSnapshot('project-configuration');
@@ -123,7 +123,7 @@ describe('infra generator', () => {
   });
 
   it('should add required dependencies to package.json', async () => {
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
     const packageJson = JSON.parse(tree.read('package.json').toString());
     // Snapshot entire package.json
     expect(packageJson).toMatchSnapshot('package-json');
@@ -146,7 +146,7 @@ describe('infra generator', () => {
   });
 
   it('should generate valid CDK application code', async () => {
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
     // Test main.ts content
     const mainTs = tree.read('packages/test/src/main.ts').toString();
     expect(mainTs).toMatchSnapshot('main-ts-content');
@@ -161,13 +161,13 @@ describe('infra generator', () => {
   });
 
   it('should handle custom project names correctly', async () => {
-    const customOptions: InfraGeneratorSchema = {
+    const customOptions: TsInfraGeneratorSchema = {
       name: 'custom-infra',
       directory: 'packages',
       ruleSet: 'aws_prototyping',
       skipInstall: true,
     };
-    await infraGenerator(tree, customOptions);
+    await tsInfraGenerator(tree, customOptions);
     // Snapshot project configuration with custom name
     const config = readProjectConfiguration(tree, '@proj/custom-infra');
     expect(config).toMatchSnapshot('custom-name-project-config');
@@ -190,7 +190,7 @@ describe('infra generator', () => {
 
   it('should generate consistent file content across runs', async () => {
     // First run
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
     const firstRunFiles = {
       'cdk.json': tree.read('packages/test/cdk.json').toString(),
       'src/main.ts': tree.read('packages/test/src/main.ts').toString(),
@@ -200,7 +200,7 @@ describe('infra generator', () => {
     };
     // Reset tree and run again
     tree = createTreeUsingTsSolutionSetup();
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
     const secondRunFiles = {
       'cdk.json': tree.read('packages/test/cdk.json').toString(),
       'src/main.ts': tree.read('packages/test/src/main.ts').toString(),
@@ -215,7 +215,7 @@ describe('infra generator', () => {
 
   it('should add generator metric to app.ts', async () => {
     // Call the generator function
-    await infraGenerator(tree, options);
+    await tsInfraGenerator(tree, options);
 
     // Verify the metric was added to app.ts
     expectHasMetricTags(tree, INFRA_APP_GENERATOR_INFO.metric);

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -15,8 +15,8 @@ import {
   getPackageManagerCommand,
   installPackagesTask,
 } from '@nx/devkit';
-import { InfraGeneratorSchema } from './schema';
-import tsLibGenerator, { getTsLibDetails } from '../../ts/lib/generator';
+import { TsInfraGeneratorSchema } from './schema';
+import tsProjectGenerator, { getTsLibDetails } from '../../ts/lib/generator';
 import { withVersions } from '../../utils/versions';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
@@ -35,12 +35,12 @@ import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 export const INFRA_APP_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
 
-export async function infraGenerator(
+export async function tsInfraGenerator(
   tree: Tree,
-  schema: InfraGeneratorSchema,
+  schema: TsInfraGeneratorSchema,
 ): Promise<GeneratorCallback> {
   const lib = getTsLibDetails(tree, schema);
-  await tsLibGenerator(tree, schema);
+  await tsProjectGenerator(tree, schema);
 
   await sharedConstructsGenerator(tree);
 
@@ -196,4 +196,4 @@ export async function infraGenerator(
     installPackagesTask(tree);
   };
 }
-export default infraGenerator;
+export default tsInfraGenerator;

--- a/packages/nx-plugin/src/infra/app/schema.d.ts
+++ b/packages/nx-plugin/src/infra/app/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export interface InfraGeneratorSchema {
+export interface TsInfraGeneratorSchema {
   name: string;
   ruleSet:
     | 'aws_prototyping'

--- a/packages/nx-plugin/src/open-api/ts-client/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { generateFiles, Tree } from '@nx/devkit';
-import { OpenApiClientSchema } from './schema';
+import { OpenApiTsClientGeneratorSchema } from './schema';
 import { parseOpenApiSpec } from '../utils/parse';
 import { buildOpenApiCodeGenData } from '../utils/codegen-data';
 import * as path from 'path';
@@ -15,15 +15,27 @@ import { formatFilesInSubtree } from '../../utils/format';
  */
 export const openApiTsClientGenerator = async (
   tree: Tree,
-  options: OpenApiClientSchema,
+  options: OpenApiTsClientGeneratorSchema,
 ) => {
-  const spec = await parseOpenApiSpec(tree, options.openApiSpecPath);
-
-  const data = await buildOpenApiCodeGenData(spec);
+  const data = await buildOpenApiCodeGenerationData(
+    tree,
+    options.openApiSpecPath,
+  );
 
   generateOpenApiTsClient(tree, data, options.outputPath);
 
   await formatFilesInSubtree(tree);
+};
+
+/**
+ * Build a data structure which can be used to generate code from OpenAPI
+ */
+export const buildOpenApiCodeGenerationData = async (
+  tree: Tree,
+  specPath: string,
+) => {
+  const spec = await parseOpenApiSpec(tree, specPath);
+  return await buildOpenApiCodeGenData(spec);
 };
 
 /**

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { generateFiles, Tree } from '@nx/devkit';
-import { OpenApiHooksSchema } from './schema';
-import { parseOpenApiSpec } from '../utils/parse';
-import { buildOpenApiCodeGenData } from '../utils/codegen-data';
-import { generateOpenApiTsClient } from '../ts-client/generator';
+import { OpenApiTsHooksGeneratorSchema } from './schema';
+import {
+  buildOpenApiCodeGenerationData,
+  generateOpenApiTsClient,
+} from '../ts-client/generator';
 import { formatFilesInSubtree } from '../../utils/format';
 import path from 'path';
 import { CodeGenData } from '../utils/codegen-data/types';
@@ -16,11 +17,12 @@ import { CodeGenData } from '../utils/codegen-data/types';
  */
 export const openApiTsHooksGenerator = async (
   tree: Tree,
-  options: OpenApiHooksSchema,
+  options: OpenApiTsHooksGeneratorSchema,
 ) => {
-  const spec = await parseOpenApiSpec(tree, options.openApiSpecPath);
-
-  const data = await buildOpenApiCodeGenData(spec);
+  const data = await buildOpenApiCodeGenerationData(
+    tree,
+    options.openApiSpecPath,
+  );
 
   generateOpenApiTsClient(tree, data, options.outputPath);
   generateOpenApiTsHooks(tree, data, options.outputPath);

--- a/packages/nx-plugin/src/open-api/ts-hooks/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface OpenApiHooksSchema {
+export interface OpenApiTsHooksGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
 }

--- a/packages/nx-plugin/src/open-api/ts-metadata/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-metadata/generator.ts
@@ -3,23 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { generateFiles, Tree } from '@nx/devkit';
-import { OpenApiMetadataSchema } from './schema';
-import { parseOpenApiSpec } from '../utils/parse';
-import { buildOpenApiCodeGenData } from '../utils/codegen-data';
+import { OpenApiTsMetadataGeneratorSchema } from './schema';
 import { formatFilesInSubtree } from '../../utils/format';
 import path from 'path';
 import { CodeGenData } from '../utils/codegen-data/types';
+import { buildOpenApiCodeGenerationData } from '../ts-client/generator';
 
 /**
  * Generates typescript metadata from an openapi spec
  */
 export const openApiTsMetadataGenerator = async (
   tree: Tree,
-  options: OpenApiMetadataSchema,
+  options: OpenApiTsMetadataGeneratorSchema,
 ) => {
-  const spec = await parseOpenApiSpec(tree, options.openApiSpecPath);
-
-  const data = await buildOpenApiCodeGenData(spec);
+  const data = await buildOpenApiCodeGenerationData(
+    tree,
+    options.openApiSpecPath,
+  );
 
   generateOpenApiTsMetadata(tree, data, options.outputPath);
 

--- a/packages/nx-plugin/src/open-api/ts-metadata/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-metadata/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface OpenApiMetadataSchema {
+export interface OpenApiTsMetadataGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
 }

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -4,7 +4,10 @@
  */
 import { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { FAST_API_GENERATOR_INFO, fastApiProjectGenerator } from './generator';
+import {
+  FAST_API_GENERATOR_INFO,
+  pyFastApiProjectGenerator,
+} from './generator';
 import { parse } from '@iarna/toml';
 import {
   PACKAGES_DIR,
@@ -23,7 +26,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should generate a FastAPI project with correct structure', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -41,7 +44,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should set up project configuration with FastAPI targets', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -81,7 +84,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should configure FastAPI dependencies', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -100,7 +103,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should set up shared constructs for http', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps/nested/path',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -139,7 +142,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should set up shared constructs for rest', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps/nested/path',
       computeType: 'ServerlessApiGatewayRestApi',
@@ -178,7 +181,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should update shared constructs build dependencies', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -200,7 +203,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should handle custom directory path', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps/nested/path',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -213,7 +216,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should set project metadata', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -228,7 +231,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should match snapshot', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -249,7 +252,7 @@ describe('fastapi project generator', () => {
 
   it('should add generator metric to app.ts', async () => {
     // Call the generator function
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -260,7 +263,7 @@ describe('fastapi project generator', () => {
   });
 
   it('should include CORS middleware in init.py when using REST API', async () => {
-    await fastApiProjectGenerator(tree, {
+    await pyFastApiProjectGenerator(tree, {
       name: 'test-api',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayRestApi',

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -14,7 +14,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { FastApiProjectGeneratorSchema } from './schema';
+import { PyFastApiProjectGeneratorSchema } from './schema';
 import { UVProvider } from '@nxlv/python/src/provider/uv/provider';
 import { Logger } from '@nxlv/python/src/executors/utils/logger';
 import pyProjectGenerator, { getPyProjectDetails } from '../project/generator';
@@ -40,9 +40,9 @@ export const FAST_API_GENERATOR_INFO: NxGeneratorInfo =
 /**
  * Generates a Python FastAPI project
  */
-export const fastApiProjectGenerator = async (
+export const pyFastApiProjectGenerator = async (
   tree: Tree,
-  schema: FastApiProjectGeneratorSchema,
+  schema: PyFastApiProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   await sharedConstructsGenerator(tree);
 
@@ -216,4 +216,4 @@ export const fastApiProjectGenerator = async (
     installPackagesTask(tree);
   };
 };
-export default fastApiProjectGenerator;
+export default pyFastApiProjectGenerator;

--- a/packages/nx-plugin/src/py/fast-api/schema.d.ts
+++ b/packages/nx-plugin/src/py/fast-api/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface FastApiProjectGeneratorSchema {
+export interface PyFastApiProjectGeneratorSchema {
   readonly name: string;
   readonly computeType:
     | 'ServerlessApiGatewayRestApi'

--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -6,7 +6,7 @@ import { Tree, updateJson } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import {
   LAMBDA_FUNCTION_GENERATOR_INFO,
-  lambdaFunctionProjectGenerator,
+  pyLambdaFunctionGenerator,
 } from './generator';
 import { parse } from '@iarna/toml';
 import {
@@ -44,7 +44,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -83,7 +83,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -146,7 +146,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -214,7 +214,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -257,7 +257,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       functionPath: 'nested/path',
@@ -296,7 +296,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -342,7 +342,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'APIGatewayProxyEventModel',
@@ -392,7 +392,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -440,7 +440,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test_project',
       functionName: 'test-function',
       eventSource: 'Any',
@@ -481,7 +481,7 @@ describe('lambda-handler project generator', () => {
       `,
     );
 
-    await lambdaFunctionProjectGenerator(tree, {
+    await pyLambdaFunctionGenerator(tree, {
       project: 'test-project',
       functionName: 'test-function',
       eventSource: 'Any',

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -13,7 +13,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { LambdaFunctionProjectGeneratorSchema } from './schema';
+import { PyLambdaFunctionGeneratorSchema } from './schema';
 import { UVProvider } from '@nxlv/python/src/provider/uv/provider';
 import { Logger } from '@nxlv/python/src/executors/utils/logger';
 import { parse, stringify } from '@iarna/toml';
@@ -77,9 +77,9 @@ const getLambdaFunctionDetails = (
 /**
  * Generates a Python Lambda Function to add to a python project
  */
-export const lambdaFunctionProjectGenerator = async (
+export const pyLambdaFunctionGenerator = async (
   tree: Tree,
-  schema: LambdaFunctionProjectGeneratorSchema,
+  schema: PyLambdaFunctionGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const projectConfig = readProjectConfigurationUnqualified(
     tree,
@@ -297,4 +297,4 @@ export const lambdaFunctionProjectGenerator = async (
     installPackagesTask(tree);
   };
 };
-export default lambdaFunctionProjectGenerator;
+export default pyLambdaFunctionGenerator;

--- a/packages/nx-plugin/src/py/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/py/lambda-function/schema.d.ts
@@ -45,7 +45,7 @@ type EventSource =
   | 'VpcLatticeModel'
   | 'VpcLatticeV2Model';
 
-export interface LambdaFunctionProjectGeneratorSchema {
+export interface PyLambdaFunctionGeneratorSchema {
   readonly project: string;
   readonly functionName: string;
   readonly functionPath?: string;

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readProjectConfiguration, Tree } from '@nx/devkit';
-import { TRPC_BACKEND_GENERATOR_INFO, trpcBackendGenerator } from './generator';
+import { TRPC_BACKEND_GENERATOR_INFO, tsTrpcApiGenerator } from './generator';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
@@ -18,7 +18,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should generate backend and schema projects', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -39,7 +39,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should set up project configuration correctly', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -55,7 +55,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should add required dependencies', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -80,7 +80,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should set up shared constructs for http', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -121,7 +121,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should set up shared constructs for rest', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayRestApi',
@@ -162,7 +162,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should add a task for starting a local server', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -180,7 +180,7 @@ describe('trpc backend generator', () => {
 
   it('should add generator metric to app.ts', async () => {
     // Call the generator function
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayHttpApi',
@@ -191,7 +191,7 @@ describe('trpc backend generator', () => {
   });
 
   it('should include CORS headers in router.ts when using REST API', async () => {
-    await trpcBackendGenerator(tree, {
+    await tsTrpcApiGenerator(tree, {
       apiName: 'TestApi',
       directory: 'apps',
       computeType: 'ServerlessApiGatewayRestApi',

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -13,14 +13,14 @@ import {
   Tree,
   updateJson,
 } from '@nx/devkit';
-import { TrpcBackendGeneratorSchema } from './schema';
+import { TsTrpcApiGeneratorSchema } from './schema';
 import kebabCase from 'lodash.kebabcase';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
 } from '../../utils/shared-constructs-constants';
-import tsLibGenerator from '../../ts/lib/generator';
+import tsProjectGenerator from '../../ts/lib/generator';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
 import { withVersions } from '../../utils/versions';
 import { toClassName } from '../../utils/names';
@@ -33,9 +33,9 @@ import { addApiGatewayConstruct } from '../../utils/api-constructs/api-construct
 export const TRPC_BACKEND_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
 
-export async function trpcBackendGenerator(
+export async function tsTrpcApiGenerator(
   tree: Tree,
-  options: TrpcBackendGeneratorSchema,
+  options: TsTrpcApiGeneratorSchema,
 ) {
   await sharedConstructsGenerator(tree);
 
@@ -64,12 +64,12 @@ export async function trpcBackendGenerator(
     pkgMgrCmd: getPackageManagerCommand().exec,
     ...options,
   };
-  await tsLibGenerator(tree, {
+  await tsProjectGenerator(tree, {
     name: backendName,
     directory: projectRoot,
     subDirectory: 'backend',
   });
-  await tsLibGenerator(tree, {
+  await tsProjectGenerator(tree, {
     name: schemaName,
     directory: projectRoot,
     subDirectory: 'schema',
@@ -185,4 +185,4 @@ export async function trpcBackendGenerator(
     installPackagesTask(tree);
   };
 }
-export default trpcBackendGenerator;
+export default tsTrpcApiGenerator;

--- a/packages/nx-plugin/src/trpc/backend/schema.d.ts
+++ b/packages/nx-plugin/src/trpc/backend/schema.d.ts
@@ -4,7 +4,7 @@
  */
 import { Linter } from '@nx/eslint';
 
-export interface TrpcBackendGeneratorSchema {
+export interface TsTrpcApiGeneratorSchema {
   apiName: string;
   computeType: 'ServerlessApiGatewayRestApi' | 'ServerlessApiGatewayHttpApi';
   directory?: TsLibGeneratorSchema['directory'];

--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readNxJson, Tree } from '@nx/devkit';
-import { TS_LIB_GENERATOR_INFO, tsLibGenerator } from './generator';
+import { TS_LIB_GENERATOR_INFO, tsProjectGenerator } from './generator';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import uniqBy from 'lodash.uniqby';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
@@ -17,7 +17,7 @@ describe('ts lib generator', () => {
   });
 
   it('should generate library with default options', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-lib',
       skipInstall: true,
     });
@@ -43,7 +43,7 @@ describe('ts lib generator', () => {
   });
 
   it('should generate library with custom directory', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-lib',
       directory: 'libs',
       skipInstall: true,
@@ -65,7 +65,7 @@ describe('ts lib generator', () => {
   });
 
   it('should generate library with subdirectory', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-lib',
       subDirectory: 'test-lib',
       directory: 'feature',
@@ -88,11 +88,11 @@ describe('ts lib generator', () => {
   });
 
   it('should not configure duplicate @nx/js/typescript plugin entries', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-1',
       skipInstall: true,
     });
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-2',
       skipInstall: true,
     });
@@ -104,7 +104,7 @@ describe('ts lib generator', () => {
   });
 
   it('should configure named inputs in nx.json', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-1',
       skipInstall: true,
     });
@@ -121,12 +121,12 @@ describe('ts lib generator', () => {
   });
 
   it('should not duplicate named inputs in nx.json', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-1',
       skipInstall: true,
     });
 
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-2',
       skipInstall: true,
     });
@@ -140,7 +140,7 @@ describe('ts lib generator', () => {
   });
 
   it('should configure target defaults in nx.json', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-1',
       skipInstall: true,
     });
@@ -159,12 +159,12 @@ describe('ts lib generator', () => {
   });
 
   it('should not configure duplicate inputs in nx.json target defaults', async () => {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-1',
       skipInstall: true,
     });
 
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-2',
       skipInstall: true,
     });
@@ -187,7 +187,7 @@ describe('ts lib generator', () => {
     await sharedConstructsGenerator(tree);
 
     // Call the generator function
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test-lib',
       skipInstall: true,
     });

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -15,7 +15,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { TsLibGeneratorSchema } from './schema';
+import { TsProjectGeneratorSchema } from './schema';
 import { libraryGenerator } from '@nx/js';
 import { getNpmScopePrefix } from '../../utils/npm-scope';
 import { configureTsProject } from './ts-project-utils';
@@ -47,7 +47,7 @@ export interface TsLibDetails {
  */
 export const getTsLibDetails = (
   tree: Tree,
-  schema: TsLibGeneratorSchema,
+  schema: TsProjectGeneratorSchema,
 ): TsLibDetails => {
   const scope = getNpmScopePrefix(tree);
   const normalizedName = toKebabCase(schema.name);
@@ -60,11 +60,11 @@ export const getTsLibDetails = (
 };
 
 /**
- * Generates a typescript library
+ * Generates a typescript project
  */
-export const tsLibGenerator = async (
+export const tsProjectGenerator = async (
   tree: Tree,
-  schema: TsLibGeneratorSchema,
+  schema: TsProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, schema);
   await libraryGenerator(tree, {
@@ -225,4 +225,4 @@ export const tsLibGenerator = async (
     }
   };
 };
-export default tsLibGenerator;
+export default tsProjectGenerator;

--- a/packages/nx-plugin/src/ts/lib/schema.d.ts
+++ b/packages/nx-plugin/src/ts/lib/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { LibraryGeneratorSchema } from '@nx/js/src/utils/schema';
-export interface TsLibGeneratorSchema {
+export interface TsProjectGeneratorSchema {
   name: LibraryGeneratorSchema['name'];
   directory?: string;
   //   unitTestRunner?: LibraryGeneratorSchema['unitTestRunner'];

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Tree } from '@nx/devkit';
-import tsLibGenerator from './generator';
+import tsProjectGenerator from './generator';
 import { configureVitest } from './vitest';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 describe('vitest utils', () => {
   let tree: Tree;
   beforeEach(async () => {
     tree = createTreeUsingTsSolutionSetup();
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: 'test',
       skipInstall: true,
     });

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -17,7 +17,7 @@ import { TsMcpServerGeneratorSchema } from './schema';
 import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { formatFilesInSubtree } from '../../utils/format';
-import tsLibGenerator, { getTsLibDetails } from '../lib/generator';
+import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
 import { withVersions } from '../../utils/versions';
 
 export const TS_MCP_SERVER_GENERATOR_INFO: NxGeneratorInfo =
@@ -28,7 +28,7 @@ export const tsMcpServerGenerator = async (
   options: TsMcpServerGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   // Generate a TypeScript library
-  await tsLibGenerator(tree, options);
+  await tsProjectGenerator(tree, options);
 
   const { fullyQualifiedName } = getTsLibDetails(tree, options);
   const project = readProjectConfiguration(tree, fullyQualifiedName);

--- a/packages/nx-plugin/src/ts/mcp-server/schema.d.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/schema.d.ts
@@ -2,10 +2,10 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { TsLibGeneratorSchema } from '../lib/schema';
+import { TsProjectGeneratorSchema } from '../lib/schema';
 
 /**
  * TypeScript types for options defined in schema.json
  * Update this to match schema.json if you make changes.
  */
-export type TsMcpServerGeneratorSchema = TsLibGeneratorSchema;
+export type TsMcpServerGeneratorSchema = TsProjectGeneratorSchema;

--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, Tree, writeJson } from '@nx/devkit';
-import { nxGeneratorGenerator, NX_GENERATOR_GENERATOR_INFO } from './generator';
+import {
+  tsNxGeneratorGenerator,
+  NX_GENERATOR_GENERATOR_INFO,
+} from './generator';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
@@ -51,7 +54,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should work when description is omitted', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'no#description',
       });
@@ -74,7 +77,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should generate an example schema, generator and test', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'foo#bar',
         description: 'Some description',
@@ -103,7 +106,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should add guide page to docs', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'foo#bar',
         description: 'Some description',
@@ -123,7 +126,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should update generators.json', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'foo#bar',
         description: 'Some description',
@@ -172,7 +175,7 @@ describe('nx-generator generator', () => {
         },
       });
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'foo#bar',
         description: 'Some description',
@@ -191,7 +194,7 @@ describe('nx-generator generator', () => {
         generators: {},
       });
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'empty#test',
         description: 'Some description',
@@ -205,7 +208,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should support a nested directory', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: NxPluginForAwsProjectJson.name,
         name: 'nested#test',
         directory: 'nested/dir',
@@ -242,7 +245,7 @@ describe('nx-generator generator', () => {
 
       // Expect the generator to throw an error
       await expect(
-        nxGeneratorGenerator(tree, {
+        tsNxGeneratorGenerator(tree, {
           pluginProject: 'other-project',
           name: 'should#fail',
           description: 'Some description',
@@ -281,7 +284,7 @@ describe('nx-generator generator', () => {
 
       // Expect the generator to throw an error
       await expect(
-        nxGeneratorGenerator(tree, {
+        tsNxGeneratorGenerator(tree, {
           pluginProject: '@test/no-tsconfig',
           name: 'should#fail',
           description: 'Some description',
@@ -296,7 +299,7 @@ describe('nx-generator generator', () => {
       tree.delete('package.json');
 
       await expect(
-        nxGeneratorGenerator(tree, {
+        tsNxGeneratorGenerator(tree, {
           pluginProject: '@test/plugin',
           name: 'no#root#pkg',
           description: 'Generator with no root package.json',
@@ -308,7 +311,7 @@ describe('nx-generator generator', () => {
       // Create an empty generators.json
       writeJson(tree, 'tools/plugin/generators.json', {});
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'empty#generators',
         description: 'Generator with empty generators.json',
@@ -339,7 +342,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should work when description is omitted', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'no#description',
       });
@@ -362,7 +365,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should generate an example schema, generator and test', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'foo#bar',
         description: 'Some description',
@@ -391,7 +394,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should support a nested directory', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'nested#test',
         directory: 'nested/dir',
@@ -419,7 +422,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should update generators.json', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'foo#bar',
         description: 'Some description',
@@ -448,7 +451,7 @@ describe('nx-generator generator', () => {
       // Ensure package.json doesn't exist
       expect(tree.exists('tools/plugin/package.json')).toBeFalsy();
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'create#pkg',
       });
@@ -469,7 +472,7 @@ describe('nx-generator generator', () => {
         version: '1.0.0',
       });
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'update#pkg',
       });
@@ -491,7 +494,7 @@ describe('nx-generator generator', () => {
         generators: './custom-generators.json',
       });
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'preserve#generators',
       });
@@ -504,7 +507,7 @@ describe('nx-generator generator', () => {
     });
 
     it('should generate an example template file', async () => {
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'template#test',
         description: 'Some description',
@@ -525,7 +528,7 @@ describe('nx-generator generator', () => {
       // Set up a tsconfig.json without module set
       writeJson(tree, 'tools/plugin/tsconfig.json', {});
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'module#test',
         description: 'Test module setting',
@@ -547,7 +550,7 @@ describe('nx-generator generator', () => {
       // Create tsconfig.json for the project
       writeJson(tree, 'tools/no-source-root/tsconfig.json', {});
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/no-source-root',
         name: 'no#source#root',
         description: 'Generator in project without sourceRoot',
@@ -565,7 +568,7 @@ describe('nx-generator generator', () => {
       // Create an index.ts file in the source root
       tree.write('tools/plugin/src/index.ts', '// This is the index file');
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'export#test',
         description: 'Generator with export test',
@@ -581,7 +584,7 @@ describe('nx-generator generator', () => {
     it('should add generator metric to app.ts', async () => {
       await sharedConstructsGenerator(tree);
 
-      await nxGeneratorGenerator(tree, {
+      await tsNxGeneratorGenerator(tree, {
         pluginProject: '@test/plugin',
         name: 'foo#bar-baz',
       });

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -13,7 +13,7 @@ import {
   updateJson,
   writeJson,
 } from '@nx/devkit';
-import { NxGeneratorGeneratorSchema } from './schema';
+import { TsNxGeneratorGeneratorSchema } from './schema';
 import kebabCase from 'lodash.kebabcase';
 import { pascalCase } from '../../utils/names';
 import camelCase from 'lodash.camelcase';
@@ -29,12 +29,13 @@ import {
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { withVersions } from '../../utils/versions';
 import { formatFilesInSubtree } from '../../utils/format';
+import PackageJson from '../../../package.json';
 
 export const NX_GENERATOR_GENERATOR_INFO = getGeneratorInfo(__filename);
 
-export const nxGeneratorGenerator = async (
+export const tsNxGeneratorGenerator = async (
   tree: Tree,
-  options: NxGeneratorGeneratorSchema,
+  options: TsNxGeneratorGeneratorSchema,
 ): Promise<GeneratorCallback | void> => {
   const { name, directory, pluginProject, description } = options;
 
@@ -156,6 +157,15 @@ export const nxGeneratorGenerator = async (
     if (tree.exists(indexPath)) {
       addStarExport(tree, indexPath, `./${generatorSubDir}/generator`);
     }
+
+    // Add a dependency on the nx plugin for aws
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      {
+        [PackageJson.name]: `^${PackageJson.version}`,
+      },
+    );
   }
 
   const factoryBasePath = `./${srcDir}/${generatorSubDir}`;
@@ -226,4 +236,4 @@ const incrementMetric = (metrics: string[]): string => {
   return `g${maxMetric + 1}`;
 };
 
-export default nxGeneratorGenerator;
+export default tsNxGeneratorGenerator;

--- a/packages/nx-plugin/src/ts/nx-generator/schema.d.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface NxGeneratorGeneratorSchema {
+export interface TsNxGeneratorGeneratorSchema {
   pluginProject: string;
   name: string;
   directory?: string;

--- a/packages/nx-plugin/src/utils/shared-constructs.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.ts
@@ -11,7 +11,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { getNpmScopePrefix, toScopeAlias } from './npm-scope';
-import tsLibGenerator from '../ts/lib/generator';
+import tsProjectGenerator from '../ts/lib/generator';
 import { withVersions } from './versions';
 import { formatFilesInSubtree } from './format';
 import {
@@ -31,7 +31,7 @@ export async function sharedConstructsGenerator(tree: Tree) {
       joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'project.json'),
     )
   ) {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: TYPE_DEFINITIONS_NAME,
       directory: PACKAGES_DIR,
       subDirectory: TYPE_DEFINITIONS_DIR,
@@ -68,7 +68,7 @@ export async function sharedConstructsGenerator(tree: Tree) {
       joinPathFragments(PACKAGES_DIR, SHARED_CONSTRUCTS_DIR, 'project.json'),
     )
   ) {
-    await tsLibGenerator(tree, {
+    await tsProjectGenerator(tree, {
       name: SHARED_CONSTRUCTS_NAME,
       directory: PACKAGES_DIR,
       subDirectory: SHARED_CONSTRUCTS_DIR,

--- a/packages/nx-plugin/tsconfig.lib.json
+++ b/packages/nx-plugin/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "bin/**/*.ts"],
+  "include": ["src/**/*.ts", "bin/**/*.ts", "sdk/**/*.ts"],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",


### PR DESCRIPTION
### Reason for this change

Make it easy for customers to extend our generators to add custom functionality.

### Description of changes

We export our generators in a more structured format, and refactor to ensure names are consistent. Update the documentation to include examples of extending our generators.

### Description of how you validated changes

- Generated a tools project with `ts#project`
- Generated a generator with `ts#nx-generator`
- `import { tsProjectGenerator } from '@aws/nx-plugin/sdk/ts';`
- Called `tsProjectGenerator` from my generator
- Invoked my generator via Nx Console and observed a ts project being generated!

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*