### PR TITLE
chore: add generator id to project metadata

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { readJson, Tree } from '@nx/devkit';
 import {
   CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO,
   tsCloudScapeWebsiteGenerator,
@@ -146,6 +146,16 @@ describe('cloudscape-website generator', () => {
     await tsCloudScapeWebsiteGenerator(tree, options);
     const packageJson = JSON.parse(tree.read('package.json').toString());
     expect(packageJson.dependencies).toMatchSnapshot('scoped-dependencies');
+  });
+
+  it('should add generator to project metadata', async () => {
+    // Call the generator function
+    await tsCloudScapeWebsiteGenerator(tree, options);
+
+    expect(readJson(tree, 'test-app/project.json').metadata).toHaveProperty(
+      'generator',
+      CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO.id,
+    );
   });
 
   it('should add generator metric to app.ts', async () => {

--- a/packages/nx-plugin/src/cloudscape-website/app/generator.ts
+++ b/packages/nx-plugin/src/cloudscape-website/app/generator.ts
@@ -44,7 +44,11 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { relative } from 'path';
 import kebabCase from 'lodash.kebabcase';
 import { sortObjectKeys } from '../../utils/object';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO: NxGeneratorInfo =
@@ -125,6 +129,11 @@ export async function tsCloudScapeWebsiteGenerator(
   projectConfiguration.targets = sortObjectKeys(targets);
 
   updateProjectConfiguration(tree, fullyQualifiedName, projectConfiguration);
+  addGeneratorMetadata(
+    tree,
+    projectConfiguration.name,
+    CLOUDSCAPE_WEBSITE_APP_GENERATOR_INFO,
+  );
 
   configureTsProject(tree, {
     dir: websiteContentPath,

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -115,6 +115,9 @@ exports[`infra generator > should configure project.json with correct targets > 
 exports[`infra generator > should configure project.json with correct targets > project-configuration 1`] = `
 {
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "metadata": {
+    "generator": "ts#infra",
+  },
   "name": "@proj/test",
   "projectType": "application",
   "root": "packages/test",
@@ -496,6 +499,9 @@ exports[`infra generator > should generate files with correct content > project-
   "sourceRoot": "packages/test/src",
   "projectType": "application",
   "tags": [],
+  "metadata": {
+    "generator": "ts#infra"
+  },
   "targets": {
     "bootstrap": {
       "executor": "nx:run-commands",
@@ -818,6 +824,9 @@ export class ApplicationStack extends cdk.Stack {
 exports[`infra generator > should handle custom project names correctly > custom-name-project-config 1`] = `
 {
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "metadata": {
+    "generator": "ts#infra",
+  },
   "name": "@proj/custom-infra",
   "projectType": "application",
   "root": "packages/custom-infra",

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import { Tree, readJson, readProjectConfiguration } from '@nx/devkit';
 import { INFRA_APP_GENERATOR_INFO, tsInfraGenerator } from './generator';
 import { TsInfraGeneratorSchema } from './schema';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
@@ -211,6 +211,15 @@ describe('infra generator', () => {
     // Compare runs
     expect(firstRunFiles).toEqual(secondRunFiles);
     expect(secondRunFiles).toMatchSnapshot('consistent-files');
+  });
+
+  it('should add generator to project metadata', async () => {
+    // Call the generator function
+    await tsInfraGenerator(tree, options);
+
+    expect(
+      readJson(tree, 'packages/test/project.json').metadata,
+    ).toHaveProperty('generator', INFRA_APP_GENERATOR_INFO.id);
   });
 
   it('should add generator metric to app.ts', async () => {

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -29,7 +29,11 @@ import path from 'path';
 import { formatFilesInSubtree } from '../../utils/format';
 import kebabCase from 'lodash.kebabcase';
 import { sortObjectKeys } from '../../utils/object';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const INFRA_APP_GENERATOR_INFO: NxGeneratorInfo =
@@ -41,6 +45,8 @@ export async function tsInfraGenerator(
 ): Promise<GeneratorCallback> {
   const lib = getTsLibDetails(tree, schema);
   await tsProjectGenerator(tree, schema);
+
+  addGeneratorMetadata(tree, lib.fullyQualifiedName, INFRA_APP_GENERATOR_INFO);
 
   await sharedConstructsGenerator(tree);
 

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -227,6 +227,7 @@ describe('fastapi project generator', () => {
     expect(config.metadata).toEqual({
       apiName: 'test-api',
       apiType: 'fast-api',
+      generator: FAST_API_GENERATOR_INFO.id,
     });
   });
 

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -28,7 +28,11 @@ import {
 import { toClassName, toKebabCase, toSnakeCase } from '../../utils/names';
 import { formatFilesInSubtree } from '../../utils/format';
 import { sortObjectKeys } from '../../utils/object';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { addApiGatewayConstruct } from '../../utils/api-constructs/api-constructs';
 import { addOpenApiGeneration } from './react/open-api';
@@ -206,6 +210,8 @@ export const pyFastApiProjectGenerator = async (
   ].concat(projectToml.project?.dependencies || []);
   projectToml['dependency-groups'] = { dev: ['fastapi[standard]>=0.115'] };
   tree.write(joinPathFragments(dir, 'pyproject.toml'), stringify(projectToml));
+
+  addGeneratorMetadata(tree, normalizedName, FAST_API_GENERATOR_INFO);
 
   await addGeneratorMetricsIfApplicable(tree, [FAST_API_GENERATOR_INFO]);
 

--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -126,6 +126,19 @@ describe('python project generator', () => {
     expect(packageJson.devDependencies).toHaveProperty('@nxlv/python');
   });
 
+  it('should add generator to project metadata', async () => {
+    // Call the generator function
+    await pyProjectGenerator(tree, {
+      name: 'test-project',
+      directory: 'apps',
+      projectType: 'application',
+    });
+
+    expect(
+      readJson(tree, 'apps/test_project/project.json').metadata,
+    ).toHaveProperty('generator', PY_PROJECT_GENERATOR_INFO.id);
+  });
+
   it('should add generator metric to app.ts', async () => {
     // Set up test tree with shared constructs
     await sharedConstructsGenerator(tree);

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -23,7 +23,11 @@ import { getNpmScope } from '../../utils/npm-scope';
 import { toSnakeCase } from '../../utils/names';
 import { sortObjectKeys } from '../../utils/object';
 import { updateGitIgnore } from '../../utils/git';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 
 export const PY_PROJECT_GENERATOR_INFO: NxGeneratorInfo =
@@ -151,6 +155,8 @@ export const pyProjectGenerator = async (
   };
   projectConfiguration.targets = sortObjectKeys(projectConfiguration.targets);
   updateProjectConfiguration(tree, normalizedName, projectConfiguration);
+
+  addGeneratorMetadata(tree, normalizedName, PY_PROJECT_GENERATOR_INFO);
 
   // Update root .gitignore
   updateGitIgnore(tree, '.', (patterns) => [...patterns, '/reports']);

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -51,6 +51,7 @@ describe('trpc backend generator', () => {
     expect(backendProjectConfig.metadata).toEqual({
       apiName: 'TestApi',
       apiType: 'trpc',
+      generator: TRPC_BACKEND_GENERATOR_INFO.id,
     });
   });
 

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -26,7 +26,11 @@ import { withVersions } from '../../utils/versions';
 import { toClassName } from '../../utils/names';
 import { formatFilesInSubtree } from '../../utils/format';
 import { sortObjectKeys } from '../../utils/object';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { addApiGatewayConstruct } from '../../utils/api-constructs/api-constructs';
 
@@ -177,6 +181,9 @@ export async function tsTrpcApiGenerator(
   );
   tree.delete(joinPathFragments(backendRoot, 'package.json'));
   tree.delete(joinPathFragments(schemaRoot, 'package.json'));
+
+  addGeneratorMetadata(tree, backendName, TRPC_BACKEND_GENERATOR_INFO);
+  addGeneratorMetadata(tree, schemaName, TRPC_BACKEND_GENERATOR_INFO);
 
   await addGeneratorMetricsIfApplicable(tree, [TRPC_BACKEND_GENERATOR_INFO]);
 

--- a/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
@@ -117,6 +117,9 @@ exports[`ts lib generator > should generate library with custom directory > cust
         "reportsDirectory": "../../coverage/libs/test-lib"
       }
     }
+  },
+  "metadata": {
+    "generator": "ts#project"
   }
 }
 "
@@ -199,6 +202,9 @@ exports[`ts lib generator > should generate library with default options > proje
         "reportsDirectory": "../coverage/test-lib"
       }
     }
+  },
+  "metadata": {
+    "generator": "ts#project"
   }
 }
 "
@@ -255,6 +261,9 @@ exports[`ts lib generator > should generate library with subdirectory > subdir-p
         "reportsDirectory": "../../coverage/feature/test-lib"
       }
     }
+  },
+  "metadata": {
+    "generator": "ts#project"
   }
 }
 "

--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readNxJson, Tree } from '@nx/devkit';
+import { readJson, readNxJson, Tree } from '@nx/devkit';
 import { TS_LIB_GENERATOR_INFO, tsProjectGenerator } from './generator';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import uniqBy from 'lodash.uniqby';
@@ -179,6 +179,19 @@ describe('ts lib generator', () => {
     );
     expect(targetDefaults.test.inputs).toHaveLength(
       uniqBy(targetDefaults.test.inputs, (x) => x).length,
+    );
+  });
+
+  it('should add generator to project metadata', async () => {
+    // Call the generator function
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      skipInstall: true,
+    });
+
+    expect(readJson(tree, 'test-lib/project.json').metadata).toHaveProperty(
+      'generator',
+      TS_LIB_GENERATOR_INFO.id,
     );
   });
 

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -23,7 +23,11 @@ import { toKebabCase } from '../../utils/names';
 import { relative } from 'path';
 import { formatFilesInSubtree } from '../../utils/format';
 import { sortObjectKeys } from '../../utils/object';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { replace } from '../../utils/ast';
 import { ArrayLiteralExpression, factory } from 'typescript';
@@ -127,6 +131,8 @@ export const tsProjectGenerator = async (
   projectConfiguration.targets = sortObjectKeys(targets);
 
   updateProjectConfiguration(tree, fullyQualifiedName, projectConfiguration);
+
+  addGeneratorMetadata(tree, fullyQualifiedName, TS_LIB_GENERATOR_INFO);
 
   updateJson(tree, 'nx.json', (nxJson: NxJsonConfiguration) => {
     nxJson.namedInputs = {

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -139,6 +139,9 @@ export default [
   "sourceRoot": "test-server/src",
   "projectType": "library",
   "tags": [],
+  "metadata": {
+    "generator": "ts#mcp-server"
+  },
   "targets": {
     "build": {
       "dependsOn": ["lint", "compile", "test", "bundle"]

--- a/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import { Tree, readJson, readProjectConfiguration } from '@nx/devkit';
 import {
   tsMcpServerGenerator,
   TS_MCP_SERVER_GENERATOR_INFO,
@@ -99,6 +99,16 @@ describe('ts#mcp-server generator', () => {
     // Check that the source files were generated in the custom directory
     expect(tree.exists('custom-dir/test-server/src/index.ts')).toBeTruthy();
     expect(tree.exists('custom-dir/test-server/src/server.ts')).toBeTruthy();
+  });
+
+  it('should add generator to project metadata', async () => {
+    // Call the generator function
+    await tsMcpServerGenerator(tree, { name: 'test-server' });
+
+    expect(readJson(tree, 'test-server/project.json').metadata).toHaveProperty(
+      'generator',
+      TS_MCP_SERVER_GENERATOR_INFO.id,
+    );
   });
 
   it('should match snapshot', async () => {

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -14,7 +14,11 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { TsMcpServerGeneratorSchema } from './schema';
-import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import {
+  NxGeneratorInfo,
+  addGeneratorMetadata,
+  getGeneratorInfo,
+} from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { formatFilesInSubtree } from '../../utils/format';
 import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
@@ -80,6 +84,8 @@ export const tsMcpServerGenerator = async (
       },
     },
   });
+
+  addGeneratorMetadata(tree, fullyQualifiedName, TS_MCP_SERVER_GENERATOR_INFO);
 
   await addGeneratorMetricsIfApplicable(tree, [TS_MCP_SERVER_GENERATOR_INFO]);
 

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -2,7 +2,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { getProjects, readProjectConfiguration, Tree } from '@nx/devkit';
+import {
+  getProjects,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
 import GeneratorsJson from '../../generators.json';
 import PackageJson from '../../package.json';
 import * as path from 'path';
@@ -86,4 +91,22 @@ export const readProjectConfigurationUnqualified = (
     }
     throw e;
   }
+};
+
+/**
+ * Add metadata about the generator to the project.json
+ */
+export const addGeneratorMetadata = (
+  tree: Tree,
+  projectName: string,
+  info: NxGeneratorInfo,
+) => {
+  const config = readProjectConfigurationUnqualified(tree, projectName);
+  updateProjectConfiguration(tree, config.name, {
+    ...config,
+    metadata: {
+      ...config?.metadata,
+      generator: info.id,
+    } as any,
+  });
 };


### PR DESCRIPTION
### Reason for this change

Useful for future validation for generators which operate on existing projects.

### Description of changes

Add the generator id to project.json metadata for each generator which creates a project.

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*