### PR TITLE
fix(py#fast-api): always use cors middleware and allow headers

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
@@ -50,6 +51,12 @@ lambda_handler = tracer.capture_lambda_handler(lambda_handler)
 lambda_handler = logger.inject_lambda_context(lambda_handler, clear_state=True)
 # Add metrics last to properly flush metrics.
 lambda_handler = metrics.log_metrics(lambda_handler, capture_cold_start_metric=True)
+
+# Add cors middleware
+app.add_middleware(CORSMiddleware,
+                   allow_origins=['*'],
+                   allow_methods=['*'],
+                   allow_headers=['*'])
 
 # Add exception middleware(s)
 app.add_middleware(ExceptionMiddleware, handlers=app.exception_handlers)

--- a/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
+++ b/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
@@ -5,9 +5,7 @@ from collections.abc import Callable
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit
 from fastapi import FastAPI, Request, Response
-<%_ if (computeType === 'ServerlessApiGatewayRestApi') { _%>
 from fastapi.middleware.cors import CORSMiddleware
-<%_ } _%>
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
@@ -41,11 +39,12 @@ lambda_handler = logger.inject_lambda_context(lambda_handler, clear_state=True)
 # Add metrics last to properly flush metrics.
 lambda_handler = metrics.log_metrics(lambda_handler, capture_cold_start_metric=True)
 
-<%_ if (computeType === 'ServerlessApiGatewayRestApi') { _%>
 # Add cors middleware
-app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['*'])
+app.add_middleware(CORSMiddleware,
+                   allow_origins=['*'],
+                   allow_methods=['*'],
+                   allow_headers=['*'])
 
-<%_ } _%>
 # Add exception middleware(s)
 app.add_middleware(ExceptionMiddleware, handlers=app.exception_handlers)
 

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -274,25 +274,29 @@ describe('fastapi project generator', () => {
     expectHasMetricTags(tree, FAST_API_GENERATOR_INFO.metric);
   });
 
-  it('should include CORS middleware in init.py when using REST API', async () => {
-    await pyFastApiProjectGenerator(tree, {
-      name: 'test-api',
-      directory: 'apps',
-      computeType: 'ServerlessApiGatewayRestApi',
-      auth: 'IAM',
-    });
+  it.each(['Rest', 'Http'])(
+    'should include CORS middleware in init.py when using %s API',
+    async (api: 'Rest' | 'Http') => {
+      await pyFastApiProjectGenerator(tree, {
+        name: 'test-api',
+        directory: 'apps',
+        computeType: `ServerlessApiGateway${api}Api`,
+        auth: 'IAM',
+      });
 
-    // Read the generated init.py file
-    const initPyContent = tree.read('apps/test_api/test_api/init.py', 'utf-8');
+      // Read the generated init.py file
+      const initPyContent = tree.read(
+        'apps/test_api/test_api/init.py',
+        'utf-8',
+      );
 
-    // Verify CORS middleware import is included
-    expect(initPyContent).toContain(
-      'from fastapi.middleware.cors import CORSMiddleware',
-    );
+      // Verify CORS middleware import is included
+      expect(initPyContent).toContain(
+        'from fastapi.middleware.cors import CORSMiddleware',
+      );
 
-    // Verify CORS middleware is added with correct configuration
-    expect(initPyContent).toContain(
-      "app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['*'])",
-    );
-  });
+      // Verify CORS middleware is added with correct configuration
+      expect(initPyContent).toContain('app.add_middleware(CORSMiddleware,');
+    },
+  );
 });


### PR DESCRIPTION
### Reason for this change

When allowing headers with the cors middleware, it works on both http and rest apis, and cors works for local development.

### Description of changes

Use cors middleware for both http and rest apis, and allow all headers

### Description of how you validated changes

Deployed an http api with cors middleware added, and pointed a website at a local fastapi server

### Issue # (if applicable)

References #192

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*