### PR TITLE
fix(license): fix bug parsing lines that don't end a block comment but use block comment end syntax

### DIFF
--- a/packages/nx-plugin/src/license/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/license/sync/generator.spec.ts
@@ -514,6 +514,38 @@ describe('licenseSyncGenerator', () => {
     );
   });
 
+  it('should work for code lines that end with a block end but are not part of block comments', async () => {
+    await addLicenseConfig({
+      header: {
+        content: {
+          lines: ['Test Header Line 1', 'Test Header Line 2'],
+        },
+        format: {
+          '**/*.{py,sh}': {
+            blockStart: '## ',
+            lineStart: '#  ',
+            blockEnd: '## ',
+          },
+        },
+      },
+    });
+
+    tree.write(
+      'test.py',
+      `test_content = """
+# Some content
+"""`,
+    );
+
+    await licenseSyncGenerator(tree);
+
+    expect(tree.read('test.py', 'utf-8')).toBe(
+      `## \n#  Test Header Line 1\n#  Test Header Line 2\n## \ntest_content = """
+# Some content
+"""`,
+    );
+  });
+
   it("should error when multiple block comments would be rendered and we couldn't therefore replace the header again", async () => {
     await addLicenseConfig({
       header: {
@@ -534,7 +566,7 @@ describe('licenseSyncGenerator', () => {
     tree.write('test.ts', `const x = 1;`);
 
     await expect(licenseSyncGenerator(tree)).rejects.toThrow(
-      'The license header content, or format for ts files would produce a header that cannot be safely replaced',
+      'The license header content, or format for ts files would produce a header that cannot be safely replaced in test.ts',
     );
   });
 

--- a/packages/nx-plugin/src/license/sync/generator.ts
+++ b/packages/nx-plugin/src/license/sync/generator.ts
@@ -332,7 +332,8 @@ const parseFile = (
     if (
       syntax.block &&
       trimmedLine.endsWith(syntax.block.end) &&
-      !withinLineCommentSeries
+      !withinLineCommentSeries &&
+      (withinBlockComment || trimmedLine.startsWith(syntax.block.start))
     ) {
       // Comment ends with the block end, so we've completed the header and therefore break out of the loop
       headerLines.push(lines[i]);
@@ -425,7 +426,7 @@ export default {
   );
   if (hashbang !== newHashbang || body !== newBody) {
     throw new Error(
-      `The license header content, or format for ${fileExtension} files would produce a header that cannot be safely replaced. Please revise license content and format in ${AWS_NX_PLUGIN_CONFIG_FILE_NAME}`,
+      `The license header content, or format for ${fileExtension} files would produce a header that cannot be safely replaced in ${file}. Please revise license content and format in ${AWS_NX_PLUGIN_CONFIG_FILE_NAME}`,
     );
   }
 


### PR DESCRIPTION
### Reason for this change

We were incorrectly assuming that if a line ends with a block comment it ends the block comment! This isn't the case, we need to be within a block comment to end it. 

### Description of changes

Check that we're either within a block comment or on a line that both starts and ends the block comment.

Additionally include the file that we encountered the error with to help users work around issues like this in future.

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Fixes #200

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*