### PR TITLE
fix(open-api): fix code generation issues with array requests and responses

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -1,0 +1,1579 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which accepts an array of objects 1`] = `
+"export type ProcessUsers200Response = {
+  processed: number;
+  status: string;
+};
+export type ProcessUsersRequestContentItem = {
+  id: string;
+  name: string;
+  email: string;
+  age?: number;
+  active?: boolean;
+};
+
+export type ProcessUsersRequest = Array<ProcessUsersRequestContentItem>;
+export type ProcessUsersError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which accepts an array of objects 2`] = `
+"import type {
+  ProcessUsers200Response,
+  ProcessUsersRequestContentItem,
+  ProcessUsersRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static ProcessUsers200Response = {
+    toJson: (model: ProcessUsers200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.processed === undefined
+          ? {}
+          : {
+              processed: model.processed,
+            }),
+        ...(model.status === undefined
+          ? {}
+          : {
+              status: model.status,
+            }),
+      };
+    },
+    fromJson: (json: any): ProcessUsers200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        processed: json['processed'],
+        status: json['status'],
+      };
+    },
+  };
+
+  public static ProcessUsersRequestContentItem = {
+    toJson: (model: ProcessUsersRequestContentItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.email === undefined
+          ? {}
+          : {
+              email: model.email,
+            }),
+        ...(model.age === undefined
+          ? {}
+          : {
+              age: model.age,
+            }),
+        ...(model.active === undefined
+          ? {}
+          : {
+              active: model.active,
+            }),
+      };
+    },
+    fromJson: (json: any): ProcessUsersRequestContentItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        name: json['name'],
+        email: json['email'],
+        ...(json['age'] === undefined
+          ? {}
+          : {
+              age: json['age'],
+            }),
+        ...(json['active'] === undefined
+          ? {}
+          : {
+              active: json['active'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.processUsers = this.processUsers.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  /**
+   * Process an array of user objects
+   */
+  public async processUsers(
+    input: ProcessUsersRequest,
+  ): Promise<ProcessUsers200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body = JSON.stringify(
+      input.map($IO.ProcessUsersRequestContentItem.toJson),
+    );
+
+    const response = await this.$fetch(
+      this.$url('/process-users', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.ProcessUsers200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which accepts an array of objects referenced from components 1`] = `
+"export type BatchCreateCustomers201Response = {
+  created: number;
+  customerIds: Array<string>;
+};
+export type Customer = {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string;
+  address?: CustomerAddress;
+  preferences?: Array<string>;
+};
+export type CustomerAddress = {
+  street: string;
+  city: string;
+  country: string;
+  zipCode?: string;
+};
+
+export type BatchCreateCustomersRequest = Array<Customer>;
+export type BatchCreateCustomersError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which accepts an array of objects referenced from components 2`] = `
+"import type {
+  BatchCreateCustomers201Response,
+  Customer,
+  CustomerAddress,
+  BatchCreateCustomersRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static BatchCreateCustomers201Response = {
+    toJson: (model: BatchCreateCustomers201Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.created === undefined
+          ? {}
+          : {
+              created: model.created,
+            }),
+        ...(model.customerIds === undefined
+          ? {}
+          : {
+              customerIds: model.customerIds,
+            }),
+      };
+    },
+    fromJson: (json: any): BatchCreateCustomers201Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        created: json['created'],
+        customerIds: json['customerIds'],
+      };
+    },
+  };
+
+  public static Customer = {
+    toJson: (model: Customer): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.email === undefined
+          ? {}
+          : {
+              email: model.email,
+            }),
+        ...(model.phone === undefined
+          ? {}
+          : {
+              phone: model.phone,
+            }),
+        ...(model.address === undefined
+          ? {}
+          : {
+              address: $IO.CustomerAddress.toJson(model.address),
+            }),
+        ...(model.preferences === undefined
+          ? {}
+          : {
+              preferences: model.preferences,
+            }),
+      };
+    },
+    fromJson: (json: any): Customer => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        name: json['name'],
+        email: json['email'],
+        ...(json['phone'] === undefined
+          ? {}
+          : {
+              phone: json['phone'],
+            }),
+        ...(json['address'] === undefined
+          ? {}
+          : {
+              address: $IO.CustomerAddress.fromJson(json['address']),
+            }),
+        ...(json['preferences'] === undefined
+          ? {}
+          : {
+              preferences: json['preferences'],
+            }),
+      };
+    },
+  };
+
+  public static CustomerAddress = {
+    toJson: (model: CustomerAddress): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.street === undefined
+          ? {}
+          : {
+              street: model.street,
+            }),
+        ...(model.city === undefined
+          ? {}
+          : {
+              city: model.city,
+            }),
+        ...(model.country === undefined
+          ? {}
+          : {
+              country: model.country,
+            }),
+        ...(model.zipCode === undefined
+          ? {}
+          : {
+              zipCode: model.zipCode,
+            }),
+      };
+    },
+    fromJson: (json: any): CustomerAddress => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        street: json['street'],
+        city: json['city'],
+        country: json['country'],
+        ...(json['zipCode'] === undefined
+          ? {}
+          : {
+              zipCode: json['zipCode'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.batchCreateCustomers = this.batchCreateCustomers.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  /**
+   * Create multiple customers from referenced component schema
+   */
+  public async batchCreateCustomers(
+    input: BatchCreateCustomersRequest,
+  ): Promise<BatchCreateCustomers201Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body = JSON.stringify(input.map($IO.Customer.toJson));
+
+    const response = await this.$fetch(
+      this.$url('/batch-customers', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 201) {
+      return $IO.BatchCreateCustomers201Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which accepts an array of strings 1`] = `
+"export type ProcessTags200Response = {
+  processed: number;
+  message: string;
+};
+
+export type ProcessTagsRequest = Array<string>;
+export type ProcessTagsError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which accepts an array of strings 2`] = `
+"import type {
+  ProcessTags200Response,
+  ProcessTagsRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static ProcessTags200Response = {
+    toJson: (model: ProcessTags200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.processed === undefined
+          ? {}
+          : {
+              processed: model.processed,
+            }),
+        ...(model.message === undefined
+          ? {}
+          : {
+              message: model.message,
+            }),
+      };
+    },
+    fromJson: (json: any): ProcessTags200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        processed: json['processed'],
+        message: json['message'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.processTags = this.processTags.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  /**
+   * Process an array of string tags
+   */
+  public async processTags(
+    input: ProcessTagsRequest,
+  ): Promise<ProcessTags200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body = JSON.stringify(input);
+
+    const response = await this.$fetch(
+      this.$url('/process-tags', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.ProcessTags200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which returns an array of objects 1`] = `
+"export type GetProducts200ResponseItem = {
+  id: string;
+  name: string;
+  price: number;
+  description?: string;
+  inStock?: boolean;
+  tags?: Array<string>;
+  metadata?: GetProducts200ResponseItemMetadata;
+};
+export type GetProducts200ResponseItemMetadata = {
+  weight?: number;
+  dimensions?: string;
+};
+/**
+ * Get an array of product objects
+ */
+export type GetProductsRequestQueryParameters = {
+  category?: string;
+  limit?: number;
+};
+
+export type GetProductsRequest = GetProductsRequestQueryParameters;
+export type GetProductsError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which returns an array of objects 2`] = `
+"import type {
+  GetProducts200ResponseItem,
+  GetProducts200ResponseItemMetadata,
+  GetProductsRequestQueryParameters,
+  GetProductsRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetProducts200ResponseItem = {
+    toJson: (model: GetProducts200ResponseItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.price === undefined
+          ? {}
+          : {
+              price: model.price,
+            }),
+        ...(model.description === undefined
+          ? {}
+          : {
+              description: model.description,
+            }),
+        ...(model.inStock === undefined
+          ? {}
+          : {
+              inStock: model.inStock,
+            }),
+        ...(model.tags === undefined
+          ? {}
+          : {
+              tags: model.tags,
+            }),
+        ...(model.metadata === undefined
+          ? {}
+          : {
+              metadata: $IO.GetProducts200ResponseItemMetadata.toJson(
+                model.metadata,
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): GetProducts200ResponseItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        name: json['name'],
+        price: json['price'],
+        ...(json['description'] === undefined
+          ? {}
+          : {
+              description: json['description'],
+            }),
+        ...(json['inStock'] === undefined
+          ? {}
+          : {
+              inStock: json['inStock'],
+            }),
+        ...(json['tags'] === undefined
+          ? {}
+          : {
+              tags: json['tags'],
+            }),
+        ...(json['metadata'] === undefined
+          ? {}
+          : {
+              metadata: $IO.GetProducts200ResponseItemMetadata.fromJson(
+                json['metadata'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static GetProducts200ResponseItemMetadata = {
+    toJson: (model: GetProducts200ResponseItemMetadata): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.weight === undefined
+          ? {}
+          : {
+              weight: model.weight,
+            }),
+        ...(model.dimensions === undefined
+          ? {}
+          : {
+              dimensions: model.dimensions,
+            }),
+      };
+    },
+    fromJson: (json: any): GetProducts200ResponseItemMetadata => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['weight'] === undefined
+          ? {}
+          : {
+              weight: json['weight'],
+            }),
+        ...(json['dimensions'] === undefined
+          ? {}
+          : {
+              dimensions: json['dimensions'],
+            }),
+      };
+    },
+  };
+
+  public static GetProductsRequestQueryParameters = {
+    toJson: (model: GetProductsRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.category === undefined
+          ? {}
+          : {
+              category: model.category,
+            }),
+        ...(model.limit === undefined
+          ? {}
+          : {
+              limit: model.limit,
+            }),
+      };
+    },
+    fromJson: (json: any): GetProductsRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['category'] === undefined
+          ? {}
+          : {
+              category: json['category'],
+            }),
+        ...(json['limit'] === undefined
+          ? {}
+          : {
+              limit: json['limit'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getProducts = this.getProducts.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  /**
+   * Get an array of product objects
+   */
+  public async getProducts(
+    input: GetProductsRequest,
+  ): Promise<Array<GetProducts200ResponseItem>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.GetProductsRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const collectionFormats = {
+      category: 'multi',
+      limit: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/get-products',
+        pathParameters,
+        queryParameters,
+        collectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return ((await response.json()) as Array<any>).map(
+        $IO.GetProducts200ResponseItem.fromJson,
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which returns an array of objects referenced from components 1`] = `
+"/**
+ * Get orders using referenced component schema
+ */
+export type GetOrdersRequestQueryParameters = {
+  customerId?: string;
+  status?: string;
+  limit?: number;
+};
+export type Order = {
+  id: string;
+  customerId: string;
+  status: OrderStatus;
+  items: Array<OrderItemsItem>;
+  totalAmount: number;
+  shippingAddress?: OrderShippingAddress;
+};
+export type OrderItemsItem = {
+  productId: string;
+  quantity: number;
+  price: number;
+};
+export type OrderShippingAddress = {
+  street: string;
+  city: string;
+  country: string;
+  zipCode?: string;
+};
+export type OrderStatus =
+  | 'pending'
+  | 'processing'
+  | 'shipped'
+  | 'delivered'
+  | 'cancelled';
+
+export type GetOrdersRequest = GetOrdersRequestQueryParameters;
+export type GetOrdersError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which returns an array of objects referenced from components 2`] = `
+"import type {
+  GetOrdersRequestQueryParameters,
+  Order,
+  OrderItemsItem,
+  OrderShippingAddress,
+  OrderStatus,
+  GetOrdersRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetOrdersRequestQueryParameters = {
+    toJson: (model: GetOrdersRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.customerId === undefined
+          ? {}
+          : {
+              customerId: model.customerId,
+            }),
+        ...(model.status === undefined
+          ? {}
+          : {
+              status: model.status,
+            }),
+        ...(model.limit === undefined
+          ? {}
+          : {
+              limit: model.limit,
+            }),
+      };
+    },
+    fromJson: (json: any): GetOrdersRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['customerId'] === undefined
+          ? {}
+          : {
+              customerId: json['customerId'],
+            }),
+        ...(json['status'] === undefined
+          ? {}
+          : {
+              status: json['status'],
+            }),
+        ...(json['limit'] === undefined
+          ? {}
+          : {
+              limit: json['limit'],
+            }),
+      };
+    },
+  };
+
+  public static Order = {
+    toJson: (model: Order): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+        ...(model.customerId === undefined
+          ? {}
+          : {
+              customerId: model.customerId,
+            }),
+        ...(model.status === undefined
+          ? {}
+          : {
+              status: model.status,
+            }),
+        ...(model.items === undefined
+          ? {}
+          : {
+              items: model.items.map($IO.OrderItemsItem.toJson),
+            }),
+        ...(model.totalAmount === undefined
+          ? {}
+          : {
+              totalAmount: model.totalAmount,
+            }),
+        ...(model.shippingAddress === undefined
+          ? {}
+          : {
+              shippingAddress: $IO.OrderShippingAddress.toJson(
+                model.shippingAddress,
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): Order => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+        customerId: json['customerId'],
+        status: json['status'],
+        items: (json['items'] as Array<any>).map($IO.OrderItemsItem.fromJson),
+        totalAmount: json['totalAmount'],
+        ...(json['shippingAddress'] === undefined
+          ? {}
+          : {
+              shippingAddress: $IO.OrderShippingAddress.fromJson(
+                json['shippingAddress'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static OrderItemsItem = {
+    toJson: (model: OrderItemsItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.productId === undefined
+          ? {}
+          : {
+              productId: model.productId,
+            }),
+        ...(model.quantity === undefined
+          ? {}
+          : {
+              quantity: model.quantity,
+            }),
+        ...(model.price === undefined
+          ? {}
+          : {
+              price: model.price,
+            }),
+      };
+    },
+    fromJson: (json: any): OrderItemsItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        productId: json['productId'],
+        quantity: json['quantity'],
+        price: json['price'],
+      };
+    },
+  };
+
+  public static OrderShippingAddress = {
+    toJson: (model: OrderShippingAddress): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.street === undefined
+          ? {}
+          : {
+              street: model.street,
+            }),
+        ...(model.city === undefined
+          ? {}
+          : {
+              city: model.city,
+            }),
+        ...(model.country === undefined
+          ? {}
+          : {
+              country: model.country,
+            }),
+        ...(model.zipCode === undefined
+          ? {}
+          : {
+              zipCode: model.zipCode,
+            }),
+      };
+    },
+    fromJson: (json: any): OrderShippingAddress => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        street: json['street'],
+        city: json['city'],
+        country: json['country'],
+        ...(json['zipCode'] === undefined
+          ? {}
+          : {
+              zipCode: json['zipCode'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getOrders = this.getOrders.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  /**
+   * Get orders using referenced component schema
+   */
+  public async getOrders(input: GetOrdersRequest): Promise<Array<Order>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.GetOrdersRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const collectionFormats = {
+      customerId: 'multi',
+      status: 'multi',
+      limit: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/orders', pathParameters, queryParameters, collectionFormats),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return ((await response.json()) as Array<any>).map($IO.Order.fromJson);
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which returns an array of strings 1`] = `
+"/**
+ * Get an array of category names
+ */
+export type GetCategoriesRequestQueryParameters = {
+  filter?: string;
+};
+
+export type GetCategoriesRequest = GetCategoriesRequestQueryParameters;
+export type GetCategoriesError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - arrays > should handle operation which returns an array of strings 2`] = `
+"import type {
+  GetCategoriesRequestQueryParameters,
+  GetCategoriesRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetCategoriesRequestQueryParameters = {
+    toJson: (model: GetCategoriesRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.filter === undefined
+          ? {}
+          : {
+              filter: model.filter,
+            }),
+      };
+    },
+    fromJson: (json: any): GetCategoriesRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['filter'] === undefined
+          ? {}
+          : {
+              filter: json['filter'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getCategories = this.getCategories.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  /**
+   * Get an array of category names
+   */
+  public async getCategories(
+    input: GetCategoriesRequest,
+  ): Promise<Array<string>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.GetCategoriesRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const collectionFormats = {
+      filter: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/get-categories',
+        pathParameters,
+        queryParameters,
+        collectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -1002,9 +1002,7 @@ export class TestApi {
     const body =
       input === undefined
         ? undefined
-        : typeof input === 'object'
-          ? JSON.stringify(input === null ? null : input)
-          : String(input === null ? null : input);
+        : JSON.stringify(input === null ? null : input);
 
     const response = await this.$fetch(
       this.$url('/single-nullable-array', pathParameters, queryParameters),
@@ -1547,12 +1545,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const body =
-      input === undefined
-        ? undefined
-        : typeof input === 'object'
-          ? JSON.stringify(input)
-          : String(input);
+    const body = input === undefined ? undefined : JSON.stringify(input);
 
     const response = await this.$fetch(
       this.$url(
@@ -1584,12 +1577,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const body =
-      input === undefined
-        ? undefined
-        : typeof input === 'object'
-          ? JSON.stringify(input)
-          : String(input);
+    const body = input === undefined ? undefined : JSON.stringify(input);
 
     const response = await this.$fetch(
       this.$url('/array-of-maps-of-numbers', pathParameters, queryParameters),

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -1060,12 +1060,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const body =
-      input === undefined
-        ? undefined
-        : typeof input === 'object'
-          ? JSON.stringify(input)
-          : String(input);
+    const body = input === undefined ? undefined : JSON.stringify(input);
 
     const response = await this.$fetch(
       this.$url('/arrays', pathParameters, queryParameters),
@@ -1100,17 +1095,10 @@ export class TestApi {
     const body =
       input === undefined
         ? undefined
-        : typeof input === 'object'
-          ? JSON.stringify(
-              $IO.TestArraysWithOtherParametersRequestBodyParameters.toJson(
-                input,
-              ).body,
-            )
-          : String(
-              $IO.TestArraysWithOtherParametersRequestBodyParameters.toJson(
-                input,
-              ).body,
-            );
+        : JSON.stringify(
+            $IO.TestArraysWithOtherParametersRequestBodyParameters.toJson(input)
+              .body,
+          );
 
     const response = await this.$fetch(
       this.$url(

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -391,9 +391,25 @@ export class <%- className %> {
     <%_ } else if (op.parametersBody.isPrimitive || ["binary", "any", "unknown"].includes(op.parametersBody.type) || op.parametersBody.isEnum || op.parametersBody.export === 'enum') { _%>
     const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>input<%- op.explicitRequestBodyParameter ? `.${op.explicitRequestBodyParameter.typescriptName}` : '' %><%- op.parametersBody.type === 'unknown' ? ' as any' : '' %>;
     <%_ } else if (op.explicitRequestBodyParameter) { _%>
-    const body = <% if (!op.explicitRequestBodyParameter.isRequired) { %>input === undefined ? undefined : <% } %>(typeof input === 'object' ? JSON.stringify($IO.<%- op.operationIdPascalCase %>RequestBodyParameters.toJson(input).<%- op.explicitRequestBodyParameter.prop %>) : String($IO.<%- op.operationIdPascalCase %>RequestBodyParameters.toJson(input).<%- op.explicitRequestBodyParameter.prop %>));
+    const body = <% if (!op.explicitRequestBodyParameter.isRequired) { %>input === undefined ? undefined : <% } %>(
+      <%_ if (op.explicitRequestBodyParameter.export !== 'array') { _%>
+      typeof input === 'object' ?
+      <%_ } _%>
+      JSON.stringify($IO.<%- op.operationIdPascalCase %>RequestBodyParameters.toJson(input).<%- op.explicitRequestBodyParameter.prop %>)
+      <%_ if (op.explicitRequestBodyParameter.export !== 'array') { _%>
+      : String($IO.<%- op.operationIdPascalCase %>RequestBodyParameters.toJson(input).<%- op.explicitRequestBodyParameter.prop %>)
+      <%_ } _%>
+      );
     <%_ } else { _%>
-    const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>(typeof input === 'object' ? JSON.stringify(<%- renderToJsonValue(op.parametersBody, 'input') %>) : String(<%- renderToJsonValue(op.parametersBody, 'input') %>));
+    const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>(
+      <%_ if (op.parametersBody.export !== 'array') { _%>
+      typeof input === 'object' ?
+      <%_ } _%>
+      JSON.stringify(<%- renderToJsonValue(op.parametersBody, 'input') %>)
+      <%_ if (op.parametersBody.export !== 'array') { _%>
+      : String(<%- renderToJsonValue(op.parametersBody, 'input') %>)
+      <%_ } _%>
+    );
     <%_ } _%>
     <%_ } else { %>
     const body = undefined;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.arrays.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.arrays.spec.ts
@@ -1,0 +1,779 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { Spec } from '../utils/types';
+import {
+  baseUrl,
+  callGeneratedClient,
+  expectTypeScriptToCompile,
+} from './generator.utils.spec';
+import { Tree } from '@nx/devkit';
+
+describe('openApiTsClientGenerator - arrays', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths);
+  };
+
+  it('should handle operation which accepts an array of strings', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/process-tags': {
+          post: {
+            operationId: 'processTags',
+            description: 'Process an array of string tags',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'Success',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        processed: { type: 'number' },
+                        message: { type: 'string' },
+                      },
+                      required: ['processed', 'message'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        processed: 3,
+        message: 'Tags processed successfully',
+      }),
+    });
+
+    const tags = ['tag1', 'tag2', 'tag3'];
+    const response = await callGeneratedClient(
+      client,
+      mockFetch,
+      'processTags',
+      tags,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/process-tags`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(tags),
+      }),
+    );
+    expect(response).toEqual({
+      processed: 3,
+      message: 'Tags processed successfully',
+    });
+  });
+
+  it('should handle operation which accepts an array of objects', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/process-users': {
+          post: {
+            operationId: 'processUsers',
+            description: 'Process an array of user objects',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                        email: { type: 'string' },
+                        age: { type: 'number' },
+                        active: { type: 'boolean' },
+                      },
+                      required: ['id', 'name', 'email'],
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'Success',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        processed: { type: 'number' },
+                        status: { type: 'string' },
+                      },
+                      required: ['processed', 'status'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        processed: 2,
+        status: 'completed',
+      }),
+    });
+
+    const users = [
+      {
+        id: '1',
+        name: 'John Doe',
+        email: 'john@example.com',
+        age: 30,
+        active: true,
+      },
+      {
+        id: '2',
+        name: 'Jane Smith',
+        email: 'jane@example.com',
+        age: 25,
+        active: false,
+      },
+    ];
+
+    const response = await callGeneratedClient(
+      client,
+      mockFetch,
+      'processUsers',
+      users,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/process-users`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(users),
+      }),
+    );
+    expect(response).toEqual({
+      processed: 2,
+      status: 'completed',
+    });
+  });
+
+  it('should handle operation which returns an array of strings', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/get-categories': {
+          get: {
+            operationId: 'getCategories',
+            description: 'Get an array of category names',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of categories',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+    const expectedCategories = ['electronics', 'clothing', 'books', 'home'];
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue(expectedCategories),
+    });
+
+    const response = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getCategories',
+      {
+        filter: 'active',
+      },
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/get-categories?filter=active`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(response).toEqual(expectedCategories);
+  });
+
+  it('should handle operation which returns an array of objects', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/get-products': {
+          get: {
+            operationId: 'getProducts',
+            description: 'Get an array of product objects',
+            parameters: [
+              {
+                name: 'category',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'number' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of products',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          id: { type: 'string' },
+                          name: { type: 'string' },
+                          price: { type: 'number' },
+                          description: { type: 'string' },
+                          inStock: { type: 'boolean' },
+                          tags: {
+                            type: 'array',
+                            items: { type: 'string' },
+                          },
+                          metadata: {
+                            type: 'object',
+                            properties: {
+                              weight: { type: 'number' },
+                              dimensions: { type: 'string' },
+                            },
+                          },
+                        },
+                        required: ['id', 'name', 'price'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+    const expectedProducts = [
+      {
+        id: 'prod-1',
+        name: 'Laptop',
+        price: 999.99,
+        description: 'High-performance laptop',
+        inStock: true,
+        tags: ['electronics', 'computers'],
+        metadata: {
+          weight: 2.5,
+          dimensions: '30x20x2 cm',
+        },
+      },
+      {
+        id: 'prod-2',
+        name: 'Mouse',
+        price: 29.99,
+        description: 'Wireless mouse',
+        inStock: false,
+        tags: ['electronics', 'accessories'],
+        metadata: {
+          weight: 0.1,
+          dimensions: '10x6x3 cm',
+        },
+      },
+    ];
+
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue(expectedProducts),
+    });
+
+    const response = await callGeneratedClient(
+      client,
+      mockFetch,
+      'getProducts',
+      {
+        category: 'electronics',
+        limit: 10,
+      },
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/get-products?category=electronics&limit=10`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(response).toEqual(expectedProducts);
+  });
+
+  it('should handle operation which accepts an array of objects referenced from components', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      components: {
+        schemas: {
+          Customer: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              email: { type: 'string', format: 'email' },
+              phone: { type: 'string' },
+              address: {
+                type: 'object',
+                properties: {
+                  street: { type: 'string' },
+                  city: { type: 'string' },
+                  country: { type: 'string' },
+                  zipCode: { type: 'string' },
+                },
+                required: ['street', 'city', 'country'],
+              },
+              preferences: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+            required: ['id', 'name', 'email'],
+          },
+        },
+      },
+      paths: {
+        '/batch-customers': {
+          post: {
+            operationId: 'batchCreateCustomers',
+            description:
+              'Create multiple customers from referenced component schema',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Customer',
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '201': {
+                description: 'Customers created successfully',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        created: { type: 'number' },
+                        customerIds: {
+                          type: 'array',
+                          items: { type: 'string' },
+                        },
+                      },
+                      required: ['created', 'customerIds'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 201,
+      json: vi.fn().mockResolvedValue({
+        created: 2,
+        customerIds: ['cust-001', 'cust-002'],
+      }),
+    });
+
+    const customers = [
+      {
+        id: 'cust-001',
+        name: 'Alice Johnson',
+        email: 'alice@example.com',
+        phone: '+1-555-0101',
+        address: {
+          street: '123 Main St',
+          city: 'New York',
+          country: 'USA',
+          zipCode: '10001',
+        },
+        preferences: ['email-notifications', 'sms-alerts'],
+      },
+      {
+        id: 'cust-002',
+        name: 'Bob Smith',
+        email: 'bob@example.com',
+        phone: '+1-555-0102',
+        address: {
+          street: '456 Oak Ave',
+          city: 'Los Angeles',
+          country: 'USA',
+        },
+        preferences: ['email-notifications'],
+      },
+    ];
+
+    const response = await callGeneratedClient(
+      client,
+      mockFetch,
+      'batchCreateCustomers',
+      customers,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/batch-customers`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(customers),
+      }),
+    );
+    expect(response).toEqual({
+      created: 2,
+      customerIds: ['cust-001', 'cust-002'],
+    });
+  });
+
+  it('should handle operation which returns an array of objects referenced from components', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      components: {
+        schemas: {
+          Order: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              customerId: { type: 'string' },
+              status: {
+                type: 'string',
+                enum: [
+                  'pending',
+                  'processing',
+                  'shipped',
+                  'delivered',
+                  'cancelled',
+                ],
+              },
+              items: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    productId: { type: 'string' },
+                    quantity: { type: 'number' },
+                    price: { type: 'number' },
+                  },
+                  required: ['productId', 'quantity', 'price'],
+                },
+              },
+              totalAmount: { type: 'number' },
+              shippingAddress: {
+                type: 'object',
+                properties: {
+                  street: { type: 'string' },
+                  city: { type: 'string' },
+                  country: { type: 'string' },
+                  zipCode: { type: 'string' },
+                },
+                required: ['street', 'city', 'country'],
+              },
+            },
+            required: ['id', 'customerId', 'status', 'items', 'totalAmount'],
+          },
+        },
+      },
+      paths: {
+        '/orders': {
+          get: {
+            operationId: 'getOrders',
+            description: 'Get orders using referenced component schema',
+            parameters: [
+              {
+                name: 'customerId',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'status',
+                in: 'query',
+                schema: {
+                  type: 'string',
+                  enum: [
+                    'pending',
+                    'processing',
+                    'shipped',
+                    'delivered',
+                    'cancelled',
+                  ],
+                },
+              },
+              {
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'number' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of orders',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        $ref: '#/components/schemas/Order',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+
+    const mockFetch = vi.fn();
+    const expectedOrders = [
+      {
+        id: 'order-001',
+        customerId: 'cust-001',
+        status: 'processing',
+        items: [
+          {
+            productId: 'prod-001',
+            quantity: 2,
+            price: 29.99,
+          },
+          {
+            productId: 'prod-002',
+            quantity: 1,
+            price: 149.99,
+          },
+        ],
+        totalAmount: 209.97,
+        shippingAddress: {
+          street: '123 Main St',
+          city: 'New York',
+          country: 'USA',
+          zipCode: '10001',
+        },
+      },
+      {
+        id: 'order-002',
+        customerId: 'cust-001',
+        status: 'shipped',
+        items: [
+          {
+            productId: 'prod-003',
+            quantity: 1,
+            price: 79.99,
+          },
+        ],
+        totalAmount: 79.99,
+        shippingAddress: {
+          street: '123 Main St',
+          city: 'New York',
+          country: 'USA',
+          zipCode: '10001',
+        },
+      },
+    ];
+
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue(expectedOrders),
+    });
+
+    const response = await callGeneratedClient(client, mockFetch, 'getOrders', {
+      customerId: 'cust-001',
+      status: 'processing',
+      limit: 10,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/orders?customerId=cust-001&status=processing&limit=10`,
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(response).toEqual(expectedOrders);
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-client/generator.petstore.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.petstore.spec.ts
@@ -1,0 +1,843 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { Spec } from '../utils/types';
+import { expectTypeScriptToCompile } from './generator.utils.spec';
+import { Tree } from '@nx/devkit';
+
+export const PET_STORE_SPEC: Spec = {
+  openapi: '3.0.4',
+  info: {
+    title: 'Swagger Petstore - OpenAPI 3.0',
+    description:
+      "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    termsOfService: 'https://swagger.io/terms/',
+    contact: { email: 'apiteam@swagger.io' },
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html',
+    },
+    version: '1.0.26',
+  },
+  externalDocs: {
+    description: 'Find out more about Swagger',
+    url: 'https://swagger.io',
+  },
+  servers: [{ url: '/api/v3' }],
+  tags: [
+    {
+      name: 'pet',
+      description: 'Everything about your Pets',
+      externalDocs: { description: 'Find out more', url: 'https://swagger.io' },
+    },
+    {
+      name: 'store',
+      description: 'Access to Petstore orders',
+      externalDocs: {
+        description: 'Find out more about our store',
+        url: 'https://swagger.io',
+      },
+    },
+    { name: 'user', description: 'Operations about user' },
+  ],
+  paths: {
+    '/pet': {
+      put: {
+        tags: ['pet'],
+        summary: 'Update an existing pet.',
+        description: 'Update an existing pet by Id.',
+        operationId: 'updatePet',
+        requestBody: {
+          description: 'Update an existent pet in the store',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/Pet' },
+            },
+            'application/xml': { schema: { $ref: '#/components/schemas/Pet' } },
+            'application/x-www-form-urlencoded': {
+              schema: { $ref: '#/components/schemas/Pet' },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+            },
+          },
+          '400': { description: 'Invalid ID supplied' },
+          '404': { description: 'Pet not found' },
+          '422': { description: 'Validation exception' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+      post: {
+        tags: ['pet'],
+        summary: 'Add a new pet to the store.',
+        description: 'Add a new pet to the store.',
+        operationId: 'addPet',
+        requestBody: {
+          description: 'Create a new pet in the store',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/Pet' },
+            },
+            'application/xml': { schema: { $ref: '#/components/schemas/Pet' } },
+            'application/x-www-form-urlencoded': {
+              schema: { $ref: '#/components/schemas/Pet' },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+            },
+          },
+          '400': { description: 'Invalid input' },
+          '422': { description: 'Validation exception' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+    },
+    '/pet/findByStatus': {
+      get: {
+        tags: ['pet'],
+        summary: 'Finds Pets by status.',
+        description:
+          'Multiple status values can be provided with comma separated strings.',
+        operationId: 'findPetsByStatus',
+        parameters: [
+          {
+            name: 'status',
+            in: 'query',
+            description: 'Status values that need to be considered for filter',
+            required: false,
+            explode: true,
+            schema: {
+              type: 'string',
+              default: 'available',
+              enum: ['available', 'pending', 'sold'],
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+              'application/xml': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid status value' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+    },
+    '/pet/findByTags': {
+      get: {
+        tags: ['pet'],
+        summary: 'Finds Pets by tags.',
+        description:
+          'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.',
+        operationId: 'findPetsByTags',
+        parameters: [
+          {
+            name: 'tags',
+            in: 'query',
+            description: 'Tags to filter by',
+            required: false,
+            explode: true,
+            schema: { type: 'array', items: { type: 'string' } },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+              'application/xml': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+            },
+          },
+          '400': { description: 'Invalid tag value' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+    },
+    '/pet/{petId}': {
+      get: {
+        tags: ['pet'],
+        summary: 'Find pet by ID.',
+        description: 'Returns a single pet.',
+        operationId: 'getPetById',
+        parameters: [
+          {
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet to return',
+            required: true,
+            schema: { type: 'integer', format: 'int64' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+            },
+          },
+          '400': { description: 'Invalid ID supplied' },
+          '404': { description: 'Pet not found' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [
+          { api_key: [] },
+          { petstore_auth: ['write:pets', 'read:pets'] },
+        ],
+      },
+      post: {
+        tags: ['pet'],
+        summary: 'Updates a pet in the store with form data.',
+        description: 'Updates a pet resource based on the form data.',
+        operationId: 'updatePetWithForm',
+        parameters: [
+          {
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet that needs to be updated',
+            required: true,
+            schema: { type: 'integer', format: 'int64' },
+          },
+          {
+            name: 'name',
+            in: 'query',
+            description: 'Name of pet that needs to be updated',
+            schema: { type: 'string' },
+          },
+          {
+            name: 'status',
+            in: 'query',
+            description: 'Status of pet that needs to be updated',
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/Pet' },
+              },
+            },
+          },
+          '400': { description: 'Invalid input' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+      delete: {
+        tags: ['pet'],
+        summary: 'Deletes a pet.',
+        description: 'Delete a pet.',
+        operationId: 'deletePet',
+        parameters: [
+          {
+            name: 'api_key',
+            in: 'header',
+            description: '',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'petId',
+            in: 'path',
+            description: 'Pet id to delete',
+            required: true,
+            schema: { type: 'integer', format: 'int64' },
+          },
+        ],
+        responses: {
+          '200': { description: 'Pet deleted' },
+          '400': { description: 'Invalid pet value' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+    },
+    '/pet/{petId}/uploadImage': {
+      post: {
+        tags: ['pet'],
+        summary: 'Uploads an image.',
+        description: 'Upload image of the pet.',
+        operationId: 'uploadFile',
+        parameters: [
+          {
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet to update',
+            required: true,
+            schema: { type: 'integer', format: 'int64' },
+          },
+          {
+            name: 'additionalMetadata',
+            in: 'query',
+            description: 'Additional Metadata',
+            required: false,
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/octet-stream': {
+              schema: { type: 'string', format: 'binary' },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ApiResponse' },
+              },
+            },
+          },
+          '400': { description: 'No file uploaded' },
+          '404': { description: 'Pet not found' },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ petstore_auth: ['write:pets', 'read:pets'] }],
+      },
+    },
+    '/store/inventory': {
+      get: {
+        tags: ['store'],
+        summary: 'Returns pet inventories by status.',
+        description: 'Returns a map of status codes to quantities.',
+        operationId: 'getInventory',
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: { type: 'integer', format: 'int32' },
+                },
+              },
+            },
+          },
+          default: { description: 'Unexpected error' },
+        },
+        security: [{ api_key: [] }],
+      },
+    },
+    '/store/order': {
+      post: {
+        tags: ['store'],
+        summary: 'Place an order for a pet.',
+        description: 'Place a new order in the store.',
+        operationId: 'placeOrder',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/Order' },
+            },
+            'application/xml': {
+              schema: { $ref: '#/components/schemas/Order' },
+            },
+            'application/x-www-form-urlencoded': {
+              schema: { $ref: '#/components/schemas/Order' },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Order' },
+              },
+            },
+          },
+          '400': { description: 'Invalid input' },
+          '422': { description: 'Validation exception' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+    '/store/order/{orderId}': {
+      get: {
+        tags: ['store'],
+        summary: 'Find purchase order by ID.',
+        description:
+          'For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.',
+        operationId: 'getOrderById',
+        parameters: [
+          {
+            name: 'orderId',
+            in: 'path',
+            description: 'ID of order that needs to be fetched',
+            required: true,
+            schema: { type: 'integer', format: 'int64' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Order' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/Order' },
+              },
+            },
+          },
+          '400': { description: 'Invalid ID supplied' },
+          '404': { description: 'Order not found' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+      delete: {
+        tags: ['store'],
+        summary: 'Delete purchase order by identifier.',
+        description:
+          'For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.',
+        operationId: 'deleteOrder',
+        parameters: [
+          {
+            name: 'orderId',
+            in: 'path',
+            description: 'ID of the order that needs to be deleted',
+            required: true,
+            schema: { type: 'integer', format: 'int64' },
+          },
+        ],
+        responses: {
+          '200': { description: 'order deleted' },
+          '400': { description: 'Invalid ID supplied' },
+          '404': { description: 'Order not found' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+    '/user': {
+      post: {
+        tags: ['user'],
+        summary: 'Create user.',
+        description: 'This can only be done by the logged in user.',
+        operationId: 'createUser',
+        requestBody: {
+          description: 'Created user object',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/User' },
+            },
+            'application/xml': {
+              schema: { $ref: '#/components/schemas/User' },
+            },
+            'application/x-www-form-urlencoded': {
+              schema: { $ref: '#/components/schemas/User' },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+    '/user/createWithList': {
+      post: {
+        tags: ['user'],
+        summary: 'Creates list of users with given input array.',
+        description: 'Creates list of users with given input array.',
+        operationId: 'createUsersWithListInput',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+    '/user/login': {
+      get: {
+        tags: ['user'],
+        summary: 'Logs user into the system.',
+        description: 'Log into the system.',
+        operationId: 'loginUser',
+        parameters: [
+          {
+            name: 'username',
+            in: 'query',
+            description: 'The user name for login',
+            required: false,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'password',
+            in: 'query',
+            description: 'The password for login in clear text',
+            required: false,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            headers: {
+              'X-Rate-Limit': {
+                description: 'calls per hour allowed by the user',
+                schema: { type: 'integer', format: 'int32' },
+              },
+              'X-Expires-After': {
+                description: 'date in UTC when token expires',
+                schema: { type: 'string', format: 'date-time' },
+              },
+            },
+            content: {
+              'application/xml': { schema: { type: 'string' } },
+              'application/json': { schema: { type: 'string' } },
+            },
+          },
+          '400': { description: 'Invalid username/password supplied' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+    '/user/logout': {
+      get: {
+        tags: ['user'],
+        summary: 'Logs out current logged in user session.',
+        description: 'Log user out of the system.',
+        operationId: 'logoutUser',
+        parameters: [],
+        responses: {
+          '200': { description: 'successful operation' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+    '/user/{username}': {
+      get: {
+        tags: ['user'],
+        summary: 'Get user by user name.',
+        description: 'Get user detail based on username.',
+        operationId: 'getUserByName',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            description:
+              'The name that needs to be fetched. Use user1 for testing',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+              'application/xml': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+          '400': { description: 'Invalid username supplied' },
+          '404': { description: 'User not found' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+      put: {
+        tags: ['user'],
+        summary: 'Update user resource.',
+        description: 'This can only be done by the logged in user.',
+        operationId: 'updateUser',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            description: 'name that need to be deleted',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          description: 'Update an existent user in the store',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/User' },
+            },
+            'application/xml': {
+              schema: { $ref: '#/components/schemas/User' },
+            },
+            'application/x-www-form-urlencoded': {
+              schema: { $ref: '#/components/schemas/User' },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'successful operation' },
+          '400': { description: 'bad request' },
+          '404': { description: 'user not found' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+      delete: {
+        tags: ['user'],
+        summary: 'Delete user resource.',
+        description: 'This can only be done by the logged in user.',
+        operationId: 'deleteUser',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            description: 'The name that needs to be deleted',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': { description: 'User deleted' },
+          '400': { description: 'Invalid username supplied' },
+          '404': { description: 'User not found' },
+          default: { description: 'Unexpected error' },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Order: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', format: 'int64', example: 10 },
+          petId: { type: 'integer', format: 'int64', example: 198772 },
+          quantity: { type: 'integer', format: 'int32', example: 7 },
+          shipDate: { type: 'string', format: 'date-time' },
+          status: {
+            type: 'string',
+            description: 'Order Status',
+            example: 'approved',
+            enum: ['placed', 'approved', 'delivered'],
+          },
+          complete: { type: 'boolean' },
+        },
+        xml: { name: 'order' },
+      },
+      Category: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', format: 'int64', example: 1 },
+          name: { type: 'string', example: 'Dogs' },
+        },
+        xml: { name: 'category' },
+      },
+      User: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', format: 'int64', example: 10 },
+          username: { type: 'string', example: 'theUser' },
+          firstName: { type: 'string', example: 'John' },
+          lastName: { type: 'string', example: 'James' },
+          email: { type: 'string', example: 'john@email.com' },
+          password: { type: 'string', example: '12345' },
+          phone: { type: 'string', example: '12345' },
+          userStatus: {
+            type: 'integer',
+            description: 'User Status',
+            format: 'int32',
+            example: 1,
+          },
+        },
+        xml: { name: 'user' },
+      },
+      Tag: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          name: { type: 'string' },
+        },
+        xml: { name: 'tag' },
+      },
+      Pet: {
+        required: ['name', 'photoUrls'],
+        type: 'object',
+        properties: {
+          id: { type: 'integer', format: 'int64', example: 10 },
+          name: { type: 'string', example: 'doggie' },
+          category: { $ref: '#/components/schemas/Category' },
+          photoUrls: {
+            type: 'array',
+            xml: { wrapped: true },
+            items: { type: 'string', xml: { name: 'photoUrl' } },
+          },
+          tags: {
+            type: 'array',
+            xml: { wrapped: true },
+            items: { $ref: '#/components/schemas/Tag' },
+          },
+          status: {
+            type: 'string',
+            description: 'pet status in the store',
+            enum: ['available', 'pending', 'sold'],
+          },
+        },
+        xml: { name: 'pet' },
+      },
+      ApiResponse: {
+        type: 'object',
+        properties: {
+          code: { type: 'integer', format: 'int32' },
+          type: { type: 'string' },
+          message: { type: 'string' },
+        },
+        xml: { name: '##default' },
+      },
+    },
+    requestBodies: {
+      Pet: {
+        description: 'Pet object that needs to be added to the store',
+        content: {
+          'application/json': { schema: { $ref: '#/components/schemas/Pet' } },
+          'application/xml': { schema: { $ref: '#/components/schemas/Pet' } },
+        },
+      },
+      UserArray: {
+        description: 'List of user object',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/User' },
+            },
+          },
+        },
+      },
+    },
+    securitySchemes: {
+      petstore_auth: {
+        type: 'oauth2',
+        flows: {
+          implicit: {
+            authorizationUrl: 'https://petstore3.swagger.io/oauth/authorize',
+            scopes: {
+              'write:pets': 'modify pets in your account',
+              'read:pets': 'read your pets',
+            },
+          },
+        },
+      },
+      api_key: { type: 'apiKey', name: 'api_key', in: 'header' },
+    },
+  },
+};
+
+describe('openApiTsClientGenerator - petstore', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths);
+  };
+
+  it('should generate valid code for the petstore example ', async () => {
+    tree.write('openapi.json', JSON.stringify(PET_STORE_SPEC));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
@@ -33,7 +33,7 @@ import type {
   });
 } _%>
 <%_ const modelsByName = Object.fromEntries(models.map(m => [m.name, m])); _%>
-<%_ uniq(allOperations.flatMap((op) => op.result && modelsByName[op.result.type] ? [op.result.typescriptType] : [])).forEach((returnTypeModel) => { _%>
+<%_ uniq(allOperations.flatMap((op) => op.result && modelsByName[op.result.type] ? [op.result.type] : [])).forEach((returnTypeModel) => { _%>
   <%- returnTypeModel %>,
 <%_ }); _%>
 } from './types.gen.js';

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
@@ -24,6 +24,7 @@ import {
 } from '@tanstack/react-query';
 import React from 'react';
 import { Mock } from 'vitest';
+import { PET_STORE_SPEC } from '../ts-client/generator.petstore.spec';
 
 describe('openApiTsHooksGenerator', () => {
   let tree: Tree;
@@ -1783,5 +1784,20 @@ describe('openApiTsHooksGenerator', () => {
         method: 'GET',
       }),
     );
+  });
+
+  it('should generate valid code for the petstore example ', async () => {
+    tree.write('openapi.json', JSON.stringify(PET_STORE_SPEC));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
   });
 });


### PR DESCRIPTION
### Reason for this change

There were two issues with array requests/responses. Firstly when the request body is an array, we'd get a type error in the client `typeof someArray === 'object'` was always true. Secondly when the response is an array of objects the options proxy would incorrectly import `Array<ObjectType>` which is invalid syntax.

### Description of changes

Fix both issues in the templates

### Description of how you validated changes

Unit tests. Added petstore unit test to both client and hooks which is the default OpenAPI example spec that has lots of mixtures of types.

### Issue # (if applicable)

Fixes #201

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*