### PR TITLE
feat(ts#trpc-api): add hot reload support to tRPC dev server

### DIFF
--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -180,7 +180,7 @@ describe('trpc backend generator', () => {
     expect(projectConfig.targets).toHaveProperty('serve');
     expect(projectConfig.targets!.serve!.executor).toBe('nx:run-commands');
     expect(projectConfig.targets!.serve!.options!.commands).toEqual([
-      'tsx src/local-server.ts',
+      'tsx --watch src/local-server.ts',
     ]);
   });
 

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -117,7 +117,7 @@ export async function tsTrpcApiGenerator(
       config.targets.serve = {
         executor: 'nx:run-commands',
         options: {
-          commands: ['tsx src/local-server.ts'],
+          commands: ['tsx --watch src/local-server.ts'],
           cwd: backendRoot,
         },
         continuous: true,


### PR DESCRIPTION
### Reason for this change

The local tRPC server currently requires manual restarts to apply code changes, which slows down the developer experience. This change adds hot reload functionality to match FastAPI's auto-reload behavior.

### Description of changes

Added `--watch` flag to the tsx command in the tRPC backend generator serve target:
- Modified `packages/nx-plugin/src/trpc/backend/generator.ts` line 120
- Changed from `tsx src/local-server.ts` to `tsx --watch src/local-server.ts`

This leverages tsx's built-in watch functionality for automatic server restarts on file changes.

### Description of how you validated changes

The change is minimal and low-risk - it only adds a standard tsx flag that enables file watching. The `tsx` package with watch support is already available as a dev dependency (v4.19.3).

### Issue # (if applicable)

Closes #207.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

Generated with [Claude Code](https://claude.ai/code)