### PR TITLE
refactor(website): Introduce router context

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
@@ -243,7 +243,6 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import { useAuth } from 'react-oidc-context';
 import { useRuntimeConfig } from './hooks/useRuntimeConfig';
-import { ContextDefinition } from '@aws-sdk/client-verifiedpermissions';
 
 import '@cloudscape-design/global-styles/index.css';
 
@@ -554,7 +553,6 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import { useAuth } from 'react-oidc-context';
 import { useRuntimeConfig } from './hooks/useRuntimeConfig';
-import { ContextDefinition } from '@aws-sdk/client-verifiedpermissions';
 
 import '@cloudscape-design/global-styles/index.css';
 

--- a/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/cloudscape-website/app/__snapshots__/generator.spec.ts.snap
@@ -241,10 +241,24 @@ import { I18nProvider } from '@cloudscape-design/components/i18n';
 import messages from '@cloudscape-design/components/i18n/messages/all.en';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
+import { useAuth } from 'react-oidc-context';
+import { useRuntimeConfig } from './hooks/useRuntimeConfig';
+import { ContextDefinition } from '@aws-sdk/client-verifiedpermissions';
 
 import '@cloudscape-design/global-styles/index.css';
 
-const router = createRouter({ routeTree });
+export type RouterProviderContextType = {
+  auth: ReturnType<typeof useAuth> | undefined;
+  runtimeConfig: ReturnType<typeof useRuntimeConfig> | undefined;
+};
+
+const router = createRouter({
+  routeTree,
+  context: {
+    auth: undefined,
+    runtimeConfig: undefined,
+  },
+});
 
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {
@@ -254,7 +268,9 @@ declare module '@tanstack/react-router' {
 }
 
 const App = () => {
-  return <RouterProvider router={router} />;
+  const auth = useAuth();
+  const runtimeConfig = useRuntimeConfig();
+  return <RouterProvider router={router} context={{ auth, runtimeConfig }} />;
 };
 
 const root = document.getElementById('root');
@@ -536,10 +552,24 @@ import { I18nProvider } from '@cloudscape-design/components/i18n';
 import messages from '@cloudscape-design/components/i18n/messages/all.en';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
+import { useAuth } from 'react-oidc-context';
+import { useRuntimeConfig } from './hooks/useRuntimeConfig';
+import { ContextDefinition } from '@aws-sdk/client-verifiedpermissions';
 
 import '@cloudscape-design/global-styles/index.css';
 
-const router = createRouter({ routeTree });
+export type RouterProviderContextType = {
+  auth: ReturnType<typeof useAuth> | undefined;
+  runtimeConfig: ReturnType<typeof useRuntimeConfig> | undefined;
+};
+
+const router = createRouter({
+  routeTree,
+  context: {
+    auth: undefined,
+    runtimeConfig: undefined,
+  },
+});
 
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {
@@ -549,7 +579,9 @@ declare module '@tanstack/react-router' {
 }
 
 const App = () => {
-  return <RouterProvider router={router} />;
+  const auth = useAuth();
+  const runtimeConfig = useRuntimeConfig();
+  return <RouterProvider router={router} context={{ auth, runtimeConfig }} />;
 };
 
 const root = document.getElementById('root');

--- a/packages/nx-plugin/src/cloudscape-website/app/files/app/src/main.tsx.template
+++ b/packages/nx-plugin/src/cloudscape-website/app/files/app/src/main.tsx.template
@@ -6,7 +6,6 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import { useAuth } from 'react-oidc-context';
 import { useRuntimeConfig } from './hooks/useRuntimeConfig';
-import { ContextDefinition } from '@aws-sdk/client-verifiedpermissions';
 
 import '@cloudscape-design/global-styles/index.css';
 

--- a/packages/nx-plugin/src/cloudscape-website/app/files/app/src/main.tsx.template
+++ b/packages/nx-plugin/src/cloudscape-website/app/files/app/src/main.tsx.template
@@ -4,10 +4,24 @@ import { I18nProvider } from '@cloudscape-design/components/i18n';
 import messages from '@cloudscape-design/components/i18n/messages/all.en';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
+import { useAuth } from 'react-oidc-context';
+import { useRuntimeConfig } from './hooks/useRuntimeConfig';
+import { ContextDefinition } from '@aws-sdk/client-verifiedpermissions';
 
 import '@cloudscape-design/global-styles/index.css';
 
-const router = createRouter({ routeTree });
+export type RouterProviderContextType = {
+  auth: ReturnType<typeof useAuth> | undefined;
+  runtimeConfig: ReturnType<typeof useRuntimeConfig> | undefined;
+};
+
+const router = createRouter({
+  routeTree,
+  context: {
+    auth: undefined,
+    runtimeConfig: undefined,
+  },
+});
 
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {
@@ -17,7 +31,9 @@ declare module '@tanstack/react-router' {
 }
 
 const App = () => {
-  return <RouterProvider router={router}/>;
+  const auth = useAuth();
+  const runtimeConfig = useRuntimeConfig();
+  return <RouterProvider router={router} context={{ auth, runtimeConfig }} />;
 };
 
 const root = document.getElementById('root');

--- a/packages/nx-plugin/src/cloudscape-website/app/files/app/src/routes/__root.tsx.template
+++ b/packages/nx-plugin/src/cloudscape-website/app/files/app/src/routes/__root.tsx.template
@@ -1,6 +1,7 @@
-import { createRootRoute } from '@tanstack/react-router';
+import { createRootRouteWithContext } from '@tanstack/react-router';
 import AppLayout from '../components/AppLayout';
+import { RouterProviderContextType } from '../main';
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<RouterProviderContextType>()({
   component: () => <AppLayout />,
 });


### PR DESCRIPTION
### Reason for this change

With the introduction of Verified Permissions, a method is needed to pass context into the router. This allows for authentication, runtimeConfig and other data to be used in routing decisions (such as authentication and authorization).

### Description of changes

Introduction of a RouterProviderContextType that includes and auth and runtime object. These are provided to the RouterProvider in the RouterProvider of main.tsx. This also introduces createRootRouteWithContext into __root.tsx.

### Description of how you validated changes

All builds and tests (including snapshots) tested locally.

### Issue # (if applicable)


### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*