### PR TITLE
fix(py): ensure bundle target only bundles required dependencies

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/3.mdx
@@ -104,7 +104,7 @@ Now we will update the `story_api` to support the [Lambda Web Adapter](https://g
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -208,11 +208,11 @@ function acurl {
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```

--- a/docs/src/content/docs/en/guides/python-project.mdx
+++ b/docs/src/content/docs/en/guides/python-project.mdx
@@ -56,13 +56,25 @@ Add your Python source code in the `<module-name>` directory.
 
 ### Importing your Library Code in Other Projects
 
-Since [UV workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) are set up for you, you can reference your Python project from any other Python project in your workspace:
+Use the `add` target to add a dependency to a Python project.
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+Suppose we have created two python projects, `my_app` and `my_lib`. These will have fully qualified project names of `my_scope.my_app` and `my_scope.my_lib`, and by default will each have module names of `my_scope_my_app` and `my_scope_my_lib`.
+
+For `my_app` to depend on `my_lib`, we can run the following command:
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+We use the fully qualified project name for both the dependant and dependee. We can use the shorthand syntax for the project we want to add the dependency to, but must fully qualify the name of the project to depend on.
+:::
+
+You can then import your library code:
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-Above, `my_library` is the module name, `hello` corresponds to the Python source file `hello.py`, and `say_hello` is a method defined in `hello.py`
+Above, `my_scope_my_lib` is the module name for the lib, `hello` corresponds to the Python source file `hello.py`, and `say_hello` is a method defined in `hello.py`
 
 ### Dependencies
 
@@ -87,7 +99,7 @@ When you use your Python project as runtime code (for example as the handler for
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/3.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Juego de Mazmorra con IA"
-description: "Un tutorial de cómo construir un juego de aventuras de mazmorra con IA utilizando el @aws/nx-plugin."
+description: "Un tutorial de cómo construir un juego de aventuras de mazmorra con IA usando el @aws/nx-plugin."
 ---
 
 
@@ -29,15 +29,15 @@ import gameConversationPng from '@assets/game-conversation.png'
 Asegúrate de haber otorgado acceso al modelo **Anthropic Claude 3.5 Sonnet v2** siguiendo los pasos descritos en [esta guía](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-La StoryApi consta de una única API `generate_story` que, dado un `Game` y una lista de `Action`s como contexto, generará una progresión de la historia. Esta API se implementará como una API de streaming en Python/FastAPI y demostrará cómo realizar modificaciones al código generado para adaptarlo a su propósito.
+La StoryApi consta de una única API `generate_story` que, dado un `Game` y una lista de `Action`s como contexto, generará una progresión de la historia. Esta API se implementará como una API de streaming en Python/FastAPI y además demostrará cómo se pueden realizar modificaciones al código generado para adaptarlo a su propósito.
 
 ### Implementación de la API
 
 Para crear nuestra API, primero necesitamos instalar algunas dependencias adicionales:
 
-- `boto3` se usará para interactuar con Amazon Bedrock;
-- `uvicorn` se utilizará para iniciar nuestra API en combinación con el [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter);
-- `copyfiles` es una dependencia de npm necesaria para soportar la copia multiplataforma de archivos al actualizar nuestra tarea `bundle`.
+- `boto3` se usará para llamar a Amazon Bedrock;
+- `uvicorn` se usará para iniciar nuestra API en conjunto con el [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter).
+- `copyfiles` es una dependencia de npm que necesitaremos para soportar la copia multiplataforma de archivos al actualizar nuestra tarea `bundle`.
 
 Para instalar estas dependencias, ejecuta los siguientes comandos:
 
@@ -54,7 +54,7 @@ Ahora reemplazaremos el contenido de los siguientes archivos en `packages/story_
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-El cambio anterior en `init.py` simplemente elimina el middleware CORS para evitar conflictos con el manejo de cabeceras CORS propio de las Lambda Function URLs.
+El cambio anterior en `init.py` simplemente elimina el middleware CORS para evitar conflictos con el manejo propio de cabeceras CORS de Lambda Function URL.
 :::
 
 </TabItem>
@@ -62,20 +62,20 @@ El cambio anterior en `init.py` simplemente elimina el middleware CORS para evit
 
 Analizando el código anterior:
 
-- Usamos la configuración `x-streaming` para indicar que es una API de streaming al generar nuestro SDK cliente. Esto nos permitirá consumir esta API en modo streaming manteniendo la seguridad de tipos.
-- Nuestra API simplemente devuelve un flujo de texto definido por `media_type="text/plain"` y `response_class=PlainTextResponse`
+- Usamos la configuración `x-streaming` para indicar que esta es una API de streaming cuando generemos nuestro SDK cliente. ¡Esto nos permitirá consumir esta API en modo streaming manteniendo la seguridad de tipos!
+- Nuestra API simplemente devuelve un flujo de texto definido tanto por `media_type="text/plain"` como por `response_class=PlainTextResponse`
 
 :::note
-Cada vez que realices cambios en tu FastAPI, necesitarás reconstruir el proyecto para ver esos cambios reflejados en el cliente generado en tu sitio web.
+Cada vez que realices cambios en tu FastAPI, necesitarás reconstruir tu proyecto para ver esos cambios reflejados en el cliente generado en tu sitio web.
 
-Haremos algunos cambios más antes de reconstruir.
+Haremos algunos cambios más a continuación antes de reconstruir.
 :::
 
 ### Infraestructura
 
-La <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestructura configurada previamente</Link> asume que todas las APIs usan API Gateway integrado con funciones Lambda. Para nuestra `story_api` no queremos usar API Gateway ya que no soporta respuestas en streaming. En su lugar, usaremos una [Lambda Function URL configurada con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+La <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestructura que configuramos anteriormente</Link> asume que todas las APIs tienen una API Gateway integrada con funciones Lambda. Para nuestra `story_api` no queremos usar API Gateway ya que no soporta respuestas en streaming. En su lugar, usaremos una [Lambda Function URL configurada con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Para implementar esto, actualizaremos primero nuestros constructos de CDK:
+Para soportar esto, primero actualizaremos nuestros constructos de CDK de la siguiente manera:
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ Para implementar esto, actualizaremos primero nuestros constructos de CDK:
 </TabItem>
 </Tabs>
 
-Ahora actualizaremos la `story_api` para soportar el despliegue con [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter):
+Ahora actualizaremos la `story_api` para soportar el despliegue con [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
 
 <Tabs>
 <TabItem label="run.sh">
@@ -106,7 +106,7 @@ Ahora actualizaremos la `story_api` para soportar el despliegue con [Lambda Web 
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -123,33 +123,33 @@ Ahora actualizaremos la `story_api` para soportar el despliegue con [Lambda Web 
 
 ### Despliegue y pruebas
 
-Primero, construyamos el código base:
+Primero, construyamos la base de código:
 
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-Si encuentras errores de linting, puedes ejecutar este comando para corregirlos automáticamente:
+Si encuentras errores de linting, puedes ejecutar el siguiente comando para corregirlos automáticamente.
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-Ahora puedes desplegar la aplicación ejecutando:
+Ahora puedes desplegar tu aplicación ejecutando el siguiente comando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-Este despliegue tomará aproximadamente 2 minutos.
+Este despliegue tomará aproximadamente 2 minutos en completarse.
 
-<Drawer title="Comando de despliegue" trigger="También puedes desplegar todos los stacks a la vez. Haz clic para más detalles.">
+<Drawer title="Comando de despliegue" trigger="También puedes desplegar todos los stacks a la vez. Haz clic aquí para más detalles.">
 
-Puedes desplegar todos los stacks de la aplicación CDK ejecutando:
+También puedes desplegar todos los stacks contenidos en la aplicación CDK ejecutando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Esto **no se recomienda** ya que podrías tener stacks separados para diferentes etapas de despliegue (ej. infra-prod). En ese caso, el flag `--all` intentaría desplegar todo, pudiendo resultar en despliegues no deseados.
+Esto **no se recomienda** ya que podrías elegir separar tus etapas de despliegue como stacks separados `ej. infra-prod`. En este caso, el flag `--all` intentará desplegar todos los stacks lo que puede resultar en despliegues no deseados.
 
 </Drawer>
 
-Una vez completado el despliegue, verás salidas similares a estas _(algunos valores fueron omitidos)_:
+Una vez completado el despliegue, deberías ver algunas salidas similares a las siguientes _(algunos valores han sido omitidos)_:
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -168,16 +168,15 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = regi
 dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
-Podemos probar nuestra API de dos formas:
+Podemos probar nuestra API de dos maneras:
 <ul>
-<li>Iniciando una instancia local del servidor FastAPI e invocando las APIs con `curl`</li>
+<li>Iniciando una instancia local del servidor FastAPI e invocando las APIs usando `curl`.</li>
 <li>
-<Drawer title="curl con Sigv4 habilitado" trigger="Llamar directamente a la API desplegada usando curl con Sigv4">
+<Drawer title="Curl con Sigv4 habilitado" trigger="Llamando a la API desplegada usando curl con Sigv4 directamente">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Puedes agregar este script a tu archivo `.bashrc` (y hacer `source`) o pegarlo directamente en la terminal:
-
+Puedes agregar el siguiente script a tu archivo `.bashrc` (y hacer `source`) o simplemente pegarlo en la misma terminal donde quieras ejecutar el comando.
 ```bash
 // ~/.bashrc
 acurl () {
@@ -188,45 +187,45 @@ acurl () {
 }
 ```
 
-Ejemplos de uso:
+Luego para hacer una petición curl autenticada con sigv4, puedes invocar `acurl` como en los siguientes ejemplos:
 
 ###### API Gateway
 ```bash
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### Lambda Function URL con streaming
+###### URL de función Lambda con streaming
 ```bash
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Agrega esta función a tu perfil de PowerShell o pégala en la sesión actual:
-
+Puedes agregar la siguiente función a tu perfil de PowerShell o simplemente pegarla en la misma sesión donde quieras ejecutar el comando.
 ```powershell
+# Perfil de PowerShell o sesión actual
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
 
-Ejemplos de uso:
+Luego para hacer una petición curl autenticada con sigv4, puedes invocar `acurl` como en los siguientes ejemplos:
 
 ###### API Gateway
 ```powershell
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### Lambda Function URL con streaming
+###### URL de función Lambda con streaming
 ```powershell
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
@@ -239,11 +238,11 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="Local">
-  Inicia el servidor FastAPI localmente con:
+  Inicia tu servidor FastAPI local ejecutando:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Una vez en ejecución, llama a la API con:
-
+    Una vez que el servidor FastAPI esté en ejecución, llámalo con:
+    
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
       -d '{"genre":"superhero", "actions":[], "playerName":"UnnamedHero"}' \
@@ -263,10 +262,10 @@ acurl ap-southeast-2 lambda -N -X POST \
   </TabItem>
 </Tabs>
 
-Si el comando se ejecuta correctamente, verás una respuesta en streaming similar a:
+Si el comando se ejecuta correctamente, deberías ver una respuesta transmitida similar a:
 
 ```
-UnnamedHero stood tall, his cape billowing in the wind....
+UnnamedHero se alzó imponente, su capa ondeando al viento....
 ```
 
 ¡Felicidades! Has construido y desplegado tu primera API usando FastAPI. 🎉🎉🎉

--- a/docs/src/content/docs/es/guides/python-project.mdx
+++ b/docs/src/content/docs/es/guides/python-project.mdx
@@ -10,13 +10,13 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-El generador de proyectos Python permite crear una biblioteca o aplicación moderna de [Python](https://www.python.org/) configurada con mejores prácticas, gestionada con [UV](https://docs.astral.sh/uv/), un único archivo de bloqueo y entorno virtual en un [espacio de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para ejecutar pruebas, y [Ruff](https://docs.astral.sh/ruff/) para análisis estático.
+El generador de proyectos Python permite crear bibliotecas o aplicaciones modernas de [Python](https://www.python.org/) configuradas con mejores prácticas, gestionadas con [UV](https://docs.astral.sh/uv/), un único archivo de bloqueo y entorno virtual en un [espacio de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para ejecutar pruebas, y [Ruff](https://docs.astral.sh/ruff/) para análisis estático.
 
 ## Uso
 
-### Generar un proyecto de Python
+### Generar un proyecto Python
 
-Puedes generar un nuevo proyecto de Python de dos formas:
+Puedes generar un nuevo proyecto Python de dos maneras:
 
 <RunGenerator generator="py#project" />
 
@@ -24,7 +24,7 @@ Puedes generar un nuevo proyecto de Python de dos formas:
 
 <GeneratorParameters generator="py#project" />
 
-## Resultado del generador
+## Salida del generador
 
 El generador creará la siguiente estructura de proyecto en el directorio `<directory>/<name>`:
 
@@ -32,23 +32,23 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
   - \<module-name>
     - \_\_init\_\_.py Inicialización del módulo
-    - hello.py Archivo de ejemplo de código Python
+    - hello.py Archivo ejemplo de código Python
   - tests
     - \_\_init\_\_.py Inicialización del módulo
     - conftest.py Configuración de pruebas
-    - test_hello.py Pruebas de ejemplo
-  - project.json Configuración del proyecto y objetivos de compilación
+    - test_hello.py Ejemplo de pruebas
+  - project.json Configuración del proyecto y objetivos de construcción
   - pyproject.toml Archivo de configuración de empaquetado usado por UV
   - .python-version Contiene la versión de Python del proyecto
 
 </FileTree>
 
-También podrás observar estos archivos creados/actualizados en la raíz de tu espacio de trabajo:
+También podrás observar estos archivos creados/actualizados en la raíz del workspace:
 
 <FileTree>
 
-  - pyproject.toml Configuración de empaquetado a nivel de espacio de trabajo para UV
-  - .python-version Contiene la versión de Python del espacio de trabajo
+  - pyproject.toml Configuración de empaquetado a nivel de workspace para UV
+  - .python-version Contiene la versión de Python del workspace
   - uv.lock Archivo de bloqueo de dependencias Python
 
 </FileTree>
@@ -57,19 +57,31 @@ También podrás observar estos archivos creados/actualizados en la raíz de tu 
 
 Añade tu código fuente Python en el directorio `<module-name>`.
 
-### Importando tu biblioteca en otros proyectos
+### Importando código de tu biblioteca en otros proyectos
 
-Como los [espacios de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/) están configurados, puedes referenciar tu proyecto Python desde cualquier otro proyecto Python en tu espacio de trabajo:
+Usa el objetivo `add` para añadir una dependencia a un proyecto Python.
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+Supongamos que hemos creado dos proyectos Python: `my_app` y `my_lib`. Estos tendrán nombres completos de proyecto `my_scope.my_app` y `my_scope.my_lib`, y por defecto tendrán nombres de módulo `my_scope_my_app` y `my_scope_my_lib`.
+
+Para que `my_app` dependa de `my_lib`, ejecutamos:
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+Usamos el nombre completo del proyecto tanto para el dependiente como para el dependido. Podemos usar sintaxis abreviada para el proyecto al que añadimos la dependencia, pero debemos calificar completamente el nombre del proyecto del que dependemos.
+:::
+
+Luego podrás importar tu biblioteca:
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-Aquí, `my_library` es el nombre del módulo, `hello` corresponde al archivo fuente Python `hello.py`, y `say_hello` es un método definido en `hello.py`.
+Aquí, `my_scope_my_lib` es el nombre del módulo de la biblioteca, `hello` corresponde al archivo fuente `hello.py`, y `say_hello` es un método definido en `hello.py`.
 
 ### Dependencias
 
-Para añadir dependencias a tu proyecto, puedes ejecutar el objetivo `add` en tu proyecto Python, por ejemplo:
+Para añadir dependencias a tu proyecto, ejecuta el objetivo `add` en tu proyecto Python:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
@@ -77,7 +89,7 @@ Esto añadirá la dependencia al archivo `pyproject.toml` de tu proyecto y actua
 
 #### Código en tiempo de ejecución
 
-Cuando uses tu proyecto Python como código de runtime (por ejemplo como manejador para una función AWS Lambda), necesitarás crear un paquete del código fuente y todas sus dependencias. Puedes lograrlo añadiendo un objetivo como el siguiente a tu archivo `project.json`:
+Cuando uses tu proyecto Python como código de runtime (por ejemplo como handler para una función AWS Lambda), necesitarás crear un paquete del código fuente y sus dependencias. Puedes lograrlo añadiendo un objetivo como este en tu `project.json`:
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ Cuando uses tu proyecto Python como código de runtime (por ejemplo como manejad
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -101,17 +113,17 @@ Cuando uses tu proyecto Python como código de runtime (por ejemplo como manejad
 }
 ```
 
-### Compilación
+### Construcción
 
-Tu proyecto Python está configurado con un objetivo `build` (definido en `project.json`), que puedes ejecutar mediante:
+Tu proyecto Python está configurado con un objetivo `build` (definido en `project.json`), que puedes ejecutar con:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 Donde `<project-name>` es el nombre completo de tu proyecto.
 
-El objetivo `build` compilará, verificará y probará tu proyecto.
+El objetivo `build` compilará, linteará y probará tu proyecto.
 
-La salida de compilación se encuentra en la carpeta `dist` raíz de tu espacio de trabajo, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<my-library>/build`.
+La salida de construcción se encuentra en la carpeta `dist` raíz de tu workspace, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<my-library>/build`.
 
 ## Pruebas
 
@@ -128,43 +140,43 @@ Las pruebas deben escribirse en el directorio `test` dentro de tu proyecto, en a
     - test_hello.py Pruebas para hello.py
 </FileTree>
 
-Las pruebas son métodos que comienzan con `test_` y realizan aserciones para verificar expectativas, por ejemplo:
+Las pruebas son métodos que comienzan con `test_` y hacen aserciones para verificar expectativas, por ejemplo:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
 
 def test_say_hello():
-  assert say_hello("Darth Vader") == "¡Hola, Darth Vader!"
+  assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
 Para más detalles sobre cómo escribir pruebas, consulta la [documentación de pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
 
 ### Ejecutando pruebas
 
-Las pruebas se ejecutarán como parte del objetivo `build` de tu proyecto, pero también puedes ejecutarlas por separado usando el objetivo `test`:
+Las pruebas se ejecutan como parte del objetivo `build`, pero también puedes ejecutarlas por separado:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puedes ejecutar una prueba individual o un conjunto de pruebas usando el flag `-k`, especificando el nombre del archivo de prueba o método:
+Puedes ejecutar una prueba individual usando el flag `-k`:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## Verificación de código
+## Linting
 
-Los proyectos Python usan [Ruff](https://docs.astral.sh/ruff/) para análisis estático.
+Los proyectos Python usan [Ruff](https://docs.astral.sh/ruff/) para linting.
 
 ### Ejecutando el linter
 
-Para invocar el linter y verificar tu proyecto, ejecuta el objetivo `lint`:
+Para invocar el linter y verificar tu proyecto:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
 ### Corrigiendo problemas de linting
 
-La mayoría de problemas de formato o análisis estático pueden corregirse automáticamente. Puedes indicar a Ruff que corrija los problemas usando el argumento `--configuration=fix`:
+La mayoría de problemas se pueden corregir automáticamente. Ejecuta Ruff con `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-De forma similar, si deseas corregir todos los problemas en todos los paquetes de tu espacio de trabajo, ejecuta:
+Para corregir todos los problemas en todos los paquetes:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/3.mdx
@@ -33,10 +33,10 @@ La StoryApi comprend une unique API `generate_story` qui, étant donné un `Game
 
 ### Implémentation de l'API
 
-Pour créer notre API, nous devons d'abord installer quelques dépendances supplémentaires.
+Pour créer notre API, nous devons d'abord installer quelques dépendances supplémentaires :
 
 - `boto3` sera utilisé pour appeler Amazon Bedrock ;
-- `uvicorn` sera utilisé pour démarrer notre API en conjonction avec le [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter).
+- `uvicorn` sera utilisé pour démarrer notre API en conjonction avec le [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter) ;
 - `copyfiles` est une dépendance npm nécessaire pour supporter la copie multiplateforme de fichiers lors de la mise à jour de notre tâche `bundle`.
 
 Pour installer ces dépendances, exécutez les commandes suivantes :
@@ -54,7 +54,7 @@ Maintenant remplaçons le contenu des fichiers suivants dans `packages/story_api
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-La modification ci-dessus de `init.py` supprime simplement le middleware CORS pour éviter les conflits avec la gestion des en-têtes CORS de l'URL de fonction Lambda.
+La modification ci-dessus dans `init.py` supprime simplement le middleware CORS pour éviter les conflits avec la gestion des en-têtes CORS de l'URL de fonction Lambda.
 :::
 
 </TabItem>
@@ -63,7 +63,7 @@ La modification ci-dessus de `init.py` supprime simplement le middleware CORS po
 Analyse du code :
 
 - Nous utilisons le paramètre `x-streaming` pour indiquer qu'il s'agit d'une API de streaming lors de la génération de notre SDK client. Cela permet de consommer cette API en streaming tout en conservant la sécurité des types !
-- Notre API retourne simplement un flux texte comme défini par `media_type="text/plain"` et `response_class=PlainTextResponse`
+- Notre API retourne simplement un flux de texte défini par `media_type="text/plain"` et `response_class=PlainTextResponse`
 
 :::note
 À chaque modification de votre FastAPI, vous devez reconstruire votre projet pour voir les changements reflétés dans le client généré de votre site web.
@@ -73,9 +73,9 @@ Nous apporterons quelques modifications supplémentaires ci-dessous avant de rec
 
 ### Infrastructure
 
-L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastructure configurée précédemment</Link> suppose que toutes les APIs utilisent une API Gateway intégrée à des fonctions Lambda. Pour notre `story_api`, nous ne voulons pas utiliser API Gateway car il ne supporte pas les réponses en streaming. À la place, nous utiliserons une [URL de fonction Lambda configurée avec le streaming de réponse](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastructure configurée précédemment</Link> suppose que toutes les API utilisent une API Gateway intégrée à des fonctions Lambda. Pour notre `story_api`, nous ne voulons pas utiliser API Gateway car il ne supporte pas les réponses en streaming. Nous utiliserons plutôt une [URL de fonction Lambda configurée avec le streaming de réponse](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Pour supporter cela, nous allons d'abord mettre à jour nos constructs CDK comme suit :
+Pour cela, mettons d'abord à jour nos constructions CDK :
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ Pour supporter cela, nous allons d'abord mettre à jour nos constructs CDK comme
 </TabItem>
 </Tabs>
 
-Maintenant nous mettrons à jour la `story_api` pour supporter le déploiement du [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
+Maintenant mettons à jour la `story_api` pour supporter le déploiement du [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
 
 <Tabs>
 <TabItem label="run.sh">
@@ -106,7 +106,7 @@ Maintenant nous mettrons à jour la `story_api` pour supporter le déploiement d
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -128,28 +128,28 @@ D'abord, construisons la base de code :
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-Si vous rencontrez des erreurs de lint, vous pouvez exécuter cette commande pour les corriger automatiquement.
+Si vous rencontrez des erreurs de linting, vous pouvez exécuter cette commande pour les corriger automatiquement :
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-Votre application peut maintenant être déployée avec la commande suivante :
+Vous pouvez maintenant déployer l'application en exécutant :
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 Ce déploiement prendra environ 2 minutes.
 
-<Drawer title="Commande de déploiement" trigger="Vous pouvez aussi déployer toutes les stacks d'un coup. Cliquez ici pour plus de détails.">
+<Drawer title="Commande de déploiement" trigger="Vous pouvez également déployer toutes les piles en une seule fois. Cliquez ici pour plus de détails.">
 
-Vous pouvez également déployer toutes les stacks de l'application CDK avec :
+Vous pouvez aussi déployer toutes les piles de l'application CDK en exécutant :
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Ceci n'est **pas recommandé** car vous pourriez choisir de séparer vos environnements de déploiement en stacks distinctes `(ex: infra-prod)`. Dans ce cas, le flag `--all` tentera de tout déployer, ce qui peut entraîner des déploiements indésirables !
+Ceci n'est **pas recommandé** car vous pourriez choisir de séparer vos étapes de déploiement en piles distinctes (ex: `infra-prod`). Dans ce cas, le flag `--all` tentera de déployer toutes les piles, ce qui peut entraîner des déploiements indésirables !
 
 </Drawer>
 
-Une fois le déploiement terminé, vous devriez voir des sorties similaires à ceci _(certaines valeurs ont été masquées)_ :
+Une fois le déploiement terminé, vous devriez voir des sorties similaires à ceci (certaines valeurs ont été masquées) :
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -168,15 +168,15 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = regi
 dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
-Nous pouvons tester notre API de deux manières :
+Nous pouvons tester notre API en :
 <ul>
-<li>Démarrer une instance locale du serveur FastAPI et appeler les APIs avec `curl`</li>
+<li>Démarrant une instance locale du serveur FastAPI et en l'appelant avec `curl`</li>
 <li>
-<Drawer title="curl avec Sigv4" trigger="Appeler l'API déployée directement avec curl activé pour Sigv4">
+<Drawer title="curl avec Sigv4 activé" trigger="Appeler l'API déployée directement avec curl sigv4">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Vous pouvez soit ajouter ce script à votre fichier `.bashrc` (et le `sourcer`), soit le coller directement dans le terminal.
+Vous pouvez ajouter ce script à votre fichier `.bashrc` (puis `source`) ou le coller directement dans le terminal :
 
 ```bash
 // ~/.bashrc
@@ -201,7 +201,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Vous pouvez ajouter cette fonction à votre profil PowerShell ou la coller dans la session actuelle.
+Ajoutez cette fonction à votre profil PowerShell ou collez-la dans la session actuelle :
 
 ```powershell
 function acurl {
@@ -210,11 +210,11 @@ function acurl {
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
@@ -242,7 +242,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
   Démarrez le serveur FastAPI local avec :
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Une fois le serveur démarré, appelez-le avec :
+    Appelez-le ensuite avec :
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -258,7 +258,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Utilisez la valeur de sortie `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` du déploiement CDK pour remplacer l'URL et ajustez la région si nécessaire.
+    Utilisez la valeur de sortie CDK `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` pour remplacer l'URL et ajustez la région.
     </Aside>
   </TabItem>
 </Tabs>
@@ -266,7 +266,7 @@ acurl ap-southeast-2 lambda -N -X POST \
 Si la commande réussit, vous devriez voir une réponse en streaming similaire à :
 
 ```
-UnnamedHero se tenait fier, sa cape flottant au vent....
+UnnamedHero se tenait droit, sa cape flottant au vent....
 ```
 
-Félicitations. Vous avez créé et déployé votre première API avec FastAPI ! 🎉🎉🎉
+Félicitations. Vous avez déployé votre première API avec FastAPI ! 🎉🎉🎉

--- a/docs/src/content/docs/fr/guides/python-project.mdx
+++ b/docs/src/content/docs/fr/guides/python-project.mdx
@@ -10,7 +10,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Le générateur de projets Python permet de créer des bibliothèques ou applications [Python](https://www.python.org/) modernes configurées avec les meilleures pratiques, gérées via [UV](https://docs.astral.sh/uv/), utilisant un fichier de verrouillage unique et un environnement virtuel dans un [espace de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) pour l'exécution des tests, et [Ruff](https://docs.astral.sh/ruff/) pour l'analyse statique.
+Le générateur de projet Python permet de créer une bibliothèque ou une application moderne [Python](https://www.python.org/) configurée avec les bonnes pratiques, gérée avec [UV](https://docs.astral.sh/uv/), un fichier de verrouillage unique et un environnement virtuel dans un [espace de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) pour exécuter les tests, et [Ruff](https://docs.astral.sh/ruff/) pour l'analyse statique.
 
 ## Utilisation
 
@@ -34,21 +34,21 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
     - \_\_init\_\_.py Initialisation du module
     - hello.py Exemple de fichier source Python
   - tests
-    - \_\_init\_\_.py Initialisation du module  
+    - \_\_init\_\_.py Initialisation du module
     - conftest.py Configuration des tests
     - test_hello.py Exemple de tests
   - project.json Configuration du projet et cibles de build
-  - pyproject.toml Fichier de configuration d'emballage utilisé par UV
+  - pyproject.toml Fichier de configuration d'empaquetage utilisé par UV
   - .python-version Contient la version Python du projet
 
 </FileTree>
 
-Vous remarquerez également ces fichiers créés/mis à jour à la racine de l'espace de travail :
+Vous remarquerez également les fichiers suivants créés/mis à jour à la racine de votre espace de travail :
 
 <FileTree>
 
-  - pyproject.toml Configuration d'emballage au niveau workspace pour UV
-  - .python-version Contient la version Python du workspace
+  - pyproject.toml Configuration d'empaquetage au niveau de l'espace de travail pour UV
+  - .python-version Contient la version Python de l'espace de travail
   - uv.lock Fichier de verrouillage des dépendances Python
 
 </FileTree>
@@ -57,19 +57,31 @@ Vous remarquerez également ces fichiers créés/mis à jour à la racine de l'e
 
 Ajoutez votre code source Python dans le répertoire `<module-name>`.
 
-### Importer votre bibliothèque dans d'autres projets
+### Importer votre code bibliothèque dans d'autres projets
 
-Grâce à la configuration des [espaces de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), vous pouvez référencer votre projet Python depuis n'importe quel autre projet Python dans votre workspace :
+Utilisez la cible `add` pour ajouter une dépendance à un projet Python.
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+Supposons que nous ayons créé deux projets Python, `my_app` et `my_lib`. Ceux-ci auront des noms de projet qualifiés complets `my_scope.my_app` et `my_scope.my_lib`, et auront par défaut des noms de module `my_scope_my_app` et `my_scope_my_lib`.
+
+Pour que `my_app` dépende de `my_lib`, nous pouvons exécuter la commande suivante :
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+Nous utilisons le nom de projet qualifié complet pour le dépendant et le dépendu. Nous pouvons utiliser la syntaxe raccourcie pour le projet auquel ajouter la dépendance, mais devons qualifier complètement le nom du projet dont dépendre.
+:::
+
+Vous pouvez ensuite importer votre code bibliothèque :
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-Ici, `my_library` correspond au nom du module, `hello` au fichier source Python `hello.py`, et `say_hello` est une méthode définie dans `hello.py`.
+Ci-dessus, `my_scope_my_lib` est le nom du module pour la bibliothèque, `hello` correspond au fichier source Python `hello.py`, et `say_hello` est une méthode définie dans `hello.py`.
 
 ### Dépendances
 
-Pour ajouter des dépendances à votre projet, exécutez la cible `add` dans votre projet Python, par exemple :
+Pour ajouter des dépendances à votre projet, vous pouvez exécuter la cible `add` dans votre projet Python, par exemple :
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
@@ -77,7 +89,7 @@ Cela ajoutera la dépendance au fichier `pyproject.toml` de votre projet et mett
 
 #### Code d'exécution
 
-Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple comme gestionnaire pour une fonction AWS Lambda), vous devrez créer un bundle du code source et de ses dépendances. Ajoutez une cible comme celle-ci dans votre fichier `project.json` :
+Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple comme gestionnaire pour une fonction AWS Lambda), vous devrez créer un bundle du code source et de toutes ses dépendances. Vous pouvez y parvenir en ajoutant une cible comme celle-ci à votre fichier `project.json` :
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple c
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -101,9 +113,9 @@ Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple c
 }
 ```
 
-### Construction
+### Build
 
-Votre projet Python est configuré avec une cible `build` (définie dans `project.json`), exécutable via :
+Votre projet Python est configuré avec une cible `build` (définie dans `project.json`), que vous pouvez exécuter via :
 
 <NxCommands commands={['run <project-name>:build']} />
 
@@ -111,7 +123,7 @@ Où `<project-name>` est le nom qualifié complet de votre projet.
 
 La cible `build` compilera, linttera et testera votre projet.
 
-Le résultat du build se trouve dans le dossier `dist` à la racine de votre workspace, dans un répertoire spécifique au package et à la cible, par exemple `dist/packages/<my-library>/build`.
+Le résultat du build se trouve dans le dossier `dist` racine de votre espace de travail, dans un répertoire pour votre package et cible, par exemple `dist/packages/<my-library>/build`.
 
 ## Tests
 
@@ -128,7 +140,7 @@ Les tests doivent être écrits dans le répertoire `test` de votre projet, dans
     - test_hello.py Tests pour hello.py
 </FileTree>
 
-Les tests sont des méthodes commençant par `test_` qui vérifient des assertions, par exemple :
+Les tests sont des méthodes commençant par `test_` et utilisant des assertions pour vérifier les attentes, par exemple :
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -137,15 +149,15 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-Pour plus de détails sur l'écriture des tests, consultez la [documentation pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
+Pour plus de détails sur l'écriture des tests, veuillez consulter la [documentation pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
 
 ### Exécution des tests
 
-Les tests s'exécutent lors de la cible `build`, mais vous pouvez aussi les lancer séparément via la cible `test` :
+Les tests s'exécuteront dans le cadre de la cible `build` de votre projet, mais vous pouvez aussi les exécuter séparément en lançant la cible `test` :
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Vous pouvez exécuter un test spécifique avec le flag `-k` en spécifiant le nom du fichier ou de la méthode :
+Vous pouvez exécuter un test individuel ou une suite de tests en utilisant le flag `-k`, en spécifiant soit le nom du fichier de test soit celui de la méthode :
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -155,16 +167,16 @@ Les projets Python utilisent [Ruff](https://docs.astral.sh/ruff/) pour le lintin
 
 ### Exécution du linter
 
-Pour lancer le linter et vérifier votre projet, utilisez la cible `lint` :
+Pour invoquer le linter et vérifier votre projet, vous pouvez exécuter la cible `lint`.
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Correction des problèmes
+### Correction des problèmes de linting
 
-La plupart des problèmes de linting ou de formatage peuvent être corrigés automatiquement. Utilisez l'argument `--configuration=fix` :
+La majorité des problèmes de linting ou de formatage peuvent être corrigés automatiquement. Vous pouvez demander à Ruff de corriger les problèmes de linting en utilisant l'argument `--configuration=fix`.
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Pour corriger tous les problèmes dans l'ensemble du workspace, exécutez :
+De même, si vous souhaitez corriger tous les problèmes de linting dans tous les packages de votre espace de travail, vous pouvez exécuter :
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/3.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gioco di Dungeon con IA"
-description: "Una guida dettagliata su come costruire un gioco di avventura dungeon basato su IA utilizzando @aws/nx-plugin."
+description: "Una guida dettagliata su come costruire un gioco di avventura dungeon alimentato da IA utilizzando il plugin @aws/nx-plugin."
 ---
 
 
@@ -23,21 +23,21 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## Modulo 3: Implementazione dell'API per la storia
+## Modulo 3: Implementazione della Story API
 
 <Aside type="caution">
 Assicurati di aver concesso l'accesso al modello **Anthropic Claude 3.5 Sonnet v2** seguendo i passaggi descritti in [questa guida](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-Lo StoryApi consiste in una singola API `generate_story` che, dato un `Game` e una lista di `Action` come contesto, farà progredire una storia. Questa API verrà implementata come API streaming in Python/FastAPI e dimostrerà inoltre come apportare modifiche al codice generato per adattarlo allo scopo.
+La StoryApi è composta da una singola API `generate_story` che, dato un `Game` e una lista di `Action` come contesto, farà progredire una storia. Questa API verrà implementata come API in streaming in Python/FastAPI e dimostrerà inoltre come apportare modifiche al codice generato per adattarlo allo scopo.
 
 ### Implementazione dell'API
 
-Per creare la nostra API, dobbiamo prima installare alcune dipendenze aggiuntive.
+Per creare la nostra API, dobbiamo prima installare alcune dipendenze aggiuntive:
 
 - `boto3` verrà utilizzato per chiamare Amazon Bedrock;
-- `uvicorn` verrà utilizzato per avviare la nostra API in combinazione con [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter).
-- `copyfiles` è una dipendenza npm necessaria per supportare la copia multipiattaforma di file durante l'aggiornamento del task `bundle`.
+- `uvicorn` verrà utilizzato per avviare la nostra API in combinazione con [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter);
+- `copyfiles` è una dipendenza npm necessaria per supportare la copia multipiattaforma dei file durante l'aggiornamento del task `bundle`.
 
 Per installare queste dipendenze, esegui i seguenti comandi:
 
@@ -54,7 +54,7 @@ Ora sostituiamo il contenuto dei seguenti file in `packages/story_api/story_api`
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-La modifica sopra indicata a `init.py` rimuove semplicemente il middleware CORS per evitare conflitti con la gestione degli header CORS della Lambda Function URL.
+La modifica sopra riportata a `init.py` rimuove semplicemente il middleware CORS per evitare conflitti con la gestione degli header CORS della Lambda Function URL.
 :::
 
 </TabItem>
@@ -62,20 +62,20 @@ La modifica sopra indicata a `init.py` rimuove semplicemente il middleware CORS 
 
 Analizzando il codice sopra:
 
-- Utilizziamo l'impostazione `x-streaming` per indicare che si tratta di un'API streaming quando genereremo il nostro client SDK. Questo ci permetterà di consumare questa API in modalità streaming mantenendo la type-safety!
+- Utilizziamo l'impostazione `x-streaming` per indicare che si tratta di un'API in streaming durante la generazione del client SDK. Questo ci permetterà di consumare l'API in modalità streaming mantenendo la type-safety!
 - La nostra API restituisce semplicemente un flusso di testo come definito sia da `media_type="text/plain"` che da `response_class=PlainTextResponse`
 
 :::note
-Ogni volta che apporti modifiche al tuo FastAPI, dovrai ricostruire il progetto per vedere queste modifiche riflesse nel client generato nel tuo sito web.
+Ogni volta che apporti modifiche alla tua FastAPI, dovrai ricostruire il progetto per vedere le modifiche riflesse nel client generato nel tuo sito web.
 
-Apporteremo alcune modifiche aggiuntive di seguito prima di ricostruire.
+Faremo altre modifiche qui sotto prima di ricostruire.
 :::
 
 ### Infrastruttura
 
 L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastruttura configurata precedentemente</Link> presuppone che tutte le API abbiano un API Gateway che si integra con funzioni Lambda. Per la nostra `story_api` non vogliamo utilizzare API Gateway poiché non supporta risposte in streaming. Utilizzeremo invece una [Lambda Function URL configurata con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Per supportare questo, aggiorneremo prima i nostri costrutti CDK come segue:
+Per supportare questo, aggiorniamo prima i nostri costrutti CDK come segue:
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ Per supportare questo, aggiorneremo prima i nostri costrutti CDK come segue:
 </TabItem>
 </Tabs>
 
-Ora aggiorneremo lo `story_api` per supportare la distribuzione con [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
+Ora aggiorneremo la `story_api` per supportare la distribuzione con [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
 
 <Tabs>
 <TabItem label="run.sh">
@@ -106,7 +106,7 @@ Ora aggiorneremo lo `story_api` per supportare la distribuzione con [Lambda Web 
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -128,7 +128,7 @@ Prima di tutto, compiliamo la codebase:
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-Se incontri errori di linting, puoi eseguire questo comando per correggerli automaticamente.
+Se incontri errori di linting, puoi eseguire questo comando per correggerli automaticamente:
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
@@ -139,17 +139,17 @@ Ora puoi distribuire l'applicazione eseguendo:
 
 La distribuzione richiederà circa 2 minuti.
 
-<Drawer title="Comando di distribuzione" trigger="Puoi anche distribuire tutti gli stack contemporaneamente. Clicca qui per maggiori dettagli.">
+<Drawer title="Comando di distribuzione" trigger="Puoi anche distribuire tutti gli stack contemporaneamente. Clicca qui per i dettagli.">
 
 Puoi distribuire tutti gli stack contenuti nell'applicazione CDK eseguendo:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-**Non è raccomandato** in quanto potresti voler separare le fasi di distribuzione in stack diversi (es. `infra-prod`). In questo caso il flag `--all` tenterà di distribuire tutti gli stack, con il rischio di distribuzioni indesiderate!
+Questo approccio **non è raccomandato** in quanto potresti voler separare le fasi di distribuzione in stack diversi (es. `infra-prod`). In questo caso il flag `--all` tenterà di distribuire tutti gli stack, con il rischio di distribuzioni indesiderate!
 
 </Drawer>
 
-Al termine della distribuzione, dovresti vedere output simili a questi (alcuni valori sono oscurati):
+Al termine della distribuzione, dovresti vedere output simili a questi (alcuni valori sono stati oscurati):
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -176,7 +176,7 @@ Possiamo testare la nostra API in due modi:
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Puoi aggiungere questo script al tuo file `.bashrc` (e eseguire `source`) oppure incollarlo direttamente nel terminale.
+Puoi aggiungere questo script al tuo file `.bashrc` (e eseguire `source`) oppure incollarlo direttamente nel terminale:
 ```bash
 // ~/.bashrc
 acurl () {
@@ -194,13 +194,13 @@ Esempi di utilizzo:
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### Lambda function url streaming
+###### Lambda Function URL streaming
 ```bash
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Aggiungi questa funzione al tuo profilo PowerShell o incollala nella sessione corrente.
+Aggiungi questa funzione al tuo profilo PowerShell o incollala nella sessione corrente:
 ```powershell
 function acurl {
     param(
@@ -208,11 +208,11 @@ function acurl {
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
@@ -224,7 +224,7 @@ Esempi di utilizzo:
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### Lambda function url streaming
+###### Lambda Function URL streaming
 ```powershell
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
@@ -240,7 +240,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
   Avvia il server FastAPI locale con:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Esegui la chiamata API con:
+    Esegui quindi la chiamata API con:
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -256,15 +256,15 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Sostituisci il placeholder dell'URL con il valore `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` dall'output di CDK e imposta la regione correttamente.
+    Utilizza il valore di output `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` da CDK per sostituire il placeholder dell'URL e imposta la regione correttamente.
     </Aside>
   </TabItem>
 </Tabs>
 
-Se il comando ha successo, dovresti vedere una risposta in streaming simile a:
+Se il comando viene eseguito correttamente, dovresti vedere una risposta in streaming simile a:
 
 ```
-UnnamedHero si ergeva maestoso, il mantello che sventolava al vento....
+UnnamedHero stood tall, his cape billowing in the wind....
 ```
 
 Congratulazioni. Hai costruito e distribuito la tua prima API con FastAPI! 🎉🎉🎉

--- a/docs/src/content/docs/it/guides/python-project.mdx
+++ b/docs/src/content/docs/it/guides/python-project.mdx
@@ -10,11 +10,11 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Il generatore di progetti Python può essere utilizzato per creare una moderna libreria o applicazione [Python](https://www.python.org/) configurata con le migliori pratiche, gestita con [UV](https://docs.astral.sh/uv/), un singolo file di lock e un ambiente virtuale in un [workspace UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) per l'esecuzione dei test e [Ruff](https://docs.astral.sh/ruff/) per l'analisi statica.
+Il generatore di progetti Python può essere utilizzato per creare una moderna libreria o applicazione [Python](https://www.python.org/) configurata con le migliori pratiche, gestita con [UV](https://docs.astral.sh/uv/), un singolo file di lock e un ambiente virtuale in un [UV workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) per l'esecuzione dei test e [Ruff](https://docs.astral.sh/ruff/) per l'analisi statica.
 
 ## Utilizzo
 
-### Genera un progetto Python
+### Generare un Progetto Python
 
 Puoi generare un nuovo progetto Python in due modi:
 
@@ -24,7 +24,7 @@ Puoi generare un nuovo progetto Python in due modi:
 
 <GeneratorParameters generator="py#project" />
 
-## Output del generatore
+## Output del Generatore
 
 Il generatore creerà la seguente struttura del progetto nella directory `<directory>/<name>`:
 
@@ -38,46 +38,58 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
     - conftest.py Configurazione dei test
     - test_hello.py Test di esempio
   - project.json Configurazione del progetto e target di build
-  - pyproject.toml File di configurazione per il packaging utilizzato da UV
+  - pyproject.toml File di configurazione del packaging utilizzato da UV
   - .python-version Contiene la versione Python del progetto
 
 </FileTree>
 
-Potresti anche notare questi file creati/aggiornati nella root del workspace:
+Potresti anche notare i seguenti file creati/aggiornati nella root del workspace:
 
 <FileTree>
 
-  - pyproject.toml Configurazione di packaging a livello workspace per UV
-  - .python-version Contiene la versione Python del workspace
+  - pyproject.toml Configurazione del packaging a livello workspace per UV
+  - .python-version Contiene la versione Python del workspace  
   - uv.lock File di lock per le dipendenze Python
 
 </FileTree>
 
-## Scrivere codice Python
+## Scrivere Codice Python
 
 Aggiungi il tuo codice sorgente Python nella directory `<module-name>`.
 
-### Importare il codice della libreria in altri progetti
+### Importare il Codice della Libreria in Altri Progetti
 
-Grazie alla configurazione dei [workspace UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), puoi referenziare il tuo progetto Python da qualsiasi altro progetto Python nel workspace:
+Utilizza il target `add` per aggiungere una dipendenza a un progetto Python.
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+Supponiamo di aver creato due progetti Python, `my_app` e `my_lib`. Questi avranno nomi completi di progetto `my_scope.my_app` e `my_scope.my_lib`, e per default avranno nomi di modulo `my_scope_my_app` e `my_scope_my_lib`.
+
+Per far dipendere `my_app` da `my_lib`, possiamo eseguire il comando:
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+Usiamo il nome completo del progetto sia per il dipendente che per il dipendente. Possiamo usare la sintassi abbreviata per il progetto a cui vogliamo aggiungere la dipendenza, ma dobbiamo specificare completamente il nome del progetto da cui dipendere.
+:::
+
+Potrai quindi importare il codice della libreria:
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-Nell'esempio, `my_library` è il nome del modulo, `hello` corrisponde al file sorgente Python `hello.py`, e `say_hello` è un metodo definito in `hello.py`.
+Nell'esempio sopra, `my_scope_my_lib` è il nome del modulo per la libreria, `hello` corrisponde al file sorgente Python `hello.py`, e `say_hello` è un metodo definito in `hello.py`
 
 ### Dipendenze
 
-Per aggiungere dipendenze al progetto, puoi eseguire il target `add` nel tuo progetto Python, ad esempio:
+Per aggiungere dipendenze al tuo progetto, puoi eseguire il target `add` nel tuo progetto Python, ad esempio:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-Questo aggiungerà la dipendenza al file `pyproject.toml` del progetto e aggiornerà il file `uv.lock` principale.
+Questo aggiungerà la dipendenza al file `pyproject.toml` del progetto e aggiornerà il root `uv.lock`.
 
-#### Codice runtime
+#### Codice Runtime
 
-Quando usi il progetto Python come codice runtime (ad esempio come handler per una funzione AWS Lambda), dovrai creare un bundle del codice sorgente e di tutte le dipendenze. Puoi farlo aggiungendo un target come il seguente al file `project.json`:
+Quando usi il tuo progetto Python come codice runtime (ad esempio come handler per una funzione AWS lambda), dovrai creare un bundle del codice sorgente e di tutte le dipendenze. Puoi farlo aggiungendo un target come il seguente al tuo file `project.json`:
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ Quando usi il progetto Python come codice runtime (ad esempio come handler per u
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -103,23 +115,23 @@ Quando usi il progetto Python come codice runtime (ad esempio come handler per u
 
 ### Build
 
-Il progetto Python è configurato con un target `build` (definito in `project.json`), eseguibile tramite:
+Il tuo progetto Python è configurato con un target `build` (definito in `project.json`), che puoi eseguire tramite:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-Dove `<project-name>` è il nome completo del progetto.
+Dove `<project-name>` è il nome completo del tuo progetto.
 
-Il target `build` eseguirà la compilazione, il linting e i test del progetto.
+Il target `build` compilerà, eseguirà il linting e testerà il progetto.
 
-L'output della build si trova nella cartella `dist` principale del workspace, all'interno di una directory specifica per il pacchetto e il target, ad esempio `dist/packages/<my-library>/build`.
+L'output della build si troverà nella cartella `dist` root del workspace, all'interno di una directory per il tuo pacchetto e target, ad esempio `dist/packages/<my-library>/build`
 
 ## Testing
 
-[pytest](https://docs.pytest.org/en/stable/) è configurato per il testing del progetto.
+[pytest](https://docs.pytest.org/en/stable/) è configurato per testare il tuo progetto.
 
-### Scrivere test
+### Scrivere Test
 
-I test vanno scritti nella directory `test` del progetto, in file Python prefissati con `test_`, ad esempio:
+I test dovrebbero essere scritti nella directory `test` del progetto, in file Python prefissati con `test_`, ad esempio:
 
 <FileTree>
   - my_library
@@ -137,15 +149,15 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-Per maggiori dettagli sulla scrittura dei test, consultare la [documentazione pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
+Per maggiori dettagli su come scrivere test, consulta la [documentazione pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
 
-### Eseguire i test
+### Eseguire Test
 
-I test vengono eseguiti durante il target `build`, ma puoi eseguirli separatamente con il target `test`:
+I test verranno eseguiti come parte del target `build` del progetto, ma puoi anche eseguirli separatamente con il target `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puoi eseguire un singolo test o un gruppo di test usando il flag `-k`, specificando il nome del file o del metodo:
+Puoi eseguire un singolo test o una suite specifica usando il flag `-k`, specificando il nome del file di test o del metodo:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -153,18 +165,18 @@ Puoi eseguire un singolo test o un gruppo di test usando il flag `-k`, specifica
 
 I progetti Python utilizzano [Ruff](https://docs.astral.sh/ruff/) per il linting.
 
-### Eseguire il linter
+### Eseguire il Linter
 
-Per invocare il linter e verificare il progetto, esegui il target `lint`:
+Per invocare il linter e controllare il progetto, puoi eseguire il target `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Correggere i problemi di lint
+### Correggere Problemi di Linting
 
-La maggior parte dei problemi di linting/formattazione può essere corretta automaticamente. Puoi chiedere a Ruff di correggere i problemi eseguendo con l'argomento `--configuration=fix`:
+La maggior parte dei problemi di linting o formattazione può essere corretta automaticamente. Puoi chiedere a Ruff di correggere i problemi eseguendo con l'argomento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Analogamente, per correggere tutti i problemi di linting in tutti i pacchetti del workspace:
+Analogamente, se vuoi correggere tutti i problemi di linting in tutti i pacchetti del workspace, puoi eseguire:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/3.mdx
@@ -26,10 +26,10 @@ import gameConversationPng from '@assets/game-conversation.png'
 ## モジュール3: ストーリーAPIの実装
 
 <Aside type="caution">
-[このガイド](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)で説明されている手順に従って、**Anthropic Claude 3.5 Sonnet v2**モデルへのアクセス権を付与していることを確認してください。
+**Anthropic Claude 3.5 Sonnet v2**モデルへのアクセス権を[このガイド](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)の手順に従って付与していることを確認してください。
 </Aside>
 
-StoryApiは、`Game`とコンテキスト用の`Action`リストを受け取り、ストーリーを進行させる単一のAPI`generate_story`で構成されます。このAPIはPython/FastAPIでストリーミングAPIとして実装され、生成されたコードを目的に合わせて変更する方法も示します。
+StoryApiは、`Game`とコンテキスト用の`Action`リストを受け取り、ストーリーを進行させる単一のAPI`generate_story`で構成されます。このAPIはPython/FastAPIでストリーミングAPIとして実装され、生成されたコードを目的に合わせて変更する方法も実演します。
 
 ### API実装
 
@@ -39,12 +39,12 @@ APIを作成するには、まず追加の依存関係をインストールす�
 - `uvicorn`は[Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)と組み合わせてAPI起動に使用
 - `copyfiles`は`bundle`タスク更新時にクロスプラットフォームのファイルコピーをサポートするnpm依存関係
 
-以下のコマンドを実行して依存関係をインストールします：
+以下のコマンドでこれらの依存関係をインストールします：
 
 <NxCommands commands={["run dungeon_adventure.story_api:add --args boto3 uvicorn"]} />
 <InstallCommand pkg="copyfiles" dev />
 
-次に、`packages/story_api/story_api`内の以下のファイルの内容を置き換えます：
+次に、`packages/story_api/story_api`内の以下のファイル内容を置き換えます：
 
 <Tabs>
 <TabItem label="main.py">
@@ -54,28 +54,28 @@ APIを作成するには、まず追加の依存関係をインストールす�
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-上記の`init.py`への変更は、Lambda Function URL自身のCORSヘッダー処理との競合を避けるため、CORSミドルウェアを削除するだけです。
+上記の`init.py`への変更は、Lambda Function URL独自のCORSヘッダー処理との競合を避けるため、CORSミドルウェアを削除するだけです。
 :::
 
 </TabItem>
 </Tabs>
 
-コードの分析：
+上記コードの分析：
 
-- クライアントSDK生成時にストリーミングAPIであることを示す`x-streaming`設定を使用
-- `media_type="text/plain"`と`response_class=PlainTextResponse`で定義されたテキストストリームを返す
+- クライアントSDK生成時にストリーミングAPIであることを示す`x-streaming`設定を使用。これにより型安全性を維持しつつストリーミング処理が可能
+- APIは`media_type="text/plain"`と`response_class=PlainTextResponse`で定義されたテキストストリームを返す
 
 :::note
-FastAPIに変更を加えるたびに、ウェブサイトの生成クライアントに変更を反映させるためプロジェクトを再ビルドする必要があります。
+FastAPIに変更を加えるたびに、Webサイトの生成クライアントに変更を反映させるためプロジェクトの再ビルドが必要です。
 
-以下の変更を加えた後、再ビルドします。
+以下の変更を加えた後で再ビルドします。
 :::
 
 ### インフラストラクチャ
 
-<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">以前に設定したインフラストラクチャ</Link>は、すべてのAPIがLambda関数と統合するAPI Gatewayを想定しています。`story_api`ではストリーミング応答をサポートしないAPI Gatewayを使用せず、[レスポンスストリーミングが有効なLambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)を使用します。
+<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">以前設定したインフラストラクチャ</Link>は、すべてのAPIがLambda関数と統合するAPI Gatewayを使用することを想定しています。`story_api`ではストリーミングレスポンスをサポートしないAPI Gatewayの代わりに、[レスポンスストリーミングを設定したLambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)を使用します。
 
-これをサポートするため、まずCDKコンストラクトを更新します：
+これをサポートするため、まずCDKコンストラクトを以下のように更新します：
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -106,7 +106,7 @@ FastAPIに変更を加えるたびに、ウェブサイトの生成クライア�
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -128,7 +128,7 @@ FastAPIに変更を加えるたびに、ウェブサイトの生成クライア�
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-リンターエラーが発生した場合、以下のコマンドで自動修正できます：
+リンターエラーが発生した場合、以下のコマンドで自動修正できます。
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
@@ -137,19 +137,19 @@ FastAPIに変更を加えるたびに、ウェブサイトの生成クライア�
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-デプロイは約2分かかります。
+このデプロイには約2分かかります。
 
-<Drawer title="デプロイコマンド" trigger="すべてのスタックを一度にデプロイすることも可能です。詳細はこちらをクリック">
+<Drawer title="デプロイコマンド" trigger="全スタックを一括デプロイする方法はこちら">
 
-CDKアプリケーション内のすべてのスタックをデプロイするには：
+CDKアプリケーション内の全スタックをデプロイするには：
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-ただし、本番環境用スタック（例：`infra-prod`）を分離している場合、`--all`フラグは望まないデプロイを引き起こす可能性があるため**推奨しません**
+ただし、本番環境用スタック（例：`infra-prod`）を別途管理する場合、`--all`フラグは意図しないデプロイを引き起こす可能性があるため**推奨しません**。
 
 </Drawer>
 
-デプロイが完了すると、以下のような出力が表示されます（一部の値は編集済み）：
+デプロイ完了後、以下のような出力が表示されます（一部値は編集済み）：
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -157,7 +157,7 @@ dungeon-adventure-infra-sandbox: deploying... [2/2]
 
  ✅  dungeon-adventure-infra-sandbox
 
-✨  Deployment time: 354s
+✨  デプロイ時間: 354秒
 
 Outputs:
 dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
@@ -168,15 +168,15 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = regi
 dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
-APIは以下の方法でテストできます：
+APIのテスト方法：
 <ul>
-<li>FastAPIサーバーをローカルで起動し`curl`でAPIを呼び出す</li>
+<li>FastAPIサーバーをローカルで起動し、`curl`でAPIを呼び出す</li>
 <li>
 <Drawer title="Sigv4対応curl" trigger="デプロイ済みAPIをsigv4対応curlで直接呼び出す">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-`.bashrc`ファイルに以下のスクリプトを追加（`source`で反映）するか、コマンド実行するターミナルに直接貼り付けます：
+以下のスクリプトを`.bashrc`に追加（`source`で反映）するか、コマンド実行前に同じターミナルに貼り付けます。
 ```bash
 // ~/.bashrc
 acurl () {
@@ -194,38 +194,38 @@ sigv4認証済みcurlリクエストの実行例：
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### ストリーミングLambda関数URL
+###### ストリーミングLambda function url
 ```bash
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-PowerShellプロファイルに関数を追加するか、現在のセッションに直接貼り付けます：
+PowerShellプロファイルに関数を追加するか、現在のセッションに貼り付けます。
 ```powershell
-# PowerShell profile or current session
+# PowerShellプロファイルまたは現在のセッション
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
 
-sigv4認証済みcurlリクエストの実行例：
+実行例：
 
 ###### API Gateway
 ```powershell
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### ストリーミングLambda関数URL
+###### ストリーミングLambda function url
 ```powershell
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
@@ -237,18 +237,19 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 </ul>
 
 <Tabs>
-  <TabItem label="Local">
-  ローカルFastAPIサーバーを起動：
+  <TabItem label="ローカル">
+  以下のコマンドでローカルFastAPIサーバーを起動：
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
     サーバー起動後、以下のコマンドで呼び出し：
+
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
       -d '{"genre":"superhero", "actions":[], "playerName":"UnnamedHero"}' \
       -H "Content-Type: application/json"
     ```
   </TabItem>
-  <TabItem label="Deployed">
+  <TabItem label="デプロイ済み">
 ```bash "https://xxx.lambda-url.ap-southeast-2.on.aws/" "ap-southeast-2"
 acurl ap-southeast-2 lambda -N -X POST \
   https://xxx.lambda-url.ap-southeast-2.on.aws/story/generate \
@@ -256,15 +257,15 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    CDKデプロイ出力の`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`値でURLプレースホルダーを置き換え、リージョンを適切に設定してください。
+    CDKデプロイ出力の`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`値でURLプレースホルダーを置換し、リージョンを適切に設定してください。
     </Aside>
   </TabItem>
 </Tabs>
 
-コマンドが成功すると、以下のようなストリーミング応答が表示されます：
+コマンドが成功すると、以下のようなストリーミングレスポンスが表示されます：
 
 ```
 UnnamedHero stood tall, his cape billowing in the wind....
 ```
 
-おめでとうございます。FastAPIを使用した最初のAPIの構築とデプロイに成功しました！ 🎉🎉🎉
+おめでとうございます。FastAPIを使った最初のAPIの構築とデプロイに成功しました！ 🎉🎉🎉

--- a/docs/src/content/docs/jp/guides/python-project.mdx
+++ b/docs/src/content/docs/jp/guides/python-project.mdx
@@ -10,7 +10,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Pythonプロジェクトジェネレータは、ベストプラクティスで構成されたモダンな[Python](https://www.python.org/)ライブラリまたはアプリケーションを作成するために使用できます。これには[UV](https://docs.astral.sh/uv/)による依存関係管理、単一のロックファイルと[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)内の仮想環境、テスト実行用の[pytest](https://docs.pytest.org/en/stable/)、静的解析用の[Ruff](https://docs.astral.sh/ruff/)が設定されています。
+Pythonプロジェクトジェネレータは、モダンな[Python](https://www.python.org/)ライブラリやアプリケーションを作成するために使用できます。ベストプラクティスに基づいて設定され、[UV](https://docs.astral.sh/uv/)による依存関係管理、単一のロックファイルと仮想環境を備えた[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)、テスト実行用の[pytest](https://docs.pytest.org/en/stable/)、静的解析用の[Ruff](https://docs.astral.sh/ruff/)が統合されています。
 
 ## 使用方法
 
@@ -32,23 +32,23 @@ Pythonプロジェクトジェネレータは、ベストプラクティスで�
 
   - \<module-name>
     - \_\_init\_\_.py モジュール初期化
-    - hello.py Pythonソースファイルの例
+    - hello.py サンプルPythonソースファイル
   - tests
     - \_\_init\_\_.py モジュール初期化
     - conftest.py テスト設定
-    - test_hello.py テストの例
+    - test_hello.py サンプルテスト
   - project.json プロジェクト設定とビルドターゲット
-  - pyproject.toml UVが使用するパッケージ設定ファイル
-  - .python-version プロジェクトのPythonバージョン
+  - pyproject.toml UV用パッケージ設定ファイル
+  - .python-version プロジェクトのPythonバージョン情報
 
 </FileTree>
 
-ワークスペースのルートにも以下のファイルが作成/更新されます:
+ワークスペースルートにも以下のファイルが作成/更新されます:
 
 <FileTree>
 
   - pyproject.toml UV用ワークスペースレベルのパッケージ設定
-  - .python-version ワークスペースのPythonバージョン
+  - .python-version ワークスペースのPythonバージョン情報
   - uv.lock Python依存関係のロックファイル
 
 </FileTree>
@@ -59,25 +59,37 @@ Pythonソースコードは`<module-name>`ディレクトリに追加します�
 
 ### 他のプロジェクトでのライブラリコードのインポート
 
-[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)が設定されているため、ワークスペース内の他のPythonプロジェクトからプロジェクトを参照できます:
+Pythonプロジェクトに依存関係を追加するには`add`ターゲットを使用します。
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+`my_app`と`my_lib`という2つのPythonプロジェクトを作成した場合、完全修飾プロジェクト名は`my_scope.my_app`と`my_scope.my_lib`になり、デフォルトのモジュール名は`my_scope_my_app`と`my_scope_my_lib`になります。
+
+`my_app`が`my_lib`に依存するようにするには、次のコマンドを実行します:
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+依存元と依存先の両方に完全修飾プロジェクト名を使用します。依存元プロジェクトには短縮構文を使用できますが、依存先プロジェクトは完全修飾名で指定する必要があります。
+:::
+
+これでライブラリコードをインポートできます:
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-上記の例では、`my_library`がモジュール名、`hello`はPythonソースファイル`hello.py`に対応し、`say_hello`は`hello.py`で定義されたメソッドです
+上記の例では、`my_scope_my_lib`がライブラリのモジュール名、`hello`は`hello.py`ファイルに対応し、`say_hello`は`hello.py`で定義されたメソッドです。
 
-### 依存関係
+### 依存関係の管理
 
-プロジェクトに依存関係を追加するには、Pythonプロジェクトで`add`ターゲットを実行します:
+プロジェクトに依存関係を追加するには、`add`ターゲットを実行します:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-これにより依存関係がプロジェクトの`pyproject.toml`ファイルに追加され、ルートの`uv.lock`が更新されます。
+これによりプロジェクトの`pyproject.toml`ファイルが更新され、ルートの`uv.lock`が更新されます。
 
 #### ランタイムコード
 
-Pythonプロジェクトをランタイムコード（例: AWS Lambda関数のハンドラ）として使用する場合、ソースコードとすべての依存関係のバンドルを作成する必要があります。`project.json`ファイルに以下のようなターゲットを追加することで実現できます:
+Pythonプロジェクトをランタイムコード（例: AWS Lambda関数のハンドラ）として使用する場合、ソースコードと依存関係をバンドルする必要があります。`project.json`ファイルに以下のようなターゲットを追加できます:
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ Pythonプロジェクトをランタイムコード（例: AWS Lambda関数の�
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -103,23 +115,23 @@ Pythonプロジェクトをランタイムコード（例: AWS Lambda関数の�
 
 ### ビルド
 
-Pythonプロジェクトには`build`ターゲット（`project.json`で定義）が設定されており、以下のコマンドで実行できます:
+Pythonプロジェクトには`build`ターゲット（`project.json`で定義）が設定されており、次のコマンドで実行できます:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 `<project-name>`はプロジェクトの完全修飾名です。
 
-`build`ターゲットはプロジェクトのコンパイル、リント、テストを実行します。
+`build`ターゲットはコンパイル、リンター実行、テストを実施します。
 
-ビルド出力はワークスペースのルート`dist`フォルダ内のパッケージとターゲットに対応するディレクトリ（例: `dist/packages/<my-library>/build`）に生成されます。
+ビルド出力はワークスペースルートの`dist`フォルダ内に生成されます（例: `dist/packages/<my-library>/build`）。
 
 ## テスト
 
-[pytest](https://docs.pytest.org/en/stable/)がプロジェクトのテスト用に設定されています。
+[pytest](https://docs.pytest.org/en/stable/)がテスト実行用に設定されています。
 
 ### テストの記述
 
-テストはプロジェクト内の`test`ディレクトリに`test_`で始まるPythonファイルとして記述します:
+テストはプロジェクト内の`test`ディレクトリに`test_`プレフィックス付きのPythonファイルで記述します:
 
 <FileTree>
   - my_library
@@ -128,7 +140,7 @@ Pythonプロジェクトには`build`ターゲット（`project.json`で定義�
     - test_hello.py hello.pyのテスト
 </FileTree>
 
-テストは`test_`で始まるメソッドとして記述し、アサーションを使用して期待値を検証します:
+テストメソッドは`test_`で始まり、アサーションで期待値を検証します:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -137,34 +149,34 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-テストの記述方法の詳細については[pytestドキュメント](https://docs.pytest.org/en/stable/how-to/assert.html#)を参照してください。
+テストの詳細な記述方法については[pytestドキュメント](https://docs.pytest.org/en/stable/how-to/assert.html#)を参照してください。
 
 ### テストの実行
 
-テストはプロジェクトの`build`ターゲットの一部として実行されますが、`test`ターゲットを個別に実行することもできます:
+テストは`build`ターゲットの一部として実行されますが、`test`ターゲットで個別に実行することも可能です:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-`-k`フラグを使用して特定のテストファイルまたはメソッドを指定して実行できます:
+`-k`フラグを使用して特定のテストファイルやメソッドを指定できます:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## リント
+## リンター
 
-Pythonプロジェクトでは[RUFF](https://docs.astral.sh/ruff/)を使用してリントを行います。
+Pythonプロジェクトでは[Ruff](https://docs.astral.sh/ruff/)をリンターとして使用しています。
 
-### リントの実行
+### リンターの実行
 
-プロジェクトのリントチェックを実行するには`lint`ターゲットを実行します:
+プロジェクトのリンターを実行するには`lint`ターゲットを使用します:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### リント問題の修正
+### リンター問題の修正
 
-ほとんどのリントやフォーマットの問題は自動修正可能です。`--configuration=fix`引数を付けて実行することで修正できます:
+ほとんどのリンターやフォーマッターの問題は自動修正可能です。`--configuration=fix`引数を付けて実行します:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-ワークスペース内の全パッケージのリント問題を修正するには以下を実行します:
+ワークスペース内の全パッケージのリンター問題を修正するには:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/3.mdx
@@ -29,14 +29,14 @@ import gameConversationPng from '@assets/game-conversation.png'
 [이 가이드](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)에 설명된 단계에 따라 **Anthropic Claude 3.5 Sonnet v2** 모델에 대한 액세스 권한을 부여했는지 확인하세요.
 </Aside>
 
-StoryApi는 `Game`과 컨텍스트용 `Action` 목록을 입력받아 스토리를 진행하는 단일 API `generate_story`로 구성됩니다. 이 API는 Python/FastAPI로 스트리밍 API로 구현되며, 생성된 코드를 목적에 맞게 수정하는 방법을 추가로 시연합니다.
+StoryApi는 `Game`과 컨텍스트용 `Action` 목록을 입력받아 스토리를 진행시키는 단일 API `generate_story`로 구성됩니다. 이 API는 Python/FastAPI로 스트리밍 API로 구현되며, 생성된 코드를 목적에 맞게 수정하는 방법을 추가로 시연합니다.
 
 ### API 구현
 
 API를 생성하기 전에 먼저 몇 가지 추가 종속성을 설치해야 합니다.
 
 - `boto3`는 Amazon Bedrock 호출에 사용됩니다.
-- `uvicorn`은 [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)와 함께 사용할 때 API 시작에 사용됩니다.
+- `uvicorn`은 [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)와 함께 사용 시 API 시작에 사용됩니다.
 - `copyfiles`는 `bundle` 작업 업데이트 시 크로스 플랫폼 파일 복사를 지원하기 위한 npm 종속성입니다.
 
 이 종속성들을 설치하려면 다음 명령어를 실행하세요:
@@ -66,16 +66,16 @@ API를 생성하기 전에 먼저 몇 가지 추가 종속성을 설치해야 �
 - API는 `media_type="text/plain"`과 `response_class=PlainTextResponse`로 정의된 텍스트 스트림을 반환합니다.
 
 :::note
-FastAPI를 변경할 때마다 웹사이트의 생성된 클라이언트에 변경사항이 반영되도록 프로젝트를 재빌드해야 합니다.
+FastAPI를 변경할 때마다 웹사이트에서 생성된 클라이언트에 변경사항이 반영되도록 프로젝트를 재빌드해야 합니다.
 
 아래에서 몇 가지 추가 변경을 진행한 후 재빌드하겠습니다.
 :::
 
-### 인프라
+### 인프라 구조
 
-이전에 설정한 <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">인프라</Link>는 모든 API가 Lambda 함수와 통합하는 API Gateway를 사용한다고 가정합니다. `story_api`의 경우 스트리밍 응답을 지원하지 않는 API Gateway 대신 [응답 스트리밍이 구성된 Lambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)을 사용합니다.
+<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">이전에 설정한 인프라</Link>는 모든 API가 Lambda 함수와 통합되는 API Gateway를 사용한다고 가정합니다. 하지만 `story_api`의 경우 스트리밍 응답을 지원하지 않는 API Gateway 대신 [응답 스트리밍이 구성된 Lambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)을 사용합니다.
 
-이를 지원하기 위해 CDK 구성을 다음과 같이 업데이트합니다:
+이를 지원하기 위해 먼저 CDK 구성을 다음과 같이 업데이트합니다:
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -106,7 +106,7 @@ FastAPI를 변경할 때마다 웹사이트의 생성된 클라이언트에 변�
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -128,28 +128,28 @@ FastAPI를 변경할 때마다 웹사이트의 생성된 클라이언트에 변�
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-린트 오류가 발생하면 다음 명령어로 자동 수정할 수 있습니다.
+린트 오류가 발생하면 다음 명령어를 실행하여 자동으로 수정할 수 있습니다.
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-이제 다음 명령어로 애플리케이션을 배포할 수 있습니다:
+이제 다음 명령어를 실행하여 애플리케이션을 배포할 수 있습니다:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 이 배포는 완료까지 약 2분 정도 소요됩니다.
 
-<Drawer title="배포 명령어" trigger="한 번에 모든 스택을 배포할 수도 있습니다. 자세한 내용을 보려면 여기를 클릭하세요.">
+<Drawer title="배포 명령어" trigger="모든 스택을 한 번에 배포할 수도 있습니다. 자세한 내용을 보려면 클릭하세요.">
 
-다음 명령어로 CDK 애플리케이션의 모든 스택을 배포할 수 있습니다:
+다음 명령어를 실행하여 CDK 애플리케이션에 포함된 모든 스택을 배포할 수 있습니다:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-인프라 프로덕션 환경을 별도 스택(`infra-prod` 등)으로 분리하는 경우 `--all` 플래그가 원치 않는 배포를 유발할 수 있으므로 **권장하지 않습니다**!
+인프라 프로덕션 스택(`infra-prod`)과 같이 배포 단계를 별도 스택으로 분리하는 경우 `--all` 플래그가 원치 않는 배포를 유발할 수 있으므로 **권장하지 않습니다**!
 
 </Drawer>
 
-배포가 완료되면 다음과 유사한 출력을 확인할 수 있습니다(일부 값은 생략됨):
+배포가 완료되면 다음과 유사한 출력이 표시됩니다 _(일부 값은 편집됨)_:
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -157,7 +157,7 @@ dungeon-adventure-infra-sandbox: deploying... [2/2]
 
  ✅  dungeon-adventure-infra-sandbox
 
-✨  배포 시간: 354초
+✨  Deployment time: 354s
 
 Outputs:
 dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
@@ -170,7 +170,7 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_x
 
 다음 방법으로 API를 테스트할 수 있습니다:
 <ul>
-<li>FastApi 서버를 로컬에서 시작하고 `curl`로 API 호출</li>
+<li>FastApi 서버를 로컬로 시작하고 `curl`로 API 호출</li>
 <li>
 <Drawer title="Sigv4 활성화 curl" trigger="배포된 API를 sigv4 활성화 curl로 직접 호출">
 
@@ -187,7 +187,7 @@ acurl () {
 }
 ```
 
-sigv4 인증 curl 요청 예시:
+sigv4 인증 curl 요청은 다음 예시처럼 `acurl`을 사용하여 실행할 수 있습니다:
 
 ###### API Gateway
 ```bash
@@ -200,25 +200,25 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-PowerShell 프로필에 다음 함수를 추가하거나 현재 세션에 직접 붙여넣으세요.
+PowerShell 프로필에 다음 함수를 추가하거나 현재 PowerShell 세션에 직접 붙여넣으세요.
 ```powershell
-# PowerShell 프로필 또는 현재 세션
+# PowerShell profile or current session
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
 
-sigv4 인증 curl 요청 예시:
+sigv4 인증 curl 요청은 다음 예시처럼 `acurl`을 사용하여 실행할 수 있습니다:
 
 ###### API Gateway
 ```powershell
@@ -241,7 +241,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
   다음 명령어로 로컬 FastAPI 서버를 시작하세요:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    서버가 실행되면 다음 명령어로 호출합니다:
+    FastAPI 서버가 실행되면 다음 명령어로 호출합니다:
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -249,7 +249,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
       -H "Content-Type: application/json"
     ```
   </TabItem>
-  <TabItem label="배포 환경 테스트">
+  <TabItem label="배포 버전 테스트">
 ```bash "https://xxx.lambda-url.ap-southeast-2.on.aws/" "ap-southeast-2"
 acurl ap-southeast-2 lambda -N -X POST \
   https://xxx.lambda-url.ap-southeast-2.on.aws/story/generate \
@@ -257,7 +257,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    CDK 배포 출력값 `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`에서 URL 자리표시자를 교체하고 리전을 적절히 설정하세요.
+    CDK 배포 출력값 `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`을 사용하여 URL 플레이스홀더를 교체하고 리전을 적절히 설정하세요.
     </Aside>
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/ko/guides/python-project.mdx
+++ b/docs/src/content/docs/ko/guides/python-project.mdx
@@ -10,13 +10,13 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [UV](https://docs.astral.sh/uv/)로 관리되는 단일 lockfile과 [UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/) 내의 가상 환경, 테스트 실행을 위한 [pytest](https://docs.pytest.org/en/stable/), 정적 분석을 위한 [Ruff](https://docs.astral.sh/ruff/)가 최적의 사례로 구성되어 있습니다.
+Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [UV](https://docs.astral.sh/uv/)로 관리되는 단일 잠금 파일 및 가상 환경을 [UV 작업 공간](https://docs.astral.sh/uv/concepts/projects/workspaces/)에 구성하고, 테스트 실행을 위한 [pytest](https://docs.pytest.org/en/stable/), 정적 분석을 위한 [Ruff](https://docs.astral.sh/ruff/) 등 모범 사례가 적용되어 있습니다.
 
 ## 사용 방법
 
 ### Python 프로젝트 생성
 
-새 Python 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
+새로운 Python 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="py#project" />
 
@@ -26,7 +26,7 @@ Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이
 
 ## 생성기 출력 결과
 
-생성기는 `<directory>/<name>` 디렉터리에 다음 프로젝트 구조를 생성합니다:
+생성기는 `<directory>/<name>` 디렉토리에 다음 프로젝트 구조를 생성합니다:
 
 <FileTree>
 
@@ -35,49 +35,61 @@ Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이
     - hello.py 예제 Python 소스 파일
   - tests
     - \_\_init\_\_.py 모듈 초기화
-    - conftest.py 테스트 설정
+    - conftest.py 테스트 구성
     - test_hello.py 예제 테스트
-  - project.json 프로젝트 설정 및 빌드 타겟
-  - pyproject.toml UV용 패키징 설정 파일
+  - project.json 프로젝트 구성 및 빌드 대상
+  - pyproject.toml UV용 패키징 구성 파일
   - .python-version 프로젝트의 Python 버전 포함
 
 </FileTree>
 
-워크스페이스 루트에 다음 파일들이 생성/업데이트된 것도 확인할 수 있습니다:
+작업 공간 루트에 다음 파일이 생성/업데이트된 것을 확인할 수도 있습니다:
 
 <FileTree>
 
-  - pyproject.toml UV용 워크스페이스 수준 패키징 설정
-  - .python-version 워크스페이스 Python 버전 포함
-  - uv.lock Python 의존성 lockfile
+  - pyproject.toml UV용 작업 공간 수준 패키징 구성
+  - .python-version 작업 공간 Python 버전 포함
+  - uv.lock Python 종속성 잠금 파일
 
 </FileTree>
 
 ## Python 소스 코드 작성
 
-Python 소스 코드는 `<module-name>` 디렉터리에 추가하세요.
+Python 소스 코드는 `<module-name>` 디렉토리에 추가하세요.
 
 ### 다른 프로젝트에서 라이브러리 코드 임포트
 
-[UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/)가 설정되어 있으므로, 워크스페이스 내 다른 Python 프로젝트에서 Python 프로젝트를 참조할 수 있습니다:
+`add` 대상을 사용하여 Python 프로젝트에 종속성을 추가할 수 있습니다.
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+`my_app`과 `my_lib` 두 개의 Python 프로젝트를 생성했다고 가정합니다. 이 프로젝트의 정규화된 이름은 `my_scope.my_app`과 `my_scope.my_lib`이 되며, 기본 모듈 이름은 각각 `my_scope_my_app`과 `my_scope_my_lib`이 됩니다.
+
+`my_app`이 `my_lib`에 종속되도록 하려면 다음 명령을 실행합니다:
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+종속 프로젝트와 피종속 프로젝트 모두 정규화된 프로젝트 이름을 사용합니다. 종속을 추가할 프로젝트에는 단축 구문을 사용할 수 있지만, 종속할 프로젝트 이름은 완전히 정규화되어야 합니다.
+:::
+
+이제 라이브러리 코드를 임포트할 수 있습니다:
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-위 예시에서 `my_library`는 모듈 이름, `hello`는 `hello.py` Python 소스 파일, `say_hello`는 `hello.py`에 정의된 메서드입니다.
+위 예시에서 `my_scope_my_lib`은 라이브러리의 모듈 이름이며, `hello`는 Python 소스 파일 `hello.py`에 해당하고, `say_hello`는 `hello.py`에 정의된 메서드입니다.
 
-### 의존성 관리
+### 종속성 관리
 
-프로젝트에 의존성을 추가하려면 Python 프로젝트에서 `add` 타겟을 실행하면 됩니다. 예시:
+프로젝트에 종속성을 추가하려면 Python 프로젝트에서 `add` 대상을 실행하세요. 예시:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-이 명령은 프로젝트의 `pyproject.toml` 파일에 의존성을 추가하고 루트 `uv.lock`을 업데이트합니다.
+이 명령은 프로젝트의 `pyproject.toml` 파일에 종속성을 추가하고 루트 `uv.lock`을 업데이트합니다.
 
 #### 런타임 코드
 
-Python 프로젝트를 런타임 코드로 사용할 때(예: AWS 람다 함수 핸들러), 소스 코드와 모든 의존성을 번들로 만들어야 합니다. `project.json` 파일에 다음 타겟을 추가하여 이를 달성할 수 있습니다:
+Python 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사용할 경우, 소스 코드와 모든 종속성을 번들로 만들어야 합니다. `project.json` 파일에 다음 예시와 같은 대상을 추가하여 이를 구현할 수 있습니다:
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ Python 프로젝트를 런타임 코드로 사용할 때(예: AWS 람다 함수 
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -103,15 +115,15 @@ Python 프로젝트를 런타임 코드로 사용할 때(예: AWS 람다 함수 
 
 ### 빌드
 
-Python 프로젝트는 `build` 타겟(`project.json`에 정의됨)으로 구성되어 있으며 다음 명령으로 실행할 수 있습니다:
+Python 프로젝트는 `build` 대상으로 구성되어 있으며(`project.json`에 정의됨), 다음 명령으로 실행할 수 있습니다:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-여기서 `<project-name>`은 프로젝트의 전체 정규화된 이름입니다.
+여기서 `<project-name>`은 프로젝트의 정규화된 이름입니다.
 
-`build` 타겟은 프로젝트를 컴파일, 린트, 테스트합니다.
+`build` 대상은 프로젝트를 컴파일, 린트, 테스트합니다.
 
-빌드 결과물은 워크스페이스 루트의 `dist` 폴더 내 패키지 및 타겟별 디렉터리(예: `dist/packages/<my-library>/build`)에서 확인할 수 있습니다.
+빌드 출력은 작업 공간 루트의 `dist` 폴더 내 프로젝트별 디렉토리(예: `dist/packages/<my-library>/build`)에서 확인할 수 있습니다.
 
 ## 테스트
 
@@ -119,7 +131,7 @@ Python 프로젝트는 `build` 타겟(`project.json`에 정의됨)으로 구성�
 
 ### 테스트 작성
 
-테스트는 프로젝트 내 `test` 디렉터리에 `test_` 접두사가 붙은 Python 파일에 작성해야 합니다. 예시:
+테스트는 프로젝트 내 `test` 디렉토리에 `test_` 접두사가 붙은 Python 파일로 작성해야 합니다. 예시:
 
 <FileTree>
   - my_library
@@ -128,7 +140,7 @@ Python 프로젝트는 `build` 타겟(`project.json`에 정의됨)으로 구성�
     - test_hello.py hello.py 테스트
 </FileTree>
 
-테스트는 `test_`로 시작하는 메서드로 작성하며, 예상 결과를 검증하기 위해 assertion을 사용합니다. 예시:
+테스트 메서드는 `test_`로 시작하며 어설션을 사용하여 기대값을 검증합니다. 예시:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -141,11 +153,11 @@ def test_say_hello():
 
 ### 테스트 실행
 
-테스트는 프로젝트의 `build` 타겟 실행 시 함께 실행되지만, `test` 타겟을 별도로 실행할 수도 있습니다:
+테스트는 프로젝트의 `build` 대상 실행 시 자동으로 실행되지만, `test` 대상으로 개별 실행도 가능합니다:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-`-k` 플래그를 사용하여 특정 테스트 파일이나 메서드를 지정해 개별 테스트를 실행할 수 있습니다:
+`-k` 플래그를 사용하여 특정 테스트 파일이나 메서드를 지정해 실행할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -155,16 +167,16 @@ Python 프로젝트는 [Ruff](https://docs.astral.sh/ruff/)를 사용해 린팅�
 
 ### 린터 실행
 
-프로젝트 린트 검사를 수행하려면 `lint` 타겟을 실행하세요:
+프로젝트 린트 검사를 위해 `lint` 대상을 실행하세요:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
 ### 린트 문제 수정
 
-대부분의 린트 또는 포맷팅 문제는 자동으로 수정할 수 있습니다. `--configuration=fix` 인자를 추가해 Ruff가 문제를 수정하도록 할 수 있습니다:
+대부분의 린트 또는 포맷팅 문제는 자동으로 수정할 수 있습니다. `--configuration=fix` 인자를 사용하여 Ruff가 문제를 수정하도록 할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-워크스페이스의 모든 패키지에서 린트 문제를 일괄 수정하려면 다음 명령을 실행하세요:
+모든 패키지의 린트 문제를 일괄 수정하려면 다음 명령을 실행하세요:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/3.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jogo de Dungeons com IA"
-description: "Um guia passo a passo de como construir um jogo de aventura de dungeon alimentado por IA usando o @aws/nx-plugin."
+description: "Um guia passo a passo de como construir um jogo de aventura de dungeon com IA usando o @aws/nx-plugin."
 ---
 
 
@@ -23,21 +23,21 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## Módulo 3: Implementação da API de História
+## Módulo 3: Implementação da API de Story
 
 <Aside type="caution">
-Certifique-se de ter concedido acesso ao modelo **Anthropic Claude 3.5 Sonnet v2** seguindo as etapas descritas [neste guia](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
+Certifique-se de ter concedido acesso ao modelo **Anthropic Claude 3.5 Sonnet v2** seguindo os passos descritos no [guia oficial](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-A StoryApi consiste em uma única API `generate_story` que, dado um `Game` e uma lista de `Action`s como contexto, irá progredir uma história. Esta API será implementada como uma API de streaming em Python/FastAPI e também demonstrará como alterações podem ser feitas no código gerado para adequá-lo ao propósito.
+A StoryApi consiste em uma única API `generate_story` que, dado um `Game` e uma lista de `Action`s como contexto, irá progredir uma história. Esta API será implementada como uma API de streaming em Python/FastAPI e também demonstrará como ajustar o código gerado para propósitos específicos.
 
 ### Implementação da API
 
-Para criar nossa API, primeiro precisamos instalar algumas dependências adicionais:
+Para criar nossa API, primeiro precisamos instalar dependências adicionais:
 
 - `boto3` será usado para chamar o Amazon Bedrock;
 - `uvicorn` será usado para iniciar nossa API em conjunto com o [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter);
-- `copyfiles` é uma dependência npm necessária para suportar a cópia multiplataforma de arquivos ao atualizar nossa tarefa `bundle`.
+- `copyfiles` é uma dependência npm necessária para suportar cópias de arquivos multiplataforma ao atualizar nossa tarefa `bundle`.
 
 Para instalar estas dependências, execute os seguintes comandos:
 
@@ -54,7 +54,7 @@ Agora vamos substituir o conteúdo dos seguintes arquivos em `packages/story_api
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-A alteração acima em `init.py` simplesmente remove o middleware CORS para evitar conflitos com o tratamento próprio de cabeçalhos CORS do Lambda Function URL.
+A alteração acima no `init.py` simplesmente remove o middleware CORS para evitar conflitos com o tratamento próprio de cabeçalhos CORS do Lambda Function URL.
 :::
 
 </TabItem>
@@ -62,20 +62,20 @@ A alteração acima em `init.py` simplesmente remove o middleware CORS para evit
 
 Analisando o código acima:
 
-- Usamos a configuração `x-streaming` para indicar que esta é uma API de streaming ao gerar nosso client SDK. Isso permitirá consumir esta API de forma streaming mantendo a segurança de tipos!
-- Nossa API simplesmente retorna um fluxo de texto conforme definido por `media_type="text/plain"` e `response_class=PlainTextResponse`
+- Usamos a configuração `x-streaming` para indicar que esta é uma API de streaming ao gerar nosso client SDK. Isso permitirá consumir a API de forma streaming mantendo a segurança de tipos!
+- Nossa API simplesmente retorna um fluxo de texto definido por `media_type="text/plain"` e `response_class=PlainTextResponse`
 
 :::note
-Sempre que fizer alterações em seu FastAPI, você precisará reconstruir o projeto para ver essas alterações refletidas no client gerado em seu website.
+Sempre que fizer alterações no FastAPI, você precisará reconstruir o projeto para ver as mudanças refletidas no client gerado no website.
 
 Faremos mais algumas alterações abaixo antes de reconstruir.
 :::
 
 ### Infraestrutura
 
-A <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestrutura que configuramos anteriormente</Link> assume que todas as APIs têm um API Gateway integrado com funções Lambda. Para nossa `story_api`, não queremos usar o API Gateway pois ele não suporta respostas em streaming. Em vez disso, usaremos um [Lambda Function URL configurado com response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+A <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestrutura configurada anteriormente</Link> assume que todas as APIs usam API Gateway integrado com funções Lambda. Para nossa `story_api`, não queremos usar API Gateway pois não suporta respostas streaming. Em vez disso, usaremos um [Lambda Function URL configurado com response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Para suportar isso, primeiro atualizaremos nossos construtos CDK da seguinte forma:
+Para isso, primeiro atualizaremos nossos constructs CDK:
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -106,7 +106,7 @@ Agora atualizaremos a `story_api` para suportar a implantação do [Lambda Web A
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -128,28 +128,28 @@ Primeiro, vamos construir a base de código:
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-Se encontrar erros de lint, você pode executar o seguinte comando para corrigi-los automaticamente:
+Se encontrar erros de lint, execute o seguinte comando para corrigi-los automaticamente:
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-Sua aplicação agora pode ser implantada executando o seguinte comando:
+Sua aplicação pode ser implantada executando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-Esta implantação levará aproximadamente 2 minutos para ser concluída.
+Esta implantação levará aproximadamente 2 minutos para completar.
 
-<Drawer title="Comando de implantação" trigger="Você também pode implantar todas as stacks de uma vez. Clique aqui para mais detalhes.">
+<Drawer title="Comando de implantação" trigger="Você também pode implantar todas as stacks de uma vez. Clique para mais detalhes.">
 
-Você também pode implantar todas as stacks contidas na aplicação CDK executando:
+Você pode implantar todas as stacks da aplicação CDK executando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Isso **não é recomendado** pois você pode optar por separar seus estágios de implantação como stacks separadas `ex: infra-prod`. Neste caso, o flag `--all` tentará implantar todas as stacks, o que pode resultar em implantações indesejadas!
+Isso **não é recomendado** pois você pode querer separar estágios de implantação em stacks diferentes (ex: `infra-prod`). Neste caso, o flag `--all` tentará implantar todas as stacks podendo causar implantações indesejadas!
 
 </Drawer>
 
-Após a conclusão da implantação, você verá saídas semelhantes às seguintes _(alguns valores foram omitidos)_:
+Após a implantação, você verá saídas similares a estas _(alguns valores foram omitidos)_:
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -170,13 +170,13 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_x
 
 Podemos testar nossa API de duas formas:
 <ul>
-<li>Iniciando uma instância local do servidor FastAPI e invocando as APIs usando `curl`</li>
+<li>Iniciando uma instância local do servidor FastAPI e invocando as APIs com `curl`</li>
 <li>
-<Drawer title="curl com Sigv4 habilitado" trigger="Chamando a API implantada diretamente usando curl com Sigv4">
+<Drawer title="Curl com Sigv4" trigger="Chamar a API implantada usando curl com Sigv4">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Você pode adicionar o seguinte script ao seu arquivo `.bashrc` (e executar `source`) ou colar diretamente no terminal onde executará o comando.
+Adicione este script ao seu `.bashrc` (e execute `source`) ou cole diretamente no terminal:
 ```bash
 // ~/.bashrc
 acurl () {
@@ -194,13 +194,13 @@ Exemplos de uso:
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### URL de função Lambda com streaming
+###### Lambda Function URL streaming
 ```bash
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Adicione esta função ao seu perfil PowerShell ou cole diretamente na sessão atual.
+Adicione esta função ao perfil PowerShell ou cole na sessão atual:
 ```powershell
 function acurl {
     param(
@@ -208,11 +208,11 @@ function acurl {
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
@@ -224,7 +224,7 @@ Exemplos de uso:
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### URL de função Lambda com streaming
+###### Lambda Function URL streaming
 ```powershell
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
@@ -237,10 +237,10 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="Local">
-  Inicie o servidor FastAPI localmente com:
+  Inicie o servidor FastAPI localmente:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Após iniciar, execute o comando:
+    Execute o comando curl:
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -256,12 +256,12 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Use o valor de saída do CDK `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` para substituir o placeholder de URL e ajustar a região corretamente.
+    Use o valor de saída `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` do CDK para substituir o placeholder de URL e ajuste a região conforme necessário.
     </Aside>
   </TabItem>
 </Tabs>
 
-Se executado com sucesso, você verá uma resposta em streaming similar a:
+Se executado com sucesso, você verá uma resposta streaming similar a:
 
 ```
 UnnamedHero stood tall, his cape billowing in the wind....

--- a/docs/src/content/docs/pt/guides/python-project.mdx
+++ b/docs/src/content/docs/pt/guides/python-project.mdx
@@ -32,11 +32,11 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
 
   - \<module-name>
     - \_\_init\_\_.py Inicialização do módulo
-    - hello.py Arquivo de exemplo em Python
+    - hello.py Exemplo de arquivo fonte Python
   - tests
-    - \_\_init\_\_.py Inicialização do módulo
+    - \_\_init\_\_.py Inicialização do módulo  
     - conftest.py Configuração de testes
-    - test_hello.py Testes de exemplo
+    - test_hello.py Exemplo de testes
   - project.json Configuração do projeto e targets de build
   - pyproject.toml Arquivo de configuração de empacotamento usado pelo UV
   - .python-version Contém a versão do Python do projeto
@@ -53,19 +53,31 @@ Você também pode notar os seguintes arquivos criados/atualizados na raiz do wo
 
 </FileTree>
 
-## Escrevendo Código Python
+## Escrevendo Código Fonte Python
 
 Adicione seu código fonte Python no diretório `<module-name>`.
 
-### Importando Código da Biblioteca em Outros Projetos
+### Importando Código da Sua Biblioteca em Outros Projetos
 
-Como os [UV workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) estão configurados para você, é possível referenciar seu projeto Python de qualquer outro projeto Python no workspace:
+Use o target `add` para adicionar uma dependência a um projeto Python.
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+Suponha que criamos dois projetos Python, `my_app` e `my_lib`. Estes terão nomes de projeto totalmente qualificados como `my_scope.my_app` e `my_scope.my_lib`, e por padrão terão nomes de módulo `my_scope_my_app` e `my_scope_my_lib`.
+
+Para que `my_app` dependa de `my_lib`, podemos executar o seguinte comando:
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+Usamos o nome totalmente qualificado do projeto tanto para o dependente quanto para a dependência. Podemos usar a sintaxe abreviada para o projeto ao qual queremos adicionar a dependência, mas devemos qualificar totalmente o nome do projeto da dependência.
+:::
+
+Você pode então importar o código da biblioteca:
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-No exemplo acima, `my_library` é o nome do módulo, `hello` corresponde ao arquivo Python `hello.py`, e `say_hello` é um método definido em `hello.py`
+Acima, `my_scope_my_lib` é o nome do módulo da biblioteca, `hello` corresponde ao arquivo fonte Python `hello.py`, e `say_hello` é um método definido em `hello.py`
 
 ### Dependências
 
@@ -75,9 +87,9 @@ Para adicionar dependências ao seu projeto, você pode executar o target `add` 
 
 Isso adicionará a dependência ao arquivo `pyproject.toml` do seu projeto e atualizará o `uv.lock` raiz.
 
-#### Código em Runtime
+#### Código de Runtime
 
-Ao usar seu projeto Python como código em runtime (por exemplo, como handler de uma função AWS Lambda), você precisará criar um bundle do código fonte com todas as dependências. Isso pode ser feito adicionando um target como o seguinte ao seu arquivo `project.json`:
+Quando você usa seu projeto Python como código de runtime (por exemplo, como handler de uma função AWS Lambda), precisará criar um bundle do código fonte e todas suas dependências. Você pode fazer isso adicionando um target como o seguinte ao seu arquivo `project.json`:
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ Ao usar seu projeto Python como código em runtime (por exemplo, como handler de
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -103,19 +115,19 @@ Ao usar seu projeto Python como código em runtime (por exemplo, como handler de
 
 ### Build
 
-Seu projeto Python está configurado com um target `build` (definido em `project.json`), que pode ser executado via:
+Seu projeto Python está configurado com um target `build` (definido em `project.json`), que você pode executar via:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 Onde `<project-name>` é o nome totalmente qualificado do seu projeto.
 
-O target `build` irá compilar, verificar lint e testar seu projeto.
+O target `build` irá compilar, lintar e testar seu projeto.
 
 A saída do build pode ser encontrada na pasta `dist` raiz do seu workspace, dentro de um diretório para seu pacote e target, por exemplo `dist/packages/<my-library>/build`
 
 ## Testes
 
-O [pytest](https://docs.pytest.org/en/stable/) está configurado para testar seu projeto.
+[pytest](https://docs.pytest.org/en/stable/) está configurado para testar seu projeto.
 
 ### Escrevendo Testes
 
@@ -155,16 +167,16 @@ Projetos Python usam [Ruff](https://docs.astral.sh/ruff/) para linting.
 
 ### Executando o Linter
 
-Para invocar o linter e verificar seu projeto, execute o target `lint`:
+Para invocar o linter e verificar seu projeto, você pode executar o target `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corrigindo Problemas de Lint
+### Corrigindo Problemas de Linting
 
-A maioria dos problemas de linting ou formatação pode ser corrigida automaticamente. Você pode pedir ao Ruff para corrigir problemas usando o argumento `--configuration=fix`:
+A maioria dos problemas de linting ou formatação pode ser corrigida automaticamente. Você pode pedir ao Ruff para corrigir problemas de linting executando com o argumento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Da mesma forma, para corrigir todos os problemas de lint em todos os pacotes do workspace:
+Da mesma forma, se quiser corrigir todos os problemas de linting em todos os pacotes do seu workspace, você pode executar:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/3.mdx
@@ -29,22 +29,22 @@ import gameConversationPng from '@assets/game-conversation.png'
 请确保已按照[本指南](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)中的步骤授予对**Anthropic Claude 3.5 Sonnet v2**模型的访问权限。
 </Aside>
 
-StoryApi包含一个单独的API`generate_story`，该API接收一个`Game`和用于上下文的`Action`列表来推进故事情节。我们将使用Python/FastAPI将此API实现为流式API，并演示如何对生成的代码进行调整以满足实际需求。
+StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`和上下文`Action`列表推进故事情节。我们将使用Python/FastAPI将其实现为流式API，并演示如何对生成的代码进行调整以满足实际需求。
 
 ### API实现
 
-要创建API，首先需要安装两个额外的依赖项：
+要创建API，首先需要安装两个额外依赖：
 
-- `boto3`用于调用Amazon Bedrock；
-- `uvicorn`与[Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)配合使用来启动API；
-- `copyfiles`是npm依赖项，用于在更新`bundle`任务时支持跨平台文件复制。
+- `boto3` 用于调用Amazon Bedrock；
+- `uvicorn` 配合[Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)启动API；
+- `copyfiles` 是npm依赖项，用于在更新`bundle`任务时支持跨平台文件复制。
 
-运行以下命令安装这些依赖项：
+运行以下命令安装依赖：
 
 <NxCommands commands={["run dungeon_adventure.story_api:add --args boto3 uvicorn"]} />
 <InstallCommand pkg="copyfiles" dev />
 
-现在替换`packages/story_api/story_api`目录中的以下文件内容：
+现在替换`packages/story_api/story_api`目录中的文件内容：
 
 <Tabs>
 <TabItem label="main.py">
@@ -54,7 +54,7 @@ StoryApi包含一个单独的API`generate_story`，该API接收一个`Game`和�
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-上述对`init.py`的修改移除了CORS中间件，以避免与Lambda函数URL自身的CORS头处理产生冲突。
+上述对`init.py`的修改移除了CORS中间件，以避免与Lambda Function URL自带的CORS头处理产生冲突。
 :::
 
 </TabItem>
@@ -62,20 +62,20 @@ StoryApi包含一个单独的API`generate_story`，该API接收一个`Game`和�
 
 代码分析：
 
-- 使用`x-streaming`设置标记为流式API，在生成客户端SDK时保持类型安全的流式消费
-- API通过`media_type="text/plain"`和`response_class=PlainTextResponse`定义返回纯文本流
+- 使用`x-streaming`设置标记流式API，后续生成客户端SDK时将保持类型安全的流式消费能力
+- API通过`media_type="text/plain"`和`response_class=PlainTextResponse`定义纯文本流响应
 
 :::note
-每次修改FastAPI后都需要重新构建项目，才能在网站生成的客户端中看到变更。
+每次修改FastAPI后都需要重新构建项目，才能在网站生成的客户端中看到变更效果。
 
-我们将在下面进行更多修改后再进行重建。
+我们将在后续进行更多修改后再执行构建。
 :::
 
 ### 基础设施
 
-先前设置的<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">基础设施</Link>假设所有API都通过API Gateway与Lambda函数集成。对于`story_api`，我们需要使用[支持响应流式的Lambda函数URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)来替代API Gateway。
+先前设置的<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">基础设施</Link>假设所有API都通过API Gateway与Lambda集成。对于`story_api`，我们需要使用支持流式响应的[Lambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)替代API Gateway。
 
-更新CDK构造如下：
+首先更新CDK构造：
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ StoryApi包含一个单独的API`generate_story`，该API接收一个`Game`和�
 </TabItem>
 </Tabs>
 
-更新`story_api`以支持[Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)部署：
+接下来更新`story_api`以支持[Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)部署：
 
 <Tabs>
 <TabItem label="run.sh">
@@ -106,7 +106,7 @@ StoryApi包含一个单独的API`generate_story`，该API接收一个`Game`和�
       "outputs": ["{workspaceRoot}/dist/packages/story_api/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project story_api -o dist/packages/story_api/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
@@ -139,13 +139,13 @@ StoryApi包含一个单独的API`generate_story`，该API接收一个`Game`和�
 
 部署过程约需2分钟。
 
-<Drawer title="部署命令" trigger="点击查看同时部署所有堆栈的详细信息">
+<Drawer title="部署命令" trigger="点击查看批量部署详情">
 
-可运行以下命令部署CDK应用包含的所有堆栈：
+也可通过以下命令部署CDK应用包含的所有堆栈：
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-**不建议**此操作，因为当您将部署阶段拆分为独立堆栈（如`infra-prod`）时，`--all`标志会尝试部署所有堆栈，可能导致意外部署！
+但**不建议**此方式，因实际环境中可能需分阶段部署不同堆栈（如infra-prod），使用`--all`参数可能导致意外部署！
 
 </Drawer>
 
@@ -170,13 +170,13 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_x
 
 可通过以下方式测试API：
 <ul>
-<li>启动FastAPI本地实例并使用`curl`调用</li>
+<li>启动本地FastAPI服务器并使用`curl`调用</li>
 <li>
-<Drawer title="启用Sigv4签名的curl" trigger="直接调用已部署API（使用Sigv4签名curl）">
+<Drawer title="Sigv4签名curl" trigger="直接调用已部署API（需签名）">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-可将以下脚本添加到`.bashrc`文件（并`source`），或直接在终端粘贴：
+可将以下脚本加入`.bashrc`文件（并`source`）或直接在终端执行：
 ```bash
 // ~/.bashrc
 acurl () {
@@ -200,7 +200,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-可将以下函数添加到PowerShell配置文件或直接粘贴：
+可将以下函数加入PowerShell配置文件或直接执行：
 ```powershell
 function acurl {
     param(
@@ -208,11 +208,11 @@ function acurl {
         [Parameter(Mandatory=$true)][string]$Service,
         [Parameter(ValueFromRemainingArguments=$true)][string[]]$CurlArgs
     )
-    
+
     $AccessKey = aws configure get aws_access_key_id
     $SecretKey = aws configure get aws_secret_access_key
     $SessionToken = aws configure get aws_session_token
-    
+
     & curl --aws-sigv4 "aws:amz:$Region`:$Service" --user "$AccessKey`:$SecretKey" -H "X-Amz-Security-Token: $SessionToken" @CurlArgs
 }
 ```
@@ -236,19 +236,18 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 </ul>
 
 <Tabs>
-  <TabItem label="本地">
-  运行以下命令启动FastAPI服务：
+  <TabItem label="本地测试">
+  启动本地FastAPI服务器：
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    服务启动后执行：
-    
+    执行测试命令：
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
       -d '{"genre":"superhero", "actions":[], "playerName":"UnnamedHero"}' \
       -H "Content-Type: application/json"
     ```
   </TabItem>
-  <TabItem label="已部署">
+  <TabItem label="云端测试">
 ```bash "https://xxx.lambda-url.ap-southeast-2.on.aws/" "ap-southeast-2"
 acurl ap-southeast-2 lambda -N -X POST \
   https://xxx.lambda-url.ap-southeast-2.on.aws/story/generate \
@@ -256,7 +255,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    请使用CDK部署输出中的`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`值替换高亮URL占位符，并正确设置区域。
+    请使用CDK部署输出中的`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`值替换URL占位符，并正确设置区域。
     </Aside>
   </TabItem>
 </Tabs>
@@ -264,7 +263,7 @@ acurl ap-southeast-2 lambda -N -X POST \
 成功执行后将看到流式响应：
 
 ```
-UnnamedHero迎风而立，披风猎猎作响....
+UnnamedHero迎风而立，披风在风中猎猎作响....
 ```
 
 恭喜！您已成功使用FastAPI构建并部署了首个流式API！🎉🎉🎉

--- a/docs/src/content/docs/zh/guides/python-project.mdx
+++ b/docs/src/content/docs/zh/guides/python-project.mdx
@@ -10,9 +10,9 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](https://www.python.org/) 库或应用程序，使用 [UV](https://docs.astral.sh/uv/) 进行依赖管理，在 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)中采用单一锁文件和虚拟环境，使用 [pytest](https://docs.pytest.org/en/stable/) 运行测试，以及 [Ruff](https://docs.astral.sh/ruff/) 进行静态分析。
+Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](https://www.python.org/) 库或应用，使用 [UV](https://docs.astral.sh/uv/) 进行依赖管理，在 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)中采用单一锁定文件和虚拟环境，使用 [pytest](https://docs.pytest.org/en/stable/) 运行测试，以及 [Ruff](https://docs.astral.sh/ruff/) 进行静态分析。
 
-## 使用方法
+## 用法
 
 ### 生成 Python 项目
 
@@ -20,64 +20,76 @@ Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](
 
 <RunGenerator generator="py#project" />
 
-### 选项参数
+### 选项
 
 <GeneratorParameters generator="py#project" />
 
 ## 生成器输出
 
-生成器将在 `<directory>/<name>` 目录下创建以下项目结构：
+生成器将在 `<directory>/<name>` 目录中创建以下项目结构：
 
 <FileTree>
 
-  - \<模块名称>
-    - \_\_init\_\_.py 模块初始化文件
-    - hello.py Python 示例源码文件
+  - \<module-name>
+    - \_\_init\_\_.py 模块初始化
+    - hello.py 示例 Python 源文件
   - tests
-    - \_\_init\_\_.py 模块初始化文件
-    - conftest.py 测试配置文件
-    - test_hello.py 示例测试文件
+    - \_\_init\_\_.py 模块初始化
+    - conftest.py 测试配置
+    - test_hello.py 示例测试
   - project.json 项目配置和构建目标
-  - pyproject.toml UV 使用的包管理配置文件
-  - .python-version 包含项目的 Python 版本信息
+  - pyproject.toml UV 使用的打包配置文件
+  - .python-version 包含项目的 Python 版本
 
 </FileTree>
 
-您可能还会注意到工作区根目录下创建/更新了以下文件：
+您可能还会注意到工作区根目录中创建/更新了以下文件：
 
 <FileTree>
 
-  - pyproject.toml UV 工作区层级的包管理配置
-  - .python-version 包含工作区 Python 版本信息
-  - uv.lock Python 依赖锁文件
+  - pyproject.toml UV 的工作区级打包配置
+  - .python-version 包含工作区 Python 版本
+  - uv.lock Python 依赖锁定文件
 
 </FileTree>
 
-## 编写 Python 源码
+## 编写 Python 源代码
 
-将您的 Python 源代码添加到 `<模块名称>` 目录中。
+在 `<module-name>` 目录中添加您的 Python 源代码。
 
 ### 在其他项目中导入库代码
 
-由于已配置 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)，您可以从工作区中的任何其他 Python 项目引用当前项目：
+使用 `add` 目标为 Python 项目添加依赖。
 
-```python title="packages/my_other_project/my_other_project/main.py"
-from "my_library.hello" import say_hello
+假设我们创建了两个 Python 项目 `my_app` 和 `my_lib`。它们的完全限定项目名称分别为 `my_scope.my_app` 和 `my_scope.my_lib`，默认模块名称为 `my_scope_my_app` 和 `my_scope_my_lib`。
+
+要让 `my_app` 依赖 `my_lib`，可以运行以下命令：
+
+<NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
+
+:::note
+我们使用完全限定的项目名称来指定依赖方和被依赖方。对于要添加依赖的项目可以使用简写语法，但被依赖的项目必须使用完全限定名称。
+:::
+
+然后即可导入库代码：
+
+```python title="packages/my_app/my_scope_my_app/main.py"
+from my_scope_my_lib.hello import say_hello
 ```
 
-上述代码中，`my_library` 是模块名称，`hello` 对应 Python 源文件 `hello.py`，`say_hello` 是 `hello.py` 中定义的方法
+上述代码中，`my_scope_my_lib` 是库的模块名称，`hello` 对应 Python 源文件 `hello.py`，`say_hello` 是 `hello.py` 中定义的方法。
 
 ### 依赖管理
 
-要为项目添加依赖，可以运行项目的 `add` 目标，例如：
+要为项目添加依赖，可以在 Python 项目中运行 `add` 目标，例如：
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-这会将依赖添加到项目的 `pyproject.toml` 文件，并更新根目录的 `uv.lock` 文件。
+这会将依赖添加到项目的 `pyproject.toml` 文件，并更新根目录的 `uv.lock`。
 
 #### 运行时代码
 
-当将 Python 项目作为运行时代码使用时（例如作为 AWS lambda 函数的处理程序），需要将源代码及其所有依赖打包。可以通过在 `project.json` 文件中添加如下目标实现：
+当将 Python 项目作为运行时代码使用时（例如作为 AWS lambda 函数的处理程序），需要创建源代码及其所有依赖的打包文件。可以通过在 `project.json` 文件中添加类似以下目标来实现：
 
 ```json title="project.json"
 {
@@ -90,7 +102,7 @@ from "my_library.hello" import say_hello
       "outputs": ["{workspaceRoot}/dist/packages/my_library/bundle"],
       "options": {
         "commands": [
-          "uv export --frozen --no-dev --no-editable --project packages/my_library -o dist/packages/my_library/bundle/requirements.txt",
+          "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
           "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
@@ -101,17 +113,17 @@ from "my_library.hello" import say_hello
 }
 ```
 
-## 构建
+### 构建
 
-项目已配置 `build` 目标（定义于 `project.json`），可通过以下命令运行：
+Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通过以下命令运行：
 
 <NxCommands commands={['run <project-name>:build']} />
 
-其中 `<project-name>` 是项目的全限定名称。
+其中 `<project-name>` 是项目的完全限定名称。
 
-`build` 目标将执行编译、代码检查及测试。
+`build` 目标将执行编译、代码检查和测试。
 
-构建输出位于工作区根目录的 `dist` 文件夹中，具体路径为 `dist/packages/<my-library>/build`
+构建输出位于工作区根目录的 `dist` 文件夹中，具体路径为 `dist/packages/<my-library>/build`。
 
 ## 测试
 
@@ -119,16 +131,16 @@ from "my_library.hello" import say_hello
 
 ### 编写测试
 
-测试文件应位于项目的 `test` 目录下，并以 `test_` 作为前缀，例如：
+测试应位于项目的 `test` 目录中，文件名以 `test_` 开头，例如：
 
 <FileTree>
   - my_library
     - hello.py
   - test
-    - test_hello.py hello.py 的测试文件
+    - test_hello.py hello.py 的测试
 </FileTree>
 
-测试方法应以 `test_` 开头，并通过断言验证预期结果，例如：
+测试方法应以 `test_` 开头并通过断言验证预期结果，例如：
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -137,15 +149,15 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-更多测试编写细节请参考 [pytest 文档](https://docs.pytest.org/en/stable/how-to/assert.html#)。
+有关如何编写测试的更多细节，请参考 [pytest 文档](https://docs.pytest.org/en/stable/how-to/assert.html#)。
 
 ### 运行测试
 
-测试会在项目构建时自动执行，也可通过 `test` 目标单独运行：
+测试会在项目构建时自动运行，也可以通过 `test` 目标单独运行：
 
 <NxCommands commands={['run <project-name>:test']} />
 
-使用 `-k` 参数可运行指定测试文件或方法：
+可以使用 `-k` 标志运行单个测试或测试套件：
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -153,18 +165,18 @@ def test_say_hello():
 
 Python 项目使用 [Ruff](https://docs.astral.sh/ruff/) 进行代码检查。
 
-### 执行检查
+### 运行检查器
 
-运行 `lint` 目标可进行代码检查：
+要检查项目代码，可以运行 `lint` 目标：
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### 修复问题
+### 修复检查问题
 
-大多数代码检查或格式问题可自动修复。通过添加 `--configuration=fix` 参数可自动修复：
+大多数代码检查或格式问题可以自动修复。通过添加 `--configuration=fix` 参数让 Ruff 自动修复：
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-若要修复工作区中所有包的检查问题，可运行：
+若要修复工作区中所有包的检查问题，可以运行：
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -77,7 +77,7 @@ describe('fastapi project generator', () => {
       '{workspaceRoot}/dist/apps/test_api/bundle',
     ]);
     expect(projectConfig.targets.bundle.options.commands).toContain(
-      'uv export --frozen --no-dev --no-editable --project apps/test_api -o dist/apps/test_api/bundle/requirements.txt',
+      'uv export --frozen --no-dev --no-editable --project apps/test_api --package proj.test_api -o dist/apps/test_api/bundle/requirements.txt',
     );
 
     // Verify openapi spec is generated

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -38,6 +38,7 @@ import { addApiGatewayConstruct } from '../../utils/api-constructs/api-construct
 import { addOpenApiGeneration } from './react/open-api';
 import { updateGitIgnore } from '../../utils/git';
 import { getLocalServerPortNumber } from '../../utils/port';
+import { createPythonBundleTarget } from '../../utils/bundle';
 
 export const FAST_API_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -75,16 +76,10 @@ export const pyFastApiProjectGenerator = async (
   const projectConfig = readProjectConfiguration(tree, fullyQualifiedName);
 
   projectConfig.targets.bundle = {
-    cache: true,
-    executor: 'nx:run-commands',
-    outputs: [`{workspaceRoot}/dist/${dir}/bundle`],
-    options: {
-      commands: [
-        `uv export --frozen --no-dev --no-editable --project ${dir} -o dist/${dir}/bundle/requirements.txt`,
-        `uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/${dir}/bundle -r dist/${dir}/bundle/requirements.txt`,
-      ],
-      parallel: false,
-    },
+    ...createPythonBundleTarget({
+      projectDir: dir,
+      packageName: fullyQualifiedName,
+    }),
     dependsOn: ['compile'],
   };
   projectConfig.targets.build.dependsOn = [

--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -99,7 +99,7 @@ describe('lambda-handler project generator', () => {
       '{workspaceRoot}/dist/apps/test_project/bundle',
     ]);
     expect(projectConfig.targets.bundle.options.commands).toContain(
-      'uv export --frozen --no-dev --no-editable --project apps/test_project -o dist/apps/test_project/bundle/requirements.txt',
+      'uv export --frozen --no-dev --no-editable --project apps/test_project --package test-project -o dist/apps/test_project/bundle/requirements.txt',
     );
 
     // Verify build dependencies

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -39,6 +39,7 @@ import {
   readProjectConfigurationUnqualified,
 } from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+import { createPythonBundleTarget } from '../../utils/bundle';
 
 export const LAMBDA_FUNCTION_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -152,16 +153,10 @@ export const pyLambdaFunctionGenerator = async (
   // Check if the project has a bundle target and if not add it
   if (!projectConfig.targets?.bundle) {
     projectConfig.targets.bundle = {
-      cache: true,
-      executor: 'nx:run-commands',
-      outputs: [`{workspaceRoot}/dist/${dir}/bundle`],
-      options: {
-        commands: [
-          `uv export --frozen --no-dev --no-editable --project ${dir} -o dist/${dir}/bundle/requirements.txt`,
-          `uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/${dir}/bundle -r dist/${dir}/bundle/requirements.txt`,
-        ],
-        parallel: false,
-      },
+      ...createPythonBundleTarget({
+        projectDir: dir,
+        packageName: projectConfig.name,
+      }),
       dependsOn: ['compile'],
     };
   }

--- a/packages/nx-plugin/src/utils/bundle.ts
+++ b/packages/nx-plugin/src/utils/bundle.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TargetConfiguration } from '@nx/devkit';
+
+export interface CreatePythonBundleTargetOptions {
+  /**
+   * Directory of the python project from the monorepo root
+   */
+  projectDir: string;
+
+  /**
+   * Python package name
+   */
+  packageName: string;
+}
+
+/**
+ * Create a target for bundling a python project
+ */
+export const createPythonBundleTarget = ({
+  projectDir,
+  packageName,
+}: CreatePythonBundleTargetOptions): TargetConfiguration => {
+  return {
+    cache: true,
+    executor: 'nx:run-commands',
+    outputs: [`{workspaceRoot}/dist/${projectDir}/bundle`],
+    options: {
+      commands: [
+        `uv export --frozen --no-dev --no-editable --project ${projectDir} --package ${packageName} -o dist/${projectDir}/bundle/requirements.txt`,
+        `uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/${projectDir}/bundle -r dist/${projectDir}/bundle/requirements.txt`,
+      ],
+      parallel: false,
+    },
+  };
+};


### PR DESCRIPTION
### Reason for this change

The bundle target for FastAPI and Python lambda functions was including the dependencies for all packages in the workspace, rather than just those for the target package. 

### Description of changes

Updated to include only the appropriate dependencies.

Also fix the python documentation on local dependencies as it was incorrect.

### Description of how you validated changes

Created and bundled multiple packages in a test project

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*