### PR TITLE
fix: do not duplicate comments in ast transforms

### DIFF
--- a/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/cloudscape-website/cognito-auth/generator.spec.ts
@@ -639,6 +639,53 @@ export default AppLayout;
     });
   });
 
+  it('should not duplicate comments in IRuntimeConfig', async () => {
+    tree.write(
+      'packages/test-project/src/main.tsx',
+      `
+      import { RuntimeConfigProvider } from './components/RuntimeConfig';
+      import { RouterProvider, createRouter } from '@tanstack/react-router';
+
+      export function App() {
+
+        const App = () => <RouterProvider router={router} />;
+
+        return (
+          <RuntimeConfigProvider>
+            <App/>
+          </RuntimeConfigProvider>
+        );
+      }
+    `,
+    );
+
+    await sharedConstructsGenerator(tree);
+
+    tree.write(
+      'packages/common/types/src/runtime-config.ts',
+      `
+// Some comment
+export interface IRuntimeConfig {}
+      `,
+    );
+
+    await tsCloudScapeWebsiteAuthGenerator(tree, {
+      ...options,
+    });
+
+    const runtimeConfigContent = tree.read(
+      'packages/common/types/src/runtime-config.ts',
+      'utf-8',
+    );
+    expect(runtimeConfigContent).toContain(`
+// Some comment
+export interface IRuntimeConfig`);
+
+    expect(runtimeConfigContent.indexOf('Some comment')).toEqual(
+      runtimeConfigContent.lastIndexOf('Some comment'),
+    );
+  });
+
   it('should add generator metric to app.ts', async () => {
     // Set up test tree with shared constructs
     await sharedConstructsGenerator(tree);

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -219,7 +219,9 @@ const applyTransform = (
 
   const transforms: { start: number; end: number; newText: string }[] = [];
 
-  const printer = ts.createPrinter();
+  const printer = ts.createPrinter({
+    removeComments: true,
+  });
 
   tsquery.map(sourceFile, selector, (node) => {
     const newNode = transformer(node);


### PR DESCRIPTION
### Reason for this change

Comments were previously being duplicated when performing AST operations. 

### Description of changes

Ensure comments are preserved but not duplicated.

Also update ast tests to use a real tree instead of mocking the tree to be consistent with other tests.

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Fixes #230

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*