### PR TITLE
fix: do not force snake/camel casing for directories

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -61,10 +61,7 @@ export const getPyProjectDetails = (
     schema.moduleName ?? `${scope}_${normalizedName}`,
   );
   const fullyQualifiedName = `${scope}.${normalizedName}`;
-  const dir = joinPathFragments(
-    toSnakeCase(schema.directory) ?? '.',
-    normalizedName,
-  );
+  const dir = joinPathFragments(schema.directory ?? '.', normalizedName);
   return { dir, fullyQualifiedName, normalizedModuleName };
 };
 

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -57,8 +57,8 @@ export const getTsLibDetails = (
   const normalizedName = toKebabCase(schema.name);
   const fullyQualifiedName = `${scope}${normalizedName}`;
   const dir = joinPathFragments(
-    toKebabCase(schema.directory) ?? '.',
-    toKebabCase(schema.subDirectory) ?? normalizedName,
+    schema.directory ?? '.',
+    schema.subDirectory ?? normalizedName,
   );
   return { dir, fullyQualifiedName };
 };


### PR DESCRIPTION
### Reason for this change

Unable to provide specific directory naming without prescriptive casing being applied.

### Description of changes

Bug fix that gives developers more flexibility in how they name their project 
directories when using the @aws/nx-plugin generators, removing the automatic case conversion that was previously enforced.

### Description of how you validated changes

- local testing

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*