### PR TITLE
fix(openapi): fixes for enums and composite types

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -1079,7 +1079,6 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which retur
   Order,
   OrderItemsItem,
   OrderShippingAddress,
-  OrderStatus,
   GetOrdersRequest,
 } from './types.gen.js';
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -577,6 +577,234 @@ export class TestApi {
 "
 `;
 
+exports[`openApiTsClientGenerator - composite schemas > should handle anyOf with enums 1`] = `
+"export type TestAnyOfEnum200Response = {
+  result?: string;
+};
+export type TestAnyOfEnumRequestContent = {
+  anyType?: TestAnyOfEnumRequestContentAnyType;
+};
+export type TestAnyOfEnumRequestContentAnyType =
+  TestAnyOfEnumRequestContentAnyTypeAnyOf | null;
+export type TestAnyOfEnumRequestContentAnyTypeAnyOf = 'a' | 'b' | 'c';
+
+export type TestAnyOfEnumRequest = TestAnyOfEnumRequestContent | undefined;
+export type TestAnyOfEnumError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - composite schemas > should handle anyOf with enums 2`] = `
+"import type {
+  TestAnyOfEnum200Response,
+  TestAnyOfEnumRequestContent,
+  TestAnyOfEnumRequestContentAnyType,
+  TestAnyOfEnumRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static TestAnyOfEnum200Response = {
+    toJson: (model: TestAnyOfEnum200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.result === undefined
+          ? {}
+          : {
+              result: model.result,
+            }),
+      };
+    },
+    fromJson: (json: any): TestAnyOfEnum200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['result'] === undefined
+          ? {}
+          : {
+              result: json['result'],
+            }),
+      };
+    },
+  };
+
+  public static TestAnyOfEnumRequestContent = {
+    toJson: (model: TestAnyOfEnumRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.anyType === undefined
+          ? {}
+          : {
+              anyType: $IO.TestAnyOfEnumRequestContentAnyType.toJson(
+                model.anyType,
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): TestAnyOfEnumRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['anyType'] === undefined
+          ? {}
+          : {
+              anyType: $IO.TestAnyOfEnumRequestContentAnyType.fromJson(
+                json['anyType'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static TestAnyOfEnumRequestContentAnyType = {
+    toJson: (model: TestAnyOfEnumRequestContentAnyType): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (typeof model === 'string') {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): TestAnyOfEnumRequestContentAnyType => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return json;
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.testAnyOfEnum = this.testAnyOfEnum.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async testAnyOfEnum(
+    input?: TestAnyOfEnumRequest,
+  ): Promise<TestAnyOfEnum200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      input === undefined
+        ? undefined
+        : typeof input === 'object'
+          ? JSON.stringify($IO.TestAnyOfEnumRequestContent.toJson(input))
+          : String($IO.TestAnyOfEnumRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/anyOfEnum', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.TestAnyOfEnum200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
 exports[`openApiTsClientGenerator - composite schemas > should handle composite primitive and array request bodies 1`] = `
 "export type CompositeRequestContent =
   | string
@@ -1168,9 +1396,6 @@ export class $IO {
     },
     fromJson: (json: any): TestCompositesRequestContent => {
       if (json === undefined || json === null) {
-        return json;
-      }
-      if (typeof json === 'string') {
         return json;
       }
       if (typeof json === 'string') {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -40,8 +40,6 @@ exports[`openApiTsClientGenerator - composite schemas > should generate valid Ty
   PutTestRequestContent,
   PutTestRequestContentOneOf,
   PutTestRequestContentOneOf1,
-  PutTestRequestContentOneOf1Type,
-  PutTestRequestContentOneOfType,
   PutTestRequest,
 } from './types.gen.js';
 
@@ -738,7 +736,6 @@ exports[`openApiTsClientGenerator - composite schemas > should handle inline pri
   TestComposites200ResponseAnyOf,
   TestComposites200ResponseAnyOf1,
   TestCompositesRequestContent,
-  TestCompositesRequestContentOneOf,
   TestEnums200Response,
   TestArraysRequest,
   TestArraysWithOtherParametersRequest,

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -354,6 +354,229 @@ export class TestApi {
 "
 `;
 
+exports[`openApiTsClientGenerator - composite schemas > should handle anyOf with any type 1`] = `
+"export type TestAnyOfAny200Response = {
+  result?: string;
+};
+export type TestAnyOfAnyRequestContent = {
+  anyType?: TestAnyOfAnyRequestContentAnyType;
+};
+export type TestAnyOfAnyRequestContentAnyType = unknown | null;
+
+export type TestAnyOfAnyRequest = TestAnyOfAnyRequestContent | undefined;
+export type TestAnyOfAnyError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - composite schemas > should handle anyOf with any type 2`] = `
+"import type {
+  TestAnyOfAny200Response,
+  TestAnyOfAnyRequestContent,
+  TestAnyOfAnyRequestContentAnyType,
+  TestAnyOfAnyRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static TestAnyOfAny200Response = {
+    toJson: (model: TestAnyOfAny200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.result === undefined
+          ? {}
+          : {
+              result: model.result,
+            }),
+      };
+    },
+    fromJson: (json: any): TestAnyOfAny200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['result'] === undefined
+          ? {}
+          : {
+              result: json['result'],
+            }),
+      };
+    },
+  };
+
+  public static TestAnyOfAnyRequestContent = {
+    toJson: (model: TestAnyOfAnyRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.anyType === undefined
+          ? {}
+          : {
+              anyType: $IO.TestAnyOfAnyRequestContentAnyType.toJson(
+                model.anyType,
+              ),
+            }),
+      };
+    },
+    fromJson: (json: any): TestAnyOfAnyRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['anyType'] === undefined
+          ? {}
+          : {
+              anyType: $IO.TestAnyOfAnyRequestContentAnyType.fromJson(
+                json['anyType'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static TestAnyOfAnyRequestContentAnyType = {
+    toJson: (model: TestAnyOfAnyRequestContentAnyType): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): TestAnyOfAnyRequestContentAnyType => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return json;
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.testAnyOfAny = this.testAnyOfAny.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async testAnyOfAny(
+    input?: TestAnyOfAnyRequest,
+  ): Promise<TestAnyOfAny200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      input === undefined
+        ? undefined
+        : typeof input === 'object'
+          ? JSON.stringify($IO.TestAnyOfAnyRequestContent.toJson(input))
+          : String($IO.TestAnyOfAnyRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/anyOfAny', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.TestAnyOfAny200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
 exports[`openApiTsClientGenerator - composite schemas > should handle composite primitive and array request bodies 1`] = `
 "export type CompositeRequestContent =
   | string

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -752,6 +752,207 @@ export class TestApi {
 "
 `;
 
+exports[`openApiTsClientGenerator - primitive types > should handle enum reference properties 1`] = `
+"export type MyStatus = 'success' | 'failed' | 'pending';
+export type UpdateStatus200Response = {
+  status?: MyStatus;
+};
+export type UpdateStatusRequestContent = {
+  status?: MyStatus;
+};
+
+export type UpdateStatusRequest = UpdateStatusRequestContent;
+export type UpdateStatusError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - primitive types > should handle enum reference properties 2`] = `
+"import type {
+  UpdateStatus200Response,
+  UpdateStatusRequestContent,
+  UpdateStatusRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static UpdateStatus200Response = {
+    toJson: (model: UpdateStatus200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.status === undefined
+          ? {}
+          : {
+              status: model.status,
+            }),
+      };
+    },
+    fromJson: (json: any): UpdateStatus200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['status'] === undefined
+          ? {}
+          : {
+              status: json['status'],
+            }),
+      };
+    },
+  };
+
+  public static UpdateStatusRequestContent = {
+    toJson: (model: UpdateStatusRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.status === undefined
+          ? {}
+          : {
+              status: model.status,
+            }),
+      };
+    },
+    fromJson: (json: any): UpdateStatusRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['status'] === undefined
+          ? {}
+          : {
+              status: json['status'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.updateStatus = this.updateStatus.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async updateStatus(
+    input: UpdateStatusRequest,
+  ): Promise<UpdateStatus200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.UpdateStatusRequestContent.toJson(input))
+        : String($IO.UpdateStatusRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/status', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.UpdateStatus200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
 exports[`openApiTsClientGenerator - primitive types > should handle enum request and response bodies 1`] = `
 "export type UpdateStatus200Response = 'accepted' | 'rejected';
 export type UpdateStatusRequestContent =
@@ -768,7 +969,6 @@ export type UpdateStatusError = never;
 exports[`openApiTsClientGenerator - primitive types > should handle enum request and response bodies 2`] = `
 "import type {
   UpdateStatus200Response,
-  UpdateStatusRequestContent,
   UpdateStatusRequest,
 } from './types.gen.js';
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -587,7 +587,6 @@ exports[`openApiTsClientGenerator - streaming > should return an iterator over a
   GetBooleanDict200Response,
   GetDateDict200Response,
   GetEnumDict200Response,
-  GetEnumDict200ResponseValue,
   GetNestedDict200Response,
   GetNestedDict200ResponseValueValue,
   GetNumberDict200Response,

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -233,7 +233,7 @@ export class $IO {
         return json;
       }
       <%_ if (isComposite) { _%>
-      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && !['null', 'unknown'].includes(p.type)).forEach((primitive) => { _%>
+      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary', 'enum'].includes(p.export) && !['null', 'unknown'].includes(p.type)).forEach((primitive) => { _%>
       if (typeof json === "<%- primitive.typescriptType %>") {
           return json;
       }

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -174,7 +174,7 @@ export class $IO {
         return model;
       }
       <%_ if (isComposite) { _%>
-      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && p.type !== 'null').forEach((primitive) => { _%>
+      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && !['null', 'unknown'].includes(p.type)).forEach((primitive) => { _%>
       if (typeof model === "<%- primitive.typescriptType %>") {
           return model;
       }
@@ -233,7 +233,7 @@ export class $IO {
         return json;
       }
       <%_ if (isComposite) { _%>
-      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && p.type !== 'null').forEach((primitive) => { _%>
+      <%_ model.composedPrimitives.filter(p => !['array', 'dictionary'].includes(p.export) && !['null', 'unknown'].includes(p.type)).forEach((primitive) => { _%>
       if (typeof json === "<%- primitive.typescriptType %>") {
           return json;
       }

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -16,10 +16,11 @@ const uniqStrings = (strings) => {
     return true;
   });
 };
+const returnTypeSet = new Set(allOperations.map(op => op.result.typescriptType));
 _%>
 <%_ if ((models.length + allOperations.filter(p => p.parameters.length > 0).length) > 0) { _%>
 import type {
-<%_ models.forEach((model) => { _%>
+<%_ models.filter(model => model.export !== 'enum' || returnTypeSet.has(model.name)).forEach((model) => { _%>
   <%- model.name %>,
 <%_ }) _%>
 <%_ allOperations.filter(p => p.parameters.length > 0).forEach((op) => { _%>

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -1009,4 +1009,73 @@ describe('openApiTsClientGenerator - composite schemas', () => {
     const client = tree.read('src/generated/client.gen.ts', 'utf-8');
     expect(client).toMatchSnapshot();
   });
+
+  it('should handle anyOf with enums', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/anyOfEnum': {
+          post: {
+            operationId: 'testAnyOfEnum',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      anyType: {
+                        anyOf: [
+                          {
+                            type: 'string',
+                            enum: ['a', 'b', 'c'],
+                          },
+                          {
+                            type: 'null' as any,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'test',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        result: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8');
+    expect(types).toMatchSnapshot();
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    expect(client).toMatchSnapshot();
+  });
 });

--- a/packages/nx-plugin/src/utils/test/ts.spec.ts
+++ b/packages/nx-plugin/src/utils/test/ts.spec.ts
@@ -29,6 +29,10 @@ export class TypeScriptVerifier {
         moduleResolution: ts.ModuleResolutionKind.NodeNext,
         skipLibCheck: true,
         strict: true,
+        noUnusedLocals: true,
+        noImplicitReturns: true,
+        noImplicitOverride: true,
+        noFallthroughCasesInSwitch: true,
       },
     });
 
@@ -220,7 +224,7 @@ describe('expectTypeScriptToCompile', () => {
   it('should not throw for valid typescript with a dependency', () => {
     tree.write(
       'test.ts',
-      'import { createProjectSync } from "@ts-morph/bootstrap"; const project = createProjectSync()',
+      'import { createProjectSync } from "@ts-morph/bootstrap"; createProjectSync()',
     );
     verifierWithDeps.expectTypeScriptToCompile(tree, ['test.ts']);
   });
@@ -228,7 +232,7 @@ describe('expectTypeScriptToCompile', () => {
   it('should throw for invalid typescript with a dependency', () => {
     tree.write(
       'test.ts',
-      'import { createProjectSync } from "@ts-morph/bootstrap"; const project = createProjectSync(42)',
+      'import { createProjectSync } from "@ts-morph/bootstrap"; createProjectSync(42)',
     );
     expect(() =>
       verifierWithDeps.expectTypeScriptToCompile(tree, ['test.ts'], true),


### PR DESCRIPTION
### Reason for this change

Fix a few compilation issues for some OpenAPI edge cases

### Description of changes

- Enums composed with other types would cause a compilation issue with the client trying to coerce a string to an enum
- When any (`{}`) was combined with null in a composite type, the client would fail to compile due to an invalid typeof check for 'unknown'
- The generated client would import all enum models, however only enum models that are top level request/response parameters are directly referenced by the client

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*