### PR TITLE
fix(ts#react-website): runtime config token resolution with latest cdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "build:all": "nx run-many --target build"
   },
   "config": {
     "commitizen": {

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`infra generator > should add required dependencies to package.json > de
 {
   "@cdklabs/cdk-validator-cfnguard": "^0.0.60",
   "aws-cdk": "^2.1006.0",
-  "aws-cdk-lib": "^2.200.0",
+  "aws-cdk-lib": "^2.207.0",
   "constructs": "^10.4.2",
   "esbuild": "^0.25.1",
   "source-map-support": "^0.5.21",
@@ -45,7 +45,7 @@ exports[`infra generator > should add required dependencies to package.json > pa
   "dependencies": {
     "@cdklabs/cdk-validator-cfnguard": "^0.0.60",
     "aws-cdk": "^2.1006.0",
-    "aws-cdk-lib": "^2.200.0",
+    "aws-cdk-lib": "^2.207.0",
     "constructs": "^10.4.2",
     "esbuild": "^0.25.1",
     "source-map-support": "^0.5.21",

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -299,7 +299,7 @@ exports[`react-website generator > Tanstack router integration > should generate
     "@cloudscape-design/board-components": "^3.0.94",
     "@cloudscape-design/components": "^3.0.928",
     "@cloudscape-design/global-styles": "^1.0.38",
-    "aws-cdk-lib": "^2.200.0",
+    "aws-cdk-lib": "^2.207.0",
     "constructs": "^10.4.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -543,7 +543,7 @@ export class RuntimeConfig extends Construct {
 `;
 
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/constructs/src/core/static-website.ts 1`] = `
-"import { CfnJson, CfnOutput, RemovalPolicy, Stack, Token } from 'aws-cdk-lib';
+"import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Distribution, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import {
@@ -666,7 +666,7 @@ export class StaticWebsite extends Construct {
         Source.asset(websiteFilePath),
         Source.jsonData(
           DEFAULT_RUNTIME_CONFIG_FILENAME,
-          this.resolveTokens(RuntimeConfig.ensure(this).config),
+          RuntimeConfig.ensure(this).config,
         ),
       ],
       destinationBucket: this.websiteBucket,
@@ -681,26 +681,6 @@ export class StaticWebsite extends Construct {
       value: this.websiteBucket.bucketName,
     });
   }
-  private resolveTokens = (payload: any) => {
-    const _payload: Record<string, any> = {};
-    Object.entries(payload).forEach(([key, value]) => {
-      if (
-        Token.isUnresolved(value) ||
-        (typeof value === 'string' && value.endsWith('}}'))
-      ) {
-        _payload[key] = new CfnJson(this, \`ResolveToken-\${key}\`, {
-          value,
-        }).value;
-      } else if (typeof value === 'object') {
-        _payload[key] = this.resolveTokens(value);
-      } else if (Array.isArray(value)) {
-        _payload[key] = value.map((v) => this.resolveTokens(v));
-      } else {
-        _payload[key] = value;
-      }
-    });
-    return _payload;
-  };
 }
 
 export class CloudfrontWebAcl extends Stack {
@@ -1842,7 +1822,7 @@ exports[`react-website generator > Tanstack router integration > should generate
     "@cloudscape-design/components": "^3.0.928",
     "@cloudscape-design/global-styles": "^1.0.38",
     "@tanstack/react-router": "^1.121.16",
-    "aws-cdk-lib": "^2.200.0",
+    "aws-cdk-lib": "^2.207.0",
     "constructs": "^10.4.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -2090,7 +2070,7 @@ export class RuntimeConfig extends Construct {
 `;
 
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/constructs/src/core/static-website.ts 1`] = `
-"import { CfnJson, CfnOutput, RemovalPolicy, Stack, Token } from 'aws-cdk-lib';
+"import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Distribution, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import {
@@ -2213,7 +2193,7 @@ export class StaticWebsite extends Construct {
         Source.asset(websiteFilePath),
         Source.jsonData(
           DEFAULT_RUNTIME_CONFIG_FILENAME,
-          this.resolveTokens(RuntimeConfig.ensure(this).config),
+          RuntimeConfig.ensure(this).config,
         ),
       ],
       destinationBucket: this.websiteBucket,
@@ -2228,26 +2208,6 @@ export class StaticWebsite extends Construct {
       value: this.websiteBucket.bucketName,
     });
   }
-  private resolveTokens = (payload: any) => {
-    const _payload: Record<string, any> = {};
-    Object.entries(payload).forEach(([key, value]) => {
-      if (
-        Token.isUnresolved(value) ||
-        (typeof value === 'string' && value.endsWith('}}'))
-      ) {
-        _payload[key] = new CfnJson(this, \`ResolveToken-\${key}\`, {
-          value,
-        }).value;
-      } else if (typeof value === 'object') {
-        _payload[key] = this.resolveTokens(value);
-      } else if (Array.isArray(value)) {
-        _payload[key] = value.map((v) => this.resolveTokens(v));
-      } else {
-        _payload[key] = value;
-      }
-    });
-    return _payload;
-  };
 }
 
 export class CloudfrontWebAcl extends Stack {
@@ -3761,7 +3721,7 @@ export * from './runtime-config.js';
 `;
 
 exports[`react-website generator > should generate shared constructs > common/constructs-core-static-website.ts 1`] = `
-"import { CfnJson, CfnOutput, RemovalPolicy, Stack, Token } from 'aws-cdk-lib';
+"import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Distribution, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import {
@@ -3884,7 +3844,7 @@ export class StaticWebsite extends Construct {
         Source.asset(websiteFilePath),
         Source.jsonData(
           DEFAULT_RUNTIME_CONFIG_FILENAME,
-          this.resolveTokens(RuntimeConfig.ensure(this).config),
+          RuntimeConfig.ensure(this).config,
         ),
       ],
       destinationBucket: this.websiteBucket,
@@ -3899,26 +3859,6 @@ export class StaticWebsite extends Construct {
       value: this.websiteBucket.bucketName,
     });
   }
-  private resolveTokens = (payload: any) => {
-    const _payload: Record<string, any> = {};
-    Object.entries(payload).forEach(([key, value]) => {
-      if (
-        Token.isUnresolved(value) ||
-        (typeof value === 'string' && value.endsWith('}}'))
-      ) {
-        _payload[key] = new CfnJson(this, \`ResolveToken-\${key}\`, {
-          value,
-        }).value;
-      } else if (typeof value === 'object') {
-        _payload[key] = this.resolveTokens(value);
-      } else if (Array.isArray(value)) {
-        _payload[key] = value.map((v) => this.resolveTokens(v));
-      } else {
-        _payload[key] = value;
-      }
-    });
-    return _payload;
-  };
 }
 
 export class CloudfrontWebAcl extends Stack {
@@ -4029,7 +3969,7 @@ exports[`react-website generator > should handle npm scope prefix correctly > sc
   "@cloudscape-design/components": "^3.0.928",
   "@cloudscape-design/global-styles": "^1.0.38",
   "@tanstack/react-router": "^1.121.16",
-  "aws-cdk-lib": "^2.200.0",
+  "aws-cdk-lib": "^2.207.0",
   "constructs": "^10.4.2",
   "react": "19.0.0",
   "react-dom": "19.0.0",

--- a/packages/nx-plugin/src/ts/react-website/app/files/common/constructs/src/core/static-website.ts.template
+++ b/packages/nx-plugin/src/ts/react-website/app/files/common/constructs/src/core/static-website.ts.template
@@ -1,4 +1,4 @@
-import { CfnJson, CfnOutput, RemovalPolicy, Stack, Token } from 'aws-cdk-lib';
+import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Distribution, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import {
@@ -121,7 +121,7 @@ export class StaticWebsite extends Construct {
         Source.asset(websiteFilePath),
         Source.jsonData(
           DEFAULT_RUNTIME_CONFIG_FILENAME,
-          this.resolveTokens(RuntimeConfig.ensure(this).config)
+          RuntimeConfig.ensure(this).config
         ),
       ],
       destinationBucket: this.websiteBucket,
@@ -136,26 +136,6 @@ export class StaticWebsite extends Construct {
       value: this.websiteBucket.bucketName,
     });
   }
-  private resolveTokens = (payload: any) => {
-    const _payload: Record<string, any> = {};
-    Object.entries(payload).forEach(([key, value]) => {
-      if (
-        Token.isUnresolved(value) ||
-        (typeof value === 'string' && value.endsWith('}}'))
-      ) {
-        _payload[key] = new CfnJson(this, `ResolveToken-${key}`, {
-          value,
-        }).value;
-      } else if (typeof value === 'object') {
-        _payload[key] = this.resolveTokens(value);
-      } else if (Array.isArray(value)) {
-        _payload[key] = value.map((v) => this.resolveTokens(v));
-      } else {
-        _payload[key] = value;
-      }
-    });
-    return _payload;
-  };
 }
 
 export class CloudfrontWebAcl extends Stack {

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -33,7 +33,7 @@ export const VERSIONS = {
   '@smithy/types': '^4.2.0',
   aws4fetch: '^1.0.20',
   'aws-cdk': '^2.1006.0',
-  'aws-cdk-lib': '^2.200.0',
+  'aws-cdk-lib': '^2.207.0',
   'aws-xray-sdk-core': '^3.10.3',
   constructs: '^10.4.2',
   cors: '^2.8.5',


### PR DESCRIPTION
### Reason for this change

CDK recently fixed token resolution for s3 deployments such that our vended resolveTokens method is no longer used. See https://github.com/aws/aws-cdk/pull/34916

This was released in aws-cdk-lib 2.207.0

### Description of changes

Remove `resolveTokens`

### Description of how you validated changes

Created a test project with cdk 2.210.0 and added a cross-stack reference to runtime config, verifying it was resolved correctly.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*