### PR TITLE
fix(py#fast-api): add missing scope to handler functions

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -332,7 +332,7 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       defaultIntegrationOptions: {
         runtime: Runtime.PYTHON_3_12,
-        handler: 'test_api.main.handler',
+        handler: 'proj_test_api.main.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
             new URL(
@@ -817,7 +817,7 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       defaultIntegrationOptions: {
         runtime: Runtime.PYTHON_3_12,
-        handler: 'test_api.main.handler',
+        handler: 'proj_test_api.main.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
             new URL(

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -158,6 +158,11 @@ describe('fastapi project generator', () => {
     expect(
       tree.exists('packages/common/constructs/src/core/api/rest-api.ts'),
     ).toBeFalsy();
+
+    // Check scope is included in function handler
+    expect(
+      tree.read('packages/common/constructs/src/app/apis/test-api.ts', 'utf-8'),
+    ).toContain("handler: 'proj_test_api.main.handler'");
   });
 
   it('should set up shared constructs for rest', async () => {
@@ -198,6 +203,11 @@ describe('fastapi project generator', () => {
     expect(
       tree.exists('packages/common/constructs/src/core/api/http-api.ts'),
     ).toBeFalsy();
+
+    // Check scope is included in function handler
+    expect(
+      tree.read('packages/common/constructs/src/app/apis/test-api.ts', 'utf-8'),
+    ).toContain("handler: 'proj_test_api.main.handler'");
   });
 
   it('should update shared constructs build dependencies', async () => {

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -60,7 +60,6 @@ export const pyFastApiProjectGenerator = async (
       moduleName: schema.moduleName,
     },
   );
-  const apiNameSnakeCase = toSnakeCase(schema.name);
   const apiNameKebabCase = toKebabCase(schema.name);
   const apiNameClassName = toClassName(schema.name);
 
@@ -136,7 +135,7 @@ export const pyFastApiProjectGenerator = async (
     backend: {
       type: 'fastapi',
       dir,
-      apiNameSnakeCase,
+      moduleName: normalizedModuleName,
     },
     auth: schema.auth,
   });

--- a/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
@@ -33,7 +33,7 @@ export interface TrpcBackendOptions extends BackendOptions {
 
 export interface FastApiBackendOptions extends BackendOptions {
   type: 'fastapi';
-  apiNameSnakeCase: string;
+  moduleName: string;
   dir: string;
 }
 

--- a/packages/nx-plugin/src/utils/api-constructs/files/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/app/apis/http/__apiNameKebabCase__.ts.template
@@ -107,7 +107,7 @@ export class <%= apiNameClassName %><
         ),
         <%_ } else if (backend.type === 'fastapi') { _%>
         runtime: Runtime.PYTHON_3_12,
-        handler: '<%= backend.apiNameSnakeCase %>.main.handler',
+        handler: '<%= backend.moduleName %>.main.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
             new URL(

--- a/packages/nx-plugin/src/utils/api-constructs/files/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -111,7 +111,7 @@ export class <%= apiNameClassName %><
         ),
         <%_ } else if (backend.type === 'fastapi') { _%>
         runtime: Runtime.PYTHON_3_12,
-        handler: '<%= backend.apiNameSnakeCase %>.main.handler',
+        handler: '<%= backend.moduleName %>.main.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
             new URL(


### PR DESCRIPTION
### Reason for this change

I missed updating the lambda function handlers to use the normalised scope in https://github.com/awslabs/nx-plugin-for-aws/pull/229 - this means that FastAPI calls got a `Runtime.ImportModuleError` when being invoked unless a custom module name was provided.

### Description of changes

Use the module name instead of the API name in the lambda function constructs.

### Description of how you validated changes

Deployed a FastAPI

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*