### PR TITLE
fix: a few fixes in preparation for python mcp server

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -25,6 +25,10 @@ runs:
       uses: astral-sh/setup-uv@v5
       with:
         version: 'latest'
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Get pnpm store directory
       id: pnpm-cache
       shell: bash

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/3.mdx
@@ -105,7 +105,7 @@ Now we will update the `story_api` to support the [Lambda Web Adapter](https://g
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false

--- a/docs/src/content/docs/en/guides/python-project.mdx
+++ b/docs/src/content/docs/en/guides/python-project.mdx
@@ -100,7 +100,7 @@ When you use your Python project as runtime code (for example as the handler for
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/3.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Juego de Mazmorra con IA"
-description: "Un tutorial de cómo construir un juego de aventuras de mazmorra con IA usando el @aws/nx-plugin."
+description: "Un tutorial de cómo construir un juego de aventuras de mazmorra con IA utilizando el @aws/nx-plugin."
 ---
 
 
@@ -29,15 +29,15 @@ import gameConversationPng from '@assets/game-conversation.png'
 Asegúrate de haber otorgado acceso al modelo **Anthropic Claude 3.5 Sonnet v2** siguiendo los pasos descritos en [esta guía](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-La StoryApi consta de una única API `generate_story` que, dado un `Game` y una lista de `Action`s como contexto, generará una progresión de la historia. Esta API se implementará como una API de streaming en Python/FastAPI y además demostrará cómo se pueden realizar modificaciones al código generado para adaptarlo a su propósito.
+La StoryApi consta de una única API `generate_story` que, dado un `Game` y una lista de `Action`s como contexto, generará una historia progresiva. Esta API se implementará como una API de streaming en Python/FastAPI y demostrará cómo realizar modificaciones al código generado para adaptarlo a su propósito.
 
 ### Implementación de la API
 
 Para crear nuestra API, primero necesitamos instalar algunas dependencias adicionales:
 
-- `boto3` se usará para llamar a Amazon Bedrock;
-- `uvicorn` se usará para iniciar nuestra API en conjunto con el [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter).
-- `copyfiles` es una dependencia de npm que necesitaremos para soportar la copia multiplataforma de archivos al actualizar nuestra tarea `bundle`.
+- `boto3` se usará para interactuar con Amazon Bedrock;
+- `uvicorn` se utilizará para iniciar nuestra API en conjunto con el [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter);
+- `copyfiles` es una dependencia npm necesaria para soportar la copia multiplataforma de archivos al actualizar nuestra tarea `bundle`.
 
 Para instalar estas dependencias, ejecuta los siguientes comandos:
 
@@ -62,20 +62,20 @@ El cambio anterior en `init.py` simplemente elimina el middleware CORS para evit
 
 Analizando el código anterior:
 
-- Usamos la configuración `x-streaming` para indicar que esta es una API de streaming cuando generemos nuestro SDK cliente. ¡Esto nos permitirá consumir esta API en modo streaming manteniendo la seguridad de tipos!
-- Nuestra API simplemente devuelve un flujo de texto definido tanto por `media_type="text/plain"` como por `response_class=PlainTextResponse`
+- Usamos la configuración `x-streaming` para indicar que esta es una API de streaming al generar nuestro SDK cliente. ¡Esto nos permitirá consumir esta API de forma streaming manteniendo la seguridad de tipos!
+- Nuestra API simplemente devuelve un flujo de texto definido por `media_type="text/plain"` y `response_class=PlainTextResponse`
 
 :::note
-Cada vez que realices cambios en tu FastAPI, necesitarás reconstruir tu proyecto para ver esos cambios reflejados en el cliente generado en tu sitio web.
+Cada vez que realices cambios en tu FastAPI, necesitarás reconstruir el proyecto para ver esos cambios reflejados en el cliente generado para tu sitio web.
 
-Haremos algunos cambios más a continuación antes de reconstruir.
+Haremos algunos cambios más antes de reconstruir.
 :::
 
 ### Infraestructura
 
-La <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestructura que configuramos anteriormente</Link> asume que todas las APIs tienen una API Gateway integrada con funciones Lambda. Para nuestra `story_api` no queremos usar API Gateway ya que no soporta respuestas en streaming. En su lugar, usaremos una [Lambda Function URL configurada con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+La <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestructura configurada previamente</Link> asume que todas las APIs usan API Gateway integrado con funciones Lambda. Para nuestra `story_api` no queremos usar API Gateway ya que no soporta respuestas streaming. En su lugar, usaremos una [Lambda Function URL configurada con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Para soportar esto, primero actualizaremos nuestros constructos de CDK de la siguiente manera:
+Para implementar esto, actualizaremos primero nuestros constructos de CDK:
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -107,7 +107,7 @@ Ahora actualizaremos la `story_api` para soportar el despliegue con [Lambda Web 
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -123,33 +123,33 @@ Ahora actualizaremos la `story_api` para soportar el despliegue con [Lambda Web 
 
 ### Despliegue y pruebas
 
-Primero, construyamos la base de código:
+Primero, construyamos el código base:
 
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-Si encuentras errores de linting, puedes ejecutar el siguiente comando para corregirlos automáticamente.
+Si encuentras errores de linting, puedes ejecutar el siguiente comando para corregirlos automáticamente:
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-Ahora puedes desplegar tu aplicación ejecutando el siguiente comando:
+Ahora puedes desplegar la aplicación ejecutando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 Este despliegue tomará aproximadamente 2 minutos en completarse.
 
-<Drawer title="Comando de despliegue" trigger="También puedes desplegar todos los stacks a la vez. Haz clic aquí para más detalles.">
+<Drawer title="Comando de despliegue" trigger="También puedes desplegar todos los stacks a la vez. Haz clic para más detalles.">
 
-También puedes desplegar todos los stacks contenidos en la aplicación CDK ejecutando:
+También puedes desplegar todos los stacks de la aplicación CDK ejecutando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Esto **no se recomienda** ya que podrías elegir separar tus etapas de despliegue como stacks separados `ej. infra-prod`. En este caso, el flag `--all` intentará desplegar todos los stacks lo que puede resultar en despliegues no deseados.
+Esto **no se recomienda** ya que podrías tener stacks separados para diferentes etapas de despliegue (ej. infra-prod). En ese caso, el flag `--all` intentaría desplegar todo, lo que podría resultar en despliegues no deseados.
 
 </Drawer>
 
-Una vez completado el despliegue, deberías ver algunas salidas similares a las siguientes _(algunos valores han sido omitidos)_:
+Una vez completado el despliegue, verás salidas similares a las siguientes _(algunos valores fueron omitidos)_:
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -168,15 +168,15 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = regi
 dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
-Podemos probar nuestra API de dos maneras:
+Podemos probar nuestra API de dos formas:
 <ul>
-<li>Iniciando una instancia local del servidor FastAPI e invocando las APIs usando `curl`.</li>
+<li>Iniciando una instancia local del servidor FastAPI e invocando las APIs con `curl`.</li>
 <li>
-<Drawer title="Curl con Sigv4 habilitado" trigger="Llamando a la API desplegada usando curl con Sigv4 directamente">
+<Drawer title="curl con Sigv4" trigger="Llamar a la API desplegada usando curl con autenticación Sigv4">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Puedes agregar el siguiente script a tu archivo `.bashrc` (y hacer `source`) o simplemente pegarlo en la misma terminal donde quieras ejecutar el comando.
+Puedes agregar este script a tu `.bashrc` (y hacer `source`) o pegarlo directamente en la terminal donde ejecutarás el comando.
 ```bash
 // ~/.bashrc
 acurl () {
@@ -187,22 +187,21 @@ acurl () {
 }
 ```
 
-Luego para hacer una petición curl autenticada con sigv4, puedes invocar `acurl` como en los siguientes ejemplos:
+Ejemplos de uso:
 
 ###### API Gateway
 ```bash
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### URL de función Lambda con streaming
+###### Lambda Function URL streaming
 ```bash
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Puedes agregar la siguiente función a tu perfil de PowerShell o simplemente pegarla en la misma sesión donde quieras ejecutar el comando.
+Agrega esta función a tu perfil de PowerShell o pégala en la sesión actual.
 ```powershell
-# Perfil de PowerShell o sesión actual
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
@@ -218,14 +217,14 @@ function acurl {
 }
 ```
 
-Luego para hacer una petición curl autenticada con sigv4, puedes invocar `acurl` como en los siguientes ejemplos:
+Ejemplos de uso:
 
 ###### API Gateway
 ```powershell
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### URL de función Lambda con streaming
+###### Lambda Function URL streaming
 ```powershell
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
@@ -238,11 +237,11 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="Local">
-  Inicia tu servidor FastAPI local ejecutando:
+  Inicia el servidor FastAPI local ejecutando:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Una vez que el servidor FastAPI esté en ejecución, llámalo con:
-    
+    Una vez iniciado, llama a la API con:
+
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
       -d '{"genre":"superhero", "actions":[], "playerName":"UnnamedHero"}' \
@@ -257,12 +256,12 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Usa el valor de salida `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` del despliegue CDK para reemplazar el marcador de posición de la URL y configura la región adecuadamente.
+    Usa el valor de salida `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` del despliegue CDK para reemplazar la URL y ajusta la región según corresponda.
     </Aside>
   </TabItem>
 </Tabs>
 
-Si el comando se ejecuta correctamente, deberías ver una respuesta transmitida similar a:
+Si el comando se ejecuta correctamente, verás una respuesta en streaming similar a:
 
 ```
 UnnamedHero se alzó imponente, su capa ondeando al viento....

--- a/docs/src/content/docs/es/guides/python-project.mdx
+++ b/docs/src/content/docs/es/guides/python-project.mdx
@@ -10,13 +10,13 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-El generador de proyectos Python permite crear bibliotecas o aplicaciones modernas de [Python](https://www.python.org/) configuradas con mejores prácticas, gestionadas con [UV](https://docs.astral.sh/uv/), un único archivo de bloqueo y entorno virtual en un [espacio de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para ejecutar pruebas, y [Ruff](https://docs.astral.sh/ruff/) para análisis estático.
+El generador de proyectos Python puede utilizarse para crear una biblioteca o aplicación moderna de [Python](https://www.python.org/) configurada con mejores prácticas, gestionada con [UV](https://docs.astral.sh/uv/), un único archivo de bloqueo y entorno virtual en un [espacio de trabajo UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para ejecutar pruebas, y [Ruff](https://docs.astral.sh/ruff/) para análisis estático.
 
 ## Uso
 
 ### Generar un proyecto Python
 
-Puedes generar un nuevo proyecto Python de dos maneras:
+Puedes generar un nuevo proyecto Python de dos formas:
 
 <RunGenerator generator="py#project" />
 
@@ -32,23 +32,23 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
   - \<module-name>
     - \_\_init\_\_.py Inicialización del módulo
-    - hello.py Archivo ejemplo de código Python
+    - hello.py Archivo de ejemplo de código Python
   - tests
     - \_\_init\_\_.py Inicialización del módulo
     - conftest.py Configuración de pruebas
-    - test_hello.py Ejemplo de pruebas
+    - test_hello.py Pruebas de ejemplo
   - project.json Configuración del proyecto y objetivos de construcción
   - pyproject.toml Archivo de configuración de empaquetado usado por UV
   - .python-version Contiene la versión de Python del proyecto
 
 </FileTree>
 
-También podrás observar estos archivos creados/actualizados en la raíz del workspace:
+También podrás notar los siguientes archivos creados/actualizados en la raíz de tu espacio de trabajo:
 
 <FileTree>
 
-  - pyproject.toml Configuración de empaquetado a nivel de workspace para UV
-  - .python-version Contiene la versión de Python del workspace
+  - pyproject.toml Configuración de empaquetado a nivel de espacio de trabajo para UV
+  - .python-version Contiene la versión de Python del espacio de trabajo
   - uv.lock Archivo de bloqueo de dependencias Python
 
 </FileTree>
@@ -59,29 +59,29 @@ Añade tu código fuente Python en el directorio `<module-name>`.
 
 ### Importando código de tu biblioteca en otros proyectos
 
-Usa el objetivo `add` para añadir una dependencia a un proyecto Python.
+Utiliza el objetivo `add` para añadir una dependencia a un proyecto Python.
 
-Supongamos que hemos creado dos proyectos Python: `my_app` y `my_lib`. Estos tendrán nombres completos de proyecto `my_scope.my_app` y `my_scope.my_lib`, y por defecto tendrán nombres de módulo `my_scope_my_app` y `my_scope_my_lib`.
+Supongamos que hemos creado dos proyectos Python, `my_app` y `my_lib`. Estos tendrán nombres completos de proyecto `my_scope.my_app` y `my_scope.my_lib`, y por defecto tendrán nombres de módulo `my_scope_my_app` y `my_scope_my_lib`.
 
-Para que `my_app` dependa de `my_lib`, ejecutamos:
+Para que `my_app` dependa de `my_lib`, podemos ejecutar el siguiente comando:
 
 <NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
 
 :::note
-Usamos el nombre completo del proyecto tanto para el dependiente como para el dependido. Podemos usar sintaxis abreviada para el proyecto al que añadimos la dependencia, pero debemos calificar completamente el nombre del proyecto del que dependemos.
+Usamos el nombre completo del proyecto tanto para el dependiente como para el dependido. Podemos usar sintaxis abreviada para el proyecto al que queremos añadir la dependencia, pero debemos calificar completamente el nombre del proyecto del que dependemos.
 :::
 
-Luego podrás importar tu biblioteca:
+Luego podrás importar el código de tu biblioteca:
 
 ```python title="packages/my_app/my_scope_my_app/main.py"
 from my_scope_my_lib.hello import say_hello
 ```
 
-Aquí, `my_scope_my_lib` es el nombre del módulo de la biblioteca, `hello` corresponde al archivo fuente `hello.py`, y `say_hello` es un método definido en `hello.py`.
+Arriba, `my_scope_my_lib` es el nombre del módulo para la biblioteca, `hello` corresponde al archivo fuente Python `hello.py`, y `say_hello` es un método definido en `hello.py`
 
 ### Dependencias
 
-Para añadir dependencias a tu proyecto, ejecuta el objetivo `add` en tu proyecto Python:
+Para añadir dependencias a tu proyecto, puedes ejecutar el objetivo `add` en tu proyecto Python, por ejemplo:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
@@ -89,7 +89,7 @@ Esto añadirá la dependencia al archivo `pyproject.toml` de tu proyecto y actua
 
 #### Código en tiempo de ejecución
 
-Cuando uses tu proyecto Python como código de runtime (por ejemplo como handler para una función AWS Lambda), necesitarás crear un paquete del código fuente y sus dependencias. Puedes lograrlo añadiendo un objetivo como este en tu `project.json`:
+Cuando uses tu proyecto Python como código de tiempo de ejecución (por ejemplo como manejador de una función AWS Lambda), necesitarás crear un paquete del código fuente y todas sus dependencias. Puedes lograrlo añadiendo un objetivo como el siguiente a tu archivo `project.json`:
 
 ```json title="project.json"
 {
@@ -103,7 +103,7 @@ Cuando uses tu proyecto Python como código de runtime (por ejemplo como handler
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -115,15 +115,15 @@ Cuando uses tu proyecto Python como código de runtime (por ejemplo como handler
 
 ### Construcción
 
-Tu proyecto Python está configurado con un objetivo `build` (definido en `project.json`), que puedes ejecutar con:
+Tu proyecto Python está configurado con un objetivo `build` (definido en `project.json`), que puedes ejecutar mediante:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 Donde `<project-name>` es el nombre completo de tu proyecto.
 
-El objetivo `build` compilará, linteará y probará tu proyecto.
+El objetivo `build` compilará, verificará y probará tu proyecto.
 
-La salida de construcción se encuentra en la carpeta `dist` raíz de tu workspace, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<my-library>/build`.
+La salida de construcción se encontrará en la carpeta `dist` raíz de tu espacio de trabajo, dentro de un directorio para tu paquete y objetivo, por ejemplo `dist/packages/<my-library>/build`
 
 ## Pruebas
 
@@ -131,7 +131,7 @@ La salida de construcción se encuentra en la carpeta `dist` raíz de tu workspa
 
 ### Escribiendo pruebas
 
-Las pruebas deben escribirse en el directorio `test` dentro de tu proyecto, en archivos Python con prefijo `test_`, por ejemplo:
+Las pruebas deben escribirse en el directorio `test` dentro de tu proyecto, en archivos Python prefijados con `test_`, por ejemplo:
 
 <FileTree>
   - my_library
@@ -153,30 +153,30 @@ Para más detalles sobre cómo escribir pruebas, consulta la [documentación de 
 
 ### Ejecutando pruebas
 
-Las pruebas se ejecutan como parte del objetivo `build`, pero también puedes ejecutarlas por separado:
+Las pruebas se ejecutarán como parte del objetivo `build` de tu proyecto, pero también puedes ejecutarlas por separado usando el objetivo `test`:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puedes ejecutar una prueba individual usando el flag `-k`:
+Puedes ejecutar una prueba individual o un conjunto de pruebas usando el flag `-k`, especificando el nombre del archivo de prueba o método:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## Linting
+## Verificación de código
 
-Los proyectos Python usan [Ruff](https://docs.astral.sh/ruff/) para linting.
+Los proyectos Python usan [Ruff](https://docs.astral.sh/ruff/) para verificación de código.
 
-### Ejecutando el linter
+### Ejecutando el verificador
 
-Para invocar el linter y verificar tu proyecto:
+Para invocar el verificador y revisar tu proyecto, puedes ejecutar el objetivo `lint`:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Corrigiendo problemas de linting
+### Corrigiendo problemas de verificación
 
-La mayoría de problemas se pueden corregir automáticamente. Ejecuta Ruff con `--configuration=fix`:
+La mayoría de los problemas de verificación o formato pueden corregirse automáticamente. Puedes indicar a Ruff que corrija problemas ejecutando con el argumento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Para corregir todos los problemas en todos los paquetes:
+De forma similar, si deseas corregir todos los problemas de verificación en todos los paquetes de tu espacio de trabajo, puedes ejecutar:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/3.mdx
@@ -29,14 +29,14 @@ import gameConversationPng from '@assets/game-conversation.png'
 Assurez-vous d'avoir accordé l'accès au modèle **Anthropic Claude 3.5 Sonnet v2** en suivant les étapes décrites dans [ce guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-La StoryApi comprend une unique API `generate_story` qui, étant donné un `Game` et une liste d'`Action` comme contexte, fait progresser une histoire. Cette API sera implémentée comme une API de streaming en Python/FastAPI et démontrera également comment modifier le code généré pour l'adapter à son usage.
+La StoryApi comprend une unique API `generate_story` qui, étant donné un `Game` et une liste d'`Action` comme contexte, fait progresser une histoire. Cette API sera implémentée en tant qu'API de streaming en Python/FastAPI et démontrera également comment modifier le code généré pour l'adapter à son usage.
 
 ### Implémentation de l'API
 
-Pour créer notre API, nous devons d'abord installer quelques dépendances supplémentaires :
+Pour créer notre API, nous devons d'abord installer quelques dépendances supplémentaires.
 
 - `boto3` sera utilisé pour appeler Amazon Bedrock ;
-- `uvicorn` sera utilisé pour démarrer notre API en conjonction avec le [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter) ;
+- `uvicorn` sera utilisé pour démarrer notre API en conjonction avec le [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter).
 - `copyfiles` est une dépendance npm nécessaire pour supporter la copie multiplateforme de fichiers lors de la mise à jour de notre tâche `bundle`.
 
 Pour installer ces dépendances, exécutez les commandes suivantes :
@@ -44,7 +44,7 @@ Pour installer ces dépendances, exécutez les commandes suivantes :
 <NxCommands commands={["run dungeon_adventure.story_api:add --args boto3 uvicorn"]} />
 <InstallCommand pkg="copyfiles" dev />
 
-Maintenant remplaçons le contenu des fichiers suivants dans `packages/story_api/story_api` :
+Maintenant, remplaçons le contenu des fichiers suivants dans `packages/story_api/story_api` :
 
 <Tabs>
 <TabItem label="main.py">
@@ -54,28 +54,28 @@ Maintenant remplaçons le contenu des fichiers suivants dans `packages/story_api
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-La modification ci-dessus dans `init.py` supprime simplement le middleware CORS pour éviter les conflits avec la gestion des en-têtes CORS de l'URL de fonction Lambda.
+La modification ci-dessus de `init.py` supprime simplement le middleware CORS pour éviter qu'il n'interfère avec la gestion des en-têtes CORS de l'URL de fonction Lambda.
 :::
 
 </TabItem>
 </Tabs>
 
-Analyse du code :
+Analyse du code ci-dessus :
 
-- Nous utilisons le paramètre `x-streaming` pour indiquer qu'il s'agit d'une API de streaming lors de la génération de notre SDK client. Cela permet de consommer cette API en streaming tout en conservant la sécurité des types !
-- Notre API retourne simplement un flux de texte défini par `media_type="text/plain"` et `response_class=PlainTextResponse`
+- Nous utilisons le paramètre `x-streaming` pour indiquer qu'il s'agit d'une API de streaming lors de la génération de notre SDK client. Cela nous permettra de consommer cette API en streaming tout en conservant la sécurité des types !
+- Notre API retourne simplement un flux texte comme défini par `media_type="text/plain"` et `response_class=PlainTextResponse`
 
 :::note
-À chaque modification de votre FastAPI, vous devez reconstruire votre projet pour voir les changements reflétés dans le client généré de votre site web.
+À chaque modification de votre FastAPI, vous devrez reconstruire votre projet pour voir ces changements reflétés dans le client généré de votre site.
 
 Nous apporterons quelques modifications supplémentaires ci-dessous avant de reconstruire.
 :::
 
 ### Infrastructure
 
-L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastructure configurée précédemment</Link> suppose que toutes les API utilisent une API Gateway intégrée à des fonctions Lambda. Pour notre `story_api`, nous ne voulons pas utiliser API Gateway car il ne supporte pas les réponses en streaming. Nous utiliserons plutôt une [URL de fonction Lambda configurée avec le streaming de réponse](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastructure que nous avons mise en place précédemment</Link> suppose que toutes les API utilisent une API Gateway intégrée à des fonctions Lambda. Pour notre `story_api`, nous ne voulons pas utiliser API Gateway car il ne supporte pas les réponses en streaming. Nous utiliserons plutôt une [URL de fonction Lambda configurée avec le streaming de réponse](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Pour cela, mettons d'abord à jour nos constructions CDK :
+Pour supporter cela, nous allons d'abord mettre à jour nos constructions CDK comme suit :
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ Pour cela, mettons d'abord à jour nos constructions CDK :
 </TabItem>
 </Tabs>
 
-Maintenant mettons à jour la `story_api` pour supporter le déploiement du [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
+Maintenant, nous mettrons à jour la `story_api` pour supporter le déploiement du [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter).
 
 <Tabs>
 <TabItem label="run.sh">
@@ -107,7 +107,7 @@ Maintenant mettons à jour la `story_api` pour supporter le déploiement du [Lam
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -128,28 +128,28 @@ D'abord, construisons la base de code :
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-Si vous rencontrez des erreurs de linting, vous pouvez exécuter cette commande pour les corriger automatiquement :
+Si vous rencontrez des erreurs de lint, vous pouvez exécuter la commande suivante pour les corriger automatiquement.
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-Vous pouvez maintenant déployer l'application en exécutant :
+Votre application peut maintenant être déployée en exécutant la commande suivante :
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
 Ce déploiement prendra environ 2 minutes.
 
-<Drawer title="Commande de déploiement" trigger="Vous pouvez également déployer toutes les piles en une seule fois. Cliquez ici pour plus de détails.">
+<Drawer title="Commande de déploiement" trigger="Vous pouvez aussi déployer toutes les stacks d'un coup. Cliquez ici pour plus de détails.">
 
-Vous pouvez aussi déployer toutes les piles de l'application CDK en exécutant :
+Vous pouvez également déployer toutes les stacks contenues dans l'application CDK en exécutant :
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Ceci n'est **pas recommandé** car vous pourriez choisir de séparer vos étapes de déploiement en piles distinctes (ex: `infra-prod`). Dans ce cas, le flag `--all` tentera de déployer toutes les piles, ce qui peut entraîner des déploiements indésirables !
+Ceci n'est **pas recommandé** car vous pourriez choisir de séparer vos étapes de déploiement en stacks distinctes `(ex: infra-prod)`. Dans ce cas, le flag `--all` tentera de déployer toutes les stacks, ce qui peut entraîner des déploiements indésirables !
 
 </Drawer>
 
-Une fois le déploiement terminé, vous devriez voir des sorties similaires à ceci (certaines valeurs ont été masquées) :
+Une fois le déploiement terminé, vous devriez voir des sorties similaires à ceci _(certaines valeurs ont été masquées)_ :
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -170,14 +170,13 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_x
 
 Nous pouvons tester notre API en :
 <ul>
-<li>Démarrant une instance locale du serveur FastAPI et en l'appelant avec `curl`</li>
+<li>Démarrant une instance locale du serveur FastApi et en appelant les API avec `curl`.</li>
 <li>
-<Drawer title="curl avec Sigv4 activé" trigger="Appeler l'API déployée directement avec curl sigv4">
+<Drawer title="curl avec Sigv4 activé" trigger="Appeler l'API déployée directement avec curl activé pour Sigv4">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Vous pouvez ajouter ce script à votre fichier `.bashrc` (puis `source`) ou le coller directement dans le terminal :
-
+Vous pouvez soit ajouter le script suivant à votre fichier `.bashrc` (et le `sourcer`), soit simplement le coller dans le même terminal où vous souhaitez exécuter la commande.
 ```bash
 // ~/.bashrc
 acurl () {
@@ -188,7 +187,7 @@ acurl () {
 }
 ```
 
-Exemples d'utilisation :
+Pour effectuer une requête curl authentifiée Sigv4, invoquez `acurl` comme dans les exemples suivants :
 
 ###### API Gateway
 ```bash
@@ -201,9 +200,9 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Ajoutez cette fonction à votre profil PowerShell ou collez-la dans la session actuelle :
-
+Vous pouvez soit ajouter cette fonction à votre profil PowerShell, soit la coller directement dans la session PowerShell actuelle.
 ```powershell
+# Profil PowerShell ou session actuelle
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
@@ -219,7 +218,7 @@ function acurl {
 }
 ```
 
-Exemples d'utilisation :
+Pour effectuer une requête curl authentifiée Sigv4, invoquez `acurl` comme dans les exemples suivants :
 
 ###### API Gateway
 ```powershell
@@ -239,10 +238,10 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="Local">
-  Démarrez le serveur FastAPI local avec :
+  Démarrez votre serveur FastAPI local en exécutant :
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Appelez-le ensuite avec :
+    Une fois le serveur démarré, appelez-le avec :
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -258,15 +257,15 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Utilisez la valeur de sortie CDK `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` pour remplacer l'URL et ajustez la région.
+    Utilisez la valeur de sortie `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` du déploiement CDK pour remplacer l'URL et ajustez la région en conséquence.
     </Aside>
   </TabItem>
 </Tabs>
 
-Si la commande réussit, vous devriez voir une réponse en streaming similaire à :
+Si la commande s'exécute correctement, vous devriez voir une réponse en streaming similaire à :
 
 ```
 UnnamedHero se tenait droit, sa cape flottant au vent....
 ```
 
-Félicitations. Vous avez déployé votre première API avec FastAPI ! 🎉🎉🎉
+Félicitations. Vous avez créé et déployé votre première API avec FastAPI ! 🎉🎉🎉

--- a/docs/src/content/docs/fr/guides/python-project.mdx
+++ b/docs/src/content/docs/fr/guides/python-project.mdx
@@ -10,7 +10,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Le générateur de projet Python permet de créer une bibliothèque ou une application moderne [Python](https://www.python.org/) configurée avec les bonnes pratiques, gérée avec [UV](https://docs.astral.sh/uv/), un fichier de verrouillage unique et un environnement virtuel dans un [espace de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) pour exécuter les tests, et [Ruff](https://docs.astral.sh/ruff/) pour l'analyse statique.
+Le générateur de projets Python permet de créer une bibliothèque ou application [Python](https://www.python.org/) moderne configurée selon les meilleures pratiques, gérée avec [UV](https://docs.astral.sh/uv/), un fichier de verrouillage unique et un environnement virtuel dans un [espace de travail UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) pour exécuter les tests, et [Ruff](https://docs.astral.sh/ruff/) pour l'analyse statique.
 
 ## Utilisation
 
@@ -43,7 +43,7 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
 
 </FileTree>
 
-Vous remarquerez également les fichiers suivants créés/mis à jour à la racine de votre espace de travail :
+Vous remarquerez peut-être également les fichiers suivants créés/mis à jour à la racine de votre espace de travail :
 
 <FileTree>
 
@@ -53,25 +53,25 @@ Vous remarquerez également les fichiers suivants créés/mis à jour à la raci
 
 </FileTree>
 
-## Écriture du code source Python
+## Écrire du code Python
 
 Ajoutez votre code source Python dans le répertoire `<module-name>`.
 
-### Importer votre code bibliothèque dans d'autres projets
+### Importer votre code dans d'autres projets
 
 Utilisez la cible `add` pour ajouter une dépendance à un projet Python.
 
 Supposons que nous ayons créé deux projets Python, `my_app` et `my_lib`. Ceux-ci auront des noms de projet qualifiés complets `my_scope.my_app` et `my_scope.my_lib`, et auront par défaut des noms de module `my_scope_my_app` et `my_scope_my_lib`.
 
-Pour que `my_app` dépende de `my_lib`, nous pouvons exécuter la commande suivante :
+Pour que `my_app` dépende de `my_lib`, exécutez la commande suivante :
 
 <NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
 
 :::note
-Nous utilisons le nom de projet qualifié complet pour le dépendant et le dépendu. Nous pouvons utiliser la syntaxe raccourcie pour le projet auquel ajouter la dépendance, mais devons qualifier complètement le nom du projet dont dépendre.
+Nous utilisons le nom qualifié complet du projet pour le dépendant et le dépendu. Nous pouvons utiliser la syntaxe raccourcie pour le projet auquel ajouter la dépendance, mais devons qualifier entièrement le nom du projet dépendu.
 :::
 
-Vous pouvez ensuite importer votre code bibliothèque :
+Vous pouvez ensuite importer votre code :
 
 ```python title="packages/my_app/my_scope_my_app/main.py"
 from my_scope_my_lib.hello import say_hello
@@ -81,7 +81,7 @@ Ci-dessus, `my_scope_my_lib` est le nom du module pour la bibliothèque, `hello`
 
 ### Dépendances
 
-Pour ajouter des dépendances à votre projet, vous pouvez exécuter la cible `add` dans votre projet Python, par exemple :
+Pour ajouter des dépendances à votre projet, exécutez la cible `add` dans votre projet Python, par exemple :
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
@@ -89,7 +89,7 @@ Cela ajoutera la dépendance au fichier `pyproject.toml` de votre projet et mett
 
 #### Code d'exécution
 
-Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple comme gestionnaire pour une fonction AWS Lambda), vous devrez créer un bundle du code source et de toutes ses dépendances. Vous pouvez y parvenir en ajoutant une cible comme celle-ci à votre fichier `project.json` :
+Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple comme gestionnaire pour une fonction AWS Lambda), vous devrez créer un bundle du code source et de toutes ses dépendances. Vous pouvez y parvenir en ajoutant une cible comme celle-ci dans votre fichier `project.json` :
 
 ```json title="project.json"
 {
@@ -103,7 +103,7 @@ Lorsque vous utilisez votre projet Python comme code d'exécution (par exemple c
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -123,13 +123,13 @@ Où `<project-name>` est le nom qualifié complet de votre projet.
 
 La cible `build` compilera, linttera et testera votre projet.
 
-Le résultat du build se trouve dans le dossier `dist` racine de votre espace de travail, dans un répertoire pour votre package et cible, par exemple `dist/packages/<my-library>/build`.
+Le résultat du build se trouve dans le dossier `dist` racine de votre espace de travail, dans un répertoire spécifique à votre package et à la cible, par exemple `dist/packages/<my-library>/build`.
 
 ## Tests
 
 [pytest](https://docs.pytest.org/en/stable/) est configuré pour tester votre projet.
 
-### Écriture des tests
+### Écrire des tests
 
 Les tests doivent être écrits dans le répertoire `test` de votre projet, dans des fichiers Python préfixés par `test_`, par exemple :
 
@@ -149,15 +149,15 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-Pour plus de détails sur l'écriture des tests, veuillez consulter la [documentation pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
+Pour plus de détails sur l'écriture de tests, consultez la [documentation pytest](https://docs.pytest.org/en/stable/how-to/assert.html#).
 
-### Exécution des tests
+### Exécuter les tests
 
-Les tests s'exécuteront dans le cadre de la cible `build` de votre projet, mais vous pouvez aussi les exécuter séparément en lançant la cible `test` :
+Les tests s'exécutent dans le cadre de la cible `build` de votre projet, mais vous pouvez aussi les exécuter séparément avec la cible `test` :
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Vous pouvez exécuter un test individuel ou une suite de tests en utilisant le flag `-k`, en spécifiant soit le nom du fichier de test soit celui de la méthode :
+Vous pouvez exécuter un test individuel ou une suite de tests avec le flag `-k`, en spécifiant le nom du fichier de test ou de la méthode :
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -165,18 +165,18 @@ Vous pouvez exécuter un test individuel ou une suite de tests en utilisant le f
 
 Les projets Python utilisent [Ruff](https://docs.astral.sh/ruff/) pour le linting.
 
-### Exécution du linter
+### Exécuter le linter
 
-Pour invoquer le linter et vérifier votre projet, vous pouvez exécuter la cible `lint`.
+Pour invoquer le linter et vérifier votre projet, exécutez la cible `lint` :
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### Correction des problèmes de linting
+### Corriger les problèmes de lint
 
-La majorité des problèmes de linting ou de formatage peuvent être corrigés automatiquement. Vous pouvez demander à Ruff de corriger les problèmes de linting en utilisant l'argument `--configuration=fix`.
+La majorité des problèmes de lint ou de formatage peuvent être corrigés automatiquement. Vous pouvez demander à Ruff de corriger les problèmes de lint en utilisant l'argument `--configuration=fix` :
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-De même, si vous souhaitez corriger tous les problèmes de linting dans tous les packages de votre espace de travail, vous pouvez exécuter :
+De même, pour corriger tous les problèmes de lint dans tous les packages de votre espace de travail, exécutez :
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/3.mdx
@@ -23,20 +23,20 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## Modulo 3: Implementazione della Story API
+## Modulo 3: Implementazione dell'API per la storia
 
 <Aside type="caution">
 Assicurati di aver concesso l'accesso al modello **Anthropic Claude 3.5 Sonnet v2** seguendo i passaggi descritti in [questa guida](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-La StoryApi è composta da una singola API `generate_story` che, dato un `Game` e una lista di `Action` come contesto, farà progredire una storia. Questa API verrà implementata come API in streaming in Python/FastAPI e dimostrerà inoltre come apportare modifiche al codice generato per adattarlo allo scopo.
+Lo StoryApi comprende una singola API `generate_story` che, dato un `Game` e una lista di `Action` come contesto, farà progredire una storia. Questa API verrà implementata come API di streaming in Python/FastAPI e dimostrerà inoltre come apportare modifiche al codice generato per adattarlo allo scopo.
 
 ### Implementazione dell'API
 
-Per creare la nostra API, dobbiamo prima installare alcune dipendenze aggiuntive:
+Per creare la nostra API, dobbiamo prima installare alcune dipendenze aggiuntive.
 
 - `boto3` verrà utilizzato per chiamare Amazon Bedrock;
-- `uvicorn` verrà utilizzato per avviare la nostra API in combinazione con [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter);
+- `uvicorn` verrà utilizzato per avviare la nostra API in combinazione con [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter).
 - `copyfiles` è una dipendenza npm necessaria per supportare la copia multipiattaforma dei file durante l'aggiornamento del task `bundle`.
 
 Per installare queste dipendenze, esegui i seguenti comandi:
@@ -54,7 +54,7 @@ Ora sostituiamo il contenuto dei seguenti file in `packages/story_api/story_api`
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-La modifica sopra riportata a `init.py` rimuove semplicemente il middleware CORS per evitare conflitti con la gestione degli header CORS della Lambda Function URL.
+La modifica sopra riportata a `init.py` rimuove semplicemente il middleware CORS per evitare conflitti con la gestione degli header CORS dell'URL della Lambda Function.
 :::
 
 </TabItem>
@@ -62,20 +62,20 @@ La modifica sopra riportata a `init.py` rimuove semplicemente il middleware CORS
 
 Analizzando il codice sopra:
 
-- Utilizziamo l'impostazione `x-streaming` per indicare che si tratta di un'API in streaming durante la generazione del client SDK. Questo ci permetterà di consumare l'API in modalità streaming mantenendo la type-safety!
+- Utilizziamo l'impostazione `x-streaming` per indicare che si tratta di un'API di streaming quando genereremo il nostro client SDK. Questo ci permetterà di consumare questa API in modalità streaming mantenendo la type-safety!
 - La nostra API restituisce semplicemente un flusso di testo come definito sia da `media_type="text/plain"` che da `response_class=PlainTextResponse`
 
 :::note
-Ogni volta che apporti modifiche alla tua FastAPI, dovrai ricostruire il progetto per vedere le modifiche riflesse nel client generato nel tuo sito web.
+Ogni volta che apporti modifiche al tuo FastAPI, dovrai ricostruire il progetto per vedere le modifiche riflesse nel client generato nel tuo sito web.
 
-Faremo altre modifiche qui sotto prima di ricostruire.
+Apporteremo alcune modifiche aggiuntive di seguito prima di ricostruire.
 :::
 
 ### Infrastruttura
 
-L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastruttura configurata precedentemente</Link> presuppone che tutte le API abbiano un API Gateway che si integra con funzioni Lambda. Per la nostra `story_api` non vogliamo utilizzare API Gateway poiché non supporta risposte in streaming. Utilizzeremo invece una [Lambda Function URL configurata con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+L'<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infrastruttura configurata in precedenza</Link> presuppone che tutte le API abbiano un API Gateway integrato con funzioni Lambda. Per la nostra `story_api` non vogliamo utilizzare API Gateway poiché non supporta le risposte in streaming. Utilizzeremo invece un [Lambda Function URL configurato con response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
-Per supportare questo, aggiorniamo prima i nostri costrutti CDK come segue:
+Per supportare questo, aggiorneremo prima i nostri costrutti CDK come segue:
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -107,7 +107,7 @@ Ora aggiorneremo la `story_api` per supportare la distribuzione con [Lambda Web 
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -139,13 +139,13 @@ Ora puoi distribuire l'applicazione eseguendo:
 
 La distribuzione richiederà circa 2 minuti.
 
-<Drawer title="Comando di distribuzione" trigger="Puoi anche distribuire tutti gli stack contemporaneamente. Clicca qui per i dettagli.">
+<Drawer title="Comando di distribuzione" trigger="Puoi anche distribuire tutti gli stack contemporaneamente. Clicca qui per maggiori dettagli.">
 
 Puoi distribuire tutti gli stack contenuti nell'applicazione CDK eseguendo:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Questo approccio **non è raccomandato** in quanto potresti voler separare le fasi di distribuzione in stack diversi (es. `infra-prod`). In questo caso il flag `--all` tenterà di distribuire tutti gli stack, con il rischio di distribuzioni indesiderate!
+Questa opzione **non è raccomandata** in quanto potresti voler separare le fasi di distribuzione in stack distinti (es. `infra-prod`). In questo caso il flag `--all` tenterà di distribuire tutti gli stack, con il rischio di distribuzioni indesiderate!
 
 </Drawer>
 
@@ -172,11 +172,11 @@ Possiamo testare la nostra API in due modi:
 <ul>
 <li>Avviando un'istanza locale del server FastAPI e invocando le API con `curl`</li>
 <li>
-<Drawer title="Curl con Sigv4 abilitato" trigger="Chiamare l'API distribuita usando curl con sigv4 abilitato">
+<Drawer title="Curl con Sigv4 abilitato" trigger="Chiamare l'API distribuita usando curl con autenticazione sigv4">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Puoi aggiungere questo script al tuo file `.bashrc` (e eseguire `source`) oppure incollarlo direttamente nel terminale:
+Puoi aggiungere questo script al tuo file `.bashrc` (e eseguire `source`) oppure incollarlo direttamente nel terminale dove vuoi eseguire il comando.
 ```bash
 // ~/.bashrc
 acurl () {
@@ -200,8 +200,9 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Aggiungi questa funzione al tuo profilo PowerShell o incollala nella sessione corrente:
+Puoi aggiungere questa funzione al tuo profilo PowerShell o incollarla direttamente nella sessione corrente.
 ```powershell
+# Profilo PowerShell o sessione corrente
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
@@ -240,7 +241,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
   Avvia il server FastAPI locale con:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Esegui quindi la chiamata API con:
+    Una volta avviato, chiama l'API con:
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -256,7 +257,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Utilizza il valore di output `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` da CDK per sostituire il placeholder dell'URL e imposta la regione correttamente.
+    Utilizza il valore di output `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` da CDK deploy per sostituire il placeholder dell'URL e impostare la regione corretta.
     </Aside>
   </TabItem>
 </Tabs>
@@ -264,7 +265,7 @@ acurl ap-southeast-2 lambda -N -X POST \
 Se il comando viene eseguito correttamente, dovresti vedere una risposta in streaming simile a:
 
 ```
-UnnamedHero stood tall, his cape billowing in the wind....
+UnnamedHero si ergeva maestoso, il mantello svolazzante al vento....
 ```
 
-Congratulazioni. Hai costruito e distribuito la tua prima API con FastAPI! 🎉🎉🎉
+Complimenti. Hai costruito e distribuito la tua prima API con FastAPI! 🎉🎉🎉

--- a/docs/src/content/docs/it/guides/python-project.mdx
+++ b/docs/src/content/docs/it/guides/python-project.mdx
@@ -10,7 +10,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Il generatore di progetti Python può essere utilizzato per creare una moderna libreria o applicazione [Python](https://www.python.org/) configurata con le migliori pratiche, gestita con [UV](https://docs.astral.sh/uv/), un singolo file di lock e un ambiente virtuale in un [UV workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) per l'esecuzione dei test e [Ruff](https://docs.astral.sh/ruff/) per l'analisi statica.
+Il generatore di progetti Python può essere utilizzato per creare una moderna libreria o applicazione [Python](https://www.python.org/) configurata con le migliori pratiche, gestita con [UV](https://docs.astral.sh/uv/), un singolo file di lock e un ambiente virtuale in un [workspace UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) per l'esecuzione dei test, e [Ruff](https://docs.astral.sh/ruff/) per l'analisi statica.
 
 ## Utilizzo
 
@@ -31,14 +31,14 @@ Il generatore creerà la seguente struttura del progetto nella directory `<direc
 <FileTree>
 
   - \<module-name>
-    - \_\_init\_\_.py Inizializzazione del modulo
+    - \_\_init\_\_.py Inizializzazione modulo
     - hello.py File Python di esempio
   - tests
-    - \_\_init\_\_.py Inizializzazione del modulo  
-    - conftest.py Configurazione dei test
+    - \_\_init\_\_.py Inizializzazione modulo
+    - conftest.py Configurazione test
     - test_hello.py Test di esempio
-  - project.json Configurazione del progetto e target di build
-  - pyproject.toml File di configurazione del packaging utilizzato da UV
+  - project.json Configurazione progetto e target di build
+  - pyproject.toml File di configurazione packaging utilizzato da UV
   - .python-version Contiene la versione Python del progetto
 
 </FileTree>
@@ -47,8 +47,8 @@ Potresti anche notare i seguenti file creati/aggiornati nella root del workspace
 
 <FileTree>
 
-  - pyproject.toml Configurazione del packaging a livello workspace per UV
-  - .python-version Contiene la versione Python del workspace  
+  - pyproject.toml Configurazione packaging a livello workspace per UV
+  - .python-version Contiene la versione Python del workspace
   - uv.lock File di lock per le dipendenze Python
 
 </FileTree>
@@ -61,14 +61,14 @@ Aggiungi il tuo codice sorgente Python nella directory `<module-name>`.
 
 Utilizza il target `add` per aggiungere una dipendenza a un progetto Python.
 
-Supponiamo di aver creato due progetti Python, `my_app` e `my_lib`. Questi avranno nomi completi di progetto `my_scope.my_app` e `my_scope.my_lib`, e per default avranno nomi di modulo `my_scope_my_app` e `my_scope_my_lib`.
+Supponiamo di aver creato due progetti Python, `my_app` e `my_lib`. Questi avranno nomi progetto completamente qualificati `my_scope.my_app` e `my_scope.my_lib`, e per default avranno nomi modulo `my_scope_my_app` e `my_scope_my_lib`.
 
 Per far dipendere `my_app` da `my_lib`, possiamo eseguire il comando:
 
 <NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
 
 :::note
-Usiamo il nome completo del progetto sia per il dipendente che per il dipendente. Possiamo usare la sintassi abbreviata per il progetto a cui vogliamo aggiungere la dipendenza, ma dobbiamo specificare completamente il nome del progetto da cui dipendere.
+Utilizziamo il nome progetto completamente qualificato sia per il dipendente che per il dipendente. Possiamo usare la sintassi abbreviata per il progetto a cui vogliamo aggiungere la dipendenza, ma dobbiamo qualificare completamente il nome del progetto da cui dipendere.
 :::
 
 Potrai quindi importare il codice della libreria:
@@ -77,7 +77,7 @@ Potrai quindi importare il codice della libreria:
 from my_scope_my_lib.hello import say_hello
 ```
 
-Nell'esempio sopra, `my_scope_my_lib` è il nome del modulo per la libreria, `hello` corrisponde al file sorgente Python `hello.py`, e `say_hello` è un metodo definito in `hello.py`
+Qui sopra, `my_scope_my_lib` è il nome modulo della libreria, `hello` corrisponde al file sorgente Python `hello.py`, e `say_hello` è un metodo definito in `hello.py`
 
 ### Dipendenze
 
@@ -89,7 +89,7 @@ Questo aggiungerà la dipendenza al file `pyproject.toml` del progetto e aggiorn
 
 #### Codice Runtime
 
-Quando usi il tuo progetto Python come codice runtime (ad esempio come handler per una funzione AWS lambda), dovrai creare un bundle del codice sorgente e di tutte le dipendenze. Puoi farlo aggiungendo un target come il seguente al tuo file `project.json`:
+Quando utilizzi il tuo progetto Python come codice runtime (ad esempio come handler per una funzione AWS lambda), dovrai creare un bundle del codice sorgente e di tutte le sue dipendenze. Puoi ottenere questo aggiungendo un target come il seguente al tuo file `project.json`:
 
 ```json title="project.json"
 {
@@ -103,7 +103,7 @@ Quando usi il tuo progetto Python come codice runtime (ad esempio come handler p
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -119,11 +119,11 @@ Il tuo progetto Python è configurato con un target `build` (definito in `projec
 
 <NxCommands commands={['run <project-name>:build']} />
 
-Dove `<project-name>` è il nome completo del tuo progetto.
+Dove `<project-name>` è il nome completamente qualificato del tuo progetto.
 
 Il target `build` compilerà, eseguirà il linting e testerà il progetto.
 
-L'output della build si troverà nella cartella `dist` root del workspace, all'interno di una directory per il tuo pacchetto e target, ad esempio `dist/packages/<my-library>/build`
+L'output della build si troverà nella cartella root `dist` del workspace, all'interno di una directory per il tuo package e target, ad esempio `dist/packages/<my-library>/build`
 
 ## Testing
 
@@ -131,7 +131,7 @@ L'output della build si troverà nella cartella `dist` root del workspace, all'i
 
 ### Scrivere Test
 
-I test dovrebbero essere scritti nella directory `test` del progetto, in file Python prefissati con `test_`, ad esempio:
+I test dovrebbero essere scritti nella directory `test` all'interno del progetto, in file Python prefissati con `test_`, ad esempio:
 
 <FileTree>
   - my_library
@@ -140,7 +140,7 @@ I test dovrebbero essere scritti nella directory `test` del progetto, in file Py
     - test_hello.py Test per hello.py
 </FileTree>
 
-I test sono metodi che iniziano con `test_` e utilizzano asserzioni per verificare le aspettative, ad esempio:
+I test sono metodi che iniziano con `test_` e fanno asserzioni per verificare le aspettative, ad esempio:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -157,7 +157,7 @@ I test verranno eseguiti come parte del target `build` del progetto, ma puoi anc
 
 <NxCommands commands={['run <project-name>:test']} />
 
-Puoi eseguire un singolo test o una suite specifica usando il flag `-k`, specificando il nome del file di test o del metodo:
+Puoi eseguire un singolo test o una suite di test usando il flag `-k`, specificando il nome del file test o del metodo:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -177,6 +177,6 @@ La maggior parte dei problemi di linting o formattazione può essere corretta au
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Analogamente, se vuoi correggere tutti i problemi di linting in tutti i pacchetti del workspace, puoi eseguire:
+Analogamente, se vuoi correggere tutti i problemi di linting in tutti i package del workspace, puoi eseguire:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/3.mdx
@@ -26,10 +26,10 @@ import gameConversationPng from '@assets/game-conversation.png'
 ## モジュール3: ストーリーAPIの実装
 
 <Aside type="caution">
-**Anthropic Claude 3.5 Sonnet v2**モデルへのアクセス権を[このガイド](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)の手順に従って付与していることを確認してください。
+以下のガイドに記載されている手順に従って、**Anthropic Claude 3.5 Sonnet v2** モデルへのアクセス権を付与していることを確認してください。[アクセス権設定ガイド](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)
 </Aside>
 
-StoryApiは、`Game`とコンテキスト用の`Action`リストを受け取り、ストーリーを進行させる単一のAPI`generate_story`で構成されます。このAPIはPython/FastAPIでストリーミングAPIとして実装され、生成されたコードを目的に合わせて変更する方法も実演します。
+StoryApiは、`Game`とコンテキスト用の`Action`リストを受け取り、ストーリーを進行させる単一のAPI`generate_story`で構成されます。このAPIはPython/FastAPIを使用したストリーミングAPIとして実装され、生成されたコードを目的に合わせて変更する方法も実演します。
 
 ### API実装
 
@@ -39,7 +39,7 @@ APIを作成するには、まず追加の依存関係をインストールす�
 - `uvicorn`は[Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)と組み合わせてAPI起動に使用
 - `copyfiles`は`bundle`タスク更新時にクロスプラットフォームのファイルコピーをサポートするnpm依存関係
 
-以下のコマンドでこれらの依存関係をインストールします：
+以下のコマンドを実行して依存関係をインストールします：
 
 <NxCommands commands={["run dungeon_adventure.story_api:add --args boto3 uvicorn"]} />
 <InstallCommand pkg="copyfiles" dev />
@@ -54,28 +54,28 @@ APIを作成するには、まず追加の依存関係をインストールす�
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-上記の`init.py`への変更は、Lambda Function URL独自のCORSヘッダー処理との競合を避けるため、CORSミドルウェアを削除するだけです。
+上記の`init.py`への変更は、Lambda Function URL自身のCORSヘッダー処理との競合を避けるため、CORSミドルウェアを削除するだけです。
 :::
 
 </TabItem>
 </Tabs>
 
-上記コードの分析：
+コードの分析ポイント：
 
-- クライアントSDK生成時にストリーミングAPIであることを示す`x-streaming`設定を使用。これにより型安全性を維持しつつストリーミング処理が可能
-- APIは`media_type="text/plain"`と`response_class=PlainTextResponse`で定義されたテキストストリームを返す
+- クライアントSDK生成時にストリーミングAPIであることを示す`x-streaming`設定を使用
+- `media_type="text/plain"`と`response_class=PlainTextResponse`で定義されたテキストストリームを返す
 
 :::note
-FastAPIに変更を加えるたびに、Webサイトの生成クライアントに変更を反映させるためプロジェクトの再ビルドが必要です。
+FastAPIに変更を加えるたびに、ウェブサイトの生成クライアントに変更を反映させるためプロジェクトの再ビルドが必要です。
 
-以下の変更を加えた後で再ビルドします。
+以下の変更を加えた後、再ビルドを行います。
 :::
 
 ### インフラストラクチャ
 
-<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">以前設定したインフラストラクチャ</Link>は、すべてのAPIがLambda関数と統合するAPI Gatewayを使用することを想定しています。`story_api`ではストリーミングレスポンスをサポートしないAPI Gatewayの代わりに、[レスポンスストリーミングを設定したLambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)を使用します。
+<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">以前に設定したインフラストラクチャ</Link>は、すべてのAPIがLambda関数と統合するAPI Gatewayを使用することを想定しています。`story_api`ではストリーミングレスポンスをサポートしないAPI Gatewayの代わりに、[レスポンスストリーミング対応のLambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)を使用します。
 
-これをサポートするため、まずCDKコンストラクトを以下のように更新します：
+これを実現するため、まずCDKコンストラクトを以下のように更新します：
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ FastAPIに変更を加えるたびに、Webサイトの生成クライアント�
 </TabItem>
 </Tabs>
 
-次に[Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)のデプロイをサポートするよう`story_api`を更新します：
+次に、[Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)のデプロイをサポートするため`story_api`を更新します：
 
 <Tabs>
 <TabItem label="run.sh">
@@ -107,7 +107,7 @@ FastAPIに変更を加えるたびに、Webサイトの生成クライアント�
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -128,7 +128,7 @@ FastAPIに変更を加えるたびに、Webサイトの生成クライアント�
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-リンターエラーが発生した場合、以下のコマンドで自動修正できます。
+リンターエラーが発生した場合は、以下のコマンドで自動修正できます。
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
@@ -137,19 +137,19 @@ FastAPIに変更を加えるたびに、Webサイトの生成クライアント�
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-このデプロイには約2分かかります。
+デプロイには約2分かかります。
 
-<Drawer title="デプロイコマンド" trigger="全スタックを一括デプロイする方法はこちら">
+<Drawer title="デプロイコマンド" trigger="すべてのスタックを一度にデプロイすることも可能です。詳細はこちらをクリック">
 
-CDKアプリケーション内の全スタックをデプロイするには：
+以下のコマンドでCDKアプリケーション内のすべてのスタックをデプロイできます：
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-ただし、本番環境用スタック（例：`infra-prod`）を別途管理する場合、`--all`フラグは意図しないデプロイを引き起こす可能性があるため**推奨しません**。
+ただし、本番環境用スタック（`infra-prod`など）を別途管理する場合、`--all`フラグはすべてのスタックをデプロイしようとするため、意図しないデプロイが発生する可能性があります。
 
 </Drawer>
 
-デプロイ完了後、以下のような出力が表示されます（一部値は編集済み）：
+デプロイが完了すると、以下のような出力が表示されます（一部の値は編集済み）：
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -157,7 +157,7 @@ dungeon-adventure-infra-sandbox: deploying... [2/2]
 
  ✅  dungeon-adventure-infra-sandbox
 
-✨  デプロイ時間: 354秒
+✨  Deployment time: 354s
 
 Outputs:
 dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
@@ -187,22 +187,21 @@ acurl () {
 }
 ```
 
-sigv4認証済みcurlリクエストの実行例：
+sigv4認証付きcurlリクエストの例：
 
 ###### API Gateway
 ```bash
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### ストリーミングLambda function url
+###### ストリーミングLambda関数URL
 ```bash
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-PowerShellプロファイルに関数を追加するか、現在のセッションに貼り付けます。
+PowerShellプロファイルまたは現在のセッションに以下の関数を追加：
 ```powershell
-# PowerShellプロファイルまたは現在のセッション
 function acurl {
     param(
         [Parameter(Mandatory=$true)][string]$Region,
@@ -225,7 +224,7 @@ function acurl {
 acurl ap-southeast-2 execute-api -X GET https://xxx
 ```
 
-###### ストリーミングLambda function url
+###### ストリーミングLambda関数URL
 ```powershell
 acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
@@ -237,11 +236,11 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 </ul>
 
 <Tabs>
-  <TabItem label="ローカル">
-  以下のコマンドでローカルFastAPIサーバーを起動：
+  <TabItem label="ローカル環境">
+  以下のコマンドでFastAPIサーバーを起動：
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    サーバー起動後、以下のコマンドで呼び出し：
+    サーバー起動後、以下のコマンドでAPIを呼び出し：
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -249,7 +248,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
       -H "Content-Type: application/json"
     ```
   </TabItem>
-  <TabItem label="デプロイ済み">
+  <TabItem label="デプロイ済み環境">
 ```bash "https://xxx.lambda-url.ap-southeast-2.on.aws/" "ap-southeast-2"
 acurl ap-southeast-2 lambda -N -X POST \
   https://xxx.lambda-url.ap-southeast-2.on.aws/story/generate \
@@ -257,7 +256,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    CDKデプロイ出力の`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`値でURLプレースホルダーを置換し、リージョンを適切に設定してください。
+    CDKデプロイ出力の`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`値でURLプレースホルダーを置き換え、リージョンを適切に設定してください。
     </Aside>
   </TabItem>
 </Tabs>
@@ -268,4 +267,4 @@ acurl ap-southeast-2 lambda -N -X POST \
 UnnamedHero stood tall, his cape billowing in the wind....
 ```
 
-おめでとうございます。FastAPIを使った最初のAPIの構築とデプロイに成功しました！ 🎉🎉🎉
+おめでとうございます。FastAPIを使用した最初のAPIの構築とデプロイに成功しました！ 🎉🎉🎉

--- a/docs/src/content/docs/jp/guides/python-project.mdx
+++ b/docs/src/content/docs/jp/guides/python-project.mdx
@@ -10,7 +10,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Pythonプロジェクトジェネレータは、モダンな[Python](https://www.python.org/)ライブラリやアプリケーションを作成するために使用できます。ベストプラクティスに基づいて設定され、[UV](https://docs.astral.sh/uv/)による依存関係管理、単一のロックファイルと仮想環境を備えた[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)、テスト実行用の[pytest](https://docs.pytest.org/en/stable/)、静的解析用の[Ruff](https://docs.astral.sh/ruff/)が統合されています。
+Pythonプロジェクトジェネレータは、モダンな[Python](https://www.python.org/)ライブラリやアプリケーションを作成するために使用できます。これらのプロジェクトはベストプラクティスに基づいて構成され、[UV](https://docs.astral.sh/uv/)による依存関係管理、単一のロックファイルと仮想環境を[UVワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)内で管理し、テスト実行には[pytest](https://docs.pytest.org/en/stable/)、静的解析には[Ruff](https://docs.astral.sh/ruff/)を使用します。
 
 ## 使用方法
 
@@ -26,24 +26,24 @@ Pythonプロジェクトジェネレータは、モダンな[Python](https://www
 
 ## ジェネレータの出力
 
-ジェネレータは`<directory>/<name>`ディレクトリに以下のプロジェクト構造を作成します:
+ジェネレータは`<directory>/<name>`ディレクトリ内に以下のプロジェクト構造を作成します:
 
 <FileTree>
 
   - \<module-name>
-    - \_\_init\_\_.py モジュール初期化
-    - hello.py サンプルPythonソースファイル
+    - \_\_init\_\_.py モジュール初期化ファイル
+    - hello.py Pythonソースファイルの例
   - tests
-    - \_\_init\_\_.py モジュール初期化
-    - conftest.py テスト設定
-    - test_hello.py サンプルテスト
+    - \_\_init\_\_.py モジュール初期化ファイル
+    - conftest.py テスト設定ファイル
+    - test_hello.py テストファイルの例
   - project.json プロジェクト設定とビルドターゲット
   - pyproject.toml UV用パッケージ設定ファイル
   - .python-version プロジェクトのPythonバージョン情報
 
 </FileTree>
 
-ワークスペースルートにも以下のファイルが作成/更新されます:
+ワークスペースのルートにも以下のファイルが作成/更新されます:
 
 <FileTree>
 
@@ -57,7 +57,7 @@ Pythonプロジェクトジェネレータは、モダンな[Python](https://www
 
 Pythonソースコードは`<module-name>`ディレクトリに追加します。
 
-### 他のプロジェクトでのライブラリコードのインポート
+### 他のプロジェクトでライブラリコードをインポートする
 
 Pythonプロジェクトに依存関係を追加するには`add`ターゲットを使用します。
 
@@ -68,7 +68,7 @@ Pythonプロジェクトに依存関係を追加するには`add`ターゲット
 <NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
 
 :::note
-依存元と依存先の両方に完全修飾プロジェクト名を使用します。依存元プロジェクトには短縮構文を使用できますが、依存先プロジェクトは完全修飾名で指定する必要があります。
+依存先と依存元の両方に完全修飾プロジェクト名を使用します。依存先プロジェクトには短縮構文を使用できますが、依存するプロジェクト名は完全修飾する必要があります。
 :::
 
 これでライブラリコードをインポートできます:
@@ -81,15 +81,15 @@ from my_scope_my_lib.hello import say_hello
 
 ### 依存関係の管理
 
-プロジェクトに依存関係を追加するには、`add`ターゲットを実行します:
+プロジェクトに依存関係を追加するには、Pythonプロジェクトで`add`ターゲットを実行します:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-これによりプロジェクトの`pyproject.toml`ファイルが更新され、ルートの`uv.lock`が更新されます。
+これによりプロジェクトの`pyproject.toml`ファイルに依存関係が追加され、ルートの`uv.lock`が更新されます。
 
 #### ランタイムコード
 
-Pythonプロジェクトをランタイムコード（例: AWS Lambda関数のハンドラ）として使用する場合、ソースコードと依存関係をバンドルする必要があります。`project.json`ファイルに以下のようなターゲットを追加できます:
+Pythonプロジェクトをランタイムコード（例: AWS Lambda関数のハンドラ）として使用する場合、ソースコードとすべての依存関係をバンドルする必要があります。`project.json`ファイルに以下のようなターゲットを追加することで実現できます:
 
 ```json title="project.json"
 {
@@ -103,7 +103,7 @@ Pythonプロジェクトをランタイムコード（例: AWS Lambda関数の�
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -115,23 +115,23 @@ Pythonプロジェクトをランタイムコード（例: AWS Lambda関数の�
 
 ### ビルド
 
-Pythonプロジェクトには`build`ターゲット（`project.json`で定義）が設定されており、次のコマンドで実行できます:
+Pythonプロジェクトには`build`ターゲットが設定されています（`project.json`で定義）。次のコマンドで実行できます:
 
 <NxCommands commands={['run <project-name>:build']} />
 
 `<project-name>`はプロジェクトの完全修飾名です。
 
-`build`ターゲットはコンパイル、リンター実行、テストを実施します。
+`build`ターゲットはプロジェクトのコンパイル、リント、テストを実行します。
 
-ビルド出力はワークスペースルートの`dist`フォルダ内に生成されます（例: `dist/packages/<my-library>/build`）。
+ビルド出力はワークスペースのルート`dist`フォルダ内に生成されます（例: `dist/packages/<my-library>/build`）。
 
 ## テスト
 
-[pytest](https://docs.pytest.org/en/stable/)がテスト実行用に設定されています。
+[pytest](https://docs.pytest.org/en/stable/)がプロジェクトのテスト用に設定されています。
 
 ### テストの記述
 
-テストはプロジェクト内の`test`ディレクトリに`test_`プレフィックス付きのPythonファイルで記述します:
+テストはプロジェクト内の`test`ディレクトリに、`test_`で始まるPythonファイルとして作成します:
 
 <FileTree>
   - my_library
@@ -149,7 +149,7 @@ def test_say_hello():
   assert say_hello("Darth Vader") == "Hello, Darth Vader!"
 ```
 
-テストの詳細な記述方法については[pytestドキュメント](https://docs.pytest.org/en/stable/how-to/assert.html#)を参照してください。
+テストの書き方の詳細は[pytestドキュメント](https://docs.pytest.org/en/stable/how-to/assert.html#)を参照してください。
 
 ### テストの実行
 
@@ -161,22 +161,22 @@ def test_say_hello():
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
-## リンター
+## リント
 
-Pythonプロジェクトでは[Ruff](https://docs.astral.sh/ruff/)をリンターとして使用しています。
+Pythonプロジェクトでは[Ruff](https://docs.astral.sh/ruff/)をリントツールとして使用しています。
 
-### リンターの実行
+### リントの実行
 
-プロジェクトのリンターを実行するには`lint`ターゲットを使用します:
+プロジェクトのリントチェックを行うには`lint`ターゲットを実行します:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### リンター問題の修正
+### リント問題の修正
 
-ほとんどのリンターやフォーマッターの問題は自動修正可能です。`--configuration=fix`引数を付けて実行します:
+ほとんどのリントやフォーマットの問題は自動修正可能です。`--configuration=fix`引数を付けて実行することで修正できます:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-ワークスペース内の全パッケージのリンター問題を修正するには:
+ワークスペース内の全パッケージのリント問題を修正するには:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/3.mdx
@@ -26,20 +26,20 @@ import gameConversationPng from '@assets/game-conversation.png'
 ## 모듈 3: 스토리 API 구현
 
 <Aside type="caution">
-[이 가이드](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)에 설명된 단계에 따라 **Anthropic Claude 3.5 Sonnet v2** 모델에 대한 액세스 권한을 부여했는지 확인하세요.
+[이 가이드](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)에 설명된 단계를 따라 **Anthropic Claude 3.5 Sonnet v2** 모델에 대한 접근 권한을 부여했는지 확인하세요.
 </Aside>
 
-StoryApi는 `Game`과 컨텍스트용 `Action` 목록을 입력받아 스토리를 진행시키는 단일 API `generate_story`로 구성됩니다. 이 API는 Python/FastAPI로 스트리밍 API로 구현되며, 생성된 코드를 목적에 맞게 수정하는 방법을 추가로 시연합니다.
+StoryApi는 `Game`과 컨텍스트용 `Action` 목록을 입력받아 스토리를 진행하는 단일 API `generate_story`로 구성됩니다. 이 API는 Python/FastAPI로 스트리밍 API로 구현되며, 생성된 코드를 목적에 맞게 수정하는 방법을 추가로 보여줍니다.
 
 ### API 구현
 
 API를 생성하기 전에 먼저 몇 가지 추가 종속성을 설치해야 합니다.
 
-- `boto3`는 Amazon Bedrock 호출에 사용됩니다.
-- `uvicorn`은 [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)와 함께 사용 시 API 시작에 사용됩니다.
-- `copyfiles`는 `bundle` 작업 업데이트 시 크로스 플랫폼 파일 복사를 지원하기 위한 npm 종속성입니다.
+- Amazon Bedrock 호출에 `boto3` 사용
+- [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)와 함께 사용 시 API 시작에 `uvicorn` 사용
+- `bundle` 작업 업데이트 시 크로스 플랫폼 파일 복사를 지원하기 위한 npm 종속성 `copyfiles`
 
-이 종속성들을 설치하려면 다음 명령어를 실행하세요:
+다음 명령어를 실행하여 종속성을 설치하세요:
 
 <NxCommands commands={["run dungeon_adventure.story_api:add --args boto3 uvicorn"]} />
 <InstallCommand pkg="copyfiles" dev />
@@ -62,18 +62,18 @@ API를 생성하기 전에 먼저 몇 가지 추가 종속성을 설치해야 �
 
 위 코드 분석:
 
-- 클라이언트 SDK 생성 시 스트리밍 API임을 나타내기 위해 `x-streaming` 설정을 사용합니다. 이는 타입 안전성을 유지하면서 스트리밍 방식으로 API를 사용할 수 있게 합니다.
-- API는 `media_type="text/plain"`과 `response_class=PlainTextResponse`로 정의된 텍스트 스트림을 반환합니다.
+- 클라이언트 SDK 생성 시 스트리밍 API임을 나타내는 `x-streaming` 설정 사용. 이는 타입 안전성을 유지하면서 스트리밍 방식으로 API를 사용할 수 있게 합니다.
+- API는 `media_type="text/plain"`과 `response_class=PlainTextResponse`로 정의된 텍스트 스트림을 반환
 
 :::note
-FastAPI를 변경할 때마다 웹사이트에서 생성된 클라이언트에 변경사항이 반영되도록 프로젝트를 재빌드해야 합니다.
+FastAPI를 변경할 때마다 웹사이트의 생성된 클라이언트에 변경사항이 반영되도록 프로젝트를 재빌드해야 합니다.
 
 아래에서 몇 가지 추가 변경을 진행한 후 재빌드하겠습니다.
 :::
 
 ### 인프라 구조
 
-<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">이전에 설정한 인프라</Link>는 모든 API가 Lambda 함수와 통합되는 API Gateway를 사용한다고 가정합니다. 하지만 `story_api`의 경우 스트리밍 응답을 지원하지 않는 API Gateway 대신 [응답 스트리밍이 구성된 Lambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)을 사용합니다.
+<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">이전에 설정한 인프라</Link>는 모든 API가 Lambda 함수와 통합하는 API Gateway를 사용한다고 가정합니다. 하지만 `story_api`의 경우 스트리밍 응답을 지원하지 않는 API Gateway 대신 [응답 스트리밍이 구성된 Lambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)을 사용합니다.
 
 이를 지원하기 위해 먼저 CDK 구성을 다음과 같이 업데이트합니다:
 
@@ -107,7 +107,7 @@ FastAPI를 변경할 때마다 웹사이트에서 생성된 클라이언트에 �
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -128,28 +128,28 @@ FastAPI를 변경할 때마다 웹사이트에서 생성된 클라이언트에 �
 <NxCommands commands={['run-many --target build --all']} />
 
 <Aside type="tip">
-린트 오류가 발생하면 다음 명령어를 실행하여 자동으로 수정할 수 있습니다.
+린트 오류가 발생하면 다음 명령어로 자동 수정할 수 있습니다.
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-이제 다음 명령어를 실행하여 애플리케이션을 배포할 수 있습니다:
+이제 다음 명령어로 애플리케이션을 배포할 수 있습니다:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-이 배포는 완료까지 약 2분 정도 소요됩니다.
+배포는 약 2분 정도 소요됩니다.
 
 <Drawer title="배포 명령어" trigger="모든 스택을 한 번에 배포할 수도 있습니다. 자세한 내용을 보려면 클릭하세요.">
 
-다음 명령어를 실행하여 CDK 애플리케이션에 포함된 모든 스택을 배포할 수 있습니다:
+다음 명령어로 CDK 애플리케이션의 모든 스택을 배포할 수 있습니다:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-인프라 프로덕션 스택(`infra-prod`)과 같이 배포 단계를 별도 스택으로 분리하는 경우 `--all` 플래그가 원치 않는 배포를 유발할 수 있으므로 **권장하지 않습니다**!
+하지만 인프라 프로덕션 스택과 같은 별도의 배포 단계로 스택을 분리할 경우 `--all` 플래그가 원치 않는 배포를 유발할 수 있으므로 **권장하지 않습니다**!
 
 </Drawer>
 
-배포가 완료되면 다음과 유사한 출력이 표시됩니다 _(일부 값은 편집됨)_:
+배포가 완료되면 다음과 유사한 출력을 확인할 수 있습니다(일부 값 생략):
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -170,13 +170,13 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_x
 
 다음 방법으로 API를 테스트할 수 있습니다:
 <ul>
-<li>FastApi 서버를 로컬로 시작하고 `curl`로 API 호출</li>
+<li>FastApi 서버를 로컬에서 시작하고 `curl`로 API 호출</li>
 <li>
 <Drawer title="Sigv4 활성화 curl" trigger="배포된 API를 sigv4 활성화 curl로 직접 호출">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-`.bashrc` 파일에 다음 스크립트를 추가하거나(추가 후 `source` 실행) 명령어를 실행할 터미널에 직접 붙여넣으세요.
+`.bashrc` 파일에 다음 스크립트 추가(후 `source` 실행) 또는 동일 터미널에 직접 붙여넣기
 ```bash
 // ~/.bashrc
 acurl () {
@@ -187,7 +187,7 @@ acurl () {
 }
 ```
 
-sigv4 인증 curl 요청은 다음 예시처럼 `acurl`을 사용하여 실행할 수 있습니다:
+sigv4 인증 curl 요청 예시:
 
 ###### API Gateway
 ```bash
@@ -200,7 +200,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-PowerShell 프로필에 다음 함수를 추가하거나 현재 PowerShell 세션에 직접 붙여넣으세요.
+PowerShell 프로필에 함수 추가 또는 현재 세션에 직접 붙여넣기
 ```powershell
 # PowerShell profile or current session
 function acurl {
@@ -218,7 +218,7 @@ function acurl {
 }
 ```
 
-sigv4 인증 curl 요청은 다음 예시처럼 `acurl`을 사용하여 실행할 수 있습니다:
+sigv4 인증 curl 요청 예시:
 
 ###### API Gateway
 ```powershell
@@ -238,10 +238,10 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="로컬 테스트">
-  다음 명령어로 로컬 FastAPI 서버를 시작하세요:
+  다음 명령어로 로컬 FastAPI 서버 시작:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    FastAPI 서버가 실행되면 다음 명령어로 호출합니다:
+    서버 실행 후 다음 명령어로 호출:
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -249,7 +249,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
       -H "Content-Type: application/json"
     ```
   </TabItem>
-  <TabItem label="배포 버전 테스트">
+  <TabItem label="배포 환경 테스트">
 ```bash "https://xxx.lambda-url.ap-southeast-2.on.aws/" "ap-southeast-2"
 acurl ap-southeast-2 lambda -N -X POST \
   https://xxx.lambda-url.ap-southeast-2.on.aws/story/generate \
@@ -257,7 +257,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    CDK 배포 출력값 `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`을 사용하여 URL 플레이스홀더를 교체하고 리전을 적절히 설정하세요.
+    CDK 배포 출력값 `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`에서 URL 자리표시자를 교체하고 지역을 적절히 설정하세요.
     </Aside>
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/ko/guides/python-project.mdx
+++ b/docs/src/content/docs/ko/guides/python-project.mdx
@@ -10,13 +10,13 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [UV](https://docs.astral.sh/uv/)로 관리되는 단일 잠금 파일 및 가상 환경을 [UV 작업 공간](https://docs.astral.sh/uv/concepts/projects/workspaces/)에 구성하고, 테스트 실행을 위한 [pytest](https://docs.pytest.org/en/stable/), 정적 분석을 위한 [Ruff](https://docs.astral.sh/ruff/) 등 모범 사례가 적용되어 있습니다.
+파이썬 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이브러리나 애플리케이션을 생성하는 데 사용할 수 있으며, [UV](https://docs.astral.sh/uv/)로 관리되는 단일 lockfile과 [UV 워크스페이스](https://docs.astral.sh/uv/concepts/projects/workspaces/) 내의 가상 환경, 테스트 실행을 위한 [pytest](https://docs.pytest.org/en/stable/), 정적 분석을 위한 [Ruff](https://docs.astral.sh/ruff/)가 구성된 모범 사례가 적용되어 있습니다.
 
 ## 사용 방법
 
-### Python 프로젝트 생성
+### 파이썬 프로젝트 생성
 
-새로운 Python 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
+새 파이썬 프로젝트를 두 가지 방법으로 생성할 수 있습니다:
 
 <RunGenerator generator="py#project" />
 
@@ -32,43 +32,43 @@ Python 프로젝트 생성기는 최신 [Python](https://www.python.org/) 라이
 
   - \<module-name>
     - \_\_init\_\_.py 모듈 초기화
-    - hello.py 예제 Python 소스 파일
+    - hello.py 예제 파이썬 소스 파일
   - tests
     - \_\_init\_\_.py 모듈 초기화
-    - conftest.py 테스트 구성
+    - conftest.py 테스트 설정
     - test_hello.py 예제 테스트
-  - project.json 프로젝트 구성 및 빌드 대상
-  - pyproject.toml UV용 패키징 구성 파일
-  - .python-version 프로젝트의 Python 버전 포함
+  - project.json 프로젝트 설정 및 빌드 타겟
+  - pyproject.toml UV용 패키징 설정 파일
+  - .python-version 프로젝트의 파이썬 버전 포함
 
 </FileTree>
 
-작업 공간 루트에 다음 파일이 생성/업데이트된 것을 확인할 수도 있습니다:
+워크스페이스 루트에 다음 파일들이 생성/업데이트되는 것도 확인할 수 있습니다:
 
 <FileTree>
 
-  - pyproject.toml UV용 작업 공간 수준 패키징 구성
-  - .python-version 작업 공간 Python 버전 포함
-  - uv.lock Python 종속성 잠금 파일
+  - pyproject.toml UV용 워크스페이스 수준 패키징 설정
+  - .python-version 워크스페이스 파이썬 버전 포함
+  - uv.lock 파이썬 의존성 lockfile
 
 </FileTree>
 
-## Python 소스 코드 작성
+## 파이썬 소스 코드 작성
 
-Python 소스 코드는 `<module-name>` 디렉토리에 추가하세요.
+파이썬 소스 코드는 `<module-name>` 디렉토리에 추가하세요.
 
 ### 다른 프로젝트에서 라이브러리 코드 임포트
 
-`add` 대상을 사용하여 Python 프로젝트에 종속성을 추가할 수 있습니다.
+`add` 타겟을 사용하여 파이썬 프로젝트에 의존성을 추가할 수 있습니다.
 
-`my_app`과 `my_lib` 두 개의 Python 프로젝트를 생성했다고 가정합니다. 이 프로젝트의 정규화된 이름은 `my_scope.my_app`과 `my_scope.my_lib`이 되며, 기본 모듈 이름은 각각 `my_scope_my_app`과 `my_scope_my_lib`이 됩니다.
+`my_app`과 `my_lib` 두 개의 파이썬 프로젝트를 생성했다고 가정합니다. 이 프로젝트들은 `my_scope.my_app`과 `my_scope.my_lib`의 완전한 프로젝트 이름을 가지며, 기본적으로 각각 `my_scope_my_app`과 `my_scope_my_lib` 모듈 이름을 가집니다.
 
-`my_app`이 `my_lib`에 종속되도록 하려면 다음 명령을 실행합니다:
+`my_app`이 `my_lib`에 의존하도록 하려면 다음 명령을 실행합니다:
 
 <NxCommands commands={['run my_scope.my_app:add my_scope.my_lib']} />
 
 :::note
-종속 프로젝트와 피종속 프로젝트 모두 정규화된 프로젝트 이름을 사용합니다. 종속을 추가할 프로젝트에는 단축 구문을 사용할 수 있지만, 종속할 프로젝트 이름은 완전히 정규화되어야 합니다.
+의존 대상과 의존 받는 대상 모두 완전한 프로젝트 이름을 사용합니다. 의존을 추가할 프로젝트에는 축약형 문법을 사용할 수 있지만, 의존할 프로젝트 이름은 완전히 지정해야 합니다.
 :::
 
 이제 라이브러리 코드를 임포트할 수 있습니다:
@@ -77,19 +77,19 @@ Python 소스 코드는 `<module-name>` 디렉토리에 추가하세요.
 from my_scope_my_lib.hello import say_hello
 ```
 
-위 예시에서 `my_scope_my_lib`은 라이브러리의 모듈 이름이며, `hello`는 Python 소스 파일 `hello.py`에 해당하고, `say_hello`는 `hello.py`에 정의된 메서드입니다.
+위 예시에서 `my_scope_my_lib`은 라이브러리의 모듈 이름이며, `hello`는 `hello.py` 파이썬 소스 파일에 해당하고, `say_hello`는 `hello.py`에 정의된 메서드입니다.
 
-### 종속성 관리
+### 의존성 관리
 
-프로젝트에 종속성을 추가하려면 Python 프로젝트에서 `add` 대상을 실행하세요. 예시:
+프로젝트에 의존성을 추가하려면 파이썬 프로젝트에서 `add` 타겟을 실행하세요:
 
 <NxCommands commands={['run my_scope.my_library:add some-pip-package']} />
 
-이 명령은 프로젝트의 `pyproject.toml` 파일에 종속성을 추가하고 루트 `uv.lock`을 업데이트합니다.
+이 명령은 프로젝트의 `pyproject.toml` 파일에 의존성을 추가하고 루트 `uv.lock`을 업데이트합니다.
 
 #### 런타임 코드
 
-Python 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사용할 경우, 소스 코드와 모든 종속성을 번들로 만들어야 합니다. `project.json` 파일에 다음 예시와 같은 대상을 추가하여 이를 구현할 수 있습니다:
+파이썬 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사용할 경우, 소스 코드와 모든 의존성을 번들로 만들어야 합니다. `project.json` 파일에 다음 타겟을 추가하여 이를 구현할 수 있습니다:
 
 ```json title="project.json"
 {
@@ -103,7 +103,7 @@ Python 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -115,15 +115,15 @@ Python 프로젝트를 런타임 코드(예: AWS 람다 함수 핸들러)로 사
 
 ### 빌드
 
-Python 프로젝트는 `build` 대상으로 구성되어 있으며(`project.json`에 정의됨), 다음 명령으로 실행할 수 있습니다:
+파이썬 프로젝트는 `build` 타겟(`project.json`에 정의)으로 구성되며 다음 명령으로 실행할 수 있습니다:
 
 <NxCommands commands={['run <project-name>:build']} />
 
-여기서 `<project-name>`은 프로젝트의 정규화된 이름입니다.
+여기서 `<project-name>`은 프로젝트의 완전한 이름입니다.
 
-`build` 대상은 프로젝트를 컴파일, 린트, 테스트합니다.
+`build` 타겟은 프로젝트를 컴파일, 린트, 테스트합니다.
 
-빌드 출력은 작업 공간 루트의 `dist` 폴더 내 프로젝트별 디렉토리(예: `dist/packages/<my-library>/build`)에서 확인할 수 있습니다.
+빌드 결과물은 워크스페이스 루트의 `dist` 폴더 내 패키지 및 타겟별 디렉토리(예: `dist/packages/<my-library>/build`)에서 확인할 수 있습니다.
 
 ## 테스트
 
@@ -131,7 +131,7 @@ Python 프로젝트는 `build` 대상으로 구성되어 있으며(`project.json
 
 ### 테스트 작성
 
-테스트는 프로젝트 내 `test` 디렉토리에 `test_` 접두사가 붙은 Python 파일로 작성해야 합니다. 예시:
+테스트는 프로젝트 내 `test` 디렉토리의 `test_` 접두사가 붙은 파이썬 파일에 작성해야 합니다:
 
 <FileTree>
   - my_library
@@ -140,7 +140,7 @@ Python 프로젝트는 `build` 대상으로 구성되어 있으며(`project.json
     - test_hello.py hello.py 테스트
 </FileTree>
 
-테스트 메서드는 `test_`로 시작하며 어설션을 사용하여 기대값을 검증합니다. 예시:
+테스트는 `test_`로 시작하는 메서드로 작성하며, 예상 결과를 검증하기 위해 assertion을 사용합니다:
 
 ```python title="test/test_hello.py"
 from my_library.hello import say_hello
@@ -153,30 +153,30 @@ def test_say_hello():
 
 ### 테스트 실행
 
-테스트는 프로젝트의 `build` 대상 실행 시 자동으로 실행되지만, `test` 대상으로 개별 실행도 가능합니다:
+테스트는 프로젝트의 `build` 타겟 실행 시 함께 실행되지만, 별도로 `test` 타겟을 실행할 수도 있습니다:
 
 <NxCommands commands={['run <project-name>:test']} />
 
-`-k` 플래그를 사용하여 특정 테스트 파일이나 메서드를 지정해 실행할 수 있습니다:
+`-k` 플래그를 사용하여 특정 테스트 파일이나 메서드를 지정해 개별 테스트를 실행할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
 ## 린팅
 
-Python 프로젝트는 [Ruff](https://docs.astral.sh/ruff/)를 사용해 린팅을 수행합니다.
+파이썬 프로젝트는 [Ruff](https://docs.astral.sh/ruff/)를 사용해 린팅을 수행합니다.
 
 ### 린터 실행
 
-프로젝트 린트 검사를 위해 `lint` 대상을 실행하세요:
+프로젝트 린트 검사를 위해 `lint` 타겟을 실행할 수 있습니다:
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### 린트 문제 수정
+### 린트 이슈 수정
 
-대부분의 린트 또는 포맷팅 문제는 자동으로 수정할 수 있습니다. `--configuration=fix` 인자를 사용하여 Ruff가 문제를 수정하도록 할 수 있습니다:
+대부분의 린트 또는 포맷팅 이슈는 자동으로 수정 가능합니다. `--configuration=fix` 인자와 함께 Ruff를 실행해 수정하세요:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-모든 패키지의 린트 문제를 일괄 수정하려면 다음 명령을 실행하세요:
+워크스페이스 전체 패키지의 린트 이슈를 한 번에 수정하려면 다음 명령을 실행합니다:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/3.mdx
@@ -23,21 +23,21 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## Módulo 3: Implementação da API de Story
+## Módulo 3: Implementação da API de História
 
 <Aside type="caution">
 Certifique-se de ter concedido acesso ao modelo **Anthropic Claude 3.5 Sonnet v2** seguindo os passos descritos no [guia oficial](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 </Aside>
 
-A StoryApi consiste em uma única API `generate_story` que, dado um `Game` e uma lista de `Action`s como contexto, irá progredir uma história. Esta API será implementada como uma API de streaming em Python/FastAPI e também demonstrará como ajustar o código gerado para propósitos específicos.
+A StoryApi consiste em uma única API `generate_story` que, dado um `Game` e uma lista de `Action`s como contexto, irá progredir uma narrativa. Esta API será implementada como uma API de streaming em Python/FastAPI e também demonstrará como fazer ajustes no código gerado para atender aos propósitos específicos.
 
 ### Implementação da API
 
-Para criar nossa API, primeiro precisamos instalar dependências adicionais:
+Para criar nossa API, primeiro precisamos instalar algumas dependências adicionais:
 
 - `boto3` será usado para chamar o Amazon Bedrock;
 - `uvicorn` será usado para iniciar nossa API em conjunto com o [Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter);
-- `copyfiles` é uma dependência npm necessária para suportar cópias de arquivos multiplataforma ao atualizar nossa tarefa `bundle`.
+- `copyfiles` é uma dependência npm necessária para suportar a cópia de arquivos multiplataforma ao atualizar nossa tarefa `bundle`.
 
 Para instalar estas dependências, execute os seguintes comandos:
 
@@ -63,17 +63,17 @@ A alteração acima no `init.py` simplesmente remove o middleware CORS para evit
 Analisando o código acima:
 
 - Usamos a configuração `x-streaming` para indicar que esta é uma API de streaming ao gerar nosso client SDK. Isso permitirá consumir a API de forma streaming mantendo a segurança de tipos!
-- Nossa API simplesmente retorna um fluxo de texto definido por `media_type="text/plain"` e `response_class=PlainTextResponse`
+- Nossa API simplesmente retorna um fluxo de texto conforme definido por `media_type="text/plain"` e `response_class=PlainTextResponse`
 
 :::note
-Sempre que fizer alterações no FastAPI, você precisará reconstruir o projeto para ver as mudanças refletidas no client gerado no website.
+Sempre que fizer alterações no FastAPI, você precisará reconstruir o projeto para ver essas mudanças refletidas no client gerado no website.
 
 Faremos mais algumas alterações abaixo antes de reconstruir.
 :::
 
 ### Infraestrutura
 
-A <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestrutura configurada anteriormente</Link> assume que todas as APIs usam API Gateway integrado com funções Lambda. Para nossa `story_api`, não queremos usar API Gateway pois não suporta respostas streaming. Em vez disso, usaremos um [Lambda Function URL configurado com response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
+A <Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">infraestrutura configurada anteriormente</Link> assume que todas as APIs usam API Gateway integrado com funções Lambda. Para nossa `story_api`, não queremos usar API Gateway pois ele não suporta respostas streaming. Em vez disso, usaremos um [Lambda Function URL configurado com response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 
 Para isso, primeiro atualizaremos nossos constructs CDK:
 
@@ -107,7 +107,7 @@ Agora atualizaremos a `story_api` para suportar a implantação do [Lambda Web A
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -133,23 +133,23 @@ Se encontrar erros de lint, execute o seguinte comando para corrigi-los automati
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-Sua aplicação pode ser implantada executando:
+Sua aplicação agora pode ser implantada com o comando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-Esta implantação levará aproximadamente 2 minutos para completar.
+Esta implantação levará aproximadamente 2 minutos para ser concluída.
 
 <Drawer title="Comando de implantação" trigger="Você também pode implantar todas as stacks de uma vez. Clique para mais detalhes.">
 
-Você pode implantar todas as stacks da aplicação CDK executando:
+Você pode implantar todas as stacks contidas na aplicação CDK executando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-Isso **não é recomendado** pois você pode querer separar estágios de implantação em stacks diferentes (ex: `infra-prod`). Neste caso, o flag `--all` tentará implantar todas as stacks podendo causar implantações indesejadas!
+Isso **não é recomendado** pois você pode querer separar seus estágios de implantação como stacks distintas `ex: infra-prod`. Neste caso, o flag `--all` tentará implantar todas as stacks, o que pode resultar em implantações indesejadas!
 
 </Drawer>
 
-Após a implantação, você verá saídas similares a estas _(alguns valores foram omitidos)_:
+Após a conclusão da implantação, você verá saídas semelhantes a estas _(alguns valores foram omitidos)_:
 
 ```bash
 dungeon-adventure-infra-sandbox
@@ -176,7 +176,8 @@ Podemos testar nossa API de duas formas:
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-Adicione este script ao seu `.bashrc` (e execute `source`) ou cole diretamente no terminal:
+Você pode adicionar este script ao seu arquivo `.bashrc` (e executar `source`) ou colar diretamente no terminal:
+
 ```bash
 // ~/.bashrc
 acurl () {
@@ -200,7 +201,8 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-Adicione esta função ao perfil PowerShell ou cole na sessão atual:
+Adicione esta função ao seu perfil PowerShell ou cole diretamente na sessão:
+
 ```powershell
 function acurl {
     param(
@@ -237,10 +239,10 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="Local">
-  Inicie o servidor FastAPI localmente:
+  Inicie seu servidor FastAPI local com:
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    Execute o comando curl:
+    Após iniciar, execute:
 
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
@@ -256,12 +258,12 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Use o valor de saída `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` do CDK para substituir o placeholder de URL e ajuste a região conforme necessário.
+    Use o valor de saída do CDK deploy `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` para substituir o placeholder da URL e ajuste a região conforme necessário.
     </Aside>
   </TabItem>
 </Tabs>
 
-Se executado com sucesso, você verá uma resposta streaming similar a:
+Se o comando for bem-sucedido, você verá uma resposta em streaming similar a:
 
 ```
 UnnamedHero stood tall, his cape billowing in the wind....

--- a/docs/src/content/docs/pt/guides/python-project.mdx
+++ b/docs/src/content/docs/pt/guides/python-project.mdx
@@ -10,7 +10,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-O gerador de projetos Python pode ser usado para criar uma biblioteca ou aplicação moderna em [Python](https://www.python.org/) configurada com melhores práticas, gerenciada com [UV](https://docs.astral.sh/uv/), um único arquivo de lock e ambiente virtual em um [UV workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para execução de testes e [Ruff](https://docs.astral.sh/ruff/) para análise estática.
+O gerador de projetos Python pode ser usado para criar uma biblioteca ou aplicação moderna em [Python](https://www.python.org/) configurada com melhores práticas, gerenciada com [UV](https://docs.astral.sh/uv/), um único arquivo de lock e ambiente virtual em um [espaço de trabalho UV](https://docs.astral.sh/uv/concepts/projects/workspaces/), [pytest](https://docs.pytest.org/en/stable/) para execução de testes e [Ruff](https://docs.astral.sh/ruff/) para análise estática.
 
 ## Utilização
 
@@ -34,7 +34,7 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
     - \_\_init\_\_.py Inicialização do módulo
     - hello.py Exemplo de arquivo fonte Python
   - tests
-    - \_\_init\_\_.py Inicialização do módulo  
+    - \_\_init\_\_.py Inicialização do módulo
     - conftest.py Configuração de testes
     - test_hello.py Exemplo de testes
   - project.json Configuração do projeto e targets de build
@@ -57,7 +57,7 @@ Você também pode notar os seguintes arquivos criados/atualizados na raiz do wo
 
 Adicione seu código fonte Python no diretório `<module-name>`.
 
-### Importando Código da Sua Biblioteca em Outros Projetos
+### Importando Código da Biblioteca em Outros Projetos
 
 Use o target `add` para adicionar uma dependência a um projeto Python.
 
@@ -77,7 +77,7 @@ Você pode então importar o código da biblioteca:
 from my_scope_my_lib.hello import say_hello
 ```
 
-Acima, `my_scope_my_lib` é o nome do módulo da biblioteca, `hello` corresponde ao arquivo fonte Python `hello.py`, e `say_hello` é um método definido em `hello.py`
+Acima, `my_scope_my_lib` é o nome do módulo para a biblioteca, `hello` corresponde ao arquivo fonte Python `hello.py`, e `say_hello` é um método definido em `hello.py`
 
 ### Dependências
 
@@ -103,7 +103,7 @@ Quando você usa seu projeto Python como código de runtime (por exemplo, como h
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -121,7 +121,7 @@ Seu projeto Python está configurado com um target `build` (definido em `project
 
 Onde `<project-name>` é o nome totalmente qualificado do seu projeto.
 
-O target `build` irá compilar, lintar e testar seu projeto.
+O target `build` irá compilar, verificar e testar seu projeto.
 
 A saída do build pode ser encontrada na pasta `dist` raiz do seu workspace, dentro de um diretório para seu pacote e target, por exemplo `dist/packages/<my-library>/build`
 
@@ -173,10 +173,10 @@ Para invocar o linter e verificar seu projeto, você pode executar o target `lin
 
 ### Corrigindo Problemas de Linting
 
-A maioria dos problemas de linting ou formatação pode ser corrigida automaticamente. Você pode pedir ao Ruff para corrigir problemas de linting executando com o argumento `--configuration=fix`:
+A maioria dos problemas de linting ou formatação pode ser corrigida automaticamente. Você pode instruir o Ruff a corrigir problemas executando com o argumento `--configuration=fix`:
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-Da mesma forma, se quiser corrigir todos os problemas de linting em todos os pacotes do seu workspace, você pode executar:
+Similarmente, se desejar corrigir todos os problemas de linting em todos os pacotes do seu workspace, você pode executar:
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/3.mdx
@@ -26,25 +26,25 @@ import gameConversationPng from '@assets/game-conversation.png'
 ## 模块3：故事API实现
 
 <Aside type="caution">
-请确保已按照[本指南](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)中的步骤授予对**Anthropic Claude 3.5 Sonnet v2**模型的访问权限。
+确保您已按照[本指南](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)中的步骤授予对**Anthropic Claude 3.5 Sonnet v2**模型的访问权限。
 </Aside>
 
-StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`和上下文`Action`列表推进故事情节。我们将使用Python/FastAPI将其实现为流式API，并演示如何对生成的代码进行调整以满足实际需求。
+StoryApi包含一个核心API`generate_story`，该API根据给定的`Game`和上下文`Action`列表推进故事情节。我们将使用Python/FastAPI将其实现为流式API，并演示如何对生成代码进行调整以满足实际需求。
 
 ### API实现
 
 要创建API，首先需要安装两个额外依赖：
 
-- `boto3` 用于调用Amazon Bedrock；
-- `uvicorn` 配合[Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)启动API；
-- `copyfiles` 是npm依赖项，用于在更新`bundle`任务时支持跨平台文件复制。
+- `boto3`用于调用Amazon Bedrock；
+- `uvicorn`配合[Lambda Web Adapter (LWA)](https://github.com/awslabs/aws-lambda-web-adapter)启动API；
+- `copyfiles`是npm依赖项，用于在更新`bundle`任务时支持跨平台文件复制。
 
 运行以下命令安装依赖：
 
 <NxCommands commands={["run dungeon_adventure.story_api:add --args boto3 uvicorn"]} />
 <InstallCommand pkg="copyfiles" dev />
 
-现在替换`packages/story_api/story_api`目录中的文件内容：
+现在替换`packages/story_api/story_api`目录下的文件内容：
 
 <Tabs>
 <TabItem label="main.py">
@@ -54,7 +54,7 @@ StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`�
 <E2ECode path="dungeon-adventure/3/init.py.template" lang="python" />
 
 :::note
-上述对`init.py`的修改移除了CORS中间件，以避免与Lambda Function URL自带的CORS头处理产生冲突。
+上述对`init.py`的修改移除了CORS中间件，以避免与Lambda函数URL自带的CORS头处理产生冲突。
 :::
 
 </TabItem>
@@ -62,20 +62,20 @@ StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`�
 
 代码分析：
 
-- 使用`x-streaming`设置标记流式API，后续生成客户端SDK时将保持类型安全的流式消费能力
+- 使用`x-streaming`设置标记流式API，在生成客户端SDK时保持类型安全的流式消费能力
 - API通过`media_type="text/plain"`和`response_class=PlainTextResponse`定义纯文本流响应
 
 :::note
-每次修改FastAPI后都需要重新构建项目，才能在网站生成的客户端中看到变更效果。
+每次修改FastAPI后都需要重新构建项目，才能在网站中看到生成的客户端更新。
 
-我们将在后续进行更多修改后再执行构建。
+我们将在下面进行更多修改后再执行构建。
 :::
 
 ### 基础设施
 
-先前设置的<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">基础设施</Link>假设所有API都通过API Gateway与Lambda集成。对于`story_api`，我们需要使用支持流式响应的[Lambda Function URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)替代API Gateway。
+先前设置的<Link path="get_started/tutorials/dungeon-game/1#game-ui-infrastructure">基础设施</Link>假设所有API都通过API Gateway与Lambda集成。对于`story_api`，我们需要使用[支持响应流式的Lambda函数URL](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)替代API Gateway。
 
-首先更新CDK构造：
+更新CDK构造如下：
 
 <Tabs>
 <TabItem label="story-api.ts">
@@ -86,7 +86,7 @@ StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`�
 </TabItem>
 </Tabs>
 
-接下来更新`story_api`以支持[Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)部署：
+更新`story_api`以支持[Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)部署：
 
 <Tabs>
 <TabItem label="run.sh">
@@ -107,7 +107,7 @@ StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`�
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/story_api --package dungeon_adventure.story_api -o dist/packages/story_api/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/packages/story_api/bundle -r dist/packages/story_api/bundle/requirements.txt",
 +          "copyfiles -f packages/story_api/run.sh dist/packages/story_api/bundle"
         ],
         "parallel": false
@@ -133,19 +133,19 @@ StoryApi包含一个单独的API `generate_story`，该API根据给定的`Game`�
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-运行以下命令部署应用：
+运行部署命令：
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
 
-部署过程约需2分钟。
+部署约需2分钟完成。
 
-<Drawer title="部署命令" trigger="点击查看批量部署详情">
+<Drawer title="部署命令" trigger="点击查看同时部署所有堆栈的详细信息">
 
 也可通过以下命令部署CDK应用包含的所有堆栈：
 
 <NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
 
-但**不建议**此方式，因实际环境中可能需分阶段部署不同堆栈（如infra-prod），使用`--all`参数可能导致意外部署！
+**不建议**此操作，因实际部署可能需分阶段部署不同堆栈（如infra-prod），使用`--all`标志可能导致意外部署！
 
 </Drawer>
 
@@ -170,13 +170,13 @@ dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_x
 
 可通过以下方式测试API：
 <ul>
-<li>启动本地FastAPI服务器并使用`curl`调用</li>
+<li>启动FastAPI本地实例并使用`curl`调用</li>
 <li>
-<Drawer title="Sigv4签名curl" trigger="直接调用已部署API（需签名）">
+<Drawer title="Sigv4签名curl" trigger="直接调用已部署API">
 
 <Tabs>
   <TabItem label="Bash/Linux/macOS">
-可将以下脚本加入`.bashrc`文件（并`source`）或直接在终端执行：
+将以下脚本加入`.bashrc`文件（并执行`source`），或在当前终端直接粘贴：
 ```bash
 // ~/.bashrc
 acurl () {
@@ -200,7 +200,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 ```
   </TabItem>
   <TabItem label="Windows PowerShell">
-可将以下函数加入PowerShell配置文件或直接执行：
+将以下函数加入PowerShell配置文件或当前会话：
 ```powershell
 function acurl {
     param(
@@ -237,17 +237,17 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 
 <Tabs>
   <TabItem label="本地测试">
-  启动本地FastAPI服务器：
+  启动本地FastAPI服务：
     <NxCommands commands={["run dungeon_adventure.story_api:serve"]} />
 
-    执行测试命令：
+    调用API：
     ```bash
     curl -N -X POST http://127.0.0.1:8000/story/generate \
       -d '{"genre":"superhero", "actions":[], "playerName":"UnnamedHero"}' \
       -H "Content-Type: application/json"
     ```
   </TabItem>
-  <TabItem label="云端测试">
+  <TabItem label="云端部署">
 ```bash "https://xxx.lambda-url.ap-southeast-2.on.aws/" "ap-southeast-2"
 acurl ap-southeast-2 lambda -N -X POST \
   https://xxx.lambda-url.ap-southeast-2.on.aws/story/generate \
@@ -255,7 +255,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    请使用CDK部署输出中的`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`值替换URL占位符，并正确设置区域。
+    使用CDK部署输出中的`dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX`值替换URL占位符，并正确设置区域。
     </Aside>
   </TabItem>
 </Tabs>
@@ -263,7 +263,7 @@ acurl ap-southeast-2 lambda -N -X POST \
 成功执行后将看到流式响应：
 
 ```
-UnnamedHero迎风而立，披风在风中猎猎作响....
+UnnamedHero迎风而立，披风猎猎作响....
 ```
 
 恭喜！您已成功使用FastAPI构建并部署了首个流式API！🎉🎉🎉

--- a/docs/src/content/docs/zh/guides/python-project.mdx
+++ b/docs/src/content/docs/zh/guides/python-project.mdx
@@ -10,9 +10,9 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 
-Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](https://www.python.org/) 库或应用，使用 [UV](https://docs.astral.sh/uv/) 进行依赖管理，在 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)中采用单一锁定文件和虚拟环境，使用 [pytest](https://docs.pytest.org/en/stable/) 运行测试，以及 [Ruff](https://docs.astral.sh/ruff/) 进行静态分析。
+Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](https://www.python.org/) 库或应用程序，使用 [UV](https://docs.astral.sh/uv/) 进行管理，包含单一锁文件和 [UV 工作区](https://docs.astral.sh/uv/concepts/projects/workspaces/)中的虚拟环境，使用 [pytest](https://docs.pytest.org/en/stable/) 运行测试，以及 [Ruff](https://docs.astral.sh/ruff/) 进行静态分析。
 
-## 用法
+## 使用方法
 
 ### 生成 Python 项目
 
@@ -49,7 +49,7 @@ Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](
 
   - pyproject.toml UV 的工作区级打包配置
   - .python-version 包含工作区 Python 版本
-  - uv.lock Python 依赖锁定文件
+  - uv.lock Python 依赖锁文件
 
 </FileTree>
 
@@ -61,7 +61,7 @@ Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](
 
 使用 `add` 目标为 Python 项目添加依赖。
 
-假设我们创建了两个 Python 项目 `my_app` 和 `my_lib`。它们的完全限定项目名称分别为 `my_scope.my_app` 和 `my_scope.my_lib`，默认模块名称为 `my_scope_my_app` 和 `my_scope_my_lib`。
+假设我们创建了两个 Python 项目 `my_app` 和 `my_lib`。它们的完全限定项目名称分别为 `my_scope.my_app` 和 `my_scope.my_lib`，默认模块名分别为 `my_scope_my_app` 和 `my_scope_my_lib`。
 
 要让 `my_app` 依赖 `my_lib`，可以运行以下命令：
 
@@ -77,7 +77,7 @@ Python 项目生成器可用于创建配置了最佳实践的现代化 [Python](
 from my_scope_my_lib.hello import say_hello
 ```
 
-上述代码中，`my_scope_my_lib` 是库的模块名称，`hello` 对应 Python 源文件 `hello.py`，`say_hello` 是 `hello.py` 中定义的方法。
+上述代码中，`my_scope_my_lib` 是库的模块名，`hello` 对应 Python 源文件 `hello.py`，`say_hello` 是 `hello.py` 中定义的方法
 
 ### 依赖管理
 
@@ -103,7 +103,7 @@ from my_scope_my_lib.hello import say_hello
       "options": {
         "commands": [
           "uv export --frozen --no-dev --no-editable --project packages/my_library --package my_scope.my_library -o dist/packages/my_library/bundle/requirements.txt",
-          "uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
+          "uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --python `uv python pin` --target dist/packages/my_library/bundle -r dist/packages/my_library/bundle/requirements.txt"
         ],
         "parallel": false
       },
@@ -113,7 +113,7 @@ from my_scope_my_lib.hello import say_hello
 }
 ```
 
-### 构建
+## 构建
 
 Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通过以下命令运行：
 
@@ -123,7 +123,7 @@ Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通
 
 `build` 目标将执行编译、代码检查和测试。
 
-构建输出位于工作区根目录的 `dist` 文件夹中，具体路径为 `dist/packages/<my-library>/build`。
+构建输出位于工作区根目录的 `dist` 文件夹中，在对应包的目录下，例如 `dist/packages/<my-library>/build`
 
 ## 测试
 
@@ -131,7 +131,7 @@ Python 项目配置了 `build` 目标（定义在 `project.json` 中），可通
 
 ### 编写测试
 
-测试应位于项目的 `test` 目录中，文件名以 `test_` 开头，例如：
+测试应写在项目的 `test` 目录中，使用 `test_` 前缀的 Python 文件，例如：
 
 <FileTree>
   - my_library
@@ -153,11 +153,11 @@ def test_say_hello():
 
 ### 运行测试
 
-测试会在项目构建时自动运行，也可以通过 `test` 目标单独运行：
+测试会在项目的 `build` 目标中自动运行，也可以通过 `test` 目标单独运行：
 
 <NxCommands commands={['run <project-name>:test']} />
 
-可以使用 `-k` 标志运行单个测试或测试套件：
+可以使用 `-k` 标志运行单个测试或测试套件，指定测试文件或方法名：
 
 <NxCommands commands={["run <project-name>:test -k 'test_say_hello'"]} />
 
@@ -165,18 +165,18 @@ def test_say_hello():
 
 Python 项目使用 [Ruff](https://docs.astral.sh/ruff/) 进行代码检查。
 
-### 运行检查器
+### 运行检查
 
 要检查项目代码，可以运行 `lint` 目标：
 
 <NxCommands commands={["run <project-name>:lint"]} />
 
-### 修复检查问题
+### 修复问题
 
-大多数代码检查或格式问题可以自动修复。通过添加 `--configuration=fix` 参数让 Ruff 自动修复：
+大多数代码检查或格式问题可以自动修复。通过添加 `--configuration=fix` 参数让 Ruff 自动修复问题：
 
 <NxCommands commands={["run <project-name>:lint --configuration=fix"]} />
 
-若要修复工作区中所有包的检查问题，可以运行：
+如果要修复工作区中所有包的代码问题，可以运行：
 
 <NxCommands commands={["run-many --target lint --all --configuration=fix"]} />

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -6,6 +6,7 @@ import {
   addDependenciesToPackageJson,
   ensurePackage,
   GeneratorCallback,
+  installPackagesTask,
   joinPathFragments,
   readNxJson,
   readProjectConfiguration,
@@ -178,6 +179,7 @@ export const pyProjectGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [PY_PROJECT_GENERATOR_INFO]);
 
   return async () => {
+    installPackagesTask(tree);
     await new UVProvider(tree.root, new Logger(), tree).install();
   };
 };

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -211,7 +211,7 @@ export * from './runtime-config.js';
 `;
 
 exports[`ts#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > mcp-server-construct.ts 1`] = `
-"import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
+"import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
 import { execSync } from 'child_process';
 import * as path from 'path';
@@ -238,6 +238,7 @@ export class SnapshotBedrockServer extends Construct {
     super(scope, id);
 
     this.dockerImage = new DockerImageAsset(this, 'DockerImage', {
+      platform: Platform.LINUX_ARM64,
       directory: path.dirname(url.fileURLToPath(new URL(import.meta.url))),
       extraHash: execSync(
         \`docker inspect proj-snapshot-bedrock-server:latest --format '{{.Descriptor.digest}}'\`,

--- a/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
@@ -404,7 +404,7 @@ describe('ts#mcp-server generator', () => {
       projectConfig.targets['test-project-mcp-server-bundle'].options.commands,
     ).toEqual([
       'esbuild apps/test-project/src/mcp-server/http.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/apps/test-project/test-project-mcp-server-bundle/index.js',
-      'docker build -t proj-test-project-mcp-server:latest apps/test-project/src/mcp-server --build-context workspace=.',
+      'docker build --platform linux/arm64 -t proj-test-project-mcp-server:latest apps/test-project/src/mcp-server --build-context workspace=.',
     ]);
   });
 

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -116,7 +116,7 @@ export const tsMcpServerGenerator = async (
       bundleTargetName: `${name}-bundle`,
       targetFilePath: `${targetSourceDir}/http.ts`,
       postBundleCommands: [
-        `docker build -t ${dockerImageTag} ${targetSourceDir} --build-context workspace=.`,
+        `docker build --platform linux/arm64 -t ${dockerImageTag} ${targetSourceDir} --build-context workspace=.`,
       ],
     });
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/app/mcp-servers/__mcpServerNameKebabCase__/__mcpServerNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/app/mcp-servers/__mcpServerNameKebabCase__/__mcpServerNameKebabCase__.ts.template
@@ -1,4 +1,4 @@
-import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
+import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
 import { execSync } from 'child_process';
 import * as path from 'path';
@@ -21,6 +21,7 @@ export class <%- mcpServerNameClassName %> extends Construct {
     super(scope, id);
 
     this.dockerImage = new DockerImageAsset(this, 'DockerImage', {
+      platform: Platform.LINUX_ARM64,
       directory: path.dirname(url.fileURLToPath(new URL(import.meta.url))),
       extraHash: execSync(
         `docker inspect <%- dockerImageTag %> --format '{{.Descriptor.digest}}'`,

--- a/packages/nx-plugin/src/utils/bundle.ts
+++ b/packages/nx-plugin/src/utils/bundle.ts
@@ -31,7 +31,7 @@ export const createPythonBundleTarget = ({
     options: {
       commands: [
         `uv export --frozen --no-dev --no-editable --project ${projectDir} --package ${packageName} -o dist/${projectDir}/bundle/requirements.txt`,
-        `uv pip install -n --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/${projectDir}/bundle -r dist/${projectDir}/bundle/requirements.txt`,
+        `uv pip install -n --no-deps --no-installer-metadata --no-compile-bytecode --python-platform x86_64-manylinux2014 --target dist/${projectDir}/bundle -r dist/${projectDir}/bundle/requirements.txt`,
       ],
       parallel: false,
     },


### PR DESCRIPTION
### Reason for this change

- `ts#mcp-server` - container is just using host platform, so won't work on an x86 machine
- `py#project` - doesn't install `@nxlv/python` meaning builds fail (unless you run another generator which does install deps prior to building)
- `py#lambda-function` and `py#fast-api` - bundle task was installing local workspace dependencies as editable, which doesn't work when deployed.

### Description of changes

- Ensure platform is always arm64 for MCP servers as per https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
- Install node dependencies for `py#project`
- Add `--no-deps` flag to `uv pip install` in bundle target - see https://github.com/astral-sh/uv/issues/13087

### Description of how you validated changes

Ran and deployed

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*