### PR TITLE
fix(py): add python dependencies with version ranges in generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "lucide-react": "^0.484.0",
     "nx": "~21.0.3",
     "openapi-types": "^12.1.3",
+    "pip-requirements-js": "^0.2.1",
     "prettier": "^3.5.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -44,6 +44,7 @@
     "lodash.uniqby": "^4.7.0",
     "minimatch": "^10.0.1",
     "openapi-types": "^12.1.3",
+    "pip-requirements-js": "^0.2.1",
     "typescript": "~5.8.2",
     "vite": "^6.2.3",
     "vitest": "^3.0.9",

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -113,10 +113,10 @@ describe('fastapi project generator', () => {
     ) as UVPyprojectToml;
 
     // Verify FastAPI dependencies
-    expect(pyprojectToml.project.dependencies).toContain('fastapi');
-    expect(pyprojectToml.project.dependencies).toContain('mangum');
+    expect(pyprojectToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(pyprojectToml.project.dependencies).toContain('mangum~=0.19.0');
     expect(pyprojectToml['dependency-groups'].dev).toContain(
-      'fastapi[standard]>=0.115',
+      'fastapi[standard]~=0.116.1',
     );
   });
 

--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -111,13 +111,13 @@ describe('lambda-handler project generator', () => {
 
     // Verify project dependencies
     expect(pyprojectToml.project.dependencies).toContain(
-      'aws-lambda-powertools',
+      'aws-lambda-powertools~=3.19.0',
     );
     expect(pyprojectToml.project.dependencies).toContain(
-      'aws-lambda-powertools[tracer]',
+      'aws-lambda-powertools[tracer]~=3.19.0',
     );
     expect(pyprojectToml.project.dependencies).toContain(
-      'aws-lambda-powertools[parser]',
+      'aws-lambda-powertools[parser]~=3.19.0',
     );
   });
 

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -16,8 +16,6 @@ import {
 import { PyLambdaFunctionGeneratorSchema } from './schema';
 import { UVProvider } from '@nxlv/python/src/provider/uv/provider';
 import { Logger } from '@nxlv/python/src/executors/utils/logger';
-import { parse, stringify } from '@iarna/toml';
-import { UVPyprojectToml } from '@nxlv/python/src/provider/uv/types';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import {
   PACKAGES_DIR,
@@ -40,6 +38,7 @@ import {
 } from '../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { addPythonBundleTarget } from '../../utils/bundle';
+import { addDependenciesToPyProjectToml } from '../../utils/py';
 
 export const LAMBDA_FUNCTION_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -245,26 +244,11 @@ export const pyLambdaFunctionGenerator = async (
     },
   );
 
-  const projectToml = parse(
-    tree.read(joinPathFragments(dir, 'pyproject.toml'), 'utf8'),
-  ) as UVPyprojectToml;
-
-  // Check if the project already has the dependencies and add them if not
-  const dependencies = projectToml.project?.dependencies || [];
-
-  if (!dependencies.includes('aws-lambda-powertools')) {
-    dependencies.push('aws-lambda-powertools');
-  }
-
-  if (!dependencies.includes('aws-lambda-powertools[tracer]')) {
-    dependencies.push('aws-lambda-powertools[tracer]');
-  }
-
-  if (!dependencies.includes('aws-lambda-powertools[parser]')) {
-    dependencies.push('aws-lambda-powertools[parser]');
-  }
-
-  tree.write(joinPathFragments(dir, 'pyproject.toml'), stringify(projectToml));
+  addDependenciesToPyProjectToml(tree, dir, [
+    'aws-lambda-powertools',
+    'aws-lambda-powertools[tracer]',
+    'aws-lambda-powertools[parser]',
+  ]);
 
   await addGeneratorMetricsIfApplicable(tree, [LAMBDA_FUNCTION_GENERATOR_INFO]);
 

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -307,7 +307,7 @@ exports[`py#mcp-server generator > should match snapshot for generated files > u
 "[project]
 name = "proj.test_project"
 version = "0.1.0"
-dependencies = [ "mcp" ]
+dependencies = [ "mcp~=1.13.0" ]
 
 [dependency-groups]
 dev = [ ]

--- a/packages/nx-plugin/src/py/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.spec.ts
@@ -83,7 +83,7 @@ dev-dependencies = []
     const pyprojectToml = parse(
       tree.read('apps/test-project/pyproject.toml', 'utf-8'),
     ) as UVPyprojectToml;
-    expect(pyprojectToml.project.dependencies).toContain('mcp');
+    expect(pyprojectToml.project.dependencies).toContain('mcp~=1.13.0');
 
     // Check root package.json dependencies for inspector
     const rootPackageJson = JSON.parse(tree.read('package.json', 'utf-8'));
@@ -326,7 +326,7 @@ dev-dependencies = []
     const pyprojectToml = parse(
       tree.read('apps/test-project/pyproject.toml', 'utf-8'),
     ) as UVPyprojectToml;
-    expect(pyprojectToml.project.dependencies).toContain('mcp');
+    expect(pyprojectToml.project.dependencies).toContain('mcp~=1.13.0');
 
     // Check that project configuration was updated with serve targets
     const projectConfig = JSON.parse(
@@ -432,7 +432,7 @@ dev-dependencies = []
     const pyprojectToml = parse(
       tree.read('apps/test-project/pyproject.toml', 'utf-8'),
     ) as UVPyprojectToml;
-    expect(pyprojectToml.project.dependencies).toContain('mcp');
+    expect(pyprojectToml.project.dependencies).toContain('mcp~=1.13.0');
   });
 
   it('should generate shared constructs for BedrockAgentCoreRuntime', async () => {

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../utils/shared-constructs-constants';
 import { getNpmScopePrefix, toScopeAlias } from '../../../utils/npm-scope';
 import { configureTsProject } from '../../lib/ts-project-utils';
-import { IVersion, withVersions } from '../../../utils/versions';
+import { ITsDepVersion, withVersions } from '../../../utils/versions';
 import { getRelativePathToRoot } from '../../../utils/paths';
 import { kebabCase, toClassName, toKebabCase } from '../../../utils/names';
 import {
@@ -524,9 +524,9 @@ export async function tsReactWebsiteGenerator(
     }),
   );
 
-  const devDependencies: IVersion[] = ['vite-tsconfig-paths'];
+  const devDependencies: ITsDepVersion[] = ['vite-tsconfig-paths'];
 
-  const dependencies: IVersion[] = [
+  const dependencies: ITsDepVersion[] = [
     '@cloudscape-design/components',
     '@cloudscape-design/board-components',
     '@cloudscape-design/global-styles',

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -1,0 +1,340 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { parse, stringify } from '@iarna/toml';
+import { UVPyprojectToml } from '@nxlv/python/src/provider/uv/types';
+import { addDependenciesToPyProjectToml } from './py';
+import { IPyDepVersion } from './versions';
+
+describe('addDependenciesToPyProjectToml', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add dependencies to an empty pyproject.toml', () => {
+    // Setup: Create a basic pyproject.toml
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: [],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add dependencies
+    const deps: IPyDepVersion[] = ['fastapi', 'mangum'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify dependencies were added
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('mangum~=0.19.0');
+    expect(updatedToml.project.dependencies).toHaveLength(2);
+  });
+
+  it('should add dependencies to existing dependencies without duplicates', () => {
+    // Setup: Create pyproject.toml with existing dependencies
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: ['requests>=2.25.0', 'pydantic~=2.0.0'],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add new dependencies
+    const deps: IPyDepVersion[] = ['fastapi', 'mangum'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify all dependencies are present
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('requests>=2.25.0');
+    expect(updatedToml.project.dependencies).toContain('pydantic~=2.0.0');
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('mangum~=0.19.0');
+    expect(updatedToml.project.dependencies).toHaveLength(4);
+  });
+
+  it('should replace existing dependencies with same name', () => {
+    // Setup: Create pyproject.toml with existing fastapi dependency
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: ['fastapi>=0.100.0', 'requests>=2.25.0'],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add fastapi dependency (should replace existing)
+    const deps: IPyDepVersion[] = ['fastapi'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify fastapi was replaced and requests remains
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('requests>=2.25.0');
+    expect(updatedToml.project.dependencies).toHaveLength(2);
+
+    // Ensure old fastapi version is not present
+    expect(updatedToml.project.dependencies).not.toContain('fastapi>=0.100.0');
+  });
+
+  it('should handle pyproject.toml without existing dependencies array', () => {
+    // Setup: Create pyproject.toml without dependencies array
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add dependencies
+    const deps: IPyDepVersion[] = ['fastapi', 'mangum'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify dependencies were added
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('mangum~=0.19.0');
+    expect(updatedToml.project.dependencies).toHaveLength(2);
+  });
+
+  it('should handle complex dependency specifications', () => {
+    // Setup: Create pyproject.toml with complex existing dependencies
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: [
+          'fastapi[all]>=0.100.0',
+          'requests[security]>=2.25.0',
+          'pydantic>=2.0.0,<3.0.0',
+        ],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add fastapi dependency (should replace complex existing one)
+    const deps: IPyDepVersion[] = ['fastapi'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify fastapi was replaced while others remain
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain(
+      'requests[security]>=2.25.0',
+    );
+    expect(updatedToml.project.dependencies).toContain(
+      'pydantic>=2.0.0,<3.0.0',
+    );
+    expect(updatedToml.project.dependencies).toHaveLength(3);
+
+    // Ensure old fastapi version is not present
+    expect(updatedToml.project.dependencies).not.toContain(
+      'fastapi[all]>=0.100.0',
+    );
+  });
+
+  it('should handle multiple dependencies with some replacements', () => {
+    // Setup: Create pyproject.toml with mixed existing dependencies
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: [
+          'fastapi>=0.100.0',
+          'requests>=2.25.0',
+          'aws-lambda-powertools>=2.0.0',
+        ],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add dependencies (some new, some replacements)
+    const deps: IPyDepVersion[] = [
+      'fastapi',
+      'mangum',
+      'aws-lambda-powertools',
+    ];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify correct dependencies are present
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('mangum~=0.19.0');
+    expect(updatedToml.project.dependencies).toContain(
+      'aws-lambda-powertools~=3.19.0',
+    );
+    expect(updatedToml.project.dependencies).toContain('requests>=2.25.0');
+    expect(updatedToml.project.dependencies).toHaveLength(4);
+
+    // Ensure old versions are not present
+    expect(updatedToml.project.dependencies).not.toContain('fastapi>=0.100.0');
+    expect(updatedToml.project.dependencies).not.toContain(
+      'aws-lambda-powertools>=2.0.0',
+    );
+  });
+
+  it('should handle empty dependencies array', () => {
+    // Setup: Create pyproject.toml with existing dependencies
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: ['requests>=2.25.0'],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add empty dependencies array
+    const deps: IPyDepVersion[] = [];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify existing dependencies remain unchanged
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('requests>=2.25.0');
+    expect(updatedToml.project.dependencies).toHaveLength(1);
+  });
+
+  it('should preserve other pyproject.toml sections', () => {
+    // Setup: Create comprehensive pyproject.toml
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        description: 'A test project',
+        authors: [{ name: 'Test Author', email: 'test@example.com' }],
+        dependencies: ['requests>=2.25.0'],
+      },
+      'dependency-groups': {
+        dev: ['pytest>=7.0.0', 'black>=22.0.0'],
+      },
+      tool: {
+        pytest: {
+          testpaths: ['tests'],
+        },
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add dependencies
+    const deps: IPyDepVersion[] = ['fastapi'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify other sections are preserved
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.name).toBe('test-project');
+    expect((updatedToml as any).project.description).toBe('A test project');
+    expect((updatedToml as any).project.authors).toEqual([
+      { name: 'Test Author', email: 'test@example.com' },
+    ]);
+    expect(updatedToml['dependency-groups']?.dev).toContain('pytest>=7.0.0');
+    expect(updatedToml['dependency-groups']?.dev).toContain('black>=22.0.0');
+    expect((updatedToml as any).tool?.pytest?.testpaths).toEqual(['tests']);
+
+    // And verify dependencies were updated
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('requests>=2.25.0');
+  });
+
+  it('should handle nested project directory paths', () => {
+    // Setup: Create pyproject.toml in nested directory
+    const initialToml = {
+      project: {
+        name: 'nested-project',
+        version: '0.1.0',
+        dependencies: [],
+      },
+    };
+    tree.write('apps/nested/path/pyproject.toml', stringify(initialToml));
+
+    // Act: Add dependencies to nested project
+    const deps: IPyDepVersion[] = ['fastapi', 'mangum'];
+    addDependenciesToPyProjectToml(tree, 'apps/nested/path', deps);
+
+    // Assert: Verify dependencies were added to correct file
+    const updatedToml = parse(
+      tree.read('apps/nested/path/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).toContain('mangum~=0.19.0');
+    expect(updatedToml.project.dependencies).toHaveLength(2);
+  });
+
+  it('should handle URL dependencies without replacing them', () => {
+    // Setup: Create pyproject.toml with URL dependencies
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: [
+          'pip@https://github.com/pypa/pip/archive/22.0.2.zip',
+          'requests @ git+https://github.com/psf/requests.git@main',
+          'fastapi>=0.100.0',
+          'pydantic @ https://files.pythonhosted.org/packages/pydantic-2.0.0.tar.gz',
+        ],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    // Act: Add fastapi dependency (should replace only the ProjectName requirement)
+    const deps: IPyDepVersion[] = ['fastapi'];
+    addDependenciesToPyProjectToml(tree, 'test-project', deps);
+
+    // Assert: Verify URL dependencies are preserved, only ProjectName fastapi is replaced
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    // URL dependencies should be preserved
+    expect(updatedToml.project.dependencies).toContain(
+      'pip@https://github.com/pypa/pip/archive/22.0.2.zip',
+    );
+    expect(updatedToml.project.dependencies).toContain(
+      'requests @ git+https://github.com/psf/requests.git@main',
+    );
+    expect(updatedToml.project.dependencies).toContain(
+      'pydantic @ https://files.pythonhosted.org/packages/pydantic-2.0.0.tar.gz',
+    );
+
+    // ProjectName fastapi should be replaced with versioned one
+    expect(updatedToml.project.dependencies).toContain('fastapi~=0.116.1');
+    expect(updatedToml.project.dependencies).not.toContain('fastapi>=0.100.0');
+
+    expect(updatedToml.project.dependencies).toHaveLength(4);
+  });
+});

--- a/packages/nx-plugin/src/utils/versions.spec.ts
+++ b/packages/nx-plugin/src/utils/versions.spec.ts
@@ -3,62 +3,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { withVersions, VERSIONS } from './versions';
+import { withVersions, TS_VERSIONS } from './versions';
 describe('versions utils', () => {
   describe('withVersions', () => {
     it('should return empty object for empty dependencies array', () => {
       expect(withVersions([])).toEqual({});
     });
     it('should map single dependency to its version', () => {
-      const deps: (keyof typeof VERSIONS)[] = ['zod'];
+      const deps: (keyof typeof TS_VERSIONS)[] = ['zod'];
       expect(withVersions(deps)).toEqual({
-        zod: VERSIONS['zod'],
+        zod: TS_VERSIONS['zod'],
       });
     });
     it('should map multiple dependencies to their versions', () => {
-      const deps: (keyof typeof VERSIONS)[] = [
+      const deps: (keyof typeof TS_VERSIONS)[] = [
         'aws-cdk-lib',
         'constructs',
         'zod',
       ];
       const expected = {
-        'aws-cdk-lib': VERSIONS['aws-cdk-lib'],
-        constructs: VERSIONS['constructs'],
-        zod: VERSIONS['zod'],
+        'aws-cdk-lib': TS_VERSIONS['aws-cdk-lib'],
+        constructs: TS_VERSIONS['constructs'],
+        zod: TS_VERSIONS['zod'],
       };
       expect(withVersions(deps)).toEqual(expected);
     });
     it('should handle aws dependencies correctly', () => {
-      const deps: (keyof typeof VERSIONS)[] = [
+      const deps: (keyof typeof TS_VERSIONS)[] = [
         '@trpc/client',
         '@tanstack/react-query',
         '@tanstack/react-query-devtools',
       ];
       const expected = {
-        '@trpc/client': VERSIONS['@trpc/client'],
-        '@tanstack/react-query': VERSIONS['@tanstack/react-query'],
+        '@trpc/client': TS_VERSIONS['@trpc/client'],
+        '@tanstack/react-query': TS_VERSIONS['@tanstack/react-query'],
         '@tanstack/react-query-devtools':
-          VERSIONS['@tanstack/react-query-devtools'],
+          TS_VERSIONS['@tanstack/react-query-devtools'],
       };
       expect(withVersions(deps)).toEqual(expected);
     });
     it('should handle cloudscape dependencies correctly', () => {
-      const deps: (keyof typeof VERSIONS)[] = [
+      const deps: (keyof typeof TS_VERSIONS)[] = [
         '@cloudscape-design/components',
         '@cloudscape-design/board-components',
       ];
       const expected = {
         '@cloudscape-design/components':
-          VERSIONS['@cloudscape-design/components'],
+          TS_VERSIONS['@cloudscape-design/components'],
         '@cloudscape-design/board-components':
-          VERSIONS['@cloudscape-design/board-components'],
+          TS_VERSIONS['@cloudscape-design/board-components'],
       };
       expect(withVersions(deps)).toEqual(expected);
     });
     it('should preserve version strings exactly as defined', () => {
-      const deps: (keyof typeof VERSIONS)[] = ['aws-cdk-lib'];
+      const deps: (keyof typeof TS_VERSIONS)[] = ['aws-cdk-lib'];
       const result = withVersions(deps);
-      expect(result['aws-cdk-lib']).toBe(VERSIONS['aws-cdk-lib']);
+      expect(result['aws-cdk-lib']).toBe(TS_VERSIONS['aws-cdk-lib']);
       expect(result['aws-cdk-lib']).toMatch(/^\^/); // Should preserve caret
     });
   });

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -2,7 +2,11 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export const VERSIONS = {
+
+/**
+ * Versons for TypeScript dependencies added by generators
+ */
+export const TS_VERSIONS = {
   '@cdklabs/cdk-validator-cfnguard': '^0.0.60',
   '@aws-sdk/client-cognito-identity': '^3.775.0',
   '@aws-sdk/credential-providers': '^3.775.0',
@@ -59,9 +63,30 @@ export const VERSIONS = {
   // https://github.com/modelcontextprotocol/typescript-sdk/issues/164
   'zod-v3': 'npm:zod@^3',
 } as const;
-export type IVersion = keyof typeof VERSIONS;
+export type ITsDepVersion = keyof typeof TS_VERSIONS;
+
 /**
  * Add versions to the given dependencies
  */
-export const withVersions = (deps: (keyof typeof VERSIONS)[]) =>
-  Object.fromEntries(deps.map((dep) => [dep, VERSIONS[dep]]));
+export const withVersions = (deps: ITsDepVersion[]) =>
+  Object.fromEntries(deps.map((dep) => [dep, TS_VERSIONS[dep]]));
+
+/**
+ * Versions for Python dependencies added by generators
+ */
+export const PY_VERSIONS = {
+  'aws-lambda-powertools': '~=3.19.0',
+  'aws-lambda-powertools[tracer]': '~=3.19.0',
+  'aws-lambda-powertools[parser]': '~=3.19.0',
+  fastapi: '~=0.116.1',
+  'fastapi[standard]': '~=0.116.1',
+  mangum: '~=0.19.0',
+  mcp: '~=1.13.0',
+} as const;
+export type IPyDepVersion = keyof typeof PY_VERSIONS;
+
+/**
+ * Add versions to the given dependencies
+ */
+export const withPyVersions = (deps: IPyDepVersion[]) =>
+  deps.map((dep) => `${dep}${PY_VERSIONS[dep]}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
+      pip-requirements-js:
+        specifier: ^0.2.1
+        version: 0.2.1
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -400,6 +403,9 @@ importers:
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
+      pip-requirements-js:
+        specifier: ^0.2.1
+        version: 0.2.1
       prettier:
         specifier: ^3.4.2
         version: 3.5.3
@@ -6671,6 +6677,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  ohm-js@17.2.1:
+    resolution: {integrity: sha512-4cXF0G09fAYU9z61kTfkNbKK1Kz/sGEZ5NbVWHoe9Qi7VB7y+Spwk051CpUTfUENdlIr+vt8tMV4/LosTE2cDQ==}
+    engines: {node: '>=0.12.1'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -6918,6 +6928,9 @@ packages:
   pino@9.6.0:
     resolution: {integrity: sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==}
     hasBin: true
+
+  pip-requirements-js@0.2.1:
+    resolution: {integrity: sha512-Ztq7fbKviguSr2If2DQpJnmDGkVUtSNUkWUxxYLUpu/6KQrktXQ60nX8nF2/O9YbWU7jv0HcJL2Rx6q3JdA5LQ==}
 
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
@@ -16752,6 +16765,8 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  ohm-js@17.2.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -17014,6 +17029,10 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
+
+  pip-requirements-js@0.2.1:
+    dependencies:
+      ohm-js: 17.2.1
 
   pirates@4.0.6:
     optional: true


### PR DESCRIPTION
### Reason for this change

To reduce the chance of breaking changes outside of our control, we add dependencies with specific version ranges in python generators.

### Description of changes

- specify version ranges for all python dependencies our generators use
- use `addDependenciesToPyProjectToml` method everywhere we add dependencies, and add type safety
- parse existing dependencies to ensure we don't add duplicate entries with different versions for the same dependency

### Description of how you validated changes

Unit/integ tests!

### Issue # (if applicable)

Fixes #269

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*