### PR TITLE
fix(py#project): run format as part of lint and increase max line length

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -153,4 +153,40 @@ describe('python project generator', () => {
     // Verify the metric was added to app.ts
     expectHasMetricTags(tree, PY_PROJECT_GENERATOR_INFO.metric);
   });
+
+  it('should set line-length to 120 in pyproject.toml', async () => {
+    await pyProjectGenerator(tree, {
+      name: 'test-project',
+      directory: 'apps',
+      projectType: 'application',
+    });
+
+    const pyprojectToml = parse(
+      tree.read('apps/test_project/pyproject.toml', 'utf-8'),
+    );
+
+    // Verify ruff line-length is set to 120
+    expect((pyprojectToml.tool as any)?.ruff?.['line-length']).toBe(120);
+  });
+
+  it('should configure lint target to depend on format target', async () => {
+    await pyProjectGenerator(tree, {
+      name: 'test-project',
+      directory: 'apps',
+      projectType: 'application',
+    });
+
+    const projectConfig = JSON.parse(
+      tree.read('apps/test_project/project.json', 'utf-8'),
+    );
+
+    // Verify lint target exists
+    expect(projectConfig.targets.lint).toBeDefined();
+
+    // Verify format target exists
+    expect(projectConfig.targets.format).toBeDefined();
+
+    // Verify lint target depends on format
+    expect(projectConfig.targets.lint.dependsOn).toContain('format');
+  });
 });


### PR DESCRIPTION
### Reason for this change

To reduce friction while working on python projects

### Description of changes

Run ruff's formatter prior to linting as it can automatically fix issues such as lines being too long. Also increase the max line length to 120.

### Description of how you validated changes

unit tests, generated project

### Issue # (if applicable)

References #232

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*