### PR TITLE
fix(license): include terraform files in default license config

### DIFF
--- a/packages/nx-plugin/src/license/__snapshots__/config.spec.ts.snap
+++ b/packages/nx-plugin/src/license/__snapshots__/config.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`license config > defaultLicenseConfig > should generate default license
         "lineEnd": " *",
         "lineStart": " *  ",
       },
-      "**/*.{py,sh}": {
+      "**/*.{py,sh,tf}": {
         "blockEnd": "######################################################################################################################",
         "blockStart": "######################################################################################################################",
         "lineEnd": " #",
@@ -59,7 +59,7 @@ exports[`license config > defaultLicenseConfig > should generate default license
         "blockStart": "/**",
         "lineStart": " * ",
       },
-      "**/*.{py,sh}": {
+      "**/*.{py,sh,tf}": {
         "blockEnd": "#",
         "blockStart": "#",
         "lineStart": "# ",
@@ -90,7 +90,7 @@ exports[`license config > defaultLicenseConfig > should generate default license
         "blockStart": "/**",
         "lineStart": " * ",
       },
-      "**/*.{py,sh}": {
+      "**/*.{py,sh,tf}": {
         "blockEnd": "#",
         "blockStart": "#",
         "lineStart": "# ",

--- a/packages/nx-plugin/src/license/config.ts
+++ b/packages/nx-plugin/src/license/config.ts
@@ -104,6 +104,8 @@ export const LANGUAGE_COMMENT_SYNTAX: { [ext: string]: CommentSyntax } = {
   psm1: { line: '#', block: { start: '<#', end: '#>' } },
   // Markdown
   md: { block: { start: '<!--', end: '-->' } },
+  // Terraform
+  tf: { line: '#', block: { start: '/*', end: '*/' } },
 };
 
 /**
@@ -144,7 +146,7 @@ export const defaultLicenseConfig = (
               lineEnd: ' *',
               blockEnd: ` ***${'*'.repeat(maxLen)}**/`,
             },
-            '**/*.{py,sh}': {
+            '**/*.{py,sh,tf}': {
               blockStart: `###${'#'.repeat(maxLen)}##`,
               lineStart: '#  ',
               lineEnd: ' #',
@@ -177,7 +179,7 @@ export const defaultLicenseConfig = (
               lineStart: ' * ',
               blockEnd: ' */',
             },
-            '**/*.{py,sh}': {
+            '**/*.{py,sh,tf}': {
               blockStart: '#',
               lineStart: '# ',
               blockEnd: '#',


### PR DESCRIPTION
### Reason for this change

Since we support Terraform projects it's useful to have those covered by the license generator by default.

### Description of changes

Add terraform comment syntax and include .tf files in default license config

### Description of how you validated changes

Ran the generator in a terraform project.

NB the sync generator won't run unless there are other projects that have a `lint` target - I think we probably want to set up the standard `build` and `lint` targets for terraform projects as a separate change.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*