### PR TITLE
feat(runtime-config): remove common types package and types for runtime config

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -496,20 +496,6 @@ export class StoryApi<
 
 This is the CDK construct that defines our StoryApi. As you can see, it provides a `defaultIntegrations` method which automatically creates a lambda function for each operation defined in our FastAPI, pointing to the bundled API implementation. This means that at `cdk synth` time, bundling does not occur (opposed to [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) as we have already bundled it as part of the backend project's build target.
 
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-Here is an example of the generator performing an AST transform which preserves all existing code and performs an update. Here you can see the `StoryApi` was added to the `IRuntimeConfig` definition which means when this is eventually consumed by our frontend, it will enforce type safety!
-
 ```py
 // packages/story_api/story_api/main.py
 from .init import app, lambda_handler, tracer

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Juego de Mazmorra con IA"
-description: "Un tutorial de cómo construir un juego de aventuras de mazmorra con IA usando el @aws/nx-plugin."
+description: "Un tutorial de cómo construir un juego de aventuras de mazmorra con IA utilizando el @aws/nx-plugin."
 ---
 
 
@@ -40,7 +40,7 @@ Esto configurará un monorepo NX dentro del directorio `dungeon-adventure` que p
 - .npmrc
 - .prettierignore
 - .prettierrc
-- nx.json configura el CLI de Nx y los valores predeterminados del monorepo
+- nx.json configura los valores predeterminados de la CLI de Nx y el monorepo
 - package.json todas las dependencias de node se definen aquí
 - pnpm-lock.yaml o bun.lock, yarn.lock, package-lock.json según el gestor de paquetes
 - pnpm-workspace.yaml si usas pnpm
@@ -53,22 +53,22 @@ Ahora estamos listos para comenzar a crear nuestros diferentes subproyectos usan
 
 <Aside type="tip">Es una buena práctica asegurar que todos tus archivos no preparados estén confirmados en Git antes de ejecutar cualquier generador. Esto te permite ver qué ha cambiado después de ejecutar tu generador mediante `git diff`</Aside>
 
-### API del Juego
+### Game API
 
-Primero creemos nuestra API del Juego. Para esto, creemos una API tRPC llamada `GameApi` siguiendo estos pasos:
+Primero creemos nuestra Game API. Para esto, creemos una API tRPC llamada `GameApi` siguiendo estos pasos:
 
 <RunGenerator generator="ts#trpc-api" requiredParameters={{ name: "GameApi" }} noInteractive />
 
 <br />
 
-Deberías ver que han aparecido algunos archivos nuevos en tu árbol de archivos.
+Deberías ver algunos archivos nuevos en tu árbol de archivos.
 
 <Aside>
-El `package.json` raíz ahora está configurado con un `type` de `module`, lo que significa que ESM es el tipo de módulo predeterminado para todos los subproyectos basados en node proporcionados por el `@aws/nx-plugin`. Para más detalles sobre cómo trabajar con proyectos TypeScript, consulta la <Link path="guides/typescript-project">guía de ts#project</Link>.
+El `package.json` raíz ahora está configurado con un `type` de `module`, lo que significa que ESM es el tipo de módulo predeterminado para todos los subproyectos basados en node proporcionados por el `@aws/nx-plugin`. Para más detalles sobre cómo trabajar con proyectos TypeScript, consulta la <Link path="guides/typescript-project">guía ts#project</Link>.
 </Aside>
 
-<Drawer title="Archivos actualizados por ts#trpc-api" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados por el generador `ts#trpc-api`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+<Drawer title="Archivos actualizados de ts#trpc-api" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados por el generador `ts#trpc-api`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - packages/
   - common/
@@ -109,7 +109,7 @@ A continuación se muestra una lista de todos los archivos generados por el gene
         - tracer.ts
       - schema/ definiciones de entradas y salidas para tu API
         - **echo.ts**
-      - procedures/ implementaciones específicas de los procedimientos/rutas de tu API
+      - procedures/ implementaciones específicas de tus procedimientos/rutas de la API
         - **echo.ts**
       - index.ts
       - init.ts configura el contexto y middleware
@@ -154,7 +154,7 @@ export const handler = awsLambdaRequestHandler({
 
 export type AppRouter = typeof appRouter;
 ```
-El enrutador define el punto de entrada para tu API tRPC y es el lugar donde declararás todos los métodos de tu API. Como puedes ver arriba, tenemos un método llamado `echo` con su implementación en el archivo `./procedures/echo.ts`.
+El enrutador define el punto de entrada para tu API tRPC y es donde declararás todos tus métodos de API. Como puedes ver arriba, tenemos un método llamado `echo` con su implementación en el archivo `./procedures/echo.ts`.
 
 ```ts {2-5}
 // packages/game-api/src/procedures/echo.ts
@@ -170,7 +170,7 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-Este archivo es la implementación del método `echo` y como puedes ver está fuertemente tipado al declarar sus estructuras de datos de entrada y salida.
+Este archivo es la implementación del método `echo` y como puedes ver está fuertemente tipado declarando sus estructuras de datos de entrada y salida.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -223,19 +223,19 @@ import { RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 
-// Tipo de unión de cadenas para todos los nombres de operaciones de la API
+// Tipo de unión de strings para todos los nombres de operaciones de la API
 type Operations = Procedures<AppRouter>;
 
 /**
  * Propiedades para crear un construct GameApi
  *
- * @template TIntegrations - Mapa de nombres de operaciones a sus integraciones
+ * @template TIntegrations - Mapa de nombres de operación a sus integraciones
  */
 export interface GameApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * Mapa de nombres de operaciones a sus integraciones de API Gateway
+   * Mapa de nombres de operación a sus integraciones de API Gateway
    */
   integrations: TIntegrations;
 }
@@ -243,7 +243,7 @@ export interface GameApiProps<
 /**
  * Un construct CDK que crea y configura una API REST de AWS API Gateway
  * específicamente para GameApi.
- * @template TIntegrations - Mapa de nombres de operaciones a sus integraciones
+ * @template TIntegrations - Mapa de nombres de operación a sus integraciones
  */
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
@@ -298,7 +298,7 @@ export class GameApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Aquí permitimos que cualquier credencial AWS de la cuenta donde se despliega el proyecto pueda llamar a la API.
+          // Aquí concedemos a cualquier credencial AWS de la cuenta en la que se despliega el proyecto para llamar a la API.
           // Se puede definir aquí acceso detallado máquina a máquina usando principios más específicos (ej. roles o
           // usuarios) y recursos (ej. qué rutas de API pueden ser invocadas por qué principal) si es necesario.
           new PolicyStatement({
@@ -323,19 +323,19 @@ export class GameApi<
 }
 ```
 
-Este es el construct CDK que define nuestro GameApi. Como puedes ver, proporciona un método `defaultIntegrations` que crea automáticamente una función lambda para cada procedimiento en nuestra API tRPC, apuntando a la implementación de la API empaquetada. Esto significa que en el momento de `cdk synth`, no ocurre empaquetado (a diferencia de usar [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) ya que ya lo hemos empaquetado como parte del objetivo de compilación del proyecto backend.
+Este es el construct CDK que define nuestro GameApi. Como puedes ver, proporciona un método `defaultIntegrations` que automáticamente crea una función lambda para cada procedimiento en nuestra API tRPC, apuntando a la implementación de la API empaquetada. Esto significa que en el momento de `cdk synth`, no ocurre empaquetado (a diferencia de usar [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) ya que ya lo hemos empaquetado como parte del objetivo de compilación del proyecto backend.
 
 </Drawer>
 
-### API de Historia
+### Story API
 
-Ahora creemos nuestra API de Historia. Para esto, creemos una API Fast llamada `StoryApi` siguiendo estos pasos:
+Ahora creemos nuestra Story API. Para esto, creemos una API Fast llamada `StoryApi` siguiendo estos pasos:
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-Deberías ver que han aparecido algunos archivos nuevos en tu árbol de archivos.
-<Drawer title="Archivos actualizados por py#fast-api" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados por el generador `py#fast-api`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+Deberías ver algunos archivos nuevos en tu árbol de archivos.
+<Drawer title="Archivos actualizados de py#fast-api" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados por el generador `py#fast-api`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - .venv/ entorno virtual único para el monorepo
 - packages/
@@ -401,13 +401,13 @@ import {
 /**
  * Propiedades para crear un construct StoryApi
  *
- * @template TIntegrations - Mapa de nombres de operaciones a sus integraciones
+ * @template TIntegrations - Mapa de nombres de operación a sus integraciones
  */
 export interface StoryApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * Mapa de nombres de operaciones a sus integraciones de API Gateway
+   * Mapa de nombres de operación a sus integraciones de API Gateway
    */
   integrations: TIntegrations;
 }
@@ -415,7 +415,7 @@ export interface StoryApiProps<
 /**
  * Un construct CDK que crea y configura una API REST de AWS API Gateway
  * específicamente para StoryApi.
- * @template TIntegrations - Mapa de nombres de operaciones a sus integraciones
+ * @template TIntegrations - Mapa de nombres de operación a sus integraciones
  */
 export class StoryApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
@@ -470,7 +470,7 @@ export class StoryApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Aquí permitimos que cualquier credencial AWS de la cuenta donde se despliega el proyecto pueda llamar a la API.
+          // Aquí concedemos a cualquier credencial AWS de la cuenta en la que se despliega el proyecto para llamar a la API.
           // Se puede definir aquí acceso detallado máquina a máquina usando principios más específicos (ej. roles o
           // usuarios) y recursos (ej. qué rutas de API pueden ser invocadas por qué principal) si es necesario.
           new PolicyStatement({
@@ -496,21 +496,7 @@ export class StoryApi<
 
 ```
 
-Este es el construct CDK que define nuestro StoryApi. Como puedes ver, proporciona un método `defaultIntegrations` que crea automáticamente una función lambda para cada operación definida en nuestra FastAPI, apuntando a la implementación de la API empaquetada. Esto significa que en el momento de `cdk synth`, no ocurre empaquetado (a diferencia de [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) ya que ya lo hemos empaquetado como parte del objetivo de compilación del proyecto backend.
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-Aquí hay un ejemplo del generador realizando una transformación AST que preserva todo el código existente y realiza una actualización. Aquí puedes ver que se agregó `StoryApi` a la definición de `IRuntimeConfig`, lo que significa que cuando esto sea consumido por nuestro frontend, ¡se aplicará la seguridad de tipos!
+Este es el construct CDK que define nuestro StoryApi. Como puedes ver, proporciona un método `defaultIntegrations` que automáticamente crea una función lambda para cada operación definida en nuestra FastAPI, apuntando a la implementación de la API empaquetada. Esto significa que en el momento de `cdk synth`, no ocurre empaquetado (a diferencia de [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) ya que ya lo hemos empaquetado como parte del objetivo de compilación del proyecto backend.
 
 ```py
 // packages/story_api/story_api/main.py
@@ -524,20 +510,20 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-Aquí es donde se definirán todos tus métodos de API. Como puedes ver aquí, tenemos un método `read_root` mapeado a la ruta `GET /`. Puedes usar [Pydantic](https://docs.pydantic.dev/latest/) para declarar las entradas y salidas de tus métodos y garantizar la seguridad de tipos.
+Aquí es donde se definirán todos tus métodos de API. Como puedes ver aquí, tenemos un método `read_root` mapeado a la ruta `GET /`. Puedes usar [Pydantic](https://docs.pydantic.dev/latest/) para declarar las entradas y salidas de tus métodos y asegurar la seguridad de tipos.
 
 </Drawer>
 
-### Interfaz de Usuario del Juego: Sitio Web
+### Game UI: Website
 
-Ahora creemos la interfaz de usuario que te permitirá interactuar con el juego. Para esto, creemos un sitio web llamado `GameUI` siguiendo estos pasos:
+Ahora creemos la UI que nos permitirá interactuar con el juego. Para esto, creemos un sitio web llamado `GameUI` siguiendo estos pasos:
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-Deberías ver que han aparecido algunos archivos nuevos en tu árbol de archivos.
+Deberías ver algunos archivos nuevos en tu árbol de archivos.
 
-<Drawer title="Archivos actualizados por ts#react-website" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados por el generador `ts#react-website`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+<Drawer title="Archivos actualizados de ts#react-website" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados por el generador `ts#react-website`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - packages/
   - common/
@@ -547,7 +533,7 @@ A continuación se muestra una lista de todos los archivos generados por el gene
           - static-websites/
             - **game-ui.ts** construct CDK para crear tu Game UI
         - core/
-          - static-website.ts construct genérico para sitios web estáticos
+          - static-website.ts construct genérico para sitio web estático
   - game-ui/
     - public/
     - src/
@@ -625,7 +611,7 @@ root &&
   );
 ```
 
-Este es el punto de entrada donde se monta React. Como se muestra, inicialmente solo configura un `@tanstack/react-router` en una configuración de [`enrutado basado en archivos`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Esto significa que, mientras tu servidor de desarrollo esté en ejecución, puedes simplemente crear archivos dentro de la carpeta `routes` y `@tanstack/react-router` creará la configuración de archivos necesaria y actualizará el archivo `routeTree.gen.ts`. Este archivo mantiene todas las rutas de manera segura en tipos, lo que significa que cuando uses `<Link>`, la opción `to` solo mostrará rutas válidas. Para más información, consulta la [documentación de `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
+Este es el punto de entrada donde se monta React. Como se muestra, inicialmente solo configura un `@tanstack/react-router` en una configuración de [`enrutado-basado-en-archivos`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Esto significa que, mientras tu servidor de desarrollo esté en ejecución, puedes simplemente crear archivos dentro de la carpeta `routes` y `@tanstack/react-router` creará la configuración de archivos necesaria y actualizará el archivo `routeTree.gen.ts`. Este archivo mantiene todas las rutas de manera segura en tipos, lo que significa que cuando usas `<Link>`, la opción `to` solo mostrará rutas válidas. Para más información, consulta la [documentación de `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
@@ -656,23 +642,23 @@ Un componente que se renderizará al navegar a la ruta `/welcome`. `@tanstack/re
 
 </Drawer>
 
-### Interfaz de Usuario del Juego: Autenticación
+### Game UI: Autenticación
 
-Ahora configuremos nuestra Game UI para requerir acceso autenticado mediante Amazon Cognito siguiendo estos pasos:
+Ahora configuremos nuestro Game UI para requerir acceso autenticado mediante Amazon Cognito siguiendo estos pasos:
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-Deberías ver que han aparecido/cambiado algunos archivos nuevos en tu árbol de archivos.
+Deberías ver algunos archivos nuevos/cambiados en tu árbol de archivos.
 
-<Drawer title="Archivos actualizados por ts#react-website#auth" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `ts#react-website#auth`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+<Drawer title="Archivos actualizados de ts#react-website#auth" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `ts#react-website#auth`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
         - core/
-          - user-identity.ts construct CDK para crear grupos de usuarios/identidad
+          - user-identity.ts construct CDK para crear pools de usuarios/identidad
     - types/
       - src/
         - runtime-config.ts actualizado para agregar cognitoProps
@@ -727,16 +713,16 @@ Los componentes `RuntimeConfigProvider` y `CognitoAuth` se han agregado al archi
 
 </Drawer>
 
-### Interfaz de Usuario del Juego: Conectar a Story API
+### Game UI: Conectar a Story API
 
-Ahora configuremos nuestra Game UI para conectarnos a nuestra Story API creada anteriormente:
+Ahora configuremos nuestro Game UI para conectarnos a nuestra Story API creada anteriormente:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-Deberías ver que han aparecido/cambiado algunos archivos nuevos en tu árbol de archivos.
+Deberías ver algunos archivos nuevos/cambiados en tu árbol de archivos.
 
-<Drawer title="Archivos actualizados por la conexión UI -> FastAPI" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `api-connection`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+<Drawer title="Archivos actualizados de la conexión UI -> FastAPI" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `api-connection`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - packages/
   - game-ui/
@@ -820,16 +806,16 @@ Los archivos `src/generated/story-api/*.gen.ts` nunca deben modificarse manualme
 
 </Drawer>
 
-### Interfaz de Usuario del Juego: Conectar a Game API
+### Game UI: Conectar a Game API
 
-Ahora configuremos nuestra Game UI para conectarnos a nuestra Game API creada anteriormente:
+Ahora configuremos nuestro Game UI para conectarnos a nuestra Game API creada anteriormente:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-Deberías ver que han aparecido/cambiado algunos archivos nuevos en tu árbol de archivos.
+Deberías ver algunos archivos nuevos/cambiados en tu árbol de archivos.
 
-<Drawer title="Archivos actualizados por la conexión UI -> tRPC" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `api-connection`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+<Drawer title="Archivos actualizados de la conexión UI -> tRPC" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `api-connection`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - packages/
   - game-ui/
@@ -853,7 +839,7 @@ export const useGameApi = GameApiTRCPContext.useTRPC;
 Este hook usa la última [integración de React Query de tRPC](https://trpc.io/blog/introducing-tanstack-react-query-client) permitiendo a los usuarios interactuar con `@tanstack/react-query` directamente sin capas adicionales de abstracción. Para ejemplos de cómo llamar a APIs tRPC, consulta la <Link path="guides/api-connection/react-trpc#using-the-generated-code">guía de uso del hook tRPC</Link>.
 
 <Aside>
-El hook `useGameApi` es diferente al hook `useStoryApi` ya que no requiere una compilación para que los cambios se reflejen gracias al uso de [inferencia de TypeScript](https://trpc.io/docs/concepts) por parte de tRPC. ¡Esto permite a los desarrolladores hacer cambios en su backend que se reflejan instantáneamente en su frontend!
+El hook `useGameApi` es diferente al hook `useStoryApi` ya que no requiere una compilación para que los cambios se reflejen gracias al uso de [inferencia de TypeScript](https://trpc.io/docs/concepts) por parte de tRPC. ¡Esto permite a los desarrolladores hacer cambios en su backend que se reflejen instantáneamente en su frontend!
 </Aside>
 
 ```diff lang="tsx"
@@ -895,20 +881,20 @@ root &&
   );
 ```
 
-El archivo `main.tsx` se ha actualizado mediante una transformación AST para inyectar los proveedores de tRPC.
+El archivo `main.tsx` ha sido actualizado mediante una transformación AST para inyectar los proveedores de tRPC.
 
 </Drawer>
 
-### Infraestructura del Juego
+### Game UI: Infraestructura
 
 Ahora el último subproyecto que necesitamos crear es para la infraestructura CDK. Para crear esto, sigue estos pasos:
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-Deberías ver que han aparecido/cambiado algunos archivos nuevos en tu árbol de archivos.
+Deberías ver algunos archivos nuevos/cambiados en tu árbol de archivos.
 
-<Drawer title="Archivos actualizados por ts#infra" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
-A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `ts#infra`. Vamos a examinar algunos de los archivos clave resaltados en el árbol de archivos:
+<Drawer title="Archivos actualizados de ts#infra" trigger="Haz clic aquí para examinar estos archivos en más detalle.">
+A continuación se muestra una lista de todos los archivos generados/actualizados por el generador `ts#infra`. Examinaremos algunos de los archivos clave resaltados en el árbol de archivos:
 <FileTree>
 - packages/
   - common/
@@ -959,11 +945,11 @@ new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip">Si ves un error de importación en tu IDE, esto se debe a que nuestro proyecto de infraestructura aún no tiene una referencia de TypeScript configurada en su tsconfig.json. Nx ha sido [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para crear estas referencias *dinámicamente* cada vez que se ejecuta una compilación/compilación o si ejecutas el comando `nx sync` manualmente. Para más información, consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guía de TypeScript</Link>.</Aside>
+<Aside type="tip">Si estás viendo un error de importación en tu IDE, es porque nuestro proyecto de infraestructura aún no tiene una referencia de typescript configurada en su tsconfig.json. Nx ha sido [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para crear estas referencias *dinámicamente* cada vez que se ejecuta un build/compile o si ejecutas el comando `nx sync` manualmente. Para más información consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guía de TypeScript</Link>.</Aside>
 
 Este es el punto de entrada para tu aplicación CDK.
 
-Está configurado para usar [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) para ejecutar validaciones de infraestructura basadas en el conjunto de reglas configurado. Esto se instrumenta post síntesis.
+Está configurado para usar [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) para ejecutar validación de infraestructura basada en el conjunto de reglas configurado. Esto se instrumenta post síntesis.
 
 <Aside type="tip">
 Puede haber casos donde quieras suprimir ciertas reglas en recursos. Puedes hacer esto de dos maneras:
@@ -1003,7 +989,7 @@ export class ApplicationStack extends cdk.Stack {
 }
 ```
 
-Aquí es donde instanciaremos nuestros constructs CDK para construir nuestro juego de aventuras de mazmorras.
+Aquí es donde instanciaremos nuestros constructs CDK para construir nuestro juego de aventuras dungeon.
 
 </Drawer>
 
@@ -1014,7 +1000,7 @@ Hagamos una actualización en nuestro `packages/infra/src/stacks/application-sta
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-Observa aquí que proporcionamos integraciones predeterminadas para nuestras dos APIs. Por defecto, cada operación en nuestra API está mapeada a una función lambda individual para manejar esa operación.
+Nota aquí que proporcionamos integraciones predeterminadas para nuestras dos APIs. Por defecto, cada operación en nuestra API está mapeada a una función lambda individual para manejar esa operación.
 
 ### Construyendo nuestro código
 
@@ -1023,7 +1009,7 @@ Observa aquí que proporcionamos integraciones predeterminadas para nuestras dos
 
 El comando `run-many` ejecutará un objetivo en múltiples subproyectos listados (`--all` los seleccionará todos). Se asegurará de que las dependencias se ejecuten en el orden correcto.
 
-También puedes activar una compilación (o cualquier otra tarea) para un objetivo de proyecto único ejecutando el objetivo en el proyecto directamente. Por ejemplo, si queremos construir el proyecto `@dungeon-adventure/infra`, puedes ejecutar el siguiente comando:
+También puedes desencadenar un build (o cualquier otra tarea) para un objetivo de proyecto único ejecutando el objetivo en el proyecto directamente. Por ejemplo, si queremos construir el proyecto `@dungeon-adventure/infra`, puedes ejecutar el siguiente comando:
 
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
 ###### Visualizando tus dependencias
@@ -1037,10 +1023,10 @@ También puedes visualizar tus dependencias mediante:
 
 ###### Caché
 
-Nx depende del [caching](https://nx.dev/concepts/how-caching-works) para que puedas reutilizar artefactos de compilaciones anteriores y acelerar el desarrollo. Se requiere cierta configuración para que esto funcione correctamente y puede haber casos donde quieras realizar una compilación **sin usar la caché**. Para hacer eso, simplemente agrega el argumento `--skip-nx-cache` a tu comando. Por ejemplo:
+Nx depende del [caché](https://nx.dev/concepts/how-caching-works) para que puedas reutilizar artefactos de builds anteriores y acelerar el desarrollo. Se requiere cierta configuración para que esto funcione correctamente y puede haber casos donde quieras realizar un build **sin usar el caché**. Para eso, simplemente agrega el argumento `--skip-nx-cache` a tu comando. Por ejemplo:
 
 <NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
-Si por alguna razón quisieras limpiar tu caché (almacenada en la carpeta `.nx`), puedes ejecutar el siguiente comando:
+Si por alguna razón quisieras limpiar tu caché (almacenado en la carpeta `.nx`), puedes ejecutar el siguiente comando:
 
 <NxCommands commands={['reset']} />
 
@@ -1062,7 +1048,7 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Este mensaje indica que NX ha detectado algunos archivos que pueden actualizarse automáticamente. En este caso, se refiere a los archivos `tsconfig.json` que no tienen referencias de TypeScript configuradas en proyectos referenciados. Selecciona la opción **Yes, sync the changes and run the tasks** para continuar. ¡Deberías notar que todos los errores de importación relacionados con tu IDE se resuelven automáticamente ya que el generador de sincronización agregará las referencias de TypeScript faltantes automáticamente!
+Este mensaje indica que NX ha detectado algunos archivos que pueden actualizarse automáticamente. En este caso, se refiere a los archivos `tsconfig.json` que no tienen referencias de Typescript configuradas en proyectos referenciados. Selecciona la opción **Yes, sync the changes and run the tasks** para continuar. ¡Deberías notar que todos los errores de importación relacionados con tu IDE se resuelven automáticamente ya que el generador de sincronización agregará las referencias de typescript faltantes automáticamente!
 
 <Aside type="tip">
 Si encuentras errores de lint, puedes ejecutar el siguiente comando para corregirlos automáticamente.
@@ -1071,8 +1057,8 @@ Si encuentras errores de lint, puedes ejecutar el siguiente comando para corregi
 </Aside>
 
 <Aside type="caution" title="Error de compilación en Windows">
-<Drawer trigger="Si estás en Windows y encuentras un error de compilación/síntesis, haz clic aquí." title="Error de compilación en Windows">
-Si encuentras un error de compilación/síntesis para el proyecto `@dungeon-adventure/infra`, esto es esperado ya que la biblioteca que instrumenta `cfn-guard` actualmente no soporta Windows. Hay una solicitud de función rastreando esto, sin embargo, mientras tanto podemos simplemente deshabilitar `cfn-guard` modificando el archivo `packages/infra/src/main.ts` de la siguiente manera:
+<Drawer trigger="Si estás en Windows y encuentras un error de compilación, haz clic aquí." title="Error de compilación en Windows">
+Si encuentras un error de compilación/síntesis para el proyecto `@dungeon-adventure/infra`, esto es esperado ya que la biblioteca que instrumenta `cfn-guard` actualmente no soporta Windows. Hay una solicitud de función rastreando esto, pero mientras tanto podemos simplemente deshabilitar `cfn-guard` modificando el archivo `packages/infra/src/main.ts` de la siguiente manera:
 
 ```diff lang="ts"
 // packages/infra/src/main.ts
@@ -1102,6 +1088,6 @@ app.synth();
 </Drawer>
 </Aside>
 
-Todos los artefactos construidos ahora están disponibles dentro de la carpeta `dist/` ubicada en la raíz del monorepo. Esta es una práctica estándar cuando se usan proyectos generados por el `@aws/nx-plugin` ya que no contamina tu árbol de archivos con archivos generados. En caso de que quieras limpiar tus archivos, simplemente puedes eliminar la carpeta `dist/` sin preocuparte por archivos generados esparcidos por el árbol de archivos.
+Todos los artefactos construidos están ahora disponibles dentro de la carpeta `dist/` ubicada en la raíz del monorepo. Esta es una práctica estándar cuando se usan proyectos generados por el `@aws/nx-plugin` ya que no contamina tu árbol de archivos con archivos generados. En caso de que quieras limpiar tus archivos, simplemente puedes eliminar la carpeta `dist/` sin preocuparte por archivos generados esparcidos por todo el árbol de archivos.
 
 ¡Felicidades! Has creado todos los subproyectos requeridos para comenzar a implementar el núcleo de nuestro juego Dunegeon Adventure.  🎉🎉🎉

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -35,25 +35,25 @@ Cela configurera un monorepo NX dans le répertoire `dungeon-adventure` que vous
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ emplacement de vos sous-projets
+- packages/ c'est ici que résideront vos sous-projets
 - .gitignore
 - .npmrc
 - .prettierignore
 - .prettierrc
 - nx.json configure les paramètres par défaut du CLI Nx et du monorepo
-- package.json toutes les dépendances Node sont définies ici
+- package.json toutes les dépendances node sont définies ici
 - pnpm-lock.yaml ou bun.lock, yarn.lock, package-lock.json selon le gestionnaire de paquets
 - pnpm-workspace.yaml si vous utilisez pnpm
 - README.md
-- tsconfig.base.json étendu par tous les sous-projets Node
+- tsconfig.base.json tous les sous-projets basés sur node étendent ce fichier
 - tsconfig.json
 </FileTree>
 
-Nous sommes maintenant prêts à créer nos différents sous-projets en utilisant le `@aws/nx-plugin`.
+Maintenant, nous sommes prêts à commencer à créer nos différents sous-projets en utilisant le `@aws/nx-plugin`.
 
-<Aside type="tip">Il est recommandé de s'assurer que tous vos fichiers non validés sont commités dans Git avant d'exécuter des générateurs. Cela vous permet de voir les modifications via `git diff` après l'exécution d'un générateur.</Aside>
+<Aside type="tip">Il est recommandé de s'assurer que tous vos fichiers non indexés sont commités dans Git avant d'exécuter des générateurs. Cela vous permet de voir ce qui a changé après l'exécution du générateur via `git diff`</Aside>
 
-### API de jeu
+### API du jeu
 
 Commençons par créer notre API de jeu. Pour cela, créons une API tRPC appelée `GameApi` en suivant les étapes ci-dessous :
 
@@ -64,11 +64,11 @@ Commençons par créer notre API de jeu. Pour cela, créons une API tRPC appelé
 Vous devriez voir apparaître de nouveaux fichiers dans votre arborescence.
 
 <Aside>
-Le `package.json` racine est maintenant configuré avec un `type` `module`, ce qui signifie qu'ESM est le type de module par défaut pour tous les sous-projets Node générés par le `@aws/nx-plugin`. Pour plus de détails sur les projets TypeScript, consultez le <Link path="guides/typescript-project">guide ts#project</Link>.
+Le `package.json` racine est maintenant configuré avec un `type` `module`, ce qui signifie qu'ESM est le type de module par défaut pour tous les sous-projets node générés par le `@aws/nx-plugin`. Pour plus de détails sur les projets TypeScript, consultez le <Link path="guides/typescript-project">guide ts#project</Link>.
 </Aside>
 
-<Drawer title="Fichiers modifiés par ts#trpc-api" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Voici la liste des fichiers générés par le générateur `ts#trpc-api`. Examinons les fichiers clés mis en évidence :
+<Drawer title="Fichiers mis à jour par ts#trpc-api" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés par le générateur `ts#trpc-api`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - packages/
   - common/
@@ -76,14 +76,14 @@ Voici la liste des fichiers générés par le générateur `ts#trpc-api`. Examin
       - src/
         - app/ constructions CDK spécifiques à l'application
           - apis/
-            - **game-api.ts** construction CDK pour l'API tRPC
+            - **game-api.ts** construction CDK pour créer votre API tRPC
             - index.ts
             - ...
           - index.ts
         - core/ constructions CDK génériques
           - api/
-            - rest-api.ts construction de base pour une API Gateway Rest
-            - trpc-utils.ts utilitaires pour les constructions CDK tRPC
+            - rest-api.ts construction CDK de base pour une API Gateway Rest
+            - trpc-utils.ts utilitaires pour les constructions CDK d'API tRPC
             - utils.ts utilitaires pour les constructions d'API
           - index.ts
           - runtime-config.ts
@@ -98,7 +98,7 @@ Voici la liste des fichiers générés par le générateur `ts#trpc-api`. Examin
       - ...
   - game-api/ API tRPC
     - src/
-      - client/ client vanilla pour appels machine à machine
+      - client/ client vanilla typiquement utilisé pour les appels machine à machine en TS
         - index.ts
         - sigv4.ts
       - middleware/ instrumentation Powertools
@@ -107,14 +107,14 @@ Voici la liste des fichiers générés par le générateur `ts#trpc-api`. Examin
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ définitions des entrées/sorties de l'API
+      - schema/ définitions des entrées et sorties de votre API
         - **echo.ts**
-      - procedures/ implémentations des procédures/routes de l'API
+      - procedures/ implémentations spécifiques des procédures/routes de votre API
         - **echo.ts**
       - index.ts
-      - init.ts configure le contexte et middleware
-      - local-server.ts pour exécuter le serveur tRPC localement
-      - **router.ts** point d'entrée du handler Lambda définissant toutes les procédures
+      - init.ts configure le contexte et les middlewares
+      - local-server.ts utilisé pour exécuter le serveur tRPC localement
+      - **router.ts** point d'entrée du handler lambda qui définit toutes les procédures
     - project.json
     - ...
 - eslint.config.mjs
@@ -154,7 +154,7 @@ export const handler = awsLambdaRequestHandler({
 
 export type AppRouter = typeof appRouter;
 ```
-Le routeur définit le point d'entrée de votre API tRPC et déclare toutes les méthodes. Nous avons ici une méthode `echo` dont l'implémentation se trouve dans `./procedures/echo.ts`.
+Le routeur définit le point d'entrée de votre API tRPC et est l'endroit où vous déclarez toutes vos méthodes d'API. Comme visible ci-dessus, nous avons une méthode appelée `echo` dont l'implémentation se trouve dans le fichier `./procedures/echo.ts`.
 
 ```ts {2-5}
 // packages/game-api/src/procedures/echo.ts
@@ -170,7 +170,7 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-Ce fichier implémente la méthode `echo` avec des types stricts pour les entrées et sorties.
+Ce fichier contient l'implémentation de la méthode `echo` et, comme visible, est fortement typé en déclarant ses structures de données d'entrée et de sortie.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -189,7 +189,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-Les schémas tRPC sont définis avec [Zod](https://zod.dev/) et exportés comme types TypeScript via `z.TypeOf`.
+Toutes les définitions de schéma tRPC utilisent [Zod](https://zod.dev/) et sont exportées comme types TypeScript via la syntaxe `z.TypeOf`.
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -223,11 +223,11 @@ import { RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 
-// Type union pour les noms d'opérations de l'API
+// Type union pour tous les noms d'opérations de l'API
 type Operations = Procedures<AppRouter>;
 
 /**
- * Propriétés pour la création d'une construction GameApi
+ * Propriétés pour créer une construction GameApi
  *
  * @template TIntegrations - Map des noms d'opérations vers leurs intégrations
  */
@@ -241,18 +241,19 @@ export interface GameApiProps<
 }
 
 /**
- * Construction CDK pour configurer une API Gateway REST API pour GameApi
+ * Une construction CDK qui crée et configure une API REST AWS API Gateway
+ * spécifiquement pour GameApi.
  * @template TIntegrations - Map des noms d'opérations vers leurs intégrations
  */
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
   /**
-   * Crée des intégrations par défaut pour toutes les opérations, implémentant chaque opération
-   * comme une fonction Lambda distincte.
+   * Crée des intégrations par défaut pour toutes les opérations, implémentant chaque opération comme
+   * sa propre fonction lambda individuelle.
    *
-   * @param scope - Portée de la construction CDK
-   * @returns Un IntegrationBuilder avec les intégrations Lambda par défaut
+   * @param scope - La portée de la construction CDK
+   * @returns Un IntegrationBuilder avec les intégrations lambda par défaut
    */
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
@@ -297,14 +298,16 @@ export class GameApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Autorise les credentials AWS du compte de déploiement à appeler l'API
+          // Ici, nous autorisons toutes les credentials AWS du compte de déploiement à appeler l'API.
+          // Un accès machine à machine granulaire peut être défini ici en utilisant des principaux plus spécifiques (ex. rôles ou
+          // utilisateurs) et ressources (ex. quels chemins d'API peuvent être invoqués par quel principal) si nécessaire.
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // Autorise les requêtes OPTIONS non authentifiées pour les prévols navigateurs
+          // Autorise OPTIONS pour permettre aux navigateurs de faire des requêtes preflight non authentifiées
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -320,42 +323,43 @@ export class GameApi<
 }
 ```
 
-Cette construction CDK pour GameApi fournit une méthode `defaultIntegrations` créant une fonction Lambda par procédure tRPC, pointant vers l'implémentation pré-bundle. Le bundling ne se fait pas au moment du `cdk synth` car il est déjà effectué lors du build du projet.
+Il s'agit de la construction CDK qui définit notre GameApi. Comme visible, elle fournit une méthode `defaultIntegrations` qui crée automatiquement une fonction lambda pour chaque procédure de notre API tRPC, pointant vers l'implémentation de l'API déjà bundle. Cela signifie qu'au moment de `cdk synth`, le bundling ne se produit pas (contrairement à l'utilisation de [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) car nous l'avons déjà bundle dans le cadre de la cible de build du projet backend.
 
 </Drawer>
 
-### API de scénario
+### API de l'histoire
 
-Créons maintenant notre API de scénario. Pour cela, créons une API FastAPI appelée `StoryApi` :
+Maintenant, créons notre API de l'histoire. Pour cela, créons une API Fast appelée `StoryApi` en suivant les étapes ci-dessous :
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-De nouveaux fichiers devraient apparaître dans votre arborescence.
-<Drawer title="Fichiers modifiés par py#fast-api" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Voici les fichiers clés générés par le générateur `py#fast-api` :
+Vous devriez voir apparaître de nouveaux fichiers dans votre arborescence.
+<Drawer title="Fichiers mis à jour par py#fast-api" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés par le générateur `py#fast-api`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - .venv/ environnement virtuel unique pour le monorepo
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 
+        - app/ constructions CDK spécifiques à l'application
           - apis/
-            - **story-api.ts** construction CDK pour l'API FastAPI
-            - index.ts mis à jour pour exporter la nouvelle API
-      - project.json ajoute une dépendance de build sur story_api
-    - types/
+            - **story-api.ts** construction CDK pour créer votre API Fast
+            - index.ts mis à jour pour exporter la nouvelle story-api
+      - project.json mis à jour pour ajouter une dépendance de build sur story_api
+    - types/ types partagés
       - src/
-        - **runtime-config.ts** mis à jour avec StoryApi
+        - **runtime-config.ts** mis à jour pour ajouter la StoryApi
   - story_api/
     - story_api/ module Python
-      - init.py configure Powertools, FastAPI et middleware
-      - **main.py** point d'entrée Lambda contenant toutes les routes
+      - init.py configure Powertools, FastAPI et les middlewares
+      - **main.py** point d'entrée du lambda contenant toutes les routes
     - tests/
     - .python-version
     - project.json
     - pyproject.toml
-- .python-version version Python figée
+    - project.json
+- .python-version version Python figée par uv
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -395,20 +399,34 @@ import {
 } from '../../generated/story-api/metadata.gen.js';
 
 /**
- * Propriétés pour la création de StoryApi
+ * Propriétés pour créer une construction StoryApi
+ *
+ * @template TIntegrations - Map des noms d'opérations vers leurs intégrations
  */
 export interface StoryApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
+  /**
+   * Map des noms d'opérations vers leurs intégrations API Gateway
+   */
   integrations: TIntegrations;
 }
 
 /**
- * Construction CDK pour l'API StoryApi
+ * Une construction CDK qui crée et configure une API REST AWS API Gateway
+ * spécifiquement pour StoryApi.
+ * @template TIntegrations - Map des noms d'opérations vers leurs intégrations
  */
 export class StoryApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  /**
+   * Crée des intégrations par défaut pour toutes les opérations, implémentant chaque opération comme
+   * sa propre fonction lambda individuelle.
+   *
+   * @param scope - La portée de la construction CDK
+   * @returns Un IntegrationBuilder avec les intégrations lambda par défaut
+   */
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: OPERATION_DETAILS,
@@ -452,12 +470,16 @@ export class StoryApi<
       },
       policy: new PolicyDocument({
         statements: [
+          // Ici, nous autorisons toutes les credentials AWS du compte de déploiement à appeler l'API.
+          // Un accès machine à machine granulaire peut être défini ici en utilisant des principaux plus spécifiques (ex. rôles ou
+          // utilisateurs) et ressources (ex. quels chemins d'API peuvent être invoqués par quel principal) si nécessaire.
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
+          // Autorise OPTIONS pour permettre aux navigateurs de faire des requêtes preflight non authentifiées
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -471,22 +493,10 @@ export class StoryApi<
     });
   }
 }
+
 ```
 
-Cette construction CDK pour StoryApi crée une fonction Lambda par opération FastAPI, utilisant le bundle pré-généré.
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-Le générateur a mis à jour `IRuntimeConfig` via une transformation AST, ajoutant `StoryApi` pour la sécurité des types frontend.
+Il s'agit de la construction CDK qui définit notre StoryApi. Comme visible, elle fournit une méthode `defaultIntegrations` qui crée automatiquement une fonction lambda pour chaque opération définie dans notre FastAPI, pointant vers l'implémentation de l'API déjà bundle. Cela signifie qu'au moment de `cdk synth`, le bundling ne se produit pas (contrairement à [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) car nous l'avons déjà bundle dans le cadre de la cible de build du projet backend.
 
 ```py
 // packages/story_api/story_api/main.py
@@ -500,50 +510,52 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-Ce fichier définit les méthodes de l'API avec [Pydantic](https://docs.pydantic.dev/latest/) pour la validation des types.
+C'est ici que toutes vos méthodes d'API seront définies. Comme visible ici, nous avons une méthode `read_root` mappée sur la route `GET /`. Vous pouvez utiliser [Pydantic](https://docs.pydantic.dev/latest/) pour déclarer les entrées et sorties de vos méthodes afin d'assurer la sécurité des types.
 
 </Drawer>
 
 ### Interface utilisateur du jeu : Site web
 
-Créons maintenant l'interface utilisateur. Utilisons le générateur pour un site React :
+Maintenant, créons l'interface utilisateur qui permettra d'interagir avec le jeu. Pour cela, créons un site web appelé `GameUI` en suivant les étapes ci-dessous :
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-De nouveaux fichiers devraient apparaître.
-<Drawer title="Fichiers modifiés par ts#react-website" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Fichiers clés générés par `ts#react-website` :
+Vous devriez voir apparaître de nouveaux fichiers dans votre arborescence.
+
+<Drawer title="Fichiers mis à jour par ts#react-website" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés par le générateur `ts#react-website`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/
+        - app/ constructions CDK spécifiques à l'application
           - static-websites/
-            - **game-ui.ts** construction CDK pour l'UI
+            - **game-ui.ts** construction CDK pour créer votre Game UI
         - core/
-          - static-website.ts construction générique de site statique
+          - static-website.ts construction générique de site web statique
   - game-ui/
     - public/
     - src/
       - components/
         - AppLayout/
-          - index.ts layout global
-          - navitems.ts éléments de navigation
+          - index.ts mise en page globale : en-tête, pied de page, barre latérale, etc
+          - navitems.ts éléments de navigation de la barre latérale
       - hooks/
-        - useAppLayout.tsx gestion dynamique du layout
-      - routes/ routage basé fichiers avec @tanstack/react-router
-        - index.tsx redirection vers '/welcome'
-        - __root.tsx composant de base
+        - useAppLayout.tsx permet de définir dynamiquement des éléments comme les notifications, le style de page, etc
+      - routes/ routes basées sur @tanstack/react-router
+        - index.tsx page racine '/' redirige vers '/welcome'
+        - __root.tsx toutes les pages utilisent ce composant comme base
         - welcome/
           - **index.tsx**
         - config.ts
         - **main.tsx** point d'entrée React
-        - routeTree.gen.ts généré automatiquement
+        - routeTree.gen.ts mis à jour automatiquement par @tanstack/react-router
         - styles.css
     - index.html
     - project.json
     - vite.config.ts
+    - ...
 </FileTree>
 
 ```ts
@@ -566,7 +578,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Cette construction CDK pointe vers le bundle Vite généré.
+Il s'agit de la construction CDK qui définit notre GameUI. Comme visible, elle a déjà configuré le chemin vers le bundle généré pour notre interface Vite. Cela signifie qu'au moment du `build`, le bundling se produit dans la cible de build du projet game-ui et sa sortie est utilisée ici.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -581,6 +593,7 @@ import '@cloudscape-design/global-styles/index.css';
 
 const router = createRouter({ routeTree });
 
+// Enregistre l'instance du routeur pour la sécurité des types
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
@@ -598,7 +611,7 @@ root &&
   );
 ```
 
-Point d'entrée React configurant le routage basé fichiers. Consultez la [doc @tanstack/react-router](https://tanstack.com/router/v1/docs/framework/react/quick-start).
+Il s'agit du point d'entrée où React est monté. Comme montré, il configure initialement un `@tanstack/react-router` dans une configuration de [`routage basé sur les fichiers`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Cela signifie que tant que votre serveur de développement est en cours d'exécution, vous pouvez simplement créer des fichiers dans le dossier `routes` et `@tanstack/react-router` créera la configuration de fichiers nécessaire tout en mettant à jour le fichier `routeTree.gen.ts`. Ce fichier maintient toutes les routes de manière type-safe, ce qui signifie que lorsque vous utilisez `<Link>`, l'option `to` n'affichera que les routes valides. Pour plus d'informations, consultez la [documentation de `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
@@ -625,41 +638,42 @@ function RouteComponent() {
 }
 ```
 
-Composant pour la route `/welcome`, géré automatiquement par le routeur.
+Un composant qui sera rendu lors de la navigation vers la route `/welcome`. `@tanstack/react-router` gérera la `Route` pour vous lorsque vous créerez/déplacerez ce fichier (tant que le serveur de développement est en cours d'exécution). Cela sera montré dans une section ultérieure de ce tutoriel.
 
 </Drawer>
 
 ### Interface utilisateur du jeu : Authentification
 
-Configurons l'authentification via Amazon Cognito :
+Maintenant, configurons notre Game UI pour exiger un accès authentifié via Amazon Cognito en suivant les étapes ci-dessous :
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-Des fichiers ont été modifiés/ajoutés.
-<Drawer title="Fichiers modifiés par ts#react-website#auth" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Fichiers clés :
+Vous devriez voir apparaître ou changer des fichiers dans votre arborescence.
+
+<Drawer title="Fichiers mis à jour par ts#react-website#auth" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés/mis à jour par le générateur `ts#react-website#auth`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
         - core/
-          - user-identity.ts construction CDK pour Cognito
+          - user-identity.ts construction CDK pour créer des pools d'utilisateurs/identités
     - types/
       - src/
-        - runtime-config.ts ajout de cognitoProps
+        - runtime-config.ts mis à jour pour ajouter cognitoProps
   - game-ui/
     - src/
       - components/
         - AppLayout/
-          - index.tsx ajout utilisateur connecté/déconnexion
+          - index.tsx ajoute l'utilisateur connecté/déconnexion à l'en-tête
         - CognitoAuth/
-          - index.ts gestion de l'authentification
+          - index.ts gère la connexion à Cognito
         - RuntimeConfig/
-          - index.tsx récupère runtime-config.json
+          - index.tsx récupère le `runtime-config.json` et le fournit aux enfants via le contexte
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** ajout de Cognito
+      - **main.tsx** Mis à jour pour ajouter Cognito
 </FileTree>
 
 ```diff lang="tsx"
@@ -674,6 +688,7 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import '@cloudscape-design/global-styles/index.css';
 const router = createRouter({ routeTree });
+// Enregistre l'instance du routeur pour la sécurité des types
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
@@ -694,35 +709,40 @@ root &&
   );
 ```
 
-Les composants `RuntimeConfigProvider` et `CognitoAuth` ont été ajoutés pour l'authentification via `runtime-config.json`.
+Les composants `RuntimeConfigProvider` et `CognitoAuth` ont été ajoutés au fichier `main.tsx` via une transformation AST. Cela permet au composant `CognitoAuth` de s'authentifier auprès d'Amazon Cognito en récupérant le `runtime-config.json` qui contient la configuration de connexion Cognito nécessaire pour effectuer les appels backend vers la bonne destination.
 
 </Drawer>
 
-### Interface utilisateur du jeu : Connexion à Story API
+### Interface utilisateur du jeu : Connexion à l'API de l'histoire
 
-Connectons l'UI à Story API :
+Maintenant, configurons notre Game UI pour se connecter à notre API Story précédemment créée :
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-Des fichiers ont été modifiés.
-<Drawer title="Fichiers modifiés par la connexion UI -> FastAPI" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Fichiers clés :
+Vous devriez voir apparaître ou changer des fichiers dans votre arborescence.
+
+<Drawer title="Fichiers mis à jour par la connexion UI -> FastAPI" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés/mis à jour par le générateur `api-connection`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - hooks/
-        - useSigV4.tsx signature des requêtes
-        - useStoryApiClient.tsx client StoryApi
-        - useStoryApi.tsx hook avec TanStack Query
+        - useSigV4.tsx utilisé par StoryApi pour signer les requêtes
+        - useStoryApiClient.tsx hook pour construire un client StoryApi
+        - useStoryApi.tsx hook pour interagir avec StoryApi via TanStack Query
       - components/
-        - QueryClientProvider.tsx fournisseur TanStack Query
-        - StoryApiProvider.tsx fournisseur du hook
-      - main.tsx injection des fournisseurs
+        - QueryClientProvider.tsx fournisseur du client TanStack Query
+        - StoryApiProvider.tsx fournisseur du hook TanStack Query pour StoryApi
+      - main.tsx Instrumente le QueryClientProvider et StoryApiProvider
+    - .gitignore ignore les fichiers client générés
+    - project.json mis à jour pour ajouter des cibles de génération de hooks openapi
+    - ...
   - story_api/
     - scripts/
       - generate_open_api.py
-    - project.json génération openapi.json
+    - project.json mis à jour pour émettre un fichier openapi.json
+
 </FileTree>
 
 ```tsx {1,12-15}
@@ -747,7 +767,7 @@ export const useStoryApi = (): StoryApi => {
 };
 ```
 
-Hook pour appels authentifiés à StoryApi. Le client est généré au build.
+Ce hook peut être utilisé pour effectuer des requêtes API authentifiées vers la `StoryApi`. Comme visible dans l'implémentation, il utilise le `StoryApi` généré au moment du build, donc vous verrez une erreur dans votre IDE jusqu'à ce que nous construisions notre code. Pour plus de détails sur la génération du client ou la consommation de l'API, consultez le <Link path="guides/api-connection/react-fastapi">guide React vers FastAPI</Link>.
 
 ```tsx
 // packages/game-ui/src/components/StoryApiProvider.tsx
@@ -776,32 +796,37 @@ export const StoryApiProvider: FC<PropsWithChildren> = ({ children }) => {
 export default StoryApiProvider;
 ```
 
-Fournisseur utilisant `StoryApiOptionsProxy` pour les options TanStack Query.
+Ce composant fournisseur utilise le hook `useStoryApiClient` et instancie le `StoryApiOptionsProxy`, qui est utilisé pour construire les options des hooks TanStack Query. Vous pouvez utiliser le hook correspondant `useStoryApi` pour accéder à ce proxy d'options, qui fournit une manière cohérente d'interagir avec votre FastAPI comme avec votre API tRPC.
+
+Comme `useStoryApiClient` nous fournit un itérateur asynchrone pour notre API de streaming, nous utiliserons directement le client vanilla dans ce tutoriel.
 
 <Aside type="caution">
-Ne modifiez pas les fichiers `src/generated/story-api/*.gen.ts` car ils sont régénérés à chaque build.
+Les fichiers `src/generated/story-api/*.gen.ts` ne doivent jamais être modifiés manuellement car ils seront régénérés à chaque build de votre API.
 </Aside>
 
 </Drawer>
 
-### Interface utilisateur du jeu : Connexion à Game API
+### Interface utilisateur du jeu : Connexion à l'API du jeu
 
-Connectons l'UI à Game API :
+Maintenant, configurons notre Game UI pour se connecter à notre API Game précédemment créée :
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-Des fichiers ont été modifiés.
-<Drawer title="Fichiers modifiés par la connexion UI -> tRPC" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Fichiers clés :
+Vous devriez voir apparaître ou changer des fichiers dans votre arborescence.
+
+<Drawer title="Fichiers mis à jour par la connexion UI -> tRPC" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés/mis à jour par le générateur `api-connection`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - GameApiClientProvider.tsx client tRPC
+        - GameApiClientProvider.tsx configure le client GameAPI
       - hooks/
-        - **useGameApi.tsx** hook tRPC
-      - **main.tsx** injection des fournisseurs tRPC
+        - **useGameApi.tsx** hooks pour appeler la GameApi
+      - **main.tsx** injecte les fournisseurs de client trpc
+- package.json
+
 </FileTree>
 
 ```tsx
@@ -811,10 +836,10 @@ import { GameApiTRCPContext } from '../components/GameApiClientProvider';
 export const useGameApi = GameApiTRCPContext.useTRPC;
 ```
 
-Hook utilisant l'intégration [React Query de tRPC](https://trpc.io/blog/introducing-tanstack-react-query-client).
+Ce hook utilise l'intégration [React Query](https://trpc.io/blog/introducing-tanstack-react-query-client) de tRPC, permettant aux utilisateurs d'interagir directement avec `@tanstack/react-query` sans couches d'abstraction supplémentaires. Pour des exemples d'appels d'API tRPC, consultez le <Link path="guides/api-connection/react-trpc#using-the-generated-code">guide d'utilisation du hook tRPC</Link>.
 
 <Aside>
-Le hook `useGameApi` bénéficie de l'inférence TypeScript de tRPC pour des mises à jour instantanées entre backend et frontend.
+Le hook `useGameApi` est différent du hook `useStoryApi` car il ne nécessite pas de build pour que les changements soient reflétés, grâce à l'utilisation de [l'inférence TypeScript](https://trpc.io/docs/concepts) par tRPC. Cela permet aux développeurs de modifier leur backend et de voir les changements instantanément dans le frontend !
 </Aside>
 
 ```diff lang="tsx"
@@ -831,6 +856,7 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import '@cloudscape-design/global-styles/index.css';
 const router = createRouter({ routeTree });
+// Enregistre l'instance du routeur pour la sécurité des types
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
@@ -855,19 +881,20 @@ root &&
   );
 ```
 
-Injection des fournisseurs tRPC via transformation AST.
+Le fichier `main.tsx` a été mis à jour via une transformation AST pour injecter les fournisseurs tRPC.
 
 </Drawer>
 
-### Infrastructure de l'interface utilisateur
+### Interface utilisateur du jeu : Infrastructure
 
-Créons le projet d'infrastructure CDK :
+Maintenant, le dernier sous-projet à créer est pour l'infrastructure CDK. Pour le créer, suivez les étapes ci-dessous :
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-Des fichiers ont été modifiés.
-<Drawer title="Fichiers modifiés par ts#infra" trigger="Cliquez ici pour examiner ces fichiers en détail.">
-Fichiers clés :
+Vous devriez voir apparaître ou changer des fichiers dans votre arborescence.
+
+<Drawer title="Fichiers mis à jour par ts#infra" trigger="Cliquez ici pour examiner ces fichiers plus en détail.">
+Voici la liste de tous les fichiers générés/mis à jour par le générateur `ts#infra`. Nous allons examiner certains fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
 - packages/
   - common/
@@ -881,12 +908,16 @@ Fichiers clés :
   - infra
     - src/
       - stacks/
-        - **application-stack.ts** ressources CDK
+        - **application-stack.ts** ressources CDK définies ici
       - index.ts
-      - **main.ts** point d'entrée CDK
+      - **main.ts** point d'entrée qui définit toutes les stacks
     - cdk.json
     - project.json
-  - tsconfig.* mises à jour des références
+    - ...
+  - package.json
+  - tsconfig.json ajoute des références
+  - tsconfig.base.json ajoute un alias
+
 </FileTree>
 
 ```ts
@@ -902,6 +933,7 @@ const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
 });
 
+// Utilisez ceci pour déployer votre propre environnement sandbox (suppose les credentials CLI)
 new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -913,11 +945,35 @@ new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip">
-Si vous voyez une erreur d'import dans votre IDE, exécutez `nx sync` pour synchroniser les références TypeScript.
-</Aside>
+<Aside type="tip">Si vous voyez une erreur d'import dans votre IDE, c'est parce que notre projet d'infrastructure n'a pas encore de référence TypeScript configurée dans son tsconfig.json. Nx a été [configuré](https://nx.dev/nx-api/js/generators/typescript-sync) pour créer ces références *dynamiquement* lors d'un build/compilation ou si vous exécutez manuellement la commande `nx sync`. Pour plus d'informations, consultez le <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guide TypeScript</Link>.</Aside>
 
-Ce point d'entrée utilise [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) pour valider l'infrastructure.
+Il s'agit du point d'entrée de votre application CDK.
+
+Elle est configurée pour utiliser [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) pour exécuter la validation d'infrastructure basée sur le jeu de règles configuré. Ceci est instrumenté post-synthèse.
+
+<Aside type="tip">
+Il peut y avoir des cas où vous souhaitez supprimer certaines règles sur des ressources. Vous pouvez le faire de deux manières :
+
+###### Supprimer une règle sur une construction donnée
+
+```typescript
+import { suppressRule } from ':dungeon-adventure/common-constructs';
+
+...
+// supprime la RULE_NAME pour la construction donnée.
+suppressRule(construct, 'RULE_NAME');
+```
+
+###### Supprimer une règle sur une construction descendante
+
+```typescript
+import { suppressRule } from ':dungeon-adventure/common-constructs';
+
+...
+// Supprime la RULE_NAME pour la construction ou ses descendantes si c'est une instance de Bucket
+suppressRule(construct, 'RULE_NAME', (construct) => construct instanceof Bucket);
+```
+</Aside>
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -928,36 +984,36 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Implémentation des ressources CDK
+    // Le code qui définit votre stack va ici
   }
 }
 ```
 
-C'est ici que nous instancierons nos constructions CDK.
+C'est ici que nous instancierons nos constructions CDK pour construire notre jeu d'aventure.
 
 </Drawer>
 
-#### Mise à jour de l'infrastructure
+#### Mettre à jour notre infrastructure
 
-Modifions `packages/infra/src/stacks/application-stack.ts` pour instancier nos constructions :
+Modifions notre `packages/infra/src/stacks/application-stack.ts` pour instancier certaines de nos constructions déjà générées :
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-Nous utilisons les intégrations par défaut pour nos APIs, chaque opération étant mappée à une fonction Lambda.
+Notez ici que nous fournissons des intégrations par défaut pour nos deux API. Par défaut, chaque opération de notre API est mappée à une fonction lambda individuelle pour gérer cette opération.
 
-### Construction du code
+### Construction de notre code
 
-<Drawer title="Commandes Nx" trigger="Construisons maintenant notre code pour la première fois">
+<Drawer title="Commandes Nx" trigger="Il est maintenant temps de construire notre code pour la première fois">
 ###### Cibles uniques vs multiples
 
-La commande `run-many` exécute une cible sur plusieurs sous-projets. Les dépendances sont respectées.
+La commande `run-many` exécutera une cible sur plusieurs sous-projets listés (`--all` les cible tous). Elle s'assure que les dépendances sont exécutées dans le bon ordre.
 
-Pour une cible unique :
+Vous pouvez aussi déclencher un build (ou toute autre tâche) pour une cible de projet unique en exécutant la cible sur le projet directement. Par exemple, si nous voulons build le projet `@dungeon-adventure/infra`, vous pouvez exécuter :
 
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
-###### Visualisation des dépendances
+###### Visualiser vos dépendances
 
-Visualisez les dépendances avec :
+Vous pouvez aussi visualiser vos dépendances via :
 
 <NxCommands commands={['graph']} />
 <br/>
@@ -966,10 +1022,10 @@ Visualisez les dépendances avec :
 
 ###### Cache
 
-Nx utilise le [cache](https://nx.dev/concepts/how-caching-works) pour accélérer les builds. Utilisez `--skip-nx-cache` pour l'ignorer :
+Nx s'appuie sur le [cache](https://nx.dev/concepts/how-caching-works) pour réutiliser les artefacts des builds précédents et accélérer le développement. Une configuration est nécessaire pour que cela fonctionne correctement, et il peut y avoir des cas où vous voulez effectuer un build **sans utiliser le cache**. Pour cela, ajoutez simplement l'argument `--skip-nx-cache` à votre commande. Par exemple :
 
 <NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
-Effacez le cache avec :
+Si jamais vous souhaitez vider votre cache (stocké dans le dossier `.nx`), vous pouvez exécuter :
 
 <NxCommands commands={['reset']} />
 
@@ -977,37 +1033,60 @@ Effacez le cache avec :
 
 <NxCommands commands={['run-many --target build --all']} />
 
-Vous devriez voir :
+Vous devriez voir apparaître ce qui suit :
 
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Certains fichiers de configuration TypeScript manquent des références de projet.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
 
-? Souhaitez-vous synchroniser les modifications pour mettre à jour l'espace de travail ? …
-Oui, synchroniser et exécuter les tâches
-Non, exécuter sans synchroniser
+This will result in an error in CI.
+
+? Would you like to sync the identified changes to get your workspace up to date? …
+Yes, sync the changes and run the tasks
+No, run the tasks without syncing the changes
 ```
 
-Sélectionnez **Oui** pour résoudre les erreurs d'import dans votre IDE.
+Ce message indique que NX a détecté des fichiers qui peuvent être mis à jour automatiquement. Dans ce cas, il s'agit des fichiers `tsconfig.json` qui n'ont pas de références TypeScript configurées sur les projets référencés. Sélectionnez l'option **Yes, sync the changes and run the tasks** pour continuer. Vous devriez voir toutes les erreurs d'import dans votre IDE se résoudre automatiquement car le générateur de synchronisation ajoutera les références TypeScript manquantes !
 
 <Aside type="tip">
-Corrigez les erreurs de lint avec :
+Si vous rencontrez des erreurs de lint, vous pouvez exécuter la commande suivante pour les corriger automatiquement.
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-<Aside type="caution" title="Erreur de build Windows">
-<Drawer trigger="Si vous rencontrez une erreur sous Windows, cliquez ici." title="Erreur Windows">
-Modifiez `packages/infra/src/main.ts` pour désactiver `cfn-guard` :
+<Aside type="caution" title="Échec de build sur Windows">
+<Drawer trigger="Si vous êtes sur Windows et rencontrez une erreur de build, cliquez ici." title="Échec de build Windows">
+Si vous rencontrez une erreur de build/synth pour le projet `@dungeon-adventure/infra`, c'est attendu car la bibliothèque qui instrumente `cfn-guard` ne supporte actuellement pas Windows. Une demande de fonctionnalité suit cela, mais en attendant nous pouvons désactiver `cfn-guard` en modifiant le fichier `packages/infra/src/main.ts` comme suit :
 
 ```diff lang="ts"
+// packages/infra/src/main.ts
+import { ApplicationStack } from './stacks/application-stack.js';
+import {
+   App,
+-  CfnGuardValidator,
+-  RuleSet,
+} from ':dungeon-adventure/common-constructs';
+-
 -const app = new App({
 -  policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
 -});
 +const app = new App();
+
+// Utilisez ceci pour déployer votre propre environnement sandbox (suppose les credentials CLI)
+new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+  crossRegionReferences: true,
+});
+
+app.synth();
 ```
 </Drawer>
 </Aside>
 
-Les artefacts sont générés dans `dist/`. Félicitations, vous avez créé tous les sous-projets nécessaires ! 🎉🎉🎉
+Tous les artefacts construits sont maintenant disponibles dans le dossier `dist/` à la racine du monorepo. C'est une pratique standard avec les projets générés par le `@aws/nx-plugin` car cela ne pollue pas votre arborescence avec des fichiers générés. Si vous souhaitez nettoyer vos fichiers, vous pouvez simplement supprimer le dossier `dist/` sans craindre de fichiers générés éparpillés.
+
+Félicitations ! Vous avez créé tous les sous-projets nécessaires pour commencer à implémenter le cœur de notre jeu Dunegeon Adventure.  🎉🎉🎉

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gioco di Dungeon con IA"
-description: "Una guida dettagliata su come costruire un gioco di avventura in dungeon alimentato dall'IA utilizzando il plugin @aws/nx-plugin."
+description: "Una guida dettagliata su come costruire un gioco di avventura dungeon alimentato da IA utilizzando il plugin @aws/nx-plugin."
 ---
 
 
@@ -25,7 +25,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## Modulo 1: Configurazione del monorepo
 
-Iniziamo creando un nuovo monorepo. All'interno della directory desiderata, esegui il seguente comando:
+Iniziamo creando un nuovo monorepo. Esegui il seguente comando dalla directory desiderata:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" />
 
@@ -35,25 +35,25 @@ Questo configurerà un monorepo NX all'interno della directory `dungeon-adventur
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ qui risiederanno i tuoi sottoprogetti
+- packages/ qui risiederanno i tuoi sotto-progetti
 - .gitignore
 - .npmrc
 - .prettierignore
 - .prettierrc
-- nx.json configura la CLI NX e le impostazioni predefinite del monorepo
+- nx.json configura le impostazioni predefinite della CLI NX e del monorepo
 - package.json tutte le dipendenze Node sono definite qui
 - pnpm-lock.yaml o bun.lock, yarn.lock, package-lock.json in base al package manager
 - pnpm-workspace.yaml se si utilizza pnpm
 - README.md
-- tsconfig.base.json tutti i sottoprogetti basati su Node estendono questo file
+- tsconfig.base.json tutti i sotto-progetti Node estendono questo file
 - tsconfig.json
 </FileTree>
 
-Ora siamo pronti per iniziare a creare i vari sottoprogetti utilizzando `@aws/nx-plugin`.
+Ora siamo pronti per iniziare a creare i diversi sotto-progetti utilizzando `@aws/nx-plugin`.
 
 <Aside type="tip">È una best practice assicurarsi che tutti i file non tracciati siano commitati in Git prima di eseguire qualsiasi generatore. Questo permette di visualizzare le modifiche dopo l'esecuzione del generatore tramite `git diff`</Aside>
 
-### API del gioco
+### Game API
 
 Iniziamo creando la nostra Game API. Per farlo, creiamo un'API tRPC chiamata `GameApi` seguendo questi passaggi:
 
@@ -61,26 +61,26 @@ Iniziamo creando la nostra Game API. Per farlo, creiamo un'API tRPC chiamata `Ga
 
 <br />
 
-Dovresti vedere alcuni nuovi file apparire nel tuo albero delle directory.
+Dovresti vedere alcuni nuovi file apparire nella struttura delle cartelle.
 
 <Aside>
-Il `package.json` principale è ora configurato con un `type` impostato a `module`, il che significa che ESM è il tipo di modulo predefinito per tutti i sottoprogetti Node gestiti da `@aws/nx-plugin`. Per maggiori dettagli sul lavoro con progetti TypeScript, consulta la <Link path="guides/typescript-project">guida ts#project</Link>.
+Il `package.json` principale è ora configurato con un `type` impostato a `module`, il che significa che ESM è il tipo di modulo predefinito per tutti i sotto-progetti Node gestiti da `@aws/nx-plugin`. Per maggiori dettagli sul lavoro con progetti TypeScript, consulta la <Link path="guides/typescript-project">guida ts#project</Link>.
 </Aside>
 
-<Drawer title="File modificati da ts#trpc-api" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#trpc-api`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+<Drawer title="File modificati da ts#trpc-api" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#trpc-api`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ componenti CDK specifici dell'applicazione
+        - app/ costrutti CDK specifici dell'applicazione
           - apis/
             - **game-api.ts** costrutto CDK per creare l'API tRPC
             - index.ts
             - ...
           - index.ts
-        - core/ componenti CDK generici
+        - core/ costrutti CDK generici
           - api/
             - rest-api.ts costrutto base CDK per un'API Gateway Rest API
             - trpc-utils.ts utility per i costrutti CDK delle API tRPC
@@ -98,7 +98,7 @@ Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#trp
       - ...
   - game-api/ API tRPC
     - src/
-      - client/ client vanilla tipicamente utilizzato per chiamate machine-to-machine in TS
+      - client/ client vanilla tipicamente utilizzato per chiamate machine-to-machine in TypeScript
         - index.ts
         - sigv4.ts
       - middleware/ strumentazione Powertools
@@ -109,12 +109,12 @@ Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#trp
         - tracer.ts
       - schema/ definizioni di input e output per la tua API
         - **echo.ts**
-      - procedures/ implementazioni specifiche delle procedure/route dell'API
+      - procedures/ implementazioni specifiche per le procedure/route dell'API
         - **echo.ts**
       - index.ts
-      - init.ts configura il contesto e il middleware
+      - init.ts configura il contesto e i middleware
       - local-server.ts utilizzato per eseguire il server tRPC localmente
-      - **router.ts** punto di ingresso per il lambda handler che definisce tutte le procedure
+      - **router.ts** punto di ingresso per l'handler lambda che definisce tutte le procedure
     - project.json
     - ...
 - eslint.config.mjs
@@ -235,7 +235,7 @@ export interface GameApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * Mappa dei nomi delle operazioni alle integrazioni API Gateway
+   * Mappa dei nomi delle operazioni alle loro integrazioni API Gateway
    */
   integrations: TIntegrations;
 }
@@ -252,7 +252,7 @@ export class GameApi<
    * Crea integrazioni predefinite per tutte le operazioni, implementando ciascuna operazione come
    * una singola funzione lambda.
    *
-   * @param scope - Il costrutto CDK
+   * @param scope - Il contesto del costrutto CDK
    * @returns Un IntegrationBuilder con integrazioni lambda predefinite
    */
   public static defaultIntegrations = (scope: Construct) => {
@@ -307,7 +307,7 @@ export class GameApi<
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // Apriamo OPTIONS per permettere ai browser di effettuare richieste preflight non autenticate
+          // Apre le OPTIONS per consentire ai browser di effettuare richieste preflight non autenticate
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -323,26 +323,26 @@ export class GameApi<
 }
 ```
 
-Questo è il costrutto CDK che definisce la nostra GameApi. Come puoi vedere, fornisce un metodo `defaultIntegrations` che crea automaticamente una funzione lambda per ogni procedura nella nostra API tRPC, puntando all'implementazione dell'API già bundled. Ciò significa che al momento di `cdk synth` non avviene il bundling (contrariamente all'uso di [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) poiché lo abbiamo già incluso come parte del target di build del progetto backend.
+Questo è il costrutto CDK che definisce la nostra GameApi. Come puoi vedere, fornisce un metodo `defaultIntegrations` che crea automaticamente una funzione lambda per ogni procedura nella nostra API tRPC, puntando all'implementazione dell'API già bundleizzata. Ciò significa che al momento di `cdk synth` non avviene alcun bundling (a differenza di [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) poiché abbiamo già effettuato il bundling come parte del target di build del progetto backend.
 
 </Drawer>
 
-### API della storia
+### Story API
 
 Ora creiamo la nostra Story API. Per farlo, creiamo un'API Fast chiamata `StoryApi` seguendo questi passaggi:
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-Dovresti vedere alcuni nuovi file apparire nel tuo albero delle directory.
-<Drawer title="File modificati da py#fast-api" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati dal generatore `py#fast-api`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+Dovresti vedere alcuni nuovi file apparire nella struttura delle cartelle.
+<Drawer title="File modificati da py#fast-api" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati dal generatore `py#fast-api`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - .venv/ singolo ambiente virtuale per il monorepo
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ componenti CDK specifici dell'applicazione
+        - app/ costrutti CDK specifici dell'applicazione
           - apis/
             - **story-api.ts** costrutto CDK per creare la tua Fast API
             - index.ts aggiornato per esportare la nuova story-api
@@ -352,7 +352,7 @@ Di seguito è riportato l'elenco di tutti i file generati dal generatore `py#fas
         - **runtime-config.ts** aggiornato per aggiungere la StoryApi
   - story_api/
     - story_api/ modulo Python
-      - init.py configura Powertools, FastAPI e middleware
+      - init.py configura Powertools, FastAPI e i middleware
       - **main.py** punto di ingresso per la lambda contenente tutte le route
     - tests/
     - .python-version
@@ -407,7 +407,7 @@ export interface StoryApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * Mappa dei nomi delle operazioni alle integrazioni API Gateway
+   * Mappa dei nomi delle operazioni alle loro integrazioni API Gateway
    */
   integrations: TIntegrations;
 }
@@ -424,7 +424,7 @@ export class StoryApi<
    * Crea integrazioni predefinite per tutte le operazioni, implementando ciascuna operazione come
    * una singola funzione lambda.
    *
-   * @param scope - Il costrutto CDK
+   * @param scope - Il contesto del costrutto CDK
    * @returns Un IntegrationBuilder con integrazioni lambda predefinite
    */
   public static defaultIntegrations = (scope: Construct) => {
@@ -479,7 +479,7 @@ export class StoryApi<
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // Apriamo OPTIONS per permettere ai browser di effettuare richieste preflight non autenticate
+          // Apre le OPTIONS per consentire ai browser di effettuare richieste preflight non autenticate
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -496,21 +496,7 @@ export class StoryApi<
 
 ```
 
-Questo è il costrutto CDK che definisce la nostra StoryApi. Come puoi vedere, fornisce un metodo `defaultIntegrations` che crea automaticamente una funzione lambda per ogni operazione definita nella nostra FastAPI, puntando all'implementazione dell'API già bundled. Ciò significa che al momento di `cdk synth` non avviene il bundling (contrariamente a [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) poiché lo abbiamo già incluso come parte del target di build del progetto backend.
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-Ecco un esempio di come il generatore esegue una trasformazione AST che preserva tutto il codice esistente e aggiorna solo le parti necessarie. Qui puoi vedere che `StoryApi` è stato aggiunto alla definizione `IRuntimeConfig`, il che significa che quando verrà utilizzato dal frontend, garantirà la type safety!
+Questo è il costrutto CDK che definisce la nostra StoryApi. Come puoi vedere, fornisce un metodo `defaultIntegrations` che crea automaticamente una funzione lambda per ogni operazione definita nella nostra FastAPI, puntando all'implementazione dell'API già bundleizzata. Ciò significa che al momento di `cdk synth` non avviene alcun bundling (a differenza di [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) poiché abbiamo già effettuato il bundling come parte del target di build del progetto backend.
 
 ```py
 // packages/story_api/story_api/main.py
@@ -524,26 +510,26 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-Questo è dove verranno definiti tutti i metodi della tua API. Come puoi vedere qui, abbiamo un metodo `read_root` mappato sulla route `GET /`. Puoi utilizzare [Pydantic](https://docs.pydantic.dev/latest/) per dichiarare input e output dei metodi e garantire la type safety.
+Questo è dove verranno definiti tutti i metodi della tua API. Come mostrato qui, abbiamo un metodo `read_root` mappato alla route `GET /`. Puoi utilizzare [Pydantic](https://docs.pydantic.dev/latest/) per dichiarare gli input e gli output dei metodi e garantire la type safety.
 
 </Drawer>
 
-### Interfaccia utente del gioco: Sito web
+### Game UI: Sito Web
 
 Ora creiamo l'interfaccia utente che ti permetterà di interagire con il gioco. Per farlo, creiamo un sito web chiamato `GameUI` seguendo questi passaggi:
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-Dovresti vedere alcuni nuovi file apparire nel tuo albero delle directory.
+Dovresti vedere alcuni nuovi file apparire nella struttura delle cartelle.
 
-<Drawer title="File modificati da ts#react-website" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#react-website`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+<Drawer title="File modificati da ts#react-website" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#react-website`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ componenti CDK specifici dell'applicazione
+        - app/ costrutti CDK specifici dell'applicazione
           - static-websites/
             - **game-ui.ts** costrutto CDK per creare la tua Game UI
         - core/
@@ -553,10 +539,10 @@ Di seguito è riportato l'elenco di tutti i file generati dal generatore `ts#rea
     - src/
       - components/
         - AppLayout/
-          - index.ts layout generale della pagina: header, footer, sidebar, ecc.
+          - index.ts layout generale della pagina: header, footer, sidebar, ecc
           - navitems.ts elementi di navigazione della sidebar
       - hooks/
-        - useAppLayout.tsx permette di impostare dinamicamente elementi come notifiche, stile della pagina, ecc.
+        - useAppLayout.tsx permette di impostare dinamicamente elementi come notifiche, stile della pagina, ecc
       - routes/ route basate su file di @tanstack/react-router
         - index.tsx pagina root '/' reindirizza a '/welcome'
         - __root.tsx tutte le pagine utilizzano questo componente come base
@@ -592,7 +578,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Questo è il costrutto CDK che definisce la nostra GameUI. Come puoi vedere, ha già configurato il percorso del file per il bundle generato per la UI basata su Vite. Ciò significa che al momento del `build`, il bundling avviene all'interno del target di build del progetto game-ui e il suo output viene utilizzato qui.
+Questo è il costrutto CDK che definisce la nostra GameUI. Come puoi vedere, ha già configurato il percorso del file al bundle generato per la nostra UI basata su Vite. Ciò significa che al momento del `build`, il bundling avviene all'interno del target di build del progetto game-ui e il suo output viene utilizzato qui.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -625,7 +611,7 @@ root &&
   );
 ```
 
-Questo è il punto di ingresso dove viene montato React. Come mostrato, inizialmente configura un `@tanstack/react-router` in una configurazione [`file-based-routing`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Ciò significa che, finché il server di sviluppo è in esecuzione, puoi semplicemente creare file nella cartella `routes` e `@tanstack/react-router` creerà automaticamente il setup boilerplate per te, aggiornando il file `routeTree.gen.ts`. Questo file mantiene tutte le route in modo type-safe, il che significa che quando usi `<Link>`, l'opzione `to` mostrerà solo route valide. Per maggiori informazioni, consulta la [documentazione di `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
+Questo è il punto di ingresso dove viene montato React. Come mostrato, inizialmente configura un `@tanstack/react-router` in una configurazione [`file-based-routing`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Ciò significa che, finché il server di sviluppo è in esecuzione, puoi semplicemente creare file all'interno della cartella `routes` e `@tanstack/react-router` creerà automaticamente la configurazione boilerplate per te, aggiornando il file `routeTree.gen.ts`. Questo file mantiene tutte le route in modo type-safe, il che significa che quando usi `<Link>`, l'opzione `to` mostrerà solo route valide. Per maggiori informazioni, consulta la [documentazione di `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
@@ -652,20 +638,20 @@ function RouteComponent() {
 }
 ```
 
-Un componente che verrà renderizzato quando si naviga alla route `/welcome`. `@tanstack/react-router` gestirà la `Route` per te ogni volta che crei/sposti questo file (finché il server di sviluppo è in esecuzione). Questo verrà mostrato in una sezione successiva di questo tutorial.
+Un componente che verrà renderizzato quando si naviga alla route `/welcome`. `@tanstack/react-router` gestirà la `Route` per te ogni volta che crei/sposti questo file (finché il dev server è in esecuzione). Questo verrà mostrato in una sezione successiva di questo tutorial.
 
 </Drawer>
 
-### Interfaccia utente del gioco: Autenticazione
+### Game UI: Autenticazione
 
 Ora configuriamo la nostra Game UI per richiedere l'accesso autenticato tramite Amazon Cognito seguendo questi passaggi:
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-Dovresti vedere alcuni nuovi file apparire/modificarsi nel tuo albero delle directory.
+Dovresti vedere alcuni nuovi file apparire/modificarsi nella struttura delle cartelle.
 
-<Drawer title="File modificati da ts#react-website#auth" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `ts#react-website#auth`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+<Drawer title="File modificati da ts#react-website#auth" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `ts#react-website#auth`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - packages/
   - common/
@@ -684,7 +670,7 @@ Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generat
         - CognitoAuth/
           - index.ts gestisce il login in Cognito
         - RuntimeConfig/
-          - index.tsx recupera il `runtime-config.json` e lo fornisce ai figli via context
+          - index.tsx recupera il `runtime-config.json` e lo fornisce ai figli via contesto
       - hooks/
         - useRuntimeConfig.tsx
       - **main.tsx** Aggiornato per aggiungere Cognito
@@ -727,16 +713,16 @@ I componenti `RuntimeConfigProvider` e `CognitoAuth` sono stati aggiunti al file
 
 </Drawer>
 
-### Interfaccia utente del gioco: Connessione a Story API
+### Game UI: Connessione a Story API
 
 Ora configuriamo la nostra Game UI per connettersi alla Story API creata precedentemente:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-Dovresti vedere alcuni nuovi file apparire/modificarsi nel tuo albero delle directory.
+Dovresti vedere alcuni nuovi file apparire/modificarsi nella struttura delle cartelle.
 
-<Drawer title="File modificati da UI -> FastAPI api-connection" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `api-connection`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+<Drawer title="File modificati da UI -> FastAPI api-connection" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `api-connection`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - packages/
   - game-ui/
@@ -748,7 +734,7 @@ Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generat
       - components/
         - QueryClientProvider.tsx provider del client TanStack Query
         - StoryApiProvider.tsx Provider per l'hook TanStack Query di StoryApi
-      - main.tsx Inietta QueryClientProvider e StoryApiProvider
+      - main.tsx Strumenta il QueryClientProvider e StoryApiProvider
     - .gitignore ignora i file client generati
     - project.json aggiornato per aggiungere target per generare hook openapi
     - ...
@@ -781,7 +767,7 @@ export const useStoryApi = (): StoryApi => {
 };
 ```
 
-Questo hook può essere utilizzato per effettuare richieste API autenticate alla `StoryApi`. Come puoi vedere nell'implementazione, utilizza `StoryApi` che viene generato al momento della build, quindi vedrai un errore nel tuo IDE finché non eseguiremo la build del codice. Per maggiori dettagli su come viene generato il client o su come consumare l'API, consulta la <Link path="guides/api-connection/react-fastapi">guida React to FastAPI</Link>.
+Questo hook può essere utilizzato per effettuare richieste API autenticate alla `StoryApi`. Come mostrato nell'implementazione, utilizza `StoryApi` che viene generato al momento del build, quindi vedrai un errore nel tuo IDE finché non compiliamo il codice. Per maggiori dettagli su come viene generato il client o su come consumare l'API, consulta la <Link path="guides/api-connection/react-fastapi">guida React to FastAPI</Link>.
 
 ```tsx
 // packages/game-ui/src/components/StoryApiProvider.tsx
@@ -815,21 +801,21 @@ Il componente provider sopra indicato utilizza l'hook `useStoryApiClient` e ista
 Poiché `useStoryApiClient` ci fornisce un async iterator per la nostra API di streaming, in questo tutorial utilizzeremo direttamente il client vanilla.
 
 <Aside type="caution">
-I file `src/generated/story-api/*.gen.ts` non devono mai essere modificati manualmente poiché verranno rigenerati ogni volta che esegui la build della tua API.
+I file `src/generated/story-api/*.gen.ts` non devono mai essere modificati manualmente poiché verranno rigenerati ogni volta che costruisci la tua API.
 </Aside>
 
 </Drawer>
 
-### Interfaccia utente del gioco: Connessione a Game API
+### Game UI: Connessione a Game API
 
 Ora configuriamo la nostra Game UI per connettersi alla Game API creata precedentemente:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-Dovresti vedere alcuni nuovi file apparire/modificarsi nel tuo albero delle directory.
+Dovresti vedere alcuni nuovi file apparire/modificarsi nella struttura delle cartelle.
 
-<Drawer title="File modificati da UI -> tRPC api-connection" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `api-connection`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+<Drawer title="File modificati da UI -> tRPC api-connection" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `api-connection`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - packages/
   - game-ui/
@@ -838,7 +824,7 @@ Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generat
         - GameApiClientProvider.tsx configura il client GameAPI
       - hooks/
         - **useGameApi.tsx** hook per chiamare la GameApi
-      - **main.tsx** inietta i provider del client trpc
+      - **main.tsx** inserisce i provider del client trpc
 - package.json
 
 </FileTree>
@@ -853,7 +839,7 @@ export const useGameApi = GameApiTRCPContext.useTRPC;
 Questo hook utilizza l'ultima [integrazione React Query di tRPC](https://trpc.io/blog/introducing-tanstack-react-query-client), permettendo agli utenti di interagire direttamente con `@tanstack/react-query` senza ulteriori livelli di astrazione. Per esempi su come chiamare le API tRPC, consulta la <Link path="guides/api-connection/react-trpc#using-the-generated-code">guida all'uso dell'hook tRPC</Link>.
 
 <Aside>
-L'hook `useGameApi` è diverso da `useStoryApi` poiché non richiede una build per riflettere le modifiche, grazie all'uso da parte di tRPC dell'[inferenza TypeScript](https://trpc.io/docs/concepts). Questo permette agli sviluppatori di apportare modifiche al backend che si riflettono istantaneamente nel frontend!
+L'hook `useGameApi` è diverso dall'hook `useStoryApi` perché non richiede una build per riflettere le modifiche, grazie all'utilizzo di [TypeScript inference](https://trpc.io/docs/concepts) da parte di tRPC. Questo permette agli sviluppatori di apportare modifiche al backend che si riflettono istantaneamente nel frontend!
 </Aside>
 
 ```diff lang="tsx"
@@ -895,20 +881,20 @@ root &&
   );
 ```
 
-Il file `main.tsx` è stato aggiornato tramite una trasformazione AST per iniettare i provider tRPC.
+Il file `main.tsx` è stato aggiornato tramite una trasformazione AST per inserire i provider tRPC.
 
 </Drawer>
 
-### Interfaccia utente del gioco: Infrastruttura
+### Game UI: Infrastruttura
 
-Ora l'ultimo sottoprogetto che dobbiamo creare è per l'infrastruttura CDK. Per crearlo, segui questi passaggi:
+Ora l'ultimo sotto-progetto che dobbiamo creare è per l'infrastruttura CDK. Per crearlo, segui questi passaggi:
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-Dovresti vedere alcuni nuovi file apparire/modificarsi nel tuo albero delle directory.
+Dovresti vedere alcuni nuovi file apparire/modificarsi nella struttura delle cartelle.
 
-<Drawer title="File modificati da ts#infra" trigger="Clicca qui per esaminare questi file nel dettaglio.">
-Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `ts#infra`. Esamineremo alcuni dei file chiave evidenziati nell'albero delle directory:
+<Drawer title="File modificati da ts#infra" trigger="Clicca qui per esaminare questi file in dettaglio.">
+Di seguito è riportato l'elenco di tutti i file generati/aggiornati dal generatore `ts#infra`. Esamineremo alcuni dei file chiave evidenziati nell'albero:
 <FileTree>
 - packages/
   - common/
@@ -959,14 +945,14 @@ new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip">Se vedi un errore di importazione nel tuo IDE, è perché il nostro progetto infrastruttura non ha ancora un riferimento TypeScript configurato nel suo tsconfig.json. Nx è stato [configurato](https://nx.dev/nx-api/js/generators/typescript-sync) per creare questi riferimenti *dinamicamente* ogni volta che viene eseguita una build/compilazione o se esegui manualmente il comando `nx sync`. Per maggiori informazioni consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guida TypeScript</Link>.</Aside>
+<Aside type="tip">Se vedi un errore di importazione nel tuo IDE, è perché il nostro progetto infrastruttura non ha ancora un riferimento TypeScript configurato nel suo tsconfig.json. Nx è stato [configurato](https://nx.dev/nx-api/js/generators/typescript-sync) per creare questi riferimenti *dinamicamente* ogni volta che viene eseguito un build/compile o se esegui manualmente il comando `nx sync`. Per maggiori informazioni consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guida TypeScript</Link>.</Aside>
 
 Questo è il punto di ingresso per la tua applicazione CDK.
 
-È configurato per utilizzare [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) per eseguire la validazione dell'infrastruttura basata sul ruleset configurato. Questo viene strumentato post-sintesi.
+È configurato per utilizzare [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) per eseguire la validazione dell'infrastruttura basata sul set di regole configurato. Questo viene strumentato post-sintesi.
 
 <Aside type="tip">
-Ci possono essere casi in cui vuoi sopprimere determinate regole su alcune risorse. Puoi farlo in due modi:
+Potrebbero esserci casi in cui desideri sopprimere determinate regole su risorse specifiche. Puoi farlo in due modi:
 
 ###### Sopprimi una regola su un costrutto specifico
 
@@ -974,7 +960,7 @@ Ci possono essere casi in cui vuoi sopprimere determinate regole su alcune risor
 import { suppressRule } from ':dungeon-adventure/common-constructs';
 
 ...
-// sopprime la RULE_NAME per il costrutto specificato
+// Sopprime la RULE_NAME per il costrutto specificato.
 suppressRule(construct, 'RULE_NAME');
 ```
 
@@ -1009,23 +995,23 @@ Questo è dove istanzieremo i nostri costrutti CDK per costruire il nostro gioco
 
 #### Aggiorniamo la nostra infrastruttura
 
-Apportiamo una modifica al file `packages/infra/src/stacks/application-stack.ts` per istanziare alcuni dei nostri costrutti già generati:
+Modifichiamo il nostro `packages/infra/src/stacks/application-stack.ts` per istanziare alcuni dei costrutti già generati:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 Nota che forniamo integrazioni predefinite per le nostre due API. Di default, ogni operazione nelle nostre API è mappata a una singola funzione lambda per gestire quell'operazione.
 
-### Compiliamo il nostro codice
+### Costruiamo il nostro codice
 
-<Drawer title="Comandi Nx" trigger="Ora è il momento di compilare il nostro codice per la prima volta">
+<Drawer title="Comandi Nx" trigger="Ora è il momento di costruire il nostro codice per la prima volta">
 ###### Target singoli vs multipli
 
-Il comando `run-many` eseguirà un target su più sottoprogetti elencati (`--all` li selezionerà tutti). Garantirà che le dipendenze vengano eseguite nell'ordine corretto.
+Il comando `run-many` eseguirà un target su più sotto-progetti elencati (`--all` li selezionerà tutti). Garantirà che le dipendenze siano eseguite nell'ordine corretto.
 
-Puoi anche attivare una build (o qualsiasi altro task) per un target di progetto singolo eseguendo il target direttamente sul progetto. Ad esempio, se vogliamo buildare il progetto `@dungeon-adventure/infra`, puoi eseguire:
+Puoi anche attivare un build (o qualsiasi altro task) per un target di progetto singolo eseguendo il target direttamente sul progetto. Ad esempio, se vogliamo costruire il progetto `@dungeon-adventure/infra`, puoi eseguire:
 
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
-###### Visualizzare le dipendenze
+###### Visualizzazione delle dipendenze
 
 Puoi anche visualizzare le tue dipendenze tramite:
 
@@ -1036,10 +1022,10 @@ Puoi anche visualizzare le tue dipendenze tramite:
 
 ###### Caching
 
-Nx si basa sul [caching](https://nx.dev/concepts/how-caching-works) per riutilizzare artefatti da build precedenti e velocizzare lo sviluppo. È necessaria una configurazione per far funzionare correttamente questa funzionalità e potrebbero esserci casi in cui vuoi eseguire una build **senza utilizzare la cache**. Per farlo, aggiungi semplicemente l'argomento `--skip-nx-cache` al tuo comando. Ad esempio:
+Nx si basa sul [caching](https://nx.dev/concepts/how-caching-works) per riutilizzare gli artefatti di build precedenti e velocizzare lo sviluppo. È necessaria una configurazione per far funzionare correttamente questa funzionalità e potrebbero esserci casi in cui desideri eseguire un build **senza utilizzare la cache**. Per farlo, aggiungi semplicemente l'argomento `--skip-nx-cache` al tuo comando. Ad esempio:
 
 <NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
-Se per qualsiasi motivo volessi cancellare la tua cache (memorizzata nella cartella `.nx`), puoi eseguire:
+Se per qualsiasi motivo desideri cancellare la tua cache (memorizzata nella cartella `.nx`), puoi eseguire:
 
 <NxCommands commands={['reset']} />
 
@@ -1071,7 +1057,7 @@ Se incontri errori di lint, puoi eseguire il seguente comando per correggerli au
 
 <Aside type="caution" title="Errore di build su Windows">
 <Drawer trigger="Se sei su Windows e incontri un errore di build, clicca qui." title="Errore di build su Windows">
-Se incontri un errore di build/synth per il progetto `@dungeon-adventure/infra`, questo è previsto poiché la libreria che strumenta `cfn-guard` attualmente non supporta Windows. C'è una richiesta di funzionalità che tiene traccia di questo, ma nel frattempo possiamo semplicemente disabilitare `cfn-guard` modificando il file `packages/infra/src/main.ts` come segue:
+Se incontri un errore di build/synth per il progetto `@dungeon-adventure/infra`, questo è previsto poiché la libreria che strumenta `cfn-guard` attualmente non supporta Windows. C'è una richiesta di funzionalità che tiene traccia di questo, ma nel frattempo possiamo disabilitare `cfn-guard` modificando il file `packages/infra/src/main.ts` come segue:
 
 ```diff lang="ts"
 // packages/infra/src/main.ts
@@ -1101,6 +1087,6 @@ app.synth();
 </Drawer>
 </Aside>
 
-Tutti gli artefatti compilati sono ora disponibili nella cartella `dist/` alla radice del monorepo. Questa è una pratica standard quando si utilizzano progetti generati da `@aws/nx-plugin` poiché non inquina l'albero dei file con file generati. Nel caso volessi pulire i tuoi file, puoi semplicemente eliminare la cartella `dist/` senza preoccuparti di file generati sparsi nell'albero delle directory.
+Tutti gli artefatti di build sono ora disponibili nella cartella `dist/` alla radice del monorepo. Questa è una pratica standard quando si utilizzano progetti generati da `@aws/nx-plugin`, poiché non inquina l'albero dei file con file generati. Nel caso desideri pulire i tuoi file, puoi semplicemente eliminare la cartella `dist/` senza preoccuparti di file generati sparsi nell'albero.
 
-Congratulazioni! Hai creato tutti i sottoprogetti necessari per iniziare a implementare il cuore del nostro gioco Dungeon Adventure.  🎉🎉🎉
+Congratulazioni! Hai creato tutti i sotto-progetti necessari per iniziare a implementare il cuore del nostro gioco Dunegeon Adventure.  🎉🎉🎉

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -25,11 +25,11 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## モジュール1: モノレポのセットアップ
 
-まず新しいモノレポを作成します。任意のディレクトリ内で次のコマンドを実行してください:
+まず新しいモノレポを作成します。任意のディレクトリで次のコマンドを実行してください：
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" />
 
-これにより`dungeon-adventure`ディレクトリ内にNXモノレポがセットアップされ、vscodeで開くことができます。以下のような構造になります:
+これにより`dungeon-adventure`ディレクトリ内にNXモノレポがセットアップされ、vscodeで開くことができます。以下のような構造になります：
 
 <FileTree>
 - .nx/
@@ -42,33 +42,33 @@ import gameConversationPng from '@assets/game-conversation.png'
 - .prettierrc
 - nx.json Nx CLIとモノレポのデフォルト設定
 - package.json すべてのnode依存関係が定義
-- pnpm-lock.yaml または使用するパッケージマネージャに応じてbun.lock, yarn.lock, package-lock.json
-- pnpm-workspace.yaml pnpm使用時
+- pnpm-lock.yaml または bun.lock, yarn.lock, package-lock.json（パッケージマネージャによる）
+- pnpm-workspace.yaml（pnpm使用時）
 - README.md
 - tsconfig.base.json すべてのnodeベースサブプロジェクトが継承
 - tsconfig.json
 </FileTree>
 
-これで`@aws/nx-plugin`を使用してさまざまなサブプロジェクトを作成する準備が整いました。
+これで`@aws/nx-plugin`を使用して様々なサブプロジェクトを作成する準備が整いました。
 
-<Aside type="tip">ジェネレータを実行する前に、すべての未ステージングファイルをGitにコミットすることがベストプラクティスです。これにより`git diff`でジェネレータ実行後の変更を確認できます</Aside>
+<Aside type="tip">ジェネレータを実行する前に、すべての未ステージングファイルをGitにコミットするのがベストプラクティスです。これにより`git diff`でジェネレータ実行後の変更を確認できます</Aside>
 
-### ゲームAPI
+### Game API
 
-最初にGame APIを作成します。以下の手順で`GameApi`というtRPC APIを作成します:
+最初にGame APIを作成します。以下の手順で`GameApi`というtRPC APIを作成します：
 
 <RunGenerator generator="ts#trpc-api" requiredParameters={{ name: "GameApi" }} noInteractive />
 
 <br />
 
-ファイルツリーに新しいファイルが生成されているはずです。
+ファイルツリーに新しいファイルが表示されているはずです。
 
 <Aside>
 ルート`package.json`に`type`が`module`として設定され、`@aws/nx-plugin`が提供するすべてのnodeベースサブプロジェクトでESMがデフォルトのモジュールタイプになります。詳細は<Link path="guides/typescript-project">ts#projectガイド</Link>を参照してください。
 </Aside>
 
-<Drawer title="ts#trpc-apiで更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`ts#trpc-api`ジェネレータによって生成されたすべてのファイルのリストです。ファイルツリー内の主要なファイルを確認します:
+<Drawer title="ts#trpc-apiで更新されたファイル" trigger="詳細を確認するにはここをクリック">
+以下は`ts#trpc-api`ジェネレータで生成されたすべてのファイルです。ファイルツリー内の主要なファイルを確認します：
 <FileTree>
 - packages/
   - common/
@@ -82,7 +82,7 @@ import gameConversationPng from '@assets/game-conversation.png'
           - index.ts
         - core/ 汎用CDKコンストラクト
           - api/
-            - rest-api.ts API Gateway Rest APIベースコンストラクト
+            - rest-api.ts API Gateway Rest API用ベースコンストラクト
             - trpc-utils.ts trpc API CDKコンストラクト用ユーティリティ
             - utils.ts APIコンストラクト用ユーティリティ
           - index.ts
@@ -93,7 +93,7 @@ import gameConversationPng from '@assets/game-conversation.png'
     - types/ 共有型定義
       - src/
         - index.ts
-        - runtime-config.ts CDKとウェブサイト両方で使用されるインターフェース定義
+        - runtime-config.ts CDKとウェブサイトで使用されるインターフェース定義
       - project.json
       - ...
   - game-api/ tRPC API
@@ -114,14 +114,14 @@ import gameConversationPng from '@assets/game-conversation.png'
       - index.ts
       - init.ts コンテキストとミドルウェアのセットアップ
       - local-server.ts ローカルtRPCサーバー実行用
-      - **router.ts** すべてのプロシージャを定義するLambdaハンドラのエントリーポイント
+      - **router.ts** すべてのプロシージャを定義するLambdaハンドラのエントリポイント
     - project.json
     - ...
 - eslint.config.mjs
 - vitest.workspace.ts
 </FileTree>
 
-主要ファイルの解説:
+主要ファイルの解説：
 
 ```ts {5,12}
 // packages/game-api/src/router.ts
@@ -154,7 +154,7 @@ export const handler = awsLambdaRequestHandler({
 
 export type AppRouter = typeof appRouter;
 ```
-ルーターはtRPC APIのエントリーポイントで、すべてのAPIメソッドを宣言する場所です。`echo`メソッドの実装は`./procedures/echo.ts`にあります。
+ルーターはtRPC APIのエントリポイントで、すべてのAPIメソッドを宣言する場所です。上記の`echo`メソッドは`./procedures/echo.ts`ファイルに実装されています。
 
 ```ts {2-5}
 // packages/game-api/src/procedures/echo.ts
@@ -170,7 +170,7 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-`echo`メソッドの実装ファイルで、入力/出力データ構造を厳密に型定義しています。
+`echo`メソッドの実装ファイルで、入力・出力データ構造を厳密に型定義しています。
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -189,7 +189,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-すべてのtRPCスキーマ定義は[Zod](https://zod.dev/)を使用して定義され、`z.TypeOf`構文でTypeScript型としてエクスポートされます。
+すべてのtRPCスキーマ定義は[Zod](https://zod.dev/)を使用し、`z.TypeOf`構文でTypeScript型としてエクスポートされます。
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -298,19 +298,19 @@ export class GameApi<
 }
 ```
 
-GameApiを定義するCDKコンストラクトです。`defaultIntegrations`メソッドにより、tRPC APIの各プロシージャに対応するLambda関数が自動生成されます。バンドリングはバックエンドプロジェクトのビルドターゲットの一部として事前に行われるため、`cdk synth`時にはバンドリングが発生しません。
+GameApiを定義するCDKコンストラクトです。`defaultIntegrations`メソッドはtRPC APIの各プロシージャ用に個別のLambda関数を自動生成します。バックエンドプロジェクトのビルドターゲットでバンドル済みのため、`cdk synth`時にバンドリングが発生しません。
 
 </Drawer>
 
-### ストーリーAPI
+### Story API
 
-次にFast APIの`StoryApi`を作成します:
+次にStory APIを作成します。以下の手順で`StoryApi`というFast APIを作成します：
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-ファイルツリーに新しいファイルが生成されているはずです。
-<Drawer title="py#fast-apiで更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`py#fast-api`ジェネレータによって生成/更新されたファイル:
+ファイルツリーに新しいファイルが表示されているはずです。
+<Drawer title="py#fast-apiで更新されたファイル" trigger="詳細を確認するにはここをクリック">
+以下は`py#fast-api`ジェネレータで生成された主要ファイルです：
 <FileTree>
 - .venv/ モノレポ用仮想環境
 - packages/
@@ -320,14 +320,14 @@ GameApiを定義するCDKコンストラクトです。`defaultIntegrations`メ�
         - app/
           - apis/
             - **story-api.ts** Fast API用CDKコンストラクト
-      - project.json story_apiへのビルド依存関係追加
+      - project.json story_apiビルド依存関係追加
     - types/
       - src/
         - **runtime-config.ts** StoryApi追加
   - story_api/
     - story_api/ Pythonモジュール
-      - init.py Powertools/FastAPIセットアップ
-      - **main.py** ルート定義用Lambdaエントリーポイント
+      - init.py Powertools、FastAPI、ミドルウェア設定
+      - **main.py** ルート定義を含むLambdaエントリポイント
     - tests/
     - .python-version
     - project.json
@@ -339,23 +339,10 @@ GameApiを定義するCDKコンストラクトです。`defaultIntegrations`メ�
 
 ```ts
 // packages/common/constructs/src/app/apis/story-api.ts
-// ...（コードは原文のまま）...
+...（構造はGameApiと同様）...
 ```
 
-StoryApiを定義するCDKコンストラクトです。`defaultIntegrations`メソッドにより、FastAPIの各操作に対応するLambda関数が自動生成されます。
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-ジェネレータがAST変換を実行し、`IRuntimeConfig`定義に`StoryApi`を追加。フロントエンドで型安全に利用可能になります。
+StoryApiを定義するCDKコンストラクトです。FastAPIの各操作用に個別のLambda関数を自動生成します。
 
 ```py
 // packages/story_api/story_api/main.py
@@ -369,331 +356,227 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-APIメソッドを定義する場所です。[Pydantic](https://docs.pydantic.dev/latest/)を使用して入出力を型定義できます。
+APIメソッドを定義する場所です。[Pydantic](https://docs.pydantic.dev/latest/)を使用して型安全性を確保できます。
 
 </Drawer>
 
-### ゲームUI: ウェブサイト
+### Game UI: ウェブサイト
 
-ゲーム操作用UIを作成します:
+ゲーム操作用UIを作成します。以下の手順で`GameUI`ウェブサイトを作成します：
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-ファイルツリーに新しいファイルが生成されているはずです。
+ファイルツリーに新しいファイルが表示されているはずです。
 
-<Drawer title="ts#react-websiteで更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`ts#react-website`ジェネレータによって生成されたファイル:
+<Drawer title="ts#react-websiteで更新されたファイル" trigger="詳細を確認するにはここをクリック">
 <FileTree>
 - packages/
-  - common/
-    - constructs/
-      - src/
-        - app/
-          - static-websites/
-            - **game-ui.ts** Game UI用CDKコンストラクト
-        - core/
-          - static-website.ts 静的ウェブサイトコンストラクト
   - game-ui/
-    - public/
     - src/
       - components/
-        - AppLayout/
-          - index.ts ページレイアウト
-          - navitems.ts ナビゲーション項目
+        - AppLayout/ ページレイアウト
       - hooks/
-        - useAppLayout.tsx 通知/ページスタイル設定
+        - useAppLayout.tsx 通知やページスタイル設定
       - routes/ ファイルベースルーティング
-        - index.tsx ルートページ
-        - __root.tsx ベースコンポーネント
         - welcome/
           - **index.tsx**
-        - config.ts
-        - **main.tsx** Reactエントリーポイント
-        - routeTree.gen.ts 自動更新ファイル
-        - styles.css
-    - index.html
-    - project.json
-    - vite.config.ts
+        - ...
+    - ...
 </FileTree>
 
 ```ts
 // packages/common/constructs/src/app/static-websites/game-ui.ts
-// ...（コードは原文のまま）...
+...（バンドルパス設定）...
 ```
 
-ViteベースUIのCDKコンストラクト。ビルドターゲットの出力を参照します。
+ViteベースUIのCDKコンストラクトです。
 
 ```tsx
 // packages/game-ui/src/main.tsx
-// ...（コードは原文のまま）...
+...（Reactルーティング設定）...
 ```
 
-Reactのマウントポイント。ファイルベースルーティングを管理します。
+Reactのエントリポイントです。[ファイルベースルーティング](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)を採用しています。
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
-// ...（コードは原文のまま）...
+...（ウェルカムページコンポーネント）...
 ```
 
-`/welcome`ルート用コンポーネント。後続のセクションで表示されます。
+`/welcome`ルート用コンポーネントです。
 
 </Drawer>
 
-### ゲームUI: 認証
+### Game UI: 認証
 
-Amazon Cognito経由の認証を設定します:
+Amazon Cognitoによる認証を設定します：
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-ファイルツリーに変更が加えられています。
+ファイルツリーが更新されているはずです。
 
-<Drawer title="ts#react-website#authで更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`ts#react-website#auth`ジェネレータによる更新:
+<Drawer title="ts#react-website#authで更新されたファイル" trigger="詳細を確認するにはここをクリック">
 <FileTree>
 - packages/
-  - common/
-    - constructs/
-      - src/
-        - core/
-          - user-identity.ts ユーザープールコンストラクト
-    - types/
-      - src/
-        - runtime-config.ts Cognito設定追加
   - game-ui/
     - src/
       - components/
-        - AppLayout/
-          - index.tsx ヘッダーに認証情報追加
-        - CognitoAuth/
-          - index.ts Cognito認証管理
-        - RuntimeConfig/
-          - index.tsx ランタイム設定取得
-      - hooks/
-        - useRuntimeConfig.tsx
-      - **main.tsx** Cognito追加
+        - CognitoAuth/ Cognito認証管理
+        - RuntimeConfig/ ランタイム設定提供
+      - ...
 </FileTree>
 
 ```diff lang="tsx"
 // packages/game-ui/src/main.tsx
-// ...（コードは原文のまま）...
+...（CognitoAuthコンポーネント追加）...
 ```
 
-AST変換により`RuntimeConfigProvider`と`CognitoAuth`コンポーネントが追加され、認証機能が実装されます。
+`runtime-config.json`を使用したCognito認証設定を追加します。
 
 </Drawer>
 
-### ゲームUI: Story API接続
+### Game UI: Story API接続
 
-Story APIへの接続を設定:
+Story APIへの接続を設定します：
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-ファイルツリーに変更が加えられています。
+ファイルツリーが更新されているはずです。
 
-<Drawer title="UI -> FastAPI接続で更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`api-connection`ジェネレータによる更新:
+<Drawer title="UI -> FastAPI接続で更新されたファイル" trigger="詳細を確認するにはここをクリック">
 <FileTree>
 - packages/
   - game-ui/
     - src/
-      - hooks/
-        - useSigV4.tsx リクエスト署名用
-        - useStoryApiClient.tsx クライアント構築用
-        - useStoryApi.tsx TanStack Query統合用
-      - components/
-        - QueryClientProvider.tsx TanStack Queryプロバイダ
-        - StoryApiProvider.tsx StoryApiプロバイダ
-      - main.tsx プロバイダ追加
-    - .gitignore 生成ファイル除外
-    - project.json OpenAPIフック生成ターゲット追加
-  - story_api/
-    - scripts/
-      - generate_open_api.py
-    - project.json OpenAPI.json生成設定
+      - hooks/ APIクライアントフック
+      - components/ プロバイダコンポーネント
+    - ...
 </FileTree>
 
-```tsx {1,12-15}
-// packages/game-ui/src/hooks/useStoryApiClient.tsx
-// ...（コードは原文のまま）...
-```
-
-ビルド時に生成されるクライアントを使用するフック。詳細は<Link path="guides/api-connection/react-fastapi">React to FastAPIガイド</Link>を参照。
-
 ```tsx
-// packages/game-ui/src/components/StoryApiProvider.tsx
-// ...（コードは原文のまま）...
+// packages/game-ui/src/hooks/useStoryApiClient.tsx
+...（署名付きAPIクライアント作成）...
 ```
 
-TanStack Queryオプションを管理するプロバイダコンポーネント。
-
-<Aside type="caution">
-`src/generated/story-api/*.gen.ts`ファイルは手動で編集しないでください。APIビルド時に再生成されます。
-</Aside>
+生成されたクライアントを使用した認証済みAPIリクエスト用フックです。
 
 </Drawer>
 
-### ゲームUI: Game API接続
+### Game UI: Game API接続
 
-Game APIへの接続を設定:
+Game APIへの接続を設定します：
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-ファイルツリーに変更が加えられています。
+ファイルツリーが更新されているはずです。
 
-<Drawer title="UI -> tRPC接続で更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`api-connection`ジェネレータによる更新:
+<Drawer title="UI -> tRPC接続で更新されたファイル" trigger="詳細を確認するにはここをクリック">
 <FileTree>
 - packages/
   - game-ui/
     - src/
-      - components/
-        - GameApiClientProvider.tsx tRPCクライアント設定
-      - hooks/
-        - **useGameApi.tsx** tRPCフック
-      - **main.tsx** tRPCプロバイダ追加
-- package.json
+      - components/ tRPCプロバイダ
+      - hooks/ tRPCフック
+    - ...
 </FileTree>
 
 ```tsx
 // packages/game-ui/src/hooks/useGameApi.tsx
-// ...（コードは原文のまま）...
+...（tRPC React Query統合）...
 ```
 
-tRPCのReact Query統合を使用するフック。バックエンド変更が即時反映されます。
-
-```diff lang="tsx"
-// packages/game-ui/src/main.tsx
-// ...（コードは原文のまま）...
-```
-
-tRPCプロバイダがAST変換により追加されます。
+tRPCの型推論を活用したAPIクライアントフックです。
 
 </Drawer>
 
-### ゲームUI: インフラストラクチャ
+### Game UI: インフラストラクチャ
 
-CDKインフラストラクチャ用サブプロジェクトを作成:
+CDKインフラストラクチャプロジェクトを作成します：
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-ファイルツリーに変更が加えられています。
+ファイルツリーが更新されているはずです。
 
-<Drawer title="ts#infraで更新されたファイル" trigger="これらのファイルの詳細を確認するにはここをクリックしてください。">
-`ts#infra`ジェネレータによる更新:
+<Drawer title="ts#infraで更新されたファイル" trigger="詳細を確認するにはここをクリック">
 <FileTree>
 - packages/
-  - common/
-    - constructs/
-      - src/
-        - core/
-          - cfn-guard-rules/
-            - *.guard
-          - cfn-guard.ts
-          - index.ts
-  - infra
+  - infra/
     - src/
-      - stacks/
-        - **application-stack.ts** CDKリソース定義
-      - index.ts
-      - **main.ts** スタックエントリーポイント
-    - cdk.json
-    - project.json
-  - tsconfig.json 参照追加
-  - tsconfig.base.json エイリアス追加
+      - stacks/ CDKスタック定義
+    - ...
 </FileTree>
 
 ```ts
 // packages/infra/src/main.ts
-// ...（コードは原文のまま）...
+...（CDKアプリケーションエントリポイント）...
 ```
 
-CDKアプリケーションのエントリーポイント。`cfn-guard`を使用したインフラ検証を実施。
-
-<Aside type="tip">
-ルール抑制方法:
-###### 特定コンストラクトでルール抑制
-```typescript
-import { suppressRule } from ':dungeon-adventure/common-constructs';
-suppressRule(construct, 'RULE_NAME');
-```
-###### 子コンストラクトでルール抑制
-```typescript
-suppressRule(construct, 'RULE_NAME', (construct) => construct instanceof Bucket);
-```
-</Aside>
+[cfn-guard](https://github.com/cdklabs/cdk-validator-cfnguard)を使用したインフラ検証を設定します。
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
-// ...（コードは原文のまま）...
+...（CDKリソース定義場所）...
 ```
-
-ダンジョンアドベンチャーゲームのインフラを構築するCDKスタック。
 
 </Drawer>
 
 #### インフラストラクチャの更新
 
-`packages/infra/src/stacks/application-stack.ts`を更新して生成済みコンストラクトをインスタンス化:
+`packages/infra/src/stacks/application-stack.ts`を更新してコンストラクトをインスタンス化します：
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-各API操作に個別のLambda関数をマッピングするデフォルト統合を設定。
+各APIのデフォルト統合を設定し、操作ごとに個別のLambda関数をマッピングします。
 
 ### コードのビルド
 
-<Drawer title="Nxコマンド" trigger="初めてのコードビルドを実行します">
+<Drawer title="Nxコマンド" trigger="初回ビルドの実行">
 ###### 単一 vs 複数ターゲット
-`run-many`コマンドは複数サブプロジェクトでターゲットを実行。依存関係を正しい順序で処理します。
 
-単一プロジェクトのビルド:
+`run-many`コマンドは複数プロジェクトでターゲットを実行します。依存関係を正しい順序で処理します。
+
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
-
 ###### 依存関係の可視化
+
 <NxCommands commands={['graph']} />
 <br/>
 
 <Image src={nxGraphPng} alt="nx-graph.png" width="800" height="600" />
 
 ###### キャッシュ
-キャッシュを無効化する場合:
-<NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
 
-キャッシュクリア:
+[Nxキャッシュ](https://nx.dev/concepts/how-caching-works)により開発速度を向上。`--skip-nx-cache`でキャッシュ無効化可能：
+
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
 <NxCommands commands={['run-many --target build --all']} />
 
-以下のプロンプトが表示されます:
+以下のプロンプトが表示されたら**Yes**を選択：
 
 ```bash
- NX   The workspace is out of sync
-
-...（プロンプト内容）...
-
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks
-No, run the tasks without syncing the changes
 ```
 
-**Yes, sync the changes and run the tasks**を選択。TypeScript参照が自動設定され、IDEエラーが解消されます。
+TypeScript参照を自動的に追加し、IDEエラーを解消します。
 
 <Aside type="tip">
-リンターエラー修正:
+リンターエラー修正コマンド：
+
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
 <Aside type="caution" title="Windowsビルドエラー">
-<Drawer trigger="Windowsでビルドエラー発生時はこちら" title="Windowsビルドエラー対応">
-`@dungeon-adventure/infra`プロジェクトでエラー発生時は`packages/infra/src/main.ts`を修正:
+<Drawer trigger="Windowsでエラー発生時はこちら" title="Windowsビルドエラー対応">
+`packages/infra/src/main.ts`を修正してcfn-guardを無効化：
 
 ```diff lang="ts"
-// ...（修正内容は原文のまま）...
+-  policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
++const app = new App();
 ```
 </Drawer>
 </Aside>
 
-ビルド成果物はモノレポルートの`dist/`フォルダに生成されます。クリーン時は`dist/`を削除可能です。
-
-おめでとうございます！これでダンジョンアドベンチャーゲームのコアを実装するために必要なすべてのサブプロジェクトを作成できました。🎉🎉🎉
+ビルド成果物は`dist/`フォルダに生成されます。Dungeon Adventureゲームのコア実装に必要なすべてのサブプロジェクトを作成完了しました！ 🎉🎉🎉

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI 던전 게임"
-description: "@aws/nx-plugin을 사용하여 AI 기반 던전 모험 게임을 구축하는 방법에 대한 연습"
+description: "@aws/nx-plugin을 사용하여 AI 기반 던전 모험 게임을 구축하는 방법에 대한 안내"
 ---
 
 
@@ -25,11 +25,11 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## 모듈 1: 모노레포 설정
 
-먼저 새로운 모노레포를 생성합니다. 원하는 디렉터리에서 다음 명령어를 실행하세요:
+먼저 새로운 모노레포를 생성합니다. 원하는 디렉토리에서 다음 명령어를 실행하세요:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" />
 
-이 명령어는 `dungeon-adventure` 디렉터리 내에 NX 모노레포를 설정하며, 이후 vscode에서 열 수 있습니다. 파일 구조는 다음과 같습니다:
+이 명령어는 `dungeon-adventure` 디렉토리 내에 NX 모노레포를 설정하며, 이후 vscode에서 열 수 있습니다. 구조는 다음과 같습니다:
 
 <FileTree>
 - .nx/
@@ -40,7 +40,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 - .npmrc
 - .prettierignore
 - .prettierrc
-- nx.json Nx CLI 및 모노레포 기본 설정 구성
+- nx.json Nx CLI 및 모노레포 기본 설정
 - package.json 모든 노드 의존성 정의
 - pnpm-lock.yaml 또는 bun.lock, yarn.lock, package-lock.json (패키지 매니저에 따라 다름)
 - pnpm-workspace.yaml (pnpm 사용 시)
@@ -51,24 +51,24 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 이제 `@aws/nx-plugin`을 사용하여 다양한 서브 프로젝트를 생성할 준비가 되었습니다.
 
-<Aside type="tip">생성기를 실행하기 전에 모든 변경되지 않은 파일을 Git에 커밋하는 것이 좋습니다. 이렇게 하면 생성기 실행 후 `git diff`를 통해 변경 사항을 확인할 수 있습니다.</Aside>
+<Aside type="tip">제너레이터 실행 전 변경 사항이 없는지 Git 커밋을 권장합니다. `git diff`로 제너레이터 실행 후 변경 사항을 확인할 수 있습니다</Aside>
 
 ### 게임 API
 
-먼저 Game API를 생성해 보겠습니다. 다음 단계에 따라 `GameApi`라는 tRPC API를 생성합니다:
+먼저 Game API를 생성합니다. 다음 단계에 따라 `GameApi`라는 tRPC API를 생성하세요:
 
 <RunGenerator generator="ts#trpc-api" requiredParameters={{ name: "GameApi" }} noInteractive />
 
 <br />
 
-파일 트리에 몇 가지 새 파일이 생성된 것을 확인할 수 있습니다.
+파일 트리에 새로운 파일들이 생성된 것을 확인할 수 있습니다.
 
 <Aside>
-루트 `package.json`이 이제 `module` 유형의 `type`으로 구성되어, `@aws/nx-plugin`에서 제공하는 모든 노드 기반 서브 프로젝트의 기본 모듈 유형이 ESM이 됩니다. TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/typescript-project">ts#project 가이드</Link>를 참조하세요.
+루트 `package.json`이 `module` 타입으로 설정되어 `@aws/nx-plugin`에서 생성된 모든 노드 기반 서브 프로젝트는 기본적으로 ESM 모듈을 사용합니다. 자세한 내용은 <Link path="guides/typescript-project">ts#project 가이드</Link>를 참조하세요.
 </Aside>
 
-<Drawer title="ts#trpc-api 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
-다음은 `ts#trpc-api` 생성기에 의해 생성된 모든 파일 목록입니다. 파일 트리에서 강조 표시된 주요 파일을 살펴보겠습니다:
+<Drawer title="ts#trpc-api 생성/수정 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+다음은 `ts#trpc-api` 제너레이터가 생성한 파일 목록입니다. 파일 트리에서 강조된 주요 파일들을 살펴보겠습니다:
 <FileTree>
 - packages/
   - common/
@@ -76,14 +76,14 @@ import gameConversationPng from '@assets/game-conversation.png'
       - src/
         - app/ 애플리케이션 특화 CDK 컨스트럭트
           - apis/
-            - **game-api.ts** tRPC API를 생성하는 CDK 컨스트럭트
+            - **game-api.ts** tRPC API 생성용 CDK 컨스트럭트
             - index.ts
             - ...
           - index.ts
-        - core/ 일반적인 CDK 컨스트럭트
+        - core/ 일반적 CDK 컨스트럭트
           - api/
-            - rest-api.ts API Gateway Rest API를 위한 기본 CDK 컨스트럭트
-            - trpc-utils.ts tRPC API CDK 컨스트럭트 유틸리티
+            - rest-api.ts API Gateway Rest API 기본 컨스트럭트
+            - trpc-utils.ts trpc API CDK 유틸리티
             - utils.ts API 컨스트럭트 유틸리티
           - index.ts
           - runtime-config.ts
@@ -93,27 +93,27 @@ import gameConversationPng from '@assets/game-conversation.png'
     - types/ 공유 타입
       - src/
         - index.ts
-        - runtime-config.ts CDK와 웹사이트 모두에서 사용되는 인터페이스 정의
+        - runtime-config.ts CDK와 웹사이트에서 공용으로 사용하는 인터페이스 정의
       - project.json
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ 기계 간 통신에 사용되는 클라이언트
+      - client/ 머신 간 통신용 클라이언트
         - index.ts
         - sigv4.ts
-      - middleware/ Powertools 계측
+      - middleware/ Powertools 인스트루멘테이션
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ API 입력 및 출력 정의
+      - schema/ API 입출력 정의
         - **echo.ts**
       - procedures/ API 프로시저/라우트 구현
         - **echo.ts**
       - index.ts
       - init.ts 컨텍스트 및 미들웨어 설정
-      - local-server.ts 로컬 tRPC 서버 실행 시 사용
+      - local-server.ts 로컬 tRPC 서버 실행용
       - **router.ts** 모든 프로시저를 정의하는 람다 핸들러 진입점
     - project.json
     - ...
@@ -121,7 +121,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 - vitest.workspace.ts
 </FileTree>
 
-주요 파일 몇 가지를 살펴보겠습니다:
+주요 파일 분석:
 
 ```ts {5,12}
 // packages/game-api/src/router.ts
@@ -154,7 +154,7 @@ export const handler = awsLambdaRequestHandler({
 
 export type AppRouter = typeof appRouter;
 ```
-라우터는 tRPC API의 진입점을 정의하며 모든 API 메서드를 선언하는 곳입니다. 위 예시에서는 `echo` 메서드가 있으며, 해당 구현은 `./procedures/echo.ts` 파일에 있습니다.
+라우터는 tRPC API의 진입점으로 모든 API 메서드를 선언하는 곳입니다. 위 예시에서는 `echo` 메서드가 `./procedures/echo.ts` 파일에 구현되어 있습니다.
 
 ```ts {2-5}
 // packages/game-api/src/procedures/echo.ts
@@ -170,7 +170,7 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-이 파일은 `echo` 메서드의 구현체이며, 입력 및 출력 데이터 구조를 강력하게 타입화합니다.
+이 파일은 `echo` 메서드의 구현체로, 입력 및 출력 데이터 구조를 강력하게 타입화합니다.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -189,7 +189,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-모든 tRPC 스키마 정의는 [Zod](https://zod.dev/)를 사용하여 정의되며, `z.TypeOf` 구문을 통해 TypeScript 타입으로 내보내집니다.
+모든 tRPC 스키마 정의는 [Zod](https://zod.dev/)를 사용하며, `z.TypeOf` 구문을 통해 타입스크립트 타입으로 내보내집니다.
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -223,17 +223,36 @@ import { RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 
+// API 작업 이름을 위한 문자열 유니온 타입
 type Operations = Procedures<AppRouter>;
 
+/**
+ * GameApi 컨스트럭트 생성 속성
+ *
+ * @template TIntegrations - 작업 이름과 통합 매핑
+ */
 export interface GameApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
+  /**
+   * 작업 이름과 API Gateway 통합 매핑
+   */
   integrations: TIntegrations;
 }
 
+/**
+ * GameApi 전용 AWS API Gateway REST API 생성 및 설정 CDK 컨스트럭트
+ * @template TIntegrations - 작업 이름과 통합 매핑
+ */
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  /**
+   * 모든 작업에 대한 기본 람다 함수 통합 생성
+   *
+   * @param scope - CDK 컨스트럭트 스코프
+   * @returns 기본 람다 통합이 포함된 IntegrationBuilder
+   */
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
@@ -277,12 +296,14 @@ export class GameApi<
       },
       policy: new PolicyDocument({
         statements: [
+          // 배포 계정의 모든 AWS 자격 증명에 API 호출 권한 부여
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
+          // 브라우저 사전 요청 허용을 위한 OPTIONS 오픈
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -298,7 +319,7 @@ export class GameApi<
 }
 ```
 
-이 CDK 컨스트럭트는 GameApi를 정의합니다. `defaultIntegrations` 메서드는 tRPC API의 각 프로시저에 대해 람다 함수를 자동 생성하며, 번들된 API 구현을 가리킵니다. 이는 `cdk synth` 시점에 번들링이 발생하지 않음을 의미합니다([NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 사용과 대조적).
+이 CDK 컨스트럭트는 GameApi를 정의합니다. `defaultIntegrations` 메서드는 tRPC API의 각 프로시저에 대해 자동으로 람다 함수를 생성하며, `cdk synth` 시점에 번들링이 발생하지 않습니다(이미 빌드 타겟에서 번들링 완료).
 
 </Drawer>
 
@@ -308,16 +329,16 @@ export class GameApi<
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-파일 트리에 새 파일이 생성된 것을 확인할 수 있습니다.
-<Drawer title="py#fast-api 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
-`py#fast-api` 생성기에 의해 생성된 주요 파일:
+파일 트리에 새로운 파일들이 생성된 것을 확인할 수 있습니다.
+<Drawer title="py#fast-api 생성/수정 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+`py#fast-api` 제너레이터가 생성한 주요 파일 분석:
 <FileTree>
-- .venv/ 모노레포 단일 가상 환경
+- .venv/ 모노레포 전용 가상 환경
 - packages/
   - common/
     - constructs/
       - src/
-        - app/
+        - app/ 
           - apis/
             - **story-api.ts** Fast API CDK 컨스트럭트
       - project.json story_api 빌드 의존성 추가
@@ -325,14 +346,14 @@ export class GameApi<
       - src/
         - **runtime-config.ts** StoryApi 추가
   - story_api/
-    - story_api/
-      - init.py Powertools, FastAPI 및 미들웨어 설정
-      - **main.py** 모든 라우트를 포함하는 람다 진입점
+    - story_api/ 파이썬 모듈
+      - init.py Powertools, FastAPI, 미들웨어 설정
+      - **main.py** 모든 라우트를 포함한 람다 진입점
     - tests/
     - .python-version
     - project.json
     - pyproject.toml
-- .python-version 고정된 uv 파이썬 버전
+- .python-version 고정된 파이썬 버전
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -371,15 +392,33 @@ import {
   Operations,
 } from '../../generated/story-api/metadata.gen.js';
 
+/**
+ * StoryApi 컨스트럭트 생성 속성
+ *
+ * @template TIntegrations - 작업 이름과 통합 매핑
+ */
 export interface StoryApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
+  /**
+   * 작업 이름과 API Gateway 통합 매핑
+   */
   integrations: TIntegrations;
 }
 
+/**
+ * StoryApi 전용 AWS API Gateway REST API CDK 컨스트럭트
+ * @template TIntegrations - 작업 이름과 통합 매핑
+ */
 export class StoryApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  /**
+   * 모든 작업에 대한 기본 람다 통합 생성
+   *
+   * @param scope - CDK 컨스트럭트 스코프
+   * @returns 기본 람다 통합이 포함된 IntegrationBuilder
+   */
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: OPERATION_DETAILS,
@@ -423,12 +462,14 @@ export class StoryApi<
       },
       policy: new PolicyDocument({
         statements: [
+          // 배포 계정의 모든 AWS 자격 증명에 API 호출 권한 부여
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
+          // 브라우저 사전 요청 허용을 위한 OPTIONS 오픈
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -444,20 +485,7 @@ export class StoryApi<
 }
 ```
 
-이 CDK 컨스트럭트는 StoryApi를 정의합니다. `defaultIntegrations` 메서드는 FastAPI의 각 작업에 대해 람다 함수를 자동 생성합니다.
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-생성기가 기존 코드를 보존하면서 `IRuntimeConfig` 정의에 `StoryApi`를 추가한 예시입니다.
+이 CDK 컨스트럭트는 StoryApi를 정의하며, FastAPI의 각 작업에 대해 람다 함수를 자동 생성합니다.
 
 ```py
 // packages/story_api/story_api/main.py
@@ -471,18 +499,20 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-API 메서드는 여기에 정의됩니다. [Pydantic](https://docs.pydantic.dev/latest/)을 사용하여 입력 및 출력을 타입 안전하게 선언할 수 있습니다.
+모든 API 메서드는 이 파일에 정의됩니다. [Pydantic](https://docs.pydantic.dev/latest/)을 사용하여 타입 안전성을 보장할 수 있습니다.
 
 </Drawer>
 
 ### 게임 UI: 웹사이트
 
-게임과 상호작용할 수 있는 UI를 생성합니다:
+게임 상호작용을 위한 UI를 생성합니다:
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-파일 트리에 새 파일이 생성됩니다.
-<Drawer title="ts#react-website 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
+파일 트리에 새로운 파일들이 생성된 것을 확인할 수 있습니다.
+
+<Drawer title="ts#react-website 생성/수정 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+`ts#react-website` 제너레이터가 생성한 주요 파일 분석:
 <FileTree>
 - packages/
   - common/
@@ -492,19 +522,19 @@ API 메서드는 여기에 정의됩니다. [Pydantic](https://docs.pydantic.dev
           - static-websites/
             - **game-ui.ts** Game UI CDK 컨스트럭트
         - core/
-          - static-website.ts 일반 정적 웹사이트 컨스트럭트
+          - static-website.ts 정적 웹사이트 기본 컨스트럭트
   - game-ui/
     - public/
     - src/
       - components/
         - AppLayout/
-          - index.ts 페이지 레이아웃
+          - index.ts 페이지 레이아웃(헤더, 푸터 등)
           - navitems.ts 사이드바 네비게이션 항목
       - hooks/
         - useAppLayout.tsx 알림, 페이지 스타일 동적 설정
       - routes/ @tanstack/react-router 파일 기반 라우팅
-        - index.tsx 루트 페이지
-        - __root.tsx 기본 컴포넌트
+        - index.tsx 루트 '/' 페이지 리다이렉트
+        - __root.tsx 모든 페이지 기본 컴포넌트
         - welcome/
           - **index.tsx**
         - config.ts
@@ -536,7 +566,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Vite 기반 UI의 번들 경로가 미리 구성된 CDK 컨스트럭트입니다.
+이 CDK 컨스트럭트는 Vite 기반 UI 번들을 사용합니다.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -568,7 +598,7 @@ root &&
   );
 ```
 
-React 진입점으로, 파일 기반 라우팅을 사용합니다.
+React 진입점으로 [`file-based-routing`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)을 사용합니다.
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
@@ -595,25 +625,27 @@ function RouteComponent() {
 }
 ```
 
-`/welcome` 라우트에 렌더링되는 컴포넌트입니다.
+`/welcome` 라우트 컴포넌트 예시입니다.
 
 </Drawer>
 
 ### 게임 UI: 인증
 
-Amazon Cognito를 통한 인증을 구성합니다:
+Amazon Cognito를 통한 인증을 설정합니다:
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-파일 트리가 변경됩니다.
-<Drawer title="ts#react-website#auth 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
+파일 트리가 변경된 것을 확인할 수 있습니다.
+
+<Drawer title="ts#react-website#auth 생성/수정 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+`ts#react-website#auth` 제너레이터가 변경한 주요 파일:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
         - core/
-          - user-identity.ts 사용자/ID 풀 CDK 컨스트럭트
+          - user-identity.ts 사용자 풀/ID 풀 생성 CDK 컨스트럭트
     - types/
       - src/
         - runtime-config.ts cognitoProps 추가
@@ -621,11 +653,11 @@ Amazon Cognito를 통한 인증을 구성합니다:
     - src/
       - components/
         - AppLayout/
-          - index.tsx 헤더에 로그인 사용자/로그아웃 추가
+          - index.tsx 헤더에 사용자 정보/로그아웃 추가
         - CognitoAuth/
           - index.ts Cognito 로그인 관리
         - RuntimeConfig/
-          - index.tsx runtime-config.json 가져오기
+          - index.tsx `runtime-config.json` 가져와 컨텍스트 제공
       - hooks/
         - useRuntimeConfig.tsx
       - **main.tsx** Cognito 추가
@@ -663,36 +695,38 @@ root &&
   );
 ```
 
-`RuntimeConfigProvider`와 `CognitoAuth` 컴포넌트가 추가되어 인증을 처리합니다.
+`RuntimeConfigProvider`와 `CognitoAuth` 컴포넌트가 추가되어 Cognito 인증을 처리합니다.
 
 </Drawer>
 
 ### 게임 UI: Story API 연결
 
-Story API 연결을 구성합니다:
+이전에 생성한 Story API에 연결합니다:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-파일 트리가 변경됩니다.
-<Drawer title="UI -> FastAPI 연결 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
+파일 트리가 변경된 것을 확인할 수 있습니다.
+
+<Drawer title="UI -> FastAPI 연결 생성 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+`api-connection` 제너레이터가 변경한 주요 파일:
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - hooks/
         - useSigV4.tsx StoryApi 요청 서명
-        - useStoryApiClient.tsx StoryApi 클라이언트 생성
-        - useStoryApi.tsx TanStack Query를 사용한 StoryApi 상호작용
+        - useStoryApiClient.tsx StoryApi 클라이언트 생성 훅
+        - useStoryApi.tsx TanStack Query를 사용한 StoryApi 훅
       - components/
         - QueryClientProvider.tsx TanStack Query 클라이언트 제공자
         - StoryApiProvider.tsx StoryApi 훅 제공자
-      - main.tsx 제공자 주입
+      - main.tsx QueryClientProvider 및 StoryApiProvider 추가
     - .gitignore 생성된 클라이언트 파일 무시
     - project.json OpenAPI 훅 생성 타겟 추가
   - story_api/
     - scripts/
       - generate_open_api.py
-    - project.json openapi.json 생성
+    - project.json openapi.json 생성 설정
 </FileTree>
 
 ```tsx {1,12-15}
@@ -717,7 +751,7 @@ export const useStoryApi = (): StoryApi => {
 };
 ```
 
-StoryApi에 인증된 요청을 보내는 훅입니다.
+인증된 API 요청을 위한 훅입니다. 빌드 후 생성된 클라이언트를 사용합니다.
 
 ```tsx
 // packages/game-ui/src/components/StoryApiProvider.tsx
@@ -742,20 +776,28 @@ export const StoryApiProvider: FC<PropsWithChildren> = ({ children }) => {
     </StoryApiContext.Provider>
   );
 };
+
+export default StoryApiProvider;
 ```
 
-TanStack Query 훅을 사용하여 FastAPI와 상호작용합니다.
+TanStack Query 훅과 통합되는 제공자 컴포넌트입니다.
+
+<Aside type="caution">
+`src/generated/story-api/*.gen.ts` 파일은 수동으로 수정하면 안 됩니다. 빌드 시 재생성됩니다.
+</Aside>
 
 </Drawer>
 
 ### 게임 UI: Game API 연결
 
-Game API 연결을 구성합니다:
+이전에 생성한 Game API에 연결합니다:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-파일 트리가 변경됩니다.
-<Drawer title="UI -> tRPC 연결 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
+파일 트리가 변경된 것을 확인할 수 있습니다.
+
+<Drawer title="UI -> tRPC 연결 생성 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+`api-connection` 제너레이터가 변경한 주요 파일:
 <FileTree>
 - packages/
   - game-ui/
@@ -775,7 +817,11 @@ import { GameApiTRCPContext } from '../components/GameApiClientProvider';
 export const useGameApi = GameApiTRCPContext.useTRPC;
 ```
 
-tRPC의 React Query 통합을 사용하는 훅입니다.
+tRPC의 [React Query 통합](https://trpc.io/blog/introducing-tanstack-react-query-client)을 사용합니다.
+
+<Aside>
+`useGameApi` 훅은 빌드 없이도 백엔드 변경 사항이 즉시 반영됩니다([타입스크립트 추론](https://trpc.io/docs/concepts) 덕분).
+</Aside>
 
 ```diff lang="tsx"
 // packages/game-ui/src/main.tsx
@@ -821,12 +867,14 @@ tRPC 제공자가 주입된 `main.tsx` 파일입니다.
 
 ### 게임 UI: 인프라
 
-CDK 인프라를 생성합니다:
+CDK 인프라 프로젝트를 생성합니다:
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-파일 트리가 변경됩니다.
-<Drawer title="ts#infra 생성된 파일" trigger="자세한 내용을 보려면 여기를 클릭하세요.">
+파일 트리가 변경된 것을 확인할 수 있습니다.
+
+<Drawer title="ts#infra 생성/수정 파일" trigger="자세한 내용을 확인하려면 클릭하세요.">
+`ts#infra` 제너레이터가 생성한 주요 파일:
 <FileTree>
 - packages/
   - common/
@@ -842,10 +890,9 @@ CDK 인프라를 생성합니다:
       - stacks/
         - **application-stack.ts** CDK 리소스 정의
       - index.ts
-      - **main.ts** 모든 스택 정의
+      - **main.ts** 모든 스택 정의 진입점
     - cdk.json
     - project.json
-  - package.json
   - tsconfig.json 참조 추가
   - tsconfig.base.json 별칭 추가
 </FileTree>
@@ -874,7 +921,9 @@ new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-CDK 애플리케이션 진입점으로, `cfn-guard`를 사용한 인프라 검증을 수행합니다.
+<Aside type="tip">IDE에서 임포트 오류가 보이면 `nx sync` 실행으로 타입스크립트 참조를 동기화하세요. 자세한 내용은 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">가이드</Link> 참조.</Aside>
+
+CDK 애플리케이션 진입점으로 [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard)를 사용합니다.
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -885,34 +934,34 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // 스택 리소스 정의
+    // 스택 리소스 정의 코드
   }
 }
 ```
 
-게임 인프라를 구축할 CDK 컨스트럭트를 정의하는 파일입니다.
+던전 어드벤처 게임을 구축할 CDK 컨스트럭트를 정의할 곳입니다.
 
 </Drawer>
 
 #### 인프라 업데이트
 
-`packages/infra/src/stacks/application-stack.ts`를 업데이트하여 생성된 컨스트럭트를 인스턴스화합니다:
+`packages/infra/src/stacks/application-stack.ts`를 수정하여 생성된 컨스트럭트를 초기화합니다:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-기본 통합을 제공하여 각 API 작업을 개별 람다 함수에 매핑합니다.
+기본 통합을 사용하여 각 API 작업을 개별 람다 함수에 매핑합니다.
 
 ### 코드 빌드
 
-<Drawer title="Nx 명령어" trigger="이제 코드를 처음으로 빌드할 시간입니다">
+<Drawer title="Nx 명령어" trigger="이제 첫 빌드를 실행합니다">
 ###### 단일 vs 다중 타겟
 
-`run-many` 명령어는 여러 서브프로젝트에서 타겟을 실행합니다. 종속성 순서를 올바르게 처리합니다.
+`run-many` 명령어는 여러 서브프로젝트에 대해 타겟을 실행합니다. 종속성 순서를 보장합니다.
 
 단일 프로젝트 빌드 예시:
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
-
 ###### 의존성 시각화
+
 <NxCommands commands={['graph']} />
 <br/>
 
@@ -922,7 +971,6 @@ export class ApplicationStack extends cdk.Stack {
 
 캐시 무시 빌드:
 <NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
-
 캐시 초기화:
 <NxCommands commands={['reset']} />
 
@@ -935,26 +983,41 @@ export class ApplicationStack extends cdk.Stack {
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references...
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-**Yes, sync the changes and run the tasks**를 선택하여 tsconfig.json 참조를 자동 업데이트합니다.
+**Yes, sync the changes and run the tasks**를 선택하여 타입스크립트 참조를 자동으로 수정합니다.
 
 <Aside type="tip">
-린트 오류 시 자동 수정 명령어:
+린트 오류 시 다음 명령어로 수정:
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-<Aside type="caution" title="Windows 빌드 오류">
-<Drawer trigger="Windows에서 빌드 오류 발생 시 여기를 클릭하세요." title="Windows 빌드 오류">
-`packages/infra/src/main.ts`에서 `cfn-guard` 관련 코드를 제거합니다.
+<Aside type="caution" title="Windows 빌드 실패">
+<Drawer trigger="Windows에서 빌드 오류 발생 시 클릭" title="Windows 빌드 실패">
+`cfn-guard` 지원 문제로 `packages/infra/src/main.ts` 파일을 수정하여 비활성화:
+```diff lang="ts"
+// packages/infra/src/main.ts
+import { ApplicationStack } from './stacks/application-stack.js';
+import {
+   App,
+-  CfnGuardValidator,
+-  RuleSet,
+} from ':dungeon-adventure/common-constructs';
+-
+-const app = new App({
+-  policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
+-});
++const app = new App();
+...
+```
 </Drawer>
 </Aside>
 
-빌드 아티팩트는 `dist/` 폴더에 생성됩니다. 모든 설정이 완료되었습니다! 🎉🎉🎉
+빌드 아티팩트는 `dist/` 폴더에 생성됩니다. 정리 시 `dist/` 폴더 삭제로 모든 생성 파일을 제거할 수 있습니다.
+
+축하합니다! 던전 어드벤처 게임 구현을 위한 모든 서브 프로젝트 생성이 완료되었습니다. 🎉🎉🎉

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -23,7 +23,7 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## Módulo 1: Configuração do Monorepo
+## Módulo 1: Configuração do monorepo
 
 Vamos começar criando um novo monorepo. Dentro do diretório desejado, execute o seguinte comando:
 
@@ -35,23 +35,23 @@ Isso configurará um monorepo NX dentro do diretório `dungeon-adventure` que vo
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ aqui é onde seus subprojetos residirão
+- packages/ aqui ficarão seus subprojetos
 - .gitignore
 - .npmrc
 - .prettierignore
 - .prettierrc
 - nx.json configura o CLI do NX e padrões do monorepo
-- package.json todas as dependências do node são definidas aqui
+- package.json todas as dependências Node são definidas aqui
 - pnpm-lock.yaml ou bun.lock, yarn.lock, package-lock.json dependendo do gerenciador de pacotes
 - pnpm-workspace.yaml se usar pnpm
 - README.md
-- tsconfig.base.json todos os subprojetos baseados em node estendem este
+- tsconfig.base.json todos os subprojetos Node estendem este
 - tsconfig.json
 </FileTree>
 
 Agora estamos prontos para começar a criar nossos diferentes subprojetos usando o `@aws/nx-plugin`.
 
-<Aside type="tip">É uma melhor prática garantir que todos os arquivos não stageados estejam commitados no Git antes de executar qualquer gerador. Isso permite que você veja o que mudou após executar seu gerador via `git diff`</Aside>
+<Aside type="tip">É uma prática recomendada garantir que todos os arquivos não stageados sejam commitados no Git antes de executar qualquer gerador. Isso permite ver o que mudou após executar o gerador via `git diff`</Aside>
 
 ### Game API
 
@@ -61,14 +61,14 @@ Primeiro vamos criar nossa Game API. Para isso, vamos criar uma API tRPC chamada
 
 <br />
 
-Você deve ver alguns novos arquivos aparecerem na sua árvore de arquivos.
+Você deve ver alguns novos arquivos aparecerem em sua árvore de arquivos.
 
 <Aside>
-O `package.json` raiz agora está configurado com um `type` de `module`, o que significa que ESM é o tipo de módulo padrão para todos os subprojetos baseados em node fornecidos pelo `@aws/nx-plugin`. Para mais detalhes sobre como trabalhar com projetos TypeScript, consulte o <Link path="guides/typescript-project">guia ts#project</Link>.
+O `package.json` raiz agora está configurado com `type` como `module`, o que significa que ESM é o tipo de módulo padrão para todos os subprojetos Node fornecidos pelo `@aws/nx-plugin`. Para mais detalhes sobre projetos TypeScript, consulte o <Link path="guides/typescript-project">guia ts#project</Link>.
 </Aside>
 
-<Drawer title="Arquivos atualizados pelo ts#trpc-api" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados pelo gerador `ts#trpc-api`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+<Drawer title="Arquivos atualizados do ts#trpc-api" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de todos os arquivos gerados pelo gerador `ts#trpc-api`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
 - packages/
   - common/
@@ -82,7 +82,7 @@ Abaixo está uma lista de todos os arquivos gerados pelo gerador `ts#trpc-api`. 
           - index.ts
         - core/ constructs CDK genéricos
           - api/
-            - rest-api.ts construct base CDK para uma API Gateway Rest API
+            - rest-api.ts construct CDK base para API Gateway Rest API
             - trpc-utils.ts utilitários para constructs CDK de API tRPC
             - utils.ts utilitários para constructs de API
           - index.ts
@@ -93,7 +93,7 @@ Abaixo está uma lista de todos os arquivos gerados pelo gerador `ts#trpc-api`. 
     - types/ tipos compartilhados
       - src/
         - index.ts
-        - runtime-config.ts definição de interface usada tanto pelo CDK quanto pelo website
+        - runtime-config.ts definição de interface usada por CDK e website
       - project.json
       - ...
   - game-api/ API tRPC
@@ -101,20 +101,20 @@ Abaixo está uma lista de todos os arquivos gerados pelo gerador `ts#trpc-api`. 
       - client/ cliente vanilla tipicamente usado para chamadas máquina a máquina em TS
         - index.ts
         - sigv4.ts
-      - middleware/ instrumentação powertools
+      - middleware/ instrumentação com powertools
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ definições de inputs e outputs para sua API
+      - schema/ definições de inputs e outputs da API
         - **echo.ts**
-      - procedures/ implementações específicas para seus procedimentos/rotas da API
+      - procedures/ implementações específicas dos procedimentos/rotas da API
         - **echo.ts**
       - index.ts
       - init.ts configura contexto e middleware
       - local-server.ts usado ao executar o servidor tRPC localmente
-      - **router.ts** ponto de entrada para seu lambda handler que define todos os procedimentos
+      - **router.ts** ponto de entrada do lambda handler que define todos os procedimentos
     - project.json
     - ...
 - eslint.config.mjs
@@ -154,7 +154,7 @@ export const handler = awsLambdaRequestHandler({
 
 export type AppRouter = typeof appRouter;
 ```
-O router define o ponto de entrada para sua API tRPC e é onde você declarará todos os métodos da API. Como visto acima, temos um método chamado `echo` com sua implementação no arquivo `./procedures/echo.ts`.
+O router define o ponto de entrada da sua API tRPC e é onde você declara todos os métodos da API. Como visto acima, temos um método chamado `echo` com implementação no arquivo `./procedures/echo.ts`.
 
 ```ts {2-5}
 // packages/game-api/src/procedures/echo.ts
@@ -170,7 +170,7 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-Este arquivo é a implementação do método `echo` e como visto é fortemente tipado declarando suas estruturas de dados de entrada e saída.
+Este arquivo é a implementação do método `echo` e como visto é fortemente tipado através da declaração de suas estruturas de dados de entrada e saída.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -189,7 +189,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-Todas as definições de esquema tRPC são definidas usando [Zod](https://zod.dev/) e exportadas como tipos TypeScript via sintaxe `z.TypeOf`.
+Todas as definições de schema tRPC são definidas usando [Zod](https://zod.dev/) e exportadas como tipos TypeScript via sintaxe `z.TypeOf`.
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -223,7 +223,7 @@ import { RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 
-// Tipo union string para todos os nomes de operações da API
+// Tipo union de strings para todos os nomes de operações da API
 type Operations = Procedures<AppRouter>;
 
 /**
@@ -235,7 +235,7 @@ export interface GameApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * Mapa de nomes de operações para suas integrações do API Gateway
+   * Mapa de nomes de operações para integrações do API Gateway
    */
   integrations: TIntegrations;
 }
@@ -298,16 +298,16 @@ export class GameApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Aqui concedemos qualquer credencial AWS da conta em que o projeto é implantado para chamar a API.
-          // Acesso refinado máquina a máquina pode ser definido aqui usando principals mais específicos (ex. roles ou
-          // usuários) e recursos (ex. quais caminhos da API podem ser invocados por qual principal) se necessário.
+          // Aqui concedemos a qualquer credencial AWS da conta de deploy para chamar a API.
+          // Acesso granular máquina a máquina pode ser definido aqui usando principals mais específicos
+          // (ex: roles ou usuários) e recursos (ex: quais caminhos da API podem ser invocados por qual principal)
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // Abre OPTIONS para permitir que navegadores façam requisições preflight não autenticadas
+          // Libera OPTIONS para permitir preflight requests não autenticadas de navegadores
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -323,21 +323,21 @@ export class GameApi<
 }
 ```
 
-Este é o construct CDK que define nossa GameApi. Como visto, ele fornece um método `defaultIntegrations` que cria automaticamente uma função lambda para cada procedimento em nossa API tRPC, apontando para a implementação da API empacotada. Isso significa que no momento do `cdk synth`, o empacotamento não ocorre (em oposição ao uso de [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) pois já o empacotamos como parte do target de build do projeto backend.
+Este é o construct CDK que define nossa GameApi. Como visto, ele fornece um método `defaultIntegrations` que cria automaticamente uma função lambda para cada procedimento na API tRPC, apontando para a implementação empacotada. Isso significa que no momento do `cdk synth`, o bundling não ocorre (diferente do [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)), pois já foi empacotado como parte do target de build do projeto backend.
 
 </Drawer>
 
 ### Story API
 
-Agora vamos criar nossa Story API. Para isso, vamos criar uma API Fast chamada `StoryApi` seguindo os passos abaixo:
+Agora vamos criar nossa Story API. Para isso, vamos criar uma API FastAPI chamada `StoryApi` seguindo os passos abaixo:
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-Você deve ver alguns novos arquivos aparecerem na sua árvore de arquivos.
-<Drawer title="Arquivos atualizados pelo py#fast-api" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados pelo gerador `py#fast-api`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+Você deve ver alguns novos arquivos aparecerem em sua árvore de arquivos.
+<Drawer title="Arquivos atualizados do py#fast-api" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de todos os arquivos gerados pelo gerador `py#fast-api`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
-- .venv/ único virtual env para o monorepo
+- .venv/ único ambiente virtual para o monorepo
 - packages/
   - common/
     - constructs/
@@ -346,20 +346,20 @@ Abaixo está uma lista de todos os arquivos gerados pelo gerador `py#fast-api`. 
           - apis/
             - **story-api.ts** construct CDK para criar sua Fast API
             - index.ts atualizado para exportar a nova story-api
-      - project.json atualizado para adicionar uma dependência de build no story_api
+      - project.json atualizado para adicionar dependência de build no story_api
     - types/ tipos compartilhados
       - src/
         - **runtime-config.ts** atualizado para adicionar a StoryApi
   - story_api/
-    - story_api/ módulo python
+    - story_api/ módulo Python
       - init.py configura powertools, FastAPI e middleware
-      - **main.py** ponto de entrada para o lambda contendo todas as rotas
+      - **main.py** ponto de entrada do lambda contendo todas as rotas
     - tests/
     - .python-version
     - project.json
     - pyproject.toml
     - project.json
-- .python-version versão python fixada do uv
+- .python-version versão Python fixada do uv
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -407,7 +407,7 @@ export interface StoryApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * Mapa de nomes de operações para suas integrações do API Gateway
+   * Mapa de nomes de operações para integrações do API Gateway
    */
   integrations: TIntegrations;
 }
@@ -470,16 +470,16 @@ export class StoryApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Aqui concedemos qualquer credencial AWS da conta em que o projeto é implantado para chamar a API.
-          // Acesso refinado máquina a máquina pode ser definido aqui usando principals mais específicos (ex. roles ou
-          // usuários) e recursos (ex. quais caminhos da API podem ser invocados por qual principal) se necessário.
+          // Aqui concedemos a qualquer credencial AWS da conta de deploy para chamar a API.
+          // Acesso granular máquina a máquina pode ser definido aqui usando principals mais específicos
+          // (ex: roles ou usuários) e recursos (ex: quais caminhos da API podem ser invocados por qual principal)
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // Abre OPTIONS para permitir que navegadores façam requisições preflight não autenticadas
+          // Libera OPTIONS para permitir preflight requests não autenticadas de navegadores
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -496,21 +496,7 @@ export class StoryApi<
 
 ```
 
-Este é o construct CDK que define nossa StoryApi. Como visto, ele fornece um método `defaultIntegrations` que cria automaticamente uma função lambda para cada operação definida em nossa FastAPI, apontando para a implementação da API empacotada. Isso significa que no momento do `cdk synth`, o empacotamento não ocorre (em oposição a [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)) pois já o empacotamos como parte do target de build do projeto backend.
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-Aqui está um exemplo do gerador realizando uma transformação AST que preserva todo o código existente e realiza uma atualização. Aqui você pode ver que a `StoryApi` foi adicionada à definição `IRuntimeConfig`, o que significa que quando isso for consumido pelo frontend, irá impor type safety!
+Este é o construct CDK que define nossa StoryApi. Como visto, ele fornece um método `defaultIntegrations` que cria automaticamente uma função lambda para cada operação definida na FastAPI, apontando para a implementação empacotada. Isso significa que no momento do `cdk synth`, o bundling não ocorre (diferente do [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)), pois já foi empacotado como parte do target de build do projeto backend.
 
 ```py
 // packages/story_api/story_api/main.py
@@ -524,7 +510,7 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-Este é onde todos os seus métodos de API serão definidos. Como visto aqui, temos um método `read_root` mapeado para a rota `GET /`. Você pode usar [Pydantic](https://docs.pydantic.dev/latest/) para declarar inputs e outputs de métodos e garantir type safety.
+Este é onde todos os métodos da API serão definidos. Como visto aqui, temos um método `read_root` mapeado para a rota `GET /`. Você pode usar [Pydantic](https://docs.pydantic.dev/latest/) para declarar inputs e outputs dos métodos e garantir type safety.
 
 </Drawer>
 
@@ -534,10 +520,10 @@ Agora vamos criar a UI que permitirá interagir com o jogo. Para isso, vamos cri
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-Você deve ver alguns novos arquivos aparecerem na sua árvore de arquivos.
+Você deve ver alguns novos arquivos aparecerem em sua árvore de arquivos.
 
-<Drawer title="Arquivos atualizados pelo ts#react-website" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados pelo gerador `ts#react-website`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+<Drawer title="Arquivos atualizados do ts#react-website" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de todos os arquivos gerados pelo gerador `ts#react-website`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
 - packages/
   - common/
@@ -553,13 +539,13 @@ Abaixo está uma lista de todos os arquivos gerados pelo gerador `ts#react-websi
     - src/
       - components/
         - AppLayout/
-          - index.ts layout geral da página: cabeçalho, rodapé, sidebar, etc
+          - index.ts layout geral da página: header, footer, sidebar, etc
           - navitems.ts itens de navegação da sidebar
       - hooks/
         - useAppLayout.tsx permite definir dinamicamente notificações, estilo da página, etc
-      - routes/ rotas baseadas em arquivo do @tanstack/react-router
+      - routes/ rotas baseadas em arquivo com @tanstack/react-router
         - index.tsx página raiz '/' redireciona para '/welcome'
-        - __root.tsx todos os componentes de página usam este como base
+        - __root.tsx todas as páginas usam este componente como base
         - welcome/
           - **index.tsx**
         - config.ts
@@ -592,7 +578,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Este é o construct CDK que define nossa GameUI. Como visto, ele já configurou o caminho para o bundle gerado para nossa UI baseada em Vite. Isso significa que no momento do `build`, o empacotamento ocorre dentro do target de build do projeto game-ui e sua saída é usada aqui.
+Este é o construct CDK que define nossa GameUI. Como visto, ele já está configurado com o caminho para o bundle gerado pela UI baseada em Vite. Isso significa que no momento do `build`, o bundling ocorre dentro do target de build do projeto game-ui e sua saída é usada aqui.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -625,7 +611,7 @@ root &&
   );
 ```
 
-Este é o ponto de entrada onde o React é montado. Como mostrado, inicialmente apenas configura um `@tanstack/react-router` em uma configuração [`file-based-routing`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Isso significa que, enquanto o servidor de desenvolvimento estiver em execução, você pode simplesmente criar arquivos na pasta `routes` e o `@tanstack/react-router` criará a configuração de arquivo boilerplate para você, atualizando o arquivo `routeTree.gen.ts`. Este arquivo mantém todas as rotas de forma type-safe, o que significa que ao usar `<Link>`, a opção `to` só mostrará rotas válidas. Para mais informações, consulte a [documentação do `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
+Este é o ponto de entrada onde o React é montado. Como mostrado, ele inicialmente apenas configura um `@tanstack/react-router` em uma configuração [`file-based-routing`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Isso significa que, enquanto o servidor de desenvolvimento estiver em execução, você pode simplesmente criar arquivos na pasta `routes` e o `@tanstack/react-router` criará a configuração de arquivos automaticamente, atualizando o arquivo `routeTree.gen.ts`. Este arquivo mantém todas as rotas de forma type-safe, o que significa que ao usar `<Link>`, a opção `to` só mostrará rotas válidas. Para mais informações, consulte a [documentação do `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
@@ -662,10 +648,10 @@ Agora vamos configurar nossa Game UI para exigir acesso autenticado via Amazon C
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-Você deve ver alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
+Você deve ver alguns arquivos novos/alterados em sua árvore de arquivos.
 
-<Drawer title="Arquivos atualizados pelo ts#react-website#auth" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados/atualizados pelo gerador `ts#react-website#auth`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+<Drawer title="Arquivos atualizados do ts#react-website#auth" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de arquivos gerados/atualizados pelo gerador `ts#react-website#auth`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
 - packages/
   - common/
@@ -680,7 +666,7 @@ Abaixo está uma lista de todos os arquivos gerados/atualizados pelo gerador `ts
     - src/
       - components/
         - AppLayout/
-          - index.tsx adiciona o usuário logado/logout ao cabeçalho
+          - index.tsx adiciona usuário logado/logout ao header
         - CognitoAuth/
           - index.ts gerencia login no Cognito
         - RuntimeConfig/
@@ -723,39 +709,39 @@ root &&
   );
 ```
 
-Os componentes `RuntimeConfigProvider` e `CognitoAuth` foram adicionados ao arquivo `main.tsx` via transformação AST. Isso permite que o componente `CognitoAuth` autentique com o Amazon Cognito buscando o `runtime-config.json` que contém a configuração de conexão Cognito necessária para fazer chamadas backend ao destino correto.
+Os componentes `RuntimeConfigProvider` e `CognitoAuth` foram adicionados ao arquivo `main.tsx` via transformação AST. Isso permite que o componente `CognitoAuth` autentique com o Amazon Cognito buscando o `runtime-config.json` que contém a configuração de conexão necessária para fazer chamadas ao backend no destino correto.
 
 </Drawer>
 
 ### Game UI: Conectar à Story API
 
-Agora vamos configurar nossa Game UI para conectar à nossa Story API criada anteriormente:
+Agora vamos configurar nossa Game UI para se conectar à Story API criada anteriormente:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-Você deve ver alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
+Você deve ver alguns arquivos novos/alterados em sua árvore de arquivos.
 
-<Drawer title="Arquivos atualizados pela conexão UI -> FastAPI" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados/atualizados pelo gerador `api-connection`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+<Drawer title="Arquivos atualizados da conexão UI -> FastAPI" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de arquivos gerados/atualizados pelo gerador `api-connection`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - hooks/
-        - useSigV4.tsx usado pelo StoryApi para assinar requisições
+        - useSigV4.tsx usado pelo StoryApi para assinar requests
         - useStoryApiClient.tsx hook para construir um cliente StoryApi
-        - useStoryApi.tsx hook para interagir com o StoryApi usando TanStack Query
+        - useStoryApi.tsx hook para interagir com StoryApi usando TanStack Query
       - components/
         - QueryClientProvider.tsx provedor do cliente TanStack Query
-        - StoryApiProvider.tsx Provedor para o hook TanStack Query do StoryApi
+        - StoryApiProvider.tsx Provedor do hook TanStack Query para StoryApi
       - main.tsx Instrumenta o QueryClientProvider e StoryApiProvider
     - .gitignore ignora arquivos de cliente gerados
-    - project.json atualizado para adicionar targets para gerar hooks openapi
+    - project.json atualizado para adicionar targets de geração de hooks openapi
     - ...
   - story_api/
     - scripts/
       - generate_open_api.py
-    - project.json atualizado para emitir um arquivo openapi.json
+    - project.json atualizado para emitir arquivo openapi.json
 
 </FileTree>
 
@@ -781,7 +767,7 @@ export const useStoryApi = (): StoryApi => {
 };
 ```
 
-Este hook pode ser usado para fazer requisições de API autenticadas para o `StoryApi`. Como visto na implementação, ele usa o `StoryApi` que é gerado no momento do build e, portanto, você verá um erro em seu IDE até que construamos nosso código. Para mais detalhes sobre como o cliente é gerado ou como consumir a API, consulte o <Link path="guides/api-connection/react-fastapi">guia React para FastAPI</Link>.
+Este hook pode ser usado para fazer requests autenticadas à `StoryApi`. Como visto na implementação, ele usa o `StoryApi` gerado no build time, portanto você verá um erro no seu IDE até que o código seja buildado. Para mais detalhes sobre como o cliente é gerado ou como consumir a API, consulte o <Link path="guides/api-connection/react-fastapi">guia React para FastAPI</Link>.
 
 ```tsx
 // packages/game-ui/src/components/StoryApiProvider.tsx
@@ -815,21 +801,21 @@ O componente provedor acima usa o hook `useStoryApiClient` e instancia o `StoryA
 Como `useStoryApiClient` nos fornece um async iterator para nossa API de streaming, usaremos o cliente vanilla diretamente neste tutorial.
 
 <Aside type="caution">
-Os arquivos `src/generated/story-api/*.gen.ts` nunca devem ser modificados manualmente pois serão re-gerados toda vez que você construir sua API.
+Os arquivos `src/generated/story-api/*.gen.ts` nunca devem ser modificados manualmente, pois serão re-gerados a cada build da API.
 </Aside>
 
 </Drawer>
 
 ### Game UI: Conectar à Game API
 
-Agora vamos configurar nossa Game UI para conectar à nossa Game API criada anteriormente:
+Agora vamos configurar nossa Game UI para se conectar à Game API criada anteriormente:
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-Você deve ver alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
+Você deve ver alguns arquivos novos/alterados em sua árvore de arquivos.
 
-<Drawer title="Arquivos atualizados pela conexão UI -> tRPC" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados/atualizados pelo gerador `api-connection`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+<Drawer title="Arquivos atualizados da conexão UI -> tRPC" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de arquivos gerados/atualizados pelo gerador `api-connection`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
 - packages/
   - game-ui/
@@ -850,10 +836,10 @@ import { GameApiTRCPContext } from '../components/GameApiClientProvider';
 export const useGameApi = GameApiTRCPContext.useTRPC;
 ```
 
-Este hook usa a [integração mais recente do React Query do tRPC](https://trpc.io/blog/introducing-tanstack-react-query-client), permitindo que os usuários interajam diretamente com `@tanstack/react-query` sem camadas adicionais de abstração. Para exemplos de como chamar APIs tRPC, consulte o <Link path="guides/api-connection/react-trpc#using-the-generated-code">guia de uso do hook tRPC</Link>.
+Este hook usa a [integração com React Query](https://trpc.io/blog/introducing-tanstack-react-query-client) mais recente do tRPC, permitindo que os usuários interajam diretamente com `@tanstack/react-query` sem camadas adicionais de abstração. Para exemplos de como chamar APIs tRPC, consulte o <Link path="guides/api-connection/react-trpc#using-the-generated-code">guia de uso do hook tRPC</Link>.
 
 <Aside>
-O hook `useGameApi` é diferente do `useStoryApi` pois não requer um build para que as mudanças sejam refletidas, graças ao uso de [inferência TypeScript](https://trpc.io/docs/concepts) pelo tRPC. Isso permite que desenvolvedores façam mudanças no backend que são instantaneamente refletidas no frontend!
+O hook `useGameApi` é diferente do `useStoryApi` pois não requer um build para que as mudanças sejam refletidas, graças ao uso de [inferência de tipos TypeScript](https://trpc.io/docs/concepts) pelo tRPC. Isso permite que desenvolvedores façam mudanças no backend que são imediatamente refletidas no frontend!
 </Aside>
 
 ```diff lang="tsx"
@@ -901,14 +887,14 @@ O arquivo `main.tsx` foi atualizado via transformação AST para injetar os prov
 
 ### Game UI: Infraestrutura
 
-Agora o subprojeto final que precisamos criar é para a infraestrutura CDK. Para criar isso, siga os passos abaixo:
+Agora o último subprojeto que precisamos criar é para a infraestrutura CDK. Para criar isso, siga os passos abaixo:
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-Você deve ver alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
+Você deve ver alguns arquivos novos/alterados em sua árvore de arquivos.
 
-<Drawer title="Arquivos atualizados pelo ts#infra" trigger="Clique aqui para examinar esses arquivos em mais detalhes.">
-Abaixo está uma lista de todos os arquivos gerados/atualizados pelo gerador `ts#infra`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
+<Drawer title="Arquivos atualizados do ts#infra" trigger="Clique aqui para examinar esses arquivos em detalhes.">
+Abaixo está a lista de arquivos gerados/atualizados pelo gerador `ts#infra`. Vamos examinar alguns dos arquivos-chave destacados na árvore de arquivos:
 <FileTree>
 - packages/
   - common/
@@ -947,7 +933,7 @@ const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
 });
 
-// Use isto para implantar seu próprio ambiente sandbox (assume suas credenciais CLI)
+// Use isto para implantar seu próprio ambiente sandbox (assume credenciais CLI)
 new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -959,14 +945,14 @@ new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip">Se você está vendo um erro de importação em seu IDE, isso ocorre porque nosso projeto de infraestrutura ainda não tem uma referência TypeScript configurada em seu tsconfig.json. O Nx foi [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para criar essas referências *dinamicamente* sempre que um build/compile é executado ou se você executar o comando `nx sync` manualmente. Para mais informações, consulte o <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guia TypeScript</Link>.</Aside>
+<Aside type="tip">Se você está vendo um erro de importação no seu IDE, é porque nosso projeto de infraestrutura ainda não tem uma referência TypeScript configurada em seu tsconfig.json. O Nx foi [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para criar essas referências *dinamicamente* durante um build/compile ou se você executar o comando `nx sync` manualmente. Para mais informações, consulte o <Link path="guides/typescript-project#importing-your-library-code-inother-projects">guia TypeScript</Link>.</Aside>
 
-Este é o ponto de entrada para sua aplicação CDK.
+Este é o ponto de entrada da sua aplicação CDK.
 
-Ele está configurado para usar [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) para executar validação de infraestrutura baseada no conjunto de regras configurado. Isso é instrumentado pós-síntese.
+Ele está configurado para usar [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) para executar validação de infraestrutura baseada no conjunto de regras configurado. Isso é instrumentado pós-synthesis.
 
 <Aside type="tip">
-Pode haver casos onde você deseja suprimir certas regras em recursos. Você pode fazer isso de duas formas:
+Pode haver casos onde você queira suprimir certas regras em recursos. Você pode fazer isso de duas formas:
 
 ###### Suprimir uma regra em um construct específico
 
@@ -974,7 +960,7 @@ Pode haver casos onde você deseja suprimir certas regras em recursos. Você pod
 import { suppressRule } from ':dungeon-adventure/common-constructs';
 
 ...
-// suprime a RULE_NAME para o construct dado.
+// suprime a RULE_NAME para o construct dado
 suppressRule(construct, 'RULE_NAME');
 ```
 
@@ -1011,22 +997,21 @@ Este é onde instanciaremos nossos constructs CDK para construir nosso jogo dung
 
 Vamos atualizar nosso `packages/infra/src/stacks/application-stack.ts` para instanciar alguns de nossos constructs já gerados:
 
-
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-Note que aqui fornecemos integrações padrão para nossas duas APIs. Por padrão, cada operação em nossa API é mapeada para uma função lambda individual para lidar com essa operação.
+Note que fornecemos integrações padrão para nossas duas APIs. Por padrão, cada operação em nossa API é mapeada para uma função lambda individual para lidar com essa operação.
 
 ### Construindo nosso código
 
-<Drawer title="Comandos Nx" trigger="Agora é hora de construir nosso código pela primeira vez">
+<Drawer title="Comandos Nx" trigger="Agora é hora de buildar nosso código pela primeira vez">
 ###### Targets únicos vs múltiplos
 
-O comando `run-many` executará um target em múltiplos subprojetos listados (`--all` irá target todos). Ele garantirá que as dependências sejam executadas na ordem correta.
+O comando `run-many` executará um target em múltiplos subprojetos listados (`--all` os incluirá todos). Ele garantirá que dependências sejam executadas na ordem correta.
 
-Você também pode disparar um build (ou qualquer outra tarefa) para um target de projeto único executando o target no projeto diretamente. Por exemplo, se quisermos construir o projeto `@dungeon-adventure/infra`, você pode executar o seguinte comando:
+Você também pode acionar um build (ou qualquer outra task) para um target de projeto único executando o target diretamente no projeto. Por exemplo, se quisermos buildar o projeto `@dungeon-adventure/infra`, você pode executar:
 
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
-###### Visualizando suas dependências
+###### Visualizando dependências
 
 Você também pode visualizar suas dependências via:
 
@@ -1037,10 +1022,10 @@ Você também pode visualizar suas dependências via:
 
 ###### Cache
 
-O Nx depende de [cache](https://nx.dev/concepts/how-caching-works) para que você possa reutilizar artefatos de builds anteriores e acelerar o desenvolvimento. Há alguma configuração necessária para que isso funcione corretamente e pode haver casos onde você deseja executar um build **sem usar o cache**. Para isso, simplesmente adicione o argumento `--skip-nx-cache` ao seu comando. Por exemplo:
+O Nx usa [cache](https://nx.dev/concepts/how-caching-works) para reutilizar artefatos de builds anteriores e acelerar o desenvolvimento. Há alguma configuração necessária para que isso funcione corretamente e pode haver casos onde você queira executar um build **sem usar o cache**. Para isso, basta adicionar o argumento `--skip-nx-cache` ao comando. Por exemplo:
 
 <NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
-Se por qualquer motivo você quiser limpar seu cache (armazenado na pasta `.nx`), você pode executar o seguinte comando:
+Se por qualquer motivo você quiser limpar seu cache (armazenado na pasta `.nx`), pode executar:
 
 <NxCommands commands={['reset']} />
 
@@ -1062,17 +1047,17 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Esta mensagem indica que o NX detectou alguns arquivos que podem ser atualizados automaticamente. Neste caso, está se referindo aos arquivos `tsconfig.json` que não têm referências TypeScript configuradas em projetos referenciados. Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir. Você deve notar que todos os erros de importação relacionados ao seu IDE são resolvidos automaticamente, pois o gerador de sync adicionará as referências TypeScript faltantes automaticamente!
+Esta mensagem indica que o NX detectou alguns arquivos que podem ser atualizados automaticamente. Neste caso, refere-se aos arquivos `tsconfig.json` que não têm referências TypeScript configuradas para projetos dependentes. Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir. Você deve notar que todos os erros de importação relacionados ao IDE são resolvidos automaticamente, pois o gerador de sync adicionará as referências TypeScript faltantes!
 
 <Aside type="tip">
-Se encontrar erros de lint, você pode executar o seguinte comando para corrigi-los automaticamente.
+Se encontrar erros de lint, você pode executar o seguinte comando para corrigi-los automaticamente:
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
 <Aside type="caution" title="Falha de build no Windows">
-<Drawer trigger="Se você está no Windows e encontrar um erro de build, clique aqui." title="Falha de build no Windows">
-Se encontrar um erro de build/synth para o projeto `@dungeon-adventure/infra`, isso é esperado pois a biblioteca que instrumenta `cfn-guard` atualmente não suporta Windows. Há uma feature request acompanhando isso, porém por enquanto podemos simplesmente desabilitar o `cfn-guard` modificando o arquivo `packages/infra/src/main.ts` como segue:
+<Drawer trigger="Se estiver no Windows e encontrar um erro de build, clique aqui." title="Falha de build no Windows">
+Se encontrar um erro de build/synth para o projeto `@dungeon-adventure/infra`, isso é esperado pois a biblioteca que instrumenta o `cfn-guard` atualmente não suporta Windows. Há uma feature request acompanhando isso, mas por enquanto podemos desabilitar o `cfn-guard` modificando o arquivo `packages/infra/src/main.ts` como segue:
 
 ```diff lang="ts"
 // packages/infra/src/main.ts
@@ -1088,7 +1073,7 @@ import {
 -});
 +const app = new App();
 
-// Use isto para implantar seu próprio ambiente sandbox (assume suas credenciais CLI)
+// Use isto para implantar seu próprio ambiente sandbox (assume credenciais CLI)
 new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -1102,6 +1087,6 @@ app.synth();
 </Drawer>
 </Aside>
 
-Todos os artefatos construídos estão agora disponíveis dentro da pasta `dist/` localizada na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin` pois não polui sua árvore de arquivos com arquivos gerados. Caso queira limpar seus arquivos, você pode simplesmente deletar a pasta `dist/` sem se preocupar com arquivos gerados espalhados pela árvore de arquivos.
+Todos os artefatos buildados agora estão disponíveis na pasta `dist/` na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin`, pois não polui sua árvore de arquivos com arquivos gerados. Caso queira limpar seus arquivos, basta deletar a pasta `dist/` sem se preocupar com arquivos gerados espalhados.
 
 Parabéns! Você criou todos os subprojetos necessários para começar a implementar o núcleo do nosso jogo Dunegeon Adventure.  🎉🎉🎉

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -3,6 +3,8 @@ title: "AI地牢游戏"
 description: "使用 @aws/nx-plugin 构建人工智能驱动的地牢冒险游戏的演练。"
 ---
 
+
+
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import Link from '@components/link.astro';
@@ -21,13 +23,13 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## 模块 1: 单仓库设置
+## 模块1：Monorepo设置
 
-我们将从创建新的单仓库开始。在目标目录下运行以下命令：
+我们将从创建一个新的monorepo开始。在您期望的目录中运行以下命令：
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" />
 
-这将在 `dungeon-adventure` 目录中设置一个 NX 单仓库，之后你可以在 vscode 中打开。其结构应如下所示：
+这将在`dungeon-adventure`目录中设置一个NX monorepo，您可以在vscode中打开它。其结构应如下所示：
 
 <FileTree>
 - .nx/
@@ -38,51 +40,51 @@ import gameConversationPng from '@assets/game-conversation.png'
 - .npmrc
 - .prettierignore
 - .prettierrc
-- nx.json 配置 Nx CLI 和单仓库默认设置
-- package.json 定义所有 Node 依赖
-- pnpm-lock.yaml 或 bun.lock、yarn.lock、package-lock.json（取决于包管理器）
-- pnpm-workspace.yaml（如果使用 pnpm）
+- nx.json 配置Nx CLI和monorepo默认值
+- package.json 定义所有node依赖项
+- pnpm-lock.yaml 或 bun.lock, yarn.lock, package-lock.json（取决于包管理器）
+- pnpm-workspace.yaml（如果使用pnpm）
 - README.md
-- tsconfig.base.json 所有基于 Node 的子项目继承此配置
+- tsconfig.base.json 所有基于node的子项目继承此配置
 - tsconfig.json
 </FileTree>
 
-现在我们可以使用 `@aws/nx-plugin` 开始创建不同的子项目了。
+现在我们可以开始使用`@aws/nx-plugin`创建不同的子项目了。
 
-<Aside type="tip">最佳实践是在运行任何生成器之前，确保所有未暂存的文件都已提交到 Git。这允许你通过 `git diff` 查看生成器运行后的变更。</Aside>
+<Aside type="tip">最佳实践是在运行任何生成器之前将所有未暂存的文件提交到Git。这允许您通过`git diff`查看生成器运行后的变更</Aside>
 
-### 游戏 API
+### 游戏API
 
-首先创建游戏 API。为此，我们按照以下步骤创建一个名为 `GameApi` 的 tRPC API：
+首先创建游戏API。通过以下步骤创建一个名为`GameApi`的tRPC API：
 
 <RunGenerator generator="ts#trpc-api" requiredParameters={{ name: "GameApi" }} noInteractive />
 
 <br />
 
-你应该看到文件树中出现了一些新文件。
+您应该看到文件树中出现了一些新文件。
 
 <Aside>
-根目录的 `package.json` 现在配置了 `"type": "module"`，这意味着由 `@aws/nx-plugin` 提供的所有基于 Node 的子项目默认使用 ESM 模块类型。有关 TypeScript 项目的更多细节，请参考 <Link path="guides/typescript-project">ts#project 指南</Link>。
+根`package.json`现在配置了`type`为`module`，这意味着由`@aws/nx-plugin`提供的所有基于node的子项目默认使用ESM模块类型。有关TypeScript项目的更多细节，请参考<Link path="guides/typescript-project">ts#project指南</Link>。
 </Aside>
 
-<Drawer title="ts#trpc-api 更新文件" trigger="点击此处查看文件详情。">
-以下是 `ts#trpc-api` 生成器生成的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+<Drawer title="ts#trpc-api更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`ts#trpc-api`生成器生成的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 应用特定 CDK 构造
+        - app/ 应用特定CDK构造
           - apis/
-            - **game-api.ts** 创建 tRPC API 的 CDK 构造
+            - **game-api.ts** 创建tRPC API的CDK构造
             - index.ts
             - ...
           - index.ts
-        - core/ 通用 CDK 构造
+        - core/ 通用CDK构造
           - api/
-            - rest-api.ts API Gateway Rest API 的基础 CDK 构造
-            - trpc-utils.ts tRPC API CDK 构造的实用工具
-            - utils.ts API 构造的实用工具
+            - rest-api.ts API Gateway Rest API的基础CDK构造
+            - trpc-utils.ts trpc API CDK构造的实用工具
+            - utils.ts API构造的实用工具
           - index.ts
           - runtime-config.ts
         - index.ts
@@ -91,28 +93,28 @@ import gameConversationPng from '@assets/game-conversation.png'
     - types/ 共享类型
       - src/
         - index.ts
-        - runtime-config.ts CDK 和网站共用的接口定义
+        - runtime-config.ts 被CDK和网站共同使用的接口定义
       - project.json
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ 用于 TS 机器间调用的原生客户端
+      - client/ 通常用于TS机器间调用的原生客户端
         - index.ts
         - sigv4.ts
-      - middleware/ Powertools 工具
+      - middleware/ Powertools仪表化
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ API 输入输出定义
+      - schema/ API输入输出定义
         - **echo.ts**
-      - procedures/ API 过程/路由的具体实现
+      - procedures/ API过程/路由的具体实现
         - **echo.ts**
       - index.ts
       - init.ts 设置上下文和中间件
-      - local-server.ts 本地运行 tRPC 服务器时使用
-      - **router.ts** Lambda 处理程序的入口点，定义所有过程
+      - local-server.ts 本地运行tRPC服务器时使用
+      - **router.ts** lambda处理程序的入口点，定义所有过程
     - project.json
     - ...
 - eslint.config.mjs
@@ -152,7 +154,7 @@ export const handler = awsLambdaRequestHandler({
 
 export type AppRouter = typeof appRouter;
 ```
-路由器定义了 tRPC API 的入口点，是你声明所有 API 方法的地方。如上所示，我们有一个名为 `echo` 的方法，其实现位于 `./procedures/echo.ts` 文件。
+路由器定义了tRPC API的入口点，是声明所有API方法的地方。如上所示，我们有一个名为`echo`的方法，其实现位于`./procedures/echo.ts`文件。
 
 ```ts {2-5}
 // packages/game-api/src/procedures/echo.ts
@@ -168,7 +170,7 @@ export const echo = publicProcedure
   .query((opts) => ({ result: opts.input.message }));
 ```
 
-此文件是 `echo` 方法的实现，通过声明输入和输出数据结构进行强类型化。
+该文件是`echo`方法的实现，通过声明输入和输出数据结构进行强类型化。
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -187,7 +189,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-所有 tRPC 模式定义均使用 [Zod](https://zod.dev/) 定义，并通过 `z.TypeOf` 语法导出为 TypeScript 类型。
+所有tRPC模式定义都使用[Zod](https://zod.dev/)定义，并通过`z.TypeOf`语法导出为TypeScript类型。
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -221,11 +223,11 @@ import { RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 
-// 所有 API 操作名称的字符串联合类型
+// 所有API操作名称的字符串联合类型
 type Operations = Procedures<AppRouter>;
 
 /**
- * 创建 GameApi 构造的属性
+ * 创建GameApi构造的属性
  *
  * @template TIntegrations - 操作名称到其集成的映射
  */
@@ -233,23 +235,23 @@ export interface GameApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * 操作名称到 API Gateway 集成的映射
+   * 操作名称到API Gateway集成的映射
    */
   integrations: TIntegrations;
 }
 
 /**
- * 用于创建和配置 AWS API Gateway REST API 的 CDK 构造，专为 GameApi 设计。
+ * 专门为GameApi创建和配置AWS API Gateway REST API的CDK构造
  * @template TIntegrations - 操作名称到其集成的映射
  */
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
   /**
-   * 为所有操作创建默认集成，将每个操作实现为独立的 Lambda 函数。
+   * 为所有操作创建默认集成，将每个操作实现为单独的lambda函数
    *
-   * @param scope - CDK 构造作用域
-   * @returns 包含默认 Lambda 集成的 IntegrationBuilder
+   * @param scope - CDK构造范围
+   * @returns 包含默认lambda集成的IntegrationBuilder
    */
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
@@ -294,15 +296,14 @@ export class GameApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // 允许部署账户中的任何 AWS 凭证调用 API。
-          // 如需更细粒度的访问控制，可在此定义更具体的委托人（如角色或用户）和资源（如哪些 API 路径可由哪些委托人调用）。
+          // 允许部署账户中的任何AWS凭证调用API
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // 开放 OPTIONS 方法以允许浏览器进行未经身份验证的预检请求
+          // 开放OPTIONS以允许浏览器进行未经身份验证的预检请求
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -318,43 +319,43 @@ export class GameApi<
 }
 ```
 
-这是定义 GameApi 的 CDK 构造。其 `defaultIntegrations` 方法自动为 tRPC API 中的每个过程创建 Lambda 函数，指向已打包的 API 实现。这意味着在 `cdk synth` 时不会进行打包（与使用 [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 不同），因为打包已作为后端项目构建目标的一部分完成。
+这是定义GameApi的CDK构造。它提供了`defaultIntegrations`方法，自动为tRPC API中的每个过程创建lambda函数，指向已打包的API实现。这意味着在`cdk synth`时不会进行打包（与使用[NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)相反），因为我们已经作为后端项目构建目标的一部分进行了打包。
 
 </Drawer>
 
-### 故事 API
+### 故事API
 
-现在创建故事 API。按照以下步骤创建一个名为 `StoryApi` 的 Fast API：
+现在创建故事API。通过以下步骤创建一个名为`StoryApi`的Fast API：
 
 <RunGenerator generator="py#fast-api" requiredParameters={{name:"StoryApi", moduleName:"story_api"}} noInteractive />
 
-你应该看到文件树中出现了一些新文件。
-<Drawer title="py#fast-api 更新文件" trigger="点击此处查看文件详情。">
-以下是 `py#fast-api` 生成器生成的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+您应该看到文件树中出现了一些新文件。
+<Drawer title="py#fast-api更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`py#fast-api`生成器生成的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
-- .venv/ 单仓库的虚拟环境
+- .venv/ 单一虚拟环境
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 应用特定 CDK 构造
+        - app/ 应用特定CDK构造
           - apis/
-            - **story-api.ts** 创建 Fast API 的 CDK 构造
-            - index.ts 更新以导出新的 story-api
-      - project.json 更新以添加对 story_api 的构建依赖
+            - **story-api.ts** 创建Fast API的CDK构造
+            - index.ts 更新以导出新的story-api
+      - project.json 更新以添加对story_api的构建依赖
     - types/ 共享类型
       - src/
-        - **runtime-config.ts** 更新以添加 StoryApi
+        - **runtime-config.ts** 更新以添加StoryApi
   - story_api/
-    - story_api/ Python 模块
-      - init.py 设置 Powertools、FastAPI 和中间件
-      - **main.py** 包含所有路由的 Lambda 入口点
+    - story_api/ Python模块
+      - init.py 设置Powertools、FastAPI和中间件
+      - **main.py** 包含所有路由的lambda入口点
     - tests/
     - .python-version
     - project.json
     - pyproject.toml
     - project.json
-- .python-version 固定的 uv Python 版本
+- .python-version 固定的uv Python版本
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -394,7 +395,7 @@ import {
 } from '../../generated/story-api/metadata.gen.js';
 
 /**
- * 创建 StoryApi 构造的属性
+ * 创建StoryApi构造的属性
  *
  * @template TIntegrations - 操作名称到其集成的映射
  */
@@ -402,23 +403,23 @@ export interface StoryApiProps<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > {
   /**
-   * 操作名称到 API Gateway 集成的映射
+   * 操作名称到API Gateway集成的映射
    */
   integrations: TIntegrations;
 }
 
 /**
- * 用于创建和配置 AWS API Gateway REST API 的 CDK 构造，专为 StoryApi 设计。
+ * 专门为StoryApi创建和配置AWS API Gateway REST API的CDK构造
  * @template TIntegrations - 操作名称到其集成的映射
  */
 export class StoryApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
   /**
-   * 为所有操作创建默认集成，将每个操作实现为独立的 Lambda 函数。
+   * 为所有操作创建默认集成，将每个操作实现为单独的lambda函数
    *
-   * @param scope - CDK 构造作用域
-   * @returns 包含默认 Lambda 集成的 IntegrationBuilder
+   * @param scope - CDK构造范围
+   * @returns 包含默认lambda集成的IntegrationBuilder
    */
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
@@ -463,15 +464,14 @@ export class StoryApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // 允许部署账户中的任何 AWS 凭证调用 API。
-          // 如需更细粒度的访问控制，可在此定义更具体的委托人（如角色或用户）和资源（如哪些 API 路径可由哪些委托人调用）。
+          // 允许部署账户中的任何AWS凭证调用API
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AccountPrincipal(Stack.of(scope).account)],
             actions: ['execute-api:Invoke'],
             resources: ['execute-api:/*'],
           }),
-          // 开放 OPTIONS 方法以允许浏览器进行未经身份验证的预检请求
+          // 开放OPTIONS以允许浏览器进行未经身份验证的预检请求
           new PolicyStatement({
             effect: Effect.ALLOW,
             principals: [new AnyPrincipal()],
@@ -488,21 +488,7 @@ export class StoryApi<
 
 ```
 
-这是定义 StoryApi 的 CDK 构造。其 `defaultIntegrations` 方法自动为 FastAPI 中的每个操作创建 Lambda 函数，指向已打包的 API 实现。这意味着在 `cdk synth` 时不会进行打包（与使用 [PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html) 不同），因为打包已作为后端项目构建目标的一部分完成。
-
-```diff lang="ts"
-// packages/common/types/src/runtime-config.ts
-export type ApiUrl = string;
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {
-  apis: {
-    GameApi: ApiUrl;
-+    StoryApi: ApiUrl;
-  };
-}
-```
-
-这是生成器执行 AST 转换的示例，保留现有代码并进行更新。此处 `StoryApi` 被添加到 `IRuntimeConfig` 定义中，这意味着当最终被前端使用时，将强制执行类型安全！
+这是定义StoryApi的CDK构造。它提供了`defaultIntegrations`方法，自动为FastAPI中定义的每个操作创建lambda函数，指向已打包的API实现。这意味着在`cdk synth`时不会进行打包（与使用[PythonFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_aws-lambda-python-alpha.PythonFunction.html)相反），因为我们已经作为后端项目构建目标的一部分进行了打包。
 
 ```py
 // packages/story_api/story_api/main.py
@@ -516,28 +502,28 @@ def read_root():
     return {"Hello": "World"}
 ```
 
-这是定义所有 API 方法的地方。如上所示，我们有一个映射到 `GET /` 路由的 `read_root` 方法。你可以使用 [Pydantic](https://docs.pydantic.dev/latest/) 声明方法输入和输出以确保类型安全。
+这是定义所有API方法的地方。如这里所示，我们有一个映射到`GET /`路由的`read_root`方法。您可以使用[Pydantic](https://docs.pydantic.dev/latest/)声明方法输入和输出以确保类型安全。
 
 </Drawer>
 
-### 游戏 UI：网站
+### 游戏UI：网站
 
-现在创建用于与游戏交互的 UI。按照以下步骤创建一个名为 `GameUI` 的网站：
+现在创建用于与游戏交互的UI。通过以下步骤创建一个名为`GameUI`的网站：
 
 <RunGenerator generator="ts#react-website" requiredParameters={{name:"GameUI"}} noInteractive />
 
-你应该看到文件树中出现了一些新文件。
+您应该看到文件树中出现了一些新文件。
 
-<Drawer title="ts#react-website 更新文件" trigger="点击此处查看文件详情。">
-以下是 `ts#react-website` 生成器生成的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+<Drawer title="ts#react-website更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`ts#react-website`生成器生成的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 应用特定 CDK 构造
+        - app/ 应用特定CDK构造
           - static-websites/
-            - **game-ui.ts** 创建 Game UI 的 CDK 构造
+            - **game-ui.ts** 创建Game UI的CDK构造
         - core/
           - static-website.ts 通用静态网站构造
   - game-ui/
@@ -545,18 +531,18 @@ def read_root():
     - src/
       - components/
         - AppLayout/
-          - index.ts 整体页面布局：页头、页脚、侧边栏等
+          - index.ts 整体页面布局：页眉、页脚、侧边栏等
           - navitems.ts 侧边栏导航项
       - hooks/
         - useAppLayout.tsx 允许动态设置通知、页面样式等
-      - routes/ @tanstack/react-router 基于文件的路由
-        - index.tsx 根 '/' 页面重定向到 '/welcome'
-        - __root.tsx 所有页面的基础组件
+      - routes/ @tanstack/react-router基于文件的路由
+        - index.tsx 根'/'页面重定向到'/welcome'
+        - __root.tsx 所有页面使用此组件作为基础
         - welcome/
           - **index.tsx**
         - config.ts
-        - **main.tsx** React 入口点
-        - routeTree.gen.ts 由 @tanstack/react-router 自动更新
+        - **main.tsx** React入口点
+        - routeTree.gen.ts 由@tanstack/react-router自动更新
         - styles.css
     - index.html
     - project.json
@@ -584,7 +570,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-这是定义 GameUI 的 CDK 构造。其已配置到基于 Vite 的 UI 生成包的路径。这意味着在 `build` 时，打包发生在 game-ui 项目的构建目标中，其输出在此处使用。
+这是定义GameUI的CDK构造。它已配置了指向Vite UI生成包的文件路径。这意味着在`build`时，打包发生在game-ui项目的构建目标中，其输出在此处使用。
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -617,7 +603,7 @@ root &&
   );
 ```
 
-这是挂载 React 的入口点。如上所示，它初始配置了采用[基于文件的路由](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)的 `@tanstack/react-router`。这意味着只要开发服务器在运行，你只需在 `routes` 文件夹中创建文件，`@tanstack/react-router` 将自动生成样板文件并更新 `routeTree.gen.ts` 文件。该文件以类型安全的方式维护所有路由，因此在使用 `<Link>` 时，`to` 选项仅显示有效路由。更多信息请参考 [`@tanstack/react-router` 文档](https://tanstack.com/router/v1/docs/framework/react/quick-start)。
+这是挂载React的入口点。如所示，它最初仅配置了基于[文件路由](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)的`@tanstack/react-router`。这意味着只要开发服务器在运行，您就可以在`routes`文件夹中创建文件，`@tanstack/react-router`将自动生成样板文件并更新`routeTree.gen.ts`文件。该文件以类型安全的方式维护所有路由，因此当使用`<Link>`时，`to`选项仅显示有效路由。更多信息请参考[`@tanstack/react-router`文档](https://tanstack.com/router/v1/docs/framework/react/quick-start)。
 
 ```tsx
 // packages/game-ui/src/routes/welcome/index.tsx
@@ -635,51 +621,51 @@ export const Route = createFileRoute('/welcome/')({
 
 function RouteComponent() {
   return (
-    <ContentLayout header={<Header>Welcome</Header>}>
+    <ContentLayout header={<Header>欢迎</Header>}>
       <SpaceBetween size="l">
-        <Container>欢迎来到你的新 Cloudscape 网站！</Container>
+        <Container>欢迎来到您的新Cloudscape网站！</Container>
       </SpaceBetween>
     </ContentLayout>
   );
 }
 ```
 
-当导航到 `/welcome` 路由时，此组件将被渲染。只要开发服务器在运行，`@tanstack/react-router` 会在你创建/移动此文件时管理 `Route`。这将在本教程的后续部分展示。
+当导航到`/welcome`路由时将渲染此组件。只要开发服务器在运行，`@tanstack/react-router`将在您创建/移动此文件时管理`Route`。这将在本教程的后续部分展示。
 
 </Drawer>
 
-### 游戏 UI：认证
+### 游戏UI：身份验证
 
-现在通过以下步骤配置 Game UI，要求通过 Amazon Cognito 进行认证访问：
+现在通过以下步骤配置GameUI以通过Amazon Cognito要求身份验证访问：
 
 <RunGenerator generator="ts#react-website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-你应该看到文件树中出现了一些新增或变更的文件。
+您应该看到文件树中出现/更改了一些新文件。
 
-<Drawer title="ts#react-website#auth 更新文件" trigger="点击此处查看文件详情。">
-以下是 `ts#react-website#auth` 生成器生成/更新的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+<Drawer title="ts#react-website#auth更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`ts#react-website#auth`生成器生成/更新的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
         - core/
-          - user-identity.ts 创建用户/身份池的 CDK 构造
+          - user-identity.ts 创建用户/身份池的CDK构造
     - types/
       - src/
-        - runtime-config.ts 更新以添加 cognitoProps
+        - runtime-config.ts 更新以添加cognitoProps
   - game-ui/
     - src/
       - components/
         - AppLayout/
-          - index.tsx 在页头添加已登录用户/注销功能
+          - index.tsx 在页头添加已登录用户/注销
         - CognitoAuth/
-          - index.ts 管理 Cognito 登录
+          - index.ts 管理Cognito登录
         - RuntimeConfig/
-          - index.tsx 获取 `runtime-config.json` 并通过上下文提供给子组件
+          - index.tsx 获取`runtime-config.json`并通过上下文提供给子组件
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** 更新以添加 Cognito
+      - **main.tsx** 更新以添加Cognito
 </FileTree>
 
 ```diff lang="tsx"
@@ -715,39 +701,39 @@ root &&
   );
 ```
 
-通过 AST 转换，`main.tsx` 文件添加了 `RuntimeConfigProvider` 和 `CognitoAuth` 组件。这使得 `CognitoAuth` 组件能够通过获取包含所需 Cognito 连接配置的 `runtime-config.json` 来与 Amazon Cognito 进行认证，从而正确调用后端服务。
+通过AST转换在`main.tsx`文件中添加了`RuntimeConfigProvider`和`CognitoAuth`组件。这使得`CognitoAuth`组件能够通过获取包含所需Cognito连接配置的`runtime-config.json`来与Amazon Cognito进行身份验证，以便向后端正确目标发起调用。
 
 </Drawer>
 
-### 游戏 UI：连接故事 API
+### 游戏UI：连接到故事API
 
-现在配置 Game UI 连接到之前创建的故事 API：
+现在配置GameUI连接到之前创建的故事API：
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"dungeon_adventure.story_api"}} noInteractive />
 
-你应该看到文件树中出现了一些新增或变更的文件。
+您应该看到文件树中出现/更改了一些新文件。
 
-<Drawer title="UI -> FastAPI api-connection 更新文件" trigger="点击此处查看文件详情。">
-以下是 `api-connection` 生成器生成/更新的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+<Drawer title="UI -> FastAPI api-connection更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`api-connection`生成器生成/更新的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - hooks/
-        - useSigV4.tsx StoryApi 用于签名请求
-        - useStoryApiClient.tsx 构建 StoryApi 客户端的钩子
-        - useStoryApi.tsx 使用 TanStack Query 与 StoryApi 交互的钩子
+        - useSigV4.tsx StoryApi用于签名请求
+        - useStoryApiClient.tsx 构建StoryApi客户端的钩子
+        - useStoryApi.tsx 使用TanStack Query与StoryApi交互的钩子
       - components/
-        - QueryClientProvider.tsx TanStack Query 客户端提供者
-        - StoryApiProvider.tsx StoryApi TanStack Query 钩子的提供者
-      - main.tsx 注入 QueryClientProvider 和 StoryApiProvider
+        - QueryClientProvider.tsx TanStack Query客户端提供者
+        - StoryApiProvider.tsx StoryApi TanStack Query钩子的提供者
+      - main.tsx 注入QueryClientProvider和StoryApiProvider
     - .gitignore 忽略生成的客户端文件
-    - project.json 更新以添加生成 OpenAPI 钩子的目标
+    - project.json 更新以添加生成openapi钩子的目标
     - ...
   - story_api/
     - scripts/
       - generate_open_api.py
-    - project.json 更新以生成 openapi.json 文件
+    - project.json 更新以生成openapi.json文件
 
 </FileTree>
 
@@ -773,7 +759,7 @@ export const useStoryApi = (): StoryApi => {
 };
 ```
 
-此钩子可用于向 `StoryApi` 发起认证 API 请求。如实现所示，它使用构建时生成的 `StoryApi`，因此在构建代码前 IDE 中会显示错误。有关客户端生成或如何消费 API 的更多细节，请参考 <Link path="guides/api-connection/react-fastapi">React 到 FastAPI 指南</Link>。
+此钩子可用于向`StoryApi`发起经过身份验证的API请求。如实现所示，它使用构建时生成的`StoryApi`，因此在构建代码之前IDE中会显示错误。有关客户端生成或如何消费API的更多细节，请参考<Link path="guides/api-connection/react-fastapi">React到FastAPI指南</Link>。
 
 ```tsx
 // packages/game-ui/src/components/StoryApiProvider.tsx
@@ -802,35 +788,35 @@ export const StoryApiProvider: FC<PropsWithChildren> = ({ children }) => {
 export default StoryApiProvider;
 ```
 
-上述提供者组件使用 `useStoryApiClient` 钩子，并实例化 `StoryApiOptionsProxy`，用于构建 TanStack Query 钩子的选项。你可以使用对应的 `useStoryApi` 钩子访问此选项代理，以一致的方式与 FastAPI 交互，类似于 tRPC API。
+上述提供者组件使用`useStoryApiClient`钩子，并实例化`StoryApiOptionsProxy`，用于构建TanStack Query钩子的选项。您可以使用相应的`useStoryApi`钩子访问此选项代理，它提供了一种与FastAPI交互的方式，与tRPC API保持一致。
 
-由于 `useStoryApiClient` 为我们的流式 API 提供了异步迭代器，本教程将直接使用原生客户端。
+由于`useStoryApiClient`为我们的流式API提供了异步迭代器，在本教程中我们将直接使用原生客户端。
 
 <Aside type="caution">
-`src/generated/story-api/*.gen.ts` 文件不应手动修改，因为它们会在每次构建 API 时重新生成。
+`src/generated/story-api/*.gen.ts`文件不应手动修改，因为它们会在每次构建API时重新生成。
 </Aside>
 
 </Drawer>
 
-### 游戏 UI：连接游戏 API
+### 游戏UI：连接到游戏API
 
-现在配置 Game UI 连接到之前创建的游戏 API：
+现在配置GameUI连接到之前创建的游戏API：
 
 <RunGenerator generator="api-connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-你应该看到文件树中出现了一些新增或变更的文件。
+您应该看到文件树中出现/更改了一些新文件。
 
-<Drawer title="UI -> tRPC api-connection 更新文件" trigger="点击此处查看文件详情。">
-以下是 `api-connection` 生成器生成/更新的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+<Drawer title="UI -> tRPC api-connection更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`api-connection`生成器生成/更新的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - GameApiClientProvider.tsx 设置 GameAPI 客户端
+        - GameApiClientProvider.tsx 设置GameAPI客户端
       - hooks/
-        - **useGameApi.tsx** 调用 GameApi 的钩子
-      - **main.tsx** 注入 trpc 客户端提供者
+        - **useGameApi.tsx** 调用GameApi的钩子
+      - **main.tsx** 注入trpc客户端提供者
 - package.json
 
 </FileTree>
@@ -842,10 +828,10 @@ import { GameApiTRCPContext } from '../components/GameApiClientProvider';
 export const useGameApi = GameApiTRCPContext.useTRPC;
 ```
 
-此钩子使用 tRPC 最新的 [React Query 集成](https://trpc.io/blog/introducing-tanstack-react-query-client)，允许用户直接与 `@tanstack/react-query` 交互，无需额外抽象层。有关调用 tRPC API 的示例，请参考 <Link path="guides/api-connection/react-trpc#using-the-generated-code">使用 tRPC 钩子指南</Link>。
+此钩子使用tRPC最新的[React Query集成](https://trpc.io/blog/introducing-tanstack-react-query-client)，允许用户直接与`@tanstack/react-query`交互而无需额外的抽象层。有关如何调用tRPC API的示例，请参考<Link path="guides/api-connection/react-trpc#using-the-generated-code">使用tRPC钩子指南</Link>。
 
 <Aside>
-`useGameApi` 钩子与 `useStoryApi` 不同，由于 tRPC 使用 [Typescript 类型推断](https://trpc.io/docs/concepts)，无需构建即可反映后端变更。这使得开发者对后端的修改能即时反映到前端！
+`useGameApi`钩子与`useStoryApi`钩子不同，由于tRPC使用[TypeScript推断](https://trpc.io/docs/concepts)，它不需要构建即可反映更改。这使得开发人员对后端的更改能立即反映在前端！
 </Aside>
 
 ```diff lang="tsx"
@@ -887,20 +873,20 @@ root &&
   );
 ```
 
-通过 AST 转换，`main.tsx` 文件更新以注入 tRPC 提供者。
+通过AST转换更新了`main.tsx`文件以注入tRPC提供者。
 
 </Drawer>
 
-### 游戏 UI：基础设施
+### 游戏UI：基础设施
 
-最后需要创建的子项目是 CDK 基础设施。按照以下步骤创建：
+现在需要创建的最后一个子项目是CDK基础设施。通过以下步骤创建：
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-你应该看到文件树中出现了一些新增或变更的文件。
+您应该看到文件树中出现/更改了一些新文件。
 
-<Drawer title="ts#infra 更新文件" trigger="点击此处查看文件详情。">
-以下是 `ts#infra` 生成器生成/更新的所有文件列表。我们将重点查看文件树中突出显示的关键文件：
+<Drawer title="ts#infra更新文件" trigger="点击此处查看这些文件的详细信息。">
+以下是`ts#infra`生成器生成/更新的所有文件列表。我们将重点检查文件树中突出显示的关键文件：
 <FileTree>
 - packages/
   - common/
@@ -914,7 +900,7 @@ root &&
   - infra
     - src/
       - stacks/
-        - **application-stack.ts** 定义 CDK 资源
+        - **application-stack.ts** 在此定义CDK资源
       - index.ts
       - **main.ts** 定义所有堆栈的入口点
     - cdk.json
@@ -939,7 +925,7 @@ const app = new App({
   policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
 });
 
-// 用于部署你自己的沙盒环境（假设已配置 CLI 凭证）
+// 使用此部署您自己的沙盒环境（假设您有CLI凭证）
 new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -951,22 +937,22 @@ new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip">如果 IDE 中显示导入错误，这是因为基础设施项目尚未在 tsconfig.json 中设置 TypeScript 引用。Nx 已[配置](https://nx.dev/nx-api/js/generators/typescript-sync)为在运行构建/编译时或手动运行 `nx sync` 命令时动态创建这些引用。更多信息请参考 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript 指南</Link>。</Aside>
+<Aside type="tip">如果在IDE中看到导入错误，这是因为我们的基础设施项目尚未在其tsconfig.json中设置TypeScript引用。Nx已[配置](https://nx.dev/nx-api/js/generators/typescript-sync)为在运行构建/编译或手动运行`nx sync`命令时动态创建这些引用。更多信息请参考<Link path="guides/typescript-project#importing-your-library-code-inother-projects">TypeScript指南</Link>。</Aside>
 
-这是 CDK 应用的入口点。
+这是CDK应用程序的入口点。
 
-其配置使用 [`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard) 根据配置的规则集运行基础设施验证。此验证在合成后执行。
+它配置为使用[`cfn-guard`](https://github.com/cdklabs/cdk-validator-cfnguard)基于配置的规则集运行基础设施验证。这将在合成后执行。
 
 <Aside type="tip">
-有时你可能需要抑制某些规则在特定资源上的应用。有两种方式实现：
+在某些情况下，您可能希望抑制某些资源上的特定规则。您可以通过两种方式实现：
 
-###### 在指定构造上抑制规则
+###### 在给定构造上抑制规则
 
 ```typescript
 import { suppressRule } from ':dungeon-adventure/common-constructs';
 
 ...
-// 抑制指定构造上的 RULE_NAME 规则
+// 抑制给定构造的RULE_NAME规则
 suppressRule(construct, 'RULE_NAME');
 ```
 
@@ -976,7 +962,7 @@ suppressRule(construct, 'RULE_NAME');
 import { suppressRule } from ':dungeon-adventure/common-constructs';
 
 ...
-// 如果构造是 Bucket 实例，抑制其或其子构造上的 RULE_NAME 规则
+// 如果构造是Bucket的实例，抑制其或其子构造的RULE_NAME规则
 suppressRule(construct, 'RULE_NAME', (construct) => construct instanceof Bucket);
 ```
 </Aside>
@@ -990,36 +976,36 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // 在此定义你的堆栈代码
+    // 定义堆栈的代码在此处
   }
 }
 ```
 
-这是我们将实例化 CDK 构造以构建地牢冒险游戏的地方。
+这是我们实例化CDK构造以构建地牢冒险游戏的地方。
 
 </Drawer>
 
 #### 更新基础设施
 
-更新 `packages/infra/src/stacks/application-stack.ts` 以实例化已生成的构造：
+让我们更新`packages/infra/src/stacks/application-stack.ts`以实例化一些已生成的构造：
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-注意此处我们为两个 API 提供了默认集成。默认情况下，API 中的每个操作都映射到独立的 Lambda 函数处理。
+注意这里我们为两个API提供了默认集成。默认情况下，API中的每个操作都映射到处理该操作的独立lambda函数。
 
 ### 构建代码
 
-<Drawer title="Nx 命令" trigger="现在首次构建代码">
-###### 单目标 vs 多目标
+<Drawer title="Nx命令" trigger="现在是我们首次构建代码的时候了">
+###### 单目标与多目标
 
-`run-many` 命令将在多个列出的子项目上运行目标（`--all` 将针对所有项目）。它将确保依赖项按正确顺序执行。
+`run-many`命令将在多个列出的子项目上运行目标（`--all`将针对所有项目）。它将确保依赖项按正确顺序执行。
 
-你也可以通过直接在项目上运行目标来触发单个项目的构建（或任何其他任务）。例如，要构建 `@dungeon-adventure/infra` 项目，可运行：
+您也可以通过直接在项目上运行目标来触发单个项目目标的构建（或任何其他任务）。例如，如果我们想构建`@dungeon-adventure/infra`项目，可以运行以下命令：
 
 <NxCommands commands={['run @dungeon-adventure/infra:build']} />
-###### 可视化依赖
+###### 可视化依赖关系
 
-可通过以下命令可视化依赖关系：
+您也可以通过以下方式可视化依赖关系：
 
 <NxCommands commands={['graph']} />
 <br/>
@@ -1028,10 +1014,10 @@ export class ApplicationStack extends cdk.Stack {
 
 ###### 缓存
 
-Nx 依赖[缓存](https://nx.dev/concepts/how-caching-works)以重用先前构建的产物加速开发。需要一些配置才能正确工作，有时你可能需要执行**不使用缓存**的构建。为此，只需在命令后添加 `--skip-nx-cache` 参数。例如：
+Nx依赖[缓存](https://nx.dev/concepts/how-caching-works)以便您可以重用先前构建的产物来加速开发。需要一些配置才能正确工作，有时您可能希望执行不使用缓存的构建。为此，只需在命令后附加`--skip-nx-cache`参数。例如：
 
 <NxCommands commands={['run @dungeon-adventure/infra:build --skip-nx-cache']} />
-如需清除缓存（存储在 `.nx` 文件夹），可运行：
+如果出于某种原因需要清除缓存（存储在`.nx`文件夹中），可以运行以下命令：
 
 <NxCommands commands={['reset']} />
 
@@ -1039,7 +1025,7 @@ Nx 依赖[缓存](https://nx.dev/concepts/how-caching-works)以重用先前构�
 
 <NxCommands commands={['run-many --target build --all']} />
 
-你应该会看到以下提示：
+您应该会看到以下提示：
 
 ```bash
  NX   The workspace is out of sync
@@ -1053,17 +1039,17 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-此消息表示 NX 检测到可自动更新的文件。此处指未设置 TypeScript 引用的 `tsconfig.json` 文件。选择 **Yes, sync the changes and run the tasks** 继续。你会注意到所有 IDE 相关的导入错误自动解决，因为同步生成器会自动添加缺失的 TypeScript 引用！
+此消息表示NX检测到可以自动更新的文件。在本例中，它指的是`tsconfig.json`文件，这些文件未在引用的项目上设置TypeScript引用。选择**Yes, sync the changes and run the tasks**选项继续。您应该注意到所有IDE相关的导入错误都会自动解决，因为同步生成器会自动添加缺失的TypeScript引用！
 
 <Aside type="tip">
-如遇 lint 错误，可运行以下命令自动修复：
+如果遇到任何lint错误，可以运行以下命令自动修复：
 
 <NxCommands commands={['run-many --target lint --configuration=fix --all']} />
 </Aside>
 
-<Aside type="caution" title="Windows 构建失败">
-<Drawer trigger="若在 Windows 上遇到构建错误，点击此处。" title="Windows 构建失败">
-如果 `@dungeon-adventure/infra` 项目出现构建/合成错误，这是预期的，因为支持 `cfn-guard` 的库目前不支持 Windows。有功能请求跟踪此问题，但在此期间我们可以通过修改 `packages/infra/src/main.ts` 文件禁用 `cfn-guard`：
+<Aside type="caution" title="Windows构建失败">
+<Drawer trigger="如果您在Windows上遇到构建错误，请点击此处。" title="Windows构建失败">
+如果遇到`@dungeon-adventure/infra`项目的构建/合成错误，这是预期的，因为检测`cfn-guard`的库目前不支持Windows。有一个功能请求正在跟踪此问题，但在此期间我们可以通过修改`packages/infra/src/main.ts`文件来禁用`cfn-guard`：
 
 ```diff lang="ts"
 // packages/infra/src/main.ts
@@ -1079,7 +1065,7 @@ import {
 -});
 +const app = new App();
 
-// 用于部署你自己的沙盒环境（假设已配置 CLI 凭证）
+// 使用此部署您自己的沙盒环境（假设您有CLI凭证）
 new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -1093,6 +1079,6 @@ app.synth();
 </Drawer>
 </Aside>
 
-所有构建产物现在位于单仓库根目录的 `dist/` 文件夹中。这是使用 `@aws/nx-plugin` 生成项目的标准实践，避免生成文件污染文件树。如需清理文件，只需删除 `dist/` 文件夹，无需担心生成文件散落各处。
+所有构建产物现在都位于monorepo根目录的`dist/`文件夹中。这是使用`@aws/nx-plugin`生成项目的标准做法，因为它不会用生成的文件污染文件树。如果您想清理文件，只需删除`dist/`文件夹，而无需担心生成的文件散落在文件树中。
 
-恭喜！你已创建了开始实现地牢冒险游戏核心所需的所有子项目。🎉🎉🎉
+恭喜！您已创建了开始实现地牢冒险游戏核心所需的所有子项目。🎉🎉🎉

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -510,14 +510,13 @@ export * from './runtime-config.js';
 `;
 
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/constructs/src/core/runtime-config.ts 1`] = `
-"import type { IRuntimeConfig } from ':proj/common-types';
-import { Stack } from 'aws-cdk-lib';
+"import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
 
 export class RuntimeConfig extends Construct {
-  private readonly _runtimeConfig: Partial<IRuntimeConfig> = {};
+  private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
     const stack = Stack.of(scope);
@@ -537,7 +536,7 @@ export class RuntimeConfig extends Construct {
     super(scope, id);
   }
 
-  get config(): Partial<IRuntimeConfig> {
+  get config(): any {
     return this._runtimeConfig;
   }
 }
@@ -853,236 +852,11 @@ export default defineConfig(() => ({
 "
 `;
 
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/README.md 1`] = `
-"# @proj/common-types
-
-This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-plugin-for-aws/).
-
-## Building
-
-Run \`npx nx build @proj/common-types [--skip-nx-cache]\` to build the application.
-
-## Running unit tests
-
-Run \`npx nx test @proj/common-types\` to execute the unit tests via Vitest.
-
-### Updating snapshots
-
-To update snapshots, run the following command:
-
-\`npx nx test @proj/common-types --configuration=update-snapshot\`
-
-## Run lint
-
-Run \`npx nx lint @proj/common-types\`
-
-### Fixable issues
-
-You can also automatiaclly fix some lint errors by running the following command:
-
-\`npx nx lint @proj/common-types --configuration=fix\`
-
-## Useful links
-
-- [common-types reference docs](TODO)
-- [Learn more about NX](https://nx.dev/getting-started/intro)
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/eslint.config.mjs 1`] = `
-"import baseConfig from '../../../eslint.config.mjs';
-
-export default [
-  ...baseConfig,
-  {
-    files: ['**/*.json'],
-    rules: {
-      '@nx/dependency-checks': [
-        'warn',
-        {
-          ignoredFiles: [
-            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
-            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
-          ],
-        },
-      ],
-    },
-    languageOptions: {
-      parser: await import('jsonc-eslint-parser'),
-    },
-  },
-];
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/project.json 1`] = `
-"{
-  "name": "@proj/common-types",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/common/types/src",
-  "projectType": "library",
-  "tags": [],
-  "targets": {
-    "build": {
-      "dependsOn": ["lint", "compile", "test"]
-    },
-    "compile": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/packages/common/types/tsc"],
-      "options": {
-        "command": "tsc --build tsconfig.lib.json",
-        "cwd": "{projectRoot}"
-      }
-    },
-    "test": {
-      "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "../../../coverage/packages/common/types"
-      }
-    }
-  },
-  "metadata": {
-    "generator": "ts#project"
-  }
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/src/index.ts 1`] = `
-"export * from './runtime-config.js';
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/src/runtime-config.ts 1`] = `
-"// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/tsconfig.json 1`] = `
-"{
-  "extends": "../../../tsconfig.base.json",
-  "files": [],
-  "include": [],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
-  ],
-  "compilerOptions": {}
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/tsconfig.lib.json 1`] = `
-"{
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "../../../dist/packages/common/types/tsc",
-    "tsBuildInfoFile": "../../../dist/packages/common/types/tsc/tsconfig.lib.tsbuildinfo",
-    "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "types": ["node"]
-  },
-  "include": ["src/**/*.ts"],
-  "references": [],
-  "exclude": [
-    "vite.config.ts",
-    "vite.config.mts",
-    "vitest.config.ts",
-    "vitest.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx"
-  ]
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/tsconfig.spec.json 1`] = `
-"{
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
-    "module": "nodenext",
-    "moduleResolution": "nodenext"
-  },
-  "include": [
-    "vite.config.ts",
-    "vite.config.mts",
-    "vitest.config.ts",
-    "vitest.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/**/*.d.ts"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
-  ]
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/types/vite.config.ts 1`] = `
-"import { defineConfig } from 'vite';
-
-export default defineConfig(() => ({
-  root: __dirname,
-  cacheDir: '../../../node_modules/.vite/packages/common/types',
-  plugins: [],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
-  test: {
-    name: '@proj/common-types',
-    watch: false,
-    globals: true,
-    environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
-    coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
-      provider: 'v8' as const,
-    },
-    passWithNoTests: true,
-  },
-}));
-"
-`;
-
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > pnpm-workspace.yaml 1`] = `
 "packages:
   - 'packages/*'
   - 'test-app'
   - 'packages/common/*'
-  - 'packages/common/constructs'
 "
 `;
 
@@ -1612,7 +1386,6 @@ exports[`react-website generator > Tanstack router integration > should generate
 "{
   "compilerOptions": {
     "paths": {
-      ":proj/common-types": ["packages/common/types/src/index.ts"],
       ":proj/test-app": ["test-app/src/index.ts"],
       ":proj/common-constructs": ["packages/common/constructs/src/index.ts"]
     },
@@ -1628,9 +1401,6 @@ exports[`react-website generator > Tanstack router integration > should generate
   "references": [
     {
       "path": "./test-app"
-    },
-    {
-      "path": "./packages/common/types"
     },
     {
       "path": "./packages/common/constructs"
@@ -2040,14 +1810,13 @@ export * from './runtime-config.js';
 `;
 
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/constructs/src/core/runtime-config.ts 1`] = `
-"import type { IRuntimeConfig } from ':proj/common-types';
-import { Stack } from 'aws-cdk-lib';
+"import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
 
 export class RuntimeConfig extends Construct {
-  private readonly _runtimeConfig: Partial<IRuntimeConfig> = {};
+  private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
     const stack = Stack.of(scope);
@@ -2067,7 +1836,7 @@ export class RuntimeConfig extends Construct {
     super(scope, id);
   }
 
-  get config(): Partial<IRuntimeConfig> {
+  get config(): any {
     return this._runtimeConfig;
   }
 }
@@ -2383,236 +2152,11 @@ export default defineConfig(() => ({
 "
 `;
 
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/README.md 1`] = `
-"# @proj/common-types
-
-This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-plugin-for-aws/).
-
-## Building
-
-Run \`npx nx build @proj/common-types [--skip-nx-cache]\` to build the application.
-
-## Running unit tests
-
-Run \`npx nx test @proj/common-types\` to execute the unit tests via Vitest.
-
-### Updating snapshots
-
-To update snapshots, run the following command:
-
-\`npx nx test @proj/common-types --configuration=update-snapshot\`
-
-## Run lint
-
-Run \`npx nx lint @proj/common-types\`
-
-### Fixable issues
-
-You can also automatiaclly fix some lint errors by running the following command:
-
-\`npx nx lint @proj/common-types --configuration=fix\`
-
-## Useful links
-
-- [common-types reference docs](TODO)
-- [Learn more about NX](https://nx.dev/getting-started/intro)
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/eslint.config.mjs 1`] = `
-"import baseConfig from '../../../eslint.config.mjs';
-
-export default [
-  ...baseConfig,
-  {
-    files: ['**/*.json'],
-    rules: {
-      '@nx/dependency-checks': [
-        'warn',
-        {
-          ignoredFiles: [
-            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
-            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
-          ],
-        },
-      ],
-    },
-    languageOptions: {
-      parser: await import('jsonc-eslint-parser'),
-    },
-  },
-];
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/project.json 1`] = `
-"{
-  "name": "@proj/common-types",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/common/types/src",
-  "projectType": "library",
-  "tags": [],
-  "targets": {
-    "build": {
-      "dependsOn": ["lint", "compile", "test"]
-    },
-    "compile": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/packages/common/types/tsc"],
-      "options": {
-        "command": "tsc --build tsconfig.lib.json",
-        "cwd": "{projectRoot}"
-      }
-    },
-    "test": {
-      "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "../../../coverage/packages/common/types"
-      }
-    }
-  },
-  "metadata": {
-    "generator": "ts#project"
-  }
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/src/index.ts 1`] = `
-"export * from './runtime-config.js';
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/src/runtime-config.ts 1`] = `
-"// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/tsconfig.json 1`] = `
-"{
-  "extends": "../../../tsconfig.base.json",
-  "files": [],
-  "include": [],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
-  ],
-  "compilerOptions": {}
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/tsconfig.lib.json 1`] = `
-"{
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "../../../dist/packages/common/types/tsc",
-    "tsBuildInfoFile": "../../../dist/packages/common/types/tsc/tsconfig.lib.tsbuildinfo",
-    "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "types": ["node"]
-  },
-  "include": ["src/**/*.ts"],
-  "references": [],
-  "exclude": [
-    "vite.config.ts",
-    "vite.config.mts",
-    "vitest.config.ts",
-    "vitest.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx"
-  ]
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/tsconfig.spec.json 1`] = `
-"{
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
-    "module": "nodenext",
-    "moduleResolution": "nodenext"
-  },
-  "include": [
-    "vite.config.ts",
-    "vite.config.mts",
-    "vitest.config.ts",
-    "vitest.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/**/*.d.ts"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
-  ]
-}
-"
-`;
-
-exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/types/vite.config.ts 1`] = `
-"import { defineConfig } from 'vite';
-
-export default defineConfig(() => ({
-  root: __dirname,
-  cacheDir: '../../../node_modules/.vite/packages/common/types',
-  plugins: [],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
-  test: {
-    name: '@proj/common-types',
-    watch: false,
-    globals: true,
-    environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
-    coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
-      provider: 'v8' as const,
-    },
-    passWithNoTests: true,
-  },
-}));
-"
-`;
-
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > pnpm-workspace.yaml 1`] = `
 "packages:
   - 'packages/*'
   - 'test-app'
   - 'packages/common/*'
-  - 'packages/common/constructs'
 "
 `;
 
@@ -3381,7 +2925,6 @@ exports[`react-website generator > Tanstack router integration > should generate
 "{
   "compilerOptions": {
     "paths": {
-      ":proj/common-types": ["packages/common/types/src/index.ts"],
       ":proj/test-app": ["test-app/src/index.ts"],
       ":proj/common-constructs": ["packages/common/constructs/src/index.ts"]
     },
@@ -3397,9 +2940,6 @@ exports[`react-website generator > Tanstack router integration > should generate
   "references": [
     {
       "path": "./test-app"
-    },
-    {
-      "path": "./packages/common/types"
     },
     {
       "path": "./packages/common/constructs"

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
@@ -661,53 +661,6 @@ export default AppLayout;
     ).rejects.toThrow(/A Cognito domain must be specified/);
   });
 
-  it('should not duplicate comments in IRuntimeConfig', async () => {
-    tree.write(
-      'packages/test-project/src/main.tsx',
-      `
-      import { RuntimeConfigProvider } from './components/RuntimeConfig';
-      import { RouterProvider, createRouter } from '@tanstack/react-router';
-
-      export function App() {
-
-        const App = () => <RouterProvider router={router} />;
-
-        return (
-          <RuntimeConfigProvider>
-            <App/>
-          </RuntimeConfigProvider>
-        );
-      }
-    `,
-    );
-
-    await sharedConstructsGenerator(tree);
-
-    tree.write(
-      'packages/common/types/src/runtime-config.ts',
-      `
-// Some comment
-export interface IRuntimeConfig {}
-      `,
-    );
-
-    await tsReactWebsiteAuthGenerator(tree, {
-      ...options,
-    });
-
-    const runtimeConfigContent = tree.read(
-      'packages/common/types/src/runtime-config.ts',
-      'utf-8',
-    );
-    expect(runtimeConfigContent).toContain(`
-// Some comment
-export interface IRuntimeConfig`);
-
-    expect(runtimeConfigContent.indexOf('Some comment')).toEqual(
-      runtimeConfigContent.lastIndexOf('Some comment'),
-    );
-  });
-
   it('should add generator metric to app.ts', async () => {
     // Set up test tree with shared constructs
     await sharedConstructsGenerator(tree);

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/__snapshots__/generator.spec.ts.snap
@@ -8,7 +8,9 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import type { IRuntimeConfig } from ':proj/common-types';
+
+// Consider specifying types if desired
+export type IRuntimeConfig = any;
 
 /**
  * Context for storing the runtimeConfig.
@@ -69,14 +71,13 @@ export * from './runtime-config.js';
 `;
 
 exports[`runtime-config generator > should generate shared constructs > runtime-config.ts 1`] = `
-"import type { IRuntimeConfig } from ':proj/common-types';
-import { Stack } from 'aws-cdk-lib';
+"import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
 
 export class RuntimeConfig extends Construct {
-  private readonly _runtimeConfig: Partial<IRuntimeConfig> = {};
+  private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
     const stack = Stack.of(scope);
@@ -96,7 +97,7 @@ export class RuntimeConfig extends Construct {
     super(scope, id);
   }
 
-  get config(): Partial<IRuntimeConfig> {
+  get config(): any {
     return this._runtimeConfig;
   }
 }

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/files/app/components/RuntimeConfig/index.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/files/app/components/RuntimeConfig/index.tsx.template
@@ -1,6 +1,8 @@
 import { Spinner } from '@cloudscape-design/components';
 import React, { createContext, PropsWithChildren, useEffect, useState } from 'react';
-import type { IRuntimeConfig } from '<%= scopeAlias %>common-types';
+
+// Consider specifying types if desired
+export type IRuntimeConfig = any;
 
 /**
  * Context for storing the runtimeConfig.

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/files/app/hooks/useRuntimeConfig.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/files/app/hooks/useRuntimeConfig.tsx.template
@@ -1,6 +1,5 @@
 import { useContext } from 'react';
-import { RuntimeConfigContext } from '../components/RuntimeConfig';
-import { IRuntimeConfig } from '<%= scopeAlias %>common-types';
+import { RuntimeConfigContext, IRuntimeConfig } from '../components/RuntimeConfig';
 
 export const useRuntimeConfig = (): IRuntimeConfig => {
   const runtimeConfig = useContext(RuntimeConfigContext);

--- a/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
@@ -38,14 +38,13 @@ export * from './runtime-config.js';
 `;
 
 exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/runtime-config.ts 1`] = `
-"import type { IRuntimeConfig } from ':test-scope/common-types';
-import { Stack } from 'aws-cdk-lib';
+"import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
 
 export class RuntimeConfig extends Construct {
-  private readonly _runtimeConfig: Partial<IRuntimeConfig> = {};
+  private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
     const stack = Stack.of(scope);
@@ -65,7 +64,7 @@ export class RuntimeConfig extends Construct {
     super(scope, id);
   }
 
-  get config(): Partial<IRuntimeConfig> {
+  get config(): any {
     return this._runtimeConfig;
   }
 }
@@ -75,16 +74,5 @@ export class RuntimeConfig extends Construct {
 exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/index.ts 1`] = `
 "export * from './app/index.js';
 export * from './core/index.js';
-"
-`;
-
-exports[`shared-constructs utils > sharedConstructsGenerator > should generate type definitions when they do not exist > packages/common/types/src/index.ts 1`] = `
-"export * from './runtime-config.js';
-"
-`;
-
-exports[`shared-constructs utils > sharedConstructsGenerator > should generate type definitions when they do not exist > packages/common/types/src/runtime-config.ts 1`] = `
-"// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {}
 "
 `;

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/runtime-config.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/runtime-config.ts.template
@@ -1,12 +1,11 @@
-import type { IRuntimeConfig } from '<%= scopeAlias %>common-types';
 import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
 
 export class RuntimeConfig extends Construct {
-  private readonly _runtimeConfig: Partial<IRuntimeConfig> = {};
-  
+  private readonly _runtimeConfig: any = {};
+
   static ensure(scope: Construct): RuntimeConfig {
     const stack = Stack.of(scope);
     return (
@@ -25,7 +24,7 @@ export class RuntimeConfig extends Construct {
     super(scope, id);
   }
 
-  get config(): Partial<IRuntimeConfig> {
+  get config(): any {
     return this._runtimeConfig;
   }
 }

--- a/packages/nx-plugin/src/utils/files/common/types/src/index.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/types/src/index.ts.template
@@ -1,1 +1,0 @@
-export * from './runtime-config.js';

--- a/packages/nx-plugin/src/utils/files/common/types/src/runtime-config.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/types/src/runtime-config.ts.template
@@ -1,2 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
-export interface IRuntimeConfig {}

--- a/packages/nx-plugin/src/utils/shared-constructs-constants.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs-constants.ts
@@ -4,7 +4,5 @@
  */
 
 export const PACKAGES_DIR = 'packages';
-export const TYPE_DEFINITIONS_NAME = 'common-types';
 export const SHARED_CONSTRUCTS_NAME = 'common-constructs';
-export const TYPE_DEFINITIONS_DIR = 'common/types';
 export const SHARED_CONSTRUCTS_DIR = 'common/constructs';

--- a/packages/nx-plugin/src/utils/shared-constructs.spec.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.spec.ts
@@ -7,9 +7,7 @@ import { Tree, joinPathFragments } from '@nx/devkit';
 import { sharedConstructsGenerator } from './shared-constructs';
 import {
   PACKAGES_DIR,
-  TYPE_DEFINITIONS_DIR,
   SHARED_CONSTRUCTS_DIR,
-  TYPE_DEFINITIONS_NAME,
   SHARED_CONSTRUCTS_NAME,
 } from './shared-constructs-constants';
 import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from './test';
@@ -34,35 +32,6 @@ describe('shared-constructs utils', () => {
   });
 
   describe('sharedConstructsGenerator', () => {
-    it('should generate type definitions when they do not exist', async () => {
-      await sharedConstructsGenerator(tree);
-
-      // Check if type definitions project was created
-      expect(
-        tree.exists(
-          joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'project.json'),
-        ),
-      ).toBeTruthy();
-
-      // Check if type definitions source files were generated
-      expect(
-        tree.exists(
-          joinPathFragments(
-            PACKAGES_DIR,
-            TYPE_DEFINITIONS_DIR,
-            'src',
-            'index.ts',
-          ),
-        ),
-      ).toBeTruthy();
-
-      // Take snapshots of the generated source files
-      snapshotTreeDir(
-        tree,
-        joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'src'),
-      );
-    });
-
     it('should generate shared constructs when they do not exist', async () => {
       await sharedConstructsGenerator(tree);
 
@@ -118,34 +87,6 @@ describe('shared-constructs utils', () => {
       expect(packageJson.dependencies).toHaveProperty('constructs');
       expect(packageJson.dependencies).toHaveProperty('aws-cdk-lib');
       expect(packageJson.devDependencies).toHaveProperty('@types/node');
-    });
-
-    it('should not generate type definitions when they already exist', async () => {
-      // Create type definitions project first
-      tree.write(
-        joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'project.json'),
-        JSON.stringify({
-          name: TYPE_DEFINITIONS_NAME,
-          sourceRoot: joinPathFragments(
-            PACKAGES_DIR,
-            TYPE_DEFINITIONS_DIR,
-            'src',
-          ),
-        }),
-      );
-
-      // Create a marker file to check if it gets overwritten
-      const markerFilePath = joinPathFragments(
-        PACKAGES_DIR,
-        TYPE_DEFINITIONS_DIR,
-        'marker.txt',
-      );
-      tree.write(markerFilePath, 'This is a marker file');
-
-      await sharedConstructsGenerator(tree);
-
-      // Check if marker file still exists (meaning the directory wasn't recreated)
-      expect(tree.exists(markerFilePath)).toBeTruthy();
     });
 
     it('should not generate shared constructs when they already exist', async () => {

--- a/packages/nx-plugin/src/utils/shared-constructs.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.ts
@@ -17,8 +17,6 @@ import { withVersions } from './versions';
 import { formatFilesInSubtree } from './format';
 import {
   PACKAGES_DIR,
-  TYPE_DEFINITIONS_DIR,
-  TYPE_DEFINITIONS_NAME,
   SHARED_CONSTRUCTS_DIR,
   SHARED_CONSTRUCTS_NAME,
 } from './shared-constructs-constants';
@@ -37,43 +35,6 @@ export async function sharedConstructsGenerator(
   updateGitignore(tree);
 
   if (iacProvider === 'CDK') {
-    if (
-      !tree.exists(
-        joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'project.json'),
-      )
-    ) {
-      await tsProjectGenerator(tree, {
-        name: TYPE_DEFINITIONS_NAME,
-        directory: PACKAGES_DIR,
-        subDirectory: TYPE_DEFINITIONS_DIR,
-      });
-      tree.delete(joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'src'));
-      generateFiles(
-        tree,
-        joinPathFragments(__dirname, 'files', TYPE_DEFINITIONS_DIR, 'src'),
-        joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR, 'src'),
-        {
-          npmScopePrefix,
-        },
-        {
-          overwriteStrategy: OverwriteStrategy.KeepExisting,
-        },
-      );
-      generateFiles(
-        tree,
-        joinPathFragments(__dirname, 'files', 'common', 'readme'),
-        joinPathFragments(PACKAGES_DIR, TYPE_DEFINITIONS_DIR),
-        {
-          fullyQualifiedName: `${npmScopePrefix}${TYPE_DEFINITIONS_NAME}`,
-          name: TYPE_DEFINITIONS_NAME,
-          pkgMgrCmd: getPackageManagerCommand().exec,
-        },
-        {
-          overwriteStrategy: OverwriteStrategy.Overwrite,
-        },
-      );
-      await formatFilesInSubtree(tree);
-    }
     if (
       !tree.exists(
         joinPathFragments(PACKAGES_DIR, SHARED_CONSTRUCTS_DIR, 'project.json'),


### PR DESCRIPTION
### Reason for this change

An entire project dedicated to type safety for a few properties was overkill and added too much complexity to the generators which needed to perform ast transforms.

Removing this makes it easier to extend in future for eg Python backends consuming runtime configs or Terraform infrastructure writing them.

### Description of changes

This change removes the common-types package and the IRuntimeConfig type, and instead the website just uses `any` for the result of reading `runtime-config.json`.

### Description of how you validated changes

Created a test project with trpc, fastapi, website, infra. Built & deployed.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*