### PR TITLE
feat(ts#infra): wrap stack in a stage and support cross-stack runtime config

### DIFF
--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -118,7 +118,7 @@ If you encounter any lint errors, you can run the following command to automatic
 
 Run the following command to deploy your project:
 
-<NxCommands commands={['run infra:deploy --all']} />
+<NxCommands commands={['run infra:deploy my-project-sandbox/*']} />
 
 :::tip
 You will need to ensure your AWS environment has been appropriately bootstrapped for CDK.

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -565,6 +565,7 @@ import { StaticWebsite } from '../../core/index.js';
 export class GameUI extends StaticWebsite {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
+      websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(
           '../../../../../../dist/packages/game-ui/bundle',
@@ -905,10 +906,12 @@ Below is a list of all files which have been generated/updated by the `ts#infra`
           - index.ts
   - infra
     - src/
+      - stages/
+        - **application-stage.ts** cdk stacks defined here
       - stacks/
         - **application-stack.ts** cdk resources defined here
       - index.ts
-      - **main.ts** entrypoint which defines all stacks
+      - **main.ts** entrypoint which defines all stages
     - cdk.json
     - project.json
     - ...
@@ -920,7 +923,7 @@ Below is a list of all files which have been generated/updated by the `ts#infra`
 
 ```ts
 // packages/infra/src/main.ts
-import { ApplicationStack } from './stacks/application-stack.js';
+import { ApplicationStage } from './stacks/application-stage.js';
 import {
   App,
   CfnGuardValidator,
@@ -932,12 +935,11 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'dungeon-adventure-infra-sandbox', {
+new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  crossRegionReferences: true,
 });
 
 app.synth();

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/2.mdx
@@ -170,43 +170,33 @@ If you encounter any lint errors, you can run the following command to automatic
 
 Your application can now be deployed by running the following command:
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox/*']} />
 
 Your first deployment will take around 8 minutes to complete. Subsequent deployments will take around 2 minutes.
 
 :::tip
 If you're iterating on lambda function code changes, you can deploy with the `--hotswap` flag after building the codebase for a much shorter (2-3 second) deployment time.
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox --hotswap']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox/* --hotswap']} />
 :::
-
-<Drawer title="Deployment command" trigger="You can also deploy all stacks at once. Click here for more details.">
-
-You can also deploy all stacks contained in the CDK application by running:
-
-<NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
-
-This is **not recommended** given that you may choose to seperate out your deployment stages as seperate stacks `i.e. infra-prod`. In this case the `--all` flag will attempt to deploy all stacks which can result in unwanted deployments!
-
-</Drawer>
 
 Once the deployment completes, you should see some outputs similar to the following _(some values have been redacted)_:
 
 ```bash
-dungeon-adventure-infra-sandbox
-dungeon-adventure-infra-sandbox: deploying... [2/2]
+dungeon-adventure-sandbox-Application
+dungeon-adventure-sandbox-Application: deploying... [2/2]
 
- ✅  dungeon-adventure-infra-sandbox
+ ✅  dungeon-adventure-sandbox-Application
 
 ✨  Deployment time: 354s
 
 Outputs:
-dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
-dungeon-adventure-infra-sandbox.GameApiEndpointXXX = https://xxx.execute-api.region.amazonaws.com/prod/
-dungeon-adventure-infra-sandbox.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
-dungeon-adventure-infra-sandbox.StoryApiEndpointXXX = https://xxx.execute-api.region.amazonaws.com/prod/
-dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
-dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
+dungeon-adventure-sandbox-Application.ElectroDbTableTableNameXXX = dungeon-adventure-sandbox-Application-ElectroDbTableXXX-YYY
+dungeon-adventure-sandbox-Application.GameApiEndpointXXX = https://xxx.execute-api.region.amazonaws.com/prod/
+dungeon-adventure-sandbox-Application.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
+dungeon-adventure-sandbox-Application.StoryApiEndpointXXX = https://xxx.execute-api.region.amazonaws.com/prod/
+dungeon-adventure-sandbox-Application.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
+dungeon-adventure-sandbox-Application.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
 We can test our API by either:
@@ -282,10 +272,10 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
   <TabItem label="Local">
     Start your local `game-api` server by running the following command:
 
-    <NxCommands highlights={['dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY']} env={{TABLE_NAME:"dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY"}} commands={["run @dungeon-adventure/game-api:serve"]} />
+    <NxCommands highlights={['dungeon-adventure-infra-sandbox-Application-ElectroDbTableXXX-YYY']} env={{TABLE_NAME:"dungeon-adventure-infra-sandbox-Application-ElectroDbTableXXX-YYY"}} commands={["run @dungeon-adventure/game-api:serve"]} />
 
     <Aside type="caution">
-    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX` to replace the highlighted placeholder.
+    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox-Application.ElectroDbTableTableNameXXX` to replace the highlighted placeholder.
     </Aside>
 
     Once your server is up and running, you can call it by running the following command:
@@ -299,7 +289,7 @@ acurl ap-southeast-2 lambda -N -X POST https://xxx
 acurl ap-southeast-2 execute-api -X GET 'https://xxx.execute-api.ap-southeast-2.amazonaws.com/prod/games.query?input=%7B%7D'
 ```
     <Aside type="caution">
-    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox.GameApiGameApiEndpointXXX` to replace the highlighted placeholder and set the region accordingly.
+    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox-Application.GameApiGameApiEndpointXXX` to replace the highlighted placeholder and set the region accordingly.
     </Aside>
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/3.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/3.mdx
@@ -133,38 +133,28 @@ If you encounter any lint errors, you can run the following command to automatic
 
 Your application can now be deployed by running the following command:
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox/*']} />
 
 This deployment will take around 2 minutes to complete.
-
-<Drawer title="Deployment command" trigger="You can also deploy all stacks at once. Click here for more details.">
-
-You can also deploy all stacks contained in the CDK application by running:
-
-<NxCommands commands={['run @dungeon-adventure/infra:deploy --all']} />
-
-This is **not recommended** given that you may choose to seperate out your deployment stages as seperate stacks `i.e. infra-prod`. In this case the `--all` flag will attempt to deploy all stacks which can result in unwanted deployments!
-
-</Drawer>
 
 
 Once the deployment completes, you should see some outputs similar to the following _(some values have been redacted)_:
 
 ```bash
-dungeon-adventure-infra-sandbox
-dungeon-adventure-infra-sandbox: deploying... [2/2]
+dungeon-adventure-infra-sandbox-Application
+dungeon-adventure-infra-sandbox-Application: deploying... [2/2]
 
- ✅  dungeon-adventure-infra-sandbox
+ ✅  dungeon-adventure-infra-sandbox-Application
 
 ✨  Deployment time: 354s
 
 Outputs:
-dungeon-adventure-infra-sandbox.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-ElectroDbTableXXX-YYY
-dungeon-adventure-infra-sandbox.GameApiEndpointXXX = https://xxx.execute-api.region.amazonaws.com/prod/
-dungeon-adventure-infra-sandbox.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
-dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX = https://xxx.lambda-url.ap-southeast-2.on.aws/
-dungeon-adventure-infra-sandbox.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
-dungeon-adventure-infra-sandbox.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
+dungeon-adventure-infra-sandbox-Application.ElectroDbTableTableNameXXX = dungeon-adventure-infra-sandbox-Application-ElectroDbTableXXX-YYY
+dungeon-adventure-infra-sandbox-Application.GameApiEndpointXXX = https://xxx.execute-api.region.amazonaws.com/prod/
+dungeon-adventure-infra-sandbox-Application.GameUIDistributionDomainNameXXX = xxx.cloudfront.net
+dungeon-adventure-infra-sandbox-Application.StoryApiStoryApiUrlXXX = https://xxx.lambda-url.ap-southeast-2.on.aws/
+dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityIdentityPoolIdXXX = region:xxx
+dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXXX = region_xxx
 ```
 
 We can test our API by either:
@@ -256,7 +246,7 @@ acurl ap-southeast-2 lambda -N -X POST \
   -H "Content-Type: application/json"
 ```
     <Aside type="caution">
-    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox.StoryApiStoryApiUrlXXX` to replace the highlighted url placeholder and set the region accordingly.
+    Use the CDK deploy output value of `dungeon-adventure-infra-sandbox-Application.StoryApiStoryApiUrlXXX` to replace the highlighted url placeholder and set the region accordingly.
     </Aside>
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
@@ -123,7 +123,7 @@ To build your code, run the following command:
 
 Now deploy your application:
 
-<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox']} />
+<NxCommands commands={['run @dungeon-adventure/infra:deploy dungeon-adventure-infra-sandbox/*']} />
 
 Once deployed, navigate to your Cloudfront url which can be found by inspecting the cdk deploy outputs.
 

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -35,6 +35,6 @@ We recommend you try your hand at extending the codebase with the following capa
 
 To destroy the AWS resources that were created, run the following command:
 
-<NxCommands commands={['run @dungeon-adventure/infra:destroy --all']} />
+<NxCommands commands={['run @dungeon-adventure/infra:destroy dungeon-adventure-infra-sandbox/*']} />
 
-This will prompt you for a list of stacks to delete which should comprise of the `waf` and `dungeon-adventure-infra-sandbox`. Enter `Y` and then Cloudformation will destroy your stacks.
+This will prompt you for a list of stacks to delete which should comprise of the `dungeon-adventure-infra-sandbox/Application/GameUI/waf` and `dungeon-adventure-infra-sandbox/Application`. Enter `Y` and then Cloudformation will destroy your stacks.

--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -164,7 +164,9 @@ Your website project is configured with a `load:runtime-config` target which you
 <NxCommands commands={['run <my-website>:"load:runtime-config"']} />
 
 :::warning
-If you change the name of your stack in your infrastructure project's `src/main.ts`, you will need to update the `load:runtime-config` target in your website's `project.json` file with the name of the stack to load runtime configuration from.
+If you change the prefix for your stage names in your infrastructure project's `src/main.ts`, you will need to update the `load:runtime-config` target in your website's `project.json` file accordingly.
+
+Additionally it's worth noting that the `load:runtime-config` target assumes a single stage of your application is deployed to the environment you have AWS credentials for. You will need to adjust the command if you deploy multiple stages to the same account and region.
 :::
 
 ## Local Development Server

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -31,7 +31,9 @@ The generator will create the following project structure in the `<directory>/<n
 <FileTree>
 
   - src
-    - main.ts Application entry point instantiating CDK stacks to deploy
+    - main.ts Application entry point instantiating CDK stages to deploy
+    - stages CDK Stage definitions
+      - application-stage.ts Defines a collection of stacks to deploy in a stage
     - stacks CDK Stack definitions
       - application-stack.ts Main application stack
   - cdk.json CDK configuration
@@ -48,16 +50,72 @@ Your infrastructure is a TypeScript project, so you can refer to the <Link path=
 You can start writing your CDK infrastructure inside `src/stacks/application-stack.ts`, for example:
 
 ```ts title="src/stacks/application-stack.ts" {9-10}
-import * as cdk from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Bucket } from 'aws-cdk-lib/aws-s3'
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // Declare your infrastructure here
     new Bucket(this, 'MyBucket');
+  }
+}
+```
+
+### Stages and Stacks
+
+You will notice that the top level `src/main.ts` file instantiates a CDK [Stage](https://docs.aws.amazon.com/cdk/v2/guide/stages.html) named `<namespace>-sandbox`. This stage is intended for your own development and testing.
+
+```ts title="src/main.ts"
+new ApplicationStage(app, 'project-sandbox', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+```
+
+You can add more stages, for example you may wish to define `beta` and `prod` stages which deploy to separate environments:
+
+```ts title="src/main.ts"
+new ApplicationStage(app, 'project-beta', {
+  env: {
+    account: '123456789012', // beta account
+    region: 'us-west-2',
+  },
+});
+new ApplicationStage(app, 'project-prod', {
+  env: {
+    account: '098765432109', // prod account
+    region: 'us-west-2',
+  },
+});
+```
+
+A Stage defines a collection of stacks that should be deployed together to make up your application. You can instantiate as many stacks as you like within a stage, for example:
+
+```ts title="src/stages/application-stage.ts"
+import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BackendStack } from '../stacks/backend-stack.js';
+import { FrontendStack } from '../stacks/frontend-stack.js';
+
+/**
+ * Defines a collection of CDK Stacks which make up your application
+ */
+export class ApplicationStage extends Stage {
+  constructor(scope: Construct, id: string, props?: StageProps) {
+    super(scope, id, props);
+
+    new BackendStack(this, 'Backend', {
+      crossRegionReferences: true,
+    })
+
+    new FrontendStack(this, 'Frontend', {
+      crossRegionReferences: true,
+    });
   }
 }
 ```
@@ -68,7 +126,7 @@ If you have used the <Link path="guides/trpc">tRPC API</Link> or <Link path="gui
 
 If, for example, you created a tRPC API called `my-api`, you can simply import and instantiate the construct to add all necessary infrastructure to deploy it:
 
-```ts title="src/stacks/application-stack.ts" {3, 9-10}
+```ts title="src/stacks/application-stack.ts" {3, 9-12}
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyApi } from ':my-scope/common-constructs';
@@ -78,7 +136,9 @@ export class ApplicationStack extends cdk.Stack {
     super(scope, id, props);
 
     // Add infrastructure for your API
-    new MyApi(this, 'MyApi');
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+    });
   }
 }
 ```
@@ -140,21 +200,29 @@ First, ensure that you have [configured credentials for your AWS account](https:
 
 Next, run the deploy target:
 
-<NxCommands commands={['run <my-infra>:deploy --all']} />
+<NxCommands commands={['run <my-infra>:deploy <my-infra>-sandbox/*']} />
 
 :::tip
-The above command deploys _all_ stacks defined in `main.ts`. You may wish to target an individual stack, especially if you have configured multiple stages of an application for example:
+The above command deploys _all_ stacks for the `<my-infra>-sandbox` stage. You can specify other stages so long as they are defined in `main.ts`.
 
-<NxCommands commands={['run <my-infra>:deploy my-sandbox-stack']} />
+You can also deploy individual stacks by specifying the full stack name, for example:
+
+<NxCommands commands={['run <my-infra>:deploy <my-infra>-sandbox/Application']} />
 :::
 
 ## Deploying to AWS in a CI/CD Pipeline
 
 Use the `deploy-ci` target if you are deploying to AWS as part of a CI/CD pipeline.
 
-<NxCommands commands={['run <my-infra>:deploy-ci my-stack']} />
+<NxCommands commands={['run <my-infra>:deploy-ci my-stage/*']} />
 
 This target differs slightly from the regular `deploy` target in that it ensures pre-synthesized cloud-assembly is deployed, rather than synthesizing on the fly. This helps to avoid potential issues with non-determinism due to changes package versions, ensuring that every pipeline stage deploys using the same cloud-assembly.
+
+## Tearing Down AWS Infrastructure
+
+Use the `destroy` target to tear down your resources:
+
+<NxCommands commands={['run <my-infra>:destroy <my-infra>-sandbox/*']} />
 
 ## More Information
 

--- a/e2e/src/files/dungeon-adventure/1/application-stack.ts.original.template
+++ b/e2e/src/files/dungeon-adventure/1/application-stack.ts.original.template
@@ -1,8 +1,8 @@
-import * as cdk from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here

--- a/e2e/src/files/dungeon-adventure/1/application-stack.ts.template
+++ b/e2e/src/files/dungeon-adventure/1/application-stack.ts.template
@@ -4,11 +4,11 @@ import {
   StoryApi,
   UserIdentity,
 } from ':dungeon-adventure/common-constructs';
-import * as cdk from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     const userIdentity = new UserIdentity(this, 'UserIdentity');

--- a/e2e/src/files/dungeon-adventure/3/application-stack.ts.template
+++ b/e2e/src/files/dungeon-adventure/3/application-stack.ts.template
@@ -4,13 +4,13 @@ import {
   StoryApi,
   UserIdentity,
 } from ':dungeon-adventure/common-constructs';
-import * as cdk from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ElectrodbDynamoTable } from '../constructs/electrodb-table.js';
 import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -285,7 +285,7 @@ exports[`infra generator > should generate consistent file content across runs >
   }
 }
 ",
-  "src/main.ts": "import { ApplicationStack } from './stacks/application-stack.js';
+  "src/main.ts": "import { ApplicationStage } from './stages/application-stage.js';
 import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
@@ -293,24 +293,40 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'proj-infra-sandbox', {
+new ApplicationStage(app, 'proj-test-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  crossRegionReferences: true,
 });
 
 app.synth();
 ",
-  "src/stacks/application-stack.ts": "import * as cdk from 'aws-cdk-lib';
+  "src/stacks/application-stack.ts": "import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here
+  }
+}
+",
+  "src/stages/application-stage.ts": "import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { ApplicationStack } from '../stacks/application-stack.js';
+
+/**
+ * Defines a collection of CDK Stacks which make up your application
+ */
+export class ApplicationStage extends Stage {
+  constructor(scope: Construct, id: string, props?: StageProps) {
+    super(scope, id, props);
+
+    new ApplicationStack(this, 'Application', {
+      crossRegionReferences: true,
+    });
   }
 }
 ",
@@ -318,14 +334,34 @@ export class ApplicationStack extends cdk.Stack {
 `;
 
 exports[`infra generator > should generate files with correct content > application-stack-ts 1`] = `
-"import * as cdk from 'aws-cdk-lib';
+"import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here
+  }
+}
+"
+`;
+
+exports[`infra generator > should generate files with correct content > application-stage-ts 1`] = `
+"import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { ApplicationStack } from '../stacks/application-stack.js';
+
+/**
+ * Defines a collection of CDK Stacks which make up your application
+ */
+export class ApplicationStage extends Stage {
+  constructor(scope: Construct, id: string, props?: StageProps) {
+    super(scope, id, props);
+
+    new ApplicationStack(this, 'Application', {
+      crossRegionReferences: true,
+    });
   }
 }
 "
@@ -403,7 +439,7 @@ exports[`infra generator > should generate files with correct content > cdk-json
 `;
 
 exports[`infra generator > should generate files with correct content > main-ts 1`] = `
-"import { ApplicationStack } from './stacks/application-stack.js';
+"import { ApplicationStage } from './stages/application-stage.js';
 import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
@@ -411,311 +447,14 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'proj-infra-sandbox', {
+new ApplicationStage(app, 'proj-test-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  crossRegionReferences: true,
 });
 
 app.synth();
-"
-`;
-
-exports[`infra generator > should generate files with correct content > project-structure 1`] = `
-{
-  "cdk.json": "{
-  "app": "tsx src/main.ts",
-  "output": "../../dist/packages/test/cdk.out",
-  "watch": {
-    "include": ["**"],
-    "exclude": [
-      "README.md",
-      "cdk*.json",
-      "**/*.d.ts",
-      "**/*.js",
-      "tsconfig.json",
-      "package*.json",
-      "yarn.lock",
-      "node_modules",
-      "test"
-    ]
-  },
-  "context": {
-    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
-    "@aws-cdk/core:checkSecretUsage": true,
-    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
-    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
-    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
-    "@aws-cdk/aws-iam:minimizePolicies": true,
-    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
-    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
-    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
-    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
-    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
-    "@aws-cdk/core:enablePartitionLiterals": true,
-    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
-    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
-    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
-    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
-    "@aws-cdk/aws-route53-patters:useCertificate": true,
-    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
-    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
-    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
-    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
-    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
-    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
-    "@aws-cdk/aws-redshift:columnId": true,
-    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
-    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
-    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
-    "@aws-cdk/aws-kms:aliasNameRef": true,
-    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
-    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
-    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
-    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
-    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
-    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
-    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
-    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
-    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
-    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
-    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
-    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
-    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true,
-    "@aws-cdk/aws-kms:reduceCrossAccountRegionPolicyScope": true,
-    "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
-    "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
-    "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
-    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false
-  }
-}
-",
-  "project.json": "{
-  "name": "@proj/test",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/test/src",
-  "projectType": "application",
-  "tags": [],
-  "metadata": {
-    "generator": "ts#infra"
-  },
-  "targets": {
-    "bootstrap": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk bootstrap"
-      }
-    },
-    "build": {
-      "dependsOn": ["lint", "compile", "test", "synth"]
-    },
-    "cdk": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk"
-      }
-    },
-    "compile": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/packages/test/tsc"],
-      "options": {
-        "command": "tsc --build tsconfig.lib.json",
-        "cwd": "{projectRoot}"
-      }
-    },
-    "deploy": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk deploy --require-approval=never"
-      }
-    },
-    "deploy-ci": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk deploy --require-approval=never --app ../../dist/packages/test/cdk.out"
-      }
-    },
-    "destroy": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk destroy --require-approval=never"
-      }
-    },
-    "destroy-ci": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk destroy --require-approval=never --app ../../dist/packages/test/cdk.out"
-      }
-    },
-    "synth": {
-      "cache": true,
-      "executor": "nx:run-commands",
-      "inputs": ["default"],
-      "outputs": ["{workspaceRoot}/dist/packages/test/cdk.out"],
-      "dependsOn": ["^build", "compile"],
-      "options": {
-        "cwd": "packages/test",
-        "command": "cdk synth"
-      }
-    },
-    "test": {
-      "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
-      "options": {
-        "reportsDirectory": "../../coverage/packages/test"
-      }
-    }
-  }
-}
-",
-  "src/main.ts": "import { ApplicationStack } from './stacks/application-stack.js';
-import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
-
-const app = new App({
-  policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
-});
-
-// Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'proj-infra-sandbox', {
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
-  crossRegionReferences: true,
-});
-
-app.synth();
-",
-  "src/stacks/application-stack.ts": "import * as cdk from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
-    super(scope, id, props);
-
-    // The code that defines your stack goes here
-  }
-}
-",
-}
-`;
-
-exports[`infra generator > should generate valid CDK application code > cdk-json-content 1`] = `
-{
-  "app": "tsx src/main.ts",
-  "context": {
-    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
-    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
-    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
-    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
-    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
-    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
-    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
-    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
-    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
-    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
-    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
-    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true,
-    "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
-    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
-    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
-    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
-    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
-    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
-    "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
-    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
-    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
-    "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
-    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
-    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
-    "@aws-cdk/aws-iam:minimizePolicies": true,
-    "@aws-cdk/aws-kms:aliasNameRef": true,
-    "@aws-cdk/aws-kms:reduceCrossAccountRegionPolicyScope": true,
-    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
-    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
-    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
-    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
-    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
-    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
-    "@aws-cdk/aws-redshift:columnId": true,
-    "@aws-cdk/aws-route53-patters:useCertificate": true,
-    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
-    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
-    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
-    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
-    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
-    "@aws-cdk/core:checkSecretUsage": true,
-    "@aws-cdk/core:enablePartitionLiterals": true,
-    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
-    "@aws-cdk/core:target-partitions": [
-      "aws",
-      "aws-cn",
-    ],
-    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
-    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false,
-    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
-  },
-  "output": "../../dist/packages/test/cdk.out",
-  "watch": {
-    "exclude": [
-      "README.md",
-      "cdk*.json",
-      "**/*.d.ts",
-      "**/*.js",
-      "tsconfig.json",
-      "package*.json",
-      "yarn.lock",
-      "node_modules",
-      "test",
-    ],
-    "include": [
-      "**",
-    ],
-  },
-}
-`;
-
-exports[`infra generator > should generate valid CDK application code > main-ts-content 1`] = `
-"import { ApplicationStack } from './stacks/application-stack.js';
-import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
-
-const app = new App({
-  policyValidationBeta1: [new CfnGuardValidator(RuleSet.AWS_PROTOTYPING)],
-});
-
-// Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'proj-infra-sandbox', {
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
-  crossRegionReferences: true,
-});
-
-app.synth();
-"
-`;
-
-exports[`infra generator > should generate valid CDK application code > stack-ts-content 1`] = `
-"import * as cdk from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
-    super(scope, id, props);
-
-    // The code that defines your stack goes here
-  }
-}
 "
 `;
 
@@ -789,7 +528,7 @@ exports[`infra generator > should handle custom project names correctly > custom
   }
 }
 ",
-  "src/main.ts": "import { ApplicationStack } from './stacks/application-stack.js';
+  "src/main.ts": "import { ApplicationStage } from './stages/application-stage.js';
 import { App, CfnGuardValidator, RuleSet } from ':proj/common-constructs';
 
 const app = new App({
@@ -797,24 +536,40 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, 'proj-infra-sandbox', {
+new ApplicationStage(app, 'proj-custom-infra-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  crossRegionReferences: true,
 });
 
 app.synth();
 ",
-  "src/stacks/application-stack.ts": "import * as cdk from 'aws-cdk-lib';
+  "src/stacks/application-stack.ts": "import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here
+  }
+}
+",
+  "src/stages/application-stage.ts": "import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { ApplicationStack } from '../stacks/application-stack.js';
+
+/**
+ * Defines a collection of CDK Stacks which make up your application
+ */
+export class ApplicationStage extends Stage {
+  constructor(scope: Construct, id: string, props?: StageProps) {
+    super(scope, id, props);
+
+    new ApplicationStack(this, 'Application', {
+      crossRegionReferences: true,
+    });
   }
 }
 ",

--- a/packages/nx-plugin/src/infra/app/files/app/README.md.template
+++ b/packages/nx-plugin/src/infra/app/files/app/README.md.template
@@ -72,5 +72,5 @@ suppressRule(construct, 'RULE_NAME', (construct) => construct instanceof Bucket)
 
 ## Useful links
 
-- [Infra reference docs](TODO)
+- [Infra reference docs](https://awslabs.github.io/nx-plugin-for-aws/en/guides/typescript-infrastructure/)
 - [Learn more about NX](https://nx.dev/getting-started/intro)

--- a/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
+++ b/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
@@ -1,4 +1,4 @@
-import { ApplicationStack } from './stacks/application-stack.js';
+import { ApplicationStage } from './stages/application-stage.js';
 import { App, CfnGuardValidator, RuleSet } from '<%= scopeAlias %>common-constructs';
 
 const app = new App({
@@ -6,12 +6,11 @@ const app = new App({
 });
 
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
-new ApplicationStack(app, '<%= namespace %>-infra-sandbox', {
+new ApplicationStage(app, '<%= namespace %>-sandbox', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  crossRegionReferences: true
 });
 
 app.synth();

--- a/packages/nx-plugin/src/infra/app/files/app/src/stacks/application-stack.ts.template
+++ b/packages/nx-plugin/src/infra/app/files/app/src/stacks/application-stack.ts.template
@@ -1,8 +1,8 @@
-import * as cdk from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ApplicationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here

--- a/packages/nx-plugin/src/infra/app/files/app/src/stages/application-stage.ts.template
+++ b/packages/nx-plugin/src/infra/app/files/app/src/stages/application-stage.ts.template
@@ -1,0 +1,16 @@
+import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { ApplicationStack } from '../stacks/application-stack.js';
+
+/**
+ * Defines a collection of CDK Stacks which make up your application
+ */
+export class ApplicationStage extends Stage {
+  constructor(scope: Construct, id: string, props?: StageProps) {
+    super(scope, id, props);
+
+    new ApplicationStack(this, 'Application', {
+      crossRegionReferences: true,
+    });
+  }
+}

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -32,6 +32,9 @@ describe('infra generator', () => {
     expect(
       tree.exists('packages/test/src/stacks/application-stack.ts'),
     ).toBeTruthy();
+    expect(
+      tree.exists('packages/test/src/stages/application-stage.ts'),
+    ).toBeTruthy();
     // Create snapshots of generated files
     expect(tree.read('packages/test/cdk.json').toString()).toMatchSnapshot(
       'cdk-json',
@@ -42,16 +45,9 @@ describe('infra generator', () => {
     expect(
       tree.read('packages/test/src/stacks/application-stack.ts').toString(),
     ).toMatchSnapshot('application-stack-ts');
-    // Snapshot the entire project structure
-    const projectFiles = {
-      'cdk.json': tree.read('packages/test/cdk.json').toString(),
-      'src/main.ts': tree.read('packages/test/src/main.ts').toString(),
-      'src/stacks/application-stack.ts': tree
-        .read('packages/test/src/stacks/application-stack.ts')
-        .toString(),
-      'project.json': tree.read('packages/test/project.json').toString(),
-    };
-    expect(projectFiles).toMatchSnapshot('project-structure');
+    expect(
+      tree.read('packages/test/src/stages/application-stage.ts').toString(),
+    ).toMatchSnapshot('application-stage-ts');
   });
 
   it('should configure project.json with correct targets', async () => {
@@ -145,21 +141,6 @@ describe('infra generator', () => {
     });
   });
 
-  it('should generate valid CDK application code', async () => {
-    await tsInfraGenerator(tree, options);
-    // Test main.ts content
-    const mainTs = tree.read('packages/test/src/main.ts').toString();
-    expect(mainTs).toMatchSnapshot('main-ts-content');
-    // Test application-stack.ts content
-    const stackTs = tree
-      .read('packages/test/src/stacks/application-stack.ts')
-      .toString();
-    expect(stackTs).toMatchSnapshot('stack-ts-content');
-    // Test cdk.json content
-    const cdkJson = JSON.parse(tree.read('packages/test/cdk.json').toString());
-    expect(cdkJson).toMatchSnapshot('cdk-json-content');
-  });
-
   it('should handle custom project names correctly', async () => {
     const customOptions: TsInfraGeneratorSchema = {
       name: 'custom-infra',
@@ -177,12 +158,18 @@ describe('infra generator', () => {
     expect(
       tree.exists('packages/custom-infra/src/stacks/application-stack.ts'),
     ).toBeTruthy();
+    expect(
+      tree.exists('packages/custom-infra/src/stages/application-stage.ts'),
+    ).toBeTruthy();
     // Snapshot files with custom name
     const customFiles = {
       'cdk.json': tree.read('packages/custom-infra/cdk.json').toString(),
       'src/main.ts': tree.read('packages/custom-infra/src/main.ts').toString(),
       'src/stacks/application-stack.ts': tree
         .read('packages/custom-infra/src/stacks/application-stack.ts')
+        .toString(),
+      'src/stages/application-stage.ts': tree
+        .read('packages/custom-infra/src/stages/application-stage.ts')
         .toString(),
     };
     expect(customFiles).toMatchSnapshot('custom-name-files');
@@ -197,6 +184,9 @@ describe('infra generator', () => {
       'src/stacks/application-stack.ts': tree
         .read('packages/test/src/stacks/application-stack.ts')
         .toString(),
+      'src/stages/application-stage.ts': tree
+        .read('packages/test/src/stages/application-stage.ts')
+        .toString(),
     };
     // Reset tree and run again
     tree = createTreeUsingTsSolutionSetup();
@@ -206,6 +196,9 @@ describe('infra generator', () => {
       'src/main.ts': tree.read('packages/test/src/main.ts').toString(),
       'src/stacks/application-stack.ts': tree
         .read('packages/test/src/stacks/application-stack.ts')
+        .toString(),
+      'src/stages/application-stage.ts': tree
+        .read('packages/test/src/stages/application-stage.ts')
         .toString(),
     };
     // Compare runs

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -69,7 +69,7 @@ export async function tsInfraGenerator(
     {
       synthDir: synthDirFromProject,
       scopeAlias: scopeAlias,
-      namespace: kebabCase(npmScopePrefix),
+      namespace: kebabCase(fullyQualifiedName),
       fullyQualifiedName,
       pkgMgrCmd: getPackageManagerCommand().exec,
       ...schema,

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -464,6 +464,7 @@ import { StaticWebsite } from '../../core/index.js';
 export class TestApp extends StaticWebsite {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
+      websiteName: 'TestApp',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../dist/test-app/bundle', import.meta.url),
       ),
@@ -510,7 +511,7 @@ export * from './runtime-config.js';
 `;
 
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/constructs/src/core/runtime-config.ts 1`] = `
-"import { Stack } from 'aws-cdk-lib';
+"import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
@@ -519,15 +520,15 @@ export class RuntimeConfig extends Construct {
   private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
-    const stack = Stack.of(scope);
+    const parent = Stage.of(scope) ?? Stack.of(scope);
     return (
-      RuntimeConfig.of(scope) ?? new RuntimeConfig(stack, RuntimeConfigKey)
+      RuntimeConfig.of(scope) ?? new RuntimeConfig(parent, RuntimeConfigKey)
     );
   }
 
   static of(scope: Construct): RuntimeConfig | undefined {
-    const stack = Stack.of(scope);
-    return stack.node.tryFindChild(RuntimeConfigKey) as
+    const parent = Stage.of(scope) ?? Stack.of(scope);
+    return parent.node.tryFindChild(RuntimeConfigKey) as
       | RuntimeConfig
       | undefined;
   }
@@ -562,6 +563,7 @@ import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
 export interface StaticWebsiteProps {
+  readonly websiteName: string;
   readonly websiteFilePath: string;
 }
 
@@ -581,7 +583,7 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    { websiteFilePath }: StaticWebsiteProps,
+    { websiteFilePath, websiteName }: StaticWebsiteProps,
   ) {
     super(scope, id);
     this.node.setContext(
@@ -678,7 +680,7 @@ export class StaticWebsite extends Construct {
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,
     });
-    new CfnOutput(this, 'WebsiteBucketName', {
+    new CfnOutput(this, \`\${websiteName}WebsiteBucketName\`, {
       value: this.websiteBucket.bucketName,
     });
   }
@@ -994,7 +996,7 @@ exports[`react-website generator > Tanstack router integration > should generate
         "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm exec nx run @proj/test-app:load:runtime-config'"
       },
       "options": {
-        "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?StackName=='proj-infra-sandbox'][].Outputs[?contains(OutputKey, 'WebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json './test-app/public/runtime-config.json'"
+        "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json './test-app/public/runtime-config.json'"
       }
     },
     "preview": {
@@ -1764,6 +1766,7 @@ import { StaticWebsite } from '../../core/index.js';
 export class TestApp extends StaticWebsite {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
+      websiteName: 'TestApp',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../dist/test-app/bundle', import.meta.url),
       ),
@@ -1810,7 +1813,7 @@ export * from './runtime-config.js';
 `;
 
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/constructs/src/core/runtime-config.ts 1`] = `
-"import { Stack } from 'aws-cdk-lib';
+"import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
@@ -1819,15 +1822,15 @@ export class RuntimeConfig extends Construct {
   private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
-    const stack = Stack.of(scope);
+    const parent = Stage.of(scope) ?? Stack.of(scope);
     return (
-      RuntimeConfig.of(scope) ?? new RuntimeConfig(stack, RuntimeConfigKey)
+      RuntimeConfig.of(scope) ?? new RuntimeConfig(parent, RuntimeConfigKey)
     );
   }
 
   static of(scope: Construct): RuntimeConfig | undefined {
-    const stack = Stack.of(scope);
-    return stack.node.tryFindChild(RuntimeConfigKey) as
+    const parent = Stage.of(scope) ?? Stack.of(scope);
+    return parent.node.tryFindChild(RuntimeConfigKey) as
       | RuntimeConfig
       | undefined;
   }
@@ -1862,6 +1865,7 @@ import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
 export interface StaticWebsiteProps {
+  readonly websiteName: string;
   readonly websiteFilePath: string;
 }
 
@@ -1881,7 +1885,7 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    { websiteFilePath }: StaticWebsiteProps,
+    { websiteFilePath, websiteName }: StaticWebsiteProps,
   ) {
     super(scope, id);
     this.node.setContext(
@@ -1978,7 +1982,7 @@ export class StaticWebsite extends Construct {
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,
     });
-    new CfnOutput(this, 'WebsiteBucketName', {
+    new CfnOutput(this, \`\${websiteName}WebsiteBucketName\`, {
       value: this.websiteBucket.bucketName,
     });
   }
@@ -2294,7 +2298,7 @@ exports[`react-website generator > Tanstack router integration > should generate
         "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm exec nx run @proj/test-app:load:runtime-config'"
       },
       "options": {
-        "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?StackName=='proj-infra-sandbox'][].Outputs[?contains(OutputKey, 'WebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json './test-app/public/runtime-config.json'"
+        "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json './test-app/public/runtime-config.json'"
       }
     },
     "preview": {
@@ -3288,6 +3292,7 @@ import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
 export interface StaticWebsiteProps {
+  readonly websiteName: string;
   readonly websiteFilePath: string;
 }
 
@@ -3307,7 +3312,7 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    { websiteFilePath }: StaticWebsiteProps,
+    { websiteFilePath, websiteName }: StaticWebsiteProps,
   ) {
     super(scope, id);
     this.node.setContext(
@@ -3404,7 +3409,7 @@ export class StaticWebsite extends Construct {
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,
     });
-    new CfnOutput(this, 'WebsiteBucketName', {
+    new CfnOutput(this, \`\${websiteName}WebsiteBucketName\`, {
       value: this.websiteBucket.bucketName,
     });
   }
@@ -3463,6 +3468,7 @@ import { StaticWebsite } from '../../core/index.js';
 export class TestApp extends StaticWebsite {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
+      websiteName: 'TestApp',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../dist/test-app/bundle', import.meta.url),
       ),

--- a/packages/nx-plugin/src/ts/react-website/app/files/common/constructs/src/app/static-websites/__websiteNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/ts/react-website/app/files/common/constructs/src/app/static-websites/__websiteNameKebabCase__.ts.template
@@ -5,6 +5,7 @@ import { StaticWebsite } from '../../core/index.js';
 export class <%= websiteNameClassName %> extends StaticWebsite {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
+      websiteName: '<%= websiteNameClassName %>',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../<%= websiteContentPath %>/bundle', import.meta.url)
       ),

--- a/packages/nx-plugin/src/ts/react-website/app/files/common/constructs/src/core/static-website.ts.template
+++ b/packages/nx-plugin/src/ts/react-website/app/files/common/constructs/src/core/static-website.ts.template
@@ -16,6 +16,7 @@ import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
 export interface StaticWebsiteProps {
+  readonly websiteName: string;
   readonly websiteFilePath: string;
 }
 
@@ -35,7 +36,7 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    { websiteFilePath }: StaticWebsiteProps
+    { websiteFilePath, websiteName }: StaticWebsiteProps
   ) {
     super(scope, id);
     this.node.setContext(
@@ -132,7 +133,7 @@ export class StaticWebsite extends Construct {
     new CfnOutput(this, 'DistributionDomainName', {
       value: this.cloudFrontDistribution.domainName,
     });
-    new CfnOutput(this, 'WebsiteBucketName', {
+    new CfnOutput(this, `${websiteName}WebsiteBucketName`, {
       value: this.websiteBucket.bucketName,
     });
   }

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -96,7 +96,7 @@ export async function tsReactWebsiteGenerator(
       description: `Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm exec nx run ${fullyQualifiedName}:load:runtime-config'`,
     },
     options: {
-      command: `aws s3 cp s3://\`aws cloudformation describe-stacks --query "Stacks[?StackName=='${kebabCase(npmScopePrefix)}-infra-sandbox'][].Outputs[?contains(OutputKey, 'WebsiteBucketName')].OutputValue" --output text\`/runtime-config.json './${websiteContentPath}/public/runtime-config.json'`,
+      command: `aws s3 cp s3://\`aws cloudformation describe-stacks --query "Stacks[?starts_with(StackName, '${kebabCase(npmScopePrefix)}-')][].Outputs[] | [?contains(OutputKey, '${websiteNameClassName}WebsiteBucketName')].OutputValue" --output text\`/runtime-config.json './${websiteContentPath}/public/runtime-config.json'`,
     },
   };
   const buildTarget = targets['build'];

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/__snapshots__/generator.spec.ts.snap
@@ -71,7 +71,7 @@ export * from './runtime-config.js';
 `;
 
 exports[`runtime-config generator > should generate shared constructs > runtime-config.ts 1`] = `
-"import { Stack } from 'aws-cdk-lib';
+"import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
@@ -80,15 +80,15 @@ export class RuntimeConfig extends Construct {
   private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
-    const stack = Stack.of(scope);
+    const parent = Stage.of(scope) ?? Stack.of(scope);
     return (
-      RuntimeConfig.of(scope) ?? new RuntimeConfig(stack, RuntimeConfigKey)
+      RuntimeConfig.of(scope) ?? new RuntimeConfig(parent, RuntimeConfigKey)
     );
   }
 
   static of(scope: Construct): RuntimeConfig | undefined {
-    const stack = Stack.of(scope);
-    return stack.node.tryFindChild(RuntimeConfigKey) as
+    const parent = Stage.of(scope) ?? Stack.of(scope);
+    return parent.node.tryFindChild(RuntimeConfigKey) as
       | RuntimeConfig
       | undefined;
   }

--- a/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
@@ -38,7 +38,7 @@ export * from './runtime-config.js';
 `;
 
 exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/runtime-config.ts 1`] = `
-"import { Stack } from 'aws-cdk-lib';
+"import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
@@ -47,15 +47,15 @@ export class RuntimeConfig extends Construct {
   private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
-    const stack = Stack.of(scope);
+    const parent = Stage.of(scope) ?? Stack.of(scope);
     return (
-      RuntimeConfig.of(scope) ?? new RuntimeConfig(stack, RuntimeConfigKey)
+      RuntimeConfig.of(scope) ?? new RuntimeConfig(parent, RuntimeConfigKey)
     );
   }
 
   static of(scope: Construct): RuntimeConfig | undefined {
-    const stack = Stack.of(scope);
-    return stack.node.tryFindChild(RuntimeConfigKey) as
+    const parent = Stage.of(scope) ?? Stack.of(scope);
+    return parent.node.tryFindChild(RuntimeConfigKey) as
       | RuntimeConfig
       | undefined;
   }

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/runtime-config.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/runtime-config.ts.template
@@ -1,4 +1,4 @@
-import { Stack } from 'aws-cdk-lib';
+import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 const RuntimeConfigKey = '__RuntimeConfig__';
@@ -7,15 +7,15 @@ export class RuntimeConfig extends Construct {
   private readonly _runtimeConfig: any = {};
 
   static ensure(scope: Construct): RuntimeConfig {
-    const stack = Stack.of(scope);
+    const parent = Stage.of(scope) ?? Stack.of(scope);
     return (
-      RuntimeConfig.of(scope) ?? new RuntimeConfig(stack, RuntimeConfigKey)
+      RuntimeConfig.of(scope) ?? new RuntimeConfig(parent, RuntimeConfigKey)
     );
   }
 
   static of(scope: Construct): RuntimeConfig | undefined {
-    const stack = Stack.of(scope);
-    return stack.node.tryFindChild(RuntimeConfigKey) as
+    const parent = Stage.of(scope) ?? Stack.of(scope);
+    return parent.node.tryFindChild(RuntimeConfigKey) as
       | RuntimeConfig
       | undefined;
   }


### PR DESCRIPTION
### Reason for this change

- Cross-stack runtime config values support
- Make it easier to build multi-stack/multi-stage apps
- More robust `load:runtime-config` target for the website

### Description of changes

- Vend an `ApplicationStage` which consists of the `ApplicationStack`
- Associate `RuntimeConfig` construct with the parent `Stage` if available (fall back to `Stack` in case the user deletes the stage parent
- Set the default sandbox stage name to `<scope>-<infra-project-name>-sandbox` to avoid clashes for multiple infra projects
- Update `load:runtime-config` to look for stacks prefixed with `<scope>-` and then filter for the bucket for its own website

### Description of how you validated changes

Built a few test projects

### Issue # (if applicable)

Fixes #162
Fixes #214

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*