### PR TITLE
fix(ts#project): creation of project in packages directory using nx interactive cli

### DIFF
--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -87,6 +87,19 @@ describe('ts lib generator', () => {
     );
   });
 
+  it('should use default subdirectory when subDirectory is empty string', async () => {
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      directory: 'feature',
+      subDirectory: '', // Empty string should fall back to normalized name
+      skipInstall: true,
+    });
+    // Verify directory structure - should use normalized name (test-lib) as subdirectory
+    expect(tree.exists('feature/test-lib')).toBeTruthy();
+    expect(tree.exists('feature/test-lib/src')).toBeTruthy();
+    expect(tree.exists('feature/test-lib/src/index.ts')).toBeTruthy();
+  });
+
   it('should not configure duplicate @nx/js/typescript plugin entries', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-1',

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -56,9 +56,10 @@ export const getTsLibDetails = (
   const scope = getNpmScopePrefix(tree);
   const normalizedName = toKebabCase(schema.name);
   const fullyQualifiedName = `${scope}${normalizedName}`;
+  // NB: interactive nx generator cli can pass empty string
   const dir = joinPathFragments(
-    schema.directory ?? '.',
-    schema.subDirectory ?? normalizedName,
+    schema.directory || '.',
+    schema.subDirectory || normalizedName,
   );
   return { dir, fullyQualifiedName };
 };


### PR DESCRIPTION
### Reason for this change

The interactive cli (ie running with `pnpm nx g @aws/nx-plugin:ts#project` and answering the prompts) passes '' instead of undefined for subDirectory which caused the project to be created directly in packages unless the user expicitly specifies a subdirectory.

### Description of changes

Addressed this by treating '' the same as undefined.

### Description of how you validated changes

Added a unit test

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*