### PR TITLE
ci: add windows smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,30 @@ jobs:
       - uses: ./.github/actions/init-monorepo
       - name: Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"
+  smoke_tests_windows:
+    name: Windows Smoke Tests - ${{matrix.smoke_test}}
+    runs-on: windows-latest
+    needs: build
+    strategy:
+      matrix:
+        smoke_test:
+          - npm
+          - dungeon-adventure
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: dist
+      - uses: ./.github/actions/init-monorepo
+      - name: Windows Smoke Test - ${{ matrix.smoke_test }}
+        run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"
   release:
     name: Release
-    needs: [build, smoke_tests]
+    needs: [build, smoke_tests, smoke_tests_windows]
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,3 +72,24 @@ jobs:
       - uses: ./.github/actions/init-monorepo
       - name: Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"
+  smoke_tests_windows:
+    name: Windows Smoke Tests - ${{matrix.smoke_test}}
+    runs-on: windows-latest
+    needs: build
+    strategy:
+      matrix:
+        smoke_test:
+          - npm
+          - dungeon-adventure
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: dist
+      - uses: ./.github/actions/init-monorepo
+      - name: Windows Smoke Test - ${{ matrix.smoke_test }}
+        run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -74,9 +74,11 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/1/application-stack.ts.template',
         ),
+        'utf-8',
       ),
     );
     await runCLI(`sync --verbose`, opts);
+    await runCLI(`run-many --target lint --all --parallel 1 --fix`, opts);
     await runCLI(
       `run-many --target build --all --parallel 1 --output-style=stream --skip-nx-cache --verbose`,
       opts,
@@ -102,6 +104,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/schema/action.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -112,6 +115,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/schema/common.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -119,6 +123,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/game-api/src/schema/game.ts`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/2/schema/game.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -129,6 +134,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/schema/index.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -141,6 +147,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/entities/action.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -151,6 +158,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/entities/game.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -161,6 +169,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/middleware/dynamodb.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -171,6 +180,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/middleware/index.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -178,6 +188,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/game-api/src/init.ts`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/2/init.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -188,6 +199,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/query-actions.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -198,6 +210,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/query-games.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -208,6 +221,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/save-action.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -218,6 +232,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/save-game.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -228,6 +243,7 @@ describe('smoke test - dungeon-adventure', () => {
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/2/router.ts.template'),
       ),
+      'utf-8',
     );
 
     ensureDirSync(`${opts.cwd}/packages/infra/src/constructs`);
@@ -239,6 +255,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/constructs/electrodb-table.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -249,6 +266,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/stacks/application-stack.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -278,6 +296,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/story_api/story_api/main.py`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/3/main.py.template'),
+        'utf-8',
       ),
     );
 
@@ -285,6 +304,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/story_api/story_api/init.py`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/3/init.py.template'),
+        'utf-8',
       ),
     );
 
@@ -292,6 +312,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/story_api/run.sh`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/3/run.sh.template'),
+        'utf-8',
       ),
     );
 
@@ -312,6 +333,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/common/constructs/src/app/apis/story-api.ts`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/3/story-api.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -322,6 +344,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/3/application-stack.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -339,6 +362,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/game-ui/src/config.ts`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/4/config.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -350,6 +374,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/AppLayout/index.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -367,6 +392,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/game-ui/src/styles.css`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/4/styles.css.template'),
+        'utf-8',
       ),
     );
 
@@ -380,6 +406,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/routes/game/index.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -390,6 +417,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/routes/game/$playerName.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -401,6 +429,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/routes/index.tsx.template',
         ),
+        'utf-8',
       ),
     );
 

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -142,7 +142,10 @@ export const smokeTest = (
       // Wire up website, cognito and trpc api
       writeFileSync(
         `${opts.cwd}/packages/infra/src/stacks/application-stack.ts`,
-        readFileSync(join(__dirname, '../files/application-stack.ts.template')),
+        readFileSync(
+          join(__dirname, '../files/application-stack.ts.template'),
+          'utf-8',
+        ),
       );
 
       // Since the smoke tests don't run in a git repo, we need to exclude some patterns for the license sync
@@ -150,10 +153,12 @@ export const smokeTest = (
         `${opts.cwd}/aws-nx-plugin.config.mts`,
         readFileSync(
           join(__dirname, '../files/aws-nx-plugin.config.mts.template'),
+          'utf-8',
         ),
       );
 
       await runCLI(`sync --verbose`, opts);
+      await runCLI(`run-many --target lint --all --parallel 1 --fix`, opts);
       await runCLI(
         `run-many --target build --all --parallel 1 --output-style=stream --skip-nx-cache --verbose`,
         opts,


### PR DESCRIPTION
### Reason for this change

Help reduce the chance we'll break windows users.

### Description of changes

Add smoke tests for windows. Just the dungeon-adventure and one of the kitchen sink smoke tests (npm) rather than running everything on both platforms.

### Description of how you validated changes

This PR

### Issue # (if applicable)

Closes #211 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*