### PR TITLE
fix: update versions workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Bump Nx Plugin for AWS versions
         run: |
           npx -y npm-check-updates@19.0.0 --configFileName .ncurc.cjs
+          pnpm i --lockfile-only
           pnpm i
           pnpm tsx ./scripts/update-versions.ts
           pnpm nx reset


### PR DESCRIPTION
### Reason for this change

`pnpm i` fails on CI because the lockfile would change

### Description of changes

`pnpm i --lockfile-only` to update the lockfile, then `pnpm i` to install

### Description of how you validated changes

`CI=true pnpm i --lockfile-only && pnpm i` works locally :)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*