### PR TITLE
fix: newer version of npm supporting trusted publishing

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -45,6 +45,9 @@ runs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
+    - name: Update NPM
+      shell: bash
+      run: npm i -g npm@11.6.1
     - name: Install Node.js Dependencies
       shell: bash
       run: pnpm i --frozen-lockfile --prefer-offline


### PR DESCRIPTION
### Reason for this change

Release is failing at the moment

### Description of changes

Node 22 came with NPM 10.x but we need 11.x to release with trusted publishing

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*