### PR TITLE
fix: add ai agents flag for creating nx workspace to avoid user prompt

### DIFF
--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -168,4 +168,4 @@ export const buildCreateNxWorkspaceCommand = (
   nxVersion: string = undefined,
   nxPluginVersion: string = undefined,
 ) =>
-  `npx ${yes ? '-y ' : ''}create-nx-workspace@${nxVersion ?? TS_VERSIONS['create-nx-workspace']} ${workspace} --pm=${pm}  --preset=@aws/nx-plugin${nxPluginVersion ? `@${nxPluginVersion}` : ''} ${iacProvider ? `--iacProvider=${iacProvider} ` : ''}--ci=skip`;
+  `npx ${yes ? '-y ' : ''}create-nx-workspace@${nxVersion ?? TS_VERSIONS['create-nx-workspace']} ${workspace} --pm=${pm}  --preset=@aws/nx-plugin${nxPluginVersion ? `@${nxPluginVersion}` : ''} ${iacProvider ? `--iacProvider=${iacProvider} ` : ''}--ci=skip --aiAgents`;

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -23,7 +23,7 @@ export const addCreateWorkspaceCommandTool = (server: McpServer) => {
           text: `Run the following command to create a workspace:
 
 \`\`\`bash
-npx create-nx-workspace@${TS_VERSIONS['create-nx-workspace']} ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip
+npx create-nx-workspace@${TS_VERSIONS['create-nx-workspace']} ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip --aiAgents
 \`\`\`
 
 This will create a new workspace within the ${workspaceName} directory.

--- a/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
@@ -242,7 +242,7 @@ export const registerCreateWorkspaceCommandTool = (server: McpServer) => {
           text: \`Run the following command to create a workspace:
 
 \\\`\\\`\\\`bash
-npx create-nx-workspace@~21.4.1 \${workspaceName} --pm=\${packageManager} --preset=@aws/nx-plugin --ci=skip
+npx create-nx-workspace@21.6.2 \${workspaceName} --pm=\${packageManager} --preset=@aws/nx-plugin --ci=skip --aiAgents
 \\\`\\\`\\\`
 
 This will create a new workspace within the \${workspaceName} directory.

--- a/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/tools/create-workspace-command.ts.template
+++ b/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/tools/create-workspace-command.ts.template
@@ -18,7 +18,7 @@ export const registerCreateWorkspaceCommandTool = (server: McpServer) => {
           text: `Run the following command to create a workspace:
 
 \`\`\`bash
-npx create-nx-workspace@~21.4.1 ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip
+npx create-nx-workspace@<%- createNxWorkspaceVersion %> ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip --aiAgents
 \`\`\`
 
 This will create a new workspace within the ${workspaceName} directory.

--- a/packages/nx-plugin/src/ts/nx-plugin/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/generator.ts
@@ -23,6 +23,7 @@ import { formatFilesInSubtree } from '../../utils/format';
 import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
 import { configureTsProjectAsNxPlugin } from './utils';
 import tsMcpServerGenerator from '../mcp-server/generator';
+import { TS_VERSIONS } from '../../utils/versions';
 
 export const TS_NX_PLUGIN_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -112,6 +113,7 @@ export const tsNxPluginGenerator = async (
     mcpPath,
     {
       name: fullyQualifiedName,
+      createNxWorkspaceVersion: TS_VERSIONS['create-nx-workspace'],
     },
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );


### PR DESCRIPTION
### Reason for this change

Latest Nx version prompts users to choose ai agents to configure when creating a workspace.

### Description of changes

Reduce the interactivity by default by passing empty in our docs/mcp server. Additionally fix a hardcoded version in our nx plugin generator.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*