### PR TITLE
test(ts): increase buffer size for dependency resolution for ts compilation assertions

### DIFF
--- a/packages/nx-plugin/src/utils/test/ts.spec.ts
+++ b/packages/nx-plugin/src/utils/test/ts.spec.ts
@@ -78,6 +78,7 @@ export class TypeScriptVerifier {
           encoding: 'utf-8',
           stdio: 'pipe',
           cwd: path.resolve(__dirname, '../../../../../'),
+          maxBuffer: 50 * 1024 * 1024, // 50 MB
         }),
       );
 


### PR DESCRIPTION
### Reason for this change

Latest version update failed: https://github.com/awslabs/nx-plugin-for-aws/actions/runs/18449475335/job/52561011191

```
 FAIL  src/ts/lambda-function/generator.spec.ts [ src/ts/lambda-function/generator.spec.ts ]
Error: spawnSync /bin/sh ENOBUFS
 ❯ TypeScriptVerifier.resolveDependencyPath src/utils/test/ts.spec.ts:77:9
     75|       // Fallback to using pnpm list command to find the dependency pa…
     76|       const pnpmData = JSON.parse(
     77|         execSync(`pnpm list --depth 1000 --json ${dependency}`, {
       |         ^
     78|           encoding: 'utf-8',
     79|           stdio: 'pipe',
```

### Description of changes

Increase buffer size to 50MB (default 1MB)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*