### PR TITLE
fix(preset): disable nx daemon by default

### DIFF
--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -166,8 +166,18 @@ export default {
 
 exports[`preset generator > should run successfully > nx.json 1`] = `
 "{
-  "affected": { "defaultBase": "main" },
-  "targetDefaults": { "build": { "cache": true }, "lint": { "cache": true } }
+  "affected": {
+    "defaultBase": "main"
+  },
+  "targetDefaults": {
+    "build": {
+      "cache": true
+    },
+    "lint": {
+      "cache": true
+    }
+  },
+  "useDaemonProcess": false
 }
 "
 `;

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { Tree, readNxJson } from '@nx/devkit';
 import { presetGenerator, isAmazonian } from './generator';
 import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from '../utils/test';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
@@ -40,6 +40,13 @@ describe('preset generator', () => {
     await presetGenerator(tree, { addTsPlugin: false, iacProvider: 'CDK' });
 
     expect((await readAwsNxPluginConfig(tree)).iac.provider).toBe('CDK');
+  });
+
+  it('should disable the nx daemon', async () => {
+    await presetGenerator(tree, { addTsPlugin: false, iacProvider: 'CDK' });
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson?.useDaemonProcess).toBe(false);
   });
 });
 

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -12,7 +12,9 @@ import {
   getPackageManagerCommand,
   installPackagesTask,
   joinPathFragments,
+  readNxJson,
   updateJson,
+  updateNxJson,
 } from '@nx/devkit';
 import { NxGeneratorInfo, getGeneratorInfo } from '../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
@@ -175,6 +177,12 @@ export const presetGenerator = async (
       overwriteStrategy: OverwriteStrategy.Overwrite,
     },
   );
+
+  // Disable the Nx Daemon by default, users can opt in
+  updateNxJson(tree, {
+    ...readNxJson(tree),
+    useDaemonProcess: false,
+  });
 
   await addGeneratorMetricsIfApplicable(tree, [PRESET_GENERATOR_INFO]);
 


### PR DESCRIPTION
### Reason for this change

The Nx Daemon is great for the performance boost with large projects, but sometimes encounters issues in various environments, needing users to run `nx reset` to fix them, or disable it themselves.

### Description of changes

This change opts out of the daemon by default. Users that know what they are doing can just remove the line from their nx.json file after creating their workspace.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*