### PR TITLE
fix(ts): disable tree shaking for aws sdk v3 when not external due to rolldown bug

### DIFF
--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -401,6 +401,19 @@ describe('tsSmithyApiGenerator', () => {
     expect(bundleTarget.options.command).toEqual(
       'rolldown -c rolldown.config.ts',
     );
+
+    const rolldownConfig = tree.read(
+      'test-api/backend/rolldown.config.ts',
+      'utf-8',
+    );
+
+    expect(rolldownConfig).toContain('defineConfig');
+    expect(rolldownConfig).toContain('src/handler.ts');
+    expect(rolldownConfig).toContain(
+      '../../dist/test-api/backend/bundle/index.js',
+    );
+    // AWS SDK is provided by lambda runtime
+    expect(rolldownConfig).toContain('external: [/@aws-sdk\\/.*/]');
   });
 
   it('should add generator metadata to backend project configuration', async () => {

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -144,6 +144,7 @@ export const tsSmithyApiGenerator = async (
   // Add bundle target using rolldown
   addTypeScriptBundleTarget(tree, backendProjectConfig, {
     targetFilePath: 'src/handler.ts',
+    external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
   });
 
   const cmd = new FsCommands(tree);

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -242,6 +242,9 @@ describe('trpc backend generator', () => {
     expect(rolldownConfig).toContain(
       '../../dist/apps/test-api/bundle/index.js',
     );
+
+    // AWS SDK is provided by lambda runtime
+    expect(rolldownConfig).toContain('external: [/@aws-sdk\\/.*/]');
   });
 
   it('should add rolldown dependency to package.json', async () => {

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -111,6 +111,7 @@ export async function tsTrpcApiGenerator(
 
   addTypeScriptBundleTarget(tree, projectConfig, {
     targetFilePath: 'src/router.ts',
+    external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
   });
 
   addDependencyToTargetIfNotPresent(projectConfig, 'build', 'bundle');

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -125,7 +125,7 @@ export const tsLambdaFunctionGenerator = async (
   addTypeScriptBundleTarget(tree, projectConfig, {
     targetFilePath: functionPathFromProjectRoot,
     bundleOutputDir,
-    external: [/@aws-sdk\/.*/],
+    external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
   });
 
   projectConfig.targets = sortObjectKeys(projectConfig.targets);

--- a/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
@@ -891,6 +891,8 @@ describe('ts#mcp-server generator', () => {
     expect(rolldownConfig).toContain(
       '../../dist/apps/test-project/bundle/mcp/test-project-mcp-server/index.js',
     );
+    // Tree shaking should be disabled for the AWS SDK
+    expect(rolldownConfig).toContain('disableTreeShake([/@aws-sdk\\/.*/])');
   });
 
   it('should ensure Dockerfile COPY path matches bundle output path', async () => {

--- a/packages/nx-plugin/src/utils/bundle/__snapshots__/bundle.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/bundle/__snapshots__/bundle.spec.ts.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`bundle utilities > addTypeScriptBundleTarget > should add disableTreeShake function and plugins when AWS SDK is not external 1`] = `
+"import { defineConfig } from 'rolldown';
+
+// Disables tree-shaking for the given module patterns
+const disableTreeShake = (patterns: RegExp[]) => ({
+  name: 'disable-treeshake',
+  transform: (code, id) => {
+    if (patterns.some(p => p.test(id))) {
+      return { code, map: null, moduleSideEffects: 'no-treeshake' };
+    }
+    return null;
+  },
+});
+
+export default defineConfig([{
+        input: 'src/index.ts',
+        output: {
+            file: '../../dist/apps/test-project/bundle/index.js',
+            format: 'cjs',
+            inlineDynamicImports: true
+        },
+        platform: 'node',
+        plugins: [disableTreeShake([/@aws-sdk\\/.*/])]
+    }]);
+"
+`;
+
+exports[`bundle utilities > addTypeScriptBundleTarget > should not add disableTreeShake or plugins when AWS SDK is external as regex 1`] = `
+"import { defineConfig } from 'rolldown';
+
+export default defineConfig([{
+        input: 'src/index.ts',
+        output: {
+            file: '../../dist/apps/test-project/bundle/index.js',
+            format: 'cjs',
+            inlineDynamicImports: true
+        },
+        platform: 'node',
+        external: [/@aws-sdk\\/.*/]
+    }]);
+"
+`;

--- a/packages/nx-plugin/src/utils/test/ts.spec.ts
+++ b/packages/nx-plugin/src/utils/test/ts.spec.ts
@@ -78,7 +78,7 @@ export class TypeScriptVerifier {
           encoding: 'utf-8',
           stdio: 'pipe',
           cwd: path.resolve(__dirname, '../../../../../'),
-          maxBuffer: 50 * 1024 * 1024, // 50 MB
+          maxBuffer: 1024 * 1024 * 1024, // 1 GB
         }),
       );
 


### PR DESCRIPTION
### Reason for this change

Rolldown tree-shakes the AWS SDK too aggressively and removes required code. See the following issue for details: https://github.com/rolldown/rolldown/issues/6513

### Description of changes

This change ensures that any bundles targeting lambda are generated with the AWS SDK as external as it's provided by the lambda runtime (`ts#smithy-api` and `ts#trpc-api` were missing this - `ts#lambda-function` already had this set).

For projects which don't target lambda and don't externalise the AWS SDK (only `ts#mcp-server` right now which runs on agentcore runtime), we disable tree shaking for AWS SDK dependencies via a custom plugin.

Additionally set `platform` to `node` by default in rolldown config - when omitted rolldown defaults to browser but we're only using it for bundles targeting the node runtime.

### Description of how you validated changes

Unit tests. Deployed a `ts#mcp-server` which uses the dynamodb client.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*