### PR TITLE
fix(ts): ensure local dependencies are bundled correctly

### DIFF
--- a/packages/nx-plugin/src/utils/bundle/__snapshots__/bundle.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/bundle/__snapshots__/bundle.spec.ts.snap
@@ -15,6 +15,7 @@ const disableTreeShake = (patterns: RegExp[]) => ({
 });
 
 export default defineConfig([{
+        tsconfig: 'tsconfig.lib.json',
         input: 'src/index.ts',
         output: {
             file: '../../dist/apps/test-project/bundle/index.js',
@@ -31,6 +32,7 @@ exports[`bundle utilities > addTypeScriptBundleTarget > should not add disableTr
 "import { defineConfig } from 'rolldown';
 
 export default defineConfig([{
+        tsconfig: 'tsconfig.lib.json',
         input: 'src/index.ts',
         output: {
             file: '../../dist/apps/test-project/bundle/index.js',

--- a/packages/nx-plugin/src/utils/bundle/bundle.spec.ts
+++ b/packages/nx-plugin/src/utils/bundle/bundle.spec.ts
@@ -374,6 +374,19 @@ export default defineConfig([
       expect(configContent).toContain('src/handler.ts');
     });
 
+    it('should configure tsconfig', () => {
+      addTypeScriptBundleTarget(tree, project, {
+        targetFilePath: 'src/index.ts',
+      });
+
+      const configContent = tree.read(
+        'apps/test-project/rolldown.config.ts',
+        'utf-8',
+      );
+
+      expect(configContent).toContain("tsconfig: 'tsconfig.lib.json'");
+    });
+
     it('should configure platform with default value of node', () => {
       addTypeScriptBundleTarget(tree, project, {
         targetFilePath: 'src/index.ts',

--- a/packages/nx-plugin/src/utils/bundle/bundle.ts
+++ b/packages/nx-plugin/src/utils/bundle/bundle.ts
@@ -239,6 +239,10 @@ const disableTreeShake = (patterns: RegExp[]) => ({
           factory.createObjectLiteralExpression(
             [
               factory.createPropertyAssignment(
+                factory.createIdentifier('tsconfig'),
+                factory.createStringLiteral('tsconfig.lib.json', true),
+              ),
+              factory.createPropertyAssignment(
                 factory.createIdentifier('input'),
                 factory.createStringLiteral(opts.targetFilePath, true),
               ),


### PR DESCRIPTION
### Reason for this change

For rolldown to resolve the aliases it needs to be explicitly pointed at tsconfig.lib.json

### Description of changes

Configure rolldown tsconfig

### Description of how you validated changes

Deployed mcp server with local dependency

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*