### PR TITLE
fix(ts#infra): remove hardcoded checkov target path

### DIFF
--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -90,7 +90,7 @@ exports[`infra generator > should configure Checkov target correctly > checkov-t
     "{workspaceRoot}/dist/{projectRoot}/cdk.out",
   ],
   "options": {
-    "command": "uvx checkov==3.2.489 --config-file packages/test/checkov.yml --file dist/packages/infra/cdk.out/**/*.template.json",
+    "command": "uvx checkov==3.2.489 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
   },
   "outputs": [
     "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -175,7 +175,7 @@ exports[`infra generator > should configure project.json with correct targets > 
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx checkov==3.2.489 --config-file packages/test/checkov.yml --file dist/packages/infra/cdk.out/**/*.template.json",
+        "command": "uvx checkov==3.2.489 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -714,7 +714,7 @@ exports[`infra generator > should handle custom project names correctly > custom
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx checkov==3.2.489 --config-file packages/custom-infra/checkov.yml --file dist/packages/infra/cdk.out/**/*.template.json",
+        "command": "uvx checkov==3.2.489 --config-file packages/custom-infra/checkov.yml --file dist/packages/custom-infra/cdk.out/**/*.template.json",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -194,6 +194,7 @@ describe('infra generator', () => {
     // Snapshot project configuration with custom name
     const config = readProjectConfiguration(tree, '@proj/custom-infra');
     expect(config).toMatchSnapshot('custom-name-project-config');
+    expect(JSON.stringify(config)).not.toContain('packages/infra');
     // Verify file paths with custom name
     expect(tree.exists('packages/custom-infra/cdk.json')).toBeTruthy();
     expect(tree.exists('packages/custom-infra/src/main.ts')).toBeTruthy();

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -115,7 +115,7 @@ export async function tsInfraGenerator(
         options: {
           command: uvxCommand(
             'checkov',
-            `--config-file ${lib.dir}/checkov.yml --file dist/packages/infra/cdk.out/**/*.template.json`,
+            `--config-file ${lib.dir}/checkov.yml --file dist/${lib.dir}/cdk.out/**/*.template.json`,
           ),
         },
       };


### PR DESCRIPTION
### Reason for this change

`checkov` target fails when infrastructure package is not named `infra`

### Description of changes

Replace hardcoded path with project directory.

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Fixes #351

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*