### PR TITLE
feat: migrate Cognito user pool to plus tier

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -161,7 +161,7 @@ export class UserIdentity extends Construct {
         tempPasswordValidity: Duration.days(3),
       },
       mfa: Mfa.REQUIRED,
-      featurePlan: FeaturePlan.ESSENTIALS,
+      featurePlan: FeaturePlan.PLUS,
       mfaSecondFactor: { sms: true, otp: true },
       signInCaseSensitive: false,
       signInAliases: { username: true, email: true },

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -81,7 +81,7 @@ export class UserIdentity extends Construct {
         tempPasswordValidity: Duration.days(3),
       },
       mfa: Mfa.REQUIRED,
-      featurePlan: FeaturePlan.ESSENTIALS,
+      featurePlan: FeaturePlan.PLUS,
       mfaSecondFactor: { sms: true, otp: true },
       signInCaseSensitive: false,
       signInAliases: { username: true, email: true },

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
@@ -147,10 +147,8 @@ resource "aws_cognito_user_pool" "user_pool" {
   # Auto verification
   auto_verified_attributes = ["email", "phone_number"]
 
-  # User pool add-ons (equivalent to FeaturePlan.ESSENTIALS)
-  user_pool_add_ons {
-    advanced_security_mode = "ENFORCED"
-  }
+  # User pool tier (equivalent to FeaturePlan.PLUS)
+  user_pool_tier = "PLUS"
 
   # Schema attributes
   schema {


### PR DESCRIPTION
### Reason for this change

This change enhances the default security of Cognito user pools by migrating the associated constructs in
- CDK from the `ESSENTIALS ` tier to the `PLUS ` tier.
- Terraform from the [deprecated](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cognito.UserPoolProps.html#advancedsecuritymodespan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan) advanced security mode to the `PLUS` tier

The `PLUS` tier includes [threat protection](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) (formerly called *advanced security features*), which can automatically shut down malicious user activity ([see](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)).

### Description of changes

- `FeaturePlan.ESSENTIALS` was changed to `FeaturePlan.PLUS` in `user-identity.ts.template` and the appropriate snapshot
- `user_pool_add_ons` was replaced with `user_pool_tier = "PLUS"` ([see](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool#user_pool_tier-1))

### Description of how you validated changes

```bash
pnpm nx run @aws/nx-plugin:test
pnpm nx run-many --target build --all
```

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*