### PR TITLE
feat: reduce API access scope to invoke access grantee

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -813,13 +813,12 @@ import {
   Cors,
   LambdaIntegration,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
   Effect,
   AnyPrincipal,
-  AccountPrincipal,
   IGrantable,
   Grant,
 } from 'aws-cdk-lib/aws-iam';
@@ -908,15 +907,6 @@ export class TestApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Here we grant any AWS credentials from the account that the project is deployed in to call the api.
-          // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
-          // users) and resources (eg which api paths may be invoked by which principal) if required.
-          new PolicyStatement({
-            effect: Effect.ALLOW,
-            principals: [new AccountPrincipal(Stack.of(scope).account)],
-            actions: ['execute-api:Invoke'],
-            resources: ['execute-api:/*'],
-          }),
           // Open up OPTIONS to allow browsers to make unauthenticated preflight requests
           new PolicyStatement({
             effect: Effect.ALLOW,
@@ -937,6 +927,18 @@ export class TestApi<
    * @param grantee - The IAM principal to grant permissions to
    */
   public grantInvokeAccess(grantee: IGrantable) {
+    // Here we grant grantee permission to call the api.
+    // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
+    // users) and resources (eg which api paths may be invoked by which principal) if required.
+    this.api.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [grantee.grantPrincipal],
+        actions: ['execute-api:Invoke'],
+        resources: ['execute-api:/*'],
+      }),
+    );
+
     Grant.addToPrincipal({
       grantee,
       actions: ['execute-api:Invoke'],

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -181,13 +181,12 @@ import {
   Cors,
   LambdaIntegration,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
   Effect,
   AnyPrincipal,
-  AccountPrincipal,
   IGrantable,
   Grant,
 } from 'aws-cdk-lib/aws-iam';
@@ -276,15 +275,6 @@ export class TestApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Here we grant any AWS credentials from the account that the project is deployed in to call the api.
-          // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
-          // users) and resources (eg which api paths may be invoked by which principal) if required.
-          new PolicyStatement({
-            effect: Effect.ALLOW,
-            principals: [new AccountPrincipal(Stack.of(scope).account)],
-            actions: ['execute-api:Invoke'],
-            resources: ['execute-api:/*'],
-          }),
           // Open up OPTIONS to allow browsers to make unauthenticated preflight requests
           new PolicyStatement({
             effect: Effect.ALLOW,
@@ -305,6 +295,18 @@ export class TestApi<
    * @param grantee - The IAM principal to grant permissions to
    */
   public grantInvokeAccess(grantee: IGrantable) {
+    // Here we grant grantee permission to call the api.
+    // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
+    // users) and resources (eg which api paths may be invoked by which principal) if required.
+    this.api.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [grantee.grantPrincipal],
+        actions: ['execute-api:Invoke'],
+        resources: ['execute-api:/*'],
+      }),
+    );
+
     Grant.addToPrincipal({
       grantee,
       actions: ['execute-api:Invoke'],

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -1639,13 +1639,12 @@ import {
   Cors,
   LambdaIntegration,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
   Effect,
   AnyPrincipal,
-  AccountPrincipal,
   IGrantable,
   Grant,
 } from 'aws-cdk-lib/aws-iam';
@@ -1735,15 +1734,6 @@ export class TestApi<
       },
       policy: new PolicyDocument({
         statements: [
-          // Here we grant any AWS credentials from the account that the project is deployed in to call the api.
-          // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
-          // users) and resources (eg which api paths may be invoked by which principal) if required.
-          new PolicyStatement({
-            effect: Effect.ALLOW,
-            principals: [new AccountPrincipal(Stack.of(scope).account)],
-            actions: ['execute-api:Invoke'],
-            resources: ['execute-api:/*'],
-          }),
           // Open up OPTIONS to allow browsers to make unauthenticated preflight requests
           new PolicyStatement({
             effect: Effect.ALLOW,
@@ -1764,6 +1754,18 @@ export class TestApi<
    * @param grantee - The IAM principal to grant permissions to
    */
   public grantInvokeAccess(grantee: IGrantable) {
+    // Here we grant grantee permission to call the api.
+    // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
+    // users) and resources (eg which api paths may be invoked by which principal) if required.
+    this.api.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [grantee.grantPrincipal],
+        actions: ['execute-api:Invoke'],
+        resources: ['execute-api:/*'],
+      }),
+    );
+
     Grant.addToPrincipal({
       grantee,
       actions: ['execute-api:Invoke'],

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -15,19 +15,13 @@ import {
   CognitoUserPoolsAuthorizer,
   <%_ } _%>
 } from 'aws-cdk-lib/aws-apigateway';
-import {
-  Duration,
-  <%_ if (auth === 'IAM') { _%>
-  Stack,
-  <%_ } _%>
-} from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
   Effect,
   AnyPrincipal,
   <%_ if (auth === 'IAM') { _%>
-  AccountPrincipal,
   IGrantable,
   Grant,
   <%_ } _%>
@@ -163,15 +157,6 @@ export class <%= apiNameClassName %><
       policy: new PolicyDocument({
         statements: [
           <%_ if (auth === 'IAM') { _%>
-          // Here we grant any AWS credentials from the account that the project is deployed in to call the api.
-          // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
-          // users) and resources (eg which api paths may be invoked by which principal) if required.
-          new PolicyStatement({
-            effect: Effect.ALLOW,
-            principals: [new AccountPrincipal(Stack.of(scope).account)],
-            actions: ['execute-api:Invoke'],
-            resources: ['execute-api:/*'],
-          }),
           // Open up OPTIONS to allow browsers to make unauthenticated preflight requests
           new PolicyStatement({
             effect: Effect.ALLOW,
@@ -206,6 +191,18 @@ export class <%= apiNameClassName %><
    * @param grantee - The IAM principal to grant permissions to
    */
   public grantInvokeAccess(grantee: IGrantable) {
+    // Here we grant grantee permission to call the api.
+    // Machine to machine fine-grained access can be defined here using more specific principals (eg roles or
+    // users) and resources (eg which api paths may be invoked by which principal) if required.
+    this.api.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [grantee.grantPrincipal],
+        actions: ['execute-api:Invoke'],
+        resources: ['execute-api:/*'],
+      }),
+    );
+
     Grant.addToPrincipal({
       grantee,
       actions: ['execute-api:Invoke'],


### PR DESCRIPTION
### Reason for this change

This change enhances the default security of the API by scoping access down to the `grantInvokeAccess` function grantee.

### Description of changes

Scoped the policy granting API access down to the grantee passed to the `grantInvokeAccess` function

### Description of how you validated changes

```zsh
pnpm nx run @aws/nx-plugin:test
pnpm nx run-many --target build --all
```

- Followed the [quick start guide](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/quick-start/) with the AWS nx plugin linked to the locally built instance
- Smoke tested the deployed solution
- Modified the solution to use the echo API, confirmed that this worked correctly

### Checklist
- [ x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*