### PR TITLE
fix: infra:deploy should work similarly to infra:synth and rebuild its inputs

### DIFF
--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -106,6 +106,10 @@ exports[`infra generator > should configure project.json with correct targets > 
 
 exports[`infra generator > should configure project.json with correct targets > deploy-target 1`] = `
 {
+  "dependsOn": [
+    "^build",
+    "compile",
+  ],
   "executor": "nx:run-commands",
   "options": {
     "command": "cdk deploy --require-approval=never",
@@ -116,6 +120,10 @@ exports[`infra generator > should configure project.json with correct targets > 
 
 exports[`infra generator > should configure project.json with correct targets > destroy-target 1`] = `
 {
+  "dependsOn": [
+    "^build",
+    "compile",
+  ],
   "executor": "nx:run-commands",
   "options": {
     "command": "cdk destroy --require-approval=never",
@@ -186,6 +194,10 @@ exports[`infra generator > should configure project.json with correct targets > 
       ],
     },
     "deploy": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
       "executor": "nx:run-commands",
       "options": {
         "command": "cdk deploy --require-approval=never",
@@ -200,6 +212,10 @@ exports[`infra generator > should configure project.json with correct targets > 
       },
     },
     "destroy": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
       "executor": "nx:run-commands",
       "options": {
         "command": "cdk destroy --require-approval=never",
@@ -725,6 +741,10 @@ exports[`infra generator > should handle custom project names correctly > custom
       ],
     },
     "deploy": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
       "executor": "nx:run-commands",
       "options": {
         "command": "cdk deploy --require-approval=never",
@@ -739,6 +759,10 @@ exports[`infra generator > should handle custom project names correctly > custom
       },
     },
     "destroy": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
       "executor": "nx:run-commands",
       "options": {
         "command": "cdk destroy --require-approval=never",

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -77,6 +77,7 @@ describe('infra generator', () => {
         cwd: 'packages/test',
         command: 'cdk deploy --require-approval=never',
       },
+      dependsOn: ['^build', 'compile'],
     });
     expect(config.targets['deploy-ci']).toMatchObject({
       executor: 'nx:run-commands',
@@ -92,6 +93,7 @@ describe('infra generator', () => {
         cwd: 'packages/test',
         command: 'cdk destroy --require-approval=never',
       },
+      dependsOn: ['^build', 'compile'],
     });
     expect(config.targets['destroy-ci']).toMatchObject({
       executor: 'nx:run-commands',

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -121,6 +121,7 @@ export async function tsInfraGenerator(
       };
       config.targets.deploy = {
         executor: 'nx:run-commands',
+        dependsOn: ['^build', 'compile'],
         options: {
           cwd: libraryRoot,
           command: `cdk deploy --require-approval=never`,
@@ -135,6 +136,7 @@ export async function tsInfraGenerator(
       };
       config.targets.destroy = {
         executor: 'nx:run-commands',
+        dependsOn: ['^build', 'compile'],
         options: {
           cwd: libraryRoot,
           command: `cdk destroy --require-approval=never`,


### PR DESCRIPTION


### Reason for this change

When iterating, it is surprising that the `deploy` target doesn't rebuild its inputs.

### Description of changes

Add the same dependencies as `synth` (ignoring inputs/outputs for caching).

### Description of how you validated changes

Running `nx deploy infra` in a generated app triggers rebuilding of inputs.

### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*