### PR TITLE
fix(ts#infra): fix pycares error when running checkov

### DIFF
--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -84,7 +84,7 @@ exports[`infra generator > should configure Checkov target correctly > checkov-t
     "{workspaceRoot}/dist/{projectRoot}/cdk.out",
   ],
   "options": {
-    "command": "uvx checkov==3.2.495 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
+    "command": "uvx --with pycares==4.11.0 checkov==3.2.495 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
   },
   "outputs": [
     "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -177,7 +177,7 @@ exports[`infra generator > should configure project.json with correct targets > 
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx checkov==3.2.495 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
+        "command": "uvx --with pycares==4.11.0 checkov==3.2.495 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -724,7 +724,7 @@ exports[`infra generator > should handle custom project names correctly > custom
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx checkov==3.2.495 --config-file packages/custom-infra/checkov.yml --file dist/packages/custom-infra/cdk.out/**/*.template.json",
+        "command": "uvx --with pycares==4.11.0 checkov==3.2.495 --config-file packages/custom-infra/checkov.yml --file dist/packages/custom-infra/cdk.out/**/*.template.json",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -156,7 +156,9 @@ describe('infra generator', () => {
       outputs: ['{workspaceRoot}/dist/{projectRoot}/checkov'],
       dependsOn: ['synth'],
       options: {
-        command: expect.stringContaining('uvx checkov'),
+        command: expect.stringContaining(
+          'uvx --with pycares==4.11.0 checkov==',
+        ),
       },
     });
 

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -116,6 +116,7 @@ export async function tsInfraGenerator(
           command: uvxCommand(
             'checkov',
             `--config-file ${lib.dir}/checkov.yml --file dist/${lib.dir}/cdk.out/**/*.template.json`,
+            [{ dep: 'pycares', version: '4.11.0' }], // TODO: remove when https://github.com/aio-libs/aiodns/issues/214 is resolved
           ),
         },
       };

--- a/packages/nx-plugin/src/terraform/project/generator.spec.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.spec.ts
@@ -224,7 +224,9 @@ describe('terraformProjectGenerator', () => {
       const testTarget = projectConfig.targets['test'];
       expect(testTarget.executor).toBe('nx:run-commands');
       expect(testTarget.cache).toBe(true);
-      expect(testTarget.options.command).toContain('uvx checkov==');
+      expect(testTarget.options.command).toContain(
+        'uvx --with pycares==4.11.0 checkov==',
+      );
     });
   });
 

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -204,6 +204,7 @@ export async function terraformProjectGenerator(
         command: uvxCommand(
           'checkov',
           `--directory . -o cli -o json --output-file-path console,${checkovReportJsonPath}`,
+          [{ dep: 'pycares', version: '4.11.0' }], // TODO: remove when https://github.com/aio-libs/aiodns/issues/214 is resolved
         ),
         forwardAllArgs: true,
         cwd: '{projectRoot}/src',

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -61,10 +61,30 @@ export const addDependenciesToDependencyGroupInPyProjectToml = (
   );
 };
 
+export interface UvxWithDep {
+  dep: string;
+  version: string;
+  specifier?: string;
+}
+
 /**
  * Render a uvx command for a given dependency
  * Pins the version to the one specified in versions.ts
+ * Optionally specify withDeps to render uvx --with dep==version
  */
-export const uvxCommand = (dep: IPyDepVersion, args?: string): string => {
-  return `uvx ${withPyVersions([dep])[0]}${args ? ` ${args}` : ''}`;
+export const uvxCommand = (
+  dep: IPyDepVersion,
+  args?: string,
+  withDeps?: UvxWithDep[],
+): string => {
+  return `uvx ${
+    withDeps
+      ? `${withDeps
+          .map(
+            ({ dep, version, specifier }) =>
+              `--with ${dep}${specifier ?? '=='}${version}`,
+          )
+          .join(' ')} `
+      : ''
+  }${withPyVersions([dep])[0]}${args ? ` ${args}` : ''}`;
 };


### PR DESCRIPTION
### Reason for this change

One of Checkov's dependencies doesn't restrict the major version of its dependency (pycares), and uvx doesn't pin dependencies, which means a pycares version which is incompatible is installed, causing an error when we run checkov.

Refer to #378 for a more detailed explanation.

### Description of changes

Specify the version of pycares manually so the breaking version is not installed.

### Description of how you validated changes

Manually ran updated checkov target in a test project.

### Issue # (if applicable)

Fixes #378

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*