### PR TITLE
fix(preset): introducing ts#sync should not ignore the nx built-in @nx/js:typescript-sync

### DIFF
--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -177,7 +177,7 @@ exports[`preset generator > should run successfully > nx.json 1`] = `
       "cache": true
     },
     "compile": {
-      "syncGenerators": ["@aws/nx-plugin:ts#sync"]
+      "syncGenerators": ["@nx/js:typescript-sync", "@aws/nx-plugin:ts#sync"]
     }
   }
 }

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -8,6 +8,8 @@ import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from '../utils/test';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
 
+const NX_TYPESCRIPT_SYNC_GENERATOR = '@nx/js:typescript-sync';
+
 // Mock execSync to control git command behavior in tests
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -54,12 +56,14 @@ describe('preset generator', () => {
     expect((await readAwsNxPluginConfig(tree)).iac.provider).toBe('CDK');
   });
 
-  it('should register the TypeScript sync generator for compile targets', async () => {
+  it('should register the TypeScript sync generators for compile targets', async () => {
     await presetGenerator(tree, { addTsPlugin: false, iacProvider: 'CDK' });
 
-    expect(readNxJson(tree).targetDefaults?.compile?.syncGenerators).toContain(
-      TS_SYNC_GENERATOR_NAME,
-    );
+    const syncGenerators =
+      readNxJson(tree).targetDefaults?.compile?.syncGenerators;
+
+    expect(syncGenerators).toContain(TS_SYNC_GENERATOR_NAME);
+    expect(syncGenerators).toContain(NX_TYPESCRIPT_SYNC_GENERATOR);
   });
 });
 

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -33,6 +33,7 @@ import {
 import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
 
 const WORKSPACES = ['packages/*'];
+const NX_TYPESCRIPT_SYNC_GENERATOR = '@nx/js:typescript-sync';
 
 export const PRESET_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -154,8 +155,12 @@ export const presetGenerator = async (
         ...nxJson.targetDefaults?.compile,
         syncGenerators: [
           ...(nxJson.targetDefaults?.compile?.syncGenerators ?? []).filter(
-            (g) => g !== TS_SYNC_GENERATOR_NAME,
+            (g) =>
+              ![TS_SYNC_GENERATOR_NAME, NX_TYPESCRIPT_SYNC_GENERATOR].includes(
+                g,
+              ),
           ),
+          NX_TYPESCRIPT_SYNC_GENERATOR,
           TS_SYNC_GENERATOR_NAME,
         ],
       },


### PR DESCRIPTION
### Reason for this change

Nx hard-codes `syncGenerators: ['@nx/js:typescript-sync']` in [plugin.js](https://github.com/nrwl/nx/blob/master/packages/js/src/plugins/typescript/plugin.ts#L558)

Looking at [project-configuration-utils.js](https://github.com/nrwl/nx/blob/d959d7018547a8735f5edcec04e06954a87a00db/packages/nx/src/project-graph/utils/project-configuration-utils.ts#L868), it seems that if we define `syncGenerators`, Nx treats that as the whole list and it does not auto-append @nx/js:typescript-sync.

### Description of changes

Updated preset generator to explicitly include both `@nx/js:typescript-sync` and `ts#sync`

### Description of how you validated changes

Unit tests, manual testing

### Issue # (if applicable)

Closes #384 .

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*