### PR TITLE
fix(ts#mcp-server): upgrade zod and mcp sdk to compatible versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@hey-api/openapi-ts": "0.64.13",
     "@iarna/toml": "^2.2.5",
     "@middy/core": "^6.4.5",
-    "@modelcontextprotocol/inspector": "^0.17.2",
-    "@modelcontextprotocol/sdk": "^1.24.0",
+    "@modelcontextprotocol/inspector": "^0.18.0",
+    "@modelcontextprotocol/sdk": "^1.25.1",
     "@nx/devkit": "~22.1.3",
     "@nx/eslint": "~22.1.3",
     "@nx/eslint-plugin": "~22.1.3",
@@ -123,7 +123,7 @@
     "verdaccio": "^6.2.2",
     "vite": "^7.2.4",
     "vitest": "^4.0.14",
-    "zod": "^4.1.13"
+    "zod": "^4.2.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -26,7 +26,7 @@
     "@apidevtools/swagger-parser": "^10.1.1",
     "@hey-api/openapi-ts": "0.64.13",
     "@iarna/toml": "^2.2.5",
-    "@modelcontextprotocol/sdk": "^1.24.0",
+    "@modelcontextprotocol/sdk": "^1.25.1",
     "@nx/devkit": "~22.1.3",
     "@nx/eslint": "~22.1.3",
     "@nx/js": "~22.1.3",
@@ -48,6 +48,6 @@
     "typescript": "~5.9.3",
     "vite": "^7.2.4",
     "vitest": "^4.0.14",
-    "zod": "^4.1.13"
+    "zod": "^4.2.1"
   }
 }

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -640,12 +640,12 @@ exports[`ts#mcp-server generator > should match snapshot for generated files > u
     "snapshot-server": "./src/snapshot-server/stdio.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.24.0",
+    "@modelcontextprotocol/sdk": "1.25.1",
     "express": "5.1.0",
-    "zod": "4.1.13"
+    "zod": "4.2.1"
   },
   "devDependencies": {
-    "@modelcontextprotocol/inspector": "0.17.2",
+    "@modelcontextprotocol/inspector": "0.18.0",
     "@types/express": "5.0.5",
     "tsx": "4.20.6"
   }

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -23,8 +23,8 @@ export const TS_VERSIONS = {
   '@nx/devkit': '22.1.3',
   '@nx/react': '22.1.3',
   'create-nx-workspace': '22.1.3',
-  '@modelcontextprotocol/sdk': '1.24.0',
-  '@modelcontextprotocol/inspector': '0.17.2',
+  '@modelcontextprotocol/sdk': '1.25.1',
+  '@modelcontextprotocol/inspector': '0.18.0',
   '@tanstack/react-router': '1.139.7',
   '@tanstack/router-plugin': '1.139.7',
   '@tanstack/router-generator': '1.139.7',
@@ -70,7 +70,7 @@ export const TS_VERSIONS = {
   '@tailwindcss/vite': '4.1.17',
   tsx: '4.20.6',
   'vite-tsconfig-paths': '5.1.4',
-  zod: '4.1.13',
+  zod: '4.2.1',
 } as const;
 export type ITsDepVersion = keyof typeof TS_VERSIONS;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.29.0(@middy/core@6.4.5)
       '@aws-lambda-powertools/parser':
         specifier: ^2.29.0
-        version: 2.29.0(@middy/core@6.4.5)(zod@4.1.13)
+        version: 2.29.0(@middy/core@6.4.5)(zod@4.2.1)
       '@aws-lambda-powertools/tracer':
         specifier: ^2.29.0
         version: 2.29.0(@middy/core@6.4.5)
@@ -66,11 +66,11 @@ importers:
         specifier: ^6.4.5
         version: 6.4.5
       '@modelcontextprotocol/inspector':
-        specifier: ^0.17.2
-        version: 0.17.2(@swc/core@1.7.26(@swc/helpers@0.5.17))(@types/node@22.19.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(typescript@5.9.3)
+        specifier: ^0.18.0
+        version: 0.18.0(@swc/core@1.7.26(@swc/helpers@0.5.17))(@types/node@22.19.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(hono@4.11.3)(typescript@5.9.3)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.24.0
-        version: 1.24.1(zod@4.1.13)
+        specifier: ^1.25.1
+        version: 1.25.1(hono@4.11.3)(zod@4.2.1)
       '@nx/devkit':
         specifier: ~22.1.3
         version: 22.1.3(nx@22.1.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.7.26(@swc/helpers@0.5.17)))
@@ -339,8 +339,8 @@ importers:
         specifier: ^4.0.14
         version: 4.0.14(@types/node@22.19.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.30.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       zod:
-        specifier: ^4.1.13
-        version: 4.1.13
+        specifier: ^4.2.1
+        version: 4.2.1
 
   packages/nx-plugin:
     dependencies:
@@ -354,8 +354,8 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5
       '@modelcontextprotocol/sdk':
-        specifier: ^1.24.0
-        version: 1.24.1(zod@4.1.13)
+        specifier: ^1.25.1
+        version: 1.25.1(hono@4.11.3)(zod@4.2.1)
       '@nx/devkit':
         specifier: ~22.1.3
         version: 22.1.3(nx@22.1.3(@swc-node/register@1.9.2(@swc/core@1.7.26(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.7.26(@swc/helpers@0.5.17)))
@@ -426,8 +426,8 @@ importers:
         specifier: ^4.0.14
         version: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.30.2)(sass@1.79.4)(stylus@0.64.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       zod:
-        specifier: ^4.1.13
-        version: 4.1.13
+        specifier: ^4.2.1
+        version: 4.2.1
 
 packages:
 
@@ -1993,6 +1993,12 @@ packages:
     peerDependencies:
       typescript: ^5.5.3
 
+  '@hono/node-server@1.19.7':
+    resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -2211,25 +2217,25 @@ packages:
     resolution: {integrity: sha512-qRGCslDHjMr08fywcfVbWR9qpx16vGD481i9GpX3r5efi8Arjp/44JTjfeJkJJxvIb/8/+E9MLvU86+3oe1oJQ==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/inspector-cli@0.17.2':
-    resolution: {integrity: sha512-xXaqZYWJz77xvmfAVlYbvz2/xw9OaalFHq0n5A8PlmZvmhi6akQocIE7ZYaoEBpLbWRSwIZWfsidnfoKb6dO2A==}
+  '@modelcontextprotocol/inspector-cli@0.18.0':
+    resolution: {integrity: sha512-QMPjKx8zKmX17S1LF2gWuwbYglKexkdgB0HhKZFXzGrQ0MYoKUsIgokMyV48xr4LipaLS3b2v3ut3nV/jhWeSg==}
     hasBin: true
 
-  '@modelcontextprotocol/inspector-client@0.17.2':
-    resolution: {integrity: sha512-llC96yU8iMjG7ny2gpjhm+ARQqBRZWeKBCxW+nBErAE43jBqd5DhGuI2abrt499Gd3ByNOImz+Z5mb8YWjRiJA==}
+  '@modelcontextprotocol/inspector-client@0.18.0':
+    resolution: {integrity: sha512-M6A5SN09tYCoTTGwMi5hdQpesX5eHYn3FCAHTWfv1pZ1Cy7h5GjB1LxL5WhbMhXWmFFJ6AnQVGAJj0P0XkVhUg==}
     hasBin: true
 
-  '@modelcontextprotocol/inspector-server@0.17.2':
-    resolution: {integrity: sha512-+logjB5XXK+8aE+eDl8cLnwY0UhOUh19vo6tg5rFVmLXNQPtxTFyWybcQfgP/cHp76+r5+EMxIpydDYEoasTvg==}
+  '@modelcontextprotocol/inspector-server@0.18.0':
+    resolution: {integrity: sha512-N7mDwUuj+gB8ZbZ52M4Oqh37qChS8kWJUkc4qL/MMsaQTVshXEOTcyiQ/mLKa17O5uODZQerAnQJWZbZYReBkg==}
     hasBin: true
 
-  '@modelcontextprotocol/inspector@0.17.2':
-    resolution: {integrity: sha512-ADWwZtbvecKCbLCR7L0Uaa2mPKFDJcTrc9xcE9pdN8gL/jFfzOMrgdNsKt+qBknzMeSQ6mJT+UguJbnQs8n13Q==}
+  '@modelcontextprotocol/inspector@0.18.0':
+    resolution: {integrity: sha512-aBrBDaI8MtvyS9j3TMRgTHZaOwbe/zh2rbIVplIBtxWifaSfvQX9DbnoI3xv9sZjgeFyF/3CwZdfEVTUx2RfBg==}
     engines: {node: '>=22.7.5'}
     hasBin: true
 
-  '@modelcontextprotocol/sdk@1.24.1':
-    resolution: {integrity: sha512-YTg4v6bKSst8EJM8NXHC3nGm8kgHD08IbIBbognUeLAgGLVgLpYrgQswzLQd4OyTL4l614ejhqsDrV1//t02Qw==}
+  '@modelcontextprotocol/sdk@1.25.1':
+    resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -6297,6 +6303,10 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
+  hono@4.11.3:
+    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -6814,6 +6824,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -10031,8 +10044,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@4.2.1:
+    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10311,13 +10324,13 @@ snapshots:
     optionalDependencies:
       '@middy/core': 6.4.5
 
-  '@aws-lambda-powertools/parser@2.29.0(@middy/core@6.4.5)(zod@4.1.13)':
+  '@aws-lambda-powertools/parser@2.29.0(@middy/core@6.4.5)(zod@4.2.1)':
     dependencies:
       '@aws-lambda-powertools/commons': 2.29.0
       '@standard-schema/spec': 1.0.0
     optionalDependencies:
       '@middy/core': 6.4.5
-      zod: 4.1.13
+      zod: 4.2.1
 
   '@aws-lambda-powertools/tracer@2.29.0(@middy/core@6.4.5)':
     dependencies:
@@ -12180,6 +12193,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@hono/node-server@1.19.7(hono@4.11.3)':
+    dependencies:
+      hono: 4.11.3
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -12384,19 +12401,20 @@ snapshots:
 
   '@middy/core@6.4.5': {}
 
-  '@modelcontextprotocol/inspector-cli@0.17.2(zod@3.25.76)':
+  '@modelcontextprotocol/inspector-cli@0.18.0(hono@4.11.3)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@3.25.76)
       commander: 13.1.0
       spawn-rx: 5.1.2
     transitivePeerDependencies:
       - '@cfworker/json-schema'
+      - hono
       - supports-color
       - zod
 
-  '@modelcontextprotocol/inspector-client@0.17.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)':
+  '@modelcontextprotocol/inspector-client@0.18.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(hono@4.11.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@3.25.76)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons': 1.3.2(react@18.3.1)
@@ -12425,11 +12443,12 @@ snapshots:
       - '@cfworker/json-schema'
       - '@types/react'
       - '@types/react-dom'
+      - hono
       - supports-color
 
-  '@modelcontextprotocol/inspector-server@0.17.2':
+  '@modelcontextprotocol/inspector-server@0.18.0(hono@4.11.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@3.25.76)
       cors: 2.8.5
       express: 5.1.0
       shell-quote: 1.8.3
@@ -12439,15 +12458,16 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bufferutil
+      - hono
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.17.2(@swc/core@1.7.26(@swc/helpers@0.5.17))(@types/node@22.19.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(typescript@5.9.3)':
+  '@modelcontextprotocol/inspector@0.18.0(@swc/core@1.7.26(@swc/helpers@0.5.17))(@types/node@22.19.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(hono@4.11.3)(typescript@5.9.3)':
     dependencies:
-      '@modelcontextprotocol/inspector-cli': 0.17.2(zod@3.25.76)
-      '@modelcontextprotocol/inspector-client': 0.17.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)
-      '@modelcontextprotocol/inspector-server': 0.17.2
-      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
+      '@modelcontextprotocol/inspector-cli': 0.18.0(hono@4.11.3)(zod@3.25.76)
+      '@modelcontextprotocol/inspector-client': 0.18.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(hono@4.11.3)
+      '@modelcontextprotocol/inspector-server': 0.18.0(hono@4.11.3)
+      '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@3.25.76)
       concurrently: 9.2.1
       node-fetch: 3.3.2
       open: 10.2.0
@@ -12463,12 +12483,14 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - bufferutil
+      - hono
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.24.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@3.25.76)':
     dependencies:
+      '@hono/node-server': 1.19.7(hono@4.11.3)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -12479,15 +12501,18 @@ snapshots:
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
       jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.0(zod@3.25.76)
     transitivePeerDependencies:
+      - hono
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.24.1(zod@4.1.13)':
+  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1)':
     dependencies:
+      '@hono/node-server': 1.19.7(hono@4.11.3)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -12498,11 +12523,13 @@ snapshots:
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
       jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
-      zod: 4.1.13
-      zod-to-json-schema: 3.25.0(zod@4.1.13)
+      zod: 4.2.1
+      zod-to-json-schema: 3.25.0(zod@4.2.1)
     transitivePeerDependencies:
+      - hono
       - supports-color
 
   '@module-federation/bridge-react-webpack-plugin@0.21.6':
@@ -17855,6 +17882,8 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hono@4.11.3: {}
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -18385,6 +18414,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -22235,9 +22266,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.0(zod@4.1.13):
+  zod-to-json-schema@3.25.0(zod@4.2.1):
     dependencies:
-      zod: 4.1.13
+      zod: 4.2.1
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:
@@ -22246,6 +22277,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.1.13: {}
+  zod@4.2.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION


### Reason for this change

Yarn and Bun use the hoisted version of zod which we render in the root package.json instead of the version which the mcp sdk depends on. This was causing an issue where the mcp sdk required zod 4.2 and above but yarn was resolving the version we vended which was 4.1.

### Description of changes

Upgrade both zod and the mcp sdk (as well as the mcp inspector).

### Description of how you validated changes

Integration tests in this PR

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*