### PR TITLE
ci: log in to docker public ecr registry

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -1,9 +1,23 @@
 name: Initialize Monorepo
 description: Initialize nx monorepo for CI workflows
 
+inputs:
+  aws-docker-login-role-arn:
+    description: 'ARN of the AWS role to assume for Docker login'
+    required: true
+
 runs:
   using: 'composite'
   steps:
+    - name: Docker login credentials
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: ${{ inputs.aws-docker-login-role-arn }}
+        aws-region: us-east-1
+    - name: Login to ECR
+      uses: docker/login-action@v3
+      with:
+        registry: public.ecr.aws
     - name: Use PNPM 10.x
       uses: pnpm/action-setup@v4
       with:
@@ -27,6 +41,8 @@ runs:
         version: 'latest'
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        image: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Set up terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Build
         run: pnpm nx run-many --target build --all --output-style=stream
       - name: Upload coverage reports to Codecov
@@ -70,6 +72,8 @@ jobs:
           name: build-artifact
           path: dist
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -94,6 +98,8 @@ jobs:
           name: build-artifact
           path: dist
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Build
         run: pnpm nx run-many --target build --all --output-style=stream
       - name: Upload coverage reports to Codecov
@@ -70,5 +72,7 @@ jobs:
           name: build-artifact
           path: dist
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -34,6 +34,8 @@ jobs:
           fetch-depth: 0 # Required to detect changed files
           token: ${{ secrets.TRANSLATE_PUSH_GITHUB_TOKEN }} # needed to trigger PR workflow after push
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -25,6 +25,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.UPDATE_VERSIONS_GITHUB_TOKEN }}
       - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Bump Nx Plugin for AWS versions
         run: |
           npx -y npm-check-updates@19.0.0 --configFileName .ncurc.cjs


### PR DESCRIPTION
### Reason for this change

Address docker rate limiting eg https://github.com/awslabs/nx-plugin-for-aws/actions/runs/21050478460/job/60536220784

### Description of changes

Use an iam role to log in to the public ecr registry (future proof for more pulls per second) and swap qemu image to one on the public ecr registry.

### Description of how you validated changes

This PR

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*