### PR TITLE
fix(ts#infra): use --directory flag for checkov to support single stack

### DIFF
--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -84,7 +84,7 @@ exports[`infra generator > should configure Checkov target correctly > checkov-t
     "{workspaceRoot}/dist/{projectRoot}/cdk.out",
   ],
   "options": {
-    "command": "uvx --with pycares==4.11.0 checkov==3.2.500 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
+    "command": "uvx --with pycares==4.11.0 checkov==3.2.500 --config-file packages/test/checkov.yml --directory dist/packages/test/cdk.out --framework cloudformation",
   },
   "outputs": [
     "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -177,7 +177,7 @@ exports[`infra generator > should configure project.json with correct targets > 
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx --with pycares==4.11.0 checkov==3.2.500 --config-file packages/test/checkov.yml --file dist/packages/test/cdk.out/**/*.template.json",
+        "command": "uvx --with pycares==4.11.0 checkov==3.2.500 --config-file packages/test/checkov.yml --directory dist/packages/test/cdk.out --framework cloudformation",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -724,7 +724,7 @@ exports[`infra generator > should handle custom project names correctly > custom
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx --with pycares==4.11.0 checkov==3.2.500 --config-file packages/custom-infra/checkov.yml --file dist/packages/custom-infra/cdk.out/**/*.template.json",
+        "command": "uvx --with pycares==4.11.0 checkov==3.2.500 --config-file packages/custom-infra/checkov.yml --directory dist/packages/custom-infra/cdk.out --framework cloudformation",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -115,7 +115,7 @@ export async function tsInfraGenerator(
         options: {
           command: uvxCommand(
             'checkov',
-            `--config-file ${lib.dir}/checkov.yml --file dist/${lib.dir}/cdk.out/**/*.template.json`,
+            `--config-file ${lib.dir}/checkov.yml --directory dist/${lib.dir}/cdk.out --framework cloudformation`,
             [{ dep: 'pycares', version: '4.11.0' }], // TODO: remove when https://github.com/aio-libs/aiodns/issues/214 is resolved
           ),
         },


### PR DESCRIPTION
## Summary

Fixes checkov failing when the CDK App declares stacks directly without stages.

## Problem

The checkov command used `--file dist/<path>/cdk.out/**/*.template.json` which only matches files in subdirectories, not files directly in `cdk.out/`.

**With Stages (worked):**
```
cdk.out/
  StageName/
    Stack.template.json  ✅ matched by **/*.template.json
```

**Without Stages (broken):**
```
cdk.out/
  Stack.template.json  ❌ not matched by **/*.template.json
```

## Solution

Changed from `--file` with glob pattern to `--directory` flag which scans all CloudFormation templates recursively. This matches the pattern already used in the Terraform generator.

**Before:**
```
--file dist/<path>/cdk.out/**/*.template.json
```

**After:**
```
--directory dist/<path>/cdk.out
```

## Testing

- [x] `pnpm nx test nx-plugin -- --run "infra/app/generator"` passes (17 tests)
- [x] Snapshot updated to reflect new command

## Related

- The Terraform generator (`terraform/project/generator.ts`) already uses `--directory` correctly

Closes #403