### PR TITLE
fix(api-connection): wrap trpc client context to avoid client[procedureType] error

### DIFF
--- a/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
@@ -3,37 +3,51 @@
 exports[`trpc react generator > should generate trpc react files > TestApiClientProvider.tsx 1`] = `
 "import { AppRouter } from 'backend';
 import { useQueryClient } from '@tanstack/react-query';
-import { createTRPCContext } from '@trpc/tanstack-react-query';
-import { FC, PropsWithChildren, useMemo } from 'react';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import { createContext, FC, PropsWithChildren, useMemo } from 'react';
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
-import { HTTPLinkOptions, createTRPCClient, httpLink } from '@trpc/client';
+import {
+  HTTPLinkOptions,
+  TRPCClient,
+  createTRPCClient,
+  httpLink,
+} from '@trpc/client';
 
-export const TestApiTRPCContext: ReturnType<
-  typeof createTRPCContext<AppRouter>
-> = createTRPCContext<AppRouter>();
+interface TestApiTRPCContextValue {
+  optionsProxy: ReturnType<typeof createTRPCOptionsProxy<AppRouter>>;
+  client: TRPCClient<AppRouter>;
+}
+
+export const TestApiTRPCContext = createContext<TestApiTRPCContextValue | null>(
+  null,
+);
 
 export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
   const queryClient = useQueryClient();
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.apis.TestApi;
 
-  const trpcClient = useMemo(() => {
+  const container = useMemo<TestApiTRPCContextValue>(() => {
     const linkOptions: HTTPLinkOptions<any> = {
       url: apiUrl,
     };
 
-    return createTRPCClient<AppRouter>({
+    const client = createTRPCClient<AppRouter>({
       links: [httpLink(linkOptions)],
     });
-  }, [apiUrl]);
+
+    const optionsProxy = createTRPCOptionsProxy<AppRouter>({
+      client,
+      queryClient,
+    });
+
+    return { optionsProxy, client };
+  }, [apiUrl, queryClient]);
 
   return (
-    <TestApiTRPCContext.TRPCProvider
-      trpcClient={trpcClient}
-      queryClient={queryClient}
-    >
+    <TestApiTRPCContext.Provider value={container}>
       {children}
-    </TestApiTRPCContext.TRPCProvider>
+    </TestApiTRPCContext.Provider>
   );
 };
 
@@ -42,34 +56,60 @@ export default TestApiClientProvider;
 `;
 
 exports[`trpc react generator > should generate trpc react files > useTestApi.tsx 1`] = `
-"import { TestApiTRPCContext } from '../components/TestApiClientProvider';
+"import { useContext } from 'react';
+import { TestApiTRPCContext } from '../components/TestApiClientProvider';
 
-export const useTestApi = TestApiTRPCContext.useTRPC;
+export const useTestApi = () => {
+  const container = useContext(TestApiTRPCContext);
+  if (!container) {
+    throw new Error('useTestApi must be used within TestApiClientProvider');
+  }
+  return container.optionsProxy;
+};
+
+export const useTestApiClient = () => {
+  const container = useContext(TestApiTRPCContext);
+  if (!container) {
+    throw new Error(
+      'useTestApiClient must be used within TestApiClientProvider',
+    );
+  }
+  return container.client;
+};
 "
 `;
 
 exports[`trpc react generator > should handle Cognito auth option > TestApiClientProvider-Cognito.tsx 1`] = `
 "import { AppRouter } from 'backend';
 import { useQueryClient } from '@tanstack/react-query';
-import { createTRPCContext } from '@trpc/tanstack-react-query';
-import { FC, PropsWithChildren, useMemo } from 'react';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import { createContext, FC, PropsWithChildren, useMemo } from 'react';
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
-import { HTTPLinkOptions, createTRPCClient, httpLink } from '@trpc/client';
+import {
+  HTTPLinkOptions,
+  TRPCClient,
+  createTRPCClient,
+  httpLink,
+} from '@trpc/client';
 import { useAuth } from 'react-oidc-context';
 
-export const TestApiTRPCContext: ReturnType<
-  typeof createTRPCContext<AppRouter>
-> = createTRPCContext<AppRouter>();
+interface TestApiTRPCContextValue {
+  optionsProxy: ReturnType<typeof createTRPCOptionsProxy<AppRouter>>;
+  client: TRPCClient<AppRouter>;
+}
+
+export const TestApiTRPCContext = createContext<TestApiTRPCContextValue | null>(
+  null,
+);
 
 export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
   const queryClient = useQueryClient();
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.apis.TestApi;
-
   const auth = useAuth();
   const user = auth?.user;
 
-  const trpcClient = useMemo(() => {
+  const container = useMemo<TestApiTRPCContextValue>(() => {
     const linkOptions: HTTPLinkOptions<any> = {
       url: apiUrl,
       headers: {
@@ -77,18 +117,22 @@ export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
       },
     };
 
-    return createTRPCClient<AppRouter>({
+    const client = createTRPCClient<AppRouter>({
       links: [httpLink(linkOptions)],
     });
-  }, [apiUrl, user]);
+
+    const optionsProxy = createTRPCOptionsProxy<AppRouter>({
+      client,
+      queryClient,
+    });
+
+    return { optionsProxy, client };
+  }, [apiUrl, queryClient, user]);
 
   return (
-    <TestApiTRPCContext.TRPCProvider
-      trpcClient={trpcClient}
-      queryClient={queryClient}
-    >
+    <TestApiTRPCContext.Provider value={container}>
       {children}
-    </TestApiTRPCContext.TRPCProvider>
+    </TestApiTRPCContext.Provider>
   );
 };
 
@@ -99,41 +143,54 @@ export default TestApiClientProvider;
 exports[`trpc react generator > should handle IAM auth option > TestApiClientProvider-IAM.tsx 1`] = `
 "import { AppRouter } from 'backend';
 import { useQueryClient } from '@tanstack/react-query';
-import { createTRPCContext } from '@trpc/tanstack-react-query';
-import { FC, PropsWithChildren, useMemo } from 'react';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import { createContext, FC, PropsWithChildren, useMemo } from 'react';
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
-import { HTTPLinkOptions, createTRPCClient, httpLink } from '@trpc/client';
+import {
+  HTTPLinkOptions,
+  TRPCClient,
+  createTRPCClient,
+  httpLink,
+} from '@trpc/client';
 import { useSigV4 } from '../hooks/useSigV4';
 
-export const TestApiTRPCContext: ReturnType<
-  typeof createTRPCContext<AppRouter>
-> = createTRPCContext<AppRouter>();
+interface TestApiTRPCContextValue {
+  optionsProxy: ReturnType<typeof createTRPCOptionsProxy<AppRouter>>;
+  client: TRPCClient<AppRouter>;
+}
+
+export const TestApiTRPCContext = createContext<TestApiTRPCContextValue | null>(
+  null,
+);
 
 export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
   const queryClient = useQueryClient();
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.apis.TestApi;
-
   const sigv4Client = useSigV4();
 
-  const trpcClient = useMemo(() => {
+  const container = useMemo<TestApiTRPCContextValue>(() => {
     const linkOptions: HTTPLinkOptions<any> = {
       url: apiUrl,
       fetch: sigv4Client,
     };
 
-    return createTRPCClient<AppRouter>({
+    const client = createTRPCClient<AppRouter>({
       links: [httpLink(linkOptions)],
     });
-  }, [apiUrl, sigv4Client]);
+
+    const optionsProxy = createTRPCOptionsProxy<AppRouter>({
+      client,
+      queryClient,
+    });
+
+    return { optionsProxy, client };
+  }, [apiUrl, queryClient, sigv4Client]);
 
   return (
-    <TestApiTRPCContext.TRPCProvider
-      trpcClient={trpcClient}
-      queryClient={queryClient}
-    >
+    <TestApiTRPCContext.Provider value={container}>
       {children}
-    </TestApiTRPCContext.TRPCProvider>
+    </TestApiTRPCContext.Provider>
   );
 };
 

--- a/packages/nx-plugin/src/trpc/react/files/src/components/__apiNameClassName__ClientProvider.tsx.template
+++ b/packages/nx-plugin/src/trpc/react/files/src/components/__apiNameClassName__ClientProvider.tsx.template
@@ -1,16 +1,21 @@
 import { AppRouter } from "<%- backendProjectAlias %>";
 import { useQueryClient } from "@tanstack/react-query";
-import { createTRPCContext } from "@trpc/tanstack-react-query";
-import { FC, PropsWithChildren, useMemo } from "react";
+import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
+import { createContext, FC, PropsWithChildren, useMemo } from "react";
 import { useRuntimeConfig } from "../hooks/useRuntimeConfig";
-import { HTTPLinkOptions, createTRPCClient, httpLink } from "@trpc/client";
+import { HTTPLinkOptions, TRPCClient, createTRPCClient, httpLink } from "@trpc/client";
 <%_ if (auth === 'IAM') { _%>
 import { useSigV4 } from "../hooks/useSigV4";
 <%_ } else if (auth === 'Cognito') { _%>
 import { useAuth } from "react-oidc-context";
 <%_ } _%>
 
-export const <%= apiNameClassName %>TRPCContext: ReturnType<typeof createTRPCContext<AppRouter>> = createTRPCContext<AppRouter>();
+interface <%= apiNameClassName %>TRPCContextValue {
+  optionsProxy: ReturnType<typeof createTRPCOptionsProxy<AppRouter>>;
+  client: TRPCClient<AppRouter>;
+}
+
+export const <%= apiNameClassName %>TRPCContext = createContext<<%= apiNameClassName %>TRPCContextValue | null>(null);
 
 export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
   children,
@@ -18,7 +23,6 @@ export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
   const queryClient = useQueryClient();
   const runtimeConfig = useRuntimeConfig();
   const apiUrl = runtimeConfig.apis.<%= apiNameClassName %>;
-
   <%_ if (auth === 'IAM') { _%>
   const sigv4Client = useSigV4();
   <%_ } else if (auth === 'Cognito') { _%>
@@ -26,7 +30,7 @@ export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
   const user = auth?.user;
   <%_ } _%>
 
-  const trpcClient = useMemo(() => {
+  const container = useMemo<<%= apiNameClassName %>TRPCContextValue>(() => {
     const linkOptions: HTTPLinkOptions<any> = {
       url: apiUrl,
       <%_ if (auth === 'IAM') { _%>
@@ -38,15 +42,22 @@ export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
       <%_ } _%>
     };
 
-    return createTRPCClient<AppRouter>({
+    const client = createTRPCClient<AppRouter>({
       links: [httpLink(linkOptions)],
     });
-  }, [apiUrl<% if (auth === 'IAM') { %>, sigv4Client<% } else if (auth === 'Cognito') { %>, user<% } %>]);
+
+    const optionsProxy = createTRPCOptionsProxy<AppRouter>({
+      client,
+      queryClient,
+    });
+
+    return { optionsProxy, client };
+  }, [apiUrl, queryClient<% if (auth === 'IAM') { %>, sigv4Client<% } else if (auth === 'Cognito') { %>, user<% } %>]);
 
   return (
-    <<%= apiNameClassName %>TRPCContext.TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+    <<%= apiNameClassName %>TRPCContext.Provider value={container}>
       {children}
-    </<%= apiNameClassName %>TRPCContext.TRPCProvider>
+    </<%= apiNameClassName %>TRPCContext.Provider>
   );
 };
 

--- a/packages/nx-plugin/src/trpc/react/files/src/hooks/use__apiNameClassName__.tsx.template
+++ b/packages/nx-plugin/src/trpc/react/files/src/hooks/use__apiNameClassName__.tsx.template
@@ -1,3 +1,18 @@
+import { useContext } from 'react';
 import { <%= apiNameClassName %>TRPCContext } from '../components/<%- apiNameClassName %>ClientProvider';
 
-export const use<%- apiNameClassName %> = <%= apiNameClassName %>TRPCContext.useTRPC;
+export const use<%- apiNameClassName %> = () => {
+  const container = useContext(<%= apiNameClassName %>TRPCContext);
+  if (!container) {
+    throw new Error('use<%- apiNameClassName %> must be used within <%= apiNameClassName %>ClientProvider');
+  }
+  return container.optionsProxy;
+};
+
+export const use<%- apiNameClassName %>Client = () => {
+  const container = useContext(<%= apiNameClassName %>TRPCContext);
+  if (!container) {
+    throw new Error('use<%- apiNameClassName %>Client must be used within <%= apiNameClassName %>ClientProvider');
+  }
+  return container.client;
+};


### PR DESCRIPTION
### Reason for this change

It seems that the trpc error still occurs with React 19.2 in some cases. It seems not to reproduce when the client and options proxy (which use javascript's Proxy under the hood) aren't directly used as context values but rather wrapped in an object, so that react's inspection of context doesn't try to access proxied properties.

### Description of changes

Wrap client and options proxy in an object in a single context, rather than using `createTRPCContext` which puts them in individual contexts.

### Description of how you validated changes

Manual testing

### Issue # (if applicable)

Fixes #399

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*