### PR TITLE
test: suppress warning for non-existent virtual workspace

### DIFF
--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -22,6 +22,7 @@ export default defineConfig({
   test: {
     env: {
       NX_DAEMON: 'false',
+      NX_NATIVE_LOGGING: 'error',
     },
     watch: false,
     globals: true,


### PR DESCRIPTION
### Reason for this change

Noisy logs for the majority of tests distract from actual test output.

### Description of changes

Set Nx native log level to `error` to suppress the warning log.

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Fixes #426

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*