### PR TITLE
test: boost speed of tests by mocking project graph creation

### DIFF
--- a/packages/nx-plugin/src/utils/mock-project-graph.ts
+++ b/packages/nx-plugin/src/utils/mock-project-graph.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Mock createProjectGraphAsync to avoid expensive project graph building in tests.
+ *
+ * This is the vitest equivalent of Nx's own internal testing utility:
+ * https://github.com/nrwl/nx/blob/master/packages/nx/src/internal-testing-utils/mock-project-graph.ts
+ *
+ * We patch the underlying nx module directly because:
+ * 1. vitest's vi.mock only affects ESM imports within the test file
+ * 2. @nx/devkit's exports are wrapped with read-only getters by vitest
+ * 3. The CJS module at nx/src/project-graph/project-graph.js is the actual
+ *    implementation that @nx/devkit re-exports
+ */
+import { createRequire } from 'module';
+
+// @ts-expect-error test utility used by vite only
+const _require = createRequire(import.meta.url);
+const projectGraph = _require('nx/src/project-graph/project-graph');
+projectGraph.createProjectGraphAsync = async () => ({
+  nodes: {},
+  dependencies: {},
+});

--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    setupFiles: ['src/utils/mock-project-graph.ts'],
     reporters: ['default'],
     coverage: {
       reportsDirectory: '../../coverage/packages/nx-plugin',


### PR DESCRIPTION
### Reason for this change

Unit test time has been creeping up, after a fairly big jump when we upgraded to nx 22 and we couldn't run the unit tests with the nx daemon enabled in ci.

### Description of changes

Use the same mechanism as nx itself and mock project graph creation for our unit tests for a massive speed improvement (7-8mins down to 50s)

### Description of how you validated changes

Ran unit tests locally.

[Previous PR build](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/22079831014/job/63802674384): `~17mins` 
[This PR build](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/22094576444/job/63848146804): `~5mins` 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*