### PR TITLE
fix: do not use response transfer mode stream for fastapi/smithy rest apis

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -871,7 +871,6 @@ import {
   AuthorizationType,
   Cors,
   LambdaIntegration,
-  ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
 import { Duration } from 'aws-cdk-lib';
 import {
@@ -945,9 +944,7 @@ export class TestApi<
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         return {
           handler,
-          integration: new LambdaIntegration(handler, {
-            responseTransferMode: ResponseTransferMode.STREAM,
-          }),
+          integration: new LambdaIntegration(handler),
         };
       },
     });

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -46,7 +46,6 @@ import {
   AuthorizationType,
   Cors,
   LambdaIntegration,
-  ResponseTransferMode,
   CognitoUserPoolsAuthorizer,
 } from 'aws-cdk-lib/aws-apigateway';
 import { Duration } from 'aws-cdk-lib';
@@ -126,9 +125,7 @@ export class TestApi<
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         return {
           handler,
-          integration: new LambdaIntegration(handler, {
-            responseTransferMode: ResponseTransferMode.STREAM,
-          }),
+          integration: new LambdaIntegration(handler),
         };
       },
     });
@@ -216,7 +213,6 @@ import {
   AuthorizationType,
   Cors,
   LambdaIntegration,
-  ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
 import { Duration } from 'aws-cdk-lib';
 import {
@@ -290,9 +286,7 @@ export class TestApi<
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         return {
           handler,
-          integration: new LambdaIntegration(handler, {
-            responseTransferMode: ResponseTransferMode.STREAM,
-          }),
+          integration: new LambdaIntegration(handler),
         };
       },
     });

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -12,7 +12,9 @@ import {
   AuthorizationType,
   Cors,
   LambdaIntegration,
+  <%_ if (backend.type === 'trpc') { _%>
   ResponseTransferMode,
+  <%_ } _%>
   <%_ if (auth === 'Cognito') { _%>
   CognitoUserPoolsAuthorizer,
   <%_ } _%>
@@ -127,9 +129,13 @@ export class <%= apiNameClassName %><
         const handler = new Function(scope, `<%= apiNameClassName %>${op}Handler`, props);
         return {
           handler,
+          <%_ if (backend.type === 'trpc') { _%>
           integration: new LambdaIntegration(handler, {
             responseTransferMode: ResponseTransferMode.STREAM,
           }),
+          <%_ } else { _%>
+          integration: new LambdaIntegration(handler),
+          <%_ } _%>
         };
       },
     });


### PR DESCRIPTION
### Reason for this change

End to end test on release caught this:

https://github.com/awslabs/nx-plugin-for-aws/actions/runs/22292036819/job/64481400345

```
Testing tRPC REST API at https://l1yiyqqh46.execute-api.us-west-2.amazonaws.com/prod/
tRPC REST API response: { result: { data: { result: 'test' } } }
Testing tRPC HTTP API at https://r1zzn428db.execute-api.us-west-2.amazonaws.com/
tRPC HTTP API response: { result: { data: { result: 'test' } } }
Testing FastAPI REST at https://zf9hd8tofg.execute-api.us-west-2.amazonaws.com/prod/
FastAPI REST response: { message: 'Internal server error' }
```

### Description of changes

Ensure that we only set response transfer mode to `STREAM` for trpc REST apis, reverts FastAPI/Smithy as before.

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*