### PR TITLE
fix: use access_token instead of id_token in story agent

### DIFF
--- a/e2e/src/files/dungeon-adventure/4/hooks/useStoryAgent.tsx.template
+++ b/e2e/src/files/dungeon-adventure/4/hooks/useStoryAgent.tsx.template
@@ -26,7 +26,7 @@ export const useStoryAgent = () => {
       ): AsyncIterableIterator<StreamChunk> {
         const response = await fetch(url, {
           headers: {
-            Authorization: `Bearer ${user?.id_token}`,
+            Authorization: `Bearer ${user?.access_token}`,
             'Content-Type': 'application/json',
           },
           method: 'POST',
@@ -61,6 +61,6 @@ export const useStoryAgent = () => {
         }
       },
     }),
-    [url, user?.id_token],
+    [url, user?.access_token],
   );
 };


### PR DESCRIPTION
### Reason for this change

The Dungeon Adventure Game UI fails to authenticate calls to the story agent because it uses `user?.id_token` instead of `user?.access_token` in the `useStoryAgent` hook.[web:34]

### Description of changes

- Updated the `useStoryAgent` hook in the Dungeon Adventure Game UI to use `user?.access_token` in the `Authorization` header instead of `user?.id_token`.[web:34]
- Updated the `useMemo` dependency array to depend on `user?.access_token` so the hook reacts correctly when the access token changes.[web:34]

### Description of how you validated changes

- Ran the Dungeon Adventure Game UI locally and verified that story generation requests succeed using the access token.
- Confirmed that there are no TypeScript build errors after the change.

### Issue # (if applicable)

Closes #437.