### PR TITLE
fix(ts-lib): remove hello world sample code from generated index.ts

### DIFF
--- a/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
@@ -74,9 +74,7 @@ exports[`ts lib generator > should configure named inputs in nx.json 1`] = `
 `;
 
 exports[`ts lib generator > should generate library with custom directory > custom-dir-index.ts 1`] = `
-"export function hello() {
-  return 'Hello!';
-}
+"// Export your library code here
 "
 `;
 
@@ -175,9 +173,7 @@ export default [
 `;
 
 exports[`ts lib generator > should generate library with default options > index.ts 1`] = `
-"export function hello() {
-  return 'Hello!';
-}
+"// Export your library code here
 "
 `;
 
@@ -247,9 +243,7 @@ exports[`ts lib generator > should generate library with default options > tscon
 `;
 
 exports[`ts lib generator > should generate library with subdirectory > subdir-index.ts 1`] = `
-"export function hello() {
-  return 'Hello!';
-}
+"// Export your library code here
 "
 `;
 

--- a/packages/nx-plugin/src/ts/lib/files/src/index.ts.template
+++ b/packages/nx-plugin/src/ts/lib/files/src/index.ts.template
@@ -1,3 +1,1 @@
-export function hello() {
-  return "Hello!";
-}
+// Export your library code here


### PR DESCRIPTION
## Summary

- Remove the default `hello()` function from `index.ts.template`
- Replace with a comment placeholder: `// Export your library code here`
- Update test snapshots to reflect the new expected output

## Problem

As described in #438, the ts#project generator creates a sample `hello()` function in `index.ts` that is often left in place as redundant code. This sample code causes confusion for new users who may not realize it should be removed.

## Solution

Replace the sample function with a simple comment that guides users to add their library exports. This approach:
- Keeps the file from being empty (which could cause issues with some tooling)
- Provides a clear indication of what the file is for
- Eliminates the need to delete sample code before using the library

## Test plan

- [x] Ran `npx vitest run src/ts/lib/generator.spec.ts` - all 20 tests pass
- [x] Ran `npx nx lint @aws/nx-plugin` - passes (only pre-existing warnings)
- [x] Ran `npx nx compile @aws/nx-plugin` - compiles successfully

Fixes #438