### PR TITLE
fix(ts#react-website): serve-local for shadcn without runtime config and cognito auth

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.ux-provider.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.ux-provider.spec.ts.snap
@@ -333,3 +333,98 @@ const AppLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
 export default AppLayout;
 "
 `;
+
+exports[`cognito-auth generator uxProvider tests > Shadcn > should update AppLayout > app-layout-with-auth 1`] = `
+"import { useEffect, useRef, useState } from 'react';
+import { useAuth } from 'react-oidc-context';
+import * as React from 'react';
+import {
+  SidebarInset,
+  SidebarProvider,
+} from 'common-shadcn/components/ui/sidebar';
+import { Separator } from 'common-shadcn/components/ui/separator';
+import Config from '../../config';
+
+const AppLayout = ({ children }: { children: React.ReactNode }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as any)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+  const { user, removeUser, signoutRedirect, clearStaleState } = useAuth();
+  return (
+    <SidebarProvider>
+      <SidebarInset>
+        <header className="supports-backdrop-blur:bg-background/60 sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background/80 px-4 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <Separator orientation="vertical" className="h-6" />
+            <div className="flex items-center gap-2">
+              <img
+                alt={\`\${Config.applicationName} logo\`}
+                className="size-10 rounded-lg border border-border/60 bg-background object-cover shadow-sm"
+                src={Config.logo}
+              />
+              <div className="flex flex-col leading-tight">
+                <span className="text-sm font-semibold">
+                  {Config.applicationName}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="ml-auto flex items-center gap-3" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setMenuOpen((open) => !open)}
+              className="focus-visible:ring-ring/60 bg-muted text-muted-foreground flex size-10 items-center justify-center rounded-full border border-border/60 font-semibold shadow-sm outline-none transition hover:bg-muted/80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background cursor-pointer"
+              aria-label="Open user menu"
+              aria-expanded={menuOpen}
+            >
+              {(user?.profile?.['cognito:username'] as any)
+                ?.charAt?.(0)
+                ?.toUpperCase?.()}
+            </button>
+            {menuOpen && (
+              <div className="bg-popover text-popover-foreground absolute right-4 top-14 w-36 overflow-hidden rounded-md border shadow-md">
+                <div className="px-3 py-2 text-sm font-semibold">
+                  Hi, {user?.profile?.['cognito:username'] as any}!
+                </div>
+                <div className="bg-border/70 h-px w-full" role="separator" />
+                <button
+                  type="button"
+                  className="hover:bg-muted w-full px-3 py-2 text-left text-sm cursor-pointer"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    removeUser();
+                    signoutRedirect({
+                      post_logout_redirect_uri: window.location.origin,
+                      extraQueryParams: {
+                        redirect_uri: window.location.origin,
+                        response_type: 'code',
+                      },
+                    });
+                    clearStaleState();
+                  }}
+                >
+                  Sign out
+                </button>
+              </div>
+            )}
+          </div>
+        </header>
+        <div className="flex flex-1 flex-col gap-6 p-6 pt-4">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+};
+
+export default AppLayout;
+"
+`;

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ux-provider.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ux-provider.spec.ts
@@ -505,6 +505,8 @@ export default AppLayout;
       expect(appLayoutContent).toContain('removeUser()');
       expect(appLayoutContent).toContain('signoutRedirect(');
       expect(appLayoutContent).toContain('clearStaleState()');
+
+      expect(appLayoutContent).toMatchSnapshot('app-layout-with-auth');
     });
   });
 });

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
@@ -466,8 +466,9 @@ export function addShadcnAuthMenu(tree: Tree, appLayoutTsxPath: string) {
   const userInitialExpr = factory.createCallChain(
     factory.createPropertyAccessChain(
       factory.createCallChain(
-        factory.createPropertyAccessExpression(
+        factory.createPropertyAccessChain(
           userNameExpr,
+          factory.createToken(SyntaxKind.QuestionDotToken),
           factory.createIdentifier('charAt'),
         ),
         factory.createToken(SyntaxKind.QuestionDotToken),


### PR DESCRIPTION


### Reason for this change

After vending a react website with uxProvider shadcn, adding cognito auth with `ts#react-website#auth`, the `serve-local` target doesn't work as it expects a logged in cognito user, and the website just shows the error: `Cannot read properties of undefined (reading 'charAt')`.

### Description of changes

There was just one ?. missing in the chain for showing the username. Added this.

Also added missing snapshot for shadcn applayout with auth.

### Description of how you validated changes

Unit tests (and manual update in a test project).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*