### PR TITLE
chore(connection): add component path to metadata in generators to prepare for agent connections

### DIFF
--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -1098,6 +1098,7 @@ describe('lambda-handler project generator', () => {
       expect(projectConfig.metadata.components).toHaveLength(1);
       expect(projectConfig.metadata.components[0]).toEqual({
         generator: LAMBDA_FUNCTION_GENERATOR_INFO.id,
+        path: 'test_project/test_function.py',
         name: 'test-function',
       });
     });

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -33,6 +33,7 @@ import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { addPythonBundleTarget } from '../../utils/bundle/bundle';
 import { addDependenciesToPyProjectToml } from '../../utils/py';
 import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
+import { toProjectRelativePath } from '../../utils/paths';
 import { resolveIacProvider } from '../../utils/iac';
 
 export const LAMBDA_FUNCTION_GENERATOR_INFO: NxGeneratorInfo =
@@ -187,6 +188,7 @@ export const pyLambdaFunctionGenerator = async (
     tree,
     projectConfig.name,
     LAMBDA_FUNCTION_GENERATOR_INFO,
+    toProjectRelativePath(projectConfig, functionPath),
     lambdaFunctionKebabCase,
   );
 

--- a/packages/nx-plugin/src/py/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.ts
@@ -31,6 +31,7 @@ import { withVersions } from '../../utils/versions';
 import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { resolveIacProvider } from '../../utils/iac';
 import { assignPort } from '../../utils/port';
+import { toProjectRelativePath } from '../../utils/paths';
 
 export const PY_MCP_SERVER_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -219,6 +220,7 @@ export const pyMcpServerGenerator = async (
     tree,
     project.name,
     PY_MCP_SERVER_GENERATOR_INFO,
+    toProjectRelativePath(project, targetSourceDir),
     mcpTargetPrefix,
     {
       port: localDevPort,

--- a/packages/nx-plugin/src/py/strands-agent/generator.ts
+++ b/packages/nx-plugin/src/py/strands-agent/generator.ts
@@ -33,6 +33,7 @@ import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { resolveIacProvider } from '../../utils/iac';
 import { assignPort } from '../../utils/port';
+import { toProjectRelativePath } from '../../utils/paths';
 
 export const PY_STRANDS_AGENT_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -187,6 +188,7 @@ export const pyStrandsAgentGenerator = async (
     tree,
     project.name,
     PY_STRANDS_AGENT_GENERATOR_INFO,
+    toProjectRelativePath(project, targetSourceDir),
     agentTargetPrefix,
     {
       port: localDevPort,

--- a/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
@@ -753,6 +753,7 @@ describe('ts-lambda-function generator', () => {
       expect(projectConfig.metadata.components).toHaveLength(1);
       expect(projectConfig.metadata.components[0]).toEqual({
         generator: TS_LAMBDA_FUNCTION_GENERATOR_INFO.id,
+        path: 'src/test-function.ts',
         name: 'test-function',
       });
     });

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -158,6 +158,7 @@ export const tsLambdaFunctionGenerator = async (
     tree,
     projectConfig.name,
     TS_LAMBDA_FUNCTION_GENERATOR_INFO,
+    functionPathFromProjectRoot,
     lambdaFunctionKebabCase,
   );
 

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -200,6 +200,7 @@ export const tsMcpServerGenerator = async (
     tree,
     project.name,
     TS_MCP_SERVER_GENERATOR_INFO,
+    targetSourceDirRelativeToProjectRoot,
     mcpTargetPrefix,
     {
       port: localDevPort,

--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -607,6 +607,7 @@ describe('nx-generator generator', () => {
       expect(projectConfig.metadata.components).toHaveLength(1);
       expect(projectConfig.metadata.components[0]).toEqual({
         generator: NX_GENERATOR_GENERATOR_INFO.id,
+        path: 'src/test-generator',
         name: 'test-generator',
       });
     });

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -147,6 +147,7 @@ export const tsNxGeneratorGenerator = async (
       tree,
       plugin.name,
       NX_GENERATOR_GENERATOR_INFO,
+      joinPathFragments(srcDir, generatorSubDir),
       name,
     );
   }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.terraform.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.terraform.spec.ts
@@ -899,9 +899,11 @@ resource "aws_s3_bucket_policy" "website_cloudfront_policy" {
     expect(projectConfig.metadata.components).toHaveLength(2);
     expect(projectConfig.metadata.components[0]).toEqual({
       generator: RUNTIME_CONFIG_GENERATOR_INFO.id,
+      path: 'src/components/RuntimeConfig',
     });
     expect(projectConfig.metadata.components[1]).toEqual({
       generator: COGNITO_AUTH_GENERATOR_INFO.id,
+      path: 'src/components/CognitoAuth',
     });
   });
 });

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -45,6 +45,7 @@ import {
   addNoneAuthMenu,
   addShadcnAuthMenu,
 } from './utils';
+import { toProjectRelativePath } from '../../../utils/paths';
 
 export const COGNITO_AUTH_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -53,10 +54,11 @@ export async function tsReactWebsiteAuthGenerator(
   tree: Tree,
   options: TsReactWebsiteAuthGeneratorSchema,
 ) {
-  const srcRoot = readProjectConfigurationUnqualified(
+  const projectConfig = readProjectConfigurationUnqualified(
     tree,
     options.project,
-  ).sourceRoot;
+  );
+  const srcRoot = projectConfig.sourceRoot;
   if (
     tree.exists(joinPathFragments(srcRoot, 'components/CognitoAuth/index.tsx'))
   ) {
@@ -249,6 +251,10 @@ export async function tsReactWebsiteAuthGenerator(
     tree,
     options.project,
     COGNITO_AUTH_GENERATOR_INFO,
+    toProjectRelativePath(
+      projectConfig,
+      joinPathFragments(srcRoot, 'components', 'CognitoAuth'),
+    ),
   );
 
   await addGeneratorMetricsIfApplicable(tree, [COGNITO_AUTH_GENERATOR_INFO]);

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/generator.spec.ts
@@ -386,6 +386,7 @@ describe('runtime-config generator', () => {
       expect(projectConfig.metadata.components).toHaveLength(1);
       expect(projectConfig.metadata.components[0]).toEqual({
         generator: RUNTIME_CONFIG_GENERATOR_INFO.id,
+        path: 'src/components/RuntimeConfig',
       });
     });
   });

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/generator.ts
@@ -20,6 +20,7 @@ import {
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { toProjectRelativePath } from '../../../utils/paths';
 import { addHookResultToRouterProviderContext } from '../../../utils/ast/website';
 
 export const RUNTIME_CONFIG_GENERATOR_INFO: NxGeneratorInfo =
@@ -29,10 +30,11 @@ export async function runtimeConfigGenerator(
   tree: Tree,
   options: RuntimeConfigGeneratorSchema,
 ) {
-  const srcRoot = readProjectConfigurationUnqualified(
+  const projectConfig = readProjectConfigurationUnqualified(
     tree,
     options.project,
-  ).sourceRoot;
+  );
+  const srcRoot = projectConfig.sourceRoot;
   const mainTsxPath = joinPathFragments(srcRoot, 'main.tsx');
   if (!tree.exists(mainTsxPath)) {
     throw new Error(
@@ -123,6 +125,10 @@ export async function runtimeConfigGenerator(
     tree,
     options.project,
     RUNTIME_CONFIG_GENERATOR_INFO,
+    toProjectRelativePath(
+      projectConfig,
+      joinPathFragments(srcRoot, 'components', 'RuntimeConfig'),
+    ),
   );
 
   await addGeneratorMetricsIfApplicable(tree, [RUNTIME_CONFIG_GENERATOR_INFO]);

--- a/packages/nx-plugin/src/ts/strands-agent/generator.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/generator.ts
@@ -168,6 +168,7 @@ export const tsStrandsAgentGenerator = async (
     tree,
     project.name,
     TS_STRANDS_AGENT_GENERATOR_INFO,
+    targetSourceDirRelativeToProjectRoot,
     agentTargetPrefix,
     { port: localDevPort },
   );

--- a/packages/nx-plugin/src/utils/nx.spec.ts
+++ b/packages/nx-plugin/src/utils/nx.spec.ts
@@ -123,6 +123,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/test-component',
       'test-component',
     );
 
@@ -134,6 +135,7 @@ describe('addComponentGeneratorMetadata', () => {
     expect(projectConfig.metadata.components).toHaveLength(1);
     expect(projectConfig.metadata.components[0]).toEqual({
       generator: 'test-generator',
+      path: 'src/test-component',
       name: 'test-component',
     });
   });
@@ -152,6 +154,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/test-component',
       'test-component',
       {
         port: 8080,
@@ -165,6 +168,7 @@ describe('addComponentGeneratorMetadata', () => {
 
     expect(projectConfig.metadata.components[0]).toEqual({
       generator: 'test-generator',
+      path: 'src/test-component',
       name: 'test-component',
       port: 8080,
       customField: 'value',
@@ -185,6 +189,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/unnamed-component',
       undefined,
       {
         port: 3000,
@@ -197,6 +202,7 @@ describe('addComponentGeneratorMetadata', () => {
 
     expect(projectConfig.metadata.components[0]).toEqual({
       generator: 'test-generator',
+      path: 'src/unnamed-component',
       port: 3000,
     });
     expect(projectConfig.metadata.components[0].name).toBeUndefined();
@@ -224,6 +230,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/new-component',
       'new-component',
     );
 
@@ -238,6 +245,7 @@ describe('addComponentGeneratorMetadata', () => {
     });
     expect(projectConfig.metadata.components[1]).toEqual({
       generator: 'test-generator',
+      path: 'src/new-component',
       name: 'new-component',
     });
   });
@@ -264,6 +272,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/test-component',
       'test-component',
     );
 
@@ -297,6 +306,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/test-component',
       'test-component',
     );
 
@@ -323,6 +333,7 @@ describe('addComponentGeneratorMetadata', () => {
       tree,
       'test-project',
       mockGeneratorInfo,
+      'src/test-component',
       'test-component',
     );
 
@@ -333,6 +344,7 @@ describe('addComponentGeneratorMetadata', () => {
     expect(projectConfig.metadata.components).toHaveLength(1);
     expect(projectConfig.metadata.components[0]).toEqual({
       generator: 'test-generator',
+      path: 'src/test-component',
       name: 'test-component',
     });
   });

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -121,6 +121,7 @@ export const addComponentGeneratorMetadata = (
   tree: Tree,
   projectName: string,
   info: NxGeneratorInfo,
+  componentPath: string,
   componentName?: string,
   additionalMetadata?: { [key: string]: any },
 ) => {
@@ -140,6 +141,7 @@ export const addComponentGeneratorMetadata = (
           ...existingComponents,
           {
             generator: info.id,
+            path: componentPath,
             ...(componentName ? { name: componentName } : {}),
             ...additionalMetadata,
           },

--- a/packages/nx-plugin/src/utils/paths.ts
+++ b/packages/nx-plugin/src/utils/paths.ts
@@ -2,7 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { ProjectConfiguration, Tree } from '@nx/devkit';
+import * as path from 'path';
 import { readProjectConfigurationUnqualified } from './nx';
 
 export const getRelativePathToRoot = (
@@ -19,4 +20,14 @@ export const getRelativePathToRootByDirectory = (directory: string): string => {
   const levels = directory.split('/').filter(Boolean).length;
   // Create the relative path back to root
   return '../'.repeat(levels);
+};
+
+/**
+ * Convert an absolute path within a project to a path relative to the project root.
+ */
+export const toProjectRelativePath = (
+  projectConfiguration: ProjectConfiguration,
+  absolutePath: string,
+): string => {
+  return path.relative(projectConfiguration.root, absolutePath);
 };


### PR DESCRIPTION
### Reason for this change

For the connection generator to support connecting to agents, we need to target a particular "component" rather than just a project. To help with resolving components, we add the path to the component metadata. This will allow us to later support specifying either the component name, generator name, or the component path to identify the component when running the connection generator.

### Description of changes

Add path to component metadata in project.json for all component type generators.

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Issue # (if applicable)

References #326

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*