### PR TITLE
fix(mcp-server): expand documentation snippets in generator guides

### DIFF
--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -34,13 +34,17 @@ describe('postProcessGuide', () => {
         required: ['name'],
       }),
     );
+    // Mock global fetch to return empty by default (no snippets found)
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 }),
+    );
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should transform NxCommands components to markdown code blocks', () => {
+  it('should transform NxCommands components to markdown code blocks', async () => {
     const input = `
 # Test Guide
 Here's how to run a command:
@@ -55,11 +59,11 @@ nx generate @aws/nx-plugin:ts#project
 \`\`\`
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(expected);
   });
 
-  it('should transform NxCommands components with single quotes', () => {
+  it('should transform NxCommands components with single quotes', async () => {
     const input = `
 # Test Guide
 Here's how to run a command:
@@ -74,11 +78,11 @@ nx generate @aws/nx-plugin:ts#project
 \`\`\`
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(expected);
   });
 
-  it('should transform NxCommands components with multiple commands', () => {
+  it('should transform NxCommands components with multiple commands', async () => {
     const input = `
 # Test Guide
 Here's how to run a command:
@@ -95,11 +99,11 @@ nx foo
 \`\`\`
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(expected);
   });
 
-  it('should transform NxCommands components with package manager prefix', () => {
+  it('should transform NxCommands components with package manager prefix', async () => {
     const input = `
 # Test Guide
 Here's how to run a command:
@@ -114,11 +118,11 @@ pnpm nx generate @aws/nx-plugin:ts#project
 \`\`\`
 `;
 
-    const result = postProcessGuide(input, generators, 'pnpm');
+    const result = await postProcessGuide(input, generators, 'pnpm');
     expect(result).toBe(expected);
   });
 
-  it('should transform RunGenerator components to generator commands', () => {
+  it('should transform RunGenerator components to generator commands', async () => {
     const input = `
 # Test Guide
 Here's how to run a generator:
@@ -133,11 +137,11 @@ nx g @aws/nx-plugin:test-generator --no-interactive --name=<name>
 \`\`\`
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(expected);
   });
 
-  it('should transform RunGenerator components with package manager prefix', () => {
+  it('should transform RunGenerator components with package manager prefix', async () => {
     const input = `
 # Test Guide
 Here's how to run a generator:
@@ -152,11 +156,11 @@ npx nx g @aws/nx-plugin:test-generator --no-interactive --name=<name>
 \`\`\`
 `;
 
-    const result = postProcessGuide(input, generators, 'npm');
+    const result = await postProcessGuide(input, generators, 'npm');
     expect(result).toBe(expected);
   });
 
-  it('should transform GeneratorParameters components to schema documentation', () => {
+  it('should transform GeneratorParameters components to schema documentation', async () => {
     const input = `
 # Test Guide
 Here are the parameters for the generator:
@@ -170,33 +174,33 @@ Here are the parameters for the generator:
 - directory [type: string] The directory to create the project in
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(expected);
   });
 
-  it('should leave GeneratorParameters components unchanged if generator is not found', () => {
+  it('should leave GeneratorParameters components unchanged if generator is not found', async () => {
     const input = `
 # Test Guide
 Here are the parameters for the generator:
 <GeneratorParameters generator="non-existent-generator" />
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(input);
   });
 
-  it('should leave GeneratorParameters components unchanged if generator parameter is missing', () => {
+  it('should leave GeneratorParameters components unchanged if generator parameter is missing', async () => {
     const input = `
 # Test Guide
 Here are the parameters for the generator:
 <GeneratorParameters somethingElse="value" />
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(input);
   });
 
-  it('should handle multiple transformations in a single guide', () => {
+  it('should handle multiple transformations in a single guide', async () => {
     const input = `
 # Test Guide
 Here's how to run a command:
@@ -226,11 +230,11 @@ Here are the parameters for the generator:
 - directory [type: string] The directory to create the project in
 `;
 
-    const result = postProcessGuide(input, generators, 'bun');
+    const result = await postProcessGuide(input, generators, 'bun');
     expect(result).toBe(expected);
   });
 
-  it('should handle errors when reading schema file', () => {
+  it('should handle errors when reading schema file', async () => {
     // Mock fs.readFileSync to throw an error
     vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
       throw new Error('File not found');
@@ -245,7 +249,173 @@ Here are the parameters for the generator:
 <GeneratorParameters generator="test-generator" />
 `;
 
-    const result = postProcessGuide(input, generators);
+    const result = await postProcessGuide(input, generators);
     expect(result).toBe(input);
+  });
+
+  it('should replace Snippet tags with fetched snippet content', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('This is shared content about constructs.', {
+        status: 200,
+      }),
+    );
+
+    const input = `
+# Test Guide
+Some intro text.
+
+<Snippet name="shared-constructs" />
+
+More text after.
+`;
+
+    const expected = `
+# Test Guide
+Some intro text.
+
+<Snippet name="shared-constructs">
+This is shared content about constructs.
+</Snippet>
+
+More text after.
+`;
+
+    const result = await postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/snippets/shared-constructs.mdx'),
+    );
+  });
+
+  it('should replace Snippet tags with nested path names', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Consider your API choice carefully.', { status: 200 }),
+    );
+
+    const input = `
+# Test Guide
+<Snippet name="api/api-choice-note" />
+`;
+
+    const expected = `
+# Test Guide
+<Snippet name="api/api-choice-note">
+Consider your API choice carefully.
+</Snippet>
+`;
+
+    const result = await postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/snippets/api/api-choice-note.mdx'),
+    );
+  });
+
+  it('should leave Snippet tags unchanged when fetch fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 }),
+    );
+
+    const input = `
+# Test Guide
+<Snippet name="non-existent-snippet" />
+`;
+
+    const result = await postProcessGuide(input, generators);
+    expect(result).toBe(input);
+  });
+
+  it('should post-process NxCommands within fetched snippet content', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        `The generator configures a bundle target:
+
+<NxCommands commands={['run <project-name>:bundle']} />`,
+        { status: 200 },
+      ),
+    );
+
+    const input = `
+# Test Guide
+<Snippet name="ts-bundle" />
+`;
+
+    const expected = `
+# Test Guide
+<Snippet name="ts-bundle">
+The generator configures a bundle target:
+
+\`\`\`bash
+pnpm nx run <project-name>:bundle
+\`\`\`
+</Snippet>
+`;
+
+    const result = await postProcessGuide(input, generators, 'pnpm');
+    expect(result).toBe(expected);
+  });
+
+  it('should handle multiple Snippet tags in a single guide', async () => {
+    let callCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('Shared constructs content.', { status: 200 });
+      }
+      return new Response('Bundle content.', { status: 200 });
+    });
+
+    const input = `
+# Test Guide
+
+<Snippet name="shared-constructs" />
+
+Some middle text.
+
+<Snippet name="ts-bundle" />
+`;
+
+    const expected = `
+# Test Guide
+
+<Snippet name="shared-constructs">
+Shared constructs content.
+</Snippet>
+
+Some middle text.
+
+<Snippet name="ts-bundle">
+Bundle content.
+</Snippet>
+`;
+
+    const result = await postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+  });
+
+  it('should handle Snippet tags with parentHeading attribute', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Deploy instructions here.', { status: 200 }),
+    );
+
+    const input = `
+# Test Guide
+<Snippet name="lambda-function/deploying-your-function" parentHeading="Deploying your Function" />
+`;
+
+    const expected = `
+# Test Guide
+<Snippet name="lambda-function/deploying-your-function">
+Deploy instructions here.
+</Snippet>
+`;
+
+    const result = await postProcessGuide(input, generators);
+    expect(result).toBe(expected);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/snippets/lambda-function/deploying-your-function.mdx',
+      ),
+    );
   });
 });

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -101,10 +101,31 @@ export const fetchGuidePages = async (
         ).text(),
     ),
   );
-  return guides
-    .filter((result) => result.status === 'fulfilled')
-    .map((result) => postProcessGuide(result.value, generators, packageManager))
-    .join('\n\n');
+  const fulfilled = guides.filter((result) => result.status === 'fulfilled');
+  const processed = await Promise.all(
+    fulfilled.map((result) =>
+      postProcessGuide(result.value, generators, packageManager),
+    ),
+  );
+  return processed.join('\n\n');
+};
+
+const SNIPPET_BASE_URL =
+  'https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/snippets';
+
+/**
+ * Fetch a snippet's content from github
+ */
+export const fetchSnippet = async (snippetName: string): Promise<string> => {
+  try {
+    const response = await fetch(`${SNIPPET_BASE_URL}/${snippetName}.mdx`);
+    if (!response.ok) {
+      return '';
+    }
+    return await response.text();
+  } catch {
+    return '';
+  }
 };
 
 const findGeneratorAndSchema = (
@@ -129,13 +150,51 @@ const findGeneratorAndSchema = (
 /**
  * Post-process a guide page to "inline" relevant components
  */
-export const postProcessGuide = (
+export const postProcessGuide = async (
   guide: string,
   generators: NxGeneratorInfo[],
   packageManager?: string,
-): string => {
+): Promise<string> => {
+  // Replace <Snippet /> with fetched snippet content
+  // Use a regex that matches the full self-closing tag, allowing / in attribute values
+  const snippetRegex = /<Snippet\s+((?:[^/]|\/(?!>))+)\s*\/>/g;
+  const snippetMatches = [...guide.matchAll(snippetRegex)];
+
+  let processedGuide = guide;
+
+  if (snippetMatches.length > 0) {
+    // Fetch all snippets in parallel
+    const snippetResults = await Promise.all(
+      snippetMatches.map(async (match) => {
+        const nameMatch = match[1].match(/name=["']([^"']+)["']/);
+        if (!nameMatch) {
+          return { original: match[0], replacement: match[0] };
+        }
+        const snippetName = nameMatch[1];
+        const snippetContent = await fetchSnippet(snippetName);
+        if (!snippetContent) {
+          return { original: match[0], replacement: match[0] };
+        }
+        // Recursively post-process the snippet content
+        const processedContent = await postProcessGuide(
+          snippetContent.trim(),
+          generators,
+          packageManager,
+        );
+        return {
+          original: match[0],
+          replacement: `<Snippet name="${snippetName}">\n${processedContent}\n</Snippet>`,
+        };
+      }),
+    );
+
+    for (const { original, replacement } of snippetResults) {
+      processedGuide = processedGuide.replace(original, replacement);
+    }
+  }
+
   // Replace <NxCommands /> with markdown code blocks
-  let processedGuide = guide.replace(
+  processedGuide = processedGuide.replace(
     /<NxCommands\s+commands={([^}]+)}\s*\/>/g,
     (match, commandsMatch) => {
       try {


### PR DESCRIPTION
### Reason for this change

The generator-guide tool in our mcp server wasn't expanding snippets, which means that ai assistants miss important context from our docs. 

### Description of changes

This change expands these snippets to ensure the full guide page is shown.

### Description of how you validated changes

`pnpm nx mcp-inspect nx-plugin` to run the MCP server inspector and tested the `generator-guide` tool returned docs content with expanded snippets.

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*