### PR TITLE
fix: enable configuration of allowOrigins for REST API CORS preflight OPTIONS

### DIFF
--- a/docs/src/content/docs/en/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/en/snippets/api/cors-configuration-cdk-note.mdx
@@ -4,19 +4,25 @@ title: CORS configuration CDK
 import Link from '@components/link.astro';
 
 :::note
-If your solution includes a website you can configure its CloudFront distribution as the only permitted CORS origin in the API gateway / API AWS Lambda integrations for HTTP / REST APIs. Note that this restriction is not applied to preflight OPTIONS for REST APIs - please +1 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) to help prioritise addressing this.
-You will need to create the API and then call the API `restrictCorsTo` method with the created website.
+For CDK APIs, configure CORS when creating the API by passing `allowOrigins`.
+
+- For HTTP APIs, this configures API Gateway CORS.
+- For REST APIs, this configures both API Gateway preflight CORS and Lambda response headers.
+
+When `allowOrigins` is omitted or empty, CORS remains open to all origins.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/es/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/es/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "Configuración de CORS en CDK"
 import Link from '@components/link.astro';
 
 :::note
-Si tu solución incluye un sitio web, puedes configurar su distribución de CloudFront como el único origen CORS permitido en el API gateway / integraciones de API AWS Lambda para APIs HTTP / REST. Ten en cuenta que esta restricción no se aplica a las solicitudes preflight OPTIONS para APIs REST - por favor +1 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) para ayudar a priorizar la solución de esto.
-Necesitarás crear la API y luego llamar al método `restrictCorsTo` de la API con el sitio web creado.
+Para APIs CDK, configura CORS al crear la API pasando `allowOrigins`.
+
+- Para APIs HTTP, esto configura CORS del API Gateway.
+- Para APIs REST, esto configura tanto el CORS preflight del API Gateway como los encabezados de respuesta de Lambda.
+
+Cuando `allowOrigins` se omite o está vacío, CORS permanece abierto a todos los orígenes.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/fr/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/fr/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "Configuration CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Si votre solution inclut un site web, vous pouvez configurer sa distribution CloudFront comme seule origine CORS autorisée dans les intégrations API gateway / API AWS Lambda pour les API HTTP / REST. Notez que cette restriction ne s'applique pas aux requêtes OPTIONS de preflight pour les API REST - merci de +1 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) pour aider à prioriser la résolution de ce problème.
-Vous devrez créer l'API puis appeler la méthode `restrictCorsTo` de l'API avec le site web créé.
+Pour les API CDK, configurez CORS lors de la création de l'API en passant `allowOrigins`.
+
+- Pour les API HTTP, cela configure CORS dans API Gateway.
+- Pour les API REST, cela configure à la fois CORS preflight dans API Gateway et les en-têtes de réponse Lambda.
+
+Lorsque `allowOrigins` est omis ou vide, CORS reste ouvert à toutes les origines.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/it/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/it/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "Configurazione CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Se la tua soluzione include un sito web, puoi configurare la sua distribuzione CloudFront come unica origine CORS consentita nelle integrazioni API gateway / API AWS Lambda per le API HTTP / REST. Nota che questa restrizione non viene applicata alle richieste preflight OPTIONS per le API REST - per favore aggiungi un +1 a [questo issue su GitHub](https://github.com/awslabs/nx-plugin-for-aws/issues/377) per aiutare a dare priorità alla risoluzione di questo problema.
-Dovrai creare l'API e poi chiamare il metodo `restrictCorsTo` dell'API con il sito web creato.
+Per le API CDK, configura CORS durante la creazione dell'API passando `allowOrigins`.
+
+- Per le API HTTP, questo configura CORS di API Gateway.
+- Per le API REST, questo configura sia CORS preflight di API Gateway che gli header di risposta Lambda.
+
+Quando `allowOrigins` viene omesso o è vuoto, CORS rimane aperto a tutte le origini.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/jp/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/jp/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "CORS設定CDK"
 import Link from '@components/link.astro';
 
 :::note
-ソリューションにウェブサイトが含まれている場合、HTTP / REST API用のAPIゲートウェイ / API AWS Lambda統合において、CloudFrontディストリビューションを唯一許可されたCORSオリジンとして設定できます。この制限はREST APIのプリフライトOPTIONSには適用されないことに注意してください - この問題に対処する優先順位を上げるために、[このGitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377)に+1をお願いします。
-APIを作成してから、作成したウェブサイトを使用してAPIの`restrictCorsTo`メソッドを呼び出す必要があります。
+CDK APIの場合、API作成時に`allowOrigins`を渡すことでCORSを設定します。
+
+- HTTP APIの場合、これによりAPI Gateway CORSが設定されます。
+- REST APIの場合、これによりAPI Gatewayプリフライト CORSとLambdaレスポンスヘッダーの両方が設定されます。
+
+`allowOrigins`が省略されているか空の場合、CORSはすべてのオリジンに対して開放されたままになります。
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/ko/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/ko/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "CORS 구성 CDK"
 import Link from '@components/link.astro';
 
 :::note
-솔루션에 웹사이트가 포함된 경우, HTTP / REST API용 API gateway / API AWS Lambda 통합에서 CloudFront 배포를 유일하게 허용되는 CORS 원본으로 구성할 수 있습니다. 이 제한은 REST API의 프리플라이트 OPTIONS에는 적용되지 않습니다 - 이 문제 해결의 우선순위를 높이는 데 도움이 되도록 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377)에 +1을 눌러주세요.
-API를 생성한 다음 생성된 웹사이트와 함께 API `restrictCorsTo` 메서드를 호출해야 합니다.
+CDK API의 경우, API를 생성할 때 `allowOrigins`를 전달하여 CORS를 구성합니다.
+
+- HTTP API의 경우, API Gateway CORS를 구성합니다.
+- REST API의 경우, API Gateway 프리플라이트 CORS와 Lambda 응답 헤더를 모두 구성합니다.
+
+`allowOrigins`가 생략되거나 비어 있으면 CORS는 모든 원본에 대해 열린 상태로 유지됩니다.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/pt/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/pt/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "Configuração CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Se a sua solução incluir um website, você pode configurar a sua distribuição CloudFront como a única origem CORS permitida nas integrações API gateway / API AWS Lambda para APIs HTTP / REST. Note que esta restrição não é aplicada ao preflight OPTIONS para APIs REST - por favor, dê +1 nesta [issue do GitHub](https://github.com/awslabs/nx-plugin-for-aws/issues/377) para ajudar a priorizar a resolução disto.
-Você precisará criar a API e então chamar o método `restrictCorsTo` da API com o website criado.
+Para APIs CDK, configure o CORS ao criar a API passando `allowOrigins`.
+
+- Para APIs HTTP, isto configura o CORS do API Gateway.
+- Para APIs REST, isto configura tanto o CORS de preflight do API Gateway quanto os cabeçalhos de resposta Lambda.
+
+Quando `allowOrigins` é omitido ou vazio, o CORS permanece aberto para todas as origens.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/vi/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/vi/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "Cấu hình CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Nếu giải pháp của bạn bao gồm một trang web, bạn có thể cấu hình phân phối CloudFront của nó làm nguồn gốc CORS duy nhất được phép trong API gateway / tích hợp API AWS Lambda cho HTTP / REST APIs. Lưu ý rằng hạn chế này không được áp dụng cho preflight OPTIONS đối với REST APIs - vui lòng +1 [GitHub issue này](https://github.com/awslabs/nx-plugin-for-aws/issues/377) để giúp ưu tiên giải quyết vấn đề này.
-Bạn sẽ cần tạo API và sau đó gọi phương thức `restrictCorsTo` của API với trang web đã tạo.
+Đối với CDK APIs, cấu hình CORS khi tạo API bằng cách truyền `allowOrigins`.
+
+- Đối với HTTP APIs, điều này cấu hình API Gateway CORS.
+- Đối với REST APIs, điều này cấu hình cả API Gateway preflight CORS và Lambda response headers.
+
+Khi `allowOrigins` bị bỏ qua hoặc để trống, CORS vẫn mở cho tất cả các nguồn gốc.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/docs/src/content/docs/zh/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/zh/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,19 +5,25 @@ title: "CORS 配置 CDK"
 import Link from '@components/link.astro';
 
 :::note
-如果您的解决方案包含网站，您可以将其 CloudFront 分发配置为 API 网关 / API AWS Lambda 集成中 HTTP / REST API 唯一允许的 CORS 源。请注意，此限制不适用于 REST API 的预检 OPTIONS 请求 - 请为 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) 点赞以帮助优先解决此问题。
-您需要先创建 API，然后使用创建的网站调用 API 的 `restrictCorsTo` 方法。
+对于 CDK API，在创建 API 时通过传递 `allowOrigins` 来配置 CORS。
+
+- 对于 HTTP API，这会配置 API Gateway CORS。
+- 对于 REST API，这会同时配置 API Gateway 预检 CORS 和 Lambda 响应头。
+
+当省略或清空 `allowOrigins` 时，CORS 将对所有源保持开放。
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
 
 export class ExampleStack extends Stack {
   constructor(scope: Construct, id: string) {
-    const api = new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+      allowOrigins: [
+        `https://${website.cloudFrontDistribution.distributionDomainName}`,
+      ],
+    });
   }
 }
 ```

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -403,7 +403,6 @@ export class HttpApi<
 exports[`fastapi project generator > should set up shared constructs for http > test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -441,6 +440,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -507,12 +512,13 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
       corsPreflight: {
-        allowOrigins: ['*'],
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
         allowMethods: [CorsHttpMethod.ANY],
         allowHeaders: [
           'authorization',
@@ -526,26 +532,14 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
-   *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * Applies the supplied origin allowlist to the API Gateway CORS configuration.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-    );
-
+  private applyAllowOrigins(allowOrigins?: string[]) {
     const cfnApi = this.api.node.defaultChild;
     if (!(cfnApi instanceof CfnApi)) {
       throw new Error(
@@ -554,11 +548,8 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins:
+        allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -1091,7 +1082,6 @@ export class RestApi<
 exports[`fastapi project generator > should set up shared constructs for rest > test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -1139,6 +1129,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -1204,7 +1200,7 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
@@ -1212,7 +1208,10 @@ export class TestApi<
         authorizationType: AuthorizationType.IAM,
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -1232,32 +1231,24 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -34,7 +34,6 @@ exports[`tsSmithyApiGenerator > should configure git and eslint ignores for gene
 exports[`tsSmithyApiGenerator > should generate smithy ts api with Cognito auth > cognito-auth-infra.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -79,6 +78,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
   /**
    * Identity details for Cognito Authentication
    */
@@ -136,7 +141,7 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
@@ -147,7 +152,10 @@ export class TestApi<
         }),
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -167,32 +175,24 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }
@@ -203,7 +203,6 @@ export class TestApi<
 exports[`tsSmithyApiGenerator > should generate smithy ts api with IAM auth > iam-auth-infra.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -248,6 +247,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -299,7 +304,7 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
@@ -307,7 +312,10 @@ export class TestApi<
         authorizationType: AuthorizationType.IAM,
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -327,32 +335,24 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -352,7 +352,6 @@ exports[`trpc backend generator > should generate with cognito auth for a REST A
 exports[`trpc backend generator > should generate with cognito auth for a REST API > packages/common/constructs/src/app/apis/test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -399,6 +398,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
   /**
    * Identity details for Cognito Authentication
    */
@@ -458,7 +463,7 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
@@ -469,7 +474,10 @@ export class TestApi<
         }),
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -489,32 +497,24 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }
@@ -553,7 +553,6 @@ exports[`trpc backend generator > should generate with cognito auth for an HTTP 
 exports[`trpc backend generator > should generate with cognito auth for an HTTP API > packages/common/constructs/src/app/apis/test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -590,6 +589,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
   /**
    * Identity details for Cognito Authentication
    */
@@ -651,12 +656,13 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
       corsPreflight: {
-        allowOrigins: ['*'],
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
         allowMethods: [CorsHttpMethod.ANY],
         allowHeaders: [
           'authorization',
@@ -676,26 +682,14 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
-   *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * Applies the supplied origin allowlist to the API Gateway CORS configuration.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-    );
-
+  private applyAllowOrigins(allowOrigins?: string[]) {
     const cfnApi = this.api.node.defaultChild;
     if (!(cfnApi instanceof CfnApi)) {
       throw new Error(
@@ -704,11 +698,8 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins:
+        allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -750,7 +741,6 @@ exports[`trpc backend generator > should generate with no auth for a REST API > 
 exports[`trpc backend generator > should generate with no auth for a REST API > packages/common/constructs/src/app/apis/test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -795,6 +785,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -848,7 +844,7 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
@@ -856,7 +852,10 @@ export class TestApi<
         authorizationType: AuthorizationType.NONE,
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -876,32 +875,24 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }
@@ -936,7 +927,6 @@ exports[`trpc backend generator > should generate with no auth for an HTTP API >
 exports[`trpc backend generator > should generate with no auth for an HTTP API > packages/common/constructs/src/app/apis/test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -975,6 +965,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -1029,12 +1025,13 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
       corsPreflight: {
-        allowOrigins: ['*'],
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
         allowMethods: [CorsHttpMethod.ANY],
         allowHeaders: [
           'authorization',
@@ -1048,26 +1045,14 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
-   *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * Applies the supplied origin allowlist to the API Gateway CORS configuration.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-    );
-
+  private applyAllowOrigins(allowOrigins?: string[]) {
     const cfnApi = this.api.node.defaultChild;
     if (!(cfnApi instanceof CfnApi)) {
       throw new Error(
@@ -1076,11 +1061,8 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins:
+        allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -1255,7 +1237,6 @@ export class HttpApi<
 exports[`trpc backend generator > should set up shared constructs for http > test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -1292,6 +1273,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -1346,12 +1333,13 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
       corsPreflight: {
-        allowOrigins: ['*'],
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
         allowMethods: [CorsHttpMethod.ANY],
         allowHeaders: [
           'authorization',
@@ -1365,26 +1353,14 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
-   *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * Applies the supplied origin allowlist to the API Gateway CORS configuration.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-    );
-
+  private applyAllowOrigins(allowOrigins?: string[]) {
     const cfnApi = this.api.node.defaultChild;
     if (!(cfnApi instanceof CfnApi)) {
       throw new Error(
@@ -1393,11 +1369,8 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins:
+        allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -2001,7 +1974,6 @@ export class RestApi<
 exports[`trpc backend generator > should set up shared constructs for rest > test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -2048,6 +2020,12 @@ export interface TestApiProps<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
 }
 
 /**
@@ -2101,7 +2079,7 @@ export class TestApi<
   constructor(
     scope: Construct,
     id: string,
-    props: TestApiProps<TIntegrations>,
+    { allowOrigins, ...props }: TestApiProps<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: 'TestApi',
@@ -2109,7 +2087,10 @@ export class TestApi<
         authorizationType: AuthorizationType.IAM,
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -2129,32 +2110,24 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/trpc/backend/files/src/handler.ts.template
+++ b/packages/nx-plugin/src/trpc/backend/files/src/handler.ts.template
@@ -26,7 +26,7 @@ export const handler = awslambda.streamifyResponse(
 /**
  * Restricts CORS origins to localhost and the domains specified in
  * the ALLOWED_ORIGINS environment variable if set, or * otherwise.
- * Customise using `restrictCorsTo` in your API CDK construct
+ * Customise using `allowOrigins` in your API CDK construct
  */
 const getAllowedOrigin = (event: <%- apiGatewayEventType %> | undefined) => {
   const origin = event?.headers?.origin ?? event?.headers?.Origin;

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -1,6 +1,5 @@
 import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -67,6 +66,12 @@ export interface <%= apiNameClassName %>Props<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
   <%_ if (auth === 'Cognito') { _%>
   /**
    * Identity details for Cognito Authentication
@@ -172,12 +177,16 @@ export class <%= apiNameClassName %><
   constructor(
     scope: Construct,
     id: string,
-    props: <%= apiNameClassName %>Props<TIntegrations>,
+    {
+      allowOrigins,
+      ...props
+    }: <%= apiNameClassName %>Props<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: '<%= apiNameClassName %>',
       corsPreflight: {
-        allowOrigins: ['*'],
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
         allowMethods: [CorsHttpMethod.ANY],
         allowHeaders: [
           'authorization',
@@ -203,27 +212,14 @@ export class <%= apiNameClassName %><
       <%_ } _%>
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
-   *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * Applies the supplied origin allowlist to the API Gateway CORS configuration.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      );
-
+  private applyAllowOrigins(allowOrigins?: string[]) {
     const cfnApi = this.api.node.defaultChild;
     if (!(cfnApi instanceof CfnApi)) {
       throw new Error(
@@ -232,11 +228,7 @@ export class <%= apiNameClassName %><
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins: allowOrigins && allowOrigins.length > 0 ? allowOrigins : ['*'],
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -1,6 +1,5 @@
 import { Construct } from 'constructs';
 import * as url from 'url';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import {
   Code,
   Runtime,
@@ -68,6 +67,12 @@ export interface <%= apiNameClassName %>Props<
    * Map of operation names to their API Gateway integrations
    */
   integrations: TIntegrations;
+  /**
+   * Restricts browser CORS access to the supplied origins.
+   *
+   * When omitted or empty, CORS remains open to all origins.
+   */
+  allowOrigins?: string[];
   <%_ if (auth === 'Cognito') { _%>
   /**
    * Identity details for Cognito Authentication
@@ -182,7 +187,10 @@ export class <%= apiNameClassName %><
   constructor(
     scope: Construct,
     id: string,
-    props: <%= apiNameClassName %>Props<TIntegrations>,
+    {
+      allowOrigins,
+      ...props
+    }: <%= apiNameClassName %>Props<TIntegrations>,
   ) {
     super(scope, id, {
       apiName: '<%= apiNameClassName %>',
@@ -199,7 +207,10 @@ export class <%= apiNameClassName %><
         <%_ } _%>
       },
       defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
+        allowOrigins:
+          allowOrigins && allowOrigins.length > 0
+            ? allowOrigins
+            : Cors.ALL_ORIGINS,
         allowMethods: Cors.ALL_METHODS,
       },
       deployOptions: {
@@ -233,32 +244,25 @@ export class <%= apiNameClassName %><
       <%_ } _%>
       ...props,
     });
+
+    this.applyAllowOrigins(allowOrigins);
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
-   *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   * 
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * Sets ALLOWED_ORIGINS on all Lambda integrations so actual responses use the
+   * same origin allowlist as the API Gateway preflight handlers.
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
-
-    // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
+  private applyAllowOrigins(allowOrigins?: string[]) {
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          (
+            allowOrigins && allowOrigins.length > 0
+              ? allowOrigins
+              : Cors.ALL_ORIGINS
+          ).join(','),
+        );
       }
     });
   }


### PR DESCRIPTION


### Reason for this change

Fix #377 

### Description of changes

- Expose `allowOrigins` in `<%= apiNameClassName %>PropsProps`
- Set `allowOrigins` during construction time of the Api instead of calling `restrictCorsTo` after construction of the Api
- Make `restrictCorsTo` private to allow setting `allowOrigins` only through the constructor

### Description of how you validated changes

Unit tests

### Issue # (if applicable)

Closes #377 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*