### PR TITLE
fix: restrictCorsTo should also configure REST API CORS preflight OPTIONS

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -282,10 +284,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -306,29 +304,52 @@ export class GameApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the AWS
+   * Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -301,6 +301,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -310,45 +311,27 @@ export class GameApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the AWS
    * Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/en/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/en/snippets/api/cors-configuration-cdk-note.mdx
@@ -4,8 +4,8 @@ title: CORS configuration CDK
 import Link from '@components/link.astro';
 
 :::note
-If your solution includes a website you can configure its CloudFront distribution as the only permitted CORS origin in the API gateway / API AWS Lambda integrations for HTTP / REST APIs. Note that this restriction is not applied to preflight OPTIONS for REST APIs - please +1 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) to help prioritise addressing this.
-You will need to create the API and then call the API `restrictCorsTo` method with the created website.
+If your solution includes a website you can configure its CloudFront distribution as the only permitted CORS origin in the API gateway / API AWS Lambda integrations for HTTP / REST APIs.
+You can call the API `restrictCorsTo` method with CloudFront distributions, origin strings, or both.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -16,7 +16,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/en/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/en/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,7 +5,7 @@ import Link from '@components/link.astro';
 
 :::note
 If your solution includes a website you can configure its CloudFront distribution as the only permitted CORS origin in the API gateway / API AWS Lambda integrations for HTTP / REST APIs.
-You can call the API `restrictCorsTo` method with CloudFront distributions, origin strings, or both.
+You can call the API `restrictCorsTo` method with website constructs, CloudFront distributions, origin strings, or a mix of them.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -16,10 +16,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Crea integraciones predeterminadas para todas las operaciones, que implementan cada operación como
@@ -301,6 +301,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -310,45 +311,27 @@ export class GameApi<
    * como los únicos orígenes CORS permitidos en las respuestas preflight de API Gateway y las
    * integraciones AWS Lambda.
    *
-   * @param allowedOrigins - Las distribuciones CloudFront o strings de origen desde los cuales otorgar CORS
+   * @param origins - Los strings de origen, distribuciones CloudFront u objetos que contienen una distribución CloudFront desde los cuales otorgar CORS
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Establece la variable de entorno ALLOWED_ORIGINS para todas las integraciones Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Crea integraciones predeterminadas para todas las operaciones, que implementan cada operación como
    * su propia función lambda individual.
@@ -282,10 +284,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -306,29 +304,52 @@ export class GameApi<
   }
 
   /**
-   * Restringe CORS a los dominios de distribución CloudFront del sitio web
+   * Restringe CORS a los orígenes proporcionados
    *
-   * Configura los dominios de distribución CloudFront como los únicos orígenes CORS permitidos
-   * (aparte de local host) en las integraciones AWS Lambda
+   * Configura los dominios de distribución CloudFront o strings de origen
+   * como los únicos orígenes CORS permitidos en las respuestas preflight de API Gateway y las
+   * integraciones AWS Lambda.
    *
-   * Nota: esta restricción no se aplica a las OPTIONS de preflight
-   *
-   * @param websites - La distribución CloudFront desde la cual otorgar CORS
+   * @param allowedOrigins - Las distribuciones CloudFront o strings de origen desde los cuales otorgar CORS
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Establece la variable de entorno ALLOWED_ORIGINS para todas las integraciones Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/es/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/es/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "Configuración de CORS en CDK"
 import Link from '@components/link.astro';
 
 :::note
-Si tu solución incluye un sitio web, puedes configurar su distribución de CloudFront como el único origen CORS permitido en el API gateway / integraciones de API AWS Lambda para APIs HTTP / REST. Ten en cuenta que esta restricción no se aplica a las solicitudes preflight OPTIONS para APIs REST - por favor +1 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) para ayudar a priorizar la solución de esto.
-Necesitarás crear la API y luego llamar al método `restrictCorsTo` de la API con el sitio web creado.
+Si tu solución incluye un sitio web, puedes configurar su distribución de CloudFront como el único origen CORS permitido en el API gateway / integraciones de API AWS Lambda para APIs HTTP / REST.
+Puedes llamar al método `restrictCorsTo` de la API con distribuciones de CloudFront, cadenas de origen, o ambas.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/es/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/es/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 Si tu solución incluye un sitio web, puedes configurar su distribución de CloudFront como el único origen CORS permitido en el API gateway / integraciones de API AWS Lambda para APIs HTTP / REST.
-Puedes llamar al método `restrictCorsTo` de la API con distribuciones de CloudFront, cadenas de origen, o ambas.
+Puedes llamar al método `restrictCorsTo` de la API con constructos de sitios web, distribuciones de CloudFront, cadenas de origen, o una combinación de ellos.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Crée des intégrations par défaut pour toutes les opérations, qui implémentent chaque opération en tant
    * que sa propre fonction Lambda individuelle.
@@ -282,10 +284,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -306,29 +304,52 @@ export class GameApi<
   }
 
   /**
-   * Restreint CORS aux domaines de distribution CloudFront du site web
+   * Restreint CORS aux origines fournies
    *
-   * Configure les domaines de distribution CloudFront comme les seules origines CORS autorisées
-   * (autres que localhost) dans les intégrations AWS Lambda
+   * Configure les domaines de distribution CloudFront ou les chaînes d'origine
+   * comme les seules origines CORS autorisées dans les réponses de pré-vérification d'API Gateway et les
+   * intégrations AWS Lambda.
    *
-   * Notez que cette restriction n'est pas appliquée aux OPTIONS de pré-vérification
-   *
-   * @param websites - La distribution CloudFront à partir de laquelle accorder CORS
+   * @param allowedOrigins - Les distributions CloudFront ou chaînes d'origine à partir desquelles accorder CORS
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Définir la variable d'environnement ALLOWED_ORIGINS pour toutes les intégrations Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Crée des intégrations par défaut pour toutes les opérations, qui implémentent chaque opération en tant
@@ -301,6 +301,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -310,45 +311,27 @@ export class GameApi<
    * comme les seules origines CORS autorisées dans les réponses de pré-vérification d'API Gateway et les
    * intégrations AWS Lambda.
    *
-   * @param allowedOrigins - Les distributions CloudFront ou chaînes d'origine à partir desquelles accorder CORS
+   * @param origins - Les chaînes d'origine, distributions CloudFront, ou objets contenant une distribution CloudFront à partir desquels accorder CORS
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Définir la variable d'environnement ALLOWED_ORIGINS pour toutes les intégrations Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/fr/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/fr/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "Configuration CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Si votre solution inclut un site web, vous pouvez configurer sa distribution CloudFront comme seule origine CORS autorisée dans les intégrations API gateway / API AWS Lambda pour les API HTTP / REST. Notez que cette restriction ne s'applique pas aux requêtes OPTIONS de preflight pour les API REST - merci de +1 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) pour aider à prioriser la résolution de ce problème.
-Vous devrez créer l'API puis appeler la méthode `restrictCorsTo` de l'API avec le site web créé.
+Si votre solution inclut un site web, vous pouvez configurer sa distribution CloudFront comme seule origine CORS autorisée dans les intégrations API gateway / API AWS Lambda pour les API HTTP / REST.
+Vous pouvez appeler la méthode `restrictCorsTo` de l'API avec des distributions CloudFront, des chaînes d'origine, ou les deux.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/fr/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/fr/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 Si votre solution inclut un site web, vous pouvez configurer sa distribution CloudFront comme seule origine CORS autorisée dans les intégrations API gateway / API AWS Lambda pour les API HTTP / REST.
-Vous pouvez appeler la méthode `restrictCorsTo` de l'API avec des distributions CloudFront, des chaînes d'origine, ou les deux.
+Vous pouvez appeler la méthode `restrictCorsTo` de l'API avec des constructs de site web, des distributions CloudFront, des chaînes d'origine, ou un mélange de ceux-ci.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Crea integrazioni predefinite per tutte le operazioni, implementando ciascuna operazione
@@ -301,6 +301,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -310,45 +311,27 @@ export class GameApi<
    * come uniche origini CORS permesse nelle risposte preflight di API Gateway e nelle
    * integrazioni AWS Lambda.
    *
-   * @param allowedOrigins - Le distribuzioni CloudFront o stringhe di origine da cui concedere CORS
+   * @param origins - Le stringhe di origine, distribuzioni CloudFront, o oggetti contenenti una distribuzione CloudFront da cui concedere CORS
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo può essere chiamato solo una volta');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Imposta la variabile d'ambiente ALLOWED_ORIGINS per tutte le integrazioni Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Crea integrazioni predefinite per tutte le operazioni, implementando ciascuna operazione
    * come singola funzione lambda.
@@ -282,10 +284,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -306,29 +304,52 @@ export class GameApi<
   }
 
   /**
-   * Limita CORS ai domini della distribuzione CloudFront del sito web
+   * Limita CORS alle origini fornite
    *
-   * Configura i domini della distribuzione CloudFront come uniche origini CORS permesse
-   * (oltre a local host) nelle integrazioni AWS Lambda
+   * Configura i domini della distribuzione CloudFront o le stringhe di origine
+   * come uniche origini CORS permesse nelle risposte preflight di API Gateway e nelle
+   * integrazioni AWS Lambda.
    *
-   * Nota che questa restrizione non viene applicata al preflight OPTIONS
-   *
-   * @param websites - La distribuzione CloudFront da cui concedere CORS
+   * @param allowedOrigins - Le distribuzioni CloudFront o stringhe di origine da cui concedere CORS
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo può essere chiamato solo una volta');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Imposta la variabile d'ambiente ALLOWED_ORIGINS per tutte le integrazioni Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }
@@ -340,7 +361,8 @@ export class GameApi<
    */
   public grantInvokeAccess(grantee: IGrantable) {
     // Qui concediamo al grantee il permesso di chiamare l'API.
-    // È possibile definire qui accessi granulari machine-to-machine usando principal specifici
+    // È possibile definire qui accessi granulari machine-to-machine usando principal specifici (es. ruoli o
+    // utenti) e risorse (es. quali percorsi API possono essere invocati da quale principal) se necessario.
     this.api.addToResourcePolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
@@ -414,7 +436,7 @@ Il generatore `py#strands-agent` genera questi file:
         - init.py configura l'app FastAPI e il middleware
         - main.py entrypoint per l'agente in Bedrock AgentCore Runtime
         - agent.py definisce un agente e strumenti di esempio
-        - agentcore_mcp_client.py utility per client MCP
+        - agentcore_mcp_client.py utility per creare client per interagire con server MCP
         - Dockerfile definisce l'immagine Docker per il deployment in AgentCore Runtime
   - common/constructs/
     - src
@@ -617,11 +639,11 @@ Il generatore `ts#mcp-server` genera questi file.
       - stdio.ts entry point per MCP con trasporto STDIO
       - http.ts entry point per MCP con trasporto HTTP streamable
       - Dockerfile builda l'immagine per AgentCore Runtime
-    - rolldown.config.ts configurazione per il bundling del server MCP
+    - rolldown.config.ts configurazione per il bundling del server MCP per il deployment in AgentCore
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
-        - inventory-mcp-server.ts construct per deployare il server MCP in AgentCore Runtime
+        - inventory-mcp-server.ts construct per deployare il server MCP inventory in AgentCore Runtime
 </FileTree>
 
 </Drawer>

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/it/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/it/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "Configurazione CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Se la tua soluzione include un sito web, puoi configurare la sua distribuzione CloudFront come unica origine CORS consentita nelle integrazioni API gateway / API AWS Lambda per le API HTTP / REST. Nota che questa restrizione non viene applicata alle richieste preflight OPTIONS per le API REST - per favore aggiungi un +1 a [questo issue su GitHub](https://github.com/awslabs/nx-plugin-for-aws/issues/377) per aiutare a dare priorità alla risoluzione di questo problema.
-Dovrai creare l'API e poi chiamare il metodo `restrictCorsTo` dell'API con il sito web creato.
+Se la tua soluzione include un sito web, puoi configurare la sua distribuzione CloudFront come unica origine CORS consentita nelle integrazioni API gateway / API AWS Lambda per le API HTTP / REST.
+Puoi chiamare il metodo `restrictCorsTo` dell'API con distribuzioni CloudFront, stringhe di origine, o entrambe.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/it/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/it/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 Se la tua soluzione include un sito web, puoi configurare la sua distribuzione CloudFront come unica origine CORS consentita nelle integrazioni API gateway / API AWS Lambda per le API HTTP / REST.
-Puoi chiamare il metodo `restrictCorsTo` dell'API con distribuzioni CloudFront, stringhe di origine, o entrambe.
+Puoi chiamare il metodo `restrictCorsTo` dell'API con costrutti di siti web, distribuzioni CloudFront, stringhe di origine, o una combinazione di essi.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -232,7 +232,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * すべての操作のデフォルト統合を作成します。各操作を
@@ -300,6 +300,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -309,45 +310,27 @@ export class GameApi<
    * API Gatewayプリフライトレスポンスおよび
    * AWS Lambda統合で許可される唯一のCORSオリジンとして設定します。
    *
-   * @param allowedOrigins - CORSを許可するCloudFrontディストリビューションまたはオリジン文字列
+   * @param origins - CORSを許可するオリジン文字列、CloudFrontディストリビューション、またはCloudFrontディストリビューションを含むオブジェクト
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // すべてのLambda統合にALLOWED_ORIGINS環境変数を設定
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -232,6 +232,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * すべての操作のデフォルト統合を作成します。各操作を
    * 独自の個別のLambda関数として実装します。
@@ -281,10 +283,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -305,29 +303,52 @@ export class GameApi<
   }
 
   /**
-   * CORSをウェブサイトのCloudFrontディストリビューションドメインに制限します
+   * CORSを指定されたオリジンに制限します
    *
-   * CloudFrontディストリビューションドメインを、AWS Lambda統合で許可される唯一のCORSオリジン
-   * （ローカルホスト以外）として設定します
+   * CloudFrontディストリビューションドメインまたはオリジン文字列を、
+   * API Gatewayプリフライトレスポンスおよび
+   * AWS Lambda統合で許可される唯一のCORSオリジンとして設定します。
    *
-   * この制限はプリフライトOPTIONSには適用されないことに注意してください
-   *
-   * @param websites - CORSを許可するCloudFrontディストリビューション
+   * @param allowedOrigins - CORSを許可するCloudFrontディストリビューションまたはオリジン文字列
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // すべてのLambda統合にALLOWED_ORIGINS環境変数を設定
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/jp/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/jp/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "CORS設定CDK"
 import Link from '@components/link.astro';
 
 :::note
-ソリューションにウェブサイトが含まれている場合、HTTP / REST API用のAPIゲートウェイ / API AWS Lambda統合において、CloudFrontディストリビューションを唯一許可されたCORSオリジンとして設定できます。この制限はREST APIのプリフライトOPTIONSには適用されないことに注意してください - この問題に対処する優先順位を上げるために、[このGitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377)に+1をお願いします。
-APIを作成してから、作成したウェブサイトを使用してAPIの`restrictCorsTo`メソッドを呼び出す必要があります。
+ソリューションにウェブサイトが含まれている場合、HTTP / REST API用のAPIゲートウェイ / API AWS Lambda統合において、CloudFrontディストリビューションを唯一許可されたCORSオリジンとして設定できます。
+APIの`restrictCorsTo`メソッドは、CloudFrontディストリビューション、オリジン文字列、またはその両方を指定して呼び出すことができます。
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/jp/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/jp/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 ソリューションにウェブサイトが含まれている場合、HTTP / REST API用のAPIゲートウェイ / API AWS Lambda統合において、CloudFrontディストリビューションを唯一許可されたCORSオリジンとして設定できます。
-APIの`restrictCorsTo`メソッドは、CloudFrontディストリビューション、オリジン文字列、またはその両方を指定して呼び出すことができます。
+APIの`restrictCorsTo`メソッドは、ウェブサイトコンストラクト、CloudFrontディストリビューション、オリジン文字列、またはそれらの組み合わせを指定して呼び出すことができます。
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -232,7 +232,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * 모든 작업에 대한 기본 람다 함수 통합 생성
@@ -300,6 +300,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -308,45 +309,27 @@ export class GameApi<
    * CloudFront 배포 도메인 또는 출처 문자열을
    * API Gateway 사전 요청 응답 및 AWS Lambda 통합에서 허용되는 유일한 CORS 출처로 구성
    *
-   * @param allowedOrigins - CORS를 허용할 CloudFront 배포 또는 출처 문자열
+   * @param origins - CORS를 허용할 출처 문자열, CloudFront 배포 또는 CloudFront 배포를 포함하는 객체
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // 모든 Lambda 통합에 대해 ALLOWED_ORIGINS 환경 변수 설정
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -232,6 +232,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * 모든 작업에 대한 기본 람다 함수 통합 생성
    * 각 작업을 개별 람다 함수로 구현
@@ -281,10 +283,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -305,29 +303,51 @@ export class GameApi<
   }
 
   /**
-   * 웹사이트 CloudFront 배포 도메인으로 CORS 제한
+   * 제공된 출처로 CORS 제한
    *
-   * CloudFront 배포 도메인을 AWS Lambda 통합에서 허용되는 유일한 CORS 출처로 구성
-   * (로컬 호스트 제외)
+   * CloudFront 배포 도메인 또는 출처 문자열을
+   * API Gateway 사전 요청 응답 및 AWS Lambda 통합에서 허용되는 유일한 CORS 출처로 구성
    *
-   * 이 제한은 사전 요청 OPTIONS에는 적용되지 않음
-   *
-   * @param websites - CORS를 허용할 CloudFront 배포
+   * @param allowedOrigins - CORS를 허용할 CloudFront 배포 또는 출처 문자열
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // 모든 Lambda 통합에 대해 ALLOWED_ORIGINS 환경 변수 설정
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/ko/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/ko/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "CORS 구성 CDK"
 import Link from '@components/link.astro';
 
 :::note
-솔루션에 웹사이트가 포함된 경우, HTTP / REST API용 API gateway / API AWS Lambda 통합에서 CloudFront 배포를 유일하게 허용되는 CORS 원본으로 구성할 수 있습니다. 이 제한은 REST API의 프리플라이트 OPTIONS에는 적용되지 않습니다 - 이 문제 해결의 우선순위를 높이는 데 도움이 되도록 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377)에 +1을 눌러주세요.
-API를 생성한 다음 생성된 웹사이트와 함께 API `restrictCorsTo` 메서드를 호출해야 합니다.
+솔루션에 웹사이트가 포함된 경우, HTTP / REST API용 API gateway / API AWS Lambda 통합에서 CloudFront 배포를 유일하게 허용되는 CORS 원본으로 구성할 수 있습니다.
+API `restrictCorsTo` 메서드를 CloudFront 배포, 원본 문자열 또는 둘 다와 함께 호출할 수 있습니다.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/ko/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/ko/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 솔루션에 웹사이트가 포함된 경우, HTTP / REST API용 API gateway / API AWS Lambda 통합에서 CloudFront 배포를 유일하게 허용되는 CORS 원본으로 구성할 수 있습니다.
-API `restrictCorsTo` 메서드를 CloudFront 배포, 원본 문자열 또는 둘 다와 함께 호출할 수 있습니다.
+API `restrictCorsTo` 메서드를 웹사이트 구성요소, CloudFront 배포, 원본 문자열 또는 이들의 조합과 함께 호출할 수 있습니다.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Cria integrações padrão para todas as operações, implementando cada operação como
    * sua própria função lambda individual.
@@ -282,10 +284,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -306,29 +304,52 @@ export class GameApi<
   }
 
   /**
-   * Restringe CORS aos domínios da distribuição CloudFront do website
+   * Restringe CORS às origens fornecidas
    *
-   * Configura os domínios da distribuição CloudFront como as únicas origens CORS permitidas
-   * (além do local host) nas integrações AWS Lambda
+   * Configura os domínios da distribuição CloudFront ou strings de origem
+   * como as únicas origens CORS permitidas nas respostas preflight do API Gateway e nas
+   * integrações AWS Lambda.
    *
-   * Note que esta restrição não é aplicada ao preflight OPTIONS
-   *
-   * @param websites - A distribuição CloudFront para conceder CORS
+   * @param allowedOrigins - As distribuições CloudFront ou strings de origem para conceder CORS
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Define a variável de ambiente ALLOWED_ORIGINS para todas as integrações Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }
@@ -737,7 +758,7 @@ root &&
 ```
 
 Este é o ponto de entrada onde o React é montado. Como mostrado, inicialmente apenas configura um `@tanstack/react-router` em uma configuração de [`roteamento baseado em arquivo`](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing). Enquanto o servidor de desenvolvimento estiver em execução, você pode criar arquivos na pasta `routes` e o `@tanstack/react-router` criará a configuração de arquivo boilerplate para você, atualizando o arquivo `routeTree.gen.ts`. Este arquivo mantém todas as rotas de forma type-safe, o que significa que ao usar `<Link>`, a opção `to` só mostrará rotas válidas.
-Para mais informações, consulte a [documentação do @tanstack/react-router](https://tanstack.com/router/v1/docs/framework/react/quick-start).
+Para mais informações, consulte a [documentação do `@tanstack/react-router`](https://tanstack.com/router/v1/docs/framework/react/quick-start).
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -208,7 +208,7 @@ import { RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 
-// Tipo union de strings para todos os nomes de operações da API
+// Tipo union de strings para todos os nomes de operação da API
 type Operations = Procedures<AppRouter>;
 
 /**
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Cria integrações padrão para todas as operações, implementando cada operação como
@@ -301,6 +301,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -310,45 +311,27 @@ export class GameApi<
    * como as únicas origens CORS permitidas nas respostas preflight do API Gateway e nas
    * integrações AWS Lambda.
    *
-   * @param allowedOrigins - As distribuições CloudFront ou strings de origem para conceder CORS
+   * @param origins - As strings de origem, distribuições CloudFront, ou objetos contendo uma distribuição CloudFront para conceder CORS
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Define a variável de ambiente ALLOWED_ORIGINS para todas as integrações Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/pt/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/pt/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 Se a sua solução incluir um website, você pode configurar a sua distribuição CloudFront como a única origem CORS permitida nas integrações API gateway / API AWS Lambda para APIs HTTP / REST.
-Você pode chamar o método `restrictCorsTo` da API com distribuições CloudFront, strings de origem, ou ambos.
+Você pode chamar o método `restrictCorsTo` da API com construtores de website, distribuições CloudFront, strings de origem, ou uma combinação deles.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/pt/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/pt/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "Configuração CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Se a sua solução incluir um website, você pode configurar a sua distribuição CloudFront como a única origem CORS permitida nas integrações API gateway / API AWS Lambda para APIs HTTP / REST. Note que esta restrição não é aplicada ao preflight OPTIONS para APIs REST - por favor, dê +1 nesta [issue do GitHub](https://github.com/awslabs/nx-plugin-for-aws/issues/377) para ajudar a priorizar a resolução disto.
-Você precisará criar a API e então chamar o método `restrictCorsTo` da API com o website criado.
+Se a sua solução incluir um website, você pode configurar a sua distribuição CloudFront como a única origem CORS permitida nas integrações API gateway / API AWS Lambda para APIs HTTP / REST.
+Você pode chamar o método `restrictCorsTo` da API com distribuições CloudFront, strings de origem, ou ambos.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Tạo các tích hợp mặc định cho tất cả các hoạt động, triển khai mỗi hoạt động như
    * một hàm lambda riêng lẻ.
@@ -282,10 +284,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -306,29 +304,52 @@ export class GameApi<
   }
 
   /**
-   * Hạn chế CORS cho các domain CloudFront distribution của website
+   * Hạn chế CORS cho các origin được cung cấp
    *
-   * Cấu hình các domain CloudFront distribution là các CORS origin được phép duy nhất
-   * (ngoài local host) trong các tích hợp AWS Lambda
+   * Cấu hình các domain CloudFront distribution hoặc chuỗi origin
+   * là các CORS origin được phép duy nhất trong các phản hồi preflight của API Gateway và các
+   * tích hợp AWS Lambda.
    *
-   * Lưu ý rằng hạn chế này không được áp dụng cho preflight OPTIONS
-   *
-   * @param websites - CloudFront distribution để cấp CORS từ
+   * @param allowedOrigins - CloudFront distribution hoặc chuỗi origin để cấp CORS từ
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Đặt biến môi trường ALLOWED_ORIGINS cho tất cả các tích hợp Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Tạo các tích hợp mặc định cho tất cả các hoạt động, triển khai mỗi hoạt động như
@@ -301,6 +301,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -310,45 +311,27 @@ export class GameApi<
    * là các CORS origin được phép duy nhất trong các phản hồi preflight của API Gateway và các
    * tích hợp AWS Lambda.
    *
-   * @param allowedOrigins - CloudFront distribution hoặc chuỗi origin để cấp CORS từ
+   * @param origins - Các chuỗi origin, CloudFront distribution, hoặc các đối tượng chứa CloudFront distribution để cấp CORS từ
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Đặt biến môi trường ALLOWED_ORIGINS cho tất cả các tích hợp Lambda
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/vi/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/vi/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "Cấu hình CORS CDK"
 import Link from '@components/link.astro';
 
 :::note
-Nếu giải pháp của bạn bao gồm một trang web, bạn có thể cấu hình phân phối CloudFront của nó làm nguồn gốc CORS duy nhất được phép trong API gateway / tích hợp API AWS Lambda cho HTTP / REST APIs. Lưu ý rằng hạn chế này không được áp dụng cho preflight OPTIONS đối với REST APIs - vui lòng +1 [GitHub issue này](https://github.com/awslabs/nx-plugin-for-aws/issues/377) để giúp ưu tiên giải quyết vấn đề này.
-Bạn sẽ cần tạo API và sau đó gọi phương thức `restrictCorsTo` của API với trang web đã tạo.
+Nếu giải pháp của bạn bao gồm một trang web, bạn có thể cấu hình phân phối CloudFront của nó làm nguồn gốc CORS duy nhất được phép trong API gateway / tích hợp API AWS Lambda cho HTTP / REST APIs.
+Bạn có thể gọi phương thức `restrictCorsTo` của API với các phân phối CloudFront, chuỗi nguồn gốc, hoặc cả hai.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/vi/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/vi/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 Nếu giải pháp của bạn bao gồm một trang web, bạn có thể cấu hình phân phối CloudFront của nó làm nguồn gốc CORS duy nhất được phép trong API gateway / tích hợp API AWS Lambda cho HTTP / REST APIs.
-Bạn có thể gọi phương thức `restrictCorsTo` của API với các phân phối CloudFront, chuỗi nguồn gốc, hoặc cả hai.
+Bạn có thể gọi phương thức `restrictCorsTo` của API với các construct website, phân phối CloudFront, chuỗi nguồn gốc, hoặc kết hợp chúng.
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -187,11 +187,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -201,6 +200,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
@@ -233,7 +233,7 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * 为所有操作创建默认集成,将每个操作实现为独立的 lambda 函数
@@ -300,6 +300,7 @@ export class GameApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -308,45 +309,27 @@ export class GameApi<
    * 将 CloudFront 分发域或来源字符串配置为 API Gateway 预检响应和 AWS
    * Lambda 集成中唯一允许的 CORS 来源
    *
-   * @param allowedOrigins - 授予 CORS 的 CloudFront 分发或来源字符串
+   * @param origins - 授予 CORS 的来源字符串、CloudFront 分发或包含 CloudFront 分发的对象
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // 为所有 Lambda 集成设置 ALLOWED_ORIGINS 环境变量
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -233,6 +233,8 @@ export interface GameApiProps<
 export class GameApi<
   TIntegrations extends Record<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * 为所有操作创建默认集成,将每个操作实现为独立的 lambda 函数
    *
@@ -281,10 +283,6 @@ export class GameApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -305,29 +303,51 @@ export class GameApi<
   }
 
   /**
-   * 将 CORS 限制为网站 CloudFront 分发域
+   * 将 CORS 限制为提供的来源
    *
-   * 将 CloudFront 分发域配置为 AWS Lambda 集成中唯一允许的 CORS 来源
-   * (除本地主机外)
+   * 将 CloudFront 分发域或来源字符串配置为 API Gateway 预检响应和 AWS
+   * Lambda 集成中唯一允许的 CORS 来源
    *
-   * 注意此限制不适用于预检 OPTIONS
-   *
-   * @param websites - 授予 CORS 的 CloudFront 分发
+   * @param allowedOrigins - 授予 CORS 的 CloudFront 分发或来源字符串
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // 为所有 Lambda 集成设置 ALLOWED_ORIGINS 环境变量
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -200,11 +200,10 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':dungeon-adventure/game-api';
 

--- a/docs/src/content/docs/zh/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/zh/snippets/api/cors-configuration-cdk-note.mdx
@@ -5,8 +5,8 @@ title: "CORS 配置 CDK"
 import Link from '@components/link.astro';
 
 :::note
-如果您的解决方案包含网站，您可以将其 CloudFront 分发配置为 API 网关 / API AWS Lambda 集成中 HTTP / REST API 唯一允许的 CORS 源。请注意，此限制不适用于 REST API 的预检 OPTIONS 请求 - 请为 [this GitHub issue](https://github.com/awslabs/nx-plugin-for-aws/issues/377) 点赞以帮助优先解决此问题。
-您需要先创建 API，然后使用创建的网站调用 API 的 `restrictCorsTo` 方法。
+如果您的解决方案包含网站，您可以将其 CloudFront 分发配置为 API 网关 / API AWS Lambda 集成中 HTTP / REST API 唯一允许的 CORS 源。
+您可以使用 CloudFront 分发、源字符串或两者调用 API 的 `restrictCorsTo` 方法。
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,7 +17,10 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo(website);
+    api.restrictCorsTo([
+      website.cloudFrontDistribution,
+      'http://localhost:4200',
+    ]);
   }
 }
 ```

--- a/docs/src/content/docs/zh/snippets/api/cors-configuration-cdk-note.mdx
+++ b/docs/src/content/docs/zh/snippets/api/cors-configuration-cdk-note.mdx
@@ -6,7 +6,7 @@ import Link from '@components/link.astro';
 
 :::note
 如果您的解决方案包含网站，您可以将其 CloudFront 分发配置为 API 网关 / API AWS Lambda 集成中 HTTP / REST API 唯一允许的 CORS 源。
-您可以使用 CloudFront 分发、源字符串或两者调用 API 的 `restrictCorsTo` 方法。
+您可以使用网站构造、CloudFront 分发、来源字符串或它们的组合来调用 API 的 `restrictCorsTo` 方法。
 
 ```ts
 import { MyApi, MyWebsite } from ':my-scope/common-constructs';
@@ -17,10 +17,7 @@ export class ExampleStack extends Stack {
       integrations: MyApi.defaultIntegrations(this).build(),
     });
     const website = new MyWebsite(this, 'MyWebsite');
-    api.restrictCorsTo([
-      website.cloudFrontDistribution,
-      'http://localhost:4200',
-    ]);
+    api.restrictCorsTo(website, 'http://localhost:4200');
   }
 }
 ```

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -590,18 +590,11 @@ export class TestApi<
 `;
 
 exports[`fastapi project generator > should set up shared constructs for http > utils.ts 1`] = `
-"import { IAspect } from 'aws-cdk-lib';
-import {
-  Cors,
-  Integration,
-  MethodOptions,
-  Resource,
-} from 'aws-cdk-lib/aws-apigateway';
+"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
-import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -942,32 +935,20 @@ export class IntegrationBuilder<
     } as unknown as TIntegrations;
   }
 }
-
-export class AddCorsPreflightAspect implements IAspect {
-  private getAllowedOrigins: () => readonly string[];
-  constructor(getAllowedOrigins: () => readonly string[]) {
-    this.getAllowedOrigins = getAllowedOrigins;
-  }
-  public visit(node: IConstruct): void {
-    if (node instanceof Resource) {
-      node.addCorsPreflight({
-        allowOrigins: [...this.getAllowedOrigins()],
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
-  }
-}
 "
 `;
 
 exports[`fastapi project generator > should set up shared constructs for rest > rest-api.ts 1`] = `
-"import { Construct } from 'constructs';
+"import { Construct, IConstruct } from 'constructs';
 import {
+  Cors,
+  Resource,
   RestApi as _RestApi,
   RestApiProps as _RestApiProps,
   IResource,
   Stage,
 } from 'aws-cdk-lib/aws-apigateway';
+import { IAspect } from 'aws-cdk-lib';
 import { RuntimeConfig } from '../runtime-config.js';
 import {
   ApiIntegrations,
@@ -1110,6 +1091,21 @@ export class RestApi<
     return this.getOrCreateResource(childResource, pathParts);
   }
 }
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
+  }
+}
 "
 `;
 
@@ -1141,12 +1137,11 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import {
   OPERATION_DETAILS,
   Operations,
@@ -1324,18 +1319,11 @@ export class TestApi<
 `;
 
 exports[`fastapi project generator > should set up shared constructs for rest > utils.ts 1`] = `
-"import { IAspect } from 'aws-cdk-lib';
-import {
-  Cors,
-  Integration,
-  MethodOptions,
-  Resource,
-} from 'aws-cdk-lib/aws-apigateway';
+"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
-import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -1674,21 +1662,6 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
-  }
-}
-
-export class AddCorsPreflightAspect implements IAspect {
-  private getAllowedOrigins: () => readonly string[];
-  constructor(getAllowedOrigins: () => readonly string[]) {
-    this.getAllowedOrigins = getAllowedOrigins;
-  }
-  public visit(node: IConstruct): void {
-    if (node instanceof Resource) {
-      node.addCorsPreflight({
-        allowOrigins: [...this.getAllowedOrigins()],
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
   }
 }
 "

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -529,21 +529,20 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins
+   * in the API gateway. The CORS origins are not configured within the AWS Lambda
+   * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -554,11 +553,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins: origins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -1149,6 +1144,8 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -1211,10 +1208,6 @@ export class TestApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -1235,29 +1228,50 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
+    );
+
+    const resourcePaths = new Set(
+      Object.values(OPERATION_DETAILS).map(({ path }) =>
+        path.startsWith('/') ? path : \`/\${path}\`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -536,13 +536,21 @@ export class TestApi<
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -553,7 +561,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: origins,
+      allowOrigins: allowedOrigins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -582,11 +590,18 @@ export class TestApi<
 `;
 
 exports[`fastapi project generator > should set up shared constructs for http > utils.ts 1`] = `
-"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
+"import { IAspect } from 'aws-cdk-lib';
+import {
+  Cors,
+  Integration,
+  MethodOptions,
+  Resource,
+} from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
+import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -925,6 +940,21 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
+  }
+}
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
   }
 }
 "
@@ -1036,7 +1066,7 @@ export class RestApi<
     };
 
     // Create API resources and methods for each operation
-    (Object.entries(operations) as [TOperation, OperationDetails][]).map(
+    (Object.entries(operations) as [TOperation, OperationDetails][]).forEach(
       ([op, details]) => {
         const integration = resolveIntegration(op);
         const resource = this.getOrCreateResource(
@@ -1098,11 +1128,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Aspects, Duration, Stack } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -1112,6 +1141,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -1144,7 +1174,7 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -1225,6 +1255,7 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -1234,43 +1265,31 @@ export class TestApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
-    const resourcePaths = new Set(
-      Object.values(OPERATION_DETAILS).map(({ path }) =>
-        path.startsWith('/') ? path : \`/\${path}\`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });
@@ -1305,11 +1324,18 @@ export class TestApi<
 `;
 
 exports[`fastapi project generator > should set up shared constructs for rest > utils.ts 1`] = `
-"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
+"import { IAspect } from 'aws-cdk-lib';
+import {
+  Cors,
+  Integration,
+  MethodOptions,
+  Resource,
+} from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
+import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -1648,6 +1674,21 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
+  }
+}
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
   }
 }
 "

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -56,12 +56,11 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import {
   OPERATION_DETAILS,
   Operations,
@@ -233,12 +232,11 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import {
   OPERATION_DETAILS,
   Operations,

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -95,6 +95,8 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -146,10 +148,6 @@ export class TestApi<
           cognitoUserPools: [props.identity.userPool],
         }),
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -170,29 +168,50 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
+    );
+
+    const resourcePaths = new Set(
+      Object.values(OPERATION_DETAILS).map(({ path }) =>
+        path.startsWith('/') ? path : \`/\${path}\`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }
@@ -258,6 +277,8 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -306,10 +327,6 @@ export class TestApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -330,29 +347,50 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
+    );
+
+    const resourcePaths = new Set(
+      Object.values(OPERATION_DETAILS).map(({ path }) =>
+        path.startsWith('/') ? path : \`/\${path}\`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -44,11 +44,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   CognitoUserPoolsAuthorizer,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -57,6 +56,7 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -95,7 +95,7 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -165,6 +165,7 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -174,43 +175,31 @@ export class TestApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
-    const resourcePaths = new Set(
-      Object.values(OPERATION_DETAILS).map(({ path }) =>
-        path.startsWith('/') ? path : \`/\${path}\`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });
@@ -232,10 +221,9 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -245,6 +233,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -277,7 +266,7 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -344,6 +333,7 @@ export class TestApi<
       operations: OPERATION_DETAILS,
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -353,43 +343,31 @@ export class TestApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
-    const resourcePaths = new Set(
-      Object.values(OPERATION_DETAILS).map(({ path }) =>
-        path.startsWith('/') ? path : \`/\${path}\`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -362,12 +362,11 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
   CognitoUserPoolsAuthorizer,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -376,6 +375,7 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -415,7 +415,7 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -487,6 +487,7 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -496,45 +497,31 @@ export class TestApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : \`/\${path}\`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });
@@ -707,13 +694,21 @@ export class TestApi<
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -724,7 +719,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: origins,
+      allowOrigins: allowedOrigins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -776,11 +771,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -788,6 +782,7 @@ import {
   AnyPrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -821,7 +816,7 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -890,6 +885,7 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -899,45 +895,31 @@ export class TestApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : \`/\${path}\`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });
@@ -1095,13 +1077,21 @@ export class TestApi<
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -1112,7 +1102,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: origins,
+      allowOrigins: allowedOrigins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -1407,13 +1397,21 @@ export class TestApi<
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -1424,7 +1422,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: origins,
+      allowOrigins: allowedOrigins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -1524,11 +1522,18 @@ export const routerToOperations = <TRouter extends AnyTRPCRouter>(
 `;
 
 exports[`trpc backend generator > should set up shared constructs for http > utils.ts 1`] = `
-"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
+"import { IAspect } from 'aws-cdk-lib';
+import {
+  Cors,
+  Integration,
+  MethodOptions,
+  Resource,
+} from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
+import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -1867,6 +1872,21 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
+  }
+}
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
   }
 }
 "
@@ -1978,7 +1998,7 @@ export class RestApi<
     };
 
     // Create API resources and methods for each operation
-    (Object.entries(operations) as [TOperation, OperationDetails][]).map(
+    (Object.entries(operations) as [TOperation, OperationDetails][]).forEach(
       ([op, details]) => {
         const integration = resolveIntegration(op);
         const resource = this.getOrCreateResource(
@@ -2038,11 +2058,10 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   ResponseTransferMode,
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration } from 'aws-cdk-lib';
+import { Aspects, Duration } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -2052,6 +2071,7 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -2085,7 +2105,7 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    * Creates default integrations for all operations, which implement each operation as
@@ -2154,6 +2174,7 @@ export class TestApi<
       operations: routerToOperations(appRouter),
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -2163,45 +2184,31 @@ export class TestApi<
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : \`https://\${allowedOrigin.distributionDomainName}\`,
+  public restrictCorsTo(
+    ...origins: (
+      | string
+      | Distribution
+      | { cloudFrontDistribution: Distribution }
+    )[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
     );
 
-    const operations = routerToOperations(appRouter);
-
-    const resourcePaths = new Set(
-      Object.values(operations).map(({ path }) =>
-        path.startsWith('/') ? path : \`/\${path}\`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });
@@ -2307,11 +2314,18 @@ export const routerToOperations = <TRouter extends AnyTRPCRouter>(
 `;
 
 exports[`trpc backend generator > should set up shared constructs for rest > utils.ts 1`] = `
-"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
+"import { IAspect } from 'aws-cdk-lib';
+import {
+  Cors,
+  Integration,
+  MethodOptions,
+  Resource,
+} from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
+import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -2650,6 +2664,21 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
+  }
+}
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
   }
 }
 "

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -415,6 +415,8 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -468,10 +470,6 @@ export class TestApi<
           cognitoUserPools: [props.identity.userPool],
         }),
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -492,29 +490,52 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : \`/\${path}\`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }
@@ -679,21 +700,20 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins
+   * in the API gateway. The CORS origins are not configured within the AWS Lambda
+   * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -704,11 +724,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins: origins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -805,6 +821,8 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -855,10 +873,6 @@ export class TestApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.NONE,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -879,29 +893,52 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : \`/\${path}\`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }
@@ -1051,21 +1088,20 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins
+   * in the API gateway. The CORS origins are not configured within the AWS Lambda
+   * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -1076,11 +1112,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins: origins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -1368,21 +1400,20 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins
+   * in the API gateway. The CORS origins are not configured within the AWS Lambda
+   * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites.map(
-      ({ cloudFrontDistribution }) =>
-        \`https://\${cloudFrontDistribution.distributionDomainName}\`,
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -1393,11 +1424,7 @@ export class TestApi<
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins: origins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',
@@ -2058,6 +2085,8 @@ export interface TestApiProps<
 export class TestApi<
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    * Creates default integrations for all operations, which implement each operation as
    * its own individual lambda function.
@@ -2108,10 +2137,6 @@ export class TestApi<
       defaultMethodOptions: {
         authorizationType: AuthorizationType.IAM,
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -2132,29 +2157,52 @@ export class TestApi<
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * Note that this restriction is not applied to preflight OPTIONS
-   *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          \`https://\${cloudFrontDistribution.distributionDomainName}\`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : \`https://\${allowedOrigin.distributionDomainName}\`,
+    );
+
+    const operations = routerToOperations(appRouter);
+
+    const resourcePaths = new Set(
+      Object.values(operations).map(({ path }) =>
+        path.startsWith('/') ? path : \`/\${path}\`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -375,12 +375,11 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':proj/test-api';
 
@@ -782,12 +781,11 @@ import {
   AnyPrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':proj/test-api';
 
@@ -1522,18 +1520,11 @@ export const routerToOperations = <TRouter extends AnyTRPCRouter>(
 `;
 
 exports[`trpc backend generator > should set up shared constructs for http > utils.ts 1`] = `
-"import { IAspect } from 'aws-cdk-lib';
-import {
-  Cors,
-  Integration,
-  MethodOptions,
-  Resource,
-} from 'aws-cdk-lib/aws-apigateway';
+"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
-import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -1874,32 +1865,20 @@ export class IntegrationBuilder<
     } as unknown as TIntegrations;
   }
 }
-
-export class AddCorsPreflightAspect implements IAspect {
-  private getAllowedOrigins: () => readonly string[];
-  constructor(getAllowedOrigins: () => readonly string[]) {
-    this.getAllowedOrigins = getAllowedOrigins;
-  }
-  public visit(node: IConstruct): void {
-    if (node instanceof Resource) {
-      node.addCorsPreflight({
-        allowOrigins: [...this.getAllowedOrigins()],
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
-  }
-}
 "
 `;
 
 exports[`trpc backend generator > should set up shared constructs for rest > rest-api.ts 1`] = `
-"import { Construct } from 'constructs';
+"import { Construct, IConstruct } from 'constructs';
 import {
+  Cors,
+  Resource,
   RestApi as _RestApi,
   RestApiProps as _RestApiProps,
   IResource,
   Stage,
 } from 'aws-cdk-lib/aws-apigateway';
+import { IAspect } from 'aws-cdk-lib';
 import { RuntimeConfig } from '../runtime-config.js';
 import {
   ApiIntegrations,
@@ -2042,6 +2021,21 @@ export class RestApi<
     return this.getOrCreateResource(childResource, pathParts);
   }
 }
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
+  }
+}
 "
 `;
 
@@ -2071,12 +2065,11 @@ import {
   Grant,
 } from 'aws-cdk-lib/aws-iam';
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from ':proj/test-api';
 
@@ -2314,18 +2307,11 @@ export const routerToOperations = <TRouter extends AnyTRPCRouter>(
 `;
 
 exports[`trpc backend generator > should set up shared constructs for rest > utils.ts 1`] = `
-"import { IAspect } from 'aws-cdk-lib';
-import {
-  Cors,
-  Integration,
-  MethodOptions,
-  Resource,
-} from 'aws-cdk-lib/aws-apigateway';
+"import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
 import {
   HttpRouteIntegration,
   AddRoutesOptions,
 } from 'aws-cdk-lib/aws-apigatewayv2';
-import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -2664,21 +2650,6 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
-  }
-}
-
-export class AddCorsPreflightAspect implements IAspect {
-  private getAllowedOrigins: () => readonly string[];
-  constructor(getAllowedOrigins: () => readonly string[]) {
-    this.getAllowedOrigins = getAllowedOrigins;
-  }
-  public visit(node: IConstruct): void {
-    if (node instanceof Resource) {
-      node.addCorsPreflight({
-        allowOrigins: [...this.getAllowedOrigins()],
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
   }
 }
 "

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -213,13 +213,17 @@ export class <%= apiNameClassName %><
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -230,7 +234,7 @@ export class <%= apiNameClassName %><
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: origins,
+      allowOrigins: allowedOrigins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -206,23 +206,21 @@ export class <%= apiNameClassName %><
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host with default ports) in the API gateway
-   * The CORS origins are not configured within the AWS Lambda integrations since
-   * the associated header is controlled by API Gateway v2
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins
+   * in the API gateway. The CORS origins are not configured within the AWS Lambda
+   * integrations since the associated header is controlled by API Gateway v2.
    *
-   * @param cloudFrontDistribution - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      );
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
 
     const cfnApi = this.api.node.defaultChild;
     if (!(cfnApi instanceof CfnApi)) {
@@ -232,11 +230,7 @@ export class <%= apiNameClassName %><
     }
 
     cfnApi.corsConfiguration = {
-      allowOrigins: [
-        'http://localhost:4200',
-        'http://localhost:4300',
-        ...allowedOrigins,
-      ],
+      allowOrigins: origins,
       allowMethods: [CorsHttpMethod.ANY],
       allowHeaders: [
         'authorization',

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -14,7 +14,6 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import {
   AuthorizationType,
-  Cors,
   LambdaIntegration,
   <%_ if (['trpc', 'fastapi'].includes(backend.type)) { _%>
   ResponseTransferMode,
@@ -23,7 +22,7 @@ import {
   CognitoUserPoolsAuthorizer,
   <%_ } _%>
 } from 'aws-cdk-lib/aws-apigateway';
-import { Duration<%_ if (backend.type === 'fastapi') { _%>, Stack<%_ } _%> } from 'aws-cdk-lib';
+import { Aspects, Duration<%_ if (backend.type === 'fastapi') { _%>, Stack<%_ } _%> } from 'aws-cdk-lib';
 import {
   PolicyDocument,
   PolicyStatement,
@@ -38,6 +37,7 @@ import {
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 <%_ } _%>
 import {
+  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
@@ -86,7 +86,7 @@ export interface <%= apiNameClassName %>Props<
 export class <%= apiNameClassName %><
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
-  private corsRestricted = false;
+  private allowedOrigins: readonly string[] = ['*'];
 
   /**
    <%_ if (backend.integrationPattern === 'shared') { _%>
@@ -231,6 +231,7 @@ export class <%= apiNameClassName %><
       <%_ } _%>
       ...props,
     });
+    Aspects.of(this).add(new AddCorsPreflightAspect(() => this.allowedOrigins));
   }
 
   /**
@@ -240,53 +241,27 @@ export class <%= apiNameClassName %><
    * as the only permitted CORS origins in API Gateway preflight responses and the
    * AWS Lambda integrations.
    *
-   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
+   * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
-  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
-    if (this.corsRestricted) {
-      throw new Error('restrictCorsTo can only be called once');
-    }
-    this.corsRestricted = true;
-
-    const origins = allowedOrigins.map((allowedOrigin) =>
-      typeof allowedOrigin === 'string'
-        ? allowedOrigin
-        : `https://${allowedOrigin.distributionDomainName}`,
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
+          : `https://${origin.distributionDomainName}`,
     );
 
-    <%_ if (backend.type === 'trpc') { _%>
-    const operations = routerToOperations(appRouter);
-    <%_ } _%>
-
-    const resourcePaths = new Set(
-      Object.values(
-        <%_ if (backend.type === 'trpc') { _%>
-        operations
-        <%_ } else { _%>
-        OPERATION_DETAILS
-        <%_ } _%>
-      ).map(({ path }) =>
-        path.startsWith('/') ? path : `/${path}`,
-      ),
-    );
-
-    for (const resourcePath of resourcePaths) {
-      const resource =
-        resourcePath === '/'
-          ? this.api.root
-          : this.api.root.resourceForPath(resourcePath.slice(1));
-      resource.addCorsPreflight({
-        allowOrigins: origins,
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
+    this.allowedOrigins = allowedOrigins;
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
         integration.handler.addEnvironment(
           'ALLOWED_ORIGINS',
-          origins.join(','),
+          allowedOrigins.join(','),
         );
       }
     });

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -86,6 +86,8 @@ export interface <%= apiNameClassName %>Props<
 export class <%= apiNameClassName %><
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
 > extends RestApi<Operations, TIntegrations> {
+  private corsRestricted = false;
+
   /**
    <%_ if (backend.integrationPattern === 'shared') { _%>
    * Creates default integrations for all operations using a single shared
@@ -198,10 +200,6 @@ export class <%= apiNameClassName %><
         authorizationType: AuthorizationType.NONE,
         <%_ } _%>
       },
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS,
-        allowMethods: Cors.ALL_METHODS,
-      },
       deployOptions: {
         tracingEnabled: true,
       },
@@ -236,29 +234,60 @@ export class <%= apiNameClassName %><
   }
 
   /**
-   * Restricts CORS to the website CloudFront distribution domains
+   * Restricts CORS to the provided origins
    *
-   * Configures the CloudFront distribution domains as the only permitted CORS origins
-   * (other than local host) in the AWS Lambda integrations
-   * 
-   * Note that this restriction is not applied to preflight OPTIONS
+   * Configures the provided CloudFront distribution domains or origin strings
+   * as the only permitted CORS origins in API Gateway preflight responses and the
+   * AWS Lambda integrations.
    *
-   * @param websites - The CloudFront distribution to grant CORS from
+   * @param allowedOrigins - The CloudFront distributions or origin strings to grant CORS from
    */
-  public restrictCorsTo(
-    ...websites: { cloudFrontDistribution: Distribution }[]
-  ) {
-    const allowedOrigins = websites
-      .map(
-        ({ cloudFrontDistribution }) =>
-          `https://${cloudFrontDistribution.distributionDomainName}`,
-      )
-      .join(',');
+  public restrictCorsTo(allowedOrigins: (Distribution | string)[]) {
+    if (this.corsRestricted) {
+      throw new Error('restrictCorsTo can only be called once');
+    }
+    this.corsRestricted = true;
+
+    const origins = allowedOrigins.map((allowedOrigin) =>
+      typeof allowedOrigin === 'string'
+        ? allowedOrigin
+        : `https://${allowedOrigin.distributionDomainName}`,
+    );
+
+    <%_ if (backend.type === 'trpc') { _%>
+    const operations = routerToOperations(appRouter);
+    <%_ } _%>
+
+    const resourcePaths = new Set(
+      Object.values(
+        <%_ if (backend.type === 'trpc') { _%>
+        operations
+        <%_ } else { _%>
+        OPERATION_DETAILS
+        <%_ } _%>
+      ).map(({ path }) =>
+        path.startsWith('/') ? path : `/${path}`,
+      ),
+    );
+
+    for (const resourcePath of resourcePaths) {
+      const resource =
+        resourcePath === '/'
+          ? this.api.root
+          : this.api.root.resourceForPath(resourcePath.slice(1));
+      resource.addCorsPreflight({
+        allowOrigins: origins,
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
 
     // Set ALLOWED_ORIGINS environment variable for all Lambda integrations
     Object.values(this.integrations).forEach((integration) => {
       if ('handler' in integration && integration.handler instanceof Function) {
-        integration.handler.addEnvironment('ALLOWED_ORIGINS', allowedOrigins);
+        integration.handler.addEnvironment(
+          'ALLOWED_ORIGINS',
+          origins.join(','),
+        );
       }
     });
   }

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -37,12 +37,11 @@ import {
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 <%_ } _%>
 import {
-  AddCorsPreflightAspect,
   ApiIntegrations,
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
-import { RestApi } from '../../core/api/rest-api.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 <%_ if (backend.type === 'trpc') { _%>
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '<%= backend.projectAlias %>';

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
@@ -1,10 +1,13 @@
-import { Construct } from 'constructs';
+import { Construct, IConstruct } from 'constructs';
 import {
+  Cors,
+  Resource,
   RestApi as _RestApi,
   RestApiProps as _RestApiProps,
   IResource,
   Stage,
 } from 'aws-cdk-lib/aws-apigateway';
+import { IAspect } from 'aws-cdk-lib';
 import { RuntimeConfig } from '../runtime-config.js';
 import {
   ApiIntegrations,
@@ -145,5 +148,20 @@ export class RestApi<
     const childResource =
       resource.getResource(nextPathPart) ?? resource.addResource(nextPathPart);
     return this.getOrCreateResource(childResource, pathParts);
+  }
+}
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
@@ -103,7 +103,7 @@ export class RestApi<
     };
 
     // Create API resources and methods for each operation
-    (Object.entries(operations) as [TOperation, OperationDetails][]).map(
+    (Object.entries(operations) as [TOperation, OperationDetails][]).forEach(
       ([op, details]) => {
         const integration = resolveIntegration(op);
         const resource = this.getOrCreateResource(

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
@@ -1,12 +1,8 @@
-import { IAspect } from 'aws-cdk-lib';
 import {
-  Cors,
   Integration,
   MethodOptions,
-  Resource,
 } from 'aws-cdk-lib/aws-apigateway';
 import { HttpRouteIntegration, AddRoutesOptions } from 'aws-cdk-lib/aws-apigatewayv2';
-import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -345,20 +341,5 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
-  }
-}
-
-export class AddCorsPreflightAspect implements IAspect {
-  private getAllowedOrigins: () => readonly string[];
-  constructor(getAllowedOrigins: () => readonly string[]) {
-    this.getAllowedOrigins = getAllowedOrigins;
-  }
-  public visit(node: IConstruct): void {
-    if (node instanceof Resource) {
-      node.addCorsPreflight({
-        allowOrigins: [...this.getAllowedOrigins()],
-        allowMethods: Cors.ALL_METHODS,
-      });
-    }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
@@ -1,5 +1,12 @@
-import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
+import { IAspect } from 'aws-cdk-lib';
+import {
+  Cors,
+  Integration,
+  MethodOptions,
+  Resource,
+} from 'aws-cdk-lib/aws-apigateway';
 import { HttpRouteIntegration, AddRoutesOptions } from 'aws-cdk-lib/aws-apigatewayv2';
+import { IConstruct } from 'constructs';
 
 /**
  * Type representing applicable HTTP Methods in API Gateway
@@ -338,5 +345,20 @@ export class IntegrationBuilder<
       ),
       ...this.integrations,
     } as unknown as TIntegrations;
+  }
+}
+
+export class AddCorsPreflightAspect implements IAspect {
+  private getAllowedOrigins: () => readonly string[];
+  constructor(getAllowedOrigins: () => readonly string[]) {
+    this.getAllowedOrigins = getAllowedOrigins;
+  }
+  public visit(node: IConstruct): void {
+    if (node instanceof Resource) {
+      node.addCorsPreflight({
+        allowOrigins: [...this.getAllowedOrigins()],
+        allowMethods: Cors.ALL_METHODS,
+      });
+    }
   }
 }


### PR DESCRIPTION


### Reason for this change

Fix #377 

### Description of changes

- Modify `restrictCorsTo` to iterate over all resourcePath and add CORS preflight in addition to just setting the integration handler environment variable. 

### Description of how you validated changes

- Unit tests
- Manually generate/deploy the API projects and check API Gateway

### Issue # (if applicable)

Closes #377 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*