### PR TITLE
fix(ts#identity): ignore external changes to cognito client callback …

### DIFF
--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
@@ -270,6 +270,7 @@ resource "aws_cognito_user_pool_client" "web_client" {
   # Auth session validity
   auth_session_validity = 3
 
+  # Callback urls are added via the add-callback-url module and should not be overwritten.
   lifecycle {
     ignore_changes = [
       callback_urls,


### PR DESCRIPTION
…and logout urls

Prevents Terraform from reverting callback_urls and logout_urls that are modified outside of Terraform (e.g. by application deployments), which could break OAuth flows for deployed apps.

### Reason for this change

When callback_urls or logout_urls on the Cognito User Pool Client are modified outside of Terraform (e.g. by application deployments or other automation), terraform apply reverts them to the values defined in the template. This can break OAuth flows for deployed applications.

### Description of changes

Added a lifecycle { ignore_changes = [callback_urls, logout_urls] } block to the aws_cognito_user_pool_client resource in identity.tf.template. This tells Terraform to set these URLs on initial creation but stop tracking drift afterward, so externally managed URL changes are preserved. The initial default values (localhost and console URLs) are still applied on first deploy.

### Description of how you validated changes

No. This is a Terraform template behavior change that doesn't introduce new logic testable at the unit level. The change can be validated by running terraform plan after an external URL modification and confirming no diff is detected.

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*