### PR TITLE
fix(py#project): remove generated hello.py

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -28,6 +28,10 @@ describe('python project generator', () => {
     expect(tree.exists('apps/test_project/pyproject.toml')).toBeTruthy();
     expect(tree.exists('apps/test_project/proj_test_project')).toBeTruthy();
     expect(tree.exists('apps/test_project/tests')).toBeTruthy();
+
+    // Verify hello.py files are removed
+    expect(tree.exists('apps/test_project/proj_test_project/hello.py')).toBeFalsy();
+    expect(tree.exists('apps/test_project/tests/test_hello.py')).toBeFalsy();
   });
 
   it('should set up project configuration correctly', async () => {

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -144,6 +144,12 @@ export const pyProjectGenerator = async (
     srcDir: false,
   });
 
+  // Remove generated hello.py and test_hello.py as they are not needed
+  [
+    joinPathFragments(dir, normalizedModuleName, 'hello.py'),
+    joinPathFragments(dir, 'tests', 'test_hello.py'),
+  ].forEach((f) => tree.delete(f));
+
   const outputPath = '{workspaceRoot}/dist/{projectRoot}';
   const buildOutputPath = joinPathFragments(outputPath, 'build');
   const projectConfiguration = readProjectConfiguration(


### PR DESCRIPTION
## Summary

Closes #475

The `uvProjectGenerator` scaffolds `hello.py` and `test_hello.py` which are always deleted by users. This PR removes them after generation, matching the approach already used by the `fast-api` generator.

## Changes

- **`generator.ts`**: Delete `hello.py` and `test_hello.py` after `uvProjectGenerator` runs
- **`generator.spec.ts`**: Add assertions verifying the files are removed

## Test plan

- [x] Added test assertions for `hello.py` removal
- [ ] `pnpm nx run @aws/nx-plugin:test -u` passes