### PR TITLE
ci: add windows smoke tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce LF line endings for all text files to ensure cross-platform consistency
+* text=auto eol=lf

--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -25,6 +25,7 @@ runs:
       with:
         version: 10
     - uses: oven-sh/setup-bun@v2
+      if: ${{ runner.os != 'Windows' }}
       with:
         bun-version: 1.3.6
     - name: Use Node.js 22.x
@@ -38,15 +39,65 @@ runs:
       with:
         version: 'latest'
     - name: Set up QEMU
+      if: ${{ runner.os != 'Windows' }}
       uses: docker/setup-qemu-action@v3
       with:
         image: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
     - name: Set up Docker Buildx
+      if: ${{ runner.os != 'Windows' }}
       uses: docker/setup-buildx-action@v3
-    - name: Set up terraform
+    - name: Set up WSL2 Docker for Linux builds (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        # Windows runners only have Docker in Windows-container mode.
+        # Install Ubuntu + Docker Engine in WSL2 to build Linux images.
+        # See .github/scripts/setup-wsl-docker.sh for the full setup.
+        wsl --install Ubuntu-24.04 --no-launch
+        wsl --set-default Ubuntu-24.04
+
+        # Convert setup script to LF line endings and run it in WSL2
+        $script = Get-Content "${{ github.workspace }}/.github/scripts/setup-wsl-docker.sh" -Raw
+        $lfScript = $script -replace "`r`n", "`n"
+        $tmpScript = "$env:RUNNER_TEMP/setup-wsl-docker.sh"
+        [System.IO.File]::WriteAllText($tmpScript, $lfScript)
+        $wslPath = wsl -d Ubuntu-24.04 wslpath ($tmpScript -replace '\\','/')
+        wsl -d Ubuntu-24.04 -u root -- bash $wslPath
+
+        # Install docker.cmd wrapper that forwards to WSL2 Linux daemon
+        # See .github/scripts/docker-wsl.cmd for the wrapper logic.
+        $wrapperDir = "C:\docker-wsl"
+        New-Item -ItemType Directory -Path $wrapperDir -Force | Out-Null
+        Copy-Item "${{ github.workspace }}/.github/scripts/docker-wsl.cmd" "$wrapperDir\docker.cmd"
+        echo "$wrapperDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:PATH = "$wrapperDir;$env:PATH"
+
+        docker version
+        docker buildx ls
+    - name: Set up terraform (non-Windows)
+      if: ${{ runner.os != 'Windows' }}
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: '1.13.1'
+        terraform_wrapper: false
+    - name: Set up terraform (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        # Install terraform manually on Windows so it lands on a PATH that
+        # Nx's run-commands executor (cmd.exe subprocess) can always see.
+        # hashicorp/setup-terraform uses GITHUB_PATH which doesn't propagate
+        # reliably to Nx executor subprocesses on Windows.
+        $version = "1.13.1"
+        $tfDir = "C:\terraform"
+        New-Item -ItemType Directory -Path $tfDir -Force | Out-Null
+        $url = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_windows_amd64.zip"
+        $zip = "$env:RUNNER_TEMP\terraform.zip"
+        Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+        Expand-Archive -Path $zip -DestinationPath $tfDir -Force
+        echo "$tfDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:PATH = "$tfDir;$env:PATH"
+        terraform version
     - name: Get pnpm store directory
       id: pnpm-cache
       shell: bash
@@ -60,6 +111,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
     - name: Update NPM
+      if: ${{ runner.os != 'Windows' }}
       shell: bash
       run: npm i -g npm@11.6.1
     - name: Install Node.js Dependencies

--- a/.github/scripts/docker-wsl.cmd
+++ b/.github/scripts/docker-wsl.cmd
@@ -1,0 +1,17 @@
+@echo off
+REM Forwards docker commands from Windows to the WSL2 Linux Docker daemon.
+REM For "docker build", uses the linux-builder (Buildx docker-container driver)
+REM and adds --load unless --output is already specified (they conflict).
+
+for /f "usebackq tokens=*" %%i in (`wsl -d Ubuntu-24.04 wslpath "%CD%"`) do set WSL_CWD=%%i
+
+if "%1"=="build" (
+  echo %* | findstr /i /c:"--output" >nul
+  if errorlevel 1 (
+    wsl -d Ubuntu-24.04 -u root --cd "%WSL_CWD%" -- env BUILDX_BUILDER=linux-builder docker %* --load
+  ) else (
+    wsl -d Ubuntu-24.04 -u root --cd "%WSL_CWD%" -- env BUILDX_BUILDER=linux-builder docker %*
+  )
+) else (
+  wsl -d Ubuntu-24.04 -u root --cd "%WSL_CWD%" -- docker %*
+)

--- a/.github/scripts/setup-wsl-docker.sh
+++ b/.github/scripts/setup-wsl-docker.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sets up Docker Engine with BuildKit + QEMU inside WSL2 Ubuntu.
+# Run as root inside the WSL2 distro:
+#   wsl -d Ubuntu-24.04 -u root -- bash /path/to/setup-wsl-docker.sh
+set -euo pipefail
+
+# ── Install Docker Engine ────────────────────────────────────────────────────
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq ca-certificates curl >/dev/null 2>&1
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  >/etc/apt/sources.list.d/docker.list
+
+apt-get update -qq
+apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin >/dev/null 2>&1
+
+# ── Configure DNS & start daemon ─────────────────────────────────────────────
+mkdir -p /etc/docker
+echo '{"dns":["8.8.8.8","8.8.4.4"]}' >/etc/docker/daemon.json
+
+dockerd >/var/log/dockerd.log 2>&1 &
+
+for i in $(seq 1 15); do
+  docker info >/dev/null 2>&1 && break || sleep 1
+done
+docker info >/dev/null 2>&1 || { echo "dockerd failed to start"; cat /var/log/dockerd.log; exit 1; }
+
+# ── QEMU + Buildx ────────────────────────────────────────────────────────────
+docker run --rm --privileged tonistiigi/binfmt --install all
+docker buildx create --name linux-builder --driver docker-container --use
+docker buildx inspect --bootstrap --builder linux-builder
+
+echo "Docker Engine with Buildx is ready."
+docker version
+docker buildx ls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,36 @@ jobs:
           aws-region: us-west-2
       - name: Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"
+  smoke_tests_windows:
+    name: Windows Smoke Tests - ${{matrix.smoke_test}}
+    runs-on: windows-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        smoke_test:
+          - pnpm
+          - dungeon-adventure
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifact
+          path: dist
+      - uses: ./.github/actions/init-monorepo
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.DEPLOY_INTEG_TESTS_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Windows Smoke Test - ${{ matrix.smoke_test }}
+        run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"
   release:
     name: Release
-    needs: [build, smoke_tests]
+    needs: [build, smoke_tests, smoke_tests_windows]
     runs-on: ubuntu-22.04
     outputs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,3 +78,25 @@ jobs:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"
+  smoke_tests_windows:
+    name: Windows Smoke Tests - ${{matrix.smoke_test}}
+    runs-on: windows-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        smoke_test:
+          - pnpm
+          - dungeon-adventure
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifact
+          path: dist
+      - uses: ./.github/actions/init-monorepo
+      - name: Windows Smoke Test - ${{ matrix.smoke_test }}
+        run: pnpm nx run @aws/nx-plugin-e2e:test -t "smoke test - ${{ matrix.smoke_test }}"

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -5,7 +5,7 @@
 import { startLocalRegistry } from '@nx/js/plugins/jest/local-registry';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { existsSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
 export default async function () {
   try {
     const registryPath = join(__dirname, '../../tmp');
@@ -27,6 +27,20 @@ export default async function () {
         cwd: join(__dirname, '../../dist/packages/nx-plugin'),
       });
       console.info('Package published to local registry');
+
+      // Read the published package version and set NX_E2E_PRESET_VERSION
+      // This is needed because create-nx-workspace uses `npm view` to resolve
+      // the preset version, which may fail on Windows with a local registry
+      const distPkgJson = JSON.parse(
+        readFileSync(
+          join(__dirname, '../../dist/packages/nx-plugin/package.json'),
+          'utf-8',
+        ),
+      );
+      process.env.NX_E2E_PRESET_VERSION = distPkgJson.version;
+      console.info(
+        `Set NX_E2E_PRESET_VERSION=${process.env.NX_E2E_PRESET_VERSION}`,
+      );
     } catch (err) {
       console.error(`Package couldn't be published to local registry: ${err}`);
       throw err;

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -29,13 +29,13 @@ const expectFileMatchesOldTemplate = (
 ) => {
   const actual = readFileSync(generatedFilePath, 'utf-8');
   if (isUpdateSnapshot()) {
-    const existing = readFileSync(oldTemplatePath).toString();
+    const existing = readFileSync(oldTemplatePath, 'utf-8');
     if (actual !== existing) {
       console.log(`Updating template: ${oldTemplatePath}`);
       writeFileSync(oldTemplatePath, actual);
     }
   } else {
-    expect(actual).toEqual(readFileSync(oldTemplatePath).toString());
+    expect(actual).toEqual(readFileSync(oldTemplatePath, 'utf-8'));
   }
 };
 
@@ -43,7 +43,7 @@ const expectFileMatchesOldTemplate = (
  * This test runs through the dungeon adventure tutorial from the docs
  */
 describe('smoke test - dungeon-adventure', () => {
-  const pkgMgr = 'pnpm';
+  const pkgMgr = process.platform === 'win32' ? 'npm' : 'pnpm';
   const targetDir = `${tmpProjPath()}/dungeon-adventure-${pkgMgr}`;
 
   beforeEach(() => {
@@ -127,6 +127,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/1/application-stack.ts.template',
         ),
+        'utf-8',
       ),
     );
     await runCLI(`sync --verbose`, opts);
@@ -155,6 +156,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/schema/index.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -167,6 +169,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/entities/index.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -177,6 +180,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/actions.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -187,6 +191,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/games.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -197,6 +202,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/procedures/inventory.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -212,6 +218,7 @@ describe('smoke test - dungeon-adventure', () => {
       routerPath,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/2/router.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -225,6 +232,7 @@ describe('smoke test - dungeon-adventure', () => {
       indexPath,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/2/index.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -241,6 +249,7 @@ describe('smoke test - dungeon-adventure', () => {
       mcpServerPath,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/2/mcp/server.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -262,6 +271,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/constructs/electrodb-table.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -272,6 +282,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/2/stacks/application-stack.ts.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -299,6 +310,7 @@ describe('smoke test - dungeon-adventure', () => {
       mainPyPath,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/3/main.py.template'),
+        'utf-8',
       ),
     );
 
@@ -312,6 +324,7 @@ describe('smoke test - dungeon-adventure', () => {
       agentPyPath,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/3/agent.py.template'),
+        'utf-8',
       ),
     );
 
@@ -332,6 +345,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/game-ui/src/config.ts`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/4/config.ts.template'),
+        'utf-8',
       ),
     );
 
@@ -343,6 +357,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/AppLayout/index.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -360,6 +375,7 @@ describe('smoke test - dungeon-adventure', () => {
       `${opts.cwd}/packages/game-ui/src/styles.css`,
       readFileSync(
         join(__dirname, '../files/dungeon-adventure/4/styles.css.template'),
+        'utf-8',
       ),
     );
 
@@ -371,6 +387,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/hooks/useStoryAgent.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -384,6 +401,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/routes/game/index.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -394,6 +412,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/routes/game/$playerName.tsx.template',
         ),
+        'utf-8',
       ),
     );
 
@@ -413,6 +432,7 @@ describe('smoke test - dungeon-adventure', () => {
           __dirname,
           '../files/dungeon-adventure/4/routes/index.tsx.template',
         ),
+        'utf-8',
       ),
     );
 

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -175,13 +175,19 @@ export const runSmokeTest = async (
   // Wire up website, cognito and trpc api
   writeFileSync(
     `${opts.cwd}/packages/infra/src/stacks/application-stack.ts`,
-    readFileSync(join(__dirname, '../files/application-stack.ts.template')),
+    readFileSync(
+      join(__dirname, '../files/application-stack.ts.template'),
+      'utf-8',
+    ),
   );
 
   // Since the smoke tests don't run in a git repo, we need to exclude some patterns for the license sync
   writeFileSync(
     `${opts.cwd}/aws-nx-plugin.config.mts`,
-    readFileSync(join(__dirname, '../files/aws-nx-plugin.config.mts.template')),
+    readFileSync(
+      join(__dirname, '../files/aws-nx-plugin.config.mts.template'),
+      'utf-8',
+    ),
   );
 
   await runCLI(`sync --verbose`, opts);

--- a/e2e/src/smoke-tests/terraform.spec.ts
+++ b/e2e/src/smoke-tests/terraform.spec.ts
@@ -106,6 +106,7 @@ describe('smoke test - terraform', () => {
       `${opts.cwd}/aws-nx-plugin.config.mts`,
       readFileSync(
         join(__dirname, '../files/aws-nx-plugin.config.mts.template'),
+        'utf-8',
       ),
     );
 

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -4,6 +4,7 @@
  */
 import { execSync } from 'child_process';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { output, PackageManager } from '@nx/devkit';
 import { existsSync } from 'fs';
 import { backOff } from 'exponential-backoff';
@@ -109,7 +110,12 @@ function getYarnMajorVersion(path: string): string | undefined {
 }
 
 export function tmpProjPath() {
-  return '/tmp/nx-plugin-for-aws/e2e';
+  // Use a shorter path on Windows to avoid path length issues with deeply
+  // nested node_modules and Vite build output
+  if (process.platform === 'win32') {
+    return 'C:\\nxe2e';
+  }
+  return join(tmpdir(), 'nx-plugin-for-aws', 'e2e');
 }
 
 function getPackageManagerCommand({

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -84,7 +84,7 @@ exports[`infra generator > should configure Checkov target correctly > checkov-t
     "{workspaceRoot}/dist/{projectRoot}/cdk.out",
   ],
   "options": {
-    "command": "uvx checkov==3.2.511 --config-file {projectRoot}/checkov.yml --directory dist/{projectRoot}/cdk.out --framework cloudformation",
+    "command": "uvx --from checkov==3.2.511 checkov --config-file {projectRoot}/checkov.yml --directory dist/{projectRoot}/cdk.out --framework cloudformation",
   },
   "outputs": [
     "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -177,7 +177,7 @@ exports[`infra generator > should configure project.json with correct targets > 
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx checkov==3.2.511 --config-file {projectRoot}/checkov.yml --directory dist/{projectRoot}/cdk.out --framework cloudformation",
+        "command": "uvx --from checkov==3.2.511 checkov --config-file {projectRoot}/checkov.yml --directory dist/{projectRoot}/cdk.out --framework cloudformation",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",
@@ -739,7 +739,7 @@ exports[`infra generator > should handle custom project names correctly > custom
         "{workspaceRoot}/dist/{projectRoot}/cdk.out",
       ],
       "options": {
-        "command": "uvx checkov==3.2.511 --config-file {projectRoot}/checkov.yml --directory dist/{projectRoot}/cdk.out --framework cloudformation",
+        "command": "uvx --from checkov==3.2.511 checkov --config-file {projectRoot}/checkov.yml --directory dist/{projectRoot}/cdk.out --framework cloudformation",
       },
       "outputs": [
         "{workspaceRoot}/dist/{projectRoot}/checkov",

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -161,7 +161,7 @@ describe('infra generator', () => {
       outputs: ['{workspaceRoot}/dist/{projectRoot}/checkov'],
       dependsOn: ['synth'],
       options: {
-        command: expect.stringContaining('uvx checkov=='),
+        command: expect.stringContaining('uvx --from checkov=='),
       },
     });
 

--- a/packages/nx-plugin/src/terraform/project/generator.spec.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.spec.ts
@@ -224,7 +224,7 @@ describe('terraformProjectGenerator', () => {
       const testTarget = projectConfig.targets['test'];
       expect(testTarget.executor).toBe('nx:run-commands');
       expect(testTarget.cache).toBe(true);
-      expect(testTarget.options.command).toContain('uvx checkov==');
+      expect(testTarget.options.command).toContain('uvx --from checkov==');
     });
   });
 

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -54,16 +54,25 @@ export async function terraformProjectGenerator(
   const outDirToRootRelativePath = relative(
     join(tree.root, lib.dir, 'src'),
     tree.root,
+  ).replace(/\\/g, '/');
+  const distDir = joinPathFragments(
+    outDirToRootRelativePath,
+    'dist',
+    '{projectRoot}',
   );
-  const distDir = join(outDirToRootRelativePath, 'dist', '{projectRoot}');
-  const tfDistDir = join(distDir, 'terraform');
-  const checkovReportJsonPath = join(distDir, 'checkov', 'checkov_report.json');
+  const tfDistDir = joinPathFragments(distDir, 'terraform');
+  const checkovReportJsonPath = joinPathFragments(
+    distDir,
+    'checkov',
+    'checkov_report.json',
+  );
 
   // Calculate relative path from current project to common/terraform/metrics
+  // Use forward slashes for terraform module source paths (even on Windows)
   const metricsModulePath = relative(
     join(tree.root, lib.dir, 'src'),
     join(tree.root, 'packages', SHARED_TERRAFORM_DIR, 'src', 'metrics'),
-  );
+  ).replace(/\\/g, '/');
 
   updateGitIgnore(tree, '.', (patterns) => [...patterns, '.terraform']);
 

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -78,7 +78,7 @@ export const uvxCommand = (
   args?: string,
   withDeps?: UvxWithDep[],
 ): string => {
-  return `uvx ${
+  return `uvx --from ${withPyVersions([dep])[0]} ${
     withDeps
       ? `${withDeps
           .map(
@@ -87,7 +87,7 @@ export const uvxCommand = (
           )
           .join(' ')} `
       : ''
-  }${withPyVersions([dep])[0]}${args ? ` ${args}` : ''}`;
+  }${dep}${args ? ` ${args}` : ''}`;
 };
 
 /**


### PR DESCRIPTION
### Reason for this change

Help reduce the chance we'll break Windows users by running a subset of smoke tests on Windows runners.

### Description of changes

- Add `smoke_tests_windows` jobs to `pr.yml` and `ci.yml` workflows running `pnpm` and `dungeon-adventure` smoke tests on `windows-latest`
- Fix `tmpProjPath()` in e2e utils to use `os.tmpdir()` instead of hardcoded `/tmp/` (which doesn't exist on Windows)
- Add `'utf-8'` encoding to all `readFileSync` calls in smoke tests to avoid Buffer/string issues across platforms
- Add `.gitattributes` with `* text=auto eol=lf` to enforce consistent LF line endings
- Make `init-monorepo` action Windows-compatible by skipping QEMU, Docker Buildx, Terraform, and Bun setup on Windows runners
- Gate the CI release job on Windows smoke tests passing

### Description of how you validated changes

CI will validate the Windows smoke tests on this PR.

### Issue # (if applicable)

Closes #211.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*