### PR TITLE
ci(e2e): grant Python strands agent permission to invoke MCP server

### DIFF
--- a/e2e/src/files/application-stack.ts.template
+++ b/e2e/src/files/application-stack.ts.template
@@ -81,8 +81,9 @@ export class ApplicationStack extends cdk.Stack {
       value: tsMcp.agentCoreRuntime.agentRuntimeArn,
     });
 
-    // Grant the TS strands agent permissions to invoke the connected MCP servers
+    // Grant the strands agents permissions to invoke the connected MCP servers
     tsMcp.grantInvokeAccess(tsStrandsAgent);
     pyMcp.grantInvokeAccess(tsStrandsAgent);
+    pyMcp.grantInvokeAccess(strandsAgent);
   }
 }


### PR DESCRIPTION
### Reason for this change

The cdk-deploy smoke test started failing after PR #556 connected the Python strands agent to the Python MCP server. The agent's MCP client connection fails at runtime with a 400 from Agent Core because the Python strands agent lacks `bedrock-agentcore:InvokeAgentRuntime` permission on the MCP server.

The e2e application stack template only granted MCP invoke access to the TS strands agent — the Python agent was missed.

### Description of changes

Add `pyMcp.grantInvokeAccess(strandsAgent)` to the e2e application stack template so the Python strands agent can invoke the connected Python MCP server.

### Description of how you validated changes

1. Created a fresh test workspace with `py#strands-agent` + `py#mcp-server` connected via the connection generator
2. Deployed with `mcpServer.agentCoreRuntime.grantInvoke(agent.agentCoreRuntime)` per the docs
3. Confirmed the root cause: Agent Core returns 400 when the runtime lacks `InvokeAgentRuntime` permission
4. Verified the fix: 3 consecutive invocations all returned valid streaming chunks (15-38 chunks each) with the agent successfully using MCP tools (`add` from MCP server, `subtract` local tool)

### Issue # (if applicable)

Fixes cdk-deploy smoke test failure: https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24116937413/job/70363712216

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*