### PR TITLE
docs(py#strands-agent): add Browser / React Website section

### DIFF
--- a/docs/src/content/docs/en/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/en/guides/py-strands-agent.mdx
@@ -355,3 +355,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### Browser / React Website
+
+For invoking your Strands Agent from a React website, you can make use of the <Link path="/guides/connection/react-py-strands-agent">`connection` generator</Link>, which automatically sets up a client with the correct authentication (IAM or Cognito).
+
+<RunGenerator generator="connection" />
+
+Refer to the <Link path="/guides/connection/react-py-strands-agent">`connection` generator guide</Link> for details about how the connection is set up.

--- a/docs/src/content/docs/es/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/es/guides/py-strands-agent.mdx
@@ -353,3 +353,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### Navegador / Sitio Web React
+
+Para invocar tu Agente Strands desde un sitio web React, puedes hacer uso del <Link path="/guides/connection/react-py-strands-agent">generador `connection`</Link>, que configura automáticamente un cliente con la autenticación correcta (IAM o Cognito).
+
+<RunGenerator generator="connection" />
+
+Consulta la <Link path="/guides/connection/react-py-strands-agent">guía del generador `connection`</Link> para detalles sobre cómo se configura la conexión.

--- a/docs/src/content/docs/fr/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/fr/guides/py-strands-agent.mdx
@@ -355,3 +355,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### Navigateur / Site web React
+
+Pour invoquer votre agent Strands depuis un site web React, vous pouvez utiliser le <Link path="/guides/connection/react-py-strands-agent">générateur `connection`</Link>, qui configure automatiquement un client avec l'authentification appropriée (IAM ou Cognito).
+
+<RunGenerator generator="connection" />
+
+Consultez le <Link path="/guides/connection/react-py-strands-agent">guide du générateur `connection`</Link> pour plus de détails sur la configuration de la connexion.

--- a/docs/src/content/docs/it/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/it/guides/py-strands-agent.mdx
@@ -355,3 +355,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### Browser / Sito Web React
+
+Per invocare il tuo Strands Agent da un sito web React, puoi utilizzare il <Link path="/guides/connection/react-py-strands-agent">generatore `connection`</Link>, che configura automaticamente un client con l'autenticazione corretta (IAM o Cognito).
+
+<RunGenerator generator="connection" />
+
+Consulta la <Link path="/guides/connection/react-py-strands-agent">guida del generatore `connection`</Link> per dettagli su come viene configurata la connessione.

--- a/docs/src/content/docs/jp/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/jp/guides/py-strands-agent.mdx
@@ -353,3 +353,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### ブラウザ / Reactウェブサイト
+
+ReactウェブサイトからStrandsエージェントを呼び出す場合、<Link path="/guides/connection/react-py-strands-agent">`connection`ジェネレーター</Link>を使用できます。これにより、正しい認証（IAMまたはCognito）を備えたクライアントが自動的にセットアップされます。
+
+<RunGenerator generator="connection" />
+
+接続の設定方法の詳細については、<Link path="/guides/connection/react-py-strands-agent">`connection`ジェネレーターガイド</Link>を参照してください。

--- a/docs/src/content/docs/ko/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/ko/guides/py-strands-agent.mdx
@@ -355,3 +355,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### 브라우저 / React 웹사이트
+
+React 웹사이트에서 Strands 에이전트를 호출하려면 <Link path="/guides/connection/react-py-strands-agent">`connection` 생성기</Link>를 활용할 수 있습니다. 이 생성기는 올바른 인증(IAM 또는 Cognito)이 설정된 클라이언트를 자동으로 설정합니다.
+
+<RunGenerator generator="connection" />
+
+연결 설정 방법에 대한 자세한 내용은 <Link path="/guides/connection/react-py-strands-agent">`connection` 생성기 가이드</Link>를 참조하세요.

--- a/docs/src/content/docs/pt/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/pt/guides/py-strands-agent.mdx
@@ -355,3 +355,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### Navegador / Website React
+
+Para invocar seu Agente Strands a partir de um website React, você pode usar o <Link path="/guides/connection/react-py-strands-agent">gerador `connection`</Link>, que configura automaticamente um cliente com a autenticação correta (IAM ou Cognito).
+
+<RunGenerator generator="connection" />
+
+Consulte o <Link path="/guides/connection/react-py-strands-agent">guia do gerador `connection`</Link> para detalhes sobre como a conexão é configurada.

--- a/docs/src/content/docs/vi/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/vi/guides/py-strands-agent.mdx
@@ -322,7 +322,7 @@ Tham số `-N` được cung cấp cho `curl` vô hiệu hóa việc buffer outp
 ```bash
 acurl <region> bedrock-agentcore -N -X POST \
 'https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations' \
--d '{"message": "what is 3 + 5?"}' \
+-d '{"prompt": "what is 3 + 5?", "session_id": "abcdefghijklmnopqrstuvwxyz0123456789"}' \
 -H 'Content-Type: application/json'
 ```
 
@@ -353,3 +353,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### Browser / React Website
+
+Để gọi Strands Agent của bạn từ một React website, bạn có thể sử dụng <Link path="/guides/connection/react-py-strands-agent">`connection` generator</Link>, tự động thiết lập một client với xác thực chính xác (IAM hoặc Cognito).
+
+<RunGenerator generator="connection" />
+
+Tham khảo <Link path="/guides/connection/react-py-strands-agent">hướng dẫn `connection` generator</Link> để biết chi tiết về cách thiết lập kết nối.

--- a/docs/src/content/docs/zh/guides/py-strands-agent.mdx
+++ b/docs/src/content/docs/zh/guides/py-strands-agent.mdx
@@ -353,3 +353,11 @@ aws cognito-idp admin-initiate-auth \
   --query 'AuthenticationResult.AccessToken' \
   --output text
 ```
+
+#### 浏览器 / React网站
+
+要从React网站调用Strands智能体，可以使用<Link path="/guides/connection/react-py-strands-agent">`connection`生成器</Link>，它会自动设置具有正确认证方式（IAM或Cognito）的客户端。
+
+<RunGenerator generator="connection" />
+
+关于连接设置的详细信息，请参考<Link path="/guides/connection/react-py-strands-agent">`connection`生成器指南</Link>。


### PR DESCRIPTION
### Reason for this change

The TypeScript Strands Agent guide includes a "Browser / React Website" section that documents how to connect a React website to the agent using the connection generator. The Python Strands Agent guide was missing this equivalent section.

### Description of changes

Added a "Browser / React Website" subsection under "Invoking your Strands Agent" in the Python Strands Agent guide, mirroring the same section in the TypeScript Strands Agent guide. It links to the existing `react-py-strands-agent` connection guide and includes the `<RunGenerator>` component.

### Description of how you validated changes

Verified the linked connection guide (`react-py-strands-agent.mdx`) exists. Confirmed the structure matches the TypeScript guide's equivalent section.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*