### PR TITLE
feat: add AI-generated headline to Slack release notifications

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -5,20 +5,37 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write # Required for OIDC
+
 jobs:
   slack-notification:
     name: Share recent changes with a channel
     runs-on: ubuntu-latest
     steps:
-      - name: Send release notification
-        uses: slackapi/slack-github-action@v3.0.1
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Use PNPM 10.x
+        uses: pnpm/action-setup@v4
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELEASE_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            {
-              "name": ${{ toJSON(github.event.release.name) }},
-              "version": "${{ github.event.release.tag_name }}",
-              "body": ${{ toJSON(github.event.release.body) }},
-              "url": "${{ github.event.release.html_url }}"
-            }
+          version: 10
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile --prefer-offline
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_TRANSLATE_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_TRANSLATE_AWS_REGION || 'us-west-2' }}
+      - name: Generate headline and send notification
+        run: pnpm tsx ./scripts/send-slack-release-notification.ts
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASE_URL }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}

--- a/scripts/send-slack-release-notification.ts
+++ b/scripts/send-slack-release-notification.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { Agent } from 'https';
+
+const MODEL_ID = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+
+/**
+ * Generate an AI-summarised headline for a release and send the Slack notification.
+ *
+ * Required env vars:
+ *   SLACK_WEBHOOK_URL  — Slack webhook trigger URL
+ *   RELEASE_NAME       — Release name (e.g. "v0.50.0")
+ *   RELEASE_VERSION    — Tag name (e.g. "v0.50.0")
+ *   RELEASE_BODY       — Release changelog body (markdown)
+ *   RELEASE_URL        — URL to the GitHub release
+ */
+async function main() {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  const name = process.env.RELEASE_NAME;
+  const version = process.env.RELEASE_VERSION;
+  const releaseBody = process.env.RELEASE_BODY;
+  const url = process.env.RELEASE_URL;
+
+  if (!webhookUrl || !name || !version || !releaseBody || !url) {
+    console.error(
+      'Missing required environment variables: SLACK_WEBHOOK_URL, RELEASE_NAME, RELEASE_VERSION, RELEASE_BODY, RELEASE_URL',
+    );
+    process.exit(1);
+  }
+
+  const headline = await generateHeadline(version, releaseBody);
+  console.log(`Generated headline: ${headline}`);
+
+  await sendSlackNotification(webhookUrl, {
+    name,
+    version,
+    body: releaseBody,
+    url,
+    headline,
+  });
+
+  console.log('Slack notification sent successfully');
+}
+
+async function generateHeadline(
+  version: string,
+  releaseBody: string,
+): Promise<string> {
+  const client = new BedrockRuntimeClient({
+    region: process.env.AWS_REGION || 'us-west-2',
+    credentials: fromNodeProviderChain(),
+    requestHandler: new NodeHttpHandler({
+      httpsAgent: new Agent({ maxSockets: 500 }),
+    }),
+  });
+
+  const systemPrompt = `You are a release notes headline writer for an open-source Nx plugin for AWS (@aws/nx-plugin).
+Given a version number and a changelog body (in markdown), produce a single short headline (max 100 characters) that summarises the most important features and fixes in this release.
+
+Rules:
+1. Be concise — the headline should read like a news title.
+2. Focus on what matters most to developers using the plugin.
+3. Do NOT include the version number in the headline — it is shown separately.
+4. Do NOT use quotes around the headline.
+5. Output ONLY the headline text, nothing else.`;
+
+  const userMessage = `Version: ${version}
+
+Changelog:
+${releaseBody}`;
+
+  const command = new InvokeModelCommand({
+    modelId: MODEL_ID,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify({
+      anthropic_version: 'bedrock-2023-05-31',
+      max_tokens: 256,
+      temperature: 0.5,
+      system: systemPrompt,
+      messages: [
+        {
+          role: 'user',
+          content: userMessage,
+        },
+      ],
+    }),
+  });
+
+  const response = await client.send(command);
+  const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+  return responseBody.content[0].text.trim();
+}
+
+async function sendSlackNotification(
+  webhookUrl: string,
+  payload: {
+    name: string;
+    version: string;
+    body: string;
+    url: string;
+    headline: string;
+  },
+): Promise<void> {
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Slack webhook returned ${response.status}: ${body}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `Failed to send release notification: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
### Reason for this change

Release notifications to Slack currently include the raw changelog body but no summary. Adding a short AI-generated headline makes it easy to see at a glance what's in a release.

### Description of changes

- Added `scripts/send-slack-release-notification.ts` — a new script that uses Bedrock (Claude Sonnet) to generate a concise headline from the release changelog, then sends the full Slack webhook payload (including the new `headline` field) directly from Node.js.
- Updated `.github/workflows/on-release.yml` to check out the repo, install dependencies, configure AWS credentials via OIDC, and run the script. All release metadata is passed via environment variables.

### Description of how you validated changes

- Ran the script locally against the real v0.50.0 release notes and verified the headline accurately reflected the release content.
- Sent test payloads to a Slack webhook and confirmed they were received correctly with the headline field.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*