### PR TITLE
fix: increase default unit test timeout to 2 minutes

### DIFF
--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -40,7 +40,7 @@ export default defineConfig({
     sequence: {
       hooks: 'list',
     },
-    testTimeout: 60000,
-    hookTimeout: 60000,
+    testTimeout: 120000,
+    hookTimeout: 120000,
   },
 });


### PR DESCRIPTION
### Reason for this change

The `should increment ports when running generator multiple times` test in `src/py/fast-api/generator.spec.ts` is [timing out in CI](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24172371321/job/70546488782) at the current 60s default.

### Description of changes

Increased `testTimeout` and `hookTimeout` from 60000ms to 120000ms in `packages/nx-plugin/vite.config.mts`.

### Description of how you validated changes

Confirmed the timeout value is picked up by running `pnpm nx run @aws/nx-plugin:test`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*