### PR TITLE
ci(windows): speed up Windows smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Disable Windows Defender real-time monitoring
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,6 +92,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Disable Windows Defender real-time monitoring
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -43,7 +43,7 @@ const expectFileMatchesOldTemplate = (
  * This test runs through the dungeon adventure tutorial from the docs
  */
 describe('smoke test - dungeon-adventure', () => {
-  const pkgMgr = process.platform === 'win32' ? 'npm' : 'pnpm';
+  const pkgMgr = 'pnpm';
   const targetDir = `${tmpProjPath()}/dungeon-adventure-${pkgMgr}`;
 
   beforeEach(() => {


### PR DESCRIPTION
### Reason for this change

Windows smoke tests take 30-40 minutes vs 10-15 minutes on Linux. Analysis of CI logs identified two major contributors:

1. **dungeon-adventure test forces `npm` on Windows** (`process.platform === 'win32' ? 'npm' : 'pnpm'`), causing 3-4 minute `npm install` calls after each generator (~12 min total overhead)
2. **Windows Defender real-time scanning** adds I/O overhead on every file written to `node_modules`

### Description of changes

- **`e2e/src/smoke-tests/dungeon-adventure.spec.ts`**: Remove the win32→npm override, use `pnpm` on all platforms
- **`.github/workflows/ci.yml` & `pr.yml`**: Add `Set-MpPreference -DisableRealtimeMonitoring $true` step before Windows smoke tests to disable Defender scanning during CI

### Measured results

| Job | Before | After | Saved |
|---|---|---|---|
| Windows Smoke Tests - pnpm | 32 min | 27 min | **5 min (16%)** |
| Windows Smoke Tests - dungeon-adventure | 41 min | 33 min | **8 min (20%)** |

**Total wall-clock savings: ~13 min across both Windows jobs.**

The dungeon-adventure improvement is primarily from switching npm→pnpm (eliminates 3-4 min npm installs after each generator). The pnpm job improvement is from disabling Windows Defender real-time scanning.

### Description of how you validated changes

Both Windows smoke tests pass on this PR (run [24223960712](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24223960712)). Timings compared against baseline run [24207942025](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24207942025).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*