### PR TITLE
fix(ts#api): use addEnvironment for required env vars in buildDefaultIntegration

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -257,7 +257,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
@@ -120,15 +120,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Lambda Environment Variables]
-If you specify `environment` in your default options this will __overwrite__ any environment variables that are defined within your generated API construct. It is usually preferable to use the `addEnvironment` method for Lambda functions. You can quite easily achieve this by looping through your integrations:
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -257,7 +257,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Variables de Entorno de Lambda]
-Si especificas `environment` en tus opciones por defecto, esto __sobrescribirá__ cualquier variable de entorno que esté definida dentro de tu constructo de API generado. Generalmente es preferible usar el método `addEnvironment` para las funciones Lambda. Puedes lograr esto fácilmente iterando a través de tus integraciones:
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -257,7 +257,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Variables d'environnement Lambda]
-Si vous spécifiez `environment` dans vos options par défaut, cela __écrasera__ toutes les variables d'environnement définies dans votre construct API généré. Il est généralement préférable d'utiliser la méthode `addEnvironment` pour les fonctions Lambda. Vous pouvez facilement y parvenir en parcourant vos intégrations :
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -257,7 +257,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Integrazioni API Type-Safe"
+title: Type-Safe API Integrations
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Variabili d'Ambiente Lambda]
-Se specifichi `environment` nelle tue opzioni predefinite, questo __sovrascriverà__ qualsiasi variabile d'ambiente definita all'interno del tuo costrutto API generato. È generalmente preferibile utilizzare il metodo `addEnvironment` per le funzioni Lambda. Puoi ottenere questo risultato facilmente iterando attraverso le tue integrazioni:
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -256,7 +256,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
@@ -1197,4 +1196,4 @@ No, run the tasks without syncing the changes
 
 すべてのビルド成果物は、モノレポのルートにある`dist/`フォルダ内で利用できるようになりました。これは、`@aws/nx-plugin`によって生成されたプロジェクトを使用する場合の標準的な慣行であり、生成されたファイルでファイルツリーが汚染されることはありません。ファイルをクリーンにしたい場合は、ビルド成果物がファイルツリー全体に散らばることを心配せずに`dist/`フォルダを削除してください。
 
-おめでとうございます！AIダンジョンアドベンチャーゲームのコアの実装を開始するために必要なすべてのサブプロジェクトを作成しました。🎉🎉🎉
+おめでとうございます!AIダンジョンアドベンチャーゲームのコアの実装を開始するために必要なすべてのサブプロジェクトを作成しました。🎉🎉🎉

--- a/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Lambda環境変数]
-デフォルトオプションで`environment`を指定すると、生成されたAPIコンストラクト内で定義されている環境変数が__上書き__されます。通常はLambda関数に対して`addEnvironment`メソッドを使用する方が望ましいです。統合をループ処理することで簡単に実現できます：
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -256,7 +256,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
@@ -120,15 +120,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Lambda 환경 변수]
-기본 옵션에서 `environment`를 지정하면 생성된 API 구문 내에 정의된 환경 변수를 __덮어씁니다__. 일반적으로 Lambda 함수에는 `addEnvironment` 메서드를 사용하는 것이 좋습니다. 통합을 반복하여 쉽게 달성할 수 있습니다:
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -257,7 +257,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Variáveis de Ambiente Lambda]
-Se você especificar `environment` em suas opções padrão, isso __sobrescreverá__ quaisquer variáveis de ambiente que estão definidas dentro do seu construto de API gerado. Geralmente é preferível usar o método `addEnvironment` para funções Lambda. Você pode facilmente conseguir isso fazendo um loop através de suas integrações:
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -257,7 +257,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Biến môi trường Lambda]
-Nếu bạn chỉ định `environment` trong các tùy chọn mặc định của mình, điều này sẽ __ghi đè__ bất kỳ biến môi trường nào được định nghĩa trong construct API đã được tạo của bạn. Thông thường tốt hơn là sử dụng phương thức `addEnvironment` cho các Lambda function. Bạn có thể dễ dàng thực hiện điều này bằng cách lặp qua các tích hợp của mình:
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -256,7 +256,6 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {},
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);

--- a/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
@@ -121,15 +121,6 @@ new MyApi(this, 'MyApi', {
 });
 ```
 
-:::caution[Lambda 环境变量]
-如果您在默认选项中指定 `environment`，这将__覆盖__在生成的 API 构造中定义的任何环境变量。通常更推荐使用 Lambda 函数的 `addEnvironment` 方法。您可以通过循环遍历集成来轻松实现：
-
-```ts
-Object.values(api.integrations).forEach(({ handler }) => {
-  handler.addEnvironment('LOG_LEVEL', 'INFO');
-});
-```
-:::
 
 </Fragment>
 <Fragment slot="terraform">

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "prettier": "3.8.2",
     "react": "19.2.5",
     "react-dom": "19.2.5",
-    "simple-git": "3.35.2",
+    "simple-git": "3.36.0",
     "starlight-blog": "0.26.1",
     "starlight-contributor-list": "0.4.0",
     "starlight-links-validator": "0.23.0",

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -491,15 +491,16 @@ export class TestApi<
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-          PORT: '8000',
-          AWS_LWA_INVOKE_MODE: 'buffered',
-          AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
+        handler.addEnvironment('PORT', '8000');
+        handler.addEnvironment('AWS_LWA_INVOKE_MODE', 'buffered');
+        handler.addEnvironment('AWS_LAMBDA_EXEC_WRAPPER', '/opt/bootstrap');
         rc.grantReadAppConfig(handler);
         const stack = Stack.of(scope);
         handler.addLayers(
@@ -1276,15 +1277,16 @@ export class TestApi<
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-          PORT: '8000',
-          AWS_LWA_INVOKE_MODE: 'response_stream',
-          AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
+        handler.addEnvironment('PORT', '8000');
+        handler.addEnvironment('AWS_LWA_INVOKE_MODE', 'response_stream');
+        handler.addEnvironment('AWS_LAMBDA_EXEC_WRAPPER', '/opt/bootstrap');
         rc.grantReadAppConfig(handler);
         const stack = Stack.of(scope);
         handler.addLayers(

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -122,12 +122,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -295,12 +296,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -442,12 +442,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -643,12 +644,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -848,12 +850,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1037,12 +1040,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1361,12 +1365,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -2204,12 +2209,13 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -137,19 +137,17 @@ export class <%= apiNameClassName %><
         <%_ if (backend.type === 'fastapi') { _%>
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
         <%_ } _%>
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-          <%_ if (backend.type === 'fastapi') { _%>
-          PORT: '8000',
-          AWS_LWA_INVOKE_MODE: 'buffered',
-          AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
-          <%_ } _%>
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         <%_ const lambdaTarget = backend.type === 'fastapi' ? 'handler.currentVersion' : 'handler'; _%>
         <%_ const integrationOptions = backend.integrationPattern === 'shared' ? ', { scopePermissionToRoute: false }' : ''; _%>
         const handler = new Function(scope, `<%= apiNameClassName %>${op}Handler`, props);
+        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        <%_ if (backend.type === 'fastapi') { _%>
+        handler.addEnvironment('PORT', '8000');
+        handler.addEnvironment('AWS_LWA_INVOKE_MODE', 'buffered');
+        handler.addEnvironment('AWS_LAMBDA_EXEC_WRAPPER', '/opt/bootstrap');
+        <%_ } _%>
         rc.grantReadAppConfig(handler);
         <%_ if (backend.type === 'fastapi') { _%>
         const stack = Stack.of(scope);

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -138,14 +138,6 @@ export class <%= apiNameClassName %><
         <%_ if (backend.type === 'fastapi') { _%>
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
         <%_ } _%>
-        environment: {
-          RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
-          <%_ if (backend.type === 'fastapi') { _%>
-          PORT: '8000',
-          AWS_LWA_INVOKE_MODE: 'response_stream',
-          AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
-          <%_ } _%>
-        },
       },
       buildDefaultIntegration: (op, props: FunctionProps) => {
         <%_ const lambdaTarget = backend.type === 'fastapi' ? 'handler.currentVersion' : 'handler'; _%>
@@ -164,6 +156,12 @@ export class <%= apiNameClassName %><
           : '';
         _%>
         const handler = new Function(scope, `<%= apiNameClassName %>${op}Handler`, props);
+        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        <%_ if (backend.type === 'fastapi') { _%>
+        handler.addEnvironment('PORT', '8000');
+        handler.addEnvironment('AWS_LWA_INVOKE_MODE', 'response_stream');
+        handler.addEnvironment('AWS_LAMBDA_EXEC_WRAPPER', '/opt/bootstrap');
+        <%_ } _%>
         rc.grantReadAppConfig(handler);
         <%_ if (backend.type === 'fastapi') { _%>
         const stack = Stack.of(scope);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,8 +309,8 @@ importers:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
       simple-git:
-        specifier: 3.35.2
-        version: 3.35.2
+        specifier: 3.36.0
+        version: 3.36.0
       starlight-blog:
         specifier: 0.26.1
         version: 0.26.1(@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@25.6.0)(aws4fetch@1.0.20)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@4.50.1)(sass@1.79.4)(stylus@0.64.0)(terser@5.44.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)))(astro@6.1.5(@types/node@25.6.0)(aws4fetch@1.0.20)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@4.50.1)(sass@1.79.4)(stylus@0.64.0)(terser@5.44.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3))
@@ -3592,6 +3592,7 @@ packages:
 
   '@simple-git/argv-parser@1.1.0':
     resolution: {integrity: sha512-sUKOu2lb5vGIWADNNLpscyj07DAeQZU3KLbnE2Tj53tW6BbDQKMly2CCfnR4oYzqtRELCPWfwaPg+Q0T8qfKBg==}
+    deprecated: Contains a breaking change that should be a major version bump
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -8952,8 +8953,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-git@3.35.2:
-    resolution: {integrity: sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -20889,7 +20890,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-git@3.35.2:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1


### PR DESCRIPTION
### Reason for this change

When users call `Api.defaultIntegrations(this).withDefaultOptions({ environment: { MY_VAR: 'value' } })`, the shallow merge in `withDefaultOptions` overwrites the entire `environment` object from `defaultIntegrationOptions`, causing required environment variables like `RUNTIME_CONFIG_APP_ID` (and FastAPI-specific vars) to be lost.

### Description of changes

- **HTTP & REST API construct templates**: Moved environment variables (`RUNTIME_CONFIG_APP_ID`, and for FastAPI: `PORT`, `AWS_LWA_INVOKE_MODE`, `AWS_LAMBDA_EXEC_WRAPPER`) from the `environment` block in `defaultIntegrationOptions` to `handler.addEnvironment()` calls in `buildDefaultIntegration`. This ensures these required variables are always set regardless of what users pass to `withDefaultOptions`.
- **Documentation**: Removed the `:::caution[Lambda Environment Variables]` warning from the type-safe API integrations docs since the issue it warns about no longer exists.
- **Tutorial**: Updated the dungeon-game tutorial step 1 to remove the now-empty `environment: {}` from `defaultIntegrationOptions`.
- **Snapshots**: Updated test snapshots to reflect the new pattern.

### Description of how you validated changes

- All 1625 unit tests pass (`pnpm nx run @aws/nx-plugin:test -u`)
- Build passes (`pnpm nx run-many --target build --all`)
- Lint passes (`pnpm nx run-many --target lint --all --fix`)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*