### PR TITLE
fix(ci): revert pnpm/action-setup to v4 in on-release workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Use PNPM 10.x
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Use Node.js 22.x


### PR DESCRIPTION
### Reason for this change

The `on-release` workflow (`Post release announcements`) started failing at v0.95.1 with `ERR_PNPM_IGNORED_BUILDS` (exit code 1) during `pnpm install`.

**Root cause:** Dependabot PR #569 bumped `pnpm/action-setup` from `v4` to `v6` in `on-release.yml`. The `v6` release was added to support pnpm 11 (`v11.0.0-rc.0`), and with `version: 10` it installs a pnpm binary that uses **store v11** (visible in [the failed run logs](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24385049599)) instead of store v10. This newer pnpm treats `ERR_PNPM_IGNORED_BUILDS` as a fatal error.

The successful v0.95.0 release used `action-setup@v4` (the version before the dependabot bump), which installed pnpm 10.33.0 with store v10.

The `init-monorepo` composite action (used by CI and PR workflows) still uses `@v4` and was unaffected.

### Description of changes

Revert `pnpm/action-setup` from `@v6` back to `@v4` in `on-release.yml`, matching the `init-monorepo` composite action used by all other workflows.

### Description of how you validated changes

- Confirmed v0.95.1 on-release run ([24385049599](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24385049599)) fails at the `Install dependencies` step with `ERR_PNPM_IGNORED_BUILDS` (store v11)
- Confirmed v0.95.0 on-release run ([24320255678](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24320255678)) succeeded with `action-setup@v4` (pnpm 10.33.0, store v10)
- Confirmed the `init-monorepo` action still uses `@v4` and CI continues to pass

### Issue # (if applicable)

N/A — regression introduced by dependabot PR #569.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*