### PR TITLE
feat: @aws/create-nx-workspace package for simplifying workspace creation command

### DIFF
--- a/docs/src/components/create-nx-workspace-command.astro
+++ b/docs/src/components/create-nx-workspace-command.astro
@@ -2,7 +2,7 @@
 import PackageManagerCommand from './package-manager-command.astro';
 import { buildCreateNxWorkspaceCommand } from '../../../packages/nx-plugin/src/utils/commands';
 
-const { workspace, iacProvider, nxPluginVersion, nxVersion } = Astro.props;
-const buildCommand = (pm) => buildCreateNxWorkspaceCommand(pm, workspace, iacProvider, false, nxVersion, nxPluginVersion);
+const { workspace, iacProvider } = Astro.props;
+const buildCommand = (pm) => buildCreateNxWorkspaceCommand(pm, workspace, iacProvider);
 ---
 <PackageManagerCommand buildCommand={buildCommand} />

--- a/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,28 @@ The shopping list application consists of the following PDK project types:
 
 To start, we'll create a new workspace for our new project. While more extreme than an in-place migration, this approach gives us the cleanest end result. Creating an Nx workspace is equivalent to using PDK's `MonorepoTsProject`:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 Open up the `shopping-list` directory this command creates in your favourite IDE.
 

--- a/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 Esta guía te lleva paso a paso a través de un ejemplo de migración de un proyecto [AWS PDK](https://github.com/aws/aws-pdk) al Nx Plugin para AWS, además de proporcionar orientación general sobre este tema.
 
@@ -56,7 +55,28 @@ La aplicación de lista de compras consiste en los siguientes tipos de proyecto 
 
 Para comenzar, crearemos un nuevo espacio de trabajo para nuestro proyecto nuevo. Aunque más extremo que una migración in situ, este enfoque nos da el resultado final más limpio. Crear un espacio de trabajo Nx es equivalente a usar el `MonorepoTsProject` de PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 Abre el directorio `shopping-list` que crea este comando en tu IDE favorito.
 

--- a/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 Ce guide vous accompagne dans un exemple de migration d'un projet [AWS PDK](https://github.com/aws/aws-pdk) vers le Nx Plugin pour AWS, tout en fournissant des conseils généraux sur le sujet.
 
@@ -56,7 +55,28 @@ L'application de liste de courses contient les types de projets PDK suivants :
 
 Pour commencer, nous allons créer un nouvel espace de travail pour notre projet. Bien que plus radical qu'une migration in situ, cette approche donne le résultat le plus propre. Créer un espace Nx équivaut à utiliser le `MonorepoTsProject` de PDK :
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 Ouvrez le répertoire `shopping-list` créé par cette commande dans votre IDE préféré.
 

--- a/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 Questa guida ti accompagna in una migrazione di esempio di un progetto [AWS PDK](https://github.com/aws/aws-pdk) al Plugin Nx per AWS, oltre a fornire indicazioni generali sull'argomento.
 
@@ -56,7 +55,28 @@ L'applicazione lista della spesa consiste nei seguenti tipi di progetto PDK:
 
 Per iniziare, creeremo un nuovo workspace per il nostro nuovo progetto. Sebbene più drastico di una migrazione in-place, questo approccio garantisce il risultato finale più pulito. Creare un workspace Nx è equivalente all'uso di `MonorepoTsProject` di PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 Apri la directory `shopping-list` creata da questo comando nel tuo IDE preferito.
 

--- a/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 このガイドでは、[AWS PDK](https://github.com/aws/aws-pdk)プロジェクトをNx Plugin for AWSに移行する具体例と、このトピックに関する一般的なガイダンスを提供します。
 
@@ -56,7 +55,28 @@ PDKからNx Plugin for AWSへの移行により、以下のメリットが得ら
 
 最初に、新しいプロジェクト用のワークスペースを作成します。既存環境での移行よりも極端なアプローチですが、最もクリーンな結果を得られます。Nxワークスペースの作成は、PDKの`MonorepoTsProject`に相当します:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 このコマンドで作成された`shopping-list`ディレクトリを、お気に入りのIDEで開きます。
 

--- a/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 이 가이드는 [AWS PDK](https://github.com/aws/aws-pdk) 프로젝트를 Nx Plugin for AWS로 마이그레이션하는 예시와 일반적인 지침을 제공합니다.
 
@@ -56,7 +55,28 @@ Nx Plugin for AWS로 마이그레이션하면 PDK 대비 다음과 같은 이점
 
 시작으로 새 프로젝트를 위한 워크스페이스를 생성합니다. 기존 프로젝트를 직접 수정하는 방식보다 깔끔한 결과를 얻을 수 있습니다. Nx 워크스페이스 생성은 PDK의 `MonorepoTsProject` 사용과 동일합니다:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 생성된 `shopping-list` 디렉토리를 선호하는 IDE에서 엽니다.
 

--- a/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 Este guia orienta você através de uma migração exemplo de um projeto [AWS PDK](https://github.com/aws/aws-pdk) para o Nx Plugin for AWS, além de fornecer orientações gerais sobre o tema.
 
@@ -56,7 +55,28 @@ A aplicação lista de compras consiste nos seguintes tipos de projeto PDK:
 
 Começaremos criando um novo workspace para nosso projeto. Embora mais radical que uma migração in-place, esta abordagem fornece o resultado mais limpo. Criar um workspace Nx é equivalente ao `MonorepoTsProject` do PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 Abra o diretório `shopping-list` criado em seu IDE favorito.
 

--- a/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
@@ -55,7 +55,28 @@ Trong hướng dẫn này, chúng ta sẽ sử dụng [Ứng dụng Danh sách M
 
 Để bắt đầu, chúng ta sẽ tạo một workspace mới cho dự án mới của mình. Mặc dù cực đoan hơn so với di chuyển tại chỗ, cách tiếp cận này mang lại cho chúng ta kết quả cuối cùng sạch sẽ nhất. Tạo một Nx workspace tương đương với việc sử dụng `MonorepoTsProject` của PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 Mở thư mục `shopping-list` mà lệnh này tạo ra trong IDE yêu thích của bạn.
 

--- a/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
@@ -6,8 +6,6 @@ authors:
  - jack
 ---
 
-
-
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Snippet from '@components/snippet.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
@@ -16,6 +14,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+
 
 本指南将引导您完成将 [AWS PDK](https://github.com/aws/aws-pdk) 项目迁移至 Nx AWS 插件的示例，并提供相关主题的通用指导。
 
@@ -56,7 +55,28 @@ import InstallCommand from '@components/install-command.astro';
 
 首先，为新建项目创建工作区。相较于原地迁移，此方法能获得最整洁的最终结果。创建 Nx 工作区相当于使用 PDK 的 `MonorepoTsProject`：
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iacProvider="CDK" nxVersion="21.4.1" nxPluginVersion="0.50.0" />
+<Tabs syncKey="cli-command">
+  <TabItem label="pnpm" icon="pnpm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=pnpm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="yarn" icon="seti:yarn">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=yarn --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="npm" icon="seti:npm">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=npm --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+  <TabItem label="bun" icon="bun">
+    ```bash
+    npx create-nx-workspace@21.4.1 shopping-list --pm=bun --preset=@aws/nx-plugin@0.50.0 --iacProvider=CDK --ci=skip --analytics=false
+    ```
+  </TabItem>
+</Tabs>
 
 在您常用的 IDE 中打开命令生成的 `shopping-list` 目录。
 

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -36,18 +36,32 @@ export default async function () {
         env: process.env,
         cwd: join(__dirname, '../../dist/packages/nx-plugin'),
       });
-      console.info('Package published to local registry');
+      console.info('@aws/nx-plugin published to local registry');
+    } catch (err) {
+      console.error(
+        `@aws/nx-plugin couldn't be published to local registry: ${err}`,
+      );
+      throw err;
+    }
 
-      console.info('Publishing @aws/nx-plugin-mcp to local registry');
-      execSync(`npm publish --tag e2e`, {
-        env: process.env,
-        cwd: join(__dirname, '../../dist/packages/nx-plugin-mcp'),
-      });
-      console.info('@aws/nx-plugin-mcp published to local registry');
+    console.info('Publishing @aws/nx-plugin-mcp to local registry');
+    execSync(`npm publish --tag e2e`, {
+      env: process.env,
+      cwd: join(__dirname, '../../dist/packages/nx-plugin-mcp'),
+    });
+    console.info('@aws/nx-plugin-mcp published to local registry');
 
-      // Read the published package version and set NX_E2E_PRESET_VERSION
-      // This is needed because create-nx-workspace uses `npm view` to resolve
-      // the preset version, which may fail on Windows with a local registry
+    console.info('Publishing @aws/create-nx-workspace to local registry');
+    execSync(`npm publish --tag e2e`, {
+      env: process.env,
+      cwd: join(__dirname, '../../dist/packages/create-nx-workspace'),
+    });
+    console.info('@aws/create-nx-workspace published to local registry');
+
+    // Read the published package version and set NX_E2E_PRESET_VERSION
+    // This is needed because create-nx-workspace uses `npm view` to resolve
+    // the preset version, which may fail on Windows with a local registry
+    try {
       const distPkgJson = JSON.parse(
         readFileSync(
           join(__dirname, '../../dist/packages/nx-plugin/package.json'),
@@ -59,7 +73,7 @@ export default async function () {
         `Set NX_E2E_PRESET_VERSION=${process.env.NX_E2E_PRESET_VERSION}`,
       );
     } catch (err) {
-      console.error(`Package couldn't be published to local registry: ${err}`);
+      console.error(`Failed to read published package version: ${err}`);
       throw err;
     }
   } catch (err) {

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -58,7 +58,7 @@ describe('smoke test - dungeon-adventure', () => {
     // 1. Monorepo Setup
 
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'dungeon-adventure', 'CDK', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'dungeon-adventure', 'CDK')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/fast-api.spec.ts
+++ b/e2e/src/smoke-tests/fast-api.spec.ts
@@ -24,7 +24,7 @@ describe('smoke test - fast-api', () => {
 
   it('should generate and build', async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'fast-api', 'CDK', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'fast-api', 'CDK')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/license-sync.spec.ts
+++ b/e2e/src/smoke-tests/license-sync.spec.ts
@@ -22,7 +22,7 @@ describe('smoke test - license-sync', () => {
 
   it('should apply license headers to ts and py source files via sync', async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'license-test', 'CDK', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'license-test', 'CDK')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/react-website.spec.ts
+++ b/e2e/src/smoke-tests/react-website.spec.ts
@@ -20,7 +20,7 @@ describe('smoke test - react-website', () => {
 
   it('should generate and build', async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'react-website', 'CDK', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'react-website', 'CDK')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/smithy-api.spec.ts
+++ b/e2e/src/smoke-tests/smithy-api.spec.ts
@@ -20,7 +20,7 @@ describe('smoke test - smithy-api', () => {
 
   it('should generate and build', async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'smithy', 'CDK', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'smithy', 'CDK')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -4,7 +4,6 @@
  */
 import { PackageManager } from '@nx/devkit';
 import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
-import { execSync } from 'child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
 import { join } from 'path';
@@ -16,7 +15,7 @@ export const runSmokeTest = async (
   onProjectCreate?: (projectRoot: string) => void,
 ) => {
   await runCLI(
-    `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'CDK', true)} --interactive=false --skipGit`,
+    `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'CDK')} --interactive=false --skipGit`,
     {
       cwd: dir,
       prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/terraform.spec.ts
+++ b/e2e/src/smoke-tests/terraform.spec.ts
@@ -24,7 +24,7 @@ describe('smoke test - terraform', () => {
 
   it(`Should generate and build - ${pkgMgr}`, async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'Terraform', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'Terraform')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/e2e/src/smoke-tests/trpc-api.spec.ts
+++ b/e2e/src/smoke-tests/trpc-api.spec.ts
@@ -24,7 +24,7 @@ describe('smoke test - trpc-api', () => {
 
   it('should generate and build', async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'trpc', 'CDK', true)} --interactive=false --skipGit`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'trpc', 'CDK')} --interactive=false --skipGit`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,

--- a/nx.json
+++ b/nx.json
@@ -99,7 +99,11 @@
     }
   ],
   "release": {
-    "projects": ["@aws/nx-plugin", "@aws/nx-plugin-mcp"],
+    "projects": [
+      "@aws/nx-plugin",
+      "@aws/nx-plugin-mcp",
+      "@aws/create-nx-workspace"
+    ],
     "version": {
       "manifestRootsToUpdate": ["dist/{projectRoot}"],
       "specifierSource": "conventional-commits",

--- a/packages/create-nx-workspace/.eslintrc.json
+++ b/packages/create-nx-workspace/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "parserOptions": {
+        "project": ["packages/create-nx-workspace/tsconfig.*?.json"]
+      },
+      "rules": {
+        "@typescript-eslint/no-floating-promises": "error"
+      }
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["**/*.spec.ts", "**/*.spec.tsx"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/create-nx-workspace/LICENSE
+++ b/packages/create-nx-workspace/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/create-nx-workspace/README.md
+++ b/packages/create-nx-workspace/README.md
@@ -1,0 +1,46 @@
+# @aws/create-nx-workspace
+
+The quickest way to start building on AWS with the [Nx Plugin for AWS](https://github.com/awslabs/nx-plugin-for-aws).
+
+## Getting Started
+
+```bash
+pnpm create @aws/nx-workspace my-project
+```
+
+This creates a new [Nx](https://nx.dev) workspace pre-configured with the [`@aws/nx-plugin`](https://www.npmjs.com/package/@aws/nx-plugin) preset — giving you access to generators for building full-stack AWS applications with TypeScript, Python, React, CDK, Terraform, and more.
+
+<details>
+<summary>Using another package manager?</summary>
+
+```bash
+# npm
+npm create @aws/nx-workspace -- my-project
+
+# yarn
+yarn create @aws/nx-workspace my-project
+
+# bun
+bun create @aws/nx-workspace my-project
+```
+
+</details>
+
+## What's Included
+
+The Nx Plugin for AWS provides generators for:
+
+- **APIs** — tRPC, FastAPI, Smithy
+- **Websites** — React with Cloudscape or Shadcn
+- **Infrastructure** — AWS CDK and Terraform
+- **AI** — Strands Agents, MCP Servers
+- **And more** — Lambda functions, Nx plugins, license management
+
+## Learn More
+
+- [Documentation](https://awslabs.github.io/nx-plugin-for-aws/)
+- [GitHub](https://github.com/awslabs/nx-plugin-for-aws)
+
+## License
+
+Apache-2.0

--- a/packages/create-nx-workspace/bin/index.ts
+++ b/packages/create-nx-workspace/bin/index.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createNxWorkspace } from '../src/create-nx-workspace';
+
+const args = process.argv.slice(2);
+process.exit(createNxWorkspace(args));

--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@aws/create-nx-workspace",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/awslabs/nx-plugin-for-aws.git",
+    "directory": "packages/create-nx-workspace"
+  },
+  "private": false,
+  "type": "commonjs",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "create-nx-workspace": "bin/index.cjs"
+  }
+}

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -1,0 +1,49 @@
+{
+  "name": "@aws/create-nx-workspace",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/create-nx-workspace/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "compile": {
+      "cache": true,
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/packages/create-nx-workspace"],
+      "options": {
+        "command": "rolldown -c rolldown.config.mjs",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "configurations": {
+        "dev": {
+          "fix": true
+        }
+      }
+    },
+    "post-compile": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["chmod +x dist/packages/create-nx-workspace/bin/index.cjs"]
+      },
+      "dependsOn": ["compile"]
+    },
+    "copy-assets": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/packages/create-nx-workspace"],
+      "options": {
+        "commands": [
+          "cp packages/create-nx-workspace/package.json dist/packages/create-nx-workspace/package.json",
+          "cp packages/create-nx-workspace/README.md dist/packages/create-nx-workspace/README.md",
+          "test -f packages/create-nx-workspace/LICENSE && cp packages/create-nx-workspace/LICENSE dist/packages/create-nx-workspace/LICENSE || true"
+        ],
+        "parallel": false
+      },
+      "dependsOn": ["compile"]
+    },
+    "build": {
+      "dependsOn": ["compile", "post-compile", "copy-assets", "lint", "test"]
+    }
+  }
+}

--- a/packages/create-nx-workspace/rolldown.config.mjs
+++ b/packages/create-nx-workspace/rolldown.config.mjs
@@ -1,0 +1,20 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { defineConfig } from 'rolldown';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  input: path.resolve(__dirname, 'bin/index.ts'),
+  output: {
+    dir: path.resolve(__dirname, '../../dist/packages/create-nx-workspace/bin'),
+    entryFileNames: 'index.cjs',
+    format: 'cjs',
+  },
+  platform: 'node',
+  external: [/^node:/],
+});

--- a/packages/create-nx-workspace/src/create-nx-workspace.spec.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  buildArgs,
+  createNxWorkspace,
+  detectPackageManager,
+} from './create-nx-workspace';
+
+describe('create-nx-workspace', () => {
+  let originalUserAgent: string | undefined;
+
+  beforeEach(() => {
+    originalUserAgent = process.env.npm_config_user_agent;
+    // Clear the user agent so tests don't depend on the test runner's PM
+    delete process.env.npm_config_user_agent;
+  });
+
+  afterEach(() => {
+    if (originalUserAgent !== undefined) {
+      process.env.npm_config_user_agent = originalUserAgent;
+    } else {
+      delete process.env.npm_config_user_agent;
+    }
+  });
+
+  describe('detectPackageManager', () => {
+    it('should detect npm', () => {
+      process.env.npm_config_user_agent = 'npm/10.0.0 node/v22.0.0 linux x64';
+      expect(detectPackageManager()).toBe('npm');
+    });
+
+    it('should detect pnpm', () => {
+      process.env.npm_config_user_agent =
+        'pnpm/9.0.0 npm/? node/v22.0.0 linux x64';
+      expect(detectPackageManager()).toBe('pnpm');
+    });
+
+    it('should detect yarn', () => {
+      process.env.npm_config_user_agent = 'yarn/4.0.0 npm/? node/v22.0.0';
+      expect(detectPackageManager()).toBe('yarn');
+    });
+
+    it('should detect bun', () => {
+      process.env.npm_config_user_agent = 'bun/1.0.0 node/v22.0.0';
+      expect(detectPackageManager()).toBe('bun');
+    });
+
+    it('should return undefined when no user agent', () => {
+      delete process.env.npm_config_user_agent;
+      expect(detectPackageManager()).toBeUndefined();
+    });
+  });
+
+  describe('buildArgs', () => {
+    it('should add --preset and default flags for a simple workspace name', () => {
+      expect(buildArgs(['my-project'])).toEqual([
+        'my-project',
+        '--preset=@aws/nx-plugin',
+        '--ci=skip',
+        '--analytics=false',
+      ]);
+    });
+
+    it('should auto-detect --pm from npm_config_user_agent', () => {
+      process.env.npm_config_user_agent = 'bun/1.0.0';
+      const result = buildArgs(['my-project']);
+      expect(result).toContain('--pm=bun');
+    });
+
+    it('should not add --pm if already provided', () => {
+      process.env.npm_config_user_agent = 'bun/1.0.0';
+      const result = buildArgs(['my-project', '--pm=pnpm']);
+      expect(result).toContain('--pm=pnpm');
+      expect(result.filter((a) => a.startsWith('--pm'))).toHaveLength(1);
+    });
+
+    it('should place positional args before flags', () => {
+      const result = buildArgs([
+        'my-project',
+        '--iacProvider=CDK',
+        '--interactive=false',
+      ]);
+      expect(result[0]).toBe('my-project');
+      expect(result[1]).toBe('--preset=@aws/nx-plugin');
+    });
+
+    it('should place --preset before user flags', () => {
+      const result = buildArgs([
+        'my-project',
+        '--iacProvider=CDK',
+        '--interactive=false',
+        '--skipGit',
+      ]);
+      const presetIndex = result.indexOf('--preset=@aws/nx-plugin');
+      const iacIndex = result.indexOf('--iacProvider=CDK');
+      expect(presetIndex).toBeLessThan(iacIndex);
+    });
+
+    it('should place default flags before user flags', () => {
+      const result = buildArgs(['my-project', '--iacProvider=CDK']);
+      const ciIndex = result.indexOf('--ci=skip');
+      const iacIndex = result.indexOf('--iacProvider=CDK');
+      expect(ciIndex).toBeLessThan(iacIndex);
+    });
+
+    it('should not duplicate --ci if already provided', () => {
+      const result = buildArgs(['my-project', '--ci=github']);
+      expect(result.filter((a) => a.startsWith('--ci'))).toEqual([
+        '--ci=github',
+      ]);
+    });
+
+    it('should not duplicate --analytics if already provided', () => {
+      const result = buildArgs(['my-project', '--analytics=true']);
+      expect(result.filter((a) => a.startsWith('--analytics'))).toEqual([
+        '--analytics=true',
+      ]);
+    });
+
+    it('should handle --pm flag as a user flag', () => {
+      const result = buildArgs(['my-project', '--pm=pnpm']);
+      expect(result).toContain('--pm=pnpm');
+    });
+
+    it('should handle no args', () => {
+      expect(buildArgs([])).toEqual([
+        '--preset=@aws/nx-plugin',
+        '--ci=skip',
+        '--analytics=false',
+      ]);
+    });
+
+    it('should handle multiple positional args', () => {
+      const result = buildArgs(['my-project', 'extra-arg']);
+      expect(result[0]).toBe('my-project');
+      expect(result[1]).toBe('extra-arg');
+      expect(result[2]).toBe('--preset=@aws/nx-plugin');
+    });
+
+    it('should preserve all user flags', () => {
+      const result = buildArgs([
+        'my-project',
+        '--iacProvider=CDK',
+        '--interactive=false',
+        '--skipGit',
+        '--pm=pnpm',
+      ]);
+      expect(result).toContain('--iacProvider=CDK');
+      expect(result).toContain('--interactive=false');
+      expect(result).toContain('--skipGit');
+      expect(result).toContain('--pm=pnpm');
+    });
+
+    it('should match the expected e2e arg order', () => {
+      const result = buildArgs([
+        'e2e-test',
+        '--iacProvider=CDK',
+        '--interactive=false',
+        '--skipGit',
+      ]);
+      expect(result).toEqual([
+        'e2e-test',
+        '--preset=@aws/nx-plugin',
+        '--ci=skip',
+        '--analytics=false',
+        '--iacProvider=CDK',
+        '--interactive=false',
+        '--skipGit',
+      ]);
+    });
+  });
+
+  describe('createNxWorkspace', () => {
+    it('should reject --preset flag', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(createNxWorkspace(['my-project', '--preset=other'])).toBe(1);
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('--preset cannot be used'),
+      );
+      spy.mockRestore();
+    });
+
+    it('should reject --preset= with any value', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(createNxWorkspace(['--preset=@nx/react'])).toBe(1);
+      spy.mockRestore();
+    });
+
+    it('should reject bare --preset flag', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(createNxWorkspace(['my-project', '--preset'])).toBe(1);
+      spy.mockRestore();
+    });
+  });
+});

--- a/packages/create-nx-workspace/src/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { spawnSync } from 'child_process';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { TS_VERSIONS } from '../../nx-plugin/src/utils/versions';
+
+const NX_VERSION = TS_VERSIONS['create-nx-workspace'];
+const PRESET = '@aws/nx-plugin';
+const DEFAULT_FLAGS = ['--ci=skip', '--analytics=false'];
+
+/**
+ * Detect the package manager from the npm_config_user_agent environment variable.
+ * This is set by package managers when running scripts/bins.
+ */
+export const detectPackageManager = (): string | undefined => {
+  const userAgent = process.env.npm_config_user_agent;
+  if (!userAgent) return undefined;
+  if (userAgent.startsWith('pnpm/')) return 'pnpm';
+  if (userAgent.startsWith('yarn/')) return 'yarn';
+  if (userAgent.startsWith('bun/')) return 'bun';
+  if (userAgent.startsWith('npm/')) return 'npm';
+  return undefined;
+};
+
+/**
+ * Build the argument list for create-nx-workspace.
+ * Positional args come first, then --preset and defaults, then user flags.
+ */
+export const buildArgs = (args: string[]): string[] => {
+  const positionalArgs = args.filter((a) => !a.startsWith('-'));
+  const flagArgs = args.filter((a) => a.startsWith('-'));
+
+  const defaultFlags = [...DEFAULT_FLAGS];
+
+  // Auto-detect and add --pm if not explicitly provided
+  if (!flagArgs.some((a) => a.startsWith('--pm'))) {
+    const pm = detectPackageManager();
+    if (pm) {
+      defaultFlags.push(`--pm=${pm}`);
+    }
+  }
+
+  const flagsToAdd = defaultFlags.filter(
+    (flag) => !flagArgs.some((a) => a.startsWith(flag.split('=')[0])),
+  );
+
+  return [...positionalArgs, `--preset=${PRESET}`, ...flagsToAdd, ...flagArgs];
+};
+
+/**
+ * Create a new Nx workspace with the @aws/nx-plugin preset.
+ * All arguments are forwarded to create-nx-workspace.
+ */
+export const createNxWorkspace = (args: string[]): number => {
+  const hasPreset = args.some((a) => a.startsWith('--preset'));
+  if (hasPreset) {
+    console.error(
+      `Error: --preset cannot be used with @aws/create-nx-workspace.\n` +
+        `This package always creates a workspace with the ${PRESET} preset.\n` +
+        `To use a different preset, run create-nx-workspace directly:\n\n` +
+        `  npx create-nx-workspace <name> --preset=<your-preset>\n`,
+    );
+    return 1;
+  }
+
+  const allArgs = buildArgs(args);
+
+  // Use npx to run create-nx-workspace to avoid bin name collision between
+  // this package (@aws/create-nx-workspace) and the create-nx-workspace dep.
+  const result = spawnSync(
+    'npx',
+    ['-y', `create-nx-workspace@${NX_VERSION}`, ...allArgs],
+    { stdio: 'inherit', env: process.env, shell: process.platform === 'win32' },
+  );
+
+  return result.status ?? 1;
+};

--- a/packages/create-nx-workspace/src/index.ts
+++ b/packages/create-nx-workspace/src/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export { createNxWorkspace, buildArgs } from './create-nx-workspace';

--- a/packages/create-nx-workspace/tsconfig.json
+++ b/packages/create-nx-workspace/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "resolveJsonModule": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/create-nx-workspace/tsconfig.lib.json
+++ b/packages/create-nx-workspace/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "bin/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/create-nx-workspace/tsconfig.spec.json
+++ b/packages/create-nx-workspace/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": [
+    "vite.config.mts",
+    "src/**/*.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/create-nx-workspace/vite.config.mts
+++ b/packages/create-nx-workspace/vite.config.mts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/create-nx-workspace',
+
+  test: {
+    watch: false,
+    globals: true,
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/packages/create-nx-workspace',
+      provider: 'v8',
+      enabled: true,
+      reporter: ['lcov'],
+    },
+  },
+});

--- a/packages/nx-plugin/LICENSE-THIRD-PARTY
+++ b/packages/nx-plugin/LICENSE-THIRD-PARTY
@@ -3325,12 +3325,12 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: @esbuild/linux-x64 (0.27.4)
+The following software may be included in this product: @esbuild/darwin-arm64 (0.27.4)
 This software contains the following license and notice below:
 
 MIT License
 
-Copyright (c) The maintainers of @esbuild/linux-x64 <https://github.com/evanw/esbuild#readme>
+Copyright (c) The maintainers of @esbuild/darwin-arm64 <https://github.com/evanw/esbuild#readme>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
 associated documentation files (the "Software"), to deal in the Software without restriction, including 
@@ -3349,12 +3349,12 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @esbuild/linux-x64 (0.28.0)
+The following software may be included in this product: @esbuild/darwin-arm64 (0.28.0)
 This software contains the following license and notice below:
 
 MIT License
 
-Copyright (c) The maintainers of @esbuild/linux-x64 <https://github.com/evanw/esbuild#readme>
+Copyright (c) The maintainers of @esbuild/darwin-arm64 <https://github.com/evanw/esbuild#readme>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
 associated documentation files (the "Software"), to deal in the Software without restriction, including 
@@ -3528,12 +3528,36 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @getgrit/gritql-linux-x64-gnu (0.0.3)
+The following software may be included in this product: @getgrit/gritql-darwin-arm64 (0.0.3)
 This software contains the following license and notice below:
 
 MIT License
 
-Copyright (c) The maintainers of @getgrit/gritql-linux-x64-gnu <https://github.com/biomejs/gritql#readme>
+Copyright (c) The maintainers of @getgrit/gritql-darwin-arm64 <https://github.com/biomejs/gritql#readme>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+The following software may be included in this product: @getgrit/gritql-darwin-universal (0.0.3)
+This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) The maintainers of @getgrit/gritql-darwin-universal <https://github.com/biomejs/gritql#readme>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
 associated documentation files (the "Software"), to deal in the Software without restriction, including 
@@ -5053,7 +5077,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @nx/nx-linux-x64-gnu (22.6.5)
+The following software may be included in this product: @nx/nx-darwin-arm64 (22.6.5)
 This software contains the following license and notice below:
 
 (The MIT License)
@@ -5304,12 +5328,12 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: @oxc-resolver/binding-linux-x64-gnu (11.19.1)
+The following software may be included in this product: @oxc-resolver/binding-darwin-arm64 (11.19.1)
 This software contains the following license and notice below:
 
 MIT License
 
-Copyright (c) The maintainers of @oxc-resolver/binding-linux-x64-gnu <https://oxc.rs>
+Copyright (c) The maintainers of @oxc-resolver/binding-darwin-arm64 <https://oxc.rs>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
 associated documentation files (the "Software"), to deal in the Software without restriction, including 
@@ -5640,12 +5664,12 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @rolldown/binding-linux-x64-gnu (1.0.0-rc.15)
+The following software may be included in this product: @rolldown/binding-darwin-arm64 (1.0.0-rc.15)
 This software contains the following license and notice below:
 
 MIT License
 
-Copyright (c) The maintainers of @rolldown/binding-linux-x64-gnu <https://rolldown.rs/>
+Copyright (c) The maintainers of @rolldown/binding-darwin-arm64 <https://rolldown.rs/>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
 associated documentation files (the "Software"), to deal in the Software without restriction, including 
@@ -5905,7 +5929,7 @@ THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @rollup/rollup-linux-x64-gnu (4.50.1)
+The following software may be included in this product: @rollup/rollup-darwin-arm64 (4.50.1)
 This software contains the following license and notice below:
 
 MIT License
@@ -5957,7 +5981,7 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: @rspack/binding-linux-x64-gnu (1.6.8)
+The following software may be included in this product: @rspack/binding-darwin-arm64 (1.6.8)
 This software contains the following license and notice below:
 
 MIT License
@@ -8979,19 +9003,6 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: axios (1.13.6)
-This software contains the following license and notice below:
-
-# Copyright (c) 2014-present Matt Zabriskie & Collaborators
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
 The following software may be included in this product: axios (1.15.0)
 This software contains the following license and notice below:
 
@@ -11243,6 +11254,34 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+The following software may be included in this product: create-nx-workspace (22.6.5)
+This software contains the following license and notice below:
+
+(The MIT License)
+
+Copyright (c) 2017-2026 Narwhal Technologies Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
@@ -14015,6 +14054,34 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
 OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+The following software may be included in this product: fsevents (2.3.3)
+This software contains the following license and notice below:
+
+MIT License
+-----------
+
+Copyright (C) 2010-2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ---
 
@@ -20826,32 +20893,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-The following software may be included in this product: proxy-from-env (1.1.0)
-This software contains the following license and notice below:
-
-The MIT License
-
-Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
@@ -41434,7 +41475,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 ---
 
-The following software may be included in this product: lightningcss-linux-x64-gnu (1.32.0)
+The following software may be included in this product: lightningcss-darwin-arm64 (1.32.0)
 This software contains the following license and notice below:
 
 Mozilla Public License Version 2.0

--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -77,8 +77,7 @@ describe('MCP Server', () => {
     // Verify result
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toContain('npx create-nx-workspace@');
-    expect(result.content[0].text).toContain('--preset=@aws/nx-plugin');
+    expect(result.content[0].text).toContain('pnpm create @aws/nx-workspace');
   });
 
   it('should execute list-generators tool', async () => {

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -6,7 +6,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PackageManagerSchema } from '../schema';
 import { IAC_PROVIDERS } from '../../utils/iac-providers';
-import { TS_VERSIONS } from '../../utils/versions';
+import { buildCreateNxWorkspaceCommand } from '../../utils/commands';
 
 /**
  * Add a tool which tells a model how to create an Nx workspace
@@ -29,7 +29,7 @@ export const addCreateWorkspaceCommandTool = (server: McpServer) => {
           text: `Run the following command to create a workspace:
 
 \`\`\`bash
-npx create-nx-workspace@${TS_VERSIONS['create-nx-workspace']} ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip --no-interactive --analytics=false --aiAgents
+${buildCreateNxWorkspaceCommand(packageManager, workspaceName)} --no-interactive
 \`\`\`
 
 This will create a new workspace within the ${workspaceName} directory.

--- a/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
@@ -225,7 +225,11 @@ exports[`ts#nx-plugin generator > should generate MCP server files > test-plugin
 "import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PackageManagerSchema } from '../schema';
-import { buildInstallCommand, getPackageName } from '../utils';
+import {
+  buildCreateCommand,
+  buildInstallCommand,
+  getPackageName,
+} from '../utils';
 
 /**
  * Registers a tool which tells a model how to create an Nx workspace
@@ -248,7 +252,7 @@ export const registerCreateWorkspaceCommandTool = (server: McpServer) => {
           text: \`Run the following command to create a workspace:
 
 \\\`\\\`\\\`bash
-npx create-nx-workspace@22.6.5 \${workspaceName} --pm=\${packageManager} --preset=@aws/nx-plugin --ci=skip --aiAgents
+\${buildCreateCommand(packageManager, workspaceName)}
 \\\`\\\`\\\`
 
 This will create a new workspace within the \${workspaceName} directory.
@@ -449,6 +453,16 @@ export const buildNxCommand = (command: string, pm?: string) =>
         } \`
       : ''
   }nx \${command}\`;
+
+const CREATE_COMMANDS: Record<string, string> = {
+  npm: 'npm create',
+  pnpm: 'pnpm create',
+  yarn: 'yarn create',
+  bun: 'bun create',
+};
+
+export const buildCreateCommand = (pm: string, workspaceName: string) =>
+  \`\${CREATE_COMMANDS[pm] ?? \`\${pm} create\`} @aws/nx-workspace \${pm === 'npm' ? '-- ' : ''}\${workspaceName}\`;
 
 export const buildInstallCommand = (pm: string, pkg: string) =>
   ({

--- a/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/tools/create-workspace-command.ts.template
+++ b/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/tools/create-workspace-command.ts.template
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PackageManagerSchema } from '../schema';
-import { buildInstallCommand, getPackageName } from '../utils';
+import { buildCreateCommand, buildInstallCommand, getPackageName } from '../utils';
 
 /**
  * Registers a tool which tells a model how to create an Nx workspace
@@ -20,7 +20,7 @@ export const registerCreateWorkspaceCommandTool = (server: McpServer) => {
           text: `Run the following command to create a workspace:
 
 \`\`\`bash
-npx create-nx-workspace@<%- createNxWorkspaceVersion %> ${workspaceName} --pm=${packageManager} --preset=@aws/nx-plugin --ci=skip --aiAgents
+${buildCreateCommand(packageManager, workspaceName)}
 \`\`\`
 
 This will create a new workspace within the ${workspaceName} directory.

--- a/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template
+++ b/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template
@@ -41,6 +41,16 @@ export const buildNxCommand = (command: string, pm?: string) =>
       : ''
   }nx ${command}`;
 
+const CREATE_COMMANDS: Record<string, string> = {
+  npm: 'npm create',
+  pnpm: 'pnpm create',
+  yarn: 'yarn create',
+  bun: 'bun create',
+};
+
+export const buildCreateCommand = (pm: string, workspaceName: string) =>
+  `${CREATE_COMMANDS[pm] ?? `${pm} create`} @aws/nx-workspace ${pm === 'npm' ? '-- ' : ''}${workspaceName}`;
+
 export const buildInstallCommand = (pm: string, pkg: string) =>
   ({
     pnpm: `pnpm add -Dw ${pkg}`,

--- a/packages/nx-plugin/src/ts/nx-plugin/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/generator.ts
@@ -24,7 +24,6 @@ import { formatFilesInSubtree } from '../../utils/format';
 import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
 import { configureTsProjectAsNxPlugin } from './utils';
 import tsMcpServerGenerator from '../mcp-server/generator';
-import { TS_VERSIONS } from '../../utils/versions';
 
 export const TS_NX_PLUGIN_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -114,7 +113,6 @@ export const tsNxPluginGenerator = async (
     mcpPath,
     {
       name: fullyQualifiedName,
-      createNxWorkspaceVersion: TS_VERSIONS['create-nx-workspace'],
     },
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );

--- a/packages/nx-plugin/src/utils/commands.ts
+++ b/packages/nx-plugin/src/utils/commands.ts
@@ -2,8 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { TS_VERSIONS } from './versions';
-
 /**
  * Display-friendly command prefixes for each package manager.
  *
@@ -18,16 +16,18 @@ export interface PackageManagerDisplayCommands {
   exec: string;
   /** Prefix for running package.json scripts: `npm run`, pnpm, yarn, bun */
   run: string;
+  /** Prefix for `create` commands: `npm create`, `pnpm create`, etc. */
+  create: string;
 }
 
 export const PACKAGE_MANAGER_COMMANDS: Record<
   string,
   PackageManagerDisplayCommands
 > = {
-  npm: { exec: 'npx', run: 'npm run' },
-  pnpm: { exec: 'pnpm', run: 'pnpm' },
-  yarn: { exec: 'yarn', run: 'yarn' },
-  bun: { exec: 'bunx', run: 'bun' },
+  npm: { exec: 'npx', run: 'npm run', create: 'npm create' },
+  pnpm: { exec: 'pnpm', run: 'pnpm', create: 'pnpm create' },
+  yarn: { exec: 'yarn', run: 'yarn', create: 'yarn create' },
+  bun: { exec: 'bunx', run: 'bun', create: 'bun create' },
 };
 
 /**
@@ -68,15 +68,30 @@ export const buildInstallCommand = (pm: string, pkg: string, dev: boolean) => {
 };
 
 /**
- * Build a create-nx-workspace command.
- * Defaults to the pinned create-nx-workspace version from TS_VERSIONS.
+ * Build a command to create a new workspace using @aws/create-nx-workspace.
+ *
+ * Uses the `create` shorthand for each package manager:
+ *   npm create @aws/nx-workspace my-project
+ *   pnpm create @aws/nx-workspace my-project
+ *   yarn create @aws/nx-workspace my-project
+ *   bun create @aws/nx-workspace my-project
+ *
+ * The package manager is auto-detected by @aws/create-nx-workspace from the
+ * invoking command, so --pm is not needed.
  */
 export const buildCreateNxWorkspaceCommand = (
   pm: string,
   workspace: string,
   iacProvider?: 'CDK' | 'Terraform',
-  yes = false,
-  nxVersion: string = TS_VERSIONS['create-nx-workspace'],
-  nxPluginVersion?: string,
-) =>
-  `npx ${yes ? '-y ' : ''}create-nx-workspace@${nxVersion} ${workspace} --pm=${pm} --preset=@aws/nx-plugin${nxPluginVersion ? `@${nxPluginVersion}` : ''}${iacProvider ? ` --iacProvider=${iacProvider}` : ''} --ci=skip --analytics=false --aiAgents`;
+) => {
+  const createPrefix = PACKAGE_MANAGER_COMMANDS[pm]?.create ?? `${pm} create`;
+  const parts = [
+    createPrefix,
+    '@aws/nx-workspace',
+    // npm requires '--' to stop interpreting subsequent flags as npm config
+    ...(pm === 'npm' ? ['--'] : []),
+    workspace,
+    ...(iacProvider ? [`--iacProvider=${iacProvider}`] : []),
+  ];
+  return parts.join(' ');
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,8 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
 
+  packages/create-nx-workspace: {}
+
   packages/nx-plugin:
     dependencies:
       '@apidevtools/swagger-parser':
@@ -4946,9 +4948,6 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
-
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
@@ -8418,9 +8417,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -12661,7 +12657,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 0.21.6
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.13.6
+      axios: 1.15.0
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -12686,7 +12682,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 2.2.3
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.13.6
+      axios: 1.15.0
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -15907,14 +15903,6 @@ snapshots:
   aws4fetch@1.0.20: {}
 
   axe-core@4.10.3: {}
-
-  axios@1.13.6:
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axios@1.15.0:
     dependencies:
@@ -20132,8 +20120,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 


### PR DESCRIPTION
### Reason for this change

Simplifies workspace creation - instead of always having to visit the docs to ensure you create a workspace with the right Nx version and args, you can use a memorable command instead:

```
pnpm create @aws/nx-workspace my-project
npm create @aws/nx-workspace my-project
yarn create @aws/nx-workspace my-project
bun create @aws/nx-workspace my-project
```

### Description of changes

Add a new package with a single bin script wraps Nx's create-nx-workspace and adds our preset generator, as well as ensuring a workspace is created with our supported Nx version.

### Description of how you validated changes

e2e tests use new command

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*