### PR TITLE
fix(e2e): configure package manager retries for transient registry failures

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -6,6 +6,9 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
     maxage: 60m
+    timeout: 60s
+    max_fails: 20
+    fail_timeout: 1m
 
 packages:
   '@aws/nx-plugin':

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -13,6 +13,16 @@ export default async function () {
       console.info('Cleaning up old registry store...');
       rmSync(registryPath, { force: true, recursive: true });
     }
+
+    // Configure package manager retry settings to handle transient registry failures.
+    // npm and pnpm both respect npm_config_* environment variables.
+    process.env.npm_config_fetch_retries = '5';
+    process.env.npm_config_fetch_retry_mintimeout = '15000';
+    process.env.npm_config_fetch_retry_maxtimeout = '90000';
+    // Yarn berry
+    process.env.YARN_HTTP_RETRY = '5';
+    process.env.YARN_HTTP_TIMEOUT = '90000';
+
     console.info('Starting local registry...');
     global.teardown = await startLocalRegistry({
       localRegistryTarget: '@aws/nx-plugin-source:local-registry',

--- a/e2e/src/smoke-tests/bun.spec.ts
+++ b/e2e/src/smoke-tests/bun.spec.ts
@@ -9,7 +9,7 @@ smokeTest('bun', (projectRoot) => {
   // Write bunfig.toml to configure bun to use the local registry and disable caching
   writeFileSync(
     `${projectRoot}/bunfig.toml`,
-    `[install]\nregistry = "${process.env.npm_config_registry}"\n\n[install.cache]\ndisable = true\ndisableManifest = true`,
+    `[install]\nregistry = "${process.env.npm_config_registry}"\nretry = 5\n\n[install.cache]\ndisable = true\ndisableManifest = true`,
     { encoding: 'utf-8' },
   );
 });


### PR DESCRIPTION
### Reason for this change

E2E smoke tests occasionally fail across all package managers (npm, yarn, pnpm, bun) due to transient npm registry failures where packages cannot be found. This is flaky and not caused by actual code issues.

### Description of changes

Configure native retry mechanisms at two levels rather than wrapping commands in brittle shell retry loops:

**Verdaccio uplink** (`.verdaccio/config.yml`):
- `timeout: 60s` — increased request timeout from default 30s
- `max_fails: 20` — allow more failures before pausing the uplink (default was 2, which meant just 2 failures would stop all proxying for 5 minutes)
- `fail_timeout: 1m` — reduced pause duration after max_fails (default 5m)

**Package manager env vars** (`e2e/src/global-setup.ts`):
- npm/pnpm: `npm_config_fetch_retries=5`, with 15s–90s backoff window
- Yarn berry: `YARN_HTTP_RETRY=5`, `YARN_HTTP_TIMEOUT=90000`

**Bun** (`e2e/src/smoke-tests/bun.spec.ts`):
- Added `retry = 5` to the `bunfig.toml` install section

### Description of how you validated changes

Build passes. The retry settings use each package manager's native configuration, so no functional behavior changes — only resilience to transient network failures.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*