### PR TITLE
feat(ts#nx-plugin): render enum options in MCP generator guide tool

### DIFF
--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -26,6 +26,11 @@ describe('postProcessGuide', () => {
             type: 'string',
             description: 'The name of the project',
           },
+          auth: {
+            type: 'string',
+            enum: ['IAM', 'Cognito', 'None'],
+            description: 'The auth method to use',
+          },
           directory: {
             type: 'string',
             description: 'The directory to create the project in',
@@ -171,6 +176,7 @@ Here are the parameters for the generator:
 # Test Guide
 Here are the parameters for the generator:
 - name [type: string] (required) The name of the project
+- auth [type: string] [options: IAM, Cognito, None] The auth method to use
 - directory [type: string] The directory to create the project in
 `;
 
@@ -227,6 +233,7 @@ bunx nx g @aws/nx-plugin:test-generator --no-interactive --name=<name>
 
 Here are the parameters for the generator:
 - name [type: string] (required) The name of the project
+- auth [type: string] [options: IAM, Cognito, None] The auth method to use
 - directory [type: string] The directory to create the project in
 `;
 

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -22,7 +22,7 @@ const renderSchema = (schema: any) =>
   Object.entries(schema.properties)
     .map(
       ([parameter, parameterSchema]: [string, any]) =>
-        `- ${parameter} [type: ${parameterSchema.type}]${(schema.required ?? []).includes(parameter) ? ` (required)` : ''} ${parameterSchema.description}`,
+        `- ${parameter} [type: ${parameterSchema.type}]${parameterSchema.enum ? ` [options: ${parameterSchema.enum.join(', ')}]` : ''}${(schema.required ?? []).includes(parameter) ? ` (required)` : ''} ${parameterSchema.description}`,
     )
     .join('\n');
 

--- a/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
@@ -462,7 +462,7 @@ const renderSchema = (schema: any) =>
   Object.entries(schema.properties)
     .map(
       ([parameter, parameterSchema]: [string, any]) =>
-        \`- \${parameter} [type: \${parameterSchema.type}]\${(schema.required ?? []).includes(parameter) ? \` (required)\` : ''} \${parameterSchema.description}\`,
+        \`- \${parameter} [type: \${parameterSchema.type}]\${parameterSchema.enum ? \` [options: \${parameterSchema.enum.join(', ')}]\` : ''}\${(schema.required ?? []).includes(parameter) ? \` (required)\` : ''} \${parameterSchema.description}\`,
     )
     .join('\\n');
 

--- a/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template
+++ b/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template
@@ -53,7 +53,7 @@ const renderSchema = (schema: any) =>
   Object.entries(schema.properties)
     .map(
       ([parameter, parameterSchema]: [string, any]) =>
-        `- ${parameter} [type: ${parameterSchema.type}]${(schema.required ?? []).includes(parameter) ? ` (required)` : ''} ${parameterSchema.description}`,
+        `- ${parameter} [type: ${parameterSchema.type}]${parameterSchema.enum ? ` [options: ${parameterSchema.enum.join(', ')}]` : ''}${(schema.required ?? []).includes(parameter) ? ` (required)` : ''} ${parameterSchema.description}`,
     )
     .join('\n');
 


### PR DESCRIPTION
### Reason for this change

The MCP generator guide tool renders parameter information for each generator, but for enum-typed options it only showed `[type: string]` without listing the valid values. This made it harder for AI assistants and users to know which values are acceptable without looking at the schema directly.

### Description of changes

Updated `renderSchema()` in both:
- `packages/nx-plugin/src/mcp-server/generator-info.ts` (used by the plugin's own MCP server)
- `packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template` (template for generated MCP servers)

When a parameter has an `enum` array in its schema, the output now includes `[options: value1, value2, ...]` after the type. For example:
```
- auth [type: string] [options: IAM, Cognito, None] The auth method to use
```

Updated tests and snapshots accordingly.

### Description of how you validated changes

- Updated existing unit tests to include an enum property in the mock schema
- Verified both `GeneratorParameters` and multi-transformation test cases render enum options correctly
- All tests pass, build succeeds, lint passes

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*