### PR TITLE
fix(ts#react-website): use Vite's native tsconfig paths resolution

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`react-website generator > TailwindCSS integration > should configure vite with TailwindCSS plugin by default > vite.config.mts-with-tailwind 1`] = `
 "import tailwindcss from '@tailwindcss/vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { resolve } from 'path';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 /// <reference types='vitest' />
@@ -27,7 +26,6 @@ export default defineConfig(() => ({
     }),
     react(),
     tailwindcss(),
-    tsconfigPaths(),
   ],
   // Uncomment this if you are using workers.
   // worker: {
@@ -54,14 +52,14 @@ export default defineConfig(() => ({
     },
     passWithNoTests: true,
   },
+  resolve: { tsconfigPaths: true },
   define: { global: {} },
 }));
 "
 `;
 
 exports[`react-website generator > TailwindCSS integration > should configure vite without TailwindCSS plugin when disabled > vite.config.mts-without-tailwind 1`] = `
-"import tsconfigPaths from 'vite-tsconfig-paths';
-import { resolve } from 'path';
+"import { resolve } from 'path';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
@@ -84,7 +82,6 @@ export default defineConfig(() => ({
       generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts'),
     }),
     react(),
-    tsconfigPaths(),
   ],
   // Uncomment this if you are using workers.
   // worker: {
@@ -111,6 +108,7 @@ export default defineConfig(() => ({
     },
     passWithNoTests: true,
   },
+  resolve: { tsconfigPaths: true },
   define: { global: {} },
 }));
 "
@@ -1102,7 +1100,6 @@ exports[`react-website generator > Tanstack router integration > should generate
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.40.0",
     "vite": "8.0.8",
-    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.4"
   },
   "type": "module"
@@ -2402,7 +2399,6 @@ exports[`react-website generator > Tanstack router integration > should generate
 
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > test-app/vite.config.mts 1`] = `
 "import tailwindcss from '@tailwindcss/vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
@@ -2418,7 +2414,7 @@ export default defineConfig(() => ({
     port: 4300,
     host: 'localhost',
   },
-  plugins: [react(), tailwindcss(), tsconfigPaths()],
+  plugins: [react(), tailwindcss()],
   // Uncomment this if you are using workers.
   // worker: {
   //  plugins: [],
@@ -2444,6 +2440,7 @@ export default defineConfig(() => ({
     },
     passWithNoTests: true,
   },
+  resolve: { tsconfigPaths: true },
   define: { global: {} },
 }));
 "
@@ -2699,7 +2696,6 @@ exports[`react-website generator > Tanstack router integration > should generate
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.40.0",
     "vite": "8.0.8",
-    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.4"
   },
   "type": "module"
@@ -4183,7 +4179,6 @@ exports[`react-website generator > Tanstack router integration > should generate
 
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > test-app/vite.config.mts 1`] = `
 "import tailwindcss from '@tailwindcss/vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { resolve } from 'path';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 /// <reference types='vitest' />
@@ -4208,7 +4203,6 @@ export default defineConfig(() => ({
     }),
     react(),
     tailwindcss(),
-    tsconfigPaths(),
   ],
   // Uncomment this if you are using workers.
   // worker: {
@@ -4235,6 +4229,7 @@ export default defineConfig(() => ({
     },
     passWithNoTests: true,
   },
+  resolve: { tsconfigPaths: true },
   define: { global: {} },
 }));
 "
@@ -4297,7 +4292,6 @@ exports[`react-website generator > should configure TypeScript correctly > tscon
 
 exports[`react-website generator > should configure vite correctly > vite.config.mts 1`] = `
 "import tailwindcss from '@tailwindcss/vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { resolve } from 'path';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 /// <reference types='vitest' />
@@ -4322,7 +4316,6 @@ export default defineConfig(() => ({
     }),
     react(),
     tailwindcss(),
-    tsconfigPaths(),
   ],
   // Uncomment this if you are using workers.
   // worker: {
@@ -4349,6 +4342,7 @@ export default defineConfig(() => ({
     },
     passWithNoTests: true,
   },
+  resolve: { tsconfigPaths: true },
   define: { global: {} },
 }));
 "

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -346,13 +346,6 @@ export async function tsReactWebsiteGenerator(
       await addDestructuredImport(tree, viteConfigPath, ['resolve'], 'path');
     }
 
-    await addSingleImport(
-      tree,
-      viteConfigPath,
-      'tsconfigPaths',
-      'vite-tsconfig-paths',
-    );
-
     // Add TailwindCSS import if enabled
     if (enableTailwind) {
       await addSingleImport(
@@ -393,10 +386,11 @@ export async function tsReactWebsiteGenerator(
       );
     }
 
+    // Use Vite's native tsconfig paths resolution (replaces vite-tsconfig-paths)
     await applyGritQL(
       tree,
       viteConfigPath,
-      '`plugins: [$items]` => `plugins: [$items, tsconfigPaths()]` where { $items <: within `defineConfig($_)`, $items <: not some `tsconfigPaths()` }',
+      'or { `defineConfig(() => ({ $props }))` where { $props <: not some `resolve: $_`, $props += `resolve: { tsconfigPaths: true }` }, `defineConfig({ $props })` where { $props <: not some `resolve: $_`, $props += `resolve: { tsconfigPaths: true }` } }',
     );
 
     // Add define: { global: {} } to the config (handles both callback and direct forms)
@@ -454,11 +448,7 @@ export async function tsReactWebsiteGenerator(
     }),
   );
 
-  const devDependencies: ITsDepVersion[] = [
-    'vite-tsconfig-paths',
-    '@nx/react',
-    '@vitest/ui',
-  ];
+  const devDependencies: ITsDepVersion[] = ['@nx/react', '@vitest/ui'];
 
   const dependencies: ITsDepVersion[] = ['react', 'react-dom'];
 

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -90,7 +90,6 @@ export const TS_VERSIONS = {
   vite: '8.0.8',
   typescript: '6.0.2',
   vitest: '4.1.4',
-  'vite-tsconfig-paths': '6.1.1',
   zod: '4.3.6',
   ws: '8.20.0',
 } as const;


### PR DESCRIPTION
### Reason for this change

`vite-tsconfig-paths@6.1.1` (recently upgraded from `5.1.4` as part of the Vite 8 upgrade) fails to resolve TypeScript path aliases (e.g. `:my-scope/common-shadcn/components/ui/sidebar`) when running `nx serve-local` on a Shadcn website.

The root cause is that `vite-tsconfig-paths@6` skips any tsconfig whose `include`/`files` arrays are empty — which is the case for the generated root `tsconfig.json` in the TS project-references setup we use. The remaining configs with populated `include` globs (`tsconfig.app.json`, referenced `tsconfig.lib.json`, etc.) fail to match importers outside their own project root (e.g. the website importer doesn't match the `common-shadcn/tsconfig.lib.json` include glob), so no resolver is ever applied to the alias import and Vite surfaces a `Failed to resolve import` pre-transform error.

Downgrading to `vite-tsconfig-paths@5.1.4` restores serve-local — the old version did not gate on include globs.

Reproduced with the `ts#react-website` generator using `uxProvider=Shadcn`:

```
Pre-transform error: Failed to resolve import ":my-scope/common-shadcn/components/ui/sidebar" from "packages/website/src/components/AppLayout/index.tsx". Does the file exist?
```

### Description of changes

Since upgrading to Vite 8, `vite` itself supports tsconfig path resolution natively via `resolve.tsconfigPaths: true` (the `vite-tsconfig-paths` plugin now logs a warning recommending exactly this migration). Switching to it fixes the issue and lets us drop a dependency.

- `packages/nx-plugin/src/ts/react-website/app/generator.ts`: stop importing/registering `vite-tsconfig-paths`, instead add `resolve: { tsconfigPaths: true }` to the generated `vite.config.mts`. Dropped from `devDependencies`.
- `packages/nx-plugin/src/utils/versions.ts`: remove the `vite-tsconfig-paths` version entry.
- Snapshots updated accordingly.

### Description of how you validated changes

- All 1626 existing unit tests pass; 5 `vite.config.mts` snapshots and 2 `package.json` snapshots updated.
- End-to-end verification against a fresh `create-nx-workspace@22.6.5 --preset=@aws/nx-plugin` workspace with the locally-linked compiled plugin:
  - Generated a `ts#react-website` with `uxProvider=Shadcn` (the affected path). The generated `vite.config.mts` no longer imports `vite-tsconfig-paths` and instead contains `resolve: { tsconfigPaths: true }`.
  - `nx serve-local website` no longer emits the pre-transform error; `src/components/AppLayout/index.tsx` and `src/components/app-sidebar.tsx` transform cleanly and their `:scope/common-shadcn/...` imports are resolved.
  - `nx bundle website` (production build) still succeeds.
  - Also verified `uxProvider=Cloudscape` generates the expected config.

### Issue # (if applicable)

Closes #581.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*