### PR TITLE
chore(ts#strands-agent): bundle @a2a-js/sdk into A2A agent images

### DIFF
--- a/packages/nx-plugin/src/ts/strands-agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/generator.spec.ts
@@ -844,10 +844,14 @@ describe('ts#strands-agent generator', () => {
     expect(indexContent).toContain('A2AExpressServer');
     expect(indexContent).not.toContain('tRPC');
 
-    // Check dependencies include express
+    // Check dependencies include express and @a2a-js/sdk
     const rootPackageJson = JSON.parse(tree.read('package.json', 'utf-8'));
     expect(rootPackageJson.dependencies['express']).toBeDefined();
     expect(rootPackageJson.devDependencies['@types/express']).toBeDefined();
+    // @a2a-js/sdk must be a direct dependency so it lands in node_modules
+    // for local dev AND is bundled into the Docker image (the Strands SDK's
+    // a2a/express-server module statically imports it via peer dependency).
+    expect(rootPackageJson.dependencies['@a2a-js/sdk']).toBeDefined();
 
     // HTTP-specific deps should not be present
     expect(rootPackageJson.dependencies['@trpc/server']).toBeUndefined();

--- a/packages/nx-plugin/src/ts/strands-agent/generator.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/generator.ts
@@ -154,7 +154,7 @@ export const tsStrandsAgentGenerator = async (
       '@aws-lambda-powertools/parameters',
       '@modelcontextprotocol/sdk',
       ...(protocol === 'A2A'
-        ? (['express'] as const)
+        ? (['express', '@a2a-js/sdk'] as const)
         : ([
             '@trpc/server',
             '@trpc/client',

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -7,6 +7,7 @@
  * Versons for TypeScript dependencies added by generators
  */
 export const TS_VERSIONS = {
+  '@a2a-js/sdk': '0.3.13',
   '@aws/aws-distro-opentelemetry-node-autoinstrumentation': '0.10.0',
   '@aws-sdk/client-dynamodb': '3.1029.0',
   '@aws-sdk/client-sts': '3.1029.0',


### PR DESCRIPTION
### Reason for this change

The post-merge CI run for #539 failed the `cdk-deploy` smoke test with a 424 when the test fetched the TypeScript A2A agent's `.well-known/agent-card.json`. CloudWatch runtime logs for the deployed container showed:

```
Error: Cannot find module '@a2a-js/sdk/server/express'
Require stack:
- /app/index.js
```

Root cause: the Strands SDK's `a2a/express-server` module statically imports `@a2a-js/sdk` as a peer dependency:

```js
// node_modules/@strands-agents/sdk/dist/src/a2a/express-server.js
import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
```

Because `@a2a-js/sdk` was only a peer dep of `@strands-agents/sdk` and not a direct dep of the generated A2A project, rolldown left two externalised requires in the bundled agent entry point:

```js
let _a2a_js_sdk_server_express = require("@a2a-js/sdk/server/express");
let _a2a_js_sdk_server = require("@a2a-js/sdk/server");
```

The AgentCore container only ships the single bundled `index.js` (plus ADOT), so those requires fail at startup, the runtime never reaches a healthy state, and AgentCore returns 424 on any agent card fetch. This is why `cdk-deploy` observed `Failed to fetch Agent Card from ...: 424`.

Labelled `chore` because A2A hasn't shipped yet.

### Description of changes

- Add `@a2a-js/sdk@0.3.13` to `TS_VERSIONS`
- `ts#strands-agent` generator: when `protocol=A2A`, add `@a2a-js/sdk` alongside `express` to the project's runtime deps so rolldown inlines it into the Docker-bundled `index.js`
- Update the corresponding unit test to assert the dep is added

Python is not affected: `strands-agents[a2a]` already pulls in `a2a-sdk` as a regular transitive dep, and the CI Python A2A container started cleanly (verified in the same run's CloudWatch logs).

### Description of how you validated changes

- Unit tests pass, including the updated A2A dependency assertion
- Build and lint clean
- End-to-end locally: deployed an A2A agent to AgentCore with the pre-fix generator → `GET .well-known/agent-card.json` returned **424** (reproduced CI failure); container logs showed the missing-module error. Regenerated the agent with the fix, redeployed, and the same fetch returned **200** with a well-formed agent card
- Confirmed the generated bundle no longer contains any `require("@a2a-js/sdk/...")` externals after the fix

### Issue # (if applicable)

Follow-up to #539.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*