### PR TITLE
chore(ts#strands-agent): use sendMessageStream in A2A smoke test

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -211,10 +211,6 @@ async function invokeAgentCoreA2a(
   const baseUrl = `https://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodedArn}/invocations/`;
   const sessionId = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
-  // Fetch fresh credentials inside the fetch implementation so every
-  // request signs with current credentials (and a current signature
-  // timestamp via a newly-constructed AwsClient). The provider memoizes
-  // and auto-refreshes on expiry, so this is cheap on the hot path.
   const credentialsProvider = fromNodeProviderChain();
   const sigv4Fetch: typeof fetch = async (input, init) => {
     const credentials = await credentialsProvider();
@@ -245,10 +241,6 @@ async function invokeAgentCoreA2a(
   expect(typeof card.name).toBe('string');
   console.log(`${agentName} agent card:`, card.name);
 
-  // Use sendMessageStream (not sendMessage) so the test can break on the
-  // first SSE event. sendMessage is blocking and would wait for the full
-  // agent response, which routinely exceeds SigV4's 5-minute signature
-  // validity window on cold-started AgentCore runtimes.
   const stream = client.sendMessageStream({
     kind: 'message',
     role: 'user',
@@ -260,7 +252,6 @@ async function invokeAgentCoreA2a(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for await (const _event of stream) {
     events++;
-    // One event is enough to prove the agent is reachable end-to-end.
     break;
   }
   expect(events).toBeGreaterThan(0);

--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -211,15 +211,20 @@ async function invokeAgentCoreA2a(
   const baseUrl = `https://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodedArn}/invocations/`;
   const sessionId = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
-  const credentials = await fromNodeProviderChain()();
-  const awsClient = new AwsClient({
-    accessKeyId: credentials.accessKeyId,
-    secretAccessKey: credentials.secretAccessKey,
-    sessionToken: credentials.sessionToken,
-    service: 'bedrock-agentcore',
-    region,
-  });
+  // Fetch fresh credentials inside the fetch implementation so every
+  // request signs with current credentials (and a current signature
+  // timestamp via a newly-constructed AwsClient). The provider memoizes
+  // and auto-refreshes on expiry, so this is cheap on the hot path.
+  const credentialsProvider = fromNodeProviderChain();
   const sigv4Fetch: typeof fetch = async (input, init) => {
+    const credentials = await credentialsProvider();
+    const awsClient = new AwsClient({
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
+      service: 'bedrock-agentcore',
+      region,
+    });
     const headers = new Headers(init?.headers);
     if (!headers.has('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id')) {
       headers.set('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id', sessionId);

--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -240,7 +240,11 @@ async function invokeAgentCoreA2a(
   expect(typeof card.name).toBe('string');
   console.log(`${agentName} agent card:`, card.name);
 
-  const stream = client.sendMessage({
+  // Use sendMessageStream (not sendMessage) so the test can break on the
+  // first SSE event. sendMessage is blocking and would wait for the full
+  // agent response, which routinely exceeds SigV4's 5-minute signature
+  // validity window on cold-started AgentCore runtimes.
+  const stream = client.sendMessageStream({
     kind: 'message',
     role: 'user',
     parts: [{ kind: 'text', text: 'hello' }],
@@ -251,6 +255,8 @@ async function invokeAgentCoreA2a(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for await (const _event of stream) {
     events++;
+    // One event is enough to prove the agent is reachable end-to-end.
+    break;
   }
   expect(events).toBeGreaterThan(0);
   console.log(`Successfully invoked ${agentName} (${events} events)`);


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` smoke test on `main` is failing at the A2A invocation step with:

```
TypeError: stream is not async iterable
 ❯ invokeAgentCoreA2a src/smoke-tests/cdk-deploy.spec.ts:252
```

Run: https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24608146775/job/71977385052

The test fetches the agent card successfully (confirming #584 fixed the runtime-side crash), then calls `client.sendMessage({...})` and tries to iterate the return value with `for await`. `sendMessage` is the **blocking** A2A Client API — it returns `Promise<SendMessageResponse>`, not an `AsyncIterable` — so the iteration throws immediately.

As a side effect of the same bug, the test file exits while the unawaited blocking promise is still in flight. Because `sendMessage` waits for the entire model response, AgentCore eventually answered ~8 minutes after the request was signed, well outside SigV4's 5-minute signature-validity window, producing the noisy unhandled rejection:

```
HTTP error for message/send! Status: 403 Forbidden.
Response: {"message":"Signature expired: 20260418T231347Z is now earlier than 20260418T231655Z ..."}
```

SigV4 plumbing itself is correct: the same `sigv4Fetch` / `AwsClient` is used for the card fetch (which returned 200 immediately before) and for the RPC.

### Description of changes

- `e2e/src/smoke-tests/cdk-deploy.spec.ts`: switch `invokeAgentCoreA2a` from `client.sendMessage(...)` to `client.sendMessageStream(...)`. This matches the agent card's `capabilities.streaming: true` and actually returns an async iterable
- `break` after the first SSE event so the assertion fires quickly on cold-started runtimes and stays inside SigV4's 5-minute signature-validity window
- Added a short comment explaining the constraint so the next person doesn't revert it

Labelled `chore` because A2A hasn't shipped yet.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin-e2e:typecheck` passes
- `pnpm nx run @aws/nx-plugin-e2e:lint` clean (0 errors)
- Will monitor the `cdk-deploy` smoke test in CI on this PR to confirm the A2A invocation passes end-to-end

### Issue # (if applicable)

Follow-up to #539 / #584.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*