### PR TITLE
chore(ts#strands-agent): wrap A2A payload in message field

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -242,10 +242,12 @@ async function invokeAgentCoreA2a(
   console.log(`${agentName} agent card:`, card.name);
 
   const stream = client.sendMessageStream({
-    kind: 'message',
-    role: 'user',
-    parts: [{ kind: 'text', text: 'hello' }],
-    messageId: crypto.randomUUID(),
+    message: {
+      kind: 'message',
+      role: 'user',
+      parts: [{ kind: 'text', text: 'hello' }],
+      messageId: crypto.randomUUID(),
+    },
   });
 
   let events = 0;


### PR DESCRIPTION
### Reason for this change

After #587, the main `cdk-deploy` smoke test failed with:

```
Error: SSE event contained an error: Cannot read properties of undefined (reading 'messageId') (Code: -32603)
Caused by: Error: JSON-RPC error: Cannot read properties of undefined (reading 'messageId') (Code: -32603)
```

Run: https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24617500656/job/71982575055

The A2A client's `Client.sendMessageStream(params)` takes `MessageSendParams`, which is `{ message: Message, configuration?, metadata? }`. The test was passing a bare `Message`, so on the server side `params.message` was `undefined` and the `@a2a-js/sdk` Express handler (`validateMessageSendParams`) threw as it tried to read `params.message.messageId`.

The agent-card fetch and everything before this worked — this is just a client-side payload-shape bug in the e2e test.

### Description of changes

- `e2e/src/smoke-tests/cdk-deploy.spec.ts`: wrap the `Message` in `{ message: {...} }` to match `MessageSendParams`

Labelled `chore` because A2A hasn't shipped yet.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin-e2e:typecheck` passes
- `pnpm nx run @aws/nx-plugin-e2e:lint` clean (0 errors)
- `cdk-deploy` only runs on `main`, so full end-to-end verification happens after merge; I'll monitor the post-merge CI run

### Issue # (if applicable)

Follow-up to #539 / #584 / #587.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*