### PR TITLE
refactor(ast): simplify matchGritQL and support language headers

### DIFF
--- a/packages/nx-plugin/src/utils/ast.spec.ts
+++ b/packages/nx-plugin/src/utils/ast.spec.ts
@@ -482,5 +482,16 @@ class MyClass implements SomeInterface {
       expect(await matchGritQL(tree, 'file.ts', '`SomeInterface`')).toBe(true);
       expect(await matchGritQL(tree, 'file.ts', '`OtherClass`')).toBe(false);
     });
+
+    it('should support patterns prefixed with a language header', async () => {
+      tree.write('file.py', `def greet():\n    print("hello")\n`);
+
+      expect(
+        await matchGritQL(tree, 'file.py', 'language python\n`print($msg)`'),
+      ).toBe(true);
+      expect(
+        await matchGritQL(tree, 'file.py', 'language python\n`unused($msg)`'),
+      ).toBe(false);
+    });
   });
 });

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -160,6 +160,10 @@ export const applyGritQL = async (
 /**
  * Check whether a GritQL pattern matches anywhere in a file.
  * Returns true if the pattern matches at least once.
+ *
+ * Accepts raw GritQL, including patterns that start with a `language <name>`
+ * header (e.g. `language python\n\`print($_)\``) — the pattern is passed
+ * straight through to QueryBuilder without any wrapping rewrite.
  */
 export const matchGritQL = async (
   tree: Tree,
@@ -168,17 +172,16 @@ export const matchGritQL = async (
 ): Promise<boolean> => {
   if (!tree.exists(filePath)) return false;
   const source = tree.read(filePath)!.toString();
+  let matched = false;
   try {
-    // Use a metavariable rewrite to check for matches — $p is constrained to
-    // the caller's pattern and rewritten to itself, avoiding rendering the
-    // pattern string twice in the query.
-    const query = new QueryBuilder(`$p => $p where { $p <: ${pattern} }`);
-    const result = await query.applyToFile({
-      path: filePath,
-      content: source,
+    const query = new QueryBuilder(pattern);
+    query.filter(() => {
+      matched = true;
+      return true;
     });
-    return result !== null;
+    await query.applyToFile({ path: filePath, content: source });
   } catch {
     return false;
   }
+  return matched;
 };


### PR DESCRIPTION
### Reason for this change

`matchGritQL` currently wraps the caller's pattern in a metavariable rewrite:

```
`$p => $p where { $p <: ${pattern} }`
```

This forces the caller's pattern to sit inside a `where` clause. GritQL's `language <name>` directive is a **pattern-file header** that must appear as the *first token* of the pattern, so callers cannot use patterns like `language python\n\`print($_)\`` for non-JS/TS files — doing so produces a `Pattern syntax error at 1:24`.

### Description of changes

- `matchGritQL` now passes the pattern straight through to `QueryBuilder` and detects matches via `filter()` instead of the rewrite wrapper. Callers can now prefix their patterns with `language python`, `language js`, `language java`, etc., or use the inline quoted-snippet form (`python\"...\"`, `js\"...\"`).
- Added a test covering the new language-header capability (`language python` matching a `.py` file).
- No behavior change for existing callers — all 1,639 tests still pass.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test` — all 82 test files / 1,639 tests pass, including the new language-header test.
- `pnpm nx run-many --target build --all` — clean.
- `pnpm nx run-many --target lint --all --fix` — no errors.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*