### PR TITLE
refactor(connection): simplify auth header merging via Headers constructor

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
@@ -113,23 +113,9 @@ const useCreateTestApiClient = (): TestApi => {
   const auth = useAuth();
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
-    const headers = { Authorization: \`Bearer \${user?.id_token}\` };
-    const existingHeaders = init?.headers;
-
-    return fetch(url, {
-      ...init,
-      headers: !existingHeaders
-        ? headers
-        : existingHeaders instanceof Headers
-          ? (() => {
-              const h = new Headers(existingHeaders);
-              Object.entries(headers).forEach(([k, v]) => h.append(k, v));
-              return h;
-            })()
-          : Array.isArray(existingHeaders)
-            ? [...existingHeaders, ...Object.entries(headers)]
-            : { ...existingHeaders, ...headers },
-    });
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', \`Bearer \${user?.id_token}\`);
+    return fetch(url, { ...init, headers });
   };
   return useMemo(
     () =>

--- a/packages/nx-plugin/src/py/strands-agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/strands-agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -104,23 +104,9 @@ const useCreateTestAgentClient = (): TestAgent => {
   const auth = useAuth();
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
-    const headers = { Authorization: \`Bearer \${user?.id_token}\` };
-    const existingHeaders = init?.headers;
-
-    return fetch(url, {
-      ...init,
-      headers: !existingHeaders
-        ? headers
-        : existingHeaders instanceof Headers
-          ? (() => {
-              const h = new Headers(existingHeaders);
-              Object.entries(headers).forEach(([k, v]) => h.append(k, v));
-              return h;
-            })()
-          : Array.isArray(existingHeaders)
-            ? [...existingHeaders, ...Object.entries(headers)]
-            : { ...existingHeaders, ...headers },
-    });
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', \`Bearer \${user?.id_token}\`);
+    return fetch(url, { ...init, headers });
   };
   return useMemo(
     () =>

--- a/packages/nx-plugin/src/smithy/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/react-connection/__snapshots__/generator.spec.ts.snap
@@ -104,23 +104,9 @@ const useCreateTestApiClient = (): TestApi => {
   const auth = useAuth();
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
-    const headers = { Authorization: \`Bearer \${user?.id_token}\` };
-    const existingHeaders = init?.headers;
-
-    return fetch(url, {
-      ...init,
-      headers: !existingHeaders
-        ? headers
-        : existingHeaders instanceof Headers
-          ? (() => {
-              const h = new Headers(existingHeaders);
-              Object.entries(headers).forEach(([k, v]) => h.append(k, v));
-              return h;
-            })()
-          : Array.isArray(existingHeaders)
-            ? [...existingHeaders, ...Object.entries(headers)]
-            : { ...existingHeaders, ...headers },
-    });
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', \`Bearer \${user?.id_token}\`);
+    return fetch(url, { ...init, headers });
   };
   return useMemo(
     () =>

--- a/packages/nx-plugin/src/ts/strands-agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/strands-agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -83,7 +83,7 @@ export class AgentCoreMcpClient {
     const {
       url,
       sessionId = randomUUID(),
-      buildHeaders = async () => ({}),
+      buildHeaders = async (): Promise<Record<string, string>> => ({}),
       fetch: customFetch,
     } = options;
 

--- a/packages/nx-plugin/src/ts/strands-agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/strands-agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -89,27 +89,12 @@ export class AgentCoreMcpClient {
 
     // Create a custom fetch that adds required headers
     const fetchWithHeaders: typeof fetch = async (input, init) => {
-      const headers = {
-        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
-        ...(await buildHeaders()),
-      };
-      const existingHeaders = init?.headers;
-
-      const mergedInit = {
-        ...init,
-        headers: !existingHeaders
-          ? headers
-          : existingHeaders instanceof Headers
-            ? (() => {
-                const h = new Headers(existingHeaders);
-                Object.entries(headers).forEach(([k, v]) => h.append(k, v));
-                return h;
-              })()
-            : Array.isArray(existingHeaders)
-              ? [...existingHeaders, ...Object.entries(headers)]
-              : { ...existingHeaders, ...headers },
-      };
-      return (customFetch || fetch)(input, mergedInit);
+      const headers = new Headers(init?.headers);
+      headers.set('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id', sessionId);
+      for (const [k, v] of Object.entries(await buildHeaders())) {
+        headers.set(k, v);
+      }
+      return (customFetch || fetch)(input, { ...init, headers });
     };
 
     // Create the transport

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-client.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-client.ts.template
@@ -76,7 +76,7 @@ export class AgentCoreMcpClient {
     const {
       url,
       sessionId = randomUUID(),
-      buildHeaders = async () => ({}),
+      buildHeaders = async (): Promise<Record<string, string>> => ({}),
       fetch: customFetch,
     } = options;
 

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-client.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-client.ts.template
@@ -82,27 +82,12 @@ export class AgentCoreMcpClient {
 
     // Create a custom fetch that adds required headers
     const fetchWithHeaders: typeof fetch = async (input, init) => {
-      const headers = {
-        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
-        ...(await buildHeaders()),
-      };
-      const existingHeaders = init?.headers;
-
-      const mergedInit = {
-        ...init,
-        headers: !existingHeaders
-          ? headers
-          : existingHeaders instanceof Headers
-            ? (() => {
-                const h = new Headers(existingHeaders);
-                Object.entries(headers).forEach(([k, v]) => h.append(k, v));
-                return h;
-              })()
-            : Array.isArray(existingHeaders)
-              ? [...existingHeaders, ...Object.entries(headers)]
-              : { ...existingHeaders, ...headers },
-      };
-      return (customFetch || fetch)(input, mergedInit);
+      const headers = new Headers(init?.headers);
+      headers.set('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id', sessionId);
+      for (const [k, v] of Object.entries(await buildHeaders())) {
+        headers.set(k, v);
+      }
+      return (customFetch || fetch)(input, { ...init, headers });
     };
 
     // Create the transport

--- a/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
+++ b/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
@@ -38,22 +38,9 @@ const useCreate<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
   const auth = useAuth();
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
-    const headers = { Authorization: `Bearer ${user?.id_token}` };
-    const existingHeaders = init?.headers;
-
-    return fetch(url, {
-      ...init,
-      headers: !existingHeaders ? headers :
-               existingHeaders instanceof Headers ?
-                 (() => {
-                   const h = new Headers(existingHeaders);
-                   Object.entries(headers).forEach(([k, v]) => h.append(k, v));
-                   return h;
-                 })() :
-               Array.isArray(existingHeaders) ?
-                 [...existingHeaders, ...Object.entries(headers)] :
-                 { ...existingHeaders, ...headers }
-    });
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Bearer ${user?.id_token}`);
+    return fetch(url, { ...init, headers });
   };
   <%_ } _%>
   return useMemo(() => new <%- apiNameClassName %>({


### PR DESCRIPTION
### Reason for this change

The React connection templates for Cognito-authenticated APIs, and the AgentCore MCP client template, merged auth headers onto incoming `RequestInit` using a multi-branch expression: a `!existingHeaders` check, an `instanceof Headers` branch wrapped in an IIFE, an `Array.isArray` branch, and an object-spread fallback. This was hard to read, repeated verbatim in two templates, and is unnecessary — the `Headers` constructor already normalizes all three input shapes (`undefined`, `Headers`, `[string, string][]`, `Record<string, string>`) into a single `Headers` instance.

### Description of changes

Replaces the branchy merge in both templates with `new Headers(init?.headers)` + `headers.set(...)`:

- `packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template` — the `cognitoClient` fetch wrapper used by the OpenAPI react connection generator (consumed by FastAPI, Smithy, and Python Strands agent React connection generators).
- `packages/nx-plugin/src/utils/agent-connection/files/core/agentcore-mcp-client.ts.template` — the `fetchWithHeaders` wrapper in `AgentCoreMcpClient.create`, which applies to both `withIamAuth` and `withJwtAuth`.

Note: the refactor uses `headers.set(...)` (overwrite) rather than `append`, matching the existing object-spread branch's semantics and ensuring our auth/session headers take precedence over any caller-supplied duplicates. This is a small tightening over the previous `Headers`/array branches which used `append`; in practice callers do not supply these headers, so behavior is equivalent for the intended use.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — all 1639 tests pass; 4 generator snapshots were regenerated and reviewed to confirm the expected simpler output (fast-api react, strands-agent react-connection, smithy react-connection, ts strands-agent mcp-connection).
- `pnpm nx run @aws/nx-plugin:compile` — compiles cleanly.
- `pnpm nx run @aws/nx-plugin:lint --fix` — 0 errors (pre-existing warnings only).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*