### PR TITLE
ci(e2e): eliminate Verdaccio cold-cache 404 flakiness

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -6,9 +6,22 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
     maxage: 60m
-    timeout: 60s
-    max_fails: 20
-    fail_timeout: 1m
+    timeout: 120s
+    # Effectively disable the per-uplink circuit breaker. Without this, a
+    # transient burst of ECONNRESET/ETIMEDOUT/5xx from npmjs trips the breaker
+    # and Verdaccio then returns 404 for any uncached package until fail_timeout
+    # elapses — which pnpm treats as terminal (it does not retry 404s).
+    max_fails: 1000
+    fail_timeout: 1s
+    # Reuse TCP connections to npmjs so the concurrent install burst doesn't
+    # open hundreds of short-lived sockets (the main source of transient errors).
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
+
+server:
+  keepAliveTimeout: 60
 
 packages:
   '@aws/nx-plugin':

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -14,12 +14,12 @@ export default async function () {
       rmSync(registryPath, { force: true, recursive: true });
     }
 
-    // Configure package manager retry settings to handle transient registry failures.
-    // npm and pnpm both respect npm_config_* environment variables.
-    process.env.npm_config_fetch_retries = '5';
-    process.env.npm_config_fetch_retry_mintimeout = '15000';
-    process.env.npm_config_fetch_retry_maxtimeout = '90000';
-    // Yarn berry
+    // Yarn and bun both retry on any non-2xx response, so bumping these helps
+    // smooth over transient 5xx/timeouts from the Verdaccio uplink.
+    // pnpm/npm do NOT retry 404s (see pnpm/network/fetch/src/fetch.ts — only
+    // 500–599, 408, 409, 420, 429 are retried), so there's no equivalent knob
+    // to set for them; that failure mode is addressed at the Verdaccio layer
+    // in .verdaccio/config.yml.
     process.env.YARN_HTTP_RETRY = '5';
     process.env.YARN_HTTP_TIMEOUT = '90000';
 


### PR DESCRIPTION
### Reason for this change

Smoke tests on `main` and PRs have been intermittently failing with errors like:

```
ERR_PNPM_FETCH_404  GET http://localhost:4873/@babel%2Fpreset-react: Not Found - 404
@babel/preset-react is not in the npm registry, or you have no permission to fetch it.
```

The 404 is being manufactured by Verdaccio, not npm. When Verdaccio starts with empty storage (per `clearStorage: true` in `global-setup.ts`), the concurrent install burst from `create-nx-workspace` produces transient `ECONNRESET`/`ETIMEDOUT`/5xx errors on the npmjs uplink. After `max_fails` is reached, Verdaccio's per-uplink circuit breaker trips and it returns **404 for any uncached package** until `fail_timeout` elapses. pnpm treats 404 as terminal — its fetch retry only covers `500–599`, `408`, `409`, `420`, `429` (see `pnpm/network/fetch/src/fetch.ts`), so the install fails.

PR #577 tried to address this by adding client-side retry env vars (`npm_config_fetch_retries` etc.) and raising `max_fails` to 20. Neither helps:
- pnpm/npm don't retry 404s, so client-side retry knobs don't apply to the observed failure.
- Raising `max_fails` only delays the trip; a cold-cache burst still blows through 20.

Confirmed failures from recent runs:
- [`71992925178`](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24621335560/job/71992925178) — Smoke Tests – npm, `@babel/preset-react` 404
- [`71992925171`](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/24621335560/job/71992925171) — Smoke Tests – terraform, `@swc/cli` 404

### Description of changes

**`.verdaccio/config.yml`**
- `max_fails: 1000` + `fail_timeout: 1s` — effectively disables the circuit breaker so a momentary upstream blip can't poison subsequent requests.
- `timeout: 120s` — raised from 60s; npmjs p95 can exceed 60s during concurrent bursts.
- `agent_options` with `keepAlive: true`, `maxSockets: 40`, `maxFreeSockets: 10` (Verdaccio ≥ 4.0.2) — reuses TCP connections to npmjs so the concurrent install doesn't open hundreds of short-lived sockets, which is the main source of transient errors in the first place.
- `server.keepAliveTimeout: 60` — matches the uplink keep-alive window.

**`e2e/src/global-setup.ts`**
- Removed `npm_config_fetch_retries`, `npm_config_fetch_retry_mintimeout`, `npm_config_fetch_retry_maxtimeout` — they never addressed the observed failure (see above). Left a comment explaining why.
- Kept `YARN_HTTP_RETRY` / `YARN_HTTP_TIMEOUT` — yarn and bun do retry non-2xx responses, so these still help for the rare 5xx case.

### Description of how you validated changes

- Reproduced the failure mode from CI logs and traced it through Verdaccio (`packages/proxy/src/proxy.ts` circuit-breaker code) and pnpm (`network/fetch/src/fetch.ts` retry conditions).
- Relying on existing e2e smoke tests across all package managers (`npm`, `yarn`, `pnpm`, `bun`, Windows `pnpm`) to validate no regressions.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*