### PR TITLE
fix: fixed createMetricsPlugin to correctly report on COLD_START events

### DIFF
--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -193,9 +193,9 @@ export interface IMetricsContext {
 
 export const createMetricsPlugin = () => {
   const t = initTRPC.context<IMetricsContext>().create();
+  const metrics = new Metrics();
 
   return t.procedure.use(async (opts) => {
-    const metrics = new Metrics();
     metrics.addDimensions({
       procedure: opts.path,
       type: opts.type,

--- a/packages/nx-plugin/src/trpc/backend/files/src/middleware/metrics.ts.template
+++ b/packages/nx-plugin/src/trpc/backend/files/src/middleware/metrics.ts.template
@@ -7,9 +7,9 @@ export interface IMetricsContext {
 
 export const createMetricsPlugin = () => {
   const t = initTRPC.context<IMetricsContext>().create();
+  const metrics = new Metrics();
 
   return t.procedure.use(async (opts) => {
-    const metrics = new Metrics();
     metrics.addDimensions({
       procedure: opts.path,
       type: opts.type,


### PR DESCRIPTION
### Reason for this change

Every invocation to a `tRPC` method is reported by `metricsPlugin` as COLD_START which is a false positive

### Description of changes

The metrics instance is currently being created within the method handler, meaning a new instance is initialized on every invocation. As a result, metrics incorrectly reports each invocation as a COLD_START.

Should create `metrics` as follows

```
export const createMetricsPlugin = () => {
  const t = initTRPC.context<IMetricsContext>().create();
  const metrics = new Metrics();
  return t.procedure.use(async (opts) => {
  ...
```

### Description of how you validated changes

- Updated unit tests
- Manually verify on CloudWatch that invoking a method repeatedly should generate only one `COLD_START` event after `INIT_START` event.

### Issue # (if applicable)

Closes #594 .

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*