### PR TITLE
docs: purple outline CTA and light-mode carousel styling

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -60,14 +60,15 @@ div.hero {
 }
 
 [data-has-hero] .hero .actions .sl-link-button.primary {
-  background: var(--sl-color-accent);
+  background: transparent;
   border-color: var(--sl-color-accent);
-  color: var(--sl-color-white);
+  color: var(--sl-color-text-accent);
 }
 
 [data-has-hero] .hero .actions .sl-link-button.primary:hover {
-  background: var(--sl-color-accent-high);
+  background: var(--sl-color-accent-low);
   border-color: var(--sl-color-accent-high);
+  color: var(--sl-color-text-accent);
 }
 
 /* Landing page sections */
@@ -198,6 +199,11 @@ div.hero {
 
 /* Generator carousel */
 .gen-carousel {
+  --gen-carousel-window-bg: #0d1117;
+  --gen-carousel-chrome-bg: #161b22;
+  --gen-carousel-border: var(--sl-color-gray-5);
+  --gen-carousel-muted: #8b949e;
+
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -206,10 +212,17 @@ div.hero {
   margin: 0 auto;
 }
 
+:root[data-theme='light'] .gen-carousel {
+  --gen-carousel-window-bg: #f6f6f6;
+  --gen-carousel-chrome-bg: #f0f0f0;
+  --gen-carousel-border: #d9d9d9;
+  --gen-carousel-muted: #6a6f7a;
+}
+
 .gen-carousel-window {
   width: 100%;
-  background: #0d1117;
-  border: 1px solid var(--sl-color-gray-5);
+  background: var(--gen-carousel-window-bg);
+  border: 1px solid var(--gen-carousel-border);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 20px 40px -20px rgba(0, 0, 0, 0.5);
@@ -220,8 +233,8 @@ div.hero {
   align-items: center;
   gap: 0.4rem;
   padding: 0.6rem 0.9rem;
-  background: #161b22;
-  border-bottom: 1px solid var(--sl-color-gray-5);
+  background: var(--gen-carousel-chrome-bg);
+  border-bottom: 1px solid var(--gen-carousel-border);
 }
 
 .gen-carousel-dot {
@@ -244,7 +257,7 @@ div.hero {
 .gen-carousel-chrome-title {
   margin-left: 0.75rem;
   font-size: 0.78rem;
-  color: #8b949e;
+  color: var(--gen-carousel-muted);
   font-family: var(--__sl-font-mono), ui-monospace, monospace;
 }
 
@@ -273,7 +286,7 @@ div.hero {
 }
 
 .gen-carousel-caption {
-  color: #8b949e;
+  color: var(--gen-carousel-muted);
   font-size: 0.85rem;
   margin: 0 0 0.75rem;
 }


### PR DESCRIPTION
### Reason for this change

A couple of small polish fixes on the docs landing page:

- The primary **Get started** hero button was a solid purple fill, which made it visually dominate next to the secondary *Build with AI* button. An outlined purple style keeps the accent colour but gives the hero a more balanced pairing of two equally-weighted CTAs.
- The generator carousel's mock terminal used hard-coded dark colours (`#0d1117` / `#161b22`) regardless of theme, so in light mode it clashed with the rest of the page and with the expressive-code blocks rendered inside it.

### Description of changes

- `[data-has-hero] .hero .actions .sl-link-button.primary` now uses a transparent background with the accent border/text colour, and a subtle tinted background on hover (reusing `--sl-color-accent-low` / `--sl-color-accent-high`).
- Extracted the carousel's window/chrome/border/muted-text colours into CSS variables on `.gen-carousel`, defaulting to the existing dark values and overriding them for `:root[data-theme='light']` with colours that match the Night Owl Light expressive-code theme (`editor.background` `#FBFBFB` area, `terminal.background` `#F6F6F6`, `titleBar.activeBackground` `#F0F0F0`, border `#d9d9d9`). Shapes, dots, radii and layout are unchanged.

### Description of how you validated changes

- `pnpm nx build docs` — passes (including link validation).
- Ran `pnpm nx start docs` and inspected the landing page in both light and dark mode — the hero CTA now renders as a purple outline, and the generator carousel terminal now blends with the expressive-code code blocks in light mode while remaining unchanged in dark mode.

### Issue # (if applicable)

n/a

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*