### PR TITLE
feat(agent-core): implements IConnectable for managing security group access

### DIFF
--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -16,6 +16,7 @@ export * from './workspace.js';
 exports[`py#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > mcp-server-construct.ts 1`] = `
 "import { Lazy, Names } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -37,7 +38,10 @@ export type SnapshotBedrockServerProps = Omit<
   | 'authorizerConfiguration'
 >;
 
-export class SnapshotBedrockServer extends Construct implements IGrantable {
+export class SnapshotBedrockServer
+  extends Construct
+  implements IGrantable, IConnectable
+{
   public readonly dockerImage: AgentRuntimeArtifact;
   public readonly agentCoreRuntime: Runtime;
 
@@ -87,6 +91,13 @@ export class SnapshotBedrockServer extends Construct implements IGrantable {
    */
   public get grantPrincipal(): IPrincipal {
     return this.agentCoreRuntime.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this agent runtime.
+   */
+  public get connections(): Connections {
+    return this.agentCoreRuntime.connections;
   }
 
   /**

--- a/packages/nx-plugin/src/py/strands-agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/strands-agent/__snapshots__/generator.spec.ts.snap
@@ -22,6 +22,7 @@ CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_test_projec
 exports[`py#strands-agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-construct.ts 1`] = `
 "import { Lazy, Names } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -48,7 +49,10 @@ export type SnapshotBedrockAgentProps = Omit<
   | 'authorizerConfiguration'
 >;
 
-export class SnapshotBedrockAgent extends Construct implements IGrantable {
+export class SnapshotBedrockAgent
+  extends Construct
+  implements IGrantable, IConnectable
+{
   public readonly dockerImage: AgentRuntimeArtifact;
   public readonly agentCoreRuntime: Runtime;
 
@@ -108,6 +112,13 @@ export class SnapshotBedrockAgent extends Construct implements IGrantable {
    */
   public get grantPrincipal(): IPrincipal {
     return this.agentCoreRuntime.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this agent runtime.
+   */
+  public get connections(): Connections {
+    return this.agentCoreRuntime.connections;
   }
 
   /**

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -16,6 +16,7 @@ export * from './workspace.js';
 exports[`ts#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > mcp-server-construct.ts 1`] = `
 "import { Lazy, Names } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -37,7 +38,10 @@ export type SnapshotBedrockServerProps = Omit<
   | 'authorizerConfiguration'
 >;
 
-export class SnapshotBedrockServer extends Construct implements IGrantable {
+export class SnapshotBedrockServer
+  extends Construct
+  implements IGrantable, IConnectable
+{
   public readonly dockerImage: AgentRuntimeArtifact;
   public readonly agentCoreRuntime: Runtime;
 
@@ -87,6 +91,13 @@ export class SnapshotBedrockServer extends Construct implements IGrantable {
    */
   public get grantPrincipal(): IPrincipal {
     return this.agentCoreRuntime.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this agent runtime.
+   */
+  public get connections(): Connections {
+    return this.agentCoreRuntime.connections;
   }
 
   /**

--- a/packages/nx-plugin/src/ts/strands-agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/strands-agent/__snapshots__/generator.spec.ts.snap
@@ -23,6 +23,7 @@ CMD [ "node", "--require", "@aws/aws-distro-opentelemetry-node-autoinstrumentati
 exports[`ts#strands-agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-construct.ts 1`] = `
 "import { Lazy, Names } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -49,7 +50,10 @@ export type SnapshotBedrockAgentProps = Omit<
   | 'authorizerConfiguration'
 >;
 
-export class SnapshotBedrockAgent extends Construct implements IGrantable {
+export class SnapshotBedrockAgent
+  extends Construct
+  implements IGrantable, IConnectable
+{
   public readonly dockerImage: AgentRuntimeArtifact;
   public readonly agentCoreRuntime: Runtime;
 
@@ -109,6 +113,13 @@ export class SnapshotBedrockAgent extends Construct implements IGrantable {
    */
   public get grantPrincipal(): IPrincipal {
     return this.agentCoreRuntime.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this agent runtime.
+   */
+  public get connections(): Connections {
+    return this.agentCoreRuntime.connections;
   }
 
   /**

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -1,5 +1,6 @@
 import { Lazy, Names } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -45,7 +46,7 @@ export type <%- nameClassName %>Props = Omit<
 };
 <%_ } _%>
 
-export class <%- nameClassName %> extends Construct implements IGrantable {
+export class <%- nameClassName %> extends Construct implements IGrantable, IConnectable {
   public readonly dockerImage: AgentRuntimeArtifact;
   public readonly agentCoreRuntime: Runtime;
 
@@ -123,6 +124,13 @@ export class <%- nameClassName %> extends Construct implements IGrantable {
    */
   public get grantPrincipal(): IPrincipal {
     return this.agentCoreRuntime.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this agent runtime.
+   */
+  public get connections(): Connections {
+    return this.agentCoreRuntime.connections;
   }
 <%_ if (auth === 'IAM') { _%>
 


### PR DESCRIPTION
### Reason for this change

Currently, the agent-core runtime construct implements IGrantable to manage IAM permissions. However, certain services such as an Aurora RDS also require the agent-core runtime to be deployed in the same VPC and port access to be granted.

### Description of changes

Add `IConnectable` interface so that we can conveniently grant port access.

```
const mcpServer = new McpServer(this, 'McpServer', {
    networkConfiguration: RuntimeNetworkConfiguration.usingVpc(this,   
    vpc,
    vpcSubnets: {
      subnetType: SubnetType.PRIVATE_WITH_EGRESS,
    },
  }),
});

// MCP server connects to the database
db.grantConnect(mcpServer); // IAM access
db.allowDefaultPortFrom(mcpServer); // Port access, requires IConnectable 
```

### Description of how you validated changes

- Updated unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*