### PR TITLE
fix(open-api): correctness fixes for ts-client multipart/cookies/response types and composite parameter types

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -2234,3 +2234,205 @@ export class TestApi {
 }
 "
 `;
+
+exports[`openApiTsClientGenerator - complex types > should render \`unknown\` value type for \`type: object\` with no additionalProperties > client.gen.ts 1`] = `
+"import type {
+  GetAdditionalPropsTrue200Response,
+  GetBareObject200Response,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetAdditionalPropsTrue200Response = {
+    toJson: (model: GetAdditionalPropsTrue200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(model, (item0) => item0),
+      };
+    },
+    fromJson: (json: any): GetAdditionalPropsTrue200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(json, (item0) => item0),
+      };
+    },
+  };
+
+  public static GetBareObject200Response = {
+    toJson: (model: GetBareObject200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.$mapValues(model, (item0) => item0),
+      };
+    },
+    fromJson: (json: any): GetBareObject200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.$mapValues(json, (item0) => item0),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getAdditionalPropsTrue = this.getAdditionalPropsTrue.bind(this);
+    this.getBareObject = this.getBareObject.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getAdditionalPropsTrue(): Promise<GetAdditionalPropsTrue200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/ap-true', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetAdditionalPropsTrue200Response.fromJson(
+        await response.json(),
+      );
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getBareObject(): Promise<GetBareObject200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/bare-object', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetBareObject200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - complex types > should render \`unknown\` value type for \`type: object\` with no additionalProperties > types.gen.ts 1`] = `
+"export type GetAdditionalPropsTrue200Response = {
+  [key: string]: unknown;
+};
+export type GetBareObject200Response = {
+  [key: string]: unknown;
+};
+export type GetAdditionalPropsTrueError = never;
+export type GetBareObjectError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -1,0 +1,475 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - content type header > should not force Content-Type for multipart/form-data bodies > client.gen.ts 1`] = `
+"import type { PostUploadRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postUpload = this.postUpload.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postUpload(input: PostUploadRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    const body = input as any;
+
+    const response = await this.$fetch(
+      this.$url('/upload', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 204) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - content type header > should not force Content-Type for multipart/form-data bodies > types.gen.ts 1`] = `
+"export type PostUploadRequest = unknown;
+export type PostUploadError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - content type header > should pick a single wire media type when the spec lists multiple > client.gen.ts 1`] = `
+"import type { PostMultiRequestContent, PostMultiRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static PostMultiRequestContent = {
+    toJson: (model: PostMultiRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.m === undefined
+          ? {}
+          : {
+              m: model.m,
+            }),
+      };
+    },
+    fromJson: (json: any): PostMultiRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['m'] === undefined
+          ? {}
+          : {
+              m: json['m'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postMulti = this.postMulti.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postMulti(input: PostMultiRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.PostMultiRequestContent.toJson(input))
+        : String($IO.PostMultiRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/multi', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 204) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - content type header > should pick a single wire media type when the spec lists multiple > types.gen.ts 1`] = `
+"export type PostMultiRequestContent = {
+  m?: string;
+};
+
+export type PostMultiRequest = PostMultiRequestContent;
+export type PostMultiError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - content type header > should serialise cookie parameters into a Cookie request header > client.gen.ts 1`] = `
+"import type {
+  GetSecretRequestCookieParameters,
+  GetSecretRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetSecretRequestCookieParameters = {
+    toJson: (model: GetSecretRequestCookieParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.session === undefined
+          ? {}
+          : {
+              session: model.session,
+            }),
+        ...(model.preference === undefined
+          ? {}
+          : {
+              preference: model.preference,
+            }),
+      };
+    },
+    fromJson: (json: any): GetSecretRequestCookieParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['session'] === undefined
+          ? {}
+          : {
+              session: json['session'],
+            }),
+        ...(json['preference'] === undefined
+          ? {}
+          : {
+              preference: json['preference'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getSecret = this.getSecret.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getSecret(input: GetSecretRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    const cookieParameters: { [key: string]: any } =
+      $IO.GetSecretRequestCookieParameters.toJson(input);
+    const cookiePairs = Object.entries(cookieParameters)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(
+        ([k, v]) => \`\${encodeURIComponent(k)}=\${encodeURIComponent(String(v))}\`,
+      );
+    if (cookiePairs.length > 0) {
+      headerParameters['Cookie'] = cookiePairs.join('; ');
+    }
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/secret', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.text();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - content type header > should serialise cookie parameters into a Cookie request header > types.gen.ts 1`] = `
+"export type GetSecretRequestCookieParameters = {
+  session?: string;
+  preference?: string;
+};
+
+export type GetSecretRequest = GetSecretRequestCookieParameters;
+export type GetSecretError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -1918,3 +1918,356 @@ export class TestApi {
 }
 "
 `;
+
+exports[`openApiTsClientGenerator - FastAPI > should hoist inline composite parameter schemas so FastAPI \`Optional[T]\` params compile > client.gen.ts 1`] = `
+"import type {
+  GetPetRequestCookieParameters,
+  GetPetRequestCookieSession,
+  GetPetRequestHeaderParameters,
+  GetPetRequestHeaderXClient,
+  GetPetRequestPathParameters,
+  GetPetRequestQueryParameters,
+  GetPetRequestQueryTag,
+  GetPetRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetPetRequestCookieParameters = {
+    toJson: (model: GetPetRequestCookieParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.session === undefined
+          ? {}
+          : {
+              session: $IO.GetPetRequestCookieSession.toJson(model.session),
+            }),
+      };
+    },
+    fromJson: (json: any): GetPetRequestCookieParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['session'] === undefined
+          ? {}
+          : {
+              session: $IO.GetPetRequestCookieSession.fromJson(json['session']),
+            }),
+      };
+    },
+  };
+
+  public static GetPetRequestCookieSession = {
+    toJson: (model: GetPetRequestCookieSession): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (typeof model === 'string') {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): GetPetRequestCookieSession => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      if (typeof json === 'string') {
+        return json;
+      }
+      return json;
+    },
+  };
+
+  public static GetPetRequestHeaderParameters = {
+    toJson: (model: GetPetRequestHeaderParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.xClient === undefined
+          ? {}
+          : {
+              'X-Client': $IO.GetPetRequestHeaderXClient.toJson(model.xClient),
+            }),
+      };
+    },
+    fromJson: (json: any): GetPetRequestHeaderParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['X-Client'] === undefined
+          ? {}
+          : {
+              xClient: $IO.GetPetRequestHeaderXClient.fromJson(
+                json['X-Client'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static GetPetRequestHeaderXClient = {
+    toJson: (model: GetPetRequestHeaderXClient): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (typeof model === 'string') {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): GetPetRequestHeaderXClient => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      if (typeof json === 'string') {
+        return json;
+      }
+      return json;
+    },
+  };
+
+  public static GetPetRequestPathParameters = {
+    toJson: (model: GetPetRequestPathParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.petId === undefined
+          ? {}
+          : {
+              petId: model.petId,
+            }),
+      };
+    },
+    fromJson: (json: any): GetPetRequestPathParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        petId: json['petId'],
+      };
+    },
+  };
+
+  public static GetPetRequestQueryParameters = {
+    toJson: (model: GetPetRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.tag === undefined
+          ? {}
+          : {
+              tag: $IO.GetPetRequestQueryTag.toJson(model.tag),
+            }),
+      };
+    },
+    fromJson: (json: any): GetPetRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['tag'] === undefined
+          ? {}
+          : {
+              tag: $IO.GetPetRequestQueryTag.fromJson(json['tag']),
+            }),
+      };
+    },
+  };
+
+  public static GetPetRequestQueryTag = {
+    toJson: (model: GetPetRequestQueryTag): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (
+        Array.isArray(model) &&
+        (model.length === 0 || typeof model[0] !== 'object')
+      ) {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): GetPetRequestQueryTag => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      if (
+        Array.isArray(json) &&
+        (json.length === 0 || typeof json[0] !== 'object')
+      ) {
+        return json;
+      }
+      return json;
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getPet = this.getPet.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getPet(input: GetPetRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } =
+      $IO.GetPetRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } =
+      $IO.GetPetRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } =
+      $IO.GetPetRequestHeaderParameters.toJson(input);
+    const cookieParameters: { [key: string]: any } =
+      $IO.GetPetRequestCookieParameters.toJson(input);
+    const cookiePairs = Object.entries(cookieParameters)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(
+        ([k, v]) => \`\${encodeURIComponent(k)}=\${encodeURIComponent(String(v))}\`,
+      );
+    if (cookiePairs.length > 0) {
+      headerParameters['Cookie'] = cookiePairs.join('; ');
+    }
+    const collectionFormats = {
+      'X-Client': 'csv',
+      tag: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/pets/{petId}',
+        pathParameters,
+        queryParameters,
+        collectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.text();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - FastAPI > should hoist inline composite parameter schemas so FastAPI \`Optional[T]\` params compile > types.gen.ts 1`] = `
+"export type GetPetRequestCookieParameters = {
+  session?: GetPetRequestCookieSession;
+};
+export type GetPetRequestCookieSession = string | null;
+export type GetPetRequestHeaderParameters = {
+  xClient?: GetPetRequestHeaderXClient;
+};
+export type GetPetRequestHeaderXClient = string | null;
+export type GetPetRequestPathParameters = {
+  petId: number;
+};
+export type GetPetRequestQueryParameters = {
+  tag?: GetPetRequestQueryTag;
+};
+export type GetPetRequestQueryTag = Array<string> | null;
+
+export type GetPetRequest = GetPetRequestPathParameters &
+  GetPetRequestHeaderParameters &
+  GetPetRequestCookieParameters &
+  GetPetRequestQueryParameters;
+export type GetPetError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -372,10 +372,31 @@ export class <%- className %> {
     const <%- position %>Parameters: {[key: string]: any} = {};
     <%_ } _%>
     <%_ }); _%>
-    <%_ if (op.parametersBody && op.parametersBody.mediaTypes) { _%>
-    if (!this.$config.options?.omitContentTypeHeader) {
-      headerParameters['Content-Type'] = '<%- op.parametersBody.mediaTypes %>';
+    <%_ /* Cookie parameters are serialised into a `Cookie:` request header.
+           (Browsers auto-attach cookies per-origin; Node-side and cross-origin
+           callers need the header set explicitly for the cookie to land.) */ _%>
+    <%_ if (op.parameters.map(p => p.in).includes('cookie')) { _%>
+    const cookieParameters: {[key: string]: any} = $IO.<%- op.operationIdPascalCase %>RequestCookieParameters.toJson(input);
+    const cookiePairs = Object.entries(cookieParameters)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+    if (cookiePairs.length > 0) {
+      headerParameters['Cookie'] = cookiePairs.join('; ');
     }
+    <%_ } _%>
+    <%_ if (op.parametersBody && op.parametersBody.mediaTypes) { _%>
+    <%_ /* Pick a single wire media type — servers parse Content-Type as a
+           single value, so the comma-joined list is wire-incorrect. */ _%>
+    <%_ const mediaTypeList = Array.isArray(op.parametersBody.mediaTypes) ? op.parametersBody.mediaTypes : [op.parametersBody.mediaTypes]; _%>
+    <%_ const chosenMediaType = mediaTypeList.find(mt => mt === 'application/json' || mt.endsWith('+json')) || mediaTypeList[0]; _%>
+    <%_ /* Skip for multipart/form-data — `fetch` needs to compute the boundary
+           itself when a FormData body is passed; pre-setting the header strips
+           the boundary param and servers fail to parse the payload. */ _%>
+    <%_ if (chosenMediaType !== 'multipart/form-data') { _%>
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = '<%- chosenMediaType %>';
+    }
+    <%_ } _%>
     <%_ } _%>
     <%_ if (op.parameters.filter(p => p.collectionFormat).length > 0) { _%>
     const collectionFormats = {

--- a/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
@@ -29,7 +29,11 @@ _%>
 <%_ } else { _%>
 <%- docString(model, '') %>export type <%= model.typescriptName %> = <% if (model.isNullable && model.type !== 'null') { %>null | <% } %>{
 <%_ if (model.export === "dictionary" && model.link) { _%>
-<%- docString(model.link, '  ') %>  [key: string]: <%- model.link.typescriptType %>;
+<%_ /* When the spec says `type: object` with `additionalProperties: true`
+      (or omits additionalProperties), hey-api sets `model.link` but the
+      link's typescriptType is empty — fall back to `unknown` to keep the
+      emitted code valid. */ _%>
+<%- docString(model.link, '  ') %>  [key: string]: <%- model.link.typescriptType || 'unknown' %>;
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>
 <%- docString(property, '  ') %>  <%= property.isReadOnly ? 'readonly ' : '' %><%= property.typescriptName %><%= property.isRequired ? '' : '?' %>: <%- property.typescriptType %><%= (property.isNullable && property.type !== 'null') ? ' | null' : '' %>;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
@@ -1308,4 +1308,58 @@ describe('openApiTsClientGenerator - complex types', () => {
       ],
     });
   });
+
+  it('should render `unknown` value type for `type: object` with no additionalProperties', async () => {
+    // Regression: the generator used to emit `[key: string]: ;` (empty
+    // value type, SyntaxError) when the response schema was a bare
+    // `{ type: 'object' }` or `{ type: 'object', additionalProperties: true }`.
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/bare-object': {
+          get: {
+            operationId: 'getBareObject',
+            responses: {
+              '200': {
+                description: 'bare object',
+                content: {
+                  'application/json': { schema: { type: 'object' } },
+                },
+              },
+            },
+          },
+        },
+        '/ap-true': {
+          get: {
+            operationId: 'getAdditionalPropsTrue',
+            responses: {
+              '200': {
+                description: 'ap=true',
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', additionalProperties: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    // The empty-value rendering used to produce `[key: string]: ;`.
+    expect(types).not.toMatch(/\[key:\s*string\]:\s*;/);
+    // Should fall back to `unknown`.
+    expect(types).toContain('[key: string]: unknown');
+  });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
@@ -1357,6 +1357,9 @@ describe('openApiTsClientGenerator - complex types', () => {
       'src/generated/types.gen.ts',
     ]);
     const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
     // The empty-value rendering used to produce `[key: string]: ;`.
     expect(types).not.toMatch(/\[key:\s*string\]:\s*;/);
     // Should fall back to `unknown`.

--- a/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
@@ -224,4 +224,170 @@ describe('openApiTsClientGenerator - content type header', () => {
       }),
     );
   });
+
+  it('should pick a single wire media type when the spec lists multiple', async () => {
+    // Regression: the generator used to emit the joined list
+    // "application/json,application/xml,application/x-www-form-urlencoded"
+    // as the Content-Type header.  Servers parse Content-Type as a single
+    // type, so we pick the first JSON-compatible media type (or the first
+    // entry) and emit it verbatim.
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.0.0',
+      paths: {
+        '/multi': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/xml': {
+                  schema: {
+                    type: 'object',
+                    properties: { m: { type: 'string' } },
+                  },
+                },
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { m: { type: 'string' } },
+                  },
+                },
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    properties: { m: { type: 'string' } },
+                  },
+                },
+              },
+            },
+            responses: { '204': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    // Not the joined list.
+    expect(client).not.toMatch(
+      /'application\/json,application\/xml,application\/x-www-form-urlencoded'/,
+    );
+    // One declared value, the JSON-compatible one preferred.
+    expect(client).toContain(
+      "headerParameters['Content-Type'] = 'application/json'",
+    );
+  });
+
+  it('should not force Content-Type for multipart/form-data bodies', async () => {
+    // Regression: setting Content-Type to a bare `multipart/form-data` string
+    // strips the boundary param that `fetch` would otherwise autocompute from
+    // a FormData body, so the server cannot parse the payload.
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.0.0',
+      paths: {
+        '/upload': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    required: ['file'],
+                    properties: {
+                      file: { type: 'string', format: 'binary' },
+                      description: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '204': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(client).not.toMatch(
+      /headerParameters\['Content-Type'\]\s*=\s*'multipart\/form-data'/,
+    );
+  });
+
+  it('should serialise cookie parameters into a Cookie request header', async () => {
+    // Regression: cookie parameters used to be typed on the request input
+    // but silently dropped at send time — the user's session cookie never
+    // reached the server.
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.0.0',
+      paths: {
+        '/secret': {
+          get: {
+            operationId: 'getSecret',
+            parameters: [
+              { name: 'session', in: 'cookie', schema: { type: 'string' } },
+              { name: 'preference', in: 'cookie', schema: { type: 'string' } },
+            ],
+            responses: {
+              '200': {
+                content: { 'application/json': { schema: { type: 'string' } } },
+                description: 'ok',
+              },
+            },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(client).toContain('RequestCookieParameters.toJson(input)');
+    expect(client).toContain("headerParameters['Cookie']");
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue('sekret'),
+    });
+    expect(
+      await callGeneratedClient(client, mockFetch, 'getSecret', {
+        session: 's=1; path=/',
+        preference: 'dark mode',
+      }),
+    ).toBe('sekret');
+
+    const headers = (mockFetch.mock.calls[0][1] as any).headers as [
+      string,
+      string,
+    ][];
+    const cookieHeader = headers.find(([k]) => k === 'Cookie')?.[1];
+    expect(cookieHeader).toBeDefined();
+    // Both cookies, percent-encoded, joined with `; `.
+    expect(cookieHeader).toContain('session=s%3D1%3B%20path%3D%2F');
+    expect(cookieHeader).toContain('preference=dark%20mode');
+  });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
@@ -274,7 +274,10 @@ describe('openApiTsClientGenerator - content type header', () => {
       'src/generated/client.gen.ts',
       'src/generated/types.gen.ts',
     ]);
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
     const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
     // Not the joined list.
     expect(client).not.toMatch(
       /'application\/json,application\/xml,application\/x-www-form-urlencoded'/,
@@ -324,7 +327,10 @@ describe('openApiTsClientGenerator - content type header', () => {
       'src/generated/client.gen.ts',
       'src/generated/types.gen.ts',
     ]);
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
     const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
     expect(client).not.toMatch(
       /headerParameters\['Content-Type'\]\s*=\s*'multipart\/form-data'/,
     );
@@ -364,7 +370,10 @@ describe('openApiTsClientGenerator - content type header', () => {
       'src/generated/client.gen.ts',
       'src/generated/types.gen.ts',
     ]);
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
     const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
     expect(client).toContain('RequestCookieParameters.toJson(input)');
     expect(client).toContain("headerParameters['Cookie']");
 

--- a/packages/nx-plugin/src/open-api/ts-client/generator.fast-api.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.fast-api.spec.ts
@@ -975,4 +975,84 @@ describe('openApiTsClientGenerator - FastAPI', () => {
       ],
     });
   });
+
+  it('should hoist inline composite parameter schemas so FastAPI `Optional[T]` params compile', async () => {
+    const spec: Spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/pets/{petId}': {
+          get: {
+            operationId: 'getPet',
+            parameters: [
+              {
+                name: 'petId',
+                in: 'path',
+                required: true,
+                schema: { type: 'integer' },
+              },
+              {
+                name: 'X-Client',
+                in: 'header',
+                schema: {
+                  anyOf: [{ type: 'string' }, { type: 'null' }],
+                  title: 'X-Client',
+                } as any,
+              },
+              {
+                name: 'session',
+                in: 'cookie',
+                schema: {
+                  anyOf: [{ type: 'string' }, { type: 'null' }],
+                  title: 'Session',
+                } as any,
+              },
+              {
+                name: 'tag',
+                in: 'query',
+                schema: {
+                  anyOf: [
+                    { type: 'array', items: { type: 'string' } },
+                    { type: 'null' },
+                  ],
+                  title: 'Tag',
+                } as any,
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    // Must actually compile (the phantom composites used to break tsc).
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
+    // The hoisted composite schemas get operation-scoped names.
+    expect(types).toMatch(/GetPetRequestHeaderXClient\s*=\s*string \| null/);
+    expect(types).toMatch(/GetPetRequestCookieSession\s*=\s*string \| null/);
+    expect(types).toMatch(/GetPetRequestQueryTag\s*=\s*Array<string> \| null/);
+    expect(types).toContain('xClient?: GetPetRequestHeaderXClient');
+    expect(types).toContain('session?: GetPetRequestCookieSession');
+    expect(types).toContain('tag?: GetPetRequestQueryTag');
+  });
 });

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -188,10 +188,15 @@ export const buildOpenApiCodeGenData = async (
           );
         }
 
-        if (parameter.in === 'body') {
-          // Parameter name for the body is 'body'
+        if (parameter.in === 'body' || parameter.in === 'formData') {
+          // Parameter name for the body is 'body'.  `formData` bodies arrive
+          // under a synthetic `formData` param (hey-api convention) that's
+          // logically the body — normalise both shapes to `in === 'body'`
+          // so every downstream consumer (including ts-client's request-
+          // type composition) sees a single body kind.
           parameter.name = 'body';
           parameter.prop = 'body';
+          parameter.in = 'body';
 
           // The request body is not in the "parameters" section of the openapi spec so we won't have added the schema
           // properties above. Find it here.

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -389,6 +389,23 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
             };
           }
         }
+
+        // Hoist parameter schemas
+        if ('parameters' in operation) {
+          (operation.parameters ?? []).forEach((p) => {
+            const param = resolveIfRef(spec, p);
+            const paramSchema = param?.schema;
+            if (
+              paramSchema &&
+              !isRef(paramSchema) &&
+              isCompositeSchema(paramSchema as OpenAPIV3.SchemaObject)
+            ) {
+              const schemaName = `${upperFirst(deduplicatedOpId)}Request${upperFirst(param.in)}${upperFirst(camelCase(param.name))}`;
+              spec.components!.schemas![schemaName] = paramSchema;
+              param.schema = { $ref: `#/components/schemas/${schemaName}` };
+            }
+          });
+        }
       }
     }),
   );


### PR DESCRIPTION
### Reason for this change

Reviewing the generated TypeScript client against a variety of OpenAPI specs — petstore v3, an `Error`-schema / oneOf spec, a multipart-upload spec, an edge spec with reserved keywords and readOnly fields, a streaming spec, and finally a real FastAPI service — surfaced five correctness bugs that either produce invalid TypeScript or silently break at runtime. Each is a small, localised fix and each gets a regression test.

### Description of changes

1. **`type: object` with no `additionalProperties` emitted invalid TypeScript.** The template rendered `[key: string]: <link.typescriptType>;` unconditionally, and the empty `typescriptType` produced `[key: string]: ;` — a `tsc` syntax error. Fall back to `unknown` so the emitted code stays valid.

2. **`multipart/form-data` bodies were sent with a boundary-less `Content-Type`.** The generator pre-set `Content-Type: multipart/form-data` before `fetch()` had a chance to compute the boundary from the `FormData` body; servers cannot parse the resulting request because RFC 7578 requires the `boundary=` parameter. Skip the assignment for multipart bodies so the runtime populates a correct header.

3. **Cookie parameters were silently dropped.** `in: cookie` parameters were typed on the request input but never serialised onto the wire — the user thought they were sending a session cookie and the server never saw it. Serialise them into a percent-encoded `Cookie:` header (both node-side and cross-origin browser callers need this explicitly).

4. **Multi-media-type request bodies produced a comma-joined `Content-Type`.** `Content-Type: 'application/json,application/xml,application/x-www-form-urlencoded'` is wire-incorrect — servers parse the header as a single value. Pick one wire type (preferring `application/json` / `+json` variants, falling back to the first entry).

5. **Composite parameter schemas were never hoisted.** FastAPI / Pydantic v2 encode `Optional[T]` parameters inline as `{anyOf: [T, {type: 'null'}], title: '<name>'}`. The existing hoisting pass walked request/response JSON schemas into `components.schemas` but didn't walk `parameters[].schema`, so hey-api-openapi synthesised an anonymous composite type named from the title (e.g. `XClient`, `Session`, `Tag`) but never emitted a declaration. Every FastAPI-generated client then failed to compile with `Cannot find name 'XClient'` / `'"Session" is not defined'`. The fix extends the hoister to walk parameter schemas too; once hoisted, the existing primitive-inlining path produces the correct `string | null` etc. — no lossy rewrite.

Also in the shared codegen data: normalise hey-api's `in: 'formData'` to `in: 'body'` so downstream consumers see a single body kind.

### Description of how you validated changes

- Regression tests for each scenario land alongside the existing `content-type`, `additional-properties` and `fast-api` spec files.
- Full suite passes: 1731 tests, lint, build, all smoke tests (incl. Windows).
- End-to-end sanity with `tsx` against a mock `fetch`: petstore (7 tests), complex (4 tests, including 409 error via renamed `_Error`), advanced (multipart → auto-boundary, Blob octet-stream, cookies, deprecated, allOf) — all green after the fix.
- Integration tests against real servers (FastAPI, tRPC-via-trpc-to-openapi, Smithy): 29 py-client + 29 ts-client tests pass. SigV4-signed FastAPI calls through a mock API Gateway IAM proxy — 6 py + 6 ts — confirm the middleware hooks work against the IAM-auth flow.

### Issue # (if applicable)

Follow-up to the review in #586.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*