### PR TITLE
fix(py#lambda-function): prevent ImportError at cold start when used with other Python generators

### DIFF
--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -8,7 +8,9 @@ import {
   LAMBDA_FUNCTION_GENERATOR_INFO,
   pyLambdaFunctionGenerator,
 } from './generator';
+import { pyMcpServerGenerator } from '../mcp-server/generator';
 import { parse } from '@iarna/toml';
+import { parsePipRequirementsLine } from 'pip-requirements-js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
@@ -509,6 +511,61 @@ describe('lambda-handler project generator', () => {
 
     // Verify the metric was added to app.ts
     expectHasMetricTags(tree, LAMBDA_FUNCTION_GENERATOR_INFO.metric);
+  });
+
+  it('should keep aws-lambda-powertools tracer/parser extras when another generator is run on the same project', async () => {
+    tree.write(
+      'apps/test_project/project.json',
+      JSON.stringify({
+        name: 'test-project',
+        root: 'apps/test_project',
+        sourceRoot: 'apps/test_project/test_project',
+        targets: {},
+      }),
+    );
+    tree.write(
+      'apps/test_project/pyproject.toml',
+      `[project]
+name = "test_project"
+version = "0.1.0"
+dependencies = []
+
+[dependency-groups]
+dev = []
+`,
+    );
+
+    await pyLambdaFunctionGenerator(tree, {
+      project: 'test-project',
+      functionName: 'test-function',
+      eventSource: 'Any',
+      iacProvider: 'CDK',
+    });
+
+    await pyMcpServerGenerator(tree, {
+      project: 'test-project',
+      computeType: 'None',
+      iacProvider: 'CDK',
+    });
+
+    const deps =
+      (
+        parse(
+          tree.read('apps/test_project/pyproject.toml', 'utf-8'),
+        ) as UVPyprojectToml
+      ).project.dependencies ?? [];
+
+    const extrasFor = (pkg: string) =>
+      deps.flatMap((dep) => {
+        const parsed = parsePipRequirementsLine(dep);
+        return parsed?.type === 'ProjectName' && parsed.name === pkg
+          ? (parsed.extras ?? [])
+          : [];
+      });
+
+    const powertoolsExtras = new Set(extrasFor('aws-lambda-powertools'));
+    expect(powertoolsExtras).toContain('tracer');
+    expect(powertoolsExtras).toContain('parser');
   });
 
   describe('terraform iacProvider', () => {

--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -10,7 +10,6 @@ import {
 } from './generator';
 import { pyMcpServerGenerator } from '../mcp-server/generator';
 import { parse } from '@iarna/toml';
-import { parsePipRequirementsLine } from 'pip-requirements-js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
@@ -555,17 +554,12 @@ dev = []
         ) as UVPyprojectToml
       ).project.dependencies ?? [];
 
-    const extrasFor = (pkg: string) =>
-      deps.flatMap((dep) => {
-        const parsed = parsePipRequirementsLine(dep);
-        return parsed?.type === 'ProjectName' && parsed.name === pkg
-          ? (parsed.extras ?? [])
-          : [];
-      });
-
-    const powertoolsExtras = new Set(extrasFor('aws-lambda-powertools'));
-    expect(powertoolsExtras).toContain('tracer');
-    expect(powertoolsExtras).toContain('parser');
+    expect(
+      deps.some((dep) => dep.startsWith('aws-lambda-powertools[tracer]==')),
+    ).toBe(true);
+    expect(
+      deps.some((dep) => dep.startsWith('aws-lambda-powertools[parser]==')),
+    ).toBe(true);
   });
 
   describe('terraform iacProvider', () => {

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -148,8 +148,8 @@ describe('addDependenciesToPyProjectToml', () => {
     expect(updatedToml.project.dependencies).toHaveLength(2);
   });
 
-  it('should handle complex dependency specifications', () => {
-    // Setup: Create pyproject.toml with complex existing dependencies
+  it('should treat bare package and the same package with extras as distinct', () => {
+    // Setup: Create pyproject.toml with extras-qualified dependencies
     const initialToml = {
       project: {
         name: 'test-project',
@@ -163,11 +163,10 @@ describe('addDependenciesToPyProjectToml', () => {
     };
     tree.write('test-project/pyproject.toml', stringify(initialToml));
 
-    // Act: Add fastapi dependency (should replace complex existing one)
+    // Act: Add bare fastapi — must not wipe the `fastapi[all]` variant
     const deps: IPyDepVersion[] = ['fastapi'];
     addDependenciesToPyProjectToml(tree, 'test-project', deps);
 
-    // Assert: Verify fastapi was replaced while others remain
     const updatedToml = parse(
       tree.read('test-project/pyproject.toml', 'utf-8'),
     ) as UVPyprojectToml;
@@ -177,17 +176,81 @@ describe('addDependenciesToPyProjectToml', () => {
         dep.startsWith('fastapi=='),
       ),
     ).toBe(true);
+    expect(updatedToml.project.dependencies).toContain('fastapi[all]>=0.100.0');
     expect(updatedToml.project.dependencies).toContain(
       'requests[security]>=2.25.0',
     );
     expect(updatedToml.project.dependencies).toContain(
       'pydantic>=2.0.0,<3.0.0',
     );
-    expect(updatedToml.project.dependencies).toHaveLength(3);
+    expect(updatedToml.project.dependencies).toHaveLength(4);
+  });
 
-    // Ensure old fastapi version is not present
+  it('should preserve existing extras entries when a later call adds the bare package', () => {
+    // Regression: a generator (e.g. py#lambda-function) adds
+    // `aws-lambda-powertools[tracer]` and `[parser]`; a subsequent generator
+    // (e.g. py#mcp-server) adds bare `aws-lambda-powertools` and must not
+    // silently drop the extras entries, which would leave aws-xray-sdk and
+    // the parser deps out of the bundle at deploy time.
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: [
+          'aws-lambda-powertools==3.27.0',
+          'aws-lambda-powertools[tracer]==3.27.0',
+          'aws-lambda-powertools[parser]==3.27.0',
+        ],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    addDependenciesToPyProjectToml(tree, 'test-project', [
+      'aws-lambda-powertools',
+    ]);
+
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toContain(
+      'aws-lambda-powertools==3.27.0',
+    );
+    expect(updatedToml.project.dependencies).toContain(
+      'aws-lambda-powertools[tracer]==3.27.0',
+    );
+    expect(updatedToml.project.dependencies).toContain(
+      'aws-lambda-powertools[parser]==3.27.0',
+    );
+    expect(updatedToml.project.dependencies).toHaveLength(3);
+  });
+
+  it('should replace an existing extras entry when the same extras set is re-added', () => {
+    const initialToml = {
+      project: {
+        name: 'test-project',
+        version: '0.1.0',
+        dependencies: ['aws-lambda-powertools[tracer]>=2.0.0'],
+      },
+    };
+    tree.write('test-project/pyproject.toml', stringify(initialToml));
+
+    addDependenciesToPyProjectToml(tree, 'test-project', [
+      'aws-lambda-powertools[tracer]',
+    ]);
+
+    const updatedToml = parse(
+      tree.read('test-project/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+    expect(updatedToml.project.dependencies).toHaveLength(1);
+    expect(
+      updatedToml.project.dependencies.some((dep) =>
+        dep.startsWith('aws-lambda-powertools[tracer]=='),
+      ),
+    ).toBe(true);
     expect(updatedToml.project.dependencies).not.toContain(
-      'fastapi[all]>=0.100.0',
+      'aws-lambda-powertools[tracer]>=2.0.0',
     );
   });
 

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -187,11 +187,6 @@ describe('addDependenciesToPyProjectToml', () => {
   });
 
   it('should preserve existing extras entries when a later call adds the bare package', () => {
-    // Regression: a generator (e.g. py#lambda-function) adds
-    // `aws-lambda-powertools[tracer]` and `[parser]`; a subsequent generator
-    // (e.g. py#mcp-server) adds bare `aws-lambda-powertools` and must not
-    // silently drop the extras entries, which would leave aws-xray-sdk and
-    // the parser deps out of the bundle at deploy time.
     const initialToml = {
       project: {
         name: 'test-project',

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -9,6 +9,29 @@ import { IPyDepVersion, withPyVersions } from './versions';
 import { parsePipRequirementsLine } from 'pip-requirements-js';
 import { updateToml } from './toml';
 
+// Dedup key that distinguishes bare packages from the same package with
+// extras (e.g. `foo` vs `foo[bar]`), so adding a bare dep doesn't drop a
+// previously-added variant with extras.
+const depKey = (dep: string): string => {
+  const parsed = parsePipRequirementsLine(dep);
+  if (parsed?.type !== 'ProjectName') {
+    return dep;
+  }
+  const extras = [...(parsed.extras ?? [])].sort().join(',');
+  return extras ? `${parsed.name}[${extras}]` : parsed.name;
+};
+
+const mergeDeps = (
+  existing: readonly string[] | undefined,
+  deps: IPyDepVersion[],
+): string[] => {
+  const incomingKeys = new Set(deps.map(depKey));
+  return [
+    ...(existing ?? []).filter((dep) => !incomingKeys.has(depKey(dep))),
+    ...withPyVersions(deps),
+  ];
+};
+
 /**
  * Add dependencies to a pyproject.toml file
  */
@@ -20,15 +43,10 @@ export const addDependenciesToPyProjectToml = (
   const projectToml = parse(
     tree.read(joinPathFragments(projectRoot, 'pyproject.toml'), 'utf8'),
   ) as UVPyprojectToml;
-  const newDeps = new Set<string>(deps);
-  projectToml.project.dependencies = [
-    // Replace any dependencies that already exist
-    ...(projectToml.project?.dependencies ?? []).filter((dep) => {
-      const parsedDep = parsePipRequirementsLine(dep);
-      return parsedDep.type !== 'ProjectName' || !newDeps.has(parsedDep.name);
-    }),
-    ...withPyVersions(deps),
-  ];
+  projectToml.project.dependencies = mergeDeps(
+    projectToml.project?.dependencies,
+    deps,
+  );
   tree.write(
     joinPathFragments(projectRoot, 'pyproject.toml'),
     stringify(projectToml),
@@ -44,17 +62,9 @@ export const addDependenciesToDependencyGroupInPyProjectToml = (
   const projectToml = parse(
     tree.read(joinPathFragments(projectRoot, 'pyproject.toml'), 'utf8'),
   ) as UVPyprojectToml;
-  const newDeps = new Set<string>(deps);
   projectToml['dependency-groups'] = {
     ...projectToml['dependency-groups'],
-    [group]: [
-      // Replace any dependencies that already exist
-      ...(projectToml['dependency-groups']?.[group] ?? []).filter((dep) => {
-        const parsedDep = parsePipRequirementsLine(dep);
-        return parsedDep.type !== 'ProjectName' || !newDeps.has(parsedDep.name);
-      }),
-      ...withPyVersions(deps),
-    ],
+    [group]: mergeDeps(projectToml['dependency-groups']?.[group], deps),
   };
   tree.write(
     joinPathFragments(projectRoot, 'pyproject.toml'),


### PR DESCRIPTION
### Reason for this change

Python Lambda functions generated with `py#lambda-function` failed at cold start with:

```
Runtime.ImportModuleError: Unable to import module '<project>.<fn>':
No module named 'aws_xray_sdk'
```

…whenever another Python generator was subsequently run on the same project (`py#mcp-server`, `py#strands-agent`, `py#fast-api`, or anything that routes through the shared `py-core-auth` connection helper). The resulting Lambda bundle was missing `aws_xray_sdk`, which `aws_lambda_powertools.Tracer` imports unconditionally.

`py#lambda-function` correctly declares `aws-lambda-powertools[tracer]` and `aws-lambda-powertools[parser]` in `pyproject.toml`, but a later generator adding bare `aws-lambda-powertools` silently dropped both extras entries from the list. `uv sync` then produced a bundle without `aws_xray_sdk`, so the handler couldn't import at runtime.

### Description of changes

- `packages/nx-plugin/src/utils/py.ts` — `addDependenciesToPyProjectToml` (and the dependency-group variant) now dedupe existing entries by **package name + sorted extras**, so `foo`, `foo[bar]`, and `foo[baz]` are treated as distinct keys. Adding bare `foo` no longer wipes `foo[bar]` / `foo[baz]`. Shared `mergeDeps` helper extracted for the two call sites.
- `packages/nx-plugin/src/py/lambda-function/generator.spec.ts` — integration test that runs `py#lambda-function` followed by `py#mcp-server` on the same project and asserts that the `[tracer]` and `[parser]` entries are still present in `pyproject.toml`. Asserts on the raw dependency strings (no hardcoded versions), so routine version bumps don't break it.
- `packages/nx-plugin/src/utils/py.spec.ts` — two extra unit cases covering the dedup rule: bare package doesn't wipe extras variant, and re-adding the same extras set replaces the old versioned entry.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test` — 1734/1734 tests pass. The new lambda-function integration test fails on `main` without the fix and passes with it (verified locally by reverting `py.ts`).
- End-to-end deploy to AWS `us-west-2`:
  1. Fresh `create-nx-workspace` with CDK preset.
  2. Generators run in order: `py#project` → `py#lambda-function` → `py#mcp-server` → `ts#infra`.
  3. **Before the fix:** `dist/packages/<proj>/bundle-x86/` had no `aws_xray_sdk`; deployed Lambda returned `Runtime.ImportModuleError: No module named 'aws_xray_sdk'`.
  4. **After the fix:** `aws_xray_sdk-2.15.0.dist-info/` is present in the bundle; CDK deploy succeeds; `aws lambda invoke` returns 200.
  5. `cdk destroy` — cleaned up.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
