### PR TITLE
test(e2e): assert Lambda invocation has no FunctionError

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -265,9 +265,19 @@ async function invokeLambda(arn: string, lambdaName: string) {
   console.log('Invoking lambda', lambdaName, 'with arn', arn);
   const res = await lambda.invoke({
     FunctionName: arn,
+    Payload: JSON.stringify({}),
   });
+  const payload = res.Payload
+    ? new TextDecoder().decode(res.Payload)
+    : undefined;
   console.log('Status code', res.StatusCode);
+  console.log('Function error', res.FunctionError);
+  console.log('Payload', payload);
+  // Lambda returns StatusCode 200 even when the handler throws — the handler
+  // failure surfaces via FunctionError. Assert both to catch runtime errors
+  // like missing-module ImportErrors that only manifest in a deployed Lambda.
   expect(res.StatusCode).toBe(200);
+  expect(res.FunctionError).toBeUndefined();
   console.log(`Successfully invoked ${lambdaName}`);
 }
 


### PR DESCRIPTION
### Reason for this change

The cdk-deploy smoke test already invoked both the Python and TypeScript lambda functions (`PyFunctionArn`, `TsFunctionArn`) after deploying, but `invokeLambda` only asserted `StatusCode === 200`. Lambda returns **200 even when the handler throws** — the handler failure surfaces via the `FunctionError` field on the invoke response.

That meant the bug fixed in #615 (Python handler `Runtime.ImportModuleError: No module named 'aws_xray_sdk'` at cold start after the shared `pyproject.toml` lost the `aws-lambda-powertools[tracer]`/`[parser]` extras) would not have been caught by this test — the deploy would succeed, the invoke would return 200, and the test would pass despite the handler never actually importing.

### Description of changes

- \`e2e/src/smoke-tests/cdk-deploy.spec.ts\` — \`invokeLambda\` now sends an empty JSON payload (both the generated py and ts handlers accept \`Any\`/\`any\`), logs \`FunctionError\` and the response payload, and asserts \`res.FunctionError\` is \`undefined\` in addition to \`StatusCode === 200\`. A short comment explains why both checks are required.

No generator/template changes — this is a targeted improvement to the smoke-test assertion so regressions like #615 that only manifest in a deployed Lambda are caught.

### Description of how you validated changes

- \`pnpm nx run @aws/nx-plugin-e2e:lint\` — clean (pre-existing warnings only).
- \`pnpm nx run @aws/nx-plugin-e2e:build\` — clean.
- Manual end-to-end validation: a full \`smoke test - cdk-deploy\` run is in progress against \`us-west-2\`; results will be posted as a comment on this PR.

### Issue # (if applicable)

N/A — follow-up hardening for the bug fixed in #615.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*