### PR TITLE
fix(ts#strands-agent,ts#mcp-server): dockerfile stripped by bundle cache restore

### DIFF
--- a/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
@@ -459,6 +459,9 @@ describe('ts#mcp-server generator', () => {
     expect(projectConfig.targets['mcp-server-docker'].dependsOn).toEqual([
       'bundle',
     ]);
+    expect(projectConfig.targets['mcp-server-docker'].outputs).toEqual([
+      '{workspaceRoot}/dist/apps/test-project/bundle/mcp/test-project-mcp-server/Dockerfile',
+    ]);
   });
 
   it('should generate MCP server with BedrockAgentCoreRuntime and custom name', async () => {

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -147,6 +147,7 @@ export const tsMcpServerGenerator = async (
     const fs = new FsCommands(tree);
     project.targets[dockerTargetName] = {
       cache: true,
+      outputs: [`{workspaceRoot}/${dockerOutputDir}/Dockerfile`],
       executor: 'nx:run-commands',
       options: {
         commands: [

--- a/packages/nx-plugin/src/ts/strands-agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/generator.spec.ts
@@ -307,6 +307,9 @@ describe('ts#strands-agent generator', () => {
     ]);
     expect(projectConfig.targets['agent-docker'].options.parallel).toBe(false);
     expect(projectConfig.targets['agent-docker'].dependsOn).toEqual(['bundle']);
+    expect(projectConfig.targets['agent-docker'].outputs).toEqual([
+      '{workspaceRoot}/dist/apps/test-project/bundle/agent/test-project-agent/Dockerfile',
+    ]);
   });
 
   it('should generate strands agent with BedrockAgentCoreRuntime and custom name', async () => {

--- a/packages/nx-plugin/src/ts/strands-agent/generator.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/generator.ts
@@ -135,6 +135,7 @@ export const tsStrandsAgentGenerator = async (
     const fs = new FsCommands(tree);
     project.targets[dockerTargetName] = {
       cache: true,
+      outputs: [`{workspaceRoot}/${dockerOutputDir}/Dockerfile`],
       executor: 'nx:run-commands',
       options: {
         commands: [


### PR DESCRIPTION
### Reason for this change

The `docker` target on the TypeScript strands-agent and mcp-server generators copied a `Dockerfile` into a directory owned by the separately-cached `bundle` target (`dist/<root>/bundle/{agent,mcp}/<name>/`). The `Dockerfile` wasn't in `docker`'s declared `outputs`, so a later `bundle` cache restore (for example during `cdk synth`) overwrote the shared directory and stripped the `Dockerfile` — subsequent `cdk synth`/`cdk deploy`/`terraform apply` then failed with `Cannot find file at …/Dockerfile` even though the `docker` target had apparently just run. Reproduces in any generated workspace with:

```bash
nx reset && nx run <project>:bundle      # writes only the bundled artefacts
nx run <project>:<name>-docker           # copies Dockerfile in
nx reset && nx run <project>:infra:synth # bundle cache-hits, wipes Dockerfile
```

### Description of changes

Added the Dockerfile path to the `docker` target's `outputs` for both the `ts#strands-agent` and `ts#mcp-server` generators. Nx now caches and restores the Dockerfile alongside the bundle, so subsequent `cdk synth`/`cdk deploy`/`terraform apply` can find it regardless of cache-hit ordering.

The Python variants (`py#strands-agent`, `py#mcp-server`) are not affected — their `docker` target stages into a disjoint `dist/<root>/docker/<name>/` directory that does not overlap with the bundle output.

### Description of how you validated changes

- Added unit-test assertions in both generator specs that confirm the `docker` target's `outputs` contains the Dockerfile path.
- All unit tests pass (`pnpm nx run @aws/nx-plugin:test`).
- Reproduced the original failure in a sandbox workspace (bundle cache-hit stripped the Dockerfile, `cdk synth` failed) and confirmed the fix makes it no longer reproducible.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
