### PR TITLE
fix(agentcore): guard Terraform authorizer_configuration dereference against null

### DIFF
--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -438,7 +438,7 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
   environment_variables = length(var.env) > 0 ? var.env : null
 
   dynamic "authorizer_configuration" {
-    for_each = var.authorizer_configuration != null && var.authorizer_configuration.custom_jwt_authorizer != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
     content {
       custom_jwt_authorizer {
         discovery_url    = authorizer_configuration.value.discovery_url

--- a/packages/nx-plugin/src/py/strands-agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/strands-agent/__snapshots__/generator.spec.ts.snap
@@ -565,7 +565,7 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
   environment_variables = length(var.env) > 0 ? var.env : null
 
   dynamic "authorizer_configuration" {
-    for_each = var.authorizer_configuration != null && var.authorizer_configuration.custom_jwt_authorizer != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
     content {
       custom_jwt_authorizer {
         discovery_url    = authorizer_configuration.value.discovery_url

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -438,7 +438,7 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
   environment_variables = length(var.env) > 0 ? var.env : null
 
   dynamic "authorizer_configuration" {
-    for_each = var.authorizer_configuration != null && var.authorizer_configuration.custom_jwt_authorizer != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
     content {
       custom_jwt_authorizer {
         discovery_url    = authorizer_configuration.value.discovery_url

--- a/packages/nx-plugin/src/ts/strands-agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/strands-agent/__snapshots__/generator.spec.ts.snap
@@ -566,7 +566,7 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
   environment_variables = length(var.env) > 0 ? var.env : null
 
   dynamic "authorizer_configuration" {
-    for_each = var.authorizer_configuration != null && var.authorizer_configuration.custom_jwt_authorizer != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
     content {
       custom_jwt_authorizer {
         discovery_url    = authorizer_configuration.value.discovery_url

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -309,7 +309,7 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
   environment_variables = length(var.env) > 0 ? var.env : null
 
   dynamic "authorizer_configuration" {
-    for_each = var.authorizer_configuration != null && var.authorizer_configuration.custom_jwt_authorizer != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
     content {
       custom_jwt_authorizer {
         discovery_url    = authorizer_configuration.value.discovery_url


### PR DESCRIPTION
### Reason for this change

The shared AgentCore Terraform module's `aws_bedrockagentcore_agent_runtime` resource reads `var.authorizer_configuration.custom_jwt_authorizer` inside the `for_each` of a `dynamic "authorizer_configuration"` block without short-circuiting around a null outer value. When the variable is null — the case for IAM-auth deployments of `ts#strands-agent`, `py#strands-agent`, `ts#mcp-server`, and `py#mcp-server` — the second clause of the `&&` is still evaluated, causing `terraform plan` to fail with:

```
Error: Attempt to get attribute from null value
  on .../core/agent-core/runtime.tf line 312, in resource "aws_bedrockagentcore_agent_runtime" "agent_runtime":
 312:     for_each = var.authorizer_configuration != null && var.authorizer_configuration.custom_jwt_authorizer != null ? ...
```

Reproducible by generating any strands-agent or mcp-server with `iacProvider=Terraform` + `auth=IAM` and running `terraform plan`.

### Description of changes

Wrapped the nested attribute read in `try(..., null)` so it is safe to evaluate when the outer value is null. IAM-only deployments now plan successfully; Cognito (JWT-authorizer) deployments continue to work unchanged because `try(...)` returns the value when it exists.

Regenerated the four snapshots in `ts#strands-agent`, `py#strands-agent`, `ts#mcp-server`, and `py#mcp-server` that capture the core Terraform template verbatim.

### Description of how you validated changes

- Reproduced the failure in a sandbox workspace (`iacProvider=Terraform`, `auth=IAM`, running `terraform plan`) — fails on main, succeeds on this branch.
- All 1738 unit tests pass (`pnpm nx run @aws/nx-plugin:test`), snapshots updated for the four generators that embed the core Terraform template.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*