### PR TITLE
docs: forward `-t` test-name filter to Vitest using `--` separator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,11 @@ The end to end tests run our generators and check that generated projects functi
 
 First ensure you have at least compiled the Nx Plugin (`pnpm nx compile nx-plugin`)
 
-You can run them using `pnpm nx test nx-plugin-e2e -t 'smoke test - xxx'` (replacing xxx with the test to run).
+You can run them using `pnpm nx test nx-plugin-e2e -- -t 'smoke test - xxx'` (replacing xxx with the test to run). The `--` separator forwards the `-t` flag to Vitest (Nx consumes a bare `-t` as its own `--target` option).
 
 Note that we have a test which runs through our main tutorial (the Dungeon Adventure Game). If you have updated generators which affect files which we show the contents of in the tutorial, you will need to update this test. You can update the "before" files automatically by running:
 
-`pnpm nx test nx-plugin-e2e -t 'dungeon-adventure' -u`
+`pnpm nx test nx-plugin-e2e -- -t 'dungeon-adventure' -u`
 
 However you will still need to make changes to any "after" files manually to ensure the tutorial works end to end. You can also use `pnpm nx start docs` to run the docs site locally and follow the tutorial yourself.
 

--- a/docs/src/content/docs/en/guides/typescript-project.mdx
+++ b/docs/src/content/docs/en/guides/typescript-project.mdx
@@ -258,9 +258,9 @@ Tests will run as part of the `build` target for your project, but you can also 
 
 <NxCommands commands={['test <project-name>']} />
 
-You can run an individual test or suite of tests using the `-t` flag:
+You can run an individual test or suite of tests using Vitest's `-t` flag. Pass it after a `--` separator so Nx forwards it to Vitest rather than consuming it as its own `--target` option:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[VSCode Integration]
 If you are a VSCode user, we recommend installing the [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) extension, which allows you to run, watch or debug tests from your IDE.

--- a/docs/src/content/docs/es/guides/typescript-project.mdx
+++ b/docs/src/content/docs/es/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ Las pruebas se ejecutarán como parte del objetivo `build` de tu proyecto, pero 
 
 <NxCommands commands={['test <project-name>']} />
 
-Puedes ejecutar una prueba individual o un conjunto de pruebas usando el flag `-t`:
+Puedes ejecutar una prueba individual o un conjunto de pruebas usando el flag `-t` de Vitest. Pásalo después de un separador `--` para que Nx lo reenvíe a Vitest en lugar de consumirlo como su propia opción `--target`:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[Integración con VSCode]
 Si usas VSCode, recomendamos instalar la extensión [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), que permite ejecutar, monitorizar o depurar pruebas directamente desde tu IDE.

--- a/docs/src/content/docs/fr/guides/typescript-project.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ Les tests s'exécuteront dans le cadre de la cible `build` de votre projet, mais
 
 <NxCommands commands={['test <project-name>']} />
 
-Vous pouvez exécuter un test individuel ou une suite de tests avec le flag `-t` :
+Vous pouvez exécuter un test individuel ou une suite de tests en utilisant le flag `-t` de Vitest. Passez-le après un séparateur `--` pour que Nx le transmette à Vitest plutôt que de le consommer comme sa propre option `--target` :
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[Intégration VSCode]
 Si vous utilisez VSCode, nous recommandons d'installer l'extension [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), qui permet d'exécuter, surveiller ou déboguer les tests depuis votre IDE.

--- a/docs/src/content/docs/it/guides/typescript-project.mdx
+++ b/docs/src/content/docs/it/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ I test verranno eseguiti come parte del target `build` del progetto, ma puoi anc
 
 <NxCommands commands={['test <project-name>']} />
 
-Puoi eseguire un singolo test o una suite di test usando il flag `-t`:
+Puoi eseguire un singolo test o una suite di test usando il flag `-t` di Vitest. Passalo dopo un separatore `--` in modo che Nx lo inoltri a Vitest invece di interpretarlo come la propria opzione `--target`:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[Integrazione VSCode]
 Se utilizzi VSCode, ti consigliamo di installare l'estensione [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), che permette di eseguire, monitorare o debuggare i test direttamente dall'IDE.

--- a/docs/src/content/docs/jp/guides/typescript-project.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ describe('sayHello', () => {
 
 <NxCommands commands={['test <project-name>']} />
 
-`-t`フラグを使用して特定のテストを実行できます:
+Vitestの`-t`フラグを使用して特定のテストまたはテストスイートを実行できます。`--`セパレータの後に渡すことで、Nxが独自の`--target`オプションとして解釈するのではなく、Vitestに転送されます:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[VSCode連携]
 VSCodeユーザーには、[実際に動作するVitest Runner for VSCode](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)拡張機能のインストールをお勧めします。IDEからテストの実行、監視、デバッグが可能になります。

--- a/docs/src/content/docs/ko/guides/typescript-project.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ describe('sayHello', () => {
 
 <NxCommands commands={['test <project-name>']} />
 
-`-t` 플래그를 사용하여 개별 테스트 또는 테스트 스위트를 실행할 수 있습니다:
+Vitest의 `-t` 플래그를 사용하여 개별 테스트 또는 테스트 스위트를 실행할 수 있습니다. Nx가 자체 `--target` 옵션으로 소비하지 않고 Vitest로 전달하도록 `--` 구분자 뒤에 전달하세요:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[VSCode 연동]
 VSCode 사용자는 [실제로 동작하는 Vitest Runner for VSCode](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) 확장을 설치하는 것을 추천합니다. 이 확장을 통해 IDE에서 테스트를 실행, 감시 또는 디버깅할 수 있습니다.

--- a/docs/src/content/docs/pt/guides/typescript-project.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-project.mdx
@@ -258,9 +258,9 @@ Testes serão executados como parte do target `build` do seu projeto, mas você 
 
 <NxCommands commands={['test <project-name>']} />
 
-Você pode executar um teste individual ou suite de testes usando a flag `-t`:
+Você pode executar um teste individual ou suite de testes usando a flag `-t` do Vitest. Passe-a após um separador `--` para que o Nx a encaminhe ao Vitest ao invés de consumi-la como sua própria opção `--target`:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[Integração VSCode]
 Se você usa VSCode, recomendamos instalar a extensão [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), que permite executar, monitorar ou debugar testes diretamente da IDE.

--- a/docs/src/content/docs/vi/guides/typescript-project.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ Tests sẽ chạy như một phần của `build` target cho dự án của bạ
 
 <NxCommands commands={['test <project-name>']} />
 
-Bạn có thể chạy một test riêng lẻ hoặc một suite tests bằng cách sử dụng flag `-t`:
+Bạn có thể chạy một test riêng lẻ hoặc một suite tests bằng cách sử dụng flag `-t` của Vitest. Truyền nó sau dấu phân cách `--` để Nx chuyển tiếp nó cho Vitest thay vì sử dụng nó như tùy chọn `--target` của chính nó:
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[Tích hợp VSCode]
 Nếu bạn là người dùng VSCode, chúng tôi khuyên bạn nên cài đặt extension [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), cho phép bạn chạy, watch hoặc debug tests từ IDE của mình.

--- a/docs/src/content/docs/zh/guides/typescript-project.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-project.mdx
@@ -259,9 +259,9 @@ describe('sayHello', () => {
 
 <NxCommands commands={['test <project-name>']} />
 
-可使用`-t`标志运行单个测试或测试套件：
+可使用Vitest的`-t`标志运行单个测试或测试套件。在`--`分隔符之后传递该标志，以便Nx将其转发给Vitest，而不是将其作为自己的`--target`选项使用：
 
-<NxCommands commands={["test <project-name> -t 'sayHello'"]} />
+<NxCommands commands={["test <project-name> -- -t 'sayHello'"]} />
 
 :::tip[VSCode集成]
 VSCode用户建议安装[真正可用的Vitest Runner扩展](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)，支持直接从IDE运行、监视或调试测试。


### PR DESCRIPTION
### Reason for this change

nx 22.7.0 added `-t` / `--target` as a reserved option on `nx run` (via `withRunOneOptions`). It is consumed by Nx for both `nx run <project>:<target>` and the infix `nx <target> <project>` form (so `nx test <project> -t '...'` is also affected). This silently prevents the flag from reaching the underlying executor (e.g. Vitest), so documentation that told readers to run `nx test <project-name> -t 'sayHello'` no longer filters tests as advertised.

The same issue was already fixed for CI in #618 by moving `-t` behind a `--` separator on the e2e smoke-test command. This PR brings the documentation and contributor guide in line with that fix.

### Description of changes

- `docs/src/content/docs/en/guides/typescript-project.mdx`: show the `-t` filter example as `test <project-name> -- -t 'sayHello'` and explain why the `--` separator is needed.
- `CONTRIBUTING.md`: update both e2e test examples (`smoke test - xxx` and `dungeon-adventure -u`) to pass `-t` after `--`, with a short note about why.

Only English docs were modified — translated docs are regenerated from English.

### Description of how you validated changes

Verified against nx 22.7.0 locally in this repo:

- Without `--`:
  ```
  $ pnpm nx test @aws/nx-plugin-e2e -t 'smoke test - xxx' --dry-run
  > nx run @aws/nx-plugin-e2e:test --dry-run    # -t is silently consumed by nx
  > vitest --dry-run                              # no test-name filter reaches vitest
  ```
- With `--`:
  ```
  $ pnpm nx test @aws/nx-plugin-e2e -- -t 'smoke test - xxx' --dry-run
  > nx run @aws/nx-plugin-e2e:test -t smoke test - xxx --dry-run
  > vitest -t \"smoke test - xxx\" --dry-run       # forwarded correctly
  ```

Also confirmed that the `-k` pytest filter in `guides/python-project.mdx` is **not** affected (no Nx-reserved short alias collides with `-k`), so no change is needed there.

### Issue # (if applicable)

n/a — follow-up to #618.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*