### PR TITLE
feat(nx-plugin-mcp): support creating workspace in current directory

### DIFF
--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -69,7 +69,6 @@ describe('MCP Server', () => {
     const result = await client.callTool({
       name: 'create-workspace-command',
       arguments: {
-        workspaceName: 'test-workspace',
         packageManager: 'pnpm',
       },
     });

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import { PackageManagerSchema } from '../schema';
 import { IAC_PROVIDERS } from '../../utils/iac-providers';
 import { buildCreateNxWorkspaceCommand } from '../../utils/commands';
@@ -18,21 +17,26 @@ export const addCreateWorkspaceCommandTool = (server: McpServer) => {
       description:
         'Tool to discover how to create a workspace to start a new project.',
       inputSchema: {
-        workspaceName: z.string(),
         packageManager: PackageManagerSchema,
       },
     },
-    ({ workspaceName, packageManager }) => ({
+    ({ packageManager }) => ({
       content: [
         {
           type: 'text' as const,
           text: `Run the following command to create a workspace:
 
 \`\`\`bash
-${buildCreateNxWorkspaceCommand(packageManager, workspaceName)} --no-interactive
+${buildCreateNxWorkspaceCommand(packageManager, '<workspace-name>')} --no-interactive
 \`\`\`
 
-This will create a new workspace within the ${workspaceName} directory.
+This will create a new workspace within the \`<workspace-name>\` directory.
+
+If you are already inside an empty directory intended for this project, you can pass \`.\` as the workspace name to create the workspace in the current directory:
+
+\`\`\`bash
+${buildCreateNxWorkspaceCommand(packageManager, '.')} --no-interactive
+\`\`\`
 
 Note that this will prompt for an Infrastructure as Code provider (${IAC_PROVIDERS.join(', ')}).
 If you know the preferred option, pass ${IAC_PROVIDERS.map((iac) => `\`--iacProvider=${iac}\``).join(' or ')} to the above command to skip the prompt.

--- a/powers/nx-plugin-for-aws/POWER.md
+++ b/powers/nx-plugin-for-aws/POWER.md
@@ -43,8 +43,8 @@ Key capabilities:
 To create a new workspace and scaffold a React website with a tRPC API:
 
 ```bash
-# Create workspace
-npx -y create-nx-workspace@latest my-app --pm pnpm --preset @aws/nx-plugin --ci=skip
+# Create workspace (pass `.` as the name to create in the current empty directory)
+pnpm create @aws/nx-workspace my-app --no-interactive
 
 # Generate a tRPC API
 pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-api
@@ -68,7 +68,13 @@ Always prompt the user for what name they want to use when executing generators 
 Use the `create_workspace_command` tool with your preferred package manager. This generates the full command to create an Nx workspace pre-configured with the AWS plugin.
 
 ```bash
-npx -y create-nx-workspace@latest my-app --pm pnpm --preset @aws/nx-plugin --ci=skip
+pnpm create @aws/nx-workspace my-app --no-interactive
+```
+
+If you are already inside an empty directory intended for this project, pass `.` as the workspace name to create the workspace in the current directory:
+
+```bash
+pnpm create @aws/nx-workspace . --no-interactive
 ```
 
 Be sure to ask the user what their preferred project name is.

--- a/powers/nx-plugin-for-aws/POWER.md
+++ b/powers/nx-plugin-for-aws/POWER.md
@@ -77,7 +77,7 @@ If you are already inside an empty directory intended for this project, pass `.`
 pnpm create @aws/nx-workspace . --no-interactive
 ```
 
-Be sure to ask the user what their preferred project name is.
+Be sure to ask the user what their preferred project name is, unless already within an empty directory intended for the project.
 
 ### Workflow 2: Discover Available Generators
 


### PR DESCRIPTION
### Reason for this change

When starting a new project, users are often already inside an empty directory they want to use as the workspace root. `create-nx-workspace` supports passing `.` as the project name to create the workspace in the current directory, but the MCP server's `create-workspace-command` tool didn't surface this option.

### Description of changes

- Update the MCP `create-workspace-command` tool to document passing `.` as the workspace name for creating the workspace in the current (empty) directory.
- Remove the `workspaceName` input parameter from the tool's schema — it now renders a `<workspace-name>` placeholder in the generated command for the non-current-dir case, leaving the actual name to the caller.
- Update `powers/nx-plugin-for-aws/POWER.md` to use the `pnpm create @aws/nx-workspace` form and document the `.` shorthand.

### Description of how you validated changes

- Updated the existing unit test in `server.spec.ts` to drop the removed `workspaceName` argument.
- Ran `pnpm nx run @aws/nx-plugin:test -u` — all 1739 tests pass.
- Ran `pnpm nx run @aws/nx-plugin:build` — build succeeds.
- Ran `pnpm nx run @aws/nx-plugin:lint --fix` — no errors.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*