### PR TITLE
feat(ts#trpc-api): add serve-local nx target

### DIFF
--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -199,6 +199,16 @@ describe('trpc backend generator', () => {
     expect(projectConfig.targets!.serve!.options!.commands).toEqual([
       'tsx --watch src/local-server.ts',
     ]);
+    expect(projectConfig.targets).toHaveProperty('serve-local');
+    expect(projectConfig.targets!['serve-local']!.executor).toBe(
+      'nx:run-commands',
+    );
+    expect(projectConfig.targets!['serve-local']!.options!.commands).toEqual([
+      'tsx --watch src/local-server.ts',
+    ]);
+    expect(projectConfig.targets!['serve-local']!.options!.env).toEqual({
+      SERVE_LOCAL: 'true',
+    });
   });
 
   it('should add rolldown bundle target', async () => {

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -122,6 +122,16 @@ export async function tsTrpcApiGenerator(
     continuous: true,
   };
 
+  projectConfig.targets['serve-local'] = {
+    ...projectConfig.targets.serve,
+    options: {
+      ...projectConfig.targets.serve.options,
+      env: {
+        SERVE_LOCAL: 'true',
+      },
+    },
+  };
+
   await addTypeScriptBundleTarget(tree, projectConfig, {
     targetFilePath: 'src/handler.ts',
     external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk


### PR DESCRIPTION
### Reason for this change

Adding a serve-local target to the tRPC API to align with other packages in the workspace that already expose this target, with SERVE_LOCAL=true set in the environment.

### Description of changes

Add a serve-local target for trpc-api that mirrors serve, but also sets SERVE_LOCAL to 'true'.

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*