### PR TITLE
feat(py#fastapi): add serve-local nx target

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -101,6 +101,16 @@ describe('fastapi project generator', () => {
     expect(projectConfig.targets.serve.options.command).toBe(
       'uv run fastapi dev proj_test_api/main.py --port 8000',
     );
+    expect(projectConfig.targets['serve-local']).toBeDefined();
+    expect(projectConfig.targets['serve-local'].executor).toBe(
+      '@nxlv/python:run-commands',
+    );
+    expect(projectConfig.targets['serve-local'].options.command).toBe(
+      'uv run fastapi dev proj_test_api/main.py --port 8000',
+    );
+    expect(projectConfig.targets['serve-local'].options.env).toEqual({
+      SERVE_LOCAL: 'true',
+    });
 
     // Verify build dependencies
     expect(projectConfig.targets.build.dependsOn).toContain('bundle');

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -101,6 +101,16 @@ export const pyFastApiProjectGenerator = async (
     continuous: true,
   };
 
+  projectConfig.targets['serve-local'] = {
+    ...projectConfig.targets.serve,
+    options: {
+      ...projectConfig.targets.serve.options,
+      env: {
+        SERVE_LOCAL: 'true',
+      },
+    },
+  };
+
   projectConfig.metadata = {
     ...projectConfig.metadata,
     apiName: schema.name,


### PR DESCRIPTION
### Reason for this change

Adding a serve-local target to the FastAPI to align with other packages in the workspace that already expose this target, with SERVE_LOCAL=true set in the environment.


### Description of changes

Add a serve-local target for FastAPI that mirrors serve, but also sets SERVE_LOCAL to 'true'.

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*