### PR TITLE
feat(ts#smithy-api): add serve-local nx target

### DIFF
--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1299,6 +1299,18 @@ exports[`tsSmithyApiGenerator > should generate smithy ts api with default optio
       },
       "continuous": true,
       "dependsOn": ["copy-ssdk", "watch-copy-ssdk"]
+    },
+    "serve-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsx --watch src/local-server.ts",
+        "cwd": "{projectRoot}",
+        "env": {
+          "SERVE_LOCAL": "true"
+        }
+      },
+      "continuous": true,
+      "dependsOn": ["copy-ssdk", "watch-copy-ssdk"]
     }
   }
 }

--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -346,6 +346,15 @@ describe('tsSmithyApiGenerator', () => {
       'tsx --watch src/local-server.ts',
     );
     expect(serveTarget.options.cwd).toBe('{projectRoot}');
+
+    const serveLocalTarget = backendProjectConfig.targets['serve-local'];
+    expect(serveLocalTarget.executor).toBe('nx:run-commands');
+    expect(serveLocalTarget.continuous).toBe(true);
+    expect(serveLocalTarget.options.command).toContain(
+      'tsx --watch src/local-server.ts',
+    );
+    expect(serveLocalTarget.options.cwd).toBe('{projectRoot}');
+    expect(serveLocalTarget.options.env).toEqual({ SERVE_LOCAL: 'true' });
   });
 
   it('should add dependencies to package.json', async () => {

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -202,6 +202,16 @@ export const tsSmithyApiGenerator = async (
     dependsOn: ['copy-ssdk', 'watch-copy-ssdk'],
   };
 
+  backendProjectConfig.targets['serve-local'] = {
+    ...backendProjectConfig.targets.serve,
+    options: {
+      ...backendProjectConfig.targets.serve.options,
+      env: {
+        SERVE_LOCAL: 'true',
+      },
+    },
+  };
+
   // Ignore generated code
   updateGitIgnore(tree, backendProjectConfig.root, (patterns) => [
     ...patterns,


### PR DESCRIPTION
### Reason for this change

Adding a serve-local target to ts#smith-api to align with other packages in the workspace that already expose this target, with SERVE_LOCAL=true set in the environment.

### Description of changes

Add a serve-local target for ts#smithy-api that mirrors serve, but also sets SERVE_LOCAL to 'true'.

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*