### PR TITLE
feat(connection): make website serve-local depend on trpc/fastapi/smithyapi serve-local targets

### DIFF
--- a/packages/nx-plugin/src/connection/serve-local.spec.ts
+++ b/packages/nx-plugin/src/connection/serve-local.spec.ts
@@ -36,7 +36,7 @@ describe('serve-local', () => {
         }),
       );
 
-      // Setup target project with continuous serve target
+      // Setup target project with continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -44,7 +44,7 @@ describe('serve-local', () => {
           root: 'apps/backend',
           sourceRoot: 'apps/backend/src',
           targets: {
-            serve: {
+            'serve-local': {
               executor: '@nx/node:execute',
               continuous: true,
               options: {},
@@ -62,7 +62,7 @@ describe('serve-local', () => {
       expect(updatedProject.targets['serve-local'].dependsOn).toEqual([
         {
           projects: ['backend'],
-          target: 'serve',
+          target: 'serve-local',
         },
       ]);
     });
@@ -90,7 +90,7 @@ describe('serve-local', () => {
         }),
       );
 
-      // Setup target project with continuous serve target
+      // Setup target project with continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -98,7 +98,7 @@ describe('serve-local', () => {
           root: 'apps/backend',
           sourceRoot: 'apps/backend/src',
           targets: {
-            serve: {
+            'serve-local': {
               executor: '@nx/node:execute',
               continuous: true,
               options: {},
@@ -120,12 +120,12 @@ describe('serve-local', () => {
         },
         {
           projects: ['backend'],
-          target: 'serve',
+          target: 'serve-local',
         },
       ]);
     });
 
-    it('should not modify project when target project lacks continuous serve target', async () => {
+    it('should not modify project when target project lacks continuous serve-local target', async () => {
       // Setup source project with serve-local target
       tree.write(
         'apps/frontend/project.json',
@@ -142,7 +142,7 @@ describe('serve-local', () => {
         }),
       );
 
-      // Setup target project with non-continuous serve target
+      // Setup target project with non-continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -167,7 +167,7 @@ describe('serve-local', () => {
       expect(updatedProject).toBe(originalProject);
     });
 
-    it('should not modify project when target project has no serve target', async () => {
+    it('should not modify project when target project has no serve-local target', async () => {
       // Setup source project with serve-local target
       tree.write(
         'apps/frontend/project.json',
@@ -184,7 +184,7 @@ describe('serve-local', () => {
         }),
       );
 
-      // Setup target project without serve target
+      // Setup target project without serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -225,7 +225,7 @@ describe('serve-local', () => {
         }),
       );
 
-      // Setup target project with continuous serve target
+      // Setup target project with continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -233,7 +233,7 @@ describe('serve-local', () => {
           root: 'apps/backend',
           sourceRoot: 'apps/backend/src',
           targets: {
-            serve: {
+            'serve-local': {
               executor: '@nx/node:execute',
               continuous: true,
               options: {},
@@ -267,7 +267,7 @@ describe('serve-local', () => {
         }),
       );
 
-      // Setup target project with continuous serve target
+      // Setup target project with continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -275,7 +275,7 @@ describe('serve-local', () => {
           root: 'apps/backend',
           sourceRoot: 'apps/backend/src',
           targets: {
-            serve: {
+            'serve-local': {
               executor: '@nx/node:execute',
               continuous: true,
               options: {},
@@ -327,7 +327,7 @@ const applyOverrides = (runtimeConfig: IRuntimeConfig) => {
         }),
       );
 
-      // Setup target project with continuous serve target
+      // Setup target project with continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -335,7 +335,7 @@ const applyOverrides = (runtimeConfig: IRuntimeConfig) => {
           root: 'apps/backend',
           sourceRoot: 'apps/backend/src',
           targets: {
-            serve: {
+            'serve-local': {
               executor: '@nx/node:execute',
               continuous: true,
               options: {},
@@ -366,7 +366,7 @@ const applyOverrides = (runtimeConfig: IRuntimeConfig) => {
         }),
       );
 
-      // Setup target project with continuous serve target
+      // Setup target project with continuous serve-local target
       tree.write(
         'apps/backend/project.json',
         JSON.stringify({
@@ -374,7 +374,7 @@ const applyOverrides = (runtimeConfig: IRuntimeConfig) => {
           root: 'apps/backend',
           sourceRoot: 'apps/backend/src',
           targets: {
-            serve: {
+            'serve-local': {
               executor: '@nx/node:execute',
               continuous: true,
               options: {},

--- a/packages/nx-plugin/src/connection/serve-local.ts
+++ b/packages/nx-plugin/src/connection/serve-local.ts
@@ -36,22 +36,22 @@ export const addTargetToServeLocal = async (
     targetProjectName,
   );
 
-  // Target project must have a serve target which is continuous
+  // Target project must have a serve-local target which is continuous
   if (
     !(
-      targetProject.targets?.serve?.continuous &&
+      targetProject.targets?.['serve-local']?.continuous &&
       sourceProject.targets?.['serve-local']
     )
   ) {
     return;
   }
 
-  // Add a dependency on the serve target
+  // Add a dependency on the serve-local target
   sourceProject.targets['serve-local'].dependsOn = [
     ...(sourceProject.targets['serve-local'].dependsOn ?? []),
     {
       projects: [targetProject.name],
-      target: 'serve',
+      target: 'serve-local',
     },
     ...(options.additionalDependencyTargets ?? []),
   ];

--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -491,10 +491,10 @@ describe(
         tree.read('frontend/project.json', 'utf-8'),
       );
 
-      // Verify that serve-local target now depends on backend serve target
+      // Verify that serve-local target now depends on backend serve-local target
       expect(frontendProject.targets['serve-local'].dependsOn).toContainEqual({
         projects: ['proj.test_api'],
-        target: 'serve',
+        target: 'serve-local',
       });
       // Should also depend on the generate target (for initial generation)
       expect(frontendProject.targets['serve-local'].dependsOn).toContain(

--- a/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
@@ -1002,10 +1002,10 @@ export function Main() {
         tree.read('frontend/project.json', 'utf-8'),
       );
 
-      // Verify that serve-local target now depends on backend serve target
+      // Verify that serve-local target now depends on backend serve-local target
       expect(frontendProject.targets['serve-local'].dependsOn).toContainEqual({
         projects: ['@proj/test-api'],
-        target: 'serve',
+        target: 'serve-local',
       });
       // Should also depend on the generate target (for initial generation)
       expect(frontendProject.targets['serve-local'].dependsOn).toContain(

--- a/packages/nx-plugin/src/trpc/react/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.spec.ts
@@ -428,10 +428,10 @@ describe('trpc react generator with real react and trpc projects', () => {
       tree.read('frontend/project.json', 'utf-8'),
     );
 
-    // Verify that serve-local target now depends on backend serve target
+    // Verify that serve-local target now depends on backend serve-local target
     expect(frontendProject.targets['serve-local'].dependsOn).toContainEqual({
       projects: ['@proj/test-api'],
-      target: 'serve',
+      target: 'serve-local',
     });
 
     // Verify that the runtime config was created and modified


### PR DESCRIPTION
### Reason for this change

Make website `serve-local` depend on trpc/fastapi/smithapi `serve-local` targets

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*