### PR TITLE
fix(ts#react-website#auth): retain sms role alongside user pool

### DIFF
--- a/docs/src/content/docs/en/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/react-website-auth.mdx
@@ -89,6 +89,10 @@ export class ApplicationStack extends Stack {
 ```
 
 The `UserIdentity` construct automatically adds the necessary <Link path="guides/react-website#runtime-configuration">Runtime Configuration</Link> to ensure that your website can point to the correct Cognito User Pool for authentication.
+
+:::note[SMS role retention]
+`UserIdentity` creates a dedicated IAM role that Cognito assumes to send SMS messages. The role's removal policy mirrors the User Pool's — by default CDK's `UserPool` uses `RemovalPolicy.RETAIN`, so on `cdk destroy` both the User Pool and its SMS role are retained and will need to be cleaned up manually if no longer needed.
+:::
 </Fragment>
 <Fragment slot="terraform">
 You will need to add the user identity module, and ensure your website depends on it:

--- a/docs/src/content/docs/en/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/react-website-auth.mdx
@@ -91,7 +91,7 @@ export class ApplicationStack extends Stack {
 The `UserIdentity` construct automatically adds the necessary <Link path="guides/react-website#runtime-configuration">Runtime Configuration</Link> to ensure that your website can point to the correct Cognito User Pool for authentication.
 
 :::note[SMS role retention]
-`UserIdentity` creates a dedicated IAM role that Cognito assumes to send SMS messages. The role's removal policy mirrors the User Pool's — by default CDK's `UserPool` uses `RemovalPolicy.RETAIN`, so on `cdk destroy` both the User Pool and its SMS role are retained and will need to be cleaned up manually if no longer needed.
+The User Pool is backed by an IAM role that Cognito assumes to send SMS messages. The role's removal policy mirrors the User Pool's — by default CDK's `UserPool` uses `RemovalPolicy.RETAIN`, so on `cdk destroy` both the User Pool and its SMS role are retained and will need to be cleaned up manually if no longer needed.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 El constructo `UserIdentity` agrega automáticamente la <Link path="guides/react-website#runtime-configuration">Configuración en tiempo de ejecución</Link> necesaria para que tu sitio web pueda apuntar al Cognito User Pool correcto para autenticación.
+
+:::note[Retención del rol de SMS]
+`UserIdentity` crea un rol IAM dedicado que Cognito asume para enviar mensajes SMS. La política de eliminación del rol refleja la del User Pool — por defecto el `UserPool` de CDK usa `RemovalPolicy.RETAIN`, por lo que al ejecutar `cdk destroy` tanto el User Pool como su rol de SMS se retienen y deberán limpiarse manualmente si ya no son necesarios.
+:::
 </Fragment>
 <Fragment slot="terraform">
 Necesitarás agregar el módulo de identidad de usuario y asegurarte que tu sitio web dependa de él:

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 El constructo `UserIdentity` agrega automáticamente la <Link path="guides/react-website#runtime-configuration">Configuración en tiempo de ejecución</Link> necesaria para que tu sitio web pueda apuntar al Cognito User Pool correcto para autenticación.
 
 :::note[Retención del rol de SMS]
-`UserIdentity` crea un rol IAM dedicado que Cognito asume para enviar mensajes SMS. La política de eliminación del rol refleja la del User Pool — por defecto el `UserPool` de CDK usa `RemovalPolicy.RETAIN`, por lo que al ejecutar `cdk destroy` tanto el User Pool como su rol de SMS se retienen y deberán limpiarse manualmente si ya no son necesarios.
+El User Pool está respaldado por un rol IAM que Cognito asume para enviar mensajes SMS. La política de eliminación del rol refleja la del User Pool — por defecto el `UserPool` de CDK usa `RemovalPolicy.RETAIN`, por lo que al ejecutar `cdk destroy` tanto el User Pool como su rol de SMS se retienen y deberán limpiarse manualmente si ya no son necesarios.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 Le construct `UserIdentity` ajoute automatiquement la <Link path="guides/react-website#runtime-configuration">Configuration d'exécution</Link> nécessaire pour que votre site web puisse pointer vers le bon Cognito User Pool pour l'authentification.
 
 :::note[Rétention du rôle SMS]
-`UserIdentity` crée un rôle IAM dédié que Cognito assume pour envoyer des messages SMS. La politique de suppression du rôle reflète celle du User Pool — par défaut, le `UserPool` de CDK utilise `RemovalPolicy.RETAIN`, donc lors d'un `cdk destroy`, le User Pool et son rôle SMS sont tous deux conservés et devront être nettoyés manuellement s'ils ne sont plus nécessaires.
+Le User Pool est soutenu par un rôle IAM que Cognito assume pour envoyer des messages SMS. La politique de suppression du rôle reflète celle du User Pool — par défaut, le `UserPool` de CDK utilise `RemovalPolicy.RETAIN`, donc lors d'un `cdk destroy`, le User Pool et son rôle SMS sont tous deux conservés et devront être nettoyés manuellement s'ils ne sont plus nécessaires.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 Le construct `UserIdentity` ajoute automatiquement la <Link path="guides/react-website#runtime-configuration">Configuration d'exécution</Link> nécessaire pour que votre site web puisse pointer vers le bon Cognito User Pool pour l'authentification.
+
+:::note[Rétention du rôle SMS]
+`UserIdentity` crée un rôle IAM dédié que Cognito assume pour envoyer des messages SMS. La politique de suppression du rôle reflète celle du User Pool — par défaut, le `UserPool` de CDK utilise `RemovalPolicy.RETAIN`, donc lors d'un `cdk destroy`, le User Pool et son rôle SMS sont tous deux conservés et devront être nettoyés manuellement s'ils ne sont plus nécessaires.
+:::
 </Fragment>
 <Fragment slot="terraform">
 Vous devrez ajouter le module d'identité utilisateur et vous assurer que votre site web en dépend :

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 Il construct `UserIdentity` aggiunge automaticamente la necessaria <Link path="guides/react-website#runtime-configuration">Configurazione Runtime</Link> per garantire che il tuo sito possa puntare al corretto Cognito User Pool per l'autenticazione.
 
 :::note[Conservazione del ruolo SMS]
-`UserIdentity` crea un ruolo IAM dedicato che Cognito assume per inviare messaggi SMS. La policy di rimozione del ruolo rispecchia quella del User Pool — per impostazione predefinita il `UserPool` di CDK utilizza `RemovalPolicy.RETAIN`, quindi con `cdk destroy` sia il User Pool che il suo ruolo SMS vengono conservati e dovranno essere eliminati manualmente se non più necessari.
+Il User Pool è supportato da un ruolo IAM che Cognito assume per inviare messaggi SMS. La policy di rimozione del ruolo rispecchia quella del User Pool — per impostazione predefinita il `UserPool` di CDK utilizza `RemovalPolicy.RETAIN`, quindi con `cdk destroy` sia il User Pool che il suo ruolo SMS vengono conservati e dovranno essere eliminati manualmente se non più necessari.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 Il construct `UserIdentity` aggiunge automaticamente la necessaria <Link path="guides/react-website#runtime-configuration">Configurazione Runtime</Link> per garantire che il tuo sito possa puntare al corretto Cognito User Pool per l'autenticazione.
+
+:::note[Conservazione del ruolo SMS]
+`UserIdentity` crea un ruolo IAM dedicato che Cognito assume per inviare messaggi SMS. La policy di rimozione del ruolo rispecchia quella del User Pool — per impostazione predefinita il `UserPool` di CDK utilizza `RemovalPolicy.RETAIN`, quindi con `cdk destroy` sia il User Pool che il suo ruolo SMS vengono conservati e dovranno essere eliminati manualmente se non più necessari.
+:::
 </Fragment>
 <Fragment slot="terraform">
 Dovrai aggiungere il modulo per l'identità utente e assicurarti che il tuo sito web dipenda da esso:

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 `UserIdentity` コンストラクトは、ウェブサイトが正しい Cognito ユーザープールを指すようにするための<Link path="guides/react-website#runtime-configuration">ランタイム設定</Link>を自動的に追加します。
 
 :::note[SMS ロールの保持]
-`UserIdentity` は、Cognito が SMS メッセージを送信するために引き受ける専用の IAM ロールを作成します。このロールの削除ポリシーはユーザープールのものと同じです — デフォルトでは CDK の `UserPool` は `RemovalPolicy.RETAIN` を使用するため、`cdk destroy` を実行すると、ユーザープールとその SMS ロールの両方が保持され、不要になった場合は手動でクリーンアップする必要があります。
+ユーザープールは、Cognito が SMS メッセージを送信するために引き受ける IAM ロールによって支えられています。このロールの削除ポリシーはユーザープールのものと同じです — デフォルトでは CDK の `UserPool` は `RemovalPolicy.RETAIN` を使用するため、`cdk destroy` を実行すると、ユーザープールとその SMS ロールの両方が保持され、不要になった場合は手動でクリーンアップする必要があります。
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 `UserIdentity` コンストラクトは、ウェブサイトが正しい Cognito ユーザープールを指すようにするための<Link path="guides/react-website#runtime-configuration">ランタイム設定</Link>を自動的に追加します。
+
+:::note[SMS ロールの保持]
+`UserIdentity` は、Cognito が SMS メッセージを送信するために引き受ける専用の IAM ロールを作成します。このロールの削除ポリシーはユーザープールのものと同じです — デフォルトでは CDK の `UserPool` は `RemovalPolicy.RETAIN` を使用するため、`cdk destroy` を実行すると、ユーザープールとその SMS ロールの両方が保持され、不要になった場合は手動でクリーンアップする必要があります。
+:::
 </Fragment>
 <Fragment slot="terraform">
 ユーザーアイデンティティモジュールを追加し、ウェブサイトがそれに依存するように設定します:

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 `UserIdentity` Construct는 웹사이트가 올바른 Cognito 사용자 풀을 가리킬 수 있도록 필요한 <Link path="guides/react-website#runtime-configuration">런타임 구성</Link>을 자동으로 추가합니다.
+
+:::note[SMS 역할 보존]
+`UserIdentity`는 Cognito가 SMS 메시지를 전송하기 위해 맡는 전용 IAM 역할을 생성합니다. 이 역할의 제거 정책은 사용자 풀의 정책을 따릅니다 — 기본적으로 CDK의 `UserPool`은 `RemovalPolicy.RETAIN`을 사용하므로, `cdk destroy` 실행 시 사용자 풀과 SMS 역할이 모두 보존되며 더 이상 필요하지 않은 경우 수동으로 정리해야 합니다.
+:::
 </Fragment>
 <Fragment slot="terraform">
 사용자 Identity 모듈을 추가하고 웹사이트가 해당 모듈에 종속되도록 설정해야 합니다:

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 `UserIdentity` Construct는 웹사이트가 올바른 Cognito 사용자 풀을 가리킬 수 있도록 필요한 <Link path="guides/react-website#runtime-configuration">런타임 구성</Link>을 자동으로 추가합니다.
 
 :::note[SMS 역할 보존]
-`UserIdentity`는 Cognito가 SMS 메시지를 전송하기 위해 맡는 전용 IAM 역할을 생성합니다. 이 역할의 제거 정책은 사용자 풀의 정책을 따릅니다 — 기본적으로 CDK의 `UserPool`은 `RemovalPolicy.RETAIN`을 사용하므로, `cdk destroy` 실행 시 사용자 풀과 SMS 역할이 모두 보존되며 더 이상 필요하지 않은 경우 수동으로 정리해야 합니다.
+사용자 풀은 Cognito가 SMS 메시지를 전송하기 위해 맡는 IAM 역할로 지원됩니다. 이 역할의 제거 정책은 사용자 풀의 정책을 따릅니다 — 기본적으로 CDK의 `UserPool`은 `RemovalPolicy.RETAIN`을 사용하므로, `cdk destroy` 실행 시 사용자 풀과 SMS 역할이 모두 보존되며 더 이상 필요하지 않은 경우 수동으로 정리해야 합니다.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/pt/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 O construct `UserIdentity` adiciona automaticamente a <Link path="guides/react-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu website possa apontar para o Cognito User Pool correto para autenticação.
+
+:::note[Retenção da função SMS]
+`UserIdentity` cria uma função IAM dedicada que o Cognito assume para enviar mensagens SMS. A política de remoção da função espelha a do User Pool — por padrão, o `UserPool` do CDK usa `RemovalPolicy.RETAIN`, então ao executar `cdk destroy` tanto o User Pool quanto sua função SMS são retidos e precisarão ser limpos manualmente se não forem mais necessários.
+:::
 </Fragment>
 <Fragment slot="terraform">
 Você precisará adicionar o módulo de identidade do usuário e garantir que seu website dependa dele:

--- a/docs/src/content/docs/pt/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 O construct `UserIdentity` adiciona automaticamente a <Link path="guides/react-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu website possa apontar para o Cognito User Pool correto para autenticação.
 
 :::note[Retenção da função SMS]
-`UserIdentity` cria uma função IAM dedicada que o Cognito assume para enviar mensagens SMS. A política de remoção da função espelha a do User Pool — por padrão, o `UserPool` do CDK usa `RemovalPolicy.RETAIN`, então ao executar `cdk destroy` tanto o User Pool quanto sua função SMS são retidos e precisarão ser limpos manualmente se não forem mais necessários.
+O User Pool é apoiado por uma função IAM que o Cognito assume para enviar mensagens SMS. A política de remoção da função espelha a do User Pool — por padrão, o `UserPool` do CDK usa `RemovalPolicy.RETAIN`, então ao executar `cdk destroy` tanto o User Pool quanto sua função SMS são retidos e precisarão ser limpos manualmente se não forem mais necessários.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -92,7 +92,7 @@ export class ApplicationStack extends Stack {
 Construct `UserIdentity` tự động thêm <Link path="guides/react-website#runtime-configuration">Cấu hình Runtime</Link> cần thiết để đảm bảo rằng website của bạn có thể trỏ đến đúng Cognito User Pool cho xác thực.
 
 :::note[Giữ lại vai trò SMS]
-`UserIdentity` tạo một vai trò IAM chuyên dụng mà Cognito sử dụng để gửi tin nhắn SMS. Chính sách xóa của vai trò này phản ánh chính sách của User Pool — theo mặc định `UserPool` của CDK sử dụng `RemovalPolicy.RETAIN`, vì vậy khi chạy `cdk destroy`, cả User Pool và vai trò SMS của nó đều được giữ lại và sẽ cần được dọn dẹp thủ công nếu không còn cần thiết nữa.
+User Pool được hỗ trợ bởi một vai trò IAM mà Cognito sử dụng để gửi tin nhắn SMS. Chính sách xóa của vai trò này phản ánh chính sách của User Pool — theo mặc định `UserPool` của CDK sử dụng `RemovalPolicy.RETAIN`, vì vậy khi chạy `cdk destroy`, cả User Pool và vai trò SMS của nó đều được giữ lại và sẽ cần được dọn dẹp thủ công nếu không còn cần thiết nữa.
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -90,6 +90,10 @@ export class ApplicationStack extends Stack {
 ```
 
 Construct `UserIdentity` tự động thêm <Link path="guides/react-website#runtime-configuration">Cấu hình Runtime</Link> cần thiết để đảm bảo rằng website của bạn có thể trỏ đến đúng Cognito User Pool cho xác thực.
+
+:::note[Giữ lại vai trò SMS]
+`UserIdentity` tạo một vai trò IAM chuyên dụng mà Cognito sử dụng để gửi tin nhắn SMS. Chính sách xóa của vai trò này phản ánh chính sách của User Pool — theo mặc định `UserPool` của CDK sử dụng `RemovalPolicy.RETAIN`, vì vậy khi chạy `cdk destroy`, cả User Pool và vai trò SMS của nó đều được giữ lại và sẽ cần được dọn dẹp thủ công nếu không còn cần thiết nữa.
+:::
 </Fragment>
 <Fragment slot="terraform">
 Bạn cần thêm module user identity và đảm bảo website của bạn phụ thuộc vào nó:

--- a/docs/src/content/docs/zh/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/react-website-auth.mdx
@@ -92,6 +92,10 @@ export class ApplicationStack extends Stack {
 ```
 
 `UserIdentity` 构造器会自动添加必要的 <Link path="guides/react-website#runtime-configuration">运行时配置</Link>，确保您的网站能正确指向 Cognito 用户池进行身份验证。
+
+:::note[SMS 角色保留]
+`UserIdentity` 会创建一个专用的 IAM 角色，供 Cognito 用于发送 SMS 消息。该角色的删除策略与用户池保持一致——默认情况下 CDK 的 `UserPool` 使用 `RemovalPolicy.RETAIN`，因此在执行 `cdk destroy` 时，用户池及其 SMS 角色都会被保留，如果不再需要，需要手动清理。
+:::
 </Fragment>
 <Fragment slot="terraform">
 您需要添加用户身份模块，并确保网站模块依赖该模块：

--- a/docs/src/content/docs/zh/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/react-website-auth.mdx
@@ -94,7 +94,7 @@ export class ApplicationStack extends Stack {
 `UserIdentity` 构造器会自动添加必要的 <Link path="guides/react-website#runtime-configuration">运行时配置</Link>，确保您的网站能正确指向 Cognito 用户池进行身份验证。
 
 :::note[SMS 角色保留]
-`UserIdentity` 会创建一个专用的 IAM 角色，供 Cognito 用于发送 SMS 消息。该角色的删除策略与用户池保持一致——默认情况下 CDK 的 `UserPool` 使用 `RemovalPolicy.RETAIN`，因此在执行 `cdk destroy` 时，用户池及其 SMS 角色都会被保留，如果不再需要，需要手动清理。
+用户池由一个 IAM 角色支持，Cognito 使用该角色发送 SMS 消息。该角色的删除策略与用户池保持一致——默认情况下 CDK 的 `UserPool` 使用 `RemovalPolicy.RETAIN`，因此在执行 `cdk destroy` 时，用户池及其 SMS 角色都会被保留，如果不再需要，需要手动清理。
 :::
 </Fragment>
 <Fragment slot="terraform">

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -90,14 +90,7 @@ exports[`cognito-auth generator > should generate files > user-identity 1`] = `
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import {
-  CfnOutput,
-  CfnResource,
-  Duration,
-  Lazy,
-  Names,
-  Stack,
-} from 'aws-cdk-lib';
+import { CfnOutput, CfnResource, Duration, Lazy, Stack } from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -108,12 +101,6 @@ import {
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
-import {
-  PolicyDocument,
-  PolicyStatement,
-  Role,
-  ServicePrincipal,
-} from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
@@ -155,10 +142,10 @@ export class UserIdentity extends Construct {
     });
 
     suppressRules(
-      this,
+      this.userPool,
       ['CKV_AWS_111'],
       'SMS Role requires wildcard resource',
-      (c) => c.node.path.includes('/SmsRole/'),
+      (c) => c.node.path.includes('/smsRole/'),
     );
 
     new CfnOutput(this, \`\${id}-UserPoolId\`, {
@@ -175,11 +162,8 @@ export class UserIdentity extends Construct {
   }
 
   private createUserPool = () => {
-    const { smsRole, smsRoleExternalId } = this.createSmsRole();
     const userPool = new UserPool(this, 'UserPool', {
       deletionProtection: true,
-      smsRole,
-      smsRoleExternalId,
       passwordPolicy: {
         minLength: 8,
         requireLowercase: true,
@@ -210,49 +194,14 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
-    this.syncSmsRoleRemovalPolicyWithUserPool(smsRole, userPool);
-    return userPool;
-  };
-
-  // Custom SMS role supplied so the trust policy meets Cognito's requirements: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html#user-pool-sms-settings-trust-policy
-  private createSmsRole = () => {
-    const smsRoleExternalId = Names.uniqueId(this);
-    const smsRole = new Role(this, 'SmsRole', {
-      assumedBy: new ServicePrincipal('cognito-idp.amazonaws.com', {
-        conditions: {
-          StringEquals: {
-            'sts:ExternalId': smsRoleExternalId,
-            'aws:SourceAccount': Stack.of(this).account,
-          },
-          ArnLike: {
-            'aws:SourceArn': \`arn:\${Stack.of(this).partition}:cognito-idp:\${Stack.of(this).region}:\${Stack.of(this).account}:userpool/*\`,
-          },
-        },
-      }),
-      inlinePolicies: {
-        sns: new PolicyDocument({
-          statements: [
-            new PolicyStatement({
-              actions: ['sns:Publish'],
-              resources: ['*'],
-            }),
-          ],
-        }),
-      },
-    });
-    return { smsRole, smsRoleExternalId };
-  };
-
-  private syncSmsRoleRemovalPolicyWithUserPool = (
-    smsRole: Role,
-    userPool: UserPool,
-  ) => {
+    // Mirror the pool's removal policy onto the auto-created SMS role so it isn't orphaned when the pool is retained
     const poolCfn = userPool.node.defaultChild as CfnResource;
-    const roleCfn = smsRole.node.defaultChild as CfnResource;
-    // Mirror the user pool's removal policy so the SMS role isn't orphaned when the pool is retained
-    roleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
-    roleCfn.cfnOptions.updateReplacePolicy =
+    const smsRoleCfn = userPool.node.findChild('smsRole').node
+      .defaultChild as CfnResource;
+    smsRoleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
+    smsRoleCfn.cfnOptions.updateReplacePolicy =
       poolCfn.cfnOptions.updateReplacePolicy;
+    return userPool;
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -90,7 +90,14 @@ exports[`cognito-auth generator > should generate files > user-identity 1`] = `
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import { CfnOutput, Duration, Lazy, Stack } from 'aws-cdk-lib';
+import {
+  CfnOutput,
+  Duration,
+  Lazy,
+  Names,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -101,6 +108,12 @@ import {
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
+import {
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
@@ -145,7 +158,7 @@ export class UserIdentity extends Construct {
       this.userPool,
       ['CKV_AWS_111'],
       'SMS Role requires wildcard resource',
-      (c) => c.node.path.includes('/smsRole/'),
+      (c) => c.node.path.includes('/SmsRole/'),
     );
 
     new CfnOutput(this, \`\${id}-UserPoolId\`, {
@@ -161,9 +174,12 @@ export class UserIdentity extends Construct {
     });
   }
 
-  private createUserPool = () =>
-    new UserPool(this, 'UserPool', {
+  private createUserPool = () => {
+    const { smsRole, smsRoleExternalId } = this.createSmsRole();
+    return new UserPool(this, 'UserPool', {
       deletionProtection: true,
+      smsRole,
+      smsRoleExternalId,
       passwordPolicy: {
         minLength: 8,
         requireLowercase: true,
@@ -194,6 +210,49 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
+  };
+
+  /**
+   * Creates an IAM role that Cognito assumes when sending SMS messages.
+   *
+   * The trust policy includes aws:SourceAccount and aws:SourceArn conditions in
+   * addition to sts:ExternalId, as required by Cognito's role validation. Without
+   * all three conditions, any subsequent UpdateUserPool call (including
+   * deactivating deletion protection) fails with
+   * InvalidSmsRoleTrustRelationshipException.
+   *
+   * The role is retained on stack deletion so that a user pool left behind by
+   * deletion protection can still be updated and deleted via the AWS CLI or
+   * console without the role having already been destroyed.
+   */
+  private createSmsRole = () => {
+    const smsRoleExternalId = Names.uniqueId(this);
+    const smsRole = new Role(this, 'SmsRole', {
+      assumedBy: new ServicePrincipal('cognito-idp.amazonaws.com', {
+        conditions: {
+          StringEquals: {
+            'sts:ExternalId': smsRoleExternalId,
+            'aws:SourceAccount': Stack.of(this).account,
+          },
+          ArnLike: {
+            'aws:SourceArn': \`arn:\${Stack.of(this).partition}:cognito-idp:\${Stack.of(this).region}:\${Stack.of(this).account}:userpool/*\`,
+          },
+        },
+      }),
+      inlinePolicies: {
+        sns: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['sns:Publish'],
+              resources: ['*'],
+            }),
+          ],
+        }),
+      },
+    });
+    smsRole.applyRemovalPolicy(RemovalPolicy.RETAIN);
+    return { smsRole, smsRoleExternalId };
+  };
 
   private createUserPoolDomain = (userPool: UserPool) =>
     new CfnUserPoolDomain(this, 'UserPoolDomain', {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -194,7 +194,7 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
-    // Mirror the pool's removal policy onto the auto-created SMS role so it isn't orphaned when the pool is retained
+    // Retain the SMS role alongside the pool so the pool can still be updated and deleted manually
     const poolCfn = userPool.node.defaultChild as CfnResource;
     const smsRoleCfn = userPool.node.findChild('smsRole').node
       .defaultChild as CfnResource;

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -155,7 +155,7 @@ export class UserIdentity extends Construct {
     });
 
     suppressRules(
-      this.userPool,
+      this,
       ['CKV_AWS_111'],
       'SMS Role requires wildcard resource',
       (c) => c.node.path.includes('/SmsRole/'),

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -92,10 +92,10 @@ exports[`cognito-auth generator > should generate files > user-identity 1`] = `
 } from 'aws-cdk-lib/aws-cognito-identitypool';
 import {
   CfnOutput,
+  CfnResource,
   Duration,
   Lazy,
   Names,
-  RemovalPolicy,
   Stack,
 } from 'aws-cdk-lib';
 import {
@@ -176,7 +176,7 @@ export class UserIdentity extends Construct {
 
   private createUserPool = () => {
     const { smsRole, smsRoleExternalId } = this.createSmsRole();
-    return new UserPool(this, 'UserPool', {
+    const userPool = new UserPool(this, 'UserPool', {
       deletionProtection: true,
       smsRole,
       smsRoleExternalId,
@@ -210,21 +210,11 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
+    this.syncSmsRoleRemovalPolicyWithUserPool(smsRole, userPool);
+    return userPool;
   };
 
-  /**
-   * Creates an IAM role that Cognito assumes when sending SMS messages.
-   *
-   * The trust policy includes aws:SourceAccount and aws:SourceArn conditions in
-   * addition to sts:ExternalId, as required by Cognito's role validation. Without
-   * all three conditions, any subsequent UpdateUserPool call (including
-   * deactivating deletion protection) fails with
-   * InvalidSmsRoleTrustRelationshipException.
-   *
-   * The role is retained on stack deletion so that a user pool left behind by
-   * deletion protection can still be updated and deleted via the AWS CLI or
-   * console without the role having already been destroyed.
-   */
+  // Custom SMS role supplied so the trust policy meets Cognito's requirements: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html#user-pool-sms-settings-trust-policy
   private createSmsRole = () => {
     const smsRoleExternalId = Names.uniqueId(this);
     const smsRole = new Role(this, 'SmsRole', {
@@ -250,8 +240,19 @@ export class UserIdentity extends Construct {
         }),
       },
     });
-    smsRole.applyRemovalPolicy(RemovalPolicy.RETAIN);
     return { smsRole, smsRoleExternalId };
+  };
+
+  private syncSmsRoleRemovalPolicyWithUserPool = (
+    smsRole: Role,
+    userPool: UserPool,
+  ) => {
+    const poolCfn = userPool.node.defaultChild as CfnResource;
+    const roleCfn = smsRole.node.defaultChild as CfnResource;
+    // Mirror the user pool's removal policy so the SMS role isn't orphaned when the pool is retained
+    roleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
+    roleCfn.cfnOptions.updateReplacePolicy =
+      poolCfn.cfnOptions.updateReplacePolicy;
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -2,7 +2,7 @@ import {
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import { CfnOutput, CfnResource, Duration, Lazy, Names, Stack } from 'aws-cdk-lib';
+import { CfnOutput, CfnResource, Duration, Lazy, Stack } from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -13,12 +13,6 @@ import {
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
-import {
-  PolicyDocument,
-  PolicyStatement,
-  Role,
-  ServicePrincipal,
-} from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
@@ -60,10 +54,10 @@ export class UserIdentity extends Construct {
     });
 
     suppressRules(
-      this,
+      this.userPool,
       ['CKV_AWS_111'],
       'SMS Role requires wildcard resource',
-      (c) => c.node.path.includes('/SmsRole/'),
+      (c) => c.node.path.includes('/smsRole/'),
     );
 
     new CfnOutput(this, `${id}-UserPoolId`, {
@@ -80,11 +74,8 @@ export class UserIdentity extends Construct {
   }
 
   private createUserPool = () => {
-    const { smsRole, smsRoleExternalId } = this.createSmsRole();
     const userPool = new UserPool(this, 'UserPool', {
       deletionProtection: true,
-      smsRole,
-      smsRoleExternalId,
       passwordPolicy: {
         minLength: 8,
         requireLowercase: true,
@@ -115,48 +106,15 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
-    this.syncSmsRoleRemovalPolicyWithUserPool(smsRole, userPool);
-    return userPool;
-  };
-
-  // Custom SMS role supplied so the trust policy meets Cognito's requirements: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html#user-pool-sms-settings-trust-policy
-  private createSmsRole = () => {
-    const smsRoleExternalId = Names.uniqueId(this);
-    const smsRole = new Role(this, 'SmsRole', {
-      assumedBy: new ServicePrincipal('cognito-idp.amazonaws.com', {
-        conditions: {
-          StringEquals: {
-            'sts:ExternalId': smsRoleExternalId,
-            'aws:SourceAccount': Stack.of(this).account,
-          },
-          ArnLike: {
-            'aws:SourceArn': `arn:${Stack.of(this).partition}:cognito-idp:${Stack.of(this).region}:${Stack.of(this).account}:userpool/*`,
-          },
-        },
-      }),
-      inlinePolicies: {
-        sns: new PolicyDocument({
-          statements: [
-            new PolicyStatement({
-              actions: ['sns:Publish'],
-              resources: ['*'],
-            }),
-          ],
-        }),
-      },
-    });
-    return { smsRole, smsRoleExternalId };
-  };
-
-  private syncSmsRoleRemovalPolicyWithUserPool = (
-    smsRole: Role,
-    userPool: UserPool,
-  ) => {
+    // Mirror the pool's removal policy onto the auto-created SMS role so it isn't orphaned when the pool is retained
     const poolCfn = userPool.node.defaultChild as CfnResource;
-    const roleCfn = smsRole.node.defaultChild as CfnResource;
-    // Mirror the user pool's removal policy so the SMS role isn't orphaned when the pool is retained
-    roleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
-    roleCfn.cfnOptions.updateReplacePolicy = poolCfn.cfnOptions.updateReplacePolicy;
+    const smsRoleCfn = userPool.node
+      .findChild('smsRole')
+      .node.defaultChild as CfnResource;
+    smsRoleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
+    smsRoleCfn.cfnOptions.updateReplacePolicy =
+      poolCfn.cfnOptions.updateReplacePolicy;
+    return userPool;
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -2,14 +2,7 @@ import {
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import {
-  CfnOutput,
-  Duration,
-  Lazy,
-  Names,
-  RemovalPolicy,
-  Stack,
-} from 'aws-cdk-lib';
+import { CfnOutput, CfnResource, Duration, Lazy, Names, Stack } from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -88,7 +81,7 @@ export class UserIdentity extends Construct {
 
   private createUserPool = () => {
     const { smsRole, smsRoleExternalId } = this.createSmsRole();
-    return new UserPool(this, 'UserPool', {
+    const userPool = new UserPool(this, 'UserPool', {
       deletionProtection: true,
       smsRole,
       smsRoleExternalId,
@@ -122,21 +115,11 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
+    this.syncSmsRoleRemovalPolicyWithUserPool(smsRole, userPool);
+    return userPool;
   };
 
-  /**
-   * Creates an IAM role that Cognito assumes when sending SMS messages.
-   *
-   * The trust policy includes aws:SourceAccount and aws:SourceArn conditions in
-   * addition to sts:ExternalId, as required by Cognito's role validation. Without
-   * all three conditions, any subsequent UpdateUserPool call (including
-   * deactivating deletion protection) fails with
-   * InvalidSmsRoleTrustRelationshipException.
-   *
-   * The role is retained on stack deletion so that a user pool left behind by
-   * deletion protection can still be updated and deleted via the AWS CLI or
-   * console without the role having already been destroyed.
-   */
+  // Custom SMS role supplied so the trust policy meets Cognito's requirements: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html#user-pool-sms-settings-trust-policy
   private createSmsRole = () => {
     const smsRoleExternalId = Names.uniqueId(this);
     const smsRole = new Role(this, 'SmsRole', {
@@ -162,8 +145,18 @@ export class UserIdentity extends Construct {
         }),
       },
     });
-    smsRole.applyRemovalPolicy(RemovalPolicy.RETAIN);
     return { smsRole, smsRoleExternalId };
+  };
+
+  private syncSmsRoleRemovalPolicyWithUserPool = (
+    smsRole: Role,
+    userPool: UserPool,
+  ) => {
+    const poolCfn = userPool.node.defaultChild as CfnResource;
+    const roleCfn = smsRole.node.defaultChild as CfnResource;
+    // Mirror the user pool's removal policy so the SMS role isn't orphaned when the pool is retained
+    roleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
+    roleCfn.cfnOptions.updateReplacePolicy = poolCfn.cfnOptions.updateReplacePolicy;
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -106,7 +106,7 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
-    // Mirror the pool's removal policy onto the auto-created SMS role so it isn't orphaned when the pool is retained
+    // Retain the SMS role alongside the pool so the pool can still be updated and deleted manually
     const poolCfn = userPool.node.defaultChild as CfnResource;
     const smsRoleCfn = userPool.node
       .findChild('smsRole')

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -2,7 +2,14 @@ import {
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import { CfnOutput, Duration, Lazy, Stack } from 'aws-cdk-lib';
+import {
+  CfnOutput,
+  Duration,
+  Lazy,
+  Names,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -13,6 +20,12 @@ import {
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
+import {
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
@@ -57,7 +70,7 @@ export class UserIdentity extends Construct {
       this.userPool,
       ['CKV_AWS_111'],
       'SMS Role requires wildcard resource',
-      (c) => c.node.path.includes('/smsRole/'),
+      (c) => c.node.path.includes('/SmsRole/'),
     );
 
     new CfnOutput(this, `${id}-UserPoolId`, {
@@ -73,9 +86,12 @@ export class UserIdentity extends Construct {
     });
   }
 
-  private createUserPool = () =>
-    new UserPool(this, 'UserPool', {
+  private createUserPool = () => {
+    const { smsRole, smsRoleExternalId } = this.createSmsRole();
+    return new UserPool(this, 'UserPool', {
       deletionProtection: true,
+      smsRole,
+      smsRoleExternalId,
       passwordPolicy: {
         minLength: 8,
         requireLowercase: true,
@@ -106,6 +122,49 @@ export class UserIdentity extends Construct {
         phone: true,
       },
     });
+  };
+
+  /**
+   * Creates an IAM role that Cognito assumes when sending SMS messages.
+   *
+   * The trust policy includes aws:SourceAccount and aws:SourceArn conditions in
+   * addition to sts:ExternalId, as required by Cognito's role validation. Without
+   * all three conditions, any subsequent UpdateUserPool call (including
+   * deactivating deletion protection) fails with
+   * InvalidSmsRoleTrustRelationshipException.
+   *
+   * The role is retained on stack deletion so that a user pool left behind by
+   * deletion protection can still be updated and deleted via the AWS CLI or
+   * console without the role having already been destroyed.
+   */
+  private createSmsRole = () => {
+    const smsRoleExternalId = Names.uniqueId(this);
+    const smsRole = new Role(this, 'SmsRole', {
+      assumedBy: new ServicePrincipal('cognito-idp.amazonaws.com', {
+        conditions: {
+          StringEquals: {
+            'sts:ExternalId': smsRoleExternalId,
+            'aws:SourceAccount': Stack.of(this).account,
+          },
+          ArnLike: {
+            'aws:SourceArn': `arn:${Stack.of(this).partition}:cognito-idp:${Stack.of(this).region}:${Stack.of(this).account}:userpool/*`,
+          },
+        },
+      }),
+      inlinePolicies: {
+        sns: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['sns:Publish'],
+              resources: ['*'],
+            }),
+          ],
+        }),
+      },
+    });
+    smsRole.applyRemovalPolicy(RemovalPolicy.RETAIN);
+    return { smsRole, smsRoleExternalId };
+  };
 
   private createUserPoolDomain = (userPool: UserPool) =>
     new CfnUserPoolDomain(this, 'UserPoolDomain', {

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -67,7 +67,7 @@ export class UserIdentity extends Construct {
     });
 
     suppressRules(
-      this.userPool,
+      this,
       ['CKV_AWS_111'],
       'SMS Role requires wildcard resource',
       (c) => c.node.path.includes('/SmsRole/'),


### PR DESCRIPTION
### Reason for this change

Deleting a Cognito User Pool created by the identity construct via the AWS CLI or console failed with:

```
InvalidSmsRoleTrustRelationshipException: Role does not have a trust relationship allowing Cognito to assume the role
```

Root cause: CDK's `UserPool` construct defaults to `RemovalPolicy.RETAIN`, so on `cdk destroy` the pool is kept but the auto-created SMS IAM role (which has no removal policy) is deleted. Any later `UpdateUserPool` — including the one the AWS console calls to deactivate deletion protection so the pool can be cleaned up — fails because the role no longer exists. Cognito surfaces this as an "invalid trust relationship" error, which is misleading: the trust policy is fine, the role is simply gone.

### Description of changes

Mirror the user pool's `DeletionPolicy` / `UpdateReplacePolicy` onto the auto-created SMS role in `UserIdentity`, so the role stays in lock-step with the pool (retained when the pool is retained, destroyed when the pool is destroyed). No other behaviour changes — CDK's default SMS role and trust policy are unchanged.

Also added a short note under the CDK tab of the auth guide documenting the retention behaviour and manual-cleanup expectation.

### Description of how you validated changes

Experimented directly against Cognito in `us-west-2` to confirm the actual failure mode:

| Scenario | Role present? | Outcome |
|---|---|---|
| `update-user-pool` preserving `SmsConfiguration` | Yes | succeeds |
| `set-user-pool-mfa-config` | Yes | succeeds |
| `update-user-pool` after `cdk destroy` deleted the role | **No** | `InvalidSmsRoleTrustRelationshipException` |

So retaining the role is sufficient; no trust-policy changes are needed.

End-to-end validation of the fix:
1. Generated a website with auth, added `new UserIdentity(this, 'Identity')` to an `ts#infra` stack, deployed.
2. Verified the synthesised template: `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain` now appear on both the user pool and the SMS role.
3. Ran `cdk destroy` — pool and role both retained.
4. `aws cognito-idp update-user-pool --deletion-protection INACTIVE ...` → success.
5. `aws cognito-idp delete-user-pool ...` → success.
6. Cleaned up the retained role via `aws iam delete-role-policy` / `delete-role`.

Unit tests updated (`pnpm nx run @aws/nx-plugin:test -u`); the `cognito-auth > should generate files > user-identity` snapshot reflects the removal-policy sync.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
