### PR TITLE
fix(preset): default iacProvider so --no-interactive works without extra flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           - yarn
           - pnpm
           - bun
+          - no-interactive
           - dungeon-adventure
           - terraform
           - trpc-api

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,6 +58,7 @@ jobs:
           - yarn
           - pnpm
           - bun
+          - no-interactive
           - dungeon-adventure
           - terraform
           - trpc-api

--- a/e2e/src/smoke-tests/no-interactive.spec.ts
+++ b/e2e/src/smoke-tests/no-interactive.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { PackageManager } from '@nx/devkit';
+import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { existsSync, rmSync } from 'fs';
+import { ensureDirSync } from 'fs-extra';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * Verifies that `<pkgMgr> create @aws/nx-workspace` succeeds with only
+ * `--no-interactive`, without any additional flags to set required schema
+ * properties (e.g. `iacProvider`). Regression coverage for a missing default
+ * that caused "Required property 'iacProvider' is missing" to abort the
+ * preset after the workspace had already been created.
+ */
+const PACKAGE_MANAGERS: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun'];
+
+describe('smoke test - no-interactive', () => {
+  PACKAGE_MANAGERS.forEach((pkgMgr) => {
+    describe(pkgMgr, () => {
+      const targetDir = `${tmpProjPath()}/no-interactive-${pkgMgr}`;
+      const projectRoot = `${targetDir}/e2e-test`;
+
+      beforeEach(() => {
+        if (existsSync(targetDir)) {
+          rmSync(targetDir, { force: true, recursive: true });
+        }
+        ensureDirSync(targetDir);
+      });
+
+      it(`Should create a workspace with --no-interactive - ${pkgMgr}`, async () => {
+        await runCLI(
+          `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test')} --no-interactive --skipGit`,
+          {
+            cwd: targetDir,
+            prefixWithPackageManagerCmd: false,
+            redirectStderr: true,
+          },
+        );
+
+        expect(existsSync(`${projectRoot}/package.json`)).toBe(true);
+        expect(existsSync(`${projectRoot}/nx.json`)).toBe(true);
+        expect(existsSync(`${projectRoot}/aws-nx-plugin.config.mts`)).toBe(
+          true,
+        );
+      });
+    });
+  });
+});

--- a/packages/nx-plugin/src/preset/schema.json
+++ b/packages/nx-plugin/src/preset/schema.json
@@ -14,9 +14,9 @@
       "type": "string",
       "description": "The preferred IaC provider.",
       "enum": ["CDK", "Terraform"],
+      "default": "CDK",
       "x-priority": "important",
       "x-prompt": "Which provider would you like to manage your infrastructure?"
     }
-  },
-  "required": ["iacProvider"]
+  }
 }


### PR DESCRIPTION
### Reason for this change

`pnpm create @aws/nx-workspace . --no-interactive` (and the equivalent for npm/yarn/bun) fails with:

```
 NX   Required property 'iacProvider' is missing

 NX   Failed to create workspace

Failed to apply preset: @aws/nx-plugin.
```

The workspace is created but the preset aborts before any files are generated, leaving the user with a broken half-created workspace.

The root cause is that `iacProvider` is `required` in the preset schema but has no `default`, so when Nx skips the prompt in non-interactive mode the property is missing.

### Description of changes

- Add `"default": "CDK"` to `iacProvider` and drop it from the `required` list in `packages/nx-plugin/src/preset/schema.json`. With a default, Nx can satisfy the schema non-interactively; interactive runs still prompt exactly as before.
- Add a dedicated `no-interactive` smoke test that runs `<pkgMgr> create @aws/nx-workspace e2e-test --no-interactive --skipGit` for each of `npm`, `pnpm`, `yarn`, and `bun` and asserts that `package.json`, `nx.json`, and `aws-nx-plugin.config.mts` are all present (i.e. the preset ran to completion).
- Wire the new smoke test into the `pr.yml` and `ci.yml` matrices.

### Description of how you validated changes

- Unit tests: `pnpm nx run @aws/nx-plugin:test` — all 1743 tests pass, including the existing preset generator tests (`should store CDK iac provider in config`, etc.).
- End-to-end: published the local packages to a Verdaccio registry and ran `<pm> create @aws/nx-workspace . --no-interactive --skipGit` for each of npm, pnpm, yarn, and bun. Before the schema change the command failed with `Required property 'iacProvider' is missing`; after the change all four succeed and produce a workspace with `iac: { provider: 'CDK' }` in `aws-nx-plugin.config.mts`.
- New smoke test: `pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - no-interactive"` — all 4 package-manager cases pass.

### Issue # (if applicable)

n/a

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*