### PR TITLE
test(e2e): exercise yarn 4 alongside yarn classic in smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
       matrix:
         smoke_test:
           - npm
-          - yarn
+          - yarn-classic
+          - yarn-4
           - pnpm
           - bun
           - no-interactive

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,8 @@ jobs:
       matrix:
         smoke_test:
           - npm
-          - yarn
+          - yarn-classic
+          - yarn-4
           - pnpm
           - bun
           - no-interactive

--- a/e2e/src/smoke-tests/no-interactive.spec.ts
+++ b/e2e/src/smoke-tests/no-interactive.spec.ts
@@ -6,7 +6,8 @@ import { PackageManager } from '@nx/devkit';
 import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
 import { existsSync, rmSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { activateYarnViaCorepack } from './yarn-corepack';
 
 /**
  * Verifies that `<pkgMgr> create @aws/nx-workspace` succeeds with only
@@ -14,23 +15,49 @@ import { beforeEach, describe, expect, it } from 'vitest';
  * properties (e.g. `iacProvider`). Regression coverage for a missing default
  * that caused "Required property 'iacProvider' is missing" to abort the
  * preset after the workspace had already been created.
+ *
+ * Yarn is exercised twice — classic (whatever `yarn` is on PATH, typically
+ * 1.x) and berry (yarn 4 activated via corepack) — since the two drive
+ * different code paths in @aws/create-nx-workspace and the nx preset.
  */
-const PACKAGE_MANAGERS: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun'];
+interface Variant {
+  variant: string;
+  pkgMgr: PackageManager;
+  setup?: () => void | (() => void);
+}
+
+const VARIANTS: Variant[] = [
+  { variant: 'npm', pkgMgr: 'npm' },
+  { variant: 'pnpm', pkgMgr: 'pnpm' },
+  { variant: 'yarn-classic', pkgMgr: 'yarn' },
+  {
+    variant: 'yarn-4',
+    pkgMgr: 'yarn',
+    setup: () => activateYarnViaCorepack('4.14.1'),
+  },
+  { variant: 'bun', pkgMgr: 'bun' },
+];
 
 describe('smoke test - no-interactive', () => {
-  PACKAGE_MANAGERS.forEach((pkgMgr) => {
-    describe(pkgMgr, () => {
-      const targetDir = `${tmpProjPath()}/no-interactive-${pkgMgr}`;
+  VARIANTS.forEach(({ variant, pkgMgr, setup }) => {
+    describe(variant, () => {
+      const targetDir = `${tmpProjPath()}/no-interactive-${variant}`;
       const projectRoot = `${targetDir}/e2e-test`;
+      let teardown: (() => void) | void;
 
       beforeEach(() => {
+        teardown = setup?.();
         if (existsSync(targetDir)) {
           rmSync(targetDir, { force: true, recursive: true });
         }
         ensureDirSync(targetDir);
       });
+      afterEach(() => {
+        teardown?.();
+        teardown = undefined;
+      });
 
-      it(`Should create a workspace with --no-interactive - ${pkgMgr}`, async () => {
+      it(`Should create a workspace with --no-interactive - ${variant}`, async () => {
         await runCLI(
           `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test')} --no-interactive --skipGit`,
           {

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -7,7 +7,7 @@ import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
 import { join } from 'path';
-import { beforeEach, describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'vitest';
 
 export const runSmokeTest = async (
   dir: string,
@@ -261,22 +261,49 @@ export const runSmokeTest = async (
   return { opts };
 };
 
+export interface SmokeTestOptions {
+  /**
+   * Label used in the describe block (defaults to `pkgMgr`). Allows separate
+   * variants of the same package manager — e.g. "yarn" for classic and
+   * "yarn-4" for berry — to be targeted individually from the CI matrix.
+   */
+  variant?: string;
+  /**
+   * Optional per-variant setup. Runs inside `beforeEach` so each test gets a
+   * clean environment (e.g. activating yarn 4 via corepack). Returning a
+   * teardown function registers it for `afterEach`.
+   */
+  setup?: () => void | (() => void);
+  onProjectCreate?: (projectRoot: string) => void;
+}
+
 export const smokeTest = (
   pkgMgr: PackageManager,
-  onProjectCreate?: (projectRoot: string) => void,
+  options: SmokeTestOptions = {},
 ) => {
-  describe(`smoke test - ${pkgMgr}`, () => {
+  const variant = options.variant ?? pkgMgr;
+  describe(`smoke test - ${variant}`, () => {
+    let teardown: (() => void) | void;
     beforeEach(() => {
-      const targetDir = `${tmpProjPath()}/${pkgMgr}`;
+      teardown = options.setup?.();
+      const targetDir = `${tmpProjPath()}/${variant}`;
       console.log(`Cleaning target directory ${targetDir}`);
       if (existsSync(targetDir)) {
         rmSync(targetDir, { force: true, recursive: true });
       }
       ensureDirSync(targetDir);
     });
+    afterEach(() => {
+      teardown?.();
+      teardown = undefined;
+    });
 
-    it(`Should generate and build - ${pkgMgr}`, async () => {
-      await runSmokeTest(`${tmpProjPath()}/${pkgMgr}`, pkgMgr, onProjectCreate);
+    it(`Should generate and build - ${variant}`, async () => {
+      await runSmokeTest(
+        `${tmpProjPath()}/${variant}`,
+        pkgMgr,
+        options.onProjectCreate,
+      );
     });
   });
 };

--- a/e2e/src/smoke-tests/yarn-4.spec.ts
+++ b/e2e/src/smoke-tests/yarn-4.spec.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { smokeTest } from './smoke-test';
+import { activateYarnViaCorepack } from './yarn-corepack';
+
+smokeTest('yarn', {
+  variant: 'yarn-4',
+  setup: () => activateYarnViaCorepack('4.14.1'),
+});

--- a/e2e/src/smoke-tests/yarn-corepack.ts
+++ b/e2e/src/smoke-tests/yarn-corepack.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync } from 'child_process';
+import { mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const PATH_SEP = process.platform === 'win32' ? ';' : ':';
+
+/**
+ * Prepare a corepack-managed yarn binary at the given major version and put
+ * its shim directory at the front of process.env.PATH. Returns a teardown
+ * function that restores the original PATH.
+ *
+ * Used by the yarn-4 smoke tests to run the generator pipeline against yarn
+ * berry, since the default `yarn` on most runners is still 1.x.
+ */
+export const activateYarnViaCorepack = (version: string): (() => void) => {
+  const originalPath = process.env.PATH ?? '';
+  const shimDir = join(
+    tmpdir(),
+    'nx-plugin-for-aws',
+    `corepack-yarn-${version}-bin`,
+  );
+  mkdirSync(shimDir, { recursive: true });
+  execSync(`corepack enable --install-directory "${shimDir}"`, {
+    stdio: 'inherit',
+  });
+  execSync(`corepack prepare yarn@${version} --activate`, {
+    stdio: 'inherit',
+  });
+  process.env.PATH = `${shimDir}${PATH_SEP}${originalPath}`;
+  return () => {
+    process.env.PATH = originalPath;
+  };
+};

--- a/e2e/src/smoke-tests/yarn-corepack.ts
+++ b/e2e/src/smoke-tests/yarn-corepack.ts
@@ -19,7 +19,18 @@ const PATH_SEP = process.platform === 'win32' ? ';' : ':';
  */
 export const activateYarnViaCorepack = (version: string): (() => void) => {
   const originalPath = process.env.PATH ?? '';
-  const originalHardenedMode = process.env.YARN_ENABLE_HARDENED_MODE;
+  // Yarn berry auto-enables hardened mode on public PR CI runs AND immutable
+  // installs whenever `CI` is set — both refuse any install that would
+  // modify the lockfile. Our smoke test scaffolds a fresh workspace whose
+  // initial yarn.lock is empty, so every dependency resolution counts as a
+  // "modification". Disable both for the duration of the test.
+  const overrides: Record<string, string> = {
+    YARN_ENABLE_HARDENED_MODE: '0',
+    YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+  };
+  const originals: Record<string, string | undefined> = Object.fromEntries(
+    Object.keys(overrides).map((k) => [k, process.env[k]]),
+  );
   const shimDir = join(
     tmpdir(),
     'nx-plugin-for-aws',
@@ -33,18 +44,17 @@ export const activateYarnViaCorepack = (version: string): (() => void) => {
     stdio: 'inherit',
   });
   process.env.PATH = `${shimDir}${PATH_SEP}${originalPath}`;
-  // Yarn berry auto-enables hardened mode on public PR CI runs, which refuses
-  // any install that would modify the lockfile. Our smoke test scaffolds a
-  // fresh workspace whose initial yarn.lock is empty, so every dependency
-  // resolution is a "modification" — disable hardened mode for the duration
-  // of the test.
-  process.env.YARN_ENABLE_HARDENED_MODE = '0';
+  for (const [k, v] of Object.entries(overrides)) {
+    process.env[k] = v;
+  }
   return () => {
     process.env.PATH = originalPath;
-    if (originalHardenedMode === undefined) {
-      delete process.env.YARN_ENABLE_HARDENED_MODE;
-    } else {
-      process.env.YARN_ENABLE_HARDENED_MODE = originalHardenedMode;
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
     }
   };
 };

--- a/e2e/src/smoke-tests/yarn-corepack.ts
+++ b/e2e/src/smoke-tests/yarn-corepack.ts
@@ -19,6 +19,7 @@ const PATH_SEP = process.platform === 'win32' ? ';' : ':';
  */
 export const activateYarnViaCorepack = (version: string): (() => void) => {
   const originalPath = process.env.PATH ?? '';
+  const originalHardenedMode = process.env.YARN_ENABLE_HARDENED_MODE;
   const shimDir = join(
     tmpdir(),
     'nx-plugin-for-aws',
@@ -32,7 +33,18 @@ export const activateYarnViaCorepack = (version: string): (() => void) => {
     stdio: 'inherit',
   });
   process.env.PATH = `${shimDir}${PATH_SEP}${originalPath}`;
+  // Yarn berry auto-enables hardened mode on public PR CI runs, which refuses
+  // any install that would modify the lockfile. Our smoke test scaffolds a
+  // fresh workspace whose initial yarn.lock is empty, so every dependency
+  // resolution is a "modification" — disable hardened mode for the duration
+  // of the test.
+  process.env.YARN_ENABLE_HARDENED_MODE = '0';
   return () => {
     process.env.PATH = originalPath;
+    if (originalHardenedMode === undefined) {
+      delete process.env.YARN_ENABLE_HARDENED_MODE;
+    } else {
+      process.env.YARN_ENABLE_HARDENED_MODE = originalHardenedMode;
+    }
   };
 };

--- a/e2e/src/smoke-tests/yarn.spec.ts
+++ b/e2e/src/smoke-tests/yarn.spec.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { smokeTest } from './smoke-test';
-smokeTest('yarn');
+
+// Classic yarn (1.x) — whichever version is on PATH. Paired with `yarn-4.spec.ts`
+// to cover both classic and berry code paths in create-nx-workspace.
+smokeTest('yarn', { variant: 'yarn-classic' });


### PR DESCRIPTION
### Reason for this change

The yarn smoke test previously ran against whichever `yarn` was on `PATH` on the runner — which is yarn 1.x (classic). That meant the berry code path in `create-nx-workspace` (writes `.yarnrc.yml`, runs `yarn set version`) was never exercised, even though the documented prerequisite in `required-prerequisites.mdx` is yarn >= 4. Users following the prereqs were effectively uncovered by e2e.

### Description of changes

- Added `e2e/src/smoke-tests/yarn-corepack.ts` — helper that creates a corepack-managed shim directory, prepends it to `process.env.PATH`, and returns a teardown restoring the original `PATH`.
- Refactored `smokeTest()` in `e2e/src/smoke-tests/smoke-test.ts` to take an options object with:
  - `variant`: label used in the `describe` block and CI matrix key (defaults to `pkgMgr`), so yarn-classic and yarn-4 can be targeted independently via vitest's `-t` flag.
  - `setup`: optional per-test hook (e.g. corepack activation) with auto-registered teardown in `afterEach`.
- Relabeled the existing yarn smoke as `yarn-classic`.
- Added `e2e/src/smoke-tests/yarn-4.spec.ts` that activates yarn 4.14.1 via corepack before running the same smoke.
- Same split in `no-interactive.spec.ts` — both `yarn-classic` and `yarn-4` variants run the create-workspace sanity check.
- Updated CI matrices in `.github/workflows/ci.yml` and `pr.yml` — replaced `yarn` with `yarn-classic`, added `yarn-4`.

### Description of how you validated changes

Locally:
- `pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - no-interactive"` — all 5 variants (npm, pnpm, yarn-classic, yarn-4, bun) pass.
- `pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - yarn-4"` — yarn 4.14.1 activated, berry-format `yarn.lock` (v9) and `.yarnrc.yml` generated, all ~40 generators ran. The final `nx run-many build` failed only on env-specific tasks (`terraform:fmt` — no terraform binary in my local sandbox — and docker cross-arch tasks — no QEMU), both of which are wired up in `init-monorepo` on CI.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*