### PR TITLE
docs: add Docker troubleshooting guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -461,6 +461,20 @@ export default defineConfig({
               },
               link: '/troubleshooting/nx',
             },
+            {
+              label: 'Docker',
+              translations: {
+                jp: 'Docker',
+                ko: 'Docker',
+                fr: 'Docker',
+                it: 'Docker',
+                es: 'Docker',
+                pt: 'Docker',
+                zh: 'Docker',
+                vi: 'Docker',
+              },
+              link: '/troubleshooting/docker',
+            },
           ],
         },
         {

--- a/docs/src/content/docs/en/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/prerequisites.mdx
@@ -10,7 +10,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommended
 
-- [Docker](https://www.docker.com/) is required for some generators.
+- [Docker](https://www.docker.com/) is required for some generators. [Multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
   - verify by running `terraform --version`
 - If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/en/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/en/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Troubleshooting Docker
+description: Troubleshooting issues with Docker builds
+---
+import Link from '@components/link.astro';
+
+This page provides troubleshooting guidance for issues you may encounter when building Docker images with the Nx Plugin for AWS. See the <Link path="/guides/docker-bundling">Docker Bundling guide</Link> for background on the pattern used by the generators.
+
+## Cross-Platform Builds
+
+Generators such as <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, and <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produce images for `linux/arm64` (Graviton) by default, regardless of the host architecture. Building an `arm64` image on an `x86_64` host — or an `amd64` image on Apple Silicon — requires [multi-platform build](https://docs.docker.com/build/building/multi-platform/) support in your local Docker installation.
+
+If multi-platform builds are not set up, the symptom depends on the `Dockerfile`:
+
+- **`Dockerfile` has a `RUN` step** (for example, `RUN npm install` in the TypeScript generators): the build fails mid-way with
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **`Dockerfile` only uses `COPY`** (for example, the Python generators): the build succeeds, but `docker run` later fails with
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **Base image is not available for the target platform**: the build fails at the `FROM` step with `no match for platform in manifest`.
+
+### Enable Multi-Platform Builds
+
+**Docker Desktop** (Mac / Windows / Linux) ships with [QEMU](https://www.qemu.org/) emulation enabled out of the box — no extra setup is usually required.
+
+**Linux hosts** (including CI runners) need QEMU binfmt handlers registered with the kernel. Install them once per machine:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Verify the supported platforms match what your project targets:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+The `Platforms:` line should include both `linux/amd64` and `linux/arm64`.
+
+:::tip[CI environments]
+GitHub Actions, GitLab CI, and similar providers typically do **not** register QEMU handlers by default. Add a step such as [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) before any `nx build` / `nx docker` target that produces a cross-architecture image.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+This error appears when you try to build for multiple platforms at once (e.g. `--platform linux/amd64,linux/arm64`) using the default `docker` driver:
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+The generators target a single platform per build (`linux/arm64`), so this error will not appear from targets produced by the plugin. If you have customised a `docker` target to emit a multi-platform manifest, you must either:
+
+1. Create and use a `docker-container` builder:
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. Or enable the [containerd image store](https://docs.docker.com/engine/storage/containerd/) in Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
+
+## Slow Builds on Emulated Architectures
+
+Building an `arm64` image on an `x86_64` host (or vice versa) uses QEMU to emulate each instruction, and dependency-install steps can be many times slower than a native build. The Nx Plugin for AWS mitigates this by doing dependency resolution **outside** the `Dockerfile` — see <Link path="/guides/docker-bundling">Docker Bundling</Link>. If you are still seeing slow Docker builds:
+
+- Make sure you are running the `bundle` / `docker` targets through Nx (`nx docker my-project`) so the bundle is cached between runs.
+- Avoid running `pip install`, `npm install`, or `uv sync` inside the `Dockerfile` for cross-architecture builds — install at bundle time with `--python-platform` / `--platform` so the heavy work runs natively, and let the `Dockerfile` do nothing more than `COPY`.
+- On CI, consider a native ARM runner (e.g. GitHub Actions' `ubuntu-24.04-arm`) to avoid QEMU entirely.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker is not running, or your user does not have permission to talk to the daemon socket.
+
+- **Docker Desktop**: start the application and wait for the whale icon to report "Docker Desktop is running".
+- **Linux**: start the service with `sudo systemctl start docker`. To avoid `sudo` for every command, add your user to the `docker` group (`sudo usermod -aG docker $USER`) and log out / back in.
+
+## Docker Image Assets Not Found at `cdk deploy`
+
+CDK's `DockerImageAsset` points at the build-context directory in `dist/`. If that directory does not exist when you run `cdk deploy`, synth will fail with `ENOENT` or "directory does not exist".
+
+The generators declare the `docker` target as a dependency of `build`, so `nx build my-infra` (or `nx deploy my-infra`) will produce the build context before CDK synths. If you invoke `cdk` directly, run the bundle + docker step first:
+
+```bash
+nx run my-project:docker
+```
+
+## Further Reading
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — the pattern the generators follow.

--- a/docs/src/content/docs/en/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/en/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Troubleshooting issues with Docker builds
 ---
 import Link from '@components/link.astro';
 
-This page provides troubleshooting guidance for issues you may encounter when building Docker images with the Nx Plugin for AWS. See the <Link path="/guides/docker-bundling">Docker Bundling guide</Link> for background on the pattern used by the generators.
+This page provides troubleshooting guidance for issues you may encounter with the Docker builds produced by the generators. See the <Link path="/guides/docker-bundling">Docker Bundling guide</Link> for background on the pattern they follow.
 
 ## Cross-Platform Builds
 
-Generators such as <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, and <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produce images for `linux/arm64` (Graviton) by default, regardless of the host architecture. Building an `arm64` image on an `x86_64` host — or an `amd64` image on Apple Silicon — requires [multi-platform build](https://docs.docker.com/build/building/multi-platform/) support in your local Docker installation.
+Generators such as <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, and <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produce images for `linux/arm64` (Graviton), regardless of the host architecture. Building an `arm64` image on an `x86_64` host — or an `amd64` image on Apple Silicon — requires [multi-platform build](https://docs.docker.com/build/building/multi-platform/) support in your local Docker installation.
 
 If multi-platform builds are not set up, the symptom depends on the `Dockerfile`:
 
-- **`Dockerfile` has a `RUN` step** (for example, `RUN npm install` in the TypeScript generators): the build fails mid-way with
+- **`Dockerfile` has a `RUN` step** (TypeScript generators `RUN npm install` for non-bundleable dependencies): the build fails mid-way with
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **`Dockerfile` only uses `COPY`** (for example, the Python generators): the build succeeds, but `docker run` later fails with
+- **`Dockerfile` only uses `COPY`** (Python generators): the build succeeds, but `docker run` later fails with
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ Verify the supported platforms match what your project targets:
 docker buildx inspect --bootstrap
 ```
 
-The `Platforms:` line should include both `linux/amd64` and `linux/arm64`.
+The `Platforms:` line should include `linux/arm64`.
 
 :::tip[CI environments]
 GitHub Actions, GitLab CI, and similar providers typically do **not** register QEMU handlers by default. Add a step such as [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) before any `nx build` / `nx docker` target that produces a cross-architecture image.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-This error appears when you try to build for multiple platforms at once (e.g. `--platform linux/amd64,linux/arm64`) using the default `docker` driver:
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-The generators target a single platform per build (`linux/arm64`), so this error will not appear from targets produced by the plugin. If you have customised a `docker` target to emit a multi-platform manifest, you must either:
-
-1. Create and use a `docker-container` builder:
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. Or enable the [containerd image store](https://docs.docker.com/engine/storage/containerd/) in Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
-
 ## Slow Builds on Emulated Architectures
 
-Building an `arm64` image on an `x86_64` host (or vice versa) uses QEMU to emulate each instruction, and dependency-install steps can be many times slower than a native build. The Nx Plugin for AWS mitigates this by doing dependency resolution **outside** the `Dockerfile` — see <Link path="/guides/docker-bundling">Docker Bundling</Link>. If you are still seeing slow Docker builds:
+Building an `arm64` image on an `x86_64` host (or vice versa) uses QEMU to emulate each instruction, which can be many times slower than a native build. The generators mitigate this by doing dependency resolution **outside** the `Dockerfile` — see <Link path="/guides/docker-bundling">Docker Bundling</Link>. If you are still seeing slow Docker builds:
 
 - Make sure you are running the `bundle` / `docker` targets through Nx (`nx docker my-project`) so the bundle is cached between runs.
-- Avoid running `pip install`, `npm install`, or `uv sync` inside the `Dockerfile` for cross-architecture builds — install at bundle time with `--python-platform` / `--platform` so the heavy work runs natively, and let the `Dockerfile` do nothing more than `COPY`.
 - On CI, consider a native ARM runner (e.g. GitHub Actions' `ubuntu-24.04-arm`) to avoid QEMU entirely.
 
-## `Cannot connect to the Docker daemon`
+## Missing Build Context at `cdk deploy` / `nx apply`
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+The generated `docker` target writes its build context to `dist/packages/<project>/docker/...` (Python) or `dist/packages/<project>/bundle/...` (TypeScript), and the generated infrastructure as code points at that directory. If that directory does not exist when you synth or apply, you will see errors like `ENOENT` or "directory does not exist".
 
-Docker is not running, or your user does not have permission to talk to the daemon socket.
-
-- **Docker Desktop**: start the application and wait for the whale icon to report "Docker Desktop is running".
-- **Linux**: start the service with `sudo systemctl start docker`. To avoid `sudo` for every command, add your user to the `docker` group (`sudo usermod -aG docker $USER`) and log out / back in.
-
-## Docker Image Assets Not Found at `cdk deploy`
-
-CDK's `DockerImageAsset` points at the build-context directory in `dist/`. If that directory does not exist when you run `cdk deploy`, synth will fail with `ENOENT` or "directory does not exist".
-
-The generators declare the `docker` target as a dependency of `build`, so `nx build my-infra` (or `nx deploy my-infra`) will produce the build context before CDK synths. If you invoke `cdk` directly, run the bundle + docker step first:
+The generators declare the `docker` target as a dependency of `build`, so `nx build` (or the generated `nx deploy` / `nx apply` targets) will produce the build context before CDK or Terraform runs. If you invoke `cdk` or `terraform` directly, run the docker step first:
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## Further Reading
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — the pattern the generators follow.

--- a/docs/src/content/docs/es/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/es/snippets/prerequisites.mdx
@@ -13,11 +13,11 @@ import Snippet from '@components/snippet.astro';
 
 ### Recomendados
 
-- [Docker](https://www.docker.com/) es necesario para algunos generadores.
+- [Docker](https://www.docker.com/) es necesario para algunos generadores. Las [compilaciones multiplataforma](https://docs.docker.com/build/building/multi-platform/) deben estar configuradas.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) es necesario si eliges usar esta herramienta para infraestructura como código en lugar de CDK
   - verifica ejecutando `terraform --version`
 - Si usas [VSCode](https://code.visualstudio.com/), recomendamos instalar el [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
 
 :::tip[Configuración del asistente IA]
-Si utilizas un Asistente de IA como Kiro, Amazon Q Developer, Cursor, Claude Code o Cline, también puedes <Link path="/get_started/building-with-ai">instalar el complemento NX para AWS MCP server.</Link>
+Si utilizas un Asistente de IA como Kiro, Kiro CLI, Cursor, Claude Code o Cline, también puedes <Link path="/get_started/building-with-ai">instalar el complemento NX para AWS MCP server.</Link>
 :::

--- a/docs/src/content/docs/es/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/es/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Solución de problemas con las compilaciones de Docker
 ---
 import Link from '@components/link.astro';
 
-Esta página proporciona orientación para solucionar problemas que pueda encontrar al compilar imágenes de Docker con el Nx Plugin para AWS. Consulte la <Link path="/guides/docker-bundling">guía de empaquetado de Docker</Link> para obtener información sobre el patrón utilizado por los generadores.
+Esta página proporciona orientación para solucionar problemas que pueda encontrar con las compilaciones de Docker producidas por los generadores. Consulte la <Link path="/guides/docker-bundling">guía de empaquetado de Docker</Link> para obtener información sobre el patrón que siguen.
 
 ## Compilaciones multiplataforma
 
-Los generadores como <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> y <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> producen imágenes para `linux/arm64` (Graviton) de forma predeterminada, independientemente de la arquitectura del host. Compilar una imagen `arm64` en un host `x86_64` — o una imagen `amd64` en Apple Silicon — requiere soporte de [compilación multiplataforma](https://docs.docker.com/build/building/multi-platform/) en su instalación local de Docker.
+Los generadores como <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> y <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> producen imágenes para `linux/arm64` (Graviton), independientemente de la arquitectura del host. Compilar una imagen `arm64` en un host `x86_64` — o una imagen `amd64` en Apple Silicon — requiere soporte de [compilación multiplataforma](https://docs.docker.com/build/building/multi-platform/) en su instalación local de Docker.
 
 Si las compilaciones multiplataforma no están configuradas, el síntoma depende del `Dockerfile`:
 
-- **El `Dockerfile` tiene un paso `RUN`** (por ejemplo, `RUN npm install` en los generadores de TypeScript): la compilación falla a mitad de camino con
+- **El `Dockerfile` tiene un paso `RUN`** (los generadores de TypeScript ejecutan `RUN npm install` para dependencias no empaquetables): la compilación falla a mitad de camino con
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **El `Dockerfile` solo usa `COPY`** (por ejemplo, los generadores de Python): la compilación tiene éxito, pero `docker run` falla más tarde con
+- **El `Dockerfile` solo usa `COPY`** (generadores de Python): la compilación tiene éxito, pero `docker run` falla más tarde con
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ Verifique que las plataformas compatibles coincidan con las que su proyecto tien
 docker buildx inspect --bootstrap
 ```
 
-La línea `Platforms:` debe incluir tanto `linux/amd64` como `linux/arm64`.
+La línea `Platforms:` debe incluir `linux/arm64`.
 
 :::tip[Entornos de CI]
 GitHub Actions, GitLab CI y proveedores similares normalmente **no** registran controladores QEMU de forma predeterminada. Agregue un paso como [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) antes de cualquier objetivo `nx build` / `nx docker` que produzca una imagen de arquitectura cruzada.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-Este error aparece cuando intenta compilar para múltiples plataformas a la vez (por ejemplo, `--platform linux/amd64,linux/arm64`) usando el controlador `docker` predeterminado:
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-Los generadores apuntan a una sola plataforma por compilación (`linux/arm64`), por lo que este error no aparecerá en los objetivos producidos por el plugin. Si ha personalizado un objetivo `docker` para emitir un manifiesto multiplataforma, debe:
-
-1. Crear y usar un constructor `docker-container`:
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. O habilitar el [almacén de imágenes containerd](https://docs.docker.com/engine/storage/containerd/) en Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
-
 ## Compilaciones lentas en arquitecturas emuladas
 
-Compilar una imagen `arm64` en un host `x86_64` (o viceversa) usa QEMU para emular cada instrucción, y los pasos de instalación de dependencias pueden ser muchas veces más lentos que una compilación nativa. El Nx Plugin para AWS mitiga esto haciendo la resolución de dependencias **fuera** del `Dockerfile` — consulte <Link path="/guides/docker-bundling">Empaquetado de Docker</Link>. Si todavía está viendo compilaciones de Docker lentas:
+Compilar una imagen `arm64` en un host `x86_64` (o viceversa) usa QEMU para emular cada instrucción, lo que puede ser muchas veces más lento que una compilación nativa. Los generadores mitigan esto haciendo la resolución de dependencias **fuera** del `Dockerfile` — consulte <Link path="/guides/docker-bundling">Empaquetado de Docker</Link>. Si todavía está viendo compilaciones de Docker lentas:
 
 - Asegúrese de ejecutar los objetivos `bundle` / `docker` a través de Nx (`nx docker my-project`) para que el paquete se almacene en caché entre ejecuciones.
-- Evite ejecutar `pip install`, `npm install` o `uv sync` dentro del `Dockerfile` para compilaciones de arquitectura cruzada — instale en el momento del empaquetado con `--python-platform` / `--platform` para que el trabajo pesado se ejecute de forma nativa, y deje que el `Dockerfile` no haga nada más que `COPY`.
 - En CI, considere un ejecutor ARM nativo (por ejemplo, `ubuntu-24.04-arm` de GitHub Actions) para evitar QEMU por completo.
 
-## `Cannot connect to the Docker daemon`
+## Contexto de compilación faltante en `cdk deploy` / `nx apply`
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+El objetivo `docker` generado escribe su contexto de compilación en `dist/packages/<project>/docker/...` (Python) o `dist/packages/<project>/bundle/...` (TypeScript), y la infraestructura como código generada apunta a ese directorio. Si ese directorio no existe cuando sintetiza o aplica, verá errores como `ENOENT` o "directory does not exist".
 
-Docker no se está ejecutando, o su usuario no tiene permiso para comunicarse con el socket del daemon.
-
-- **Docker Desktop**: inicie la aplicación y espere a que el ícono de la ballena informe "Docker Desktop is running".
-- **Linux**: inicie el servicio con `sudo systemctl start docker`. Para evitar `sudo` en cada comando, agregue su usuario al grupo `docker` (`sudo usermod -aG docker $USER`) e inicie/cierre sesión.
-
-## Activos de imagen de Docker no encontrados en `cdk deploy`
-
-El `DockerImageAsset` de CDK apunta al directorio de contexto de compilación en `dist/`. Si ese directorio no existe cuando ejecuta `cdk deploy`, la síntesis fallará con `ENOENT` o "directory does not exist".
-
-Los generadores declaran el objetivo `docker` como una dependencia de `build`, por lo que `nx build my-infra` (o `nx deploy my-infra`) producirá el contexto de compilación antes de que CDK sintetice. Si invoca `cdk` directamente, ejecute primero el paso de empaquetado + docker:
+Los generadores declaran el objetivo `docker` como una dependencia de `build`, por lo que `nx build` (o los objetivos generados `nx deploy` / `nx apply`) producirán el contexto de compilación antes de que CDK o Terraform se ejecute. Si invoca `cdk` o `terraform` directamente, ejecute primero el paso de docker:
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## Lectura adicional
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Guía de empaquetado de Docker</Link> — el patrón que siguen los generadores.

--- a/docs/src/content/docs/es/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/es/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Solución de problemas de Docker
+description: Solución de problemas con las compilaciones de Docker
+---
+import Link from '@components/link.astro';
+
+Esta página proporciona orientación para solucionar problemas que pueda encontrar al compilar imágenes de Docker con el Nx Plugin para AWS. Consulte la <Link path="/guides/docker-bundling">guía de empaquetado de Docker</Link> para obtener información sobre el patrón utilizado por los generadores.
+
+## Compilaciones multiplataforma
+
+Los generadores como <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> y <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> producen imágenes para `linux/arm64` (Graviton) de forma predeterminada, independientemente de la arquitectura del host. Compilar una imagen `arm64` en un host `x86_64` — o una imagen `amd64` en Apple Silicon — requiere soporte de [compilación multiplataforma](https://docs.docker.com/build/building/multi-platform/) en su instalación local de Docker.
+
+Si las compilaciones multiplataforma no están configuradas, el síntoma depende del `Dockerfile`:
+
+- **El `Dockerfile` tiene un paso `RUN`** (por ejemplo, `RUN npm install` en los generadores de TypeScript): la compilación falla a mitad de camino con
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **El `Dockerfile` solo usa `COPY`** (por ejemplo, los generadores de Python): la compilación tiene éxito, pero `docker run` falla más tarde con
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **La imagen base no está disponible para la plataforma de destino**: la compilación falla en el paso `FROM` con `no match for platform in manifest`.
+
+### Habilitar compilaciones multiplataforma
+
+**Docker Desktop** (Mac / Windows / Linux) viene con emulación [QEMU](https://www.qemu.org/) habilitada de forma predeterminada — normalmente no se requiere configuración adicional.
+
+**Los hosts Linux** (incluidos los ejecutores de CI) necesitan controladores binfmt de QEMU registrados con el kernel. Instálelos una vez por máquina:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Verifique que las plataformas compatibles coincidan con las que su proyecto tiene como objetivo:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+La línea `Platforms:` debe incluir tanto `linux/amd64` como `linux/arm64`.
+
+:::tip[Entornos de CI]
+GitHub Actions, GitLab CI y proveedores similares normalmente **no** registran controladores QEMU de forma predeterminada. Agregue un paso como [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) antes de cualquier objetivo `nx build` / `nx docker` que produzca una imagen de arquitectura cruzada.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+Este error aparece cuando intenta compilar para múltiples plataformas a la vez (por ejemplo, `--platform linux/amd64,linux/arm64`) usando el controlador `docker` predeterminado:
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+Los generadores apuntan a una sola plataforma por compilación (`linux/arm64`), por lo que este error no aparecerá en los objetivos producidos por el plugin. Si ha personalizado un objetivo `docker` para emitir un manifiesto multiplataforma, debe:
+
+1. Crear y usar un constructor `docker-container`:
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. O habilitar el [almacén de imágenes containerd](https://docs.docker.com/engine/storage/containerd/) en Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
+
+## Compilaciones lentas en arquitecturas emuladas
+
+Compilar una imagen `arm64` en un host `x86_64` (o viceversa) usa QEMU para emular cada instrucción, y los pasos de instalación de dependencias pueden ser muchas veces más lentos que una compilación nativa. El Nx Plugin para AWS mitiga esto haciendo la resolución de dependencias **fuera** del `Dockerfile` — consulte <Link path="/guides/docker-bundling">Empaquetado de Docker</Link>. Si todavía está viendo compilaciones de Docker lentas:
+
+- Asegúrese de ejecutar los objetivos `bundle` / `docker` a través de Nx (`nx docker my-project`) para que el paquete se almacene en caché entre ejecuciones.
+- Evite ejecutar `pip install`, `npm install` o `uv sync` dentro del `Dockerfile` para compilaciones de arquitectura cruzada — instale en el momento del empaquetado con `--python-platform` / `--platform` para que el trabajo pesado se ejecute de forma nativa, y deje que el `Dockerfile` no haga nada más que `COPY`.
+- En CI, considere un ejecutor ARM nativo (por ejemplo, `ubuntu-24.04-arm` de GitHub Actions) para evitar QEMU por completo.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker no se está ejecutando, o su usuario no tiene permiso para comunicarse con el socket del daemon.
+
+- **Docker Desktop**: inicie la aplicación y espere a que el ícono de la ballena informe "Docker Desktop is running".
+- **Linux**: inicie el servicio con `sudo systemctl start docker`. Para evitar `sudo` en cada comando, agregue su usuario al grupo `docker` (`sudo usermod -aG docker $USER`) e inicie/cierre sesión.
+
+## Activos de imagen de Docker no encontrados en `cdk deploy`
+
+El `DockerImageAsset` de CDK apunta al directorio de contexto de compilación en `dist/`. Si ese directorio no existe cuando ejecuta `cdk deploy`, la síntesis fallará con `ENOENT` o "directory does not exist".
+
+Los generadores declaran el objetivo `docker` como una dependencia de `build`, por lo que `nx build my-infra` (o `nx deploy my-infra`) producirá el contexto de compilación antes de que CDK sintetice. Si invoca `cdk` directamente, ejecute primero el paso de empaquetado + docker:
+
+```bash
+nx run my-project:docker
+```
+
+## Lectura adicional
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Guía de empaquetado de Docker</Link> — el patrón que siguen los generadores.

--- a/docs/src/content/docs/fr/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/fr/snippets/prerequisites.mdx
@@ -13,11 +13,11 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommandé
 
-- [Docker](https://www.docker.com/) est requis pour certains générateurs.
+- [Docker](https://www.docker.com/) est requis pour certains générateurs. Les [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) doivent être configurés.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) est requis si vous choisissez de l'utiliser pour l'infrastructure as code au lieu de CDK
   - vérifiez en exécutant `terraform --version`
 - Si vous utilisez [VSCode](https://code.visualstudio.com/), nous recommandons d'installer le [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
 
 :::tip[Configuration de l'assistant IA]
-Si vous utilisez un assistant d'IA tel que Kiro, Amazon Q Developer, Cursor, Claude Code ou Cline, vous pouvez également <Link path="/get_started/building-with-ai">installer le Nx Plugin pour AWS MCP server.</Link>
+Si vous utilisez un assistant d'IA tel que Kiro, Kiro CLI, Cursor, Claude Code ou Cline, vous pouvez également <Link path="/get_started/building-with-ai">installer le Nx Plugin pour AWS MCP server.</Link>
 :::

--- a/docs/src/content/docs/fr/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/fr/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Dépannage des problèmes liés aux builds Docker
 ---
 import Link from '@components/link.astro';
 
-Cette page fournit des conseils de dépannage pour les problèmes que vous pouvez rencontrer lors de la construction d'images Docker avec le plugin Nx pour AWS. Consultez le <Link path="/guides/docker-bundling">guide Docker Bundling</Link> pour en savoir plus sur le modèle utilisé par les générateurs.
+Cette page fournit des conseils de dépannage pour les problèmes que vous pouvez rencontrer avec les builds Docker produits par les générateurs. Consultez le <Link path="/guides/docker-bundling">guide Docker Bundling</Link> pour en savoir plus sur le modèle qu'ils suivent.
 
 ## Builds multi-plateformes
 
-Les générateurs tels que <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> et <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produisent des images pour `linux/arm64` (Graviton) par défaut, quelle que soit l'architecture de l'hôte. Construire une image `arm64` sur un hôte `x86_64` — ou une image `amd64` sur Apple Silicon — nécessite la prise en charge des [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) dans votre installation Docker locale.
+Les générateurs tels que <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> et <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produisent des images pour `linux/arm64` (Graviton), quelle que soit l'architecture de l'hôte. Construire une image `arm64` sur un hôte `x86_64` — ou une image `amd64` sur Apple Silicon — nécessite la prise en charge des [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) dans votre installation Docker locale.
 
 Si les builds multi-plateformes ne sont pas configurés, le symptôme dépend du `Dockerfile` :
 
-- **Le `Dockerfile` contient une étape `RUN`** (par exemple, `RUN npm install` dans les générateurs TypeScript) : le build échoue en cours de route avec
+- **Le `Dockerfile` contient une étape `RUN`** (les générateurs TypeScript exécutent `RUN npm install` pour les dépendances non empaquetables) : le build échoue en cours de route avec
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **Le `Dockerfile` utilise uniquement `COPY`** (par exemple, les générateurs Python) : le build réussit, mais `docker run` échoue plus tard avec
+- **Le `Dockerfile` utilise uniquement `COPY`** (générateurs Python) : le build réussit, mais `docker run` échoue plus tard avec
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ Vérifiez que les plateformes prises en charge correspondent à ce que votre pro
 docker buildx inspect --bootstrap
 ```
 
-La ligne `Platforms:` doit inclure à la fois `linux/amd64` et `linux/arm64`.
+La ligne `Platforms:` doit inclure `linux/arm64`.
 
 :::tip[Environnements CI]
 GitHub Actions, GitLab CI et les fournisseurs similaires n'enregistrent généralement **pas** les gestionnaires QEMU par défaut. Ajoutez une étape telle que [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) avant toute cible `nx build` / `nx docker` qui produit une image multi-architecture.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-Cette erreur apparaît lorsque vous essayez de construire pour plusieurs plateformes à la fois (par exemple `--platform linux/amd64,linux/arm64`) en utilisant le pilote `docker` par défaut :
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-Les générateurs ciblent une seule plateforme par build (`linux/arm64`), donc cette erreur n'apparaîtra pas à partir des cibles produites par le plugin. Si vous avez personnalisé une cible `docker` pour émettre un manifeste multi-plateforme, vous devez soit :
-
-1. Créer et utiliser un builder `docker-container` :
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. Ou activer le [containerd image store](https://docs.docker.com/engine/storage/containerd/) dans Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
-
 ## Builds lents sur architectures émulées
 
-Construire une image `arm64` sur un hôte `x86_64` (ou vice versa) utilise QEMU pour émuler chaque instruction, et les étapes d'installation des dépendances peuvent être plusieurs fois plus lentes qu'un build natif. Le plugin Nx pour AWS atténue ce problème en effectuant la résolution des dépendances **en dehors** du `Dockerfile` — voir <Link path="/guides/docker-bundling">Docker Bundling</Link>. Si vous constatez toujours des builds Docker lents :
+Construire une image `arm64` sur un hôte `x86_64` (ou vice versa) utilise QEMU pour émuler chaque instruction, ce qui peut être plusieurs fois plus lent qu'un build natif. Les générateurs atténuent ce problème en effectuant la résolution des dépendances **en dehors** du `Dockerfile` — voir <Link path="/guides/docker-bundling">Docker Bundling</Link>. Si vous constatez toujours des builds Docker lents :
 
 - Assurez-vous d'exécuter les cibles `bundle` / `docker` via Nx (`nx docker my-project`) afin que le bundle soit mis en cache entre les exécutions.
-- Évitez d'exécuter `pip install`, `npm install` ou `uv sync` à l'intérieur du `Dockerfile` pour les builds multi-architecture — installez au moment du bundle avec `--python-platform` / `--platform` afin que le travail lourd s'exécute nativement, et laissez le `Dockerfile` ne faire rien de plus que `COPY`.
 - Sur CI, envisagez un runner ARM natif (par exemple `ubuntu-24.04-arm` de GitHub Actions) pour éviter complètement QEMU.
 
-## `Cannot connect to the Docker daemon`
+## Contexte de build manquant lors de `cdk deploy` / `nx apply`
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+La cible `docker` générée écrit son contexte de build dans `dist/packages/<project>/docker/...` (Python) ou `dist/packages/<project>/bundle/...` (TypeScript), et l'infrastructure en tant que code générée pointe vers ce répertoire. Si ce répertoire n'existe pas lorsque vous synthétisez ou appliquez, vous verrez des erreurs comme `ENOENT` ou "directory does not exist".
 
-Docker n'est pas en cours d'exécution, ou votre utilisateur n'a pas la permission de communiquer avec le socket du daemon.
-
-- **Docker Desktop** : démarrez l'application et attendez que l'icône de baleine indique "Docker Desktop is running".
-- **Linux** : démarrez le service avec `sudo systemctl start docker`. Pour éviter `sudo` à chaque commande, ajoutez votre utilisateur au groupe `docker` (`sudo usermod -aG docker $USER`) et déconnectez-vous / reconnectez-vous.
-
-## Assets d'image Docker introuvables lors de `cdk deploy`
-
-Le `DockerImageAsset` de CDK pointe vers le répertoire de contexte de build dans `dist/`. Si ce répertoire n'existe pas lorsque vous exécutez `cdk deploy`, la synthèse échouera avec `ENOENT` ou "directory does not exist".
-
-Les générateurs déclarent la cible `docker` comme dépendance de `build`, donc `nx build my-infra` (ou `nx deploy my-infra`) produira le contexte de build avant que CDK ne synthétise. Si vous invoquez `cdk` directement, exécutez d'abord l'étape bundle + docker :
+Les générateurs déclarent la cible `docker` comme dépendance de `build`, donc `nx build` (ou les cibles générées `nx deploy` / `nx apply`) produira le contexte de build avant que CDK ou Terraform ne s'exécute. Si vous invoquez `cdk` ou `terraform` directement, exécutez d'abord l'étape docker :
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## Lectures complémentaires
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — le modèle que suivent les générateurs.

--- a/docs/src/content/docs/fr/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/fr/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Dépannage Docker
+description: Dépannage des problèmes liés aux builds Docker
+---
+import Link from '@components/link.astro';
+
+Cette page fournit des conseils de dépannage pour les problèmes que vous pouvez rencontrer lors de la construction d'images Docker avec le plugin Nx pour AWS. Consultez le <Link path="/guides/docker-bundling">guide Docker Bundling</Link> pour en savoir plus sur le modèle utilisé par les générateurs.
+
+## Builds multi-plateformes
+
+Les générateurs tels que <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> et <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produisent des images pour `linux/arm64` (Graviton) par défaut, quelle que soit l'architecture de l'hôte. Construire une image `arm64` sur un hôte `x86_64` — ou une image `amd64` sur Apple Silicon — nécessite la prise en charge des [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) dans votre installation Docker locale.
+
+Si les builds multi-plateformes ne sont pas configurés, le symptôme dépend du `Dockerfile` :
+
+- **Le `Dockerfile` contient une étape `RUN`** (par exemple, `RUN npm install` dans les générateurs TypeScript) : le build échoue en cours de route avec
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **Le `Dockerfile` utilise uniquement `COPY`** (par exemple, les générateurs Python) : le build réussit, mais `docker run` échoue plus tard avec
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **L'image de base n'est pas disponible pour la plateforme cible** : le build échoue à l'étape `FROM` avec `no match for platform in manifest`.
+
+### Activer les builds multi-plateformes
+
+**Docker Desktop** (Mac / Windows / Linux) est livré avec l'émulation [QEMU](https://www.qemu.org/) activée par défaut — aucune configuration supplémentaire n'est généralement requise.
+
+**Les hôtes Linux** (y compris les runners CI) nécessitent l'enregistrement des gestionnaires QEMU binfmt avec le noyau. Installez-les une fois par machine :
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Vérifiez que les plateformes prises en charge correspondent à ce que votre projet cible :
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+La ligne `Platforms:` doit inclure à la fois `linux/amd64` et `linux/arm64`.
+
+:::tip[Environnements CI]
+GitHub Actions, GitLab CI et les fournisseurs similaires n'enregistrent généralement **pas** les gestionnaires QEMU par défaut. Ajoutez une étape telle que [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) avant toute cible `nx build` / `nx docker` qui produit une image multi-architecture.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+Cette erreur apparaît lorsque vous essayez de construire pour plusieurs plateformes à la fois (par exemple `--platform linux/amd64,linux/arm64`) en utilisant le pilote `docker` par défaut :
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+Les générateurs ciblent une seule plateforme par build (`linux/arm64`), donc cette erreur n'apparaîtra pas à partir des cibles produites par le plugin. Si vous avez personnalisé une cible `docker` pour émettre un manifeste multi-plateforme, vous devez soit :
+
+1. Créer et utiliser un builder `docker-container` :
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. Ou activer le [containerd image store](https://docs.docker.com/engine/storage/containerd/) dans Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
+
+## Builds lents sur architectures émulées
+
+Construire une image `arm64` sur un hôte `x86_64` (ou vice versa) utilise QEMU pour émuler chaque instruction, et les étapes d'installation des dépendances peuvent être plusieurs fois plus lentes qu'un build natif. Le plugin Nx pour AWS atténue ce problème en effectuant la résolution des dépendances **en dehors** du `Dockerfile` — voir <Link path="/guides/docker-bundling">Docker Bundling</Link>. Si vous constatez toujours des builds Docker lents :
+
+- Assurez-vous d'exécuter les cibles `bundle` / `docker` via Nx (`nx docker my-project`) afin que le bundle soit mis en cache entre les exécutions.
+- Évitez d'exécuter `pip install`, `npm install` ou `uv sync` à l'intérieur du `Dockerfile` pour les builds multi-architecture — installez au moment du bundle avec `--python-platform` / `--platform` afin que le travail lourd s'exécute nativement, et laissez le `Dockerfile` ne faire rien de plus que `COPY`.
+- Sur CI, envisagez un runner ARM natif (par exemple `ubuntu-24.04-arm` de GitHub Actions) pour éviter complètement QEMU.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker n'est pas en cours d'exécution, ou votre utilisateur n'a pas la permission de communiquer avec le socket du daemon.
+
+- **Docker Desktop** : démarrez l'application et attendez que l'icône de baleine indique "Docker Desktop is running".
+- **Linux** : démarrez le service avec `sudo systemctl start docker`. Pour éviter `sudo` à chaque commande, ajoutez votre utilisateur au groupe `docker` (`sudo usermod -aG docker $USER`) et déconnectez-vous / reconnectez-vous.
+
+## Assets d'image Docker introuvables lors de `cdk deploy`
+
+Le `DockerImageAsset` de CDK pointe vers le répertoire de contexte de build dans `dist/`. Si ce répertoire n'existe pas lorsque vous exécutez `cdk deploy`, la synthèse échouera avec `ENOENT` ou "directory does not exist".
+
+Les générateurs déclarent la cible `docker` comme dépendance de `build`, donc `nx build my-infra` (ou `nx deploy my-infra`) produira le contexte de build avant que CDK ne synthétise. Si vous invoquez `cdk` directement, exécutez d'abord l'étape bundle + docker :
+
+```bash
+nx run my-project:docker
+```
+
+## Lectures complémentaires
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — le modèle que suivent les générateurs.

--- a/docs/src/content/docs/it/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/it/snippets/prerequisites.mdx
@@ -13,11 +13,11 @@ import Snippet from '@components/snippet.astro';
 
 ### Consigliati
 
-- [Docker](https://www.docker.com/) è necessario per alcuni generatori.
+- [Docker](https://www.docker.com/) è necessario per alcuni generatori. Le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) devono essere configurate.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) è richiesto se scegli di utilizzarlo per l'infrastructure as code invece di CDK
   - verifica eseguendo `terraform --version`
 - Se utilizzi [VSCode](https://code.visualstudio.com/), consigliamo di installare il [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
 
 :::tip[Configurazione dell'assistente IA]
-Se utilizzi un Assistente AI come Kiro, Amazon Q Developer, Cursor, Claude Code o Cline, potresti voler <Link path="/get_started/building-with-ai">installare il Plugin Nx per AWS MCP server.</Link>
+Se utilizzi un Assistente AI come Kiro, Kiro CLI, Cursor, Claude Code o Cline, potresti voler <Link path="/get_started/building-with-ai">installare il Plugin Nx per AWS MCP server.</Link>
 :::

--- a/docs/src/content/docs/it/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/it/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Risoluzione dei problemi Docker
+description: Risoluzione dei problemi con le build Docker
+---
+import Link from '@components/link.astro';
+
+Questa pagina fornisce una guida alla risoluzione dei problemi che potresti incontrare durante la creazione di immagini Docker con il Plugin Nx per AWS. Consulta la <Link path="/guides/docker-bundling">guida al Docker Bundling</Link> per informazioni sul pattern utilizzato dai generatori.
+
+## Build Multi-Piattaforma
+
+I generatori come <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> e <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> producono immagini per `linux/arm64` (Graviton) per impostazione predefinita, indipendentemente dall'architettura dell'host. La creazione di un'immagine `arm64` su un host `x86_64` — o di un'immagine `amd64` su Apple Silicon — richiede il supporto per le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) nella tua installazione Docker locale.
+
+Se le build multi-piattaforma non sono configurate, il sintomo dipende dal `Dockerfile`:
+
+- **Il `Dockerfile` ha uno step `RUN`** (ad esempio, `RUN npm install` nei generatori TypeScript): la build fallisce a metà con
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **Il `Dockerfile` usa solo `COPY`** (ad esempio, i generatori Python): la build ha successo, ma `docker run` fallisce successivamente con
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **L'immagine base non è disponibile per la piattaforma di destinazione**: la build fallisce allo step `FROM` con `no match for platform in manifest`.
+
+### Abilitare le Build Multi-Piattaforma
+
+**Docker Desktop** (Mac / Windows / Linux) viene fornito con l'emulazione [QEMU](https://www.qemu.org/) abilitata di default — di solito non è richiesta alcuna configurazione aggiuntiva.
+
+**Gli host Linux** (inclusi i runner CI) necessitano dei gestori binfmt QEMU registrati con il kernel. Installali una volta per macchina:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Verifica che le piattaforme supportate corrispondano a quelle di destinazione del tuo progetto:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+La riga `Platforms:` dovrebbe includere sia `linux/amd64` che `linux/arm64`.
+
+:::tip[Ambienti CI]
+GitHub Actions, GitLab CI e provider simili tipicamente **non** registrano i gestori QEMU per impostazione predefinita. Aggiungi uno step come [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) prima di qualsiasi target `nx build` / `nx docker` che produce un'immagine cross-architettura.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+Questo errore appare quando provi a costruire per più piattaforme contemporaneamente (ad es. `--platform linux/amd64,linux/arm64`) usando il driver `docker` predefinito:
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+I generatori puntano a una singola piattaforma per build (`linux/arm64`), quindi questo errore non apparirà dai target prodotti dal plugin. Se hai personalizzato un target `docker` per emettere un manifest multi-piattaforma, devi:
+
+1. Creare e usare un builder `docker-container`:
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. Oppure abilitare il [containerd image store](https://docs.docker.com/engine/storage/containerd/) in Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
+
+## Build Lente su Architetture Emulate
+
+La creazione di un'immagine `arm64` su un host `x86_64` (o viceversa) usa QEMU per emulare ogni istruzione, e gli step di installazione delle dipendenze possono essere molte volte più lenti di una build nativa. Il Plugin Nx per AWS mitiga questo problema eseguendo la risoluzione delle dipendenze **al di fuori** del `Dockerfile` — vedi <Link path="/guides/docker-bundling">Docker Bundling</Link>. Se stai ancora riscontrando build Docker lente:
+
+- Assicurati di eseguire i target `bundle` / `docker` attraverso Nx (`nx docker my-project`) in modo che il bundle sia memorizzato nella cache tra le esecuzioni.
+- Evita di eseguire `pip install`, `npm install` o `uv sync` all'interno del `Dockerfile` per le build cross-architettura — installa al momento del bundle con `--python-platform` / `--platform` in modo che il lavoro pesante venga eseguito nativamente, e lascia che il `Dockerfile` faccia nient'altro che `COPY`.
+- Su CI, considera un runner ARM nativo (ad es. `ubuntu-24.04-arm` di GitHub Actions) per evitare completamente QEMU.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker non è in esecuzione, oppure il tuo utente non ha i permessi per comunicare con il socket del daemon.
+
+- **Docker Desktop**: avvia l'applicazione e attendi che l'icona della balena riporti "Docker Desktop is running".
+- **Linux**: avvia il servizio con `sudo systemctl start docker`. Per evitare `sudo` per ogni comando, aggiungi il tuo utente al gruppo `docker` (`sudo usermod -aG docker $USER`) ed esci/rientra.
+
+## Asset di Immagini Docker Non Trovati durante `cdk deploy`
+
+Il `DockerImageAsset` di CDK punta alla directory del contesto di build in `dist/`. Se quella directory non esiste quando esegui `cdk deploy`, la sintesi fallirà con `ENOENT` o "directory does not exist".
+
+I generatori dichiarano il target `docker` come dipendenza di `build`, quindi `nx build my-infra` (o `nx deploy my-infra`) produrrà il contesto di build prima che CDK esegua la sintesi. Se invochi `cdk` direttamente, esegui prima lo step bundle + docker:
+
+```bash
+nx run my-project:docker
+```
+
+## Ulteriori Letture
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — il pattern seguito dai generatori.

--- a/docs/src/content/docs/it/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/it/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Risoluzione dei problemi con le build Docker
 ---
 import Link from '@components/link.astro';
 
-Questa pagina fornisce una guida alla risoluzione dei problemi che potresti incontrare durante la creazione di immagini Docker con il Plugin Nx per AWS. Consulta la <Link path="/guides/docker-bundling">guida al Docker Bundling</Link> per informazioni sul pattern utilizzato dai generatori.
+Questa pagina fornisce una guida alla risoluzione dei problemi che potresti incontrare con le build Docker prodotte dai generatori. Consulta la <Link path="/guides/docker-bundling">guida al Docker Bundling</Link> per informazioni sul pattern che seguono.
 
 ## Build Multi-Piattaforma
 
-I generatori come <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> e <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> producono immagini per `linux/arm64` (Graviton) per impostazione predefinita, indipendentemente dall'architettura dell'host. La creazione di un'immagine `arm64` su un host `x86_64` — o di un'immagine `amd64` su Apple Silicon — richiede il supporto per le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) nella tua installazione Docker locale.
+I generatori come <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> e <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> producono immagini per `linux/arm64` (Graviton), indipendentemente dall'architettura dell'host. La creazione di un'immagine `arm64` su un host `x86_64` — o di un'immagine `amd64` su Apple Silicon — richiede il supporto per le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) nella tua installazione Docker locale.
 
 Se le build multi-piattaforma non sono configurate, il sintomo dipende dal `Dockerfile`:
 
-- **Il `Dockerfile` ha uno step `RUN`** (ad esempio, `RUN npm install` nei generatori TypeScript): la build fallisce a metà con
+- **Il `Dockerfile` ha uno step `RUN`** (i generatori TypeScript eseguono `RUN npm install` per le dipendenze non raggruppabili): la build fallisce a metà con
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **Il `Dockerfile` usa solo `COPY`** (ad esempio, i generatori Python): la build ha successo, ma `docker run` fallisce successivamente con
+- **Il `Dockerfile` usa solo `COPY`** (generatori Python): la build ha successo, ma `docker run` fallisce successivamente con
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ Verifica che le piattaforme supportate corrispondano a quelle di destinazione de
 docker buildx inspect --bootstrap
 ```
 
-La riga `Platforms:` dovrebbe includere sia `linux/amd64` che `linux/arm64`.
+La riga `Platforms:` dovrebbe includere `linux/arm64`.
 
 :::tip[Ambienti CI]
 GitHub Actions, GitLab CI e provider simili tipicamente **non** registrano i gestori QEMU per impostazione predefinita. Aggiungi uno step come [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) prima di qualsiasi target `nx build` / `nx docker` che produce un'immagine cross-architettura.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-Questo errore appare quando provi a costruire per più piattaforme contemporaneamente (ad es. `--platform linux/amd64,linux/arm64`) usando il driver `docker` predefinito:
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-I generatori puntano a una singola piattaforma per build (`linux/arm64`), quindi questo errore non apparirà dai target prodotti dal plugin. Se hai personalizzato un target `docker` per emettere un manifest multi-piattaforma, devi:
-
-1. Creare e usare un builder `docker-container`:
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. Oppure abilitare il [containerd image store](https://docs.docker.com/engine/storage/containerd/) in Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
-
 ## Build Lente su Architetture Emulate
 
-La creazione di un'immagine `arm64` su un host `x86_64` (o viceversa) usa QEMU per emulare ogni istruzione, e gli step di installazione delle dipendenze possono essere molte volte più lenti di una build nativa. Il Plugin Nx per AWS mitiga questo problema eseguendo la risoluzione delle dipendenze **al di fuori** del `Dockerfile` — vedi <Link path="/guides/docker-bundling">Docker Bundling</Link>. Se stai ancora riscontrando build Docker lente:
+La creazione di un'immagine `arm64` su un host `x86_64` (o viceversa) usa QEMU per emulare ogni istruzione, il che può essere molte volte più lento di una build nativa. I generatori mitigano questo problema eseguendo la risoluzione delle dipendenze **al di fuori** del `Dockerfile` — vedi <Link path="/guides/docker-bundling">Docker Bundling</Link>. Se stai ancora riscontrando build Docker lente:
 
 - Assicurati di eseguire i target `bundle` / `docker` attraverso Nx (`nx docker my-project`) in modo che il bundle sia memorizzato nella cache tra le esecuzioni.
-- Evita di eseguire `pip install`, `npm install` o `uv sync` all'interno del `Dockerfile` per le build cross-architettura — installa al momento del bundle con `--python-platform` / `--platform` in modo che il lavoro pesante venga eseguito nativamente, e lascia che il `Dockerfile` faccia nient'altro che `COPY`.
 - Su CI, considera un runner ARM nativo (ad es. `ubuntu-24.04-arm` di GitHub Actions) per evitare completamente QEMU.
 
-## `Cannot connect to the Docker daemon`
+## Contesto di Build Mancante durante `cdk deploy` / `nx apply`
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+Il target `docker` generato scrive il suo contesto di build in `dist/packages/<project>/docker/...` (Python) o `dist/packages/<project>/bundle/...` (TypeScript), e l'infrastruttura come codice generata punta a quella directory. Se quella directory non esiste quando esegui synth o apply, vedrai errori come `ENOENT` o "directory does not exist".
 
-Docker non è in esecuzione, oppure il tuo utente non ha i permessi per comunicare con il socket del daemon.
-
-- **Docker Desktop**: avvia l'applicazione e attendi che l'icona della balena riporti "Docker Desktop is running".
-- **Linux**: avvia il servizio con `sudo systemctl start docker`. Per evitare `sudo` per ogni comando, aggiungi il tuo utente al gruppo `docker` (`sudo usermod -aG docker $USER`) ed esci/rientra.
-
-## Asset di Immagini Docker Non Trovati durante `cdk deploy`
-
-Il `DockerImageAsset` di CDK punta alla directory del contesto di build in `dist/`. Se quella directory non esiste quando esegui `cdk deploy`, la sintesi fallirà con `ENOENT` o "directory does not exist".
-
-I generatori dichiarano il target `docker` come dipendenza di `build`, quindi `nx build my-infra` (o `nx deploy my-infra`) produrrà il contesto di build prima che CDK esegua la sintesi. Se invochi `cdk` direttamente, esegui prima lo step bundle + docker:
+I generatori dichiarano il target `docker` come dipendenza di `build`, quindi `nx build` (o i target generati `nx deploy` / `nx apply`) produrrà il contesto di build prima che CDK o Terraform venga eseguito. Se invochi `cdk` o `terraform` direttamente, esegui prima lo step docker:
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## Ulteriori Letture
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — il pattern seguito dai generatori.

--- a/docs/src/content/docs/jp/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/jp/snippets/prerequisites.mdx
@@ -1,9 +1,6 @@
 ---
 title: "前提条件"
 ---
-
-
-
 import Link from '@components/link.astro';
 import Snippet from '@components/snippet.astro';
 
@@ -13,11 +10,11 @@ import Snippet from '@components/snippet.astro';
 
 ### 推奨
 
-- [Docker](https://www.docker.com/)は一部のジェネレーターで必要です
+- [Docker](https://www.docker.com/)は一部のジェネレーターで必要です。[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)をセットアップする必要があります。
 - CDKの代わりにインフラストラクチャー・アズ・コードでTerraformを使用する場合、[Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)が必要です
   - `terraform --version` を実行して確認してください
 - [VSCode](https://code.visualstudio.com/)を使用する場合、[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)のインストールを推奨します
 
 :::tip[AIアシスタントのセットアップ]
-Kiro、Amazon Q Developer、Cursor、Claude Code、ClineなどのAIアシスタントを使用する場合、<Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP serverのインストール</Link>も推奨します
+Kiro、Kiro CLI、Cursor、Claude Code、ClineなどのAIアシスタントを使用する場合、<Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP serverのインストール</Link>も推奨します
 :::

--- a/docs/src/content/docs/jp/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/jp/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Docker のトラブルシューティング
+description: Docker ビルドに関する問題のトラブルシューティング
+---
+import Link from '@components/link.astro';
+
+このページでは、Nx Plugin for AWS で Docker イメージをビルドする際に遭遇する可能性のある問題のトラブルシューティングガイダンスを提供します。ジェネレーターが使用するパターンの背景については、<Link path="/guides/docker-bundling">Docker Bundling ガイド</Link>を参照してください。
+
+## クロスプラットフォームビルド
+
+<Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>、<Link path="/guides/py-strands-agent">`py#strands-agent`</Link>、<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>、<Link path="/guides/py-mcp-server">`py#mcp-server`</Link> などのジェネレーターは、ホストアーキテクチャに関係なく、デフォルトで `linux/arm64`（Graviton）用のイメージを生成します。`x86_64` ホスト上で `arm64` イメージをビルドする場合、または Apple Silicon 上で `amd64` イメージをビルドする場合は、ローカルの Docker インストールで[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)のサポートが必要です。
+
+マルチプラットフォームビルドが設定されていない場合、症状は `Dockerfile` によって異なります：
+
+- **`Dockerfile` に `RUN` ステップがある場合**（例：TypeScript ジェネレーターの `RUN npm install`）：ビルドが途中で失敗し、次のエラーが表示されます
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **`Dockerfile` が `COPY` のみを使用する場合**（例：Python ジェネレーター）：ビルドは成功しますが、後で `docker run` が次のエラーで失敗します
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **ベースイメージがターゲットプラットフォームで利用できない場合**：`FROM` ステップで `no match for platform in manifest` というエラーでビルドが失敗します。
+
+### マルチプラットフォームビルドを有効にする
+
+**Docker Desktop**（Mac / Windows / Linux）は、[QEMU](https://www.qemu.org/) エミュレーションが標準で有効になっており、通常は追加のセットアップは必要ありません。
+
+**Linux ホスト**（CI ランナーを含む）では、QEMU binfmt ハンドラーをカーネルに登録する必要があります。マシンごとに一度インストールしてください：
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+サポートされているプラットフォームがプロジェクトのターゲットと一致することを確認します：
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+`Platforms:` 行には `linux/amd64` と `linux/arm64` の両方が含まれている必要があります。
+
+:::tip[CI 環境]
+GitHub Actions、GitLab CI、および同様のプロバイダーは、通常デフォルトでは QEMU ハンドラーを登録**しません**。クロスアーキテクチャイメージを生成する `nx build` / `nx docker` ターゲットの前に、[`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) などのステップを追加してください。
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+このエラーは、デフォルトの `docker` ドライバーを使用して複数のプラットフォームを一度にビルドしようとした場合（例：`--platform linux/amd64,linux/arm64`）に表示されます：
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+ジェネレーターはビルドごとに単一のプラットフォーム（`linux/arm64`）をターゲットとするため、このエラーはプラグインによって生成されたターゲットからは表示されません。マルチプラットフォームマニフェストを出力するように `docker` ターゲットをカスタマイズした場合は、次のいずれかを行う必要があります：
+
+1. `docker-container` ビルダーを作成して使用する：
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. または、Docker Desktop で [containerd イメージストア](https://docs.docker.com/engine/storage/containerd/)を有効にする（`Settings → General → Use containerd for pulling and storing images`）。
+
+## エミュレートされたアーキテクチャでのビルドの遅さ
+
+`x86_64` ホスト上で `arm64` イメージをビルドする場合（またはその逆）、QEMU を使用して各命令をエミュレートするため、依存関係のインストールステップはネイティブビルドよりも何倍も遅くなる可能性があります。Nx Plugin for AWS は、`Dockerfile` の**外部**で依存関係の解決を行うことでこれを軽減します — <Link path="/guides/docker-bundling">Docker Bundling</Link> を参照してください。それでも Docker ビルドが遅い場合：
+
+- `bundle` / `docker` ターゲットを Nx 経由で実行している（`nx docker my-project`）ことを確認し、実行間でバンドルがキャッシュされるようにします。
+- クロスアーキテクチャビルドの場合、`Dockerfile` 内で `pip install`、`npm install`、または `uv sync` を実行しないでください — `--python-platform` / `--platform` を使用してバンドル時にインストールし、重い作業をネイティブで実行し、`Dockerfile` では `COPY` 以外何もしないようにします。
+- CI では、QEMU を完全に回避するために、ネイティブ ARM ランナー（例：GitHub Actions の `ubuntu-24.04-arm`）の使用を検討してください。
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker が実行されていないか、ユーザーがデーモンソケットと通信する権限を持っていません。
+
+- **Docker Desktop**：アプリケーションを起動し、クジラのアイコンが「Docker Desktop is running」と報告するまで待ちます。
+- **Linux**：`sudo systemctl start docker` でサービスを起動します。すべてのコマンドで `sudo` を避けるには、ユーザーを `docker` グループに追加し（`sudo usermod -aG docker $USER`）、ログアウト/ログインしてください。
+
+## `cdk deploy` 時に Docker イメージアセットが見つからない
+
+CDK の `DockerImageAsset` は `dist/` 内のビルドコンテキストディレクトリを指しています。`cdk deploy` を実行したときにそのディレクトリが存在しない場合、synth は `ENOENT` または「directory does not exist」で失敗します。
+
+ジェネレーターは `docker` ターゲットを `build` の依存関係として宣言しているため、`nx build my-infra`（または `nx deploy my-infra`）は CDK が synth する前にビルドコンテキストを生成します。`cdk` を直接呼び出す場合は、最初に bundle + docker ステップを実行してください：
+
+```bash
+nx run my-project:docker
+```
+
+## 参考資料
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — ジェネレーターが従うパターン。

--- a/docs/src/content/docs/jp/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/jp/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Docker ビルドに関する問題のトラブルシューティン
 ---
 import Link from '@components/link.astro';
 
-このページでは、Nx Plugin for AWS で Docker イメージをビルドする際に遭遇する可能性のある問題のトラブルシューティングガイダンスを提供します。ジェネレーターが使用するパターンの背景については、<Link path="/guides/docker-bundling">Docker Bundling ガイド</Link>を参照してください。
+このページでは、ジェネレーターによって生成される Docker ビルドで遭遇する可能性のある問題のトラブルシューティングガイダンスを提供します。ジェネレーターが従うパターンの背景については、<Link path="/guides/docker-bundling">Docker Bundling ガイド</Link>を参照してください。
 
 ## クロスプラットフォームビルド
 
-<Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>、<Link path="/guides/py-strands-agent">`py#strands-agent`</Link>、<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>、<Link path="/guides/py-mcp-server">`py#mcp-server`</Link> などのジェネレーターは、ホストアーキテクチャに関係なく、デフォルトで `linux/arm64`（Graviton）用のイメージを生成します。`x86_64` ホスト上で `arm64` イメージをビルドする場合、または Apple Silicon 上で `amd64` イメージをビルドする場合は、ローカルの Docker インストールで[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)のサポートが必要です。
+<Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>、<Link path="/guides/py-strands-agent">`py#strands-agent`</Link>、<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>、<Link path="/guides/py-mcp-server">`py#mcp-server`</Link> などのジェネレーターは、ホストアーキテクチャに関係なく、`linux/arm64`（Graviton）用のイメージを生成します。`x86_64` ホスト上で `arm64` イメージをビルドする場合、または Apple Silicon 上で `amd64` イメージをビルドする場合は、ローカルの Docker インストールで[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)のサポートが必要です。
 
 マルチプラットフォームビルドが設定されていない場合、症状は `Dockerfile` によって異なります：
 
-- **`Dockerfile` に `RUN` ステップがある場合**（例：TypeScript ジェネレーターの `RUN npm install`）：ビルドが途中で失敗し、次のエラーが表示されます
+- **`Dockerfile` に `RUN` ステップがある場合**（TypeScript ジェネレーターはバンドル不可能な依存関係のために `RUN npm install` を実行します）：ビルドが途中で失敗し、次のエラーが表示されます
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **`Dockerfile` が `COPY` のみを使用する場合**（例：Python ジェネレーター）：ビルドは成功しますが、後で `docker run` が次のエラーで失敗します
+- **`Dockerfile` が `COPY` のみを使用する場合**（Python ジェネレーター）：ビルドは成功しますが、後で `docker run` が次のエラーで失敗します
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 docker buildx inspect --bootstrap
 ```
 
-`Platforms:` 行には `linux/amd64` と `linux/arm64` の両方が含まれている必要があります。
+`Platforms:` 行には `linux/arm64` が含まれている必要があります。
 
 :::tip[CI 環境]
 GitHub Actions、GitLab CI、および同様のプロバイダーは、通常デフォルトでは QEMU ハンドラーを登録**しません**。クロスアーキテクチャイメージを生成する `nx build` / `nx docker` ターゲットの前に、[`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) などのステップを追加してください。
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-このエラーは、デフォルトの `docker` ドライバーを使用して複数のプラットフォームを一度にビルドしようとした場合（例：`--platform linux/amd64,linux/arm64`）に表示されます：
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-ジェネレーターはビルドごとに単一のプラットフォーム（`linux/arm64`）をターゲットとするため、このエラーはプラグインによって生成されたターゲットからは表示されません。マルチプラットフォームマニフェストを出力するように `docker` ターゲットをカスタマイズした場合は、次のいずれかを行う必要があります：
-
-1. `docker-container` ビルダーを作成して使用する：
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. または、Docker Desktop で [containerd イメージストア](https://docs.docker.com/engine/storage/containerd/)を有効にする（`Settings → General → Use containerd for pulling and storing images`）。
-
 ## エミュレートされたアーキテクチャでのビルドの遅さ
 
-`x86_64` ホスト上で `arm64` イメージをビルドする場合（またはその逆）、QEMU を使用して各命令をエミュレートするため、依存関係のインストールステップはネイティブビルドよりも何倍も遅くなる可能性があります。Nx Plugin for AWS は、`Dockerfile` の**外部**で依存関係の解決を行うことでこれを軽減します — <Link path="/guides/docker-bundling">Docker Bundling</Link> を参照してください。それでも Docker ビルドが遅い場合：
+`x86_64` ホスト上で `arm64` イメージをビルドする場合（またはその逆）、QEMU を使用して各命令をエミュレートするため、ネイティブビルドよりも何倍も遅くなる可能性があります。ジェネレーターは、`Dockerfile` の**外部**で依存関係の解決を行うことでこれを軽減します — <Link path="/guides/docker-bundling">Docker Bundling</Link> を参照してください。それでも Docker ビルドが遅い場合：
 
 - `bundle` / `docker` ターゲットを Nx 経由で実行している（`nx docker my-project`）ことを確認し、実行間でバンドルがキャッシュされるようにします。
-- クロスアーキテクチャビルドの場合、`Dockerfile` 内で `pip install`、`npm install`、または `uv sync` を実行しないでください — `--python-platform` / `--platform` を使用してバンドル時にインストールし、重い作業をネイティブで実行し、`Dockerfile` では `COPY` 以外何もしないようにします。
 - CI では、QEMU を完全に回避するために、ネイティブ ARM ランナー（例：GitHub Actions の `ubuntu-24.04-arm`）の使用を検討してください。
 
-## `Cannot connect to the Docker daemon`
+## `cdk deploy` / `nx apply` 時にビルドコンテキストが見つからない
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+生成された `docker` ターゲットは、ビルドコンテキストを `dist/packages/<project>/docker/...`（Python）または `dist/packages/<project>/bundle/...`（TypeScript）に書き込み、生成された Infrastructure as Code はそのディレクトリを指しています。synth または apply を実行したときにそのディレクトリが存在しない場合、`ENOENT` または「directory does not exist」のようなエラーが表示されます。
 
-Docker が実行されていないか、ユーザーがデーモンソケットと通信する権限を持っていません。
-
-- **Docker Desktop**：アプリケーションを起動し、クジラのアイコンが「Docker Desktop is running」と報告するまで待ちます。
-- **Linux**：`sudo systemctl start docker` でサービスを起動します。すべてのコマンドで `sudo` を避けるには、ユーザーを `docker` グループに追加し（`sudo usermod -aG docker $USER`）、ログアウト/ログインしてください。
-
-## `cdk deploy` 時に Docker イメージアセットが見つからない
-
-CDK の `DockerImageAsset` は `dist/` 内のビルドコンテキストディレクトリを指しています。`cdk deploy` を実行したときにそのディレクトリが存在しない場合、synth は `ENOENT` または「directory does not exist」で失敗します。
-
-ジェネレーターは `docker` ターゲットを `build` の依存関係として宣言しているため、`nx build my-infra`（または `nx deploy my-infra`）は CDK が synth する前にビルドコンテキストを生成します。`cdk` を直接呼び出す場合は、最初に bundle + docker ステップを実行してください：
+ジェネレーターは `docker` ターゲットを `build` の依存関係として宣言しているため、`nx build`（または生成された `nx deploy` / `nx apply` ターゲット）は CDK または Terraform が実行される前にビルドコンテキストを生成します。`cdk` または `terraform` を直接呼び出す場合は、最初に docker ステップを実行してください：
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## 参考資料
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — ジェネレーターが従うパターン。

--- a/docs/src/content/docs/ko/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/ko/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 권장 사항
 
-- 일부 생성기에는 [Docker](https://www.docker.com/)가 필요합니다
+- 일부 생성기에는 [Docker](https://www.docker.com/)가 필요합니다. [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/)가 설정되어 있어야 합니다.
 - CDK 대신 인프라스트럭처 코드로 Terraform을 사용할 경우 [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) 설치 필요
   - `terraform --version` 명령어로 버전 확인
 - [VSCode](https://code.visualstudio.com/) 사용 시 [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) 설치 권장

--- a/docs/src/content/docs/ko/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/ko/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Docker 문제 해결
+description: Docker 빌드 관련 문제 해결
+---
+import Link from '@components/link.astro';
+
+이 페이지는 Nx Plugin for AWS로 Docker 이미지를 빌드할 때 발생할 수 있는 문제에 대한 해결 방법을 제공합니다. 제너레이터가 사용하는 패턴에 대한 배경 정보는 <Link path="/guides/docker-bundling">Docker 번들링 가이드</Link>를 참조하세요.
+
+## 크로스 플랫폼 빌드
+
+<Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, <Link path="/guides/py-mcp-server">`py#mcp-server`</Link>와 같은 제너레이터는 호스트 아키텍처와 관계없이 기본적으로 `linux/arm64` (Graviton) 이미지를 생성합니다. `x86_64` 호스트에서 `arm64` 이미지를 빌드하거나 Apple Silicon에서 `amd64` 이미지를 빌드하려면 로컬 Docker 설치에서 [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/) 지원이 필요합니다.
+
+멀티 플랫폼 빌드가 설정되지 않은 경우, 증상은 `Dockerfile`에 따라 다릅니다:
+
+- **`Dockerfile`에 `RUN` 단계가 있는 경우** (예: TypeScript 제너레이터의 `RUN npm install`): 빌드가 중간에 실패하며 다음 오류가 발생합니다
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **`Dockerfile`이 `COPY`만 사용하는 경우** (예: Python 제너레이터): 빌드는 성공하지만 나중에 `docker run`이 실패하며 다음 오류가 발생합니다
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **대상 플랫폼에 대한 베이스 이미지를 사용할 수 없는 경우**: `FROM` 단계에서 빌드가 실패하며 `no match for platform in manifest` 오류가 발생합니다.
+
+### 멀티 플랫폼 빌드 활성화
+
+**Docker Desktop** (Mac / Windows / Linux)은 기본적으로 [QEMU](https://www.qemu.org/) 에뮬레이션이 활성화되어 제공되므로 일반적으로 추가 설정이 필요하지 않습니다.
+
+**Linux 호스트** (CI 러너 포함)는 커널에 등록된 QEMU binfmt 핸들러가 필요합니다. 머신당 한 번 설치하세요:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+지원되는 플랫폼이 프로젝트 대상과 일치하는지 확인하세요:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+`Platforms:` 줄에 `linux/amd64`와 `linux/arm64`가 모두 포함되어야 합니다.
+
+:::tip[CI 환경]
+GitHub Actions, GitLab CI 및 유사한 제공업체는 일반적으로 기본적으로 QEMU 핸들러를 등록하지 **않습니다**. 크로스 아키텍처 이미지를 생성하는 `nx build` / `nx docker` 타겟 전에 [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action)과 같은 단계를 추가하세요.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+이 오류는 기본 `docker` 드라이버를 사용하여 여러 플랫폼을 동시에 빌드하려고 할 때 (예: `--platform linux/amd64,linux/arm64`) 나타납니다:
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+제너레이터는 빌드당 단일 플랫폼(`linux/arm64`)을 대상으로 하므로 플러그인에서 생성된 타겟에서는 이 오류가 나타나지 않습니다. 멀티 플랫폼 매니페스트를 생성하도록 `docker` 타겟을 사용자 정의한 경우 다음 중 하나를 수행해야 합니다:
+
+1. `docker-container` 빌더를 생성하고 사용:
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. 또는 Docker Desktop에서 [containerd 이미지 스토어](https://docs.docker.com/engine/storage/containerd/)를 활성화 (`Settings → General → Use containerd for pulling and storing images`).
+
+## 에뮬레이트된 아키텍처에서의 느린 빌드
+
+`x86_64` 호스트에서 `arm64` 이미지를 빌드하거나 (또는 그 반대) QEMU를 사용하여 각 명령을 에뮬레이트하므로 종속성 설치 단계가 네이티브 빌드보다 몇 배 느릴 수 있습니다. Nx Plugin for AWS는 `Dockerfile` **외부**에서 종속성 해결을 수행하여 이를 완화합니다 — <Link path="/guides/docker-bundling">Docker 번들링</Link>을 참조하세요. 여전히 느린 Docker 빌드가 발생하는 경우:
+
+- Nx를 통해 `bundle` / `docker` 타겟을 실행하고 있는지 확인하세요 (`nx docker my-project`) 그러면 번들이 실행 간에 캐시됩니다.
+- 크로스 아키텍처 빌드를 위해 `Dockerfile` 내부에서 `pip install`, `npm install` 또는 `uv sync`를 실행하지 마세요 — `--python-platform` / `--platform`을 사용하여 번들 시간에 설치하여 무거운 작업이 네이티브로 실행되도록 하고, `Dockerfile`은 `COPY` 이상의 작업을 하지 않도록 하세요.
+- CI에서는 QEMU를 완전히 피하기 위해 네이티브 ARM 러너(예: GitHub Actions의 `ubuntu-24.04-arm`)를 고려하세요.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker가 실행되고 있지 않거나 사용자에게 데몬 소켓과 통신할 권한이 없습니다.
+
+- **Docker Desktop**: 애플리케이션을 시작하고 고래 아이콘이 "Docker Desktop is running"을 보고할 때까지 기다리세요.
+- **Linux**: `sudo systemctl start docker`로 서비스를 시작하세요. 모든 명령에 `sudo`를 사용하지 않으려면 사용자를 `docker` 그룹에 추가하고 (`sudo usermod -aG docker $USER`) 로그아웃 / 로그인하세요.
+
+## `cdk deploy` 시 Docker 이미지 자산을 찾을 수 없음
+
+CDK의 `DockerImageAsset`은 `dist/`의 빌드 컨텍스트 디렉터리를 가리킵니다. `cdk deploy`를 실행할 때 해당 디렉터리가 존재하지 않으면 synth가 `ENOENT` 또는 "directory does not exist" 오류로 실패합니다.
+
+제너레이터는 `docker` 타겟을 `build`의 종속성으로 선언하므로 `nx build my-infra` (또는 `nx deploy my-infra`)는 CDK가 synth하기 전에 빌드 컨텍스트를 생성합니다. `cdk`를 직접 호출하는 경우 먼저 번들 + docker 단계를 실행하세요:
+
+```bash
+nx run my-project:docker
+```
+
+## 추가 자료
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker 번들링 가이드</Link> — 제너레이터가 따르는 패턴.

--- a/docs/src/content/docs/ko/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/ko/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Docker 빌드 관련 문제 해결
 ---
 import Link from '@components/link.astro';
 
-이 페이지는 Nx Plugin for AWS로 Docker 이미지를 빌드할 때 발생할 수 있는 문제에 대한 해결 방법을 제공합니다. 제너레이터가 사용하는 패턴에 대한 배경 정보는 <Link path="/guides/docker-bundling">Docker 번들링 가이드</Link>를 참조하세요.
+이 페이지는 제너레이터가 생성하는 Docker 빌드에서 발생할 수 있는 문제에 대한 해결 방법을 제공합니다. 제너레이터가 따르는 패턴에 대한 배경 정보는 <Link path="/guides/docker-bundling">Docker 번들링 가이드</Link>를 참조하세요.
 
 ## 크로스 플랫폼 빌드
 
-<Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, <Link path="/guides/py-mcp-server">`py#mcp-server`</Link>와 같은 제너레이터는 호스트 아키텍처와 관계없이 기본적으로 `linux/arm64` (Graviton) 이미지를 생성합니다. `x86_64` 호스트에서 `arm64` 이미지를 빌드하거나 Apple Silicon에서 `amd64` 이미지를 빌드하려면 로컬 Docker 설치에서 [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/) 지원이 필요합니다.
+<Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, <Link path="/guides/py-mcp-server">`py#mcp-server`</Link>와 같은 제너레이터는 호스트 아키텍처와 관계없이 `linux/arm64` (Graviton) 이미지를 생성합니다. `x86_64` 호스트에서 `arm64` 이미지를 빌드하거나 Apple Silicon에서 `amd64` 이미지를 빌드하려면 로컬 Docker 설치에서 [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/) 지원이 필요합니다.
 
 멀티 플랫폼 빌드가 설정되지 않은 경우, 증상은 `Dockerfile`에 따라 다릅니다:
 
-- **`Dockerfile`에 `RUN` 단계가 있는 경우** (예: TypeScript 제너레이터의 `RUN npm install`): 빌드가 중간에 실패하며 다음 오류가 발생합니다
+- **`Dockerfile`에 `RUN` 단계가 있는 경우** (TypeScript 제너레이터는 번들링할 수 없는 종속성에 대해 `RUN npm install`을 실행): 빌드가 중간에 실패하며 다음 오류가 발생합니다
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **`Dockerfile`이 `COPY`만 사용하는 경우** (예: Python 제너레이터): 빌드는 성공하지만 나중에 `docker run`이 실패하며 다음 오류가 발생합니다
+- **`Dockerfile`이 `COPY`만 사용하는 경우** (Python 제너레이터): 빌드는 성공하지만 나중에 `docker run`이 실패하며 다음 오류가 발생합니다
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 docker buildx inspect --bootstrap
 ```
 
-`Platforms:` 줄에 `linux/amd64`와 `linux/arm64`가 모두 포함되어야 합니다.
+`Platforms:` 줄에 `linux/arm64`가 포함되어야 합니다.
 
 :::tip[CI 환경]
 GitHub Actions, GitLab CI 및 유사한 제공업체는 일반적으로 기본적으로 QEMU 핸들러를 등록하지 **않습니다**. 크로스 아키텍처 이미지를 생성하는 `nx build` / `nx docker` 타겟 전에 [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action)과 같은 단계를 추가하세요.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-이 오류는 기본 `docker` 드라이버를 사용하여 여러 플랫폼을 동시에 빌드하려고 할 때 (예: `--platform linux/amd64,linux/arm64`) 나타납니다:
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-제너레이터는 빌드당 단일 플랫폼(`linux/arm64`)을 대상으로 하므로 플러그인에서 생성된 타겟에서는 이 오류가 나타나지 않습니다. 멀티 플랫폼 매니페스트를 생성하도록 `docker` 타겟을 사용자 정의한 경우 다음 중 하나를 수행해야 합니다:
-
-1. `docker-container` 빌더를 생성하고 사용:
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. 또는 Docker Desktop에서 [containerd 이미지 스토어](https://docs.docker.com/engine/storage/containerd/)를 활성화 (`Settings → General → Use containerd for pulling and storing images`).
-
 ## 에뮬레이트된 아키텍처에서의 느린 빌드
 
-`x86_64` 호스트에서 `arm64` 이미지를 빌드하거나 (또는 그 반대) QEMU를 사용하여 각 명령을 에뮬레이트하므로 종속성 설치 단계가 네이티브 빌드보다 몇 배 느릴 수 있습니다. Nx Plugin for AWS는 `Dockerfile` **외부**에서 종속성 해결을 수행하여 이를 완화합니다 — <Link path="/guides/docker-bundling">Docker 번들링</Link>을 참조하세요. 여전히 느린 Docker 빌드가 발생하는 경우:
+`x86_64` 호스트에서 `arm64` 이미지를 빌드하거나 (또는 그 반대) QEMU를 사용하여 각 명령을 에뮬레이트하므로 네이티브 빌드보다 몇 배 느릴 수 있습니다. 제너레이터는 `Dockerfile` **외부**에서 종속성 해결을 수행하여 이를 완화합니다 — <Link path="/guides/docker-bundling">Docker 번들링</Link>을 참조하세요. 여전히 느린 Docker 빌드가 발생하는 경우:
 
 - Nx를 통해 `bundle` / `docker` 타겟을 실행하고 있는지 확인하세요 (`nx docker my-project`) 그러면 번들이 실행 간에 캐시됩니다.
-- 크로스 아키텍처 빌드를 위해 `Dockerfile` 내부에서 `pip install`, `npm install` 또는 `uv sync`를 실행하지 마세요 — `--python-platform` / `--platform`을 사용하여 번들 시간에 설치하여 무거운 작업이 네이티브로 실행되도록 하고, `Dockerfile`은 `COPY` 이상의 작업을 하지 않도록 하세요.
 - CI에서는 QEMU를 완전히 피하기 위해 네이티브 ARM 러너(예: GitHub Actions의 `ubuntu-24.04-arm`)를 고려하세요.
 
-## `Cannot connect to the Docker daemon`
+## `cdk deploy` / `nx apply` 시 빌드 컨텍스트 누락
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+생성된 `docker` 타겟은 빌드 컨텍스트를 `dist/packages/<project>/docker/...` (Python) 또는 `dist/packages/<project>/bundle/...` (TypeScript)에 작성하며, 생성된 infrastructure as code는 해당 디렉터리를 가리킵니다. synth 또는 apply할 때 해당 디렉터리가 존재하지 않으면 `ENOENT` 또는 "directory does not exist"와 같은 오류가 표시됩니다.
 
-Docker가 실행되고 있지 않거나 사용자에게 데몬 소켓과 통신할 권한이 없습니다.
-
-- **Docker Desktop**: 애플리케이션을 시작하고 고래 아이콘이 "Docker Desktop is running"을 보고할 때까지 기다리세요.
-- **Linux**: `sudo systemctl start docker`로 서비스를 시작하세요. 모든 명령에 `sudo`를 사용하지 않으려면 사용자를 `docker` 그룹에 추가하고 (`sudo usermod -aG docker $USER`) 로그아웃 / 로그인하세요.
-
-## `cdk deploy` 시 Docker 이미지 자산을 찾을 수 없음
-
-CDK의 `DockerImageAsset`은 `dist/`의 빌드 컨텍스트 디렉터리를 가리킵니다. `cdk deploy`를 실행할 때 해당 디렉터리가 존재하지 않으면 synth가 `ENOENT` 또는 "directory does not exist" 오류로 실패합니다.
-
-제너레이터는 `docker` 타겟을 `build`의 종속성으로 선언하므로 `nx build my-infra` (또는 `nx deploy my-infra`)는 CDK가 synth하기 전에 빌드 컨텍스트를 생성합니다. `cdk`를 직접 호출하는 경우 먼저 번들 + docker 단계를 실행하세요:
+제너레이터는 `docker` 타겟을 `build`의 종속성으로 선언하므로 `nx build` (또는 생성된 `nx deploy` / `nx apply` 타겟)는 CDK 또는 Terraform이 실행되기 전에 빌드 컨텍스트를 생성합니다. `cdk` 또는 `terraform`을 직접 호출하는 경우 먼저 docker 단계를 실행하세요:
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## 추가 자료
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker 번들링 가이드</Link> — 제너레이터가 따르는 패턴.

--- a/docs/src/content/docs/pt/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/pt/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recomendados
 
-- [Docker](https://www.docker.com/) é necessário para alguns geradores.
+- [Docker](https://www.docker.com/) é necessário para alguns geradores. [Compilações multi-plataforma](https://docs.docker.com/build/building/multi-platform/) devem ser configuradas.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) é necessário se você optar por usar isso para infraestrutura como código em vez do CDK
   - verifique executando `terraform --version`
 - Se você usa [VSCode](https://code.visualstudio.com/), recomendamos instalar o [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/pt/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/pt/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Solução de Problemas do Docker
+description: Solução de problemas com builds do Docker
+---
+import Link from '@components/link.astro';
+
+Esta página fornece orientações para solução de problemas que você pode encontrar ao construir imagens Docker com o Nx Plugin for AWS. Consulte o <Link path="/guides/docker-bundling">guia de Docker Bundling</Link> para obter informações sobre o padrão usado pelos geradores.
+
+## Builds Multi-Plataforma
+
+Geradores como <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> e <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produzem imagens para `linux/arm64` (Graviton) por padrão, independentemente da arquitetura do host. Construir uma imagem `arm64` em um host `x86_64` — ou uma imagem `amd64` no Apple Silicon — requer suporte a [build multi-plataforma](https://docs.docker.com/build/building/multi-platform/) na sua instalação local do Docker.
+
+Se os builds multi-plataforma não estiverem configurados, o sintoma depende do `Dockerfile`:
+
+- **`Dockerfile` tem uma etapa `RUN`** (por exemplo, `RUN npm install` nos geradores TypeScript): o build falha no meio do caminho com
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **`Dockerfile` usa apenas `COPY`** (por exemplo, os geradores Python): o build é bem-sucedido, mas `docker run` falha posteriormente com
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **Imagem base não está disponível para a plataforma de destino**: o build falha na etapa `FROM` com `no match for platform in manifest`.
+
+### Habilitar Builds Multi-Plataforma
+
+**Docker Desktop** (Mac / Windows / Linux) vem com emulação [QEMU](https://www.qemu.org/) habilitada por padrão — nenhuma configuração extra é geralmente necessária.
+
+**Hosts Linux** (incluindo runners de CI) precisam de manipuladores QEMU binfmt registrados no kernel. Instale-os uma vez por máquina:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Verifique se as plataformas suportadas correspondem ao que seu projeto tem como alvo:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+A linha `Platforms:` deve incluir tanto `linux/amd64` quanto `linux/arm64`.
+
+:::tip[Ambientes de CI]
+GitHub Actions, GitLab CI e provedores similares normalmente **não** registram manipuladores QEMU por padrão. Adicione uma etapa como [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) antes de qualquer target `nx build` / `nx docker` que produza uma imagem de arquitetura cruzada.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+Este erro aparece quando você tenta construir para múltiplas plataformas de uma vez (por exemplo, `--platform linux/amd64,linux/arm64`) usando o driver `docker` padrão:
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+Os geradores têm como alvo uma única plataforma por build (`linux/arm64`), então este erro não aparecerá de targets produzidos pelo plugin. Se você personalizou um target `docker` para emitir um manifesto multi-plataforma, você deve:
+
+1. Criar e usar um builder `docker-container`:
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. Ou habilitar o [containerd image store](https://docs.docker.com/engine/storage/containerd/) no Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
+
+## Builds Lentos em Arquiteturas Emuladas
+
+Construir uma imagem `arm64` em um host `x86_64` (ou vice-versa) usa QEMU para emular cada instrução, e as etapas de instalação de dependências podem ser muitas vezes mais lentas do que um build nativo. O Nx Plugin for AWS mitiga isso fazendo a resolução de dependências **fora** do `Dockerfile` — consulte <Link path="/guides/docker-bundling">Docker Bundling</Link>. Se você ainda estiver vendo builds Docker lentos:
+
+- Certifique-se de estar executando os targets `bundle` / `docker` através do Nx (`nx docker my-project`) para que o bundle seja armazenado em cache entre as execuções.
+- Evite executar `pip install`, `npm install` ou `uv sync` dentro do `Dockerfile` para builds de arquitetura cruzada — instale no momento do bundle com `--python-platform` / `--platform` para que o trabalho pesado seja executado nativamente, e deixe o `Dockerfile` fazer nada mais do que `COPY`.
+- No CI, considere um runner ARM nativo (por exemplo, `ubuntu-24.04-arm` do GitHub Actions) para evitar QEMU completamente.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+O Docker não está em execução, ou seu usuário não tem permissão para se comunicar com o socket do daemon.
+
+- **Docker Desktop**: inicie o aplicativo e aguarde o ícone da baleia informar "Docker Desktop is running".
+- **Linux**: inicie o serviço com `sudo systemctl start docker`. Para evitar `sudo` em cada comando, adicione seu usuário ao grupo `docker` (`sudo usermod -aG docker $USER`) e faça logout / login novamente.
+
+## Assets de Imagem Docker Não Encontrados em `cdk deploy`
+
+O `DockerImageAsset` do CDK aponta para o diretório de contexto de build em `dist/`. Se esse diretório não existir quando você executar `cdk deploy`, o synth falhará com `ENOENT` ou "directory does not exist".
+
+Os geradores declaram o target `docker` como uma dependência de `build`, então `nx build my-infra` (ou `nx deploy my-infra`) produzirá o contexto de build antes do synth do CDK. Se você invocar `cdk` diretamente, execute a etapa de bundle + docker primeiro:
+
+```bash
+nx run my-project:docker
+```
+
+## Leitura Adicional
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — o padrão que os geradores seguem.

--- a/docs/src/content/docs/pt/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/pt/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Solução de problemas com builds do Docker
 ---
 import Link from '@components/link.astro';
 
-Esta página fornece orientações para solução de problemas que você pode encontrar ao construir imagens Docker com o Nx Plugin for AWS. Consulte o <Link path="/guides/docker-bundling">guia de Docker Bundling</Link> para obter informações sobre o padrão usado pelos geradores.
+Esta página fornece orientações para solução de problemas que você pode encontrar com os builds Docker produzidos pelos geradores. Consulte o <Link path="/guides/docker-bundling">guia de Docker Bundling</Link> para obter informações sobre o padrão que eles seguem.
 
 ## Builds Multi-Plataforma
 
-Geradores como <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> e <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produzem imagens para `linux/arm64` (Graviton) por padrão, independentemente da arquitetura do host. Construir uma imagem `arm64` em um host `x86_64` — ou uma imagem `amd64` no Apple Silicon — requer suporte a [build multi-plataforma](https://docs.docker.com/build/building/multi-platform/) na sua instalação local do Docker.
+Geradores como <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> e <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> produzem imagens para `linux/arm64` (Graviton), independentemente da arquitetura do host. Construir uma imagem `arm64` em um host `x86_64` — ou uma imagem `amd64` no Apple Silicon — requer suporte a [build multi-plataforma](https://docs.docker.com/build/building/multi-platform/) na sua instalação local do Docker.
 
 Se os builds multi-plataforma não estiverem configurados, o sintoma depende do `Dockerfile`:
 
-- **`Dockerfile` tem uma etapa `RUN`** (por exemplo, `RUN npm install` nos geradores TypeScript): o build falha no meio do caminho com
+- **`Dockerfile` tem uma etapa `RUN`** (geradores TypeScript executam `RUN npm install` para dependências não empacotáveis): o build falha no meio do caminho com
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **`Dockerfile` usa apenas `COPY`** (por exemplo, os geradores Python): o build é bem-sucedido, mas `docker run` falha posteriormente com
+- **`Dockerfile` usa apenas `COPY`** (geradores Python): o build é bem-sucedido, mas `docker run` falha posteriormente com
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ Verifique se as plataformas suportadas correspondem ao que seu projeto tem como 
 docker buildx inspect --bootstrap
 ```
 
-A linha `Platforms:` deve incluir tanto `linux/amd64` quanto `linux/arm64`.
+A linha `Platforms:` deve incluir `linux/arm64`.
 
 :::tip[Ambientes de CI]
 GitHub Actions, GitLab CI e provedores similares normalmente **não** registram manipuladores QEMU por padrão. Adicione uma etapa como [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) antes de qualquer target `nx build` / `nx docker` que produza uma imagem de arquitetura cruzada.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-Este erro aparece quando você tenta construir para múltiplas plataformas de uma vez (por exemplo, `--platform linux/amd64,linux/arm64`) usando o driver `docker` padrão:
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-Os geradores têm como alvo uma única plataforma por build (`linux/arm64`), então este erro não aparecerá de targets produzidos pelo plugin. Se você personalizou um target `docker` para emitir um manifesto multi-plataforma, você deve:
-
-1. Criar e usar um builder `docker-container`:
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. Ou habilitar o [containerd image store](https://docs.docker.com/engine/storage/containerd/) no Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
-
 ## Builds Lentos em Arquiteturas Emuladas
 
-Construir uma imagem `arm64` em um host `x86_64` (ou vice-versa) usa QEMU para emular cada instrução, e as etapas de instalação de dependências podem ser muitas vezes mais lentas do que um build nativo. O Nx Plugin for AWS mitiga isso fazendo a resolução de dependências **fora** do `Dockerfile` — consulte <Link path="/guides/docker-bundling">Docker Bundling</Link>. Se você ainda estiver vendo builds Docker lentos:
+Construir uma imagem `arm64` em um host `x86_64` (ou vice-versa) usa QEMU para emular cada instrução, o que pode ser muitas vezes mais lento do que um build nativo. Os geradores mitigam isso fazendo a resolução de dependências **fora** do `Dockerfile` — consulte <Link path="/guides/docker-bundling">Docker Bundling</Link>. Se você ainda estiver vendo builds Docker lentos:
 
 - Certifique-se de estar executando os targets `bundle` / `docker` através do Nx (`nx docker my-project`) para que o bundle seja armazenado em cache entre as execuções.
-- Evite executar `pip install`, `npm install` ou `uv sync` dentro do `Dockerfile` para builds de arquitetura cruzada — instale no momento do bundle com `--python-platform` / `--platform` para que o trabalho pesado seja executado nativamente, e deixe o `Dockerfile` fazer nada mais do que `COPY`.
 - No CI, considere um runner ARM nativo (por exemplo, `ubuntu-24.04-arm` do GitHub Actions) para evitar QEMU completamente.
 
-## `Cannot connect to the Docker daemon`
+## Contexto de Build Ausente em `cdk deploy` / `nx apply`
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+O target `docker` gerado escreve seu contexto de build em `dist/packages/<project>/docker/...` (Python) ou `dist/packages/<project>/bundle/...` (TypeScript), e a infraestrutura como código gerada aponta para esse diretório. Se esse diretório não existir quando você executar synth ou apply, você verá erros como `ENOENT` ou "directory does not exist".
 
-O Docker não está em execução, ou seu usuário não tem permissão para se comunicar com o socket do daemon.
-
-- **Docker Desktop**: inicie o aplicativo e aguarde o ícone da baleia informar "Docker Desktop is running".
-- **Linux**: inicie o serviço com `sudo systemctl start docker`. Para evitar `sudo` em cada comando, adicione seu usuário ao grupo `docker` (`sudo usermod -aG docker $USER`) e faça logout / login novamente.
-
-## Assets de Imagem Docker Não Encontrados em `cdk deploy`
-
-O `DockerImageAsset` do CDK aponta para o diretório de contexto de build em `dist/`. Se esse diretório não existir quando você executar `cdk deploy`, o synth falhará com `ENOENT` ou "directory does not exist".
-
-Os geradores declaram o target `docker` como uma dependência de `build`, então `nx build my-infra` (ou `nx deploy my-infra`) produzirá o contexto de build antes do synth do CDK. Se você invocar `cdk` diretamente, execute a etapa de bundle + docker primeiro:
+Os geradores declaram o target `docker` como uma dependência de `build`, então `nx build` (ou os targets `nx deploy` / `nx apply` gerados) produzirão o contexto de build antes do CDK ou Terraform executar. Se você invocar `cdk` ou `terraform` diretamente, execute a etapa docker primeiro:
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## Leitura Adicional
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — o padrão que os geradores seguem.

--- a/docs/src/content/docs/vi/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/vi/snippets/prerequisites.mdx
@@ -11,7 +11,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Khuyến nghị
 
-- [Docker](https://www.docker.com/) là bắt buộc đối với một số trình tạo.
+- [Docker](https://www.docker.com/) là bắt buộc đối với một số trình tạo. [Multi-platform builds](https://docs.docker.com/build/building/multi-platform/) phải được thiết lập.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) là bắt buộc nếu bạn chọn sử dụng công cụ này cho cơ sở hạ tầng dưới dạng mã thay vì CDK
   - xác minh bằng cách chạy `terraform --version`
 - Nếu bạn đang sử dụng [VSCode](https://code.visualstudio.com/), chúng tôi khuyến nghị cài đặt [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/vi/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/vi/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Khắc phục sự cố Docker
+description: Khắc phục các vấn đề với Docker builds
+---
+import Link from '@components/link.astro';
+
+Trang này cung cấp hướng dẫn khắc phục sự cố cho các vấn đề bạn có thể gặp phải khi xây dựng Docker images với Nx Plugin for AWS. Xem <Link path="/guides/docker-bundling">hướng dẫn Docker Bundling</Link> để hiểu về mẫu được sử dụng bởi các generators.
+
+## Cross-Platform Builds
+
+Các generators như <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, và <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> tạo ra images cho `linux/arm64` (Graviton) theo mặc định, bất kể kiến trúc máy chủ. Xây dựng một image `arm64` trên máy chủ `x86_64` — hoặc một image `amd64` trên Apple Silicon — yêu cầu hỗ trợ [multi-platform build](https://docs.docker.com/build/building/multi-platform/) trong cài đặt Docker cục bộ của bạn.
+
+Nếu multi-platform builds không được thiết lập, triệu chứng phụ thuộc vào `Dockerfile`:
+
+- **`Dockerfile` có bước `RUN`** (ví dụ, `RUN npm install` trong các TypeScript generators): quá trình build thất bại giữa chừng với
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **`Dockerfile` chỉ sử dụng `COPY`** (ví dụ, các Python generators): quá trình build thành công, nhưng `docker run` sau đó thất bại với
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **Base image không khả dụng cho nền tảng đích**: quá trình build thất bại ở bước `FROM` với `no match for platform in manifest`.
+
+### Kích hoạt Multi-Platform Builds
+
+**Docker Desktop** (Mac / Windows / Linux) đi kèm với mô phỏng [QEMU](https://www.qemu.org/) được bật sẵn — thường không cần thiết lập thêm.
+
+**Linux hosts** (bao gồm CI runners) cần QEMU binfmt handlers được đăng ký với kernel. Cài đặt chúng một lần cho mỗi máy:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+Xác minh các nền tảng được hỗ trợ khớp với những gì dự án của bạn nhắm đến:
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+Dòng `Platforms:` nên bao gồm cả `linux/amd64` và `linux/arm64`.
+
+:::tip[Môi trường CI]
+GitHub Actions, GitLab CI, và các nhà cung cấp tương tự thường **không** đăng ký QEMU handlers theo mặc định. Thêm một bước như [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) trước bất kỳ target `nx build` / `nx docker` nào tạo ra cross-architecture image.
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+Lỗi này xuất hiện khi bạn cố gắng build cho nhiều nền tảng cùng lúc (ví dụ: `--platform linux/amd64,linux/arm64`) sử dụng `docker` driver mặc định:
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+Các generators nhắm đến một nền tảng duy nhất cho mỗi build (`linux/arm64`), vì vậy lỗi này sẽ không xuất hiện từ các targets được tạo bởi plugin. Nếu bạn đã tùy chỉnh một target `docker` để phát ra multi-platform manifest, bạn phải:
+
+1. Tạo và sử dụng một `docker-container` builder:
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. Hoặc kích hoạt [containerd image store](https://docs.docker.com/engine/storage/containerd/) trong Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
+
+## Slow Builds trên Emulated Architectures
+
+Xây dựng một image `arm64` trên máy chủ `x86_64` (hoặc ngược lại) sử dụng QEMU để mô phỏng từng lệnh, và các bước cài đặt dependencies có thể chậm hơn nhiều lần so với native build. Nx Plugin for AWS giảm thiểu điều này bằng cách thực hiện dependency resolution **bên ngoài** `Dockerfile` — xem <Link path="/guides/docker-bundling">Docker Bundling</Link>. Nếu bạn vẫn thấy Docker builds chậm:
+
+- Đảm bảo bạn đang chạy các targets `bundle` / `docker` thông qua Nx (`nx docker my-project`) để bundle được cache giữa các lần chạy.
+- Tránh chạy `pip install`, `npm install`, hoặc `uv sync` bên trong `Dockerfile` cho cross-architecture builds — cài đặt tại thời điểm bundle với `--python-platform` / `--platform` để công việc nặng chạy natively, và để `Dockerfile` không làm gì nhiều hơn `COPY`.
+- Trên CI, hãy xem xét một native ARM runner (ví dụ: GitHub Actions' `ubuntu-24.04-arm`) để tránh QEMU hoàn toàn.
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker không chạy, hoặc người dùng của bạn không có quyền để giao tiếp với daemon socket.
+
+- **Docker Desktop**: khởi động ứng dụng và đợi biểu tượng cá voi báo cáo "Docker Desktop is running".
+- **Linux**: khởi động dịch vụ với `sudo systemctl start docker`. Để tránh `sudo` cho mỗi lệnh, thêm người dùng của bạn vào nhóm `docker` (`sudo usermod -aG docker $USER`) và đăng xuất / đăng nhập lại.
+
+## Docker Image Assets Not Found tại `cdk deploy`
+
+`DockerImageAsset` của CDK trỏ đến thư mục build-context trong `dist/`. Nếu thư mục đó không tồn tại khi bạn chạy `cdk deploy`, synth sẽ thất bại với `ENOENT` hoặc "directory does not exist".
+
+Các generators khai báo target `docker` là một dependency của `build`, vì vậy `nx build my-infra` (hoặc `nx deploy my-infra`) sẽ tạo ra build context trước khi CDK synths. Nếu bạn gọi `cdk` trực tiếp, hãy chạy bước bundle + docker trước:
+
+```bash
+nx run my-project:docker
+```
+
+## Đọc thêm
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — mẫu mà các generators tuân theo.

--- a/docs/src/content/docs/vi/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/vi/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Khắc phục các vấn đề với Docker builds
 ---
 import Link from '@components/link.astro';
 
-Trang này cung cấp hướng dẫn khắc phục sự cố cho các vấn đề bạn có thể gặp phải khi xây dựng Docker images với Nx Plugin for AWS. Xem <Link path="/guides/docker-bundling">hướng dẫn Docker Bundling</Link> để hiểu về mẫu được sử dụng bởi các generators.
+Trang này cung cấp hướng dẫn khắc phục sự cố cho các vấn đề bạn có thể gặp phải với Docker builds được tạo ra bởi các generators. Xem <Link path="/guides/docker-bundling">hướng dẫn Docker Bundling</Link> để hiểu về mẫu mà chúng tuân theo.
 
 ## Cross-Platform Builds
 
-Các generators như <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, và <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> tạo ra images cho `linux/arm64` (Graviton) theo mặc định, bất kể kiến trúc máy chủ. Xây dựng một image `arm64` trên máy chủ `x86_64` — hoặc một image `amd64` trên Apple Silicon — yêu cầu hỗ trợ [multi-platform build](https://docs.docker.com/build/building/multi-platform/) trong cài đặt Docker cục bộ của bạn.
+Các generators như <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>, <Link path="/guides/py-strands-agent">`py#strands-agent`</Link>, <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, và <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> tạo ra images cho `linux/arm64` (Graviton), bất kể kiến trúc máy chủ. Xây dựng một image `arm64` trên máy chủ `x86_64` — hoặc một image `amd64` trên Apple Silicon — yêu cầu hỗ trợ [multi-platform build](https://docs.docker.com/build/building/multi-platform/) trong cài đặt Docker cục bộ của bạn.
 
 Nếu multi-platform builds không được thiết lập, triệu chứng phụ thuộc vào `Dockerfile`:
 
-- **`Dockerfile` có bước `RUN`** (ví dụ, `RUN npm install` trong các TypeScript generators): quá trình build thất bại giữa chừng với
+- **`Dockerfile` có bước `RUN`** (các TypeScript generators `RUN npm install` cho các dependencies không thể bundle): quá trình build thất bại giữa chừng với
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **`Dockerfile` chỉ sử dụng `COPY`** (ví dụ, các Python generators): quá trình build thành công, nhưng `docker run` sau đó thất bại với
+- **`Dockerfile` chỉ sử dụng `COPY`** (các Python generators): quá trình build thành công, nhưng `docker run` sau đó thất bại với
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ Xác minh các nền tảng được hỗ trợ khớp với những gì dự á
 docker buildx inspect --bootstrap
 ```
 
-Dòng `Platforms:` nên bao gồm cả `linux/amd64` và `linux/arm64`.
+Dòng `Platforms:` nên bao gồm `linux/arm64`.
 
 :::tip[Môi trường CI]
 GitHub Actions, GitLab CI, và các nhà cung cấp tương tự thường **không** đăng ký QEMU handlers theo mặc định. Thêm một bước như [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) trước bất kỳ target `nx build` / `nx docker` nào tạo ra cross-architecture image.
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-Lỗi này xuất hiện khi bạn cố gắng build cho nhiều nền tảng cùng lúc (ví dụ: `--platform linux/amd64,linux/arm64`) sử dụng `docker` driver mặc định:
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-Các generators nhắm đến một nền tảng duy nhất cho mỗi build (`linux/arm64`), vì vậy lỗi này sẽ không xuất hiện từ các targets được tạo bởi plugin. Nếu bạn đã tùy chỉnh một target `docker` để phát ra multi-platform manifest, bạn phải:
-
-1. Tạo và sử dụng một `docker-container` builder:
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. Hoặc kích hoạt [containerd image store](https://docs.docker.com/engine/storage/containerd/) trong Docker Desktop (`Settings → General → Use containerd for pulling and storing images`).
-
 ## Slow Builds trên Emulated Architectures
 
-Xây dựng một image `arm64` trên máy chủ `x86_64` (hoặc ngược lại) sử dụng QEMU để mô phỏng từng lệnh, và các bước cài đặt dependencies có thể chậm hơn nhiều lần so với native build. Nx Plugin for AWS giảm thiểu điều này bằng cách thực hiện dependency resolution **bên ngoài** `Dockerfile` — xem <Link path="/guides/docker-bundling">Docker Bundling</Link>. Nếu bạn vẫn thấy Docker builds chậm:
+Xây dựng một image `arm64` trên máy chủ `x86_64` (hoặc ngược lại) sử dụng QEMU để mô phỏng từng lệnh, có thể chậm hơn nhiều lần so với native build. Các generators giảm thiểu điều này bằng cách thực hiện dependency resolution **bên ngoài** `Dockerfile` — xem <Link path="/guides/docker-bundling">Docker Bundling</Link>. Nếu bạn vẫn thấy Docker builds chậm:
 
 - Đảm bảo bạn đang chạy các targets `bundle` / `docker` thông qua Nx (`nx docker my-project`) để bundle được cache giữa các lần chạy.
-- Tránh chạy `pip install`, `npm install`, hoặc `uv sync` bên trong `Dockerfile` cho cross-architecture builds — cài đặt tại thời điểm bundle với `--python-platform` / `--platform` để công việc nặng chạy natively, và để `Dockerfile` không làm gì nhiều hơn `COPY`.
 - Trên CI, hãy xem xét một native ARM runner (ví dụ: GitHub Actions' `ubuntu-24.04-arm`) để tránh QEMU hoàn toàn.
 
-## `Cannot connect to the Docker daemon`
+## Missing Build Context tại `cdk deploy` / `nx apply`
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+Target `docker` được tạo ra ghi build context của nó vào `dist/packages/<project>/docker/...` (Python) hoặc `dist/packages/<project>/bundle/...` (TypeScript), và infrastructure as code được tạo ra trỏ đến thư mục đó. Nếu thư mục đó không tồn tại khi bạn synth hoặc apply, bạn sẽ thấy các lỗi như `ENOENT` hoặc "directory does not exist".
 
-Docker không chạy, hoặc người dùng của bạn không có quyền để giao tiếp với daemon socket.
-
-- **Docker Desktop**: khởi động ứng dụng và đợi biểu tượng cá voi báo cáo "Docker Desktop is running".
-- **Linux**: khởi động dịch vụ với `sudo systemctl start docker`. Để tránh `sudo` cho mỗi lệnh, thêm người dùng của bạn vào nhóm `docker` (`sudo usermod -aG docker $USER`) và đăng xuất / đăng nhập lại.
-
-## Docker Image Assets Not Found tại `cdk deploy`
-
-`DockerImageAsset` của CDK trỏ đến thư mục build-context trong `dist/`. Nếu thư mục đó không tồn tại khi bạn chạy `cdk deploy`, synth sẽ thất bại với `ENOENT` hoặc "directory does not exist".
-
-Các generators khai báo target `docker` là một dependency của `build`, vì vậy `nx build my-infra` (hoặc `nx deploy my-infra`) sẽ tạo ra build context trước khi CDK synths. Nếu bạn gọi `cdk` trực tiếp, hãy chạy bước bundle + docker trước:
+Các generators khai báo target `docker` là một dependency của `build`, vì vậy `nx build` (hoặc các targets `nx deploy` / `nx apply` được tạo ra) sẽ tạo ra build context trước khi CDK hoặc Terraform chạy. Nếu bạn gọi `cdk` hoặc `terraform` trực tiếp, hãy chạy bước docker trước:
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## Đọc thêm
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker Bundling guide</Link> — mẫu mà các generators tuân theo.

--- a/docs/src/content/docs/zh/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/zh/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 推荐
 
-- [Docker](https://www.docker.com/)：部分生成器需要
+- [Docker](https://www.docker.com/)：部分生成器需要。必须设置[多平台构建](https://docs.docker.com/build/building/multi-platform/)。
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)：如果选择使用 Terraform 替代 CDK 进行基础设施即代码时需要
   - 可通过运行 `terraform --version` 验证版本
 - 如果使用 [VSCode](https://code.visualstudio.com/)，推荐安装 [Nx Console VSCode 插件](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)

--- a/docs/src/content/docs/zh/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/zh/troubleshooting/docker.mdx
@@ -1,0 +1,102 @@
+---
+title: Docker 故障排除
+description: Docker 构建问题的故障排除
+---
+import Link from '@components/link.astro';
+
+本页面提供了使用 Nx Plugin for AWS 构建 Docker 镜像时可能遇到的问题的故障排除指南。有关生成器使用的模式的背景信息，请参阅 <Link path="/guides/docker-bundling">Docker 打包指南</Link>。
+
+## 跨平台构建
+
+诸如 <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>、<Link path="/guides/py-strands-agent">`py#strands-agent`</Link>、<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> 和 <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> 等生成器默认为 `linux/arm64` (Graviton) 生成镜像，无论主机架构如何。在 `x86_64` 主机上构建 `arm64` 镜像——或在 Apple Silicon 上构建 `amd64` 镜像——需要本地 Docker 安装支持[多平台构建](https://docs.docker.com/build/building/multi-platform/)。
+
+如果未设置多平台构建，症状取决于 `Dockerfile`：
+
+- **`Dockerfile` 有 `RUN` 步骤**（例如，TypeScript 生成器中的 `RUN npm install`）：构建中途失败，显示
+
+  ```bash
+  exec /bin/sh: exec format error
+  ```
+
+- **`Dockerfile` 仅使用 `COPY`**（例如，Python 生成器）：构建成功，但稍后 `docker run` 失败，显示
+
+  ```bash
+  exec /usr/local/bin/python: exec format error
+  ```
+
+- **基础镜像不适用于目标平台**：构建在 `FROM` 步骤失败，显示 `no match for platform in manifest`。
+
+### 启用多平台构建
+
+**Docker Desktop**（Mac / Windows / Linux）默认启用了 [QEMU](https://www.qemu.org/) 模拟——通常不需要额外设置。
+
+**Linux 主机**（包括 CI 运行器）需要向内核注册 QEMU binfmt 处理程序。每台机器安装一次：
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+验证支持的平台是否与您的项目目标匹配：
+
+```bash
+docker buildx inspect --bootstrap
+```
+
+`Platforms:` 行应同时包含 `linux/amd64` 和 `linux/arm64`。
+
+:::tip[CI 环境]
+GitHub Actions、GitLab CI 和类似提供商通常默认**不**注册 QEMU 处理程序。在任何生成跨架构镜像的 `nx build` / `nx docker` 目标之前，添加诸如 [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) 之类的步骤。
+:::
+
+## `multi-platform build is not supported for the docker driver`
+
+当您尝试使用默认的 `docker` 驱动程序一次为多个平台构建（例如 `--platform linux/amd64,linux/arm64`）时，会出现此错误：
+
+```bash
+ERROR: failed to build: Multi-platform build is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+生成器每次构建针对单个平台（`linux/arm64`），因此此错误不会出现在插件生成的目标中。如果您自定义了 `docker` 目标以发出多平台清单，则必须：
+
+1. 创建并使用 `docker-container` 构建器：
+   ```bash
+   docker buildx create --name multiarch --driver docker-container --use
+   docker buildx inspect --bootstrap
+   ```
+2. 或在 Docker Desktop 中启用 [containerd 镜像存储](https://docs.docker.com/engine/storage/containerd/)（`Settings → General → Use containerd for pulling and storing images`）。
+
+## 模拟架构上的慢速构建
+
+在 `x86_64` 主机上构建 `arm64` 镜像（或反之）使用 QEMU 模拟每条指令，依赖项安装步骤可能比原生构建慢许多倍。Nx Plugin for AWS 通过在 `Dockerfile` **之外**进行依赖项解析来缓解这一问题——请参阅 <Link path="/guides/docker-bundling">Docker 打包</Link>。如果您仍然看到缓慢的 Docker 构建：
+
+- 确保您通过 Nx 运行 `bundle` / `docker` 目标（`nx docker my-project`），以便在运行之间缓存打包。
+- 避免在 `Dockerfile` 内为跨架构构建运行 `pip install`、`npm install` 或 `uv sync`——在打包时使用 `--python-platform` / `--platform` 进行安装，以便繁重的工作在本地运行，让 `Dockerfile` 只做 `COPY`。
+- 在 CI 上，考虑使用原生 ARM 运行器（例如 GitHub Actions 的 `ubuntu-24.04-arm`）以完全避免 QEMU。
+
+## `Cannot connect to the Docker daemon`
+
+```bash
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker 未运行，或您的用户没有权限与守护进程套接字通信。
+
+- **Docker Desktop**：启动应用程序并等待鲸鱼图标报告"Docker Desktop is running"。
+- **Linux**：使用 `sudo systemctl start docker` 启动服务。要避免每个命令都使用 `sudo`，将您的用户添加到 `docker` 组（`sudo usermod -aG docker $USER`）并注销/重新登录。
+
+## `cdk deploy` 时找不到 Docker 镜像资产
+
+CDK 的 `DockerImageAsset` 指向 `dist/` 中的构建上下文目录。如果在运行 `cdk deploy` 时该目录不存在，synth 将失败，显示 `ENOENT` 或"directory does not exist"。
+
+生成器将 `docker` 目标声明为 `build` 的依赖项，因此 `nx build my-infra`（或 `nx deploy my-infra`）将在 CDK synth 之前生成构建上下文。如果您直接调用 `cdk`，请先运行打包 + docker 步骤：
+
+```bash
+nx run my-project:docker
+```
+
+## 延伸阅读
+
+- [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
+- <Link path="/guides/docker-bundling">Docker 打包指南</Link> — 生成器遵循的模式。

--- a/docs/src/content/docs/zh/troubleshooting/docker.mdx
+++ b/docs/src/content/docs/zh/troubleshooting/docker.mdx
@@ -4,21 +4,21 @@ description: Docker 构建问题的故障排除
 ---
 import Link from '@components/link.astro';
 
-本页面提供了使用 Nx Plugin for AWS 构建 Docker 镜像时可能遇到的问题的故障排除指南。有关生成器使用的模式的背景信息，请参阅 <Link path="/guides/docker-bundling">Docker 打包指南</Link>。
+本页面提供了生成器生成的 Docker 构建可能遇到的问题的故障排除指南。有关它们遵循的模式的背景信息，请参阅 <Link path="/guides/docker-bundling">Docker 打包指南</Link>。
 
 ## 跨平台构建
 
-诸如 <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>、<Link path="/guides/py-strands-agent">`py#strands-agent`</Link>、<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> 和 <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> 等生成器默认为 `linux/arm64` (Graviton) 生成镜像，无论主机架构如何。在 `x86_64` 主机上构建 `arm64` 镜像——或在 Apple Silicon 上构建 `amd64` 镜像——需要本地 Docker 安装支持[多平台构建](https://docs.docker.com/build/building/multi-platform/)。
+诸如 <Link path="/guides/ts-strands-agent">`ts#strands-agent`</Link>、<Link path="/guides/py-strands-agent">`py#strands-agent`</Link>、<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> 和 <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> 等生成器为 `linux/arm64` (Graviton) 生成镜像，无论主机架构如何。在 `x86_64` 主机上构建 `arm64` 镜像——或在 Apple Silicon 上构建 `amd64` 镜像——需要本地 Docker 安装支持[多平台构建](https://docs.docker.com/build/building/multi-platform/)。
 
 如果未设置多平台构建，症状取决于 `Dockerfile`：
 
-- **`Dockerfile` 有 `RUN` 步骤**（例如，TypeScript 生成器中的 `RUN npm install`）：构建中途失败，显示
+- **`Dockerfile` 有 `RUN` 步骤**（TypeScript 生成器为不可打包的依赖项 `RUN npm install`）：构建中途失败，显示
 
   ```bash
   exec /bin/sh: exec format error
   ```
 
-- **`Dockerfile` 仅使用 `COPY`**（例如，Python 生成器）：构建成功，但稍后 `docker run` 失败，显示
+- **`Dockerfile` 仅使用 `COPY`**（Python 生成器）：构建成功，但稍后 `docker run` 失败，显示
 
   ```bash
   exec /usr/local/bin/python: exec format error
@@ -42,54 +42,24 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 docker buildx inspect --bootstrap
 ```
 
-`Platforms:` 行应同时包含 `linux/amd64` 和 `linux/arm64`。
+`Platforms:` 行应包含 `linux/arm64`。
 
 :::tip[CI 环境]
 GitHub Actions、GitLab CI 和类似提供商通常默认**不**注册 QEMU 处理程序。在任何生成跨架构镜像的 `nx build` / `nx docker` 目标之前，添加诸如 [`docker/setup-qemu-action`](https://github.com/docker/setup-qemu-action) 之类的步骤。
 :::
 
-## `multi-platform build is not supported for the docker driver`
-
-当您尝试使用默认的 `docker` 驱动程序一次为多个平台构建（例如 `--platform linux/amd64,linux/arm64`）时，会出现此错误：
-
-```bash
-ERROR: failed to build: Multi-platform build is not supported for the docker driver.
-Switch to a different driver, or turn on the containerd image store, and try again.
-```
-
-生成器每次构建针对单个平台（`linux/arm64`），因此此错误不会出现在插件生成的目标中。如果您自定义了 `docker` 目标以发出多平台清单，则必须：
-
-1. 创建并使用 `docker-container` 构建器：
-   ```bash
-   docker buildx create --name multiarch --driver docker-container --use
-   docker buildx inspect --bootstrap
-   ```
-2. 或在 Docker Desktop 中启用 [containerd 镜像存储](https://docs.docker.com/engine/storage/containerd/)（`Settings → General → Use containerd for pulling and storing images`）。
-
 ## 模拟架构上的慢速构建
 
-在 `x86_64` 主机上构建 `arm64` 镜像（或反之）使用 QEMU 模拟每条指令，依赖项安装步骤可能比原生构建慢许多倍。Nx Plugin for AWS 通过在 `Dockerfile` **之外**进行依赖项解析来缓解这一问题——请参阅 <Link path="/guides/docker-bundling">Docker 打包</Link>。如果您仍然看到缓慢的 Docker 构建：
+在 `x86_64` 主机上构建 `arm64` 镜像（或反之）使用 QEMU 模拟每条指令，这可能比原生构建慢许多倍。生成器通过在 `Dockerfile` **之外**进行依赖项解析来缓解这一问题——请参阅 <Link path="/guides/docker-bundling">Docker 打包</Link>。如果您仍然看到缓慢的 Docker 构建：
 
 - 确保您通过 Nx 运行 `bundle` / `docker` 目标（`nx docker my-project`），以便在运行之间缓存打包。
-- 避免在 `Dockerfile` 内为跨架构构建运行 `pip install`、`npm install` 或 `uv sync`——在打包时使用 `--python-platform` / `--platform` 进行安装，以便繁重的工作在本地运行，让 `Dockerfile` 只做 `COPY`。
 - 在 CI 上，考虑使用原生 ARM 运行器（例如 GitHub Actions 的 `ubuntu-24.04-arm`）以完全避免 QEMU。
 
-## `Cannot connect to the Docker daemon`
+## `cdk deploy` / `nx apply` 时缺少构建上下文
 
-```bash
-Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
-```
+生成的 `docker` 目标将其构建上下文写入 `dist/packages/<project>/docker/...`（Python）或 `dist/packages/<project>/bundle/...`（TypeScript），生成的基础设施即代码指向该目录。如果在 synth 或 apply 时该目录不存在，您将看到诸如 `ENOENT` 或"directory does not exist"之类的错误。
 
-Docker 未运行，或您的用户没有权限与守护进程套接字通信。
-
-- **Docker Desktop**：启动应用程序并等待鲸鱼图标报告"Docker Desktop is running"。
-- **Linux**：使用 `sudo systemctl start docker` 启动服务。要避免每个命令都使用 `sudo`，将您的用户添加到 `docker` 组（`sudo usermod -aG docker $USER`）并注销/重新登录。
-
-## `cdk deploy` 时找不到 Docker 镜像资产
-
-CDK 的 `DockerImageAsset` 指向 `dist/` 中的构建上下文目录。如果在运行 `cdk deploy` 时该目录不存在，synth 将失败，显示 `ENOENT` 或"directory does not exist"。
-
-生成器将 `docker` 目标声明为 `build` 的依赖项，因此 `nx build my-infra`（或 `nx deploy my-infra`）将在 CDK synth 之前生成构建上下文。如果您直接调用 `cdk`，请先运行打包 + docker 步骤：
+生成器将 `docker` 目标声明为 `build` 的依赖项，因此 `nx build`（或生成的 `nx deploy` / `nx apply` 目标）将在 CDK 或 Terraform 运行之前生成构建上下文。如果您直接调用 `cdk` 或 `terraform`，请先运行 docker 步骤：
 
 ```bash
 nx run my-project:docker
@@ -98,5 +68,4 @@ nx run my-project:docker
 ## 延伸阅读
 
 - [Docker — Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
-- [Docker — `buildx` reference](https://docs.docker.com/reference/cli/docker/buildx/)
 - <Link path="/guides/docker-bundling">Docker 打包指南</Link> — 生成器遵循的模式。


### PR DESCRIPTION
### Reason for this change

Several generators (`ts#strands-agent`, `py#strands-agent`, `ts#mcp-server`, `py#mcp-server`) produce a `Dockerfile` and a `docker` target that hardcodes `--platform linux/arm64`. On any host whose native architecture differs from that target (e.g. an `x86_64` CI runner or an Apple Silicon laptop building `amd64`), this relies on Docker's [multi-platform build](https://docs.docker.com/build/building/multi-platform/) support, which is not always enabled out of the box — especially on Linux CI runners without QEMU binfmt handlers.

When multi-platform builds aren't set up, users see confusing errors like `exec format error` or `no match for platform in manifest`. There was no documentation to help them diagnose this.

### Description of changes

- Adds `docs/src/content/docs/en/troubleshooting/docker.mdx` following the same pattern as the existing Nx troubleshooting page. Covers:
  - Cross-platform build setup (different symptoms depending on the Dockerfile shape) and how to install QEMU handlers on Linux / CI.
  - The `multi-platform build is not supported for the docker driver` error and the `docker-container` / containerd image store fixes.
  - Slow QEMU-emulated builds and why bundling outside the Dockerfile helps.
  - `Cannot connect to the Docker daemon`.
  - Missing `dist/` build context at `cdk deploy`.
- Registers the new page in `docs/astro.config.mjs` alongside the existing Nx entry.
- Updates `docs/src/content/docs/en/snippets/prerequisites.mdx` to note that Docker multi-platform builds must be set up, with a link to the Docker docs.

### Description of how you validated changes

- Ran `pnpm nx run docs:build --skip-nx-cache` — build succeeds and emits `/en/troubleshooting/docker/index.html`.
- Verified the cross-platform symptoms described in the guide end-to-end in a test workspace: generated `py#strands-agent` with `BedrockAgentCoreRuntime`, ran `nx run <project>:agent-docker`, and confirmed the `linux/arm64` image builds via QEMU on an `x86_64` host when multi-platform support is installed.
- Verified `Multi-platform build is not supported for the docker driver` reproduces when using the default `docker` driver — the fix in the guide (switching to a `docker-container` builder or the containerd image store) is what I used to unblock it.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*