### PR TITLE
refactor: replace deprecated aws_region.current.name in Terraform templates

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -2030,7 +2030,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.\${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.\${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -2042,7 +2042,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
           }
         }
       }
@@ -2318,7 +2318,7 @@ resource "aws_lambda_function" "api_lambda" {
   role            = aws_iam_role.lambda_execution_role.arn
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:\${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:\${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   timeout         = 30
   memory_size     = 128
   publish         = true
@@ -2417,7 +2417,7 @@ resource "aws_apigatewayv2_authorizer" "cognito_authorizer" {
 
   jwt_configuration {
     audience = var.user_pool_client_ids
-    issuer   = "https://cognito-idp.\${data.aws_region.current.name}.amazonaws.com/\${var.user_pool_id}"
+    issuer   = "https://cognito-idp.\${data.aws_region.current.region}.amazonaws.com/\${var.user_pool_id}"
   }
 }
 
@@ -2701,7 +2701,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.\${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.\${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -2713,7 +2713,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
           }
         }
       }
@@ -2979,7 +2979,7 @@ resource "aws_lambda_function" "api_lambda" {
   role            = aws_iam_role.lambda_execution_role.arn
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:\${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:\${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   timeout         = 30
   memory_size     = 128
   publish         = true
@@ -3349,7 +3349,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.\${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.\${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -3361,7 +3361,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
           }
         }
       }
@@ -3627,7 +3627,7 @@ resource "aws_lambda_function" "api_lambda" {
   role            = aws_iam_role.lambda_execution_role.arn
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:\${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:\${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   timeout         = 30
   memory_size     = 128
   publish         = true
@@ -4299,7 +4299,7 @@ resource "aws_lambda_function" "api_lambda" {
   role            = aws_iam_role.lambda_execution_role.arn
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:\${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:\${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   timeout         = 30
   memory_size     = 128
   publish         = true
@@ -4394,7 +4394,7 @@ resource "aws_api_gateway_authorizer" "cognito_authorizer" {
   name                   = "TestApiAuthorizer-\${random_string.suffix.result}"
   rest_api_id           = module.rest_api.api_id
   type                  = "COGNITO_USER_POOLS"
-  provider_arns         = ["arn:aws:cognito-idp:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:userpool/\${var.user_pool_id}"]
+  provider_arns         = ["arn:aws:cognito-idp:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:userpool/\${var.user_pool_id}"]
   identity_source       = "method.request.header.Authorization"
 }
 
@@ -4414,7 +4414,7 @@ resource "aws_api_gateway_integration" "lambda_integration" {
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
   # Use the response streaming invocation path with the alias ARN for SnapStart
-  uri                     = "arn:aws:apigateway:\${data.aws_region.current.name}:lambda:path/2021-11-15/functions/\${aws_lambda_alias.live.arn}/response-streaming-invocations"
+  uri                     = "arn:aws:apigateway:\${data.aws_region.current.region}:lambda:path/2021-11-15/functions/\${aws_lambda_alias.live.arn}/response-streaming-invocations"
   response_transfer_mode  = "STREAM"
 
   depends_on = [aws_lambda_alias.live]
@@ -5115,7 +5115,7 @@ resource "aws_lambda_function" "api_lambda" {
   role            = aws_iam_role.lambda_execution_role.arn
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:\${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:\${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   timeout         = 30
   memory_size     = 128
   publish         = true
@@ -5222,7 +5222,7 @@ resource "aws_api_gateway_integration" "lambda_integration" {
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
   # Use the response streaming invocation path with the alias ARN for SnapStart
-  uri                     = "arn:aws:apigateway:\${data.aws_region.current.name}:lambda:path/2021-11-15/functions/\${aws_lambda_alias.live.arn}/response-streaming-invocations"
+  uri                     = "arn:aws:apigateway:\${data.aws_region.current.region}:lambda:path/2021-11-15/functions/\${aws_lambda_alias.live.arn}/response-streaming-invocations"
   response_transfer_mode  = "STREAM"
 
   depends_on = [aws_lambda_alias.live]
@@ -5933,7 +5933,7 @@ resource "aws_lambda_function" "api_lambda" {
   role            = aws_iam_role.lambda_execution_role.arn
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:\${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:\${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   timeout         = 30
   memory_size     = 128
   publish         = true
@@ -6040,7 +6040,7 @@ resource "aws_api_gateway_integration" "lambda_integration" {
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
   # Use the response streaming invocation path with the alias ARN for SnapStart
-  uri                     = "arn:aws:apigateway:\${data.aws_region.current.name}:lambda:path/2021-11-15/functions/\${aws_lambda_alias.live.arn}/response-streaming-invocations"
+  uri                     = "arn:aws:apigateway:\${data.aws_region.current.region}:lambda:path/2021-11-15/functions/\${aws_lambda_alias.live.arn}/response-streaming-invocations"
   response_transfer_mode  = "STREAM"
 
   depends_on = [aws_lambda_alias.live]

--- a/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -111,7 +111,7 @@ data "aws_region" "current" {}
 
 locals {
   aws_account_id = data.aws_caller_identity.current.account_id
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
 }
 
 resource "random_string" "suffix" {
@@ -292,7 +292,7 @@ data "aws_region" "current" {}
 
 locals {
   aws_account_id = data.aws_caller_identity.current.account_id
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
 }
 
 resource "random_string" "suffix" {

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -2098,7 +2098,7 @@ resource "aws_api_gateway_authorizer" "cognito_authorizer" {
   name                   = "TestApiAuthorizer-\${random_string.suffix.result}"
   rest_api_id           = module.rest_api.api_id
   type                  = "COGNITO_USER_POOLS"
-  provider_arns         = ["arn:aws:cognito-idp:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:userpool/\${var.user_pool_id}"]
+  provider_arns         = ["arn:aws:cognito-idp:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:userpool/\${var.user_pool_id}"]
   identity_source       = "method.request.header.Authorization"
 }
 

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3034,7 +3034,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.\${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.\${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -3046,7 +3046,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
           }
         }
       }
@@ -3404,7 +3404,7 @@ resource "aws_apigatewayv2_authorizer" "cognito_authorizer" {
 
   jwt_configuration {
     audience = var.user_pool_client_ids
-    issuer   = "https://cognito-idp.\${data.aws_region.current.name}.amazonaws.com/\${var.user_pool_id}"
+    issuer   = "https://cognito-idp.\${data.aws_region.current.region}.amazonaws.com/\${var.user_pool_id}"
   }
 }
 
@@ -3687,7 +3687,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.\${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.\${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -3699,7 +3699,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
           }
         }
       }
@@ -4317,7 +4317,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.\${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.\${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -4329,7 +4329,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/\${var.api_name}"
           }
         }
       }
@@ -5327,7 +5327,7 @@ resource "aws_api_gateway_authorizer" "cognito_authorizer" {
   name                   = "TestApiAuthorizer-\${random_string.suffix.result}"
   rest_api_id           = module.rest_api.api_id
   type                  = "COGNITO_USER_POOLS"
-  provider_arns         = ["arn:aws:cognito-idp:\${data.aws_region.current.name}:\${data.aws_caller_identity.current.account_id}:userpool/\${var.user_pool_id}"]
+  provider_arns         = ["arn:aws:cognito-idp:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:userpool/\${var.user_pool_id}"]
   identity_source       = "method.request.header.Authorization"
 }
 

--- a/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -180,7 +180,7 @@ data "aws_region" "current" {}
 
 locals {
   aws_account_id = data.aws_caller_identity.current.account_id
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
 }
 
 resource "random_string" "suffix" {
@@ -361,7 +361,7 @@ data "aws_region" "current" {}
 
 locals {
   aws_account_id = data.aws_caller_identity.current.account_id
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
 }
 
 resource "random_string" "suffix" {

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -155,7 +155,7 @@ resource "aws_lambda_function" "api_lambda" {
   <%_ } else if (backend.type === 'fastapi') { _%>
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   <%_ } _%>
   timeout         = 30
   memory_size     = 128
@@ -264,7 +264,7 @@ resource "aws_apigatewayv2_authorizer" "cognito_authorizer" {
 
   jwt_configuration {
     audience = var.user_pool_client_ids
-    issuer   = "https://cognito-idp.${data.aws_region.current.name}.amazonaws.com/${var.user_pool_id}"
+    issuer   = "https://cognito-idp.${data.aws_region.current.region}.amazonaws.com/${var.user_pool_id}"
   }
 }
 <%_ } _%>

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -152,7 +152,7 @@ resource "aws_lambda_function" "api_lambda" {
   <%_ } else if (backend.type === 'fastapi') { _%>
   handler         = "run.sh"
   runtime         = "python3.14"
-  layers          = ["arn:aws:lambda:${data.aws_region.current.name}:753240598075:layer:LambdaAdapterLayerX86:24"]
+  layers          = ["arn:aws:lambda:${data.aws_region.current.region}:753240598075:layer:LambdaAdapterLayerX86:24"]
   <%_ } _%>
   timeout         = 30
   memory_size     = 128
@@ -257,7 +257,7 @@ resource "aws_api_gateway_authorizer" "cognito_authorizer" {
   name                   = "<%- apiNameClassName %>Authorizer-${random_string.suffix.result}"
   rest_api_id           = module.rest_api.api_id
   type                  = "COGNITO_USER_POOLS"
-  provider_arns         = ["arn:aws:cognito-idp:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:userpool/${var.user_pool_id}"]
+  provider_arns         = ["arn:aws:cognito-idp:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:userpool/${var.user_pool_id}"]
   identity_source       = "method.request.header.Authorization"
 }
 <%_ } _%>
@@ -279,7 +279,7 @@ resource "aws_api_gateway_integration" "lambda_integration" {
   type                    = "AWS_PROXY"
   <%_ if (backend.type === 'fastapi') { _%>
   # Use the response streaming invocation path with the alias ARN for SnapStart
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2021-11-15/functions/${aws_lambda_alias.live.arn}/response-streaming-invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2021-11-15/functions/${aws_lambda_alias.live.arn}/response-streaming-invocations"
   response_transfer_mode  = "STREAM"
   <%_ } else if (backend.type === 'trpc') { _%>
   uri                     = aws_lambda_function.api_lambda.response_streaming_invoke_arn

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/http/http-api/http-api.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/http/http-api/http-api.tf.template
@@ -111,7 +111,7 @@ resource "aws_kms_key" "logs_key" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -123,7 +123,7 @@ resource "aws_kms_key" "logs_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/${var.api_name}"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/${var.api_name}"
           }
         }
       }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
@@ -41,7 +41,7 @@ resource "aws_s3_bucket" "access_logs" {
   #checkov:skip=CKV2_AWS_62:Event notifications not required for access log bucket
   #checkov:skip=CKV_AWS_18:Access logging the access log bucket would create a cycle
   #checkov:skip=CKV_AWS_145:AES256 (S3-managed) encryption is sufficient for access logs
-  bucket        = "${var.bucket_name_prefix}-logs-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-${random_string.suffix.result}"
+  bucket        = "${var.bucket_name_prefix}-logs-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-${random_string.suffix.result}"
   force_destroy = true
 
   tags = var.tags
@@ -118,7 +118,7 @@ resource "aws_s3_bucket" "assets" {
   #checkov:skip=CKV_AWS_144:Cross-region replication not required for asset bucket
   #checkov:skip=CKV2_AWS_62:Event notifications not required for asset bucket
   #checkov:skip=CKV_AWS_145:AES256 (S3-managed) encryption is sufficient for build artefacts
-  bucket        = "${var.bucket_name_prefix}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-${random_string.suffix.result}"
+  bucket        = "${var.bucket_name_prefix}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-${random_string.suffix.result}"
   force_destroy = true
 
   tags = var.tags

--- a/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__functionNameKebabCase__/__functionNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__functionNameKebabCase__/__functionNameKebabCase__.tf.template
@@ -43,7 +43,7 @@ data "aws_region" "current" {}
 
 locals {
   aws_account_id = data.aws_caller_identity.current.account_id
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
 }
 
 resource "random_string" "suffix" {

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
@@ -65,7 +65,7 @@ resource "aws_iam_role" "cognito_sms_role" {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
           ArnLike = {
-            "aws:SourceArn" = "arn:aws:cognito-idp:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:userpool/*"
+            "aws:SourceArn" = "arn:aws:cognito-idp:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:userpool/*"
           }
         }
       }
@@ -124,7 +124,7 @@ resource "aws_cognito_user_pool" "user_pool" {
   sms_configuration {
     external_id    = random_uuid.sms_external_id.result
     sns_caller_arn = aws_iam_role.cognito_sms_role.arn
-    sns_region     = data.aws_region.current.name
+    sns_region     = data.aws_region.current.region
   }
 
   depends_on = [aws_iam_role_policy.cognito_sms_policy]
@@ -250,13 +250,13 @@ resource "aws_cognito_user_pool_client" "web_client" {
   callback_urls = concat([
     "http://localhost:4200",
     "http://localhost:4300",
-    "https://${data.aws_region.current.name}.console.aws.amazon.com"
+    "https://${data.aws_region.current.region}.console.aws.amazon.com"
   ], var.callback_urls)
 
   logout_urls = concat([
     "http://localhost:4200",
     "http://localhost:4300",
-    "https://${data.aws_region.current.name}.console.aws.amazon.com"
+    "https://${data.aws_region.current.region}.console.aws.amazon.com"
   ], var.logout_urls)
 
   # Security settings
@@ -379,7 +379,7 @@ module "add_cognito_to_runtime_config" {
   namespace = "connection"
   key       = "cognitoProps"
   value = {
-    region              = data.aws_region.current.name
+    region              = data.aws_region.current.region
     identityPoolId      = aws_cognito_identity_pool.identity_pool.id
     userPoolId          = aws_cognito_user_pool.user_pool.id
     userPoolWebClientId = aws_cognito_user_pool_client.web_client.id
@@ -389,7 +389,7 @@ module "add_cognito_to_runtime_config" {
 # Outputs
 output "region" {
   description = "AWS region"
-  value       = data.aws_region.current.name
+  value       = data.aws_region.current.region
 }
 
 output "user_pool_id" {


### PR DESCRIPTION
### Reason for this change

`aws_region.current.name` is now deprecated in AWS 6.0.0. We're using `hashicorp/aws: ~> 6.0`, hence, we can replace all occurrences of `aws_region.current.name` with `aws_region.current.region` to get rid of all the warnings during Terraform deployment.

https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/255

<!--What is the bug or use case behind this change?-->

### Description of changes

Replace all `aws_region.current.name` with `aws_region.current.region` in Terraform templates

### Description of how you validated changes

Unit tests

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*