### PR TITLE
refactor: replace deprecated ext ms-azuretools.vscode-docker with ms-azuretools.vscode-containers

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,7 @@
     "ms-python.python",
     "ms-python.vscode-pylance",
     "ms-python.debugpy",
-    "ms-azuretools.vscode-docker",
+    "ms-azuretools.vscode-containers",
     "esbenp.prettier-vscode",
     "astro-build.astro-vscode"
   ]


### PR DESCRIPTION
### Reason for this change

The Docker extension is no longer maintained. The Container Tools extension replaces the Docker extension for Visual Studio Code. It contains all the functionality of the Docker extension, with additional Podman support and other features.

### Description of changes

Replace `ms-azuretools.vscode-docker` with `ms-azuretools.vscode-containers` in `.vscode/extensions.json`

### Description of how you validated changes

NA

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*