### PR TITLE
fix(generators): make dependsOn updates idempotent

### DIFF
--- a/packages/nx-plugin/src/connection/agent-serve-local.ts
+++ b/packages/nx-plugin/src/connection/agent-serve-local.ts
@@ -10,6 +10,7 @@ import {
 import { applyGritQL } from '../utils/ast';
 import {
   ComponentMetadata,
+  addDependencyToTargetIfNotPresent,
   readProjectConfigurationUnqualified,
 } from '../utils/nx';
 
@@ -72,14 +73,13 @@ export const addAgentTargetToServeLocal = async (
 
   // Add a dependency on the agent serve-local target (so that the agent's
   // own serve-local dependencies, such as MCP servers, are also started)
-  sourceProject.targets['serve-local'].dependsOn = [
-    ...(sourceProject.targets['serve-local'].dependsOn ?? []),
-    {
-      projects: [targetProject.name],
-      target: agentServeLocalTargetName,
-    },
-    ...(options.additionalDependencyTargets ?? []),
-  ];
+  addDependencyToTargetIfNotPresent(sourceProject, 'serve-local', {
+    projects: [targetProject.name],
+    target: agentServeLocalTargetName,
+  });
+  for (const additional of options.additionalDependencyTargets ?? []) {
+    addDependencyToTargetIfNotPresent(sourceProject, 'serve-local', additional);
+  }
   updateProjectConfiguration(tree, sourceProject.name, sourceProject);
 
   // Add an override to runtime-config for the serve-local target to use the local url

--- a/packages/nx-plugin/src/connection/serve-local.spec.ts
+++ b/packages/nx-plugin/src/connection/serve-local.spec.ts
@@ -391,6 +391,52 @@ const applyOverrides = (runtimeConfig: IRuntimeConfig) => {
       expect(updatedProject).toBe(originalProject);
     });
 
+    it('should be idempotent when called twice with the same inputs', async () => {
+      tree.write(
+        'apps/frontend/project.json',
+        JSON.stringify({
+          name: 'frontend',
+          root: 'apps/frontend',
+          sourceRoot: 'apps/frontend/src',
+          targets: {
+            'serve-local': {
+              executor: '@nx/webpack:dev-server',
+              options: {},
+            },
+          },
+        }),
+      );
+      tree.write(
+        'apps/backend/project.json',
+        JSON.stringify({
+          name: 'backend',
+          root: 'apps/backend',
+          sourceRoot: 'apps/backend/src',
+          targets: {
+            'serve-local': {
+              executor: '@nx/node:execute',
+              continuous: true,
+              options: {},
+            },
+          },
+        }),
+      );
+
+      await addTargetToServeLocal(tree, 'frontend', 'backend', options);
+      await addTargetToServeLocal(tree, 'frontend', 'backend', options);
+
+      const updatedProject = JSON.parse(
+        tree.read('apps/frontend/project.json', 'utf-8'),
+      );
+
+      expect(updatedProject.targets['serve-local'].dependsOn).toEqual([
+        {
+          projects: ['backend'],
+          target: 'serve-local',
+        },
+      ]);
+    });
+
     it('should handle target project with missing targets object', async () => {
       // Setup source project with serve-local target
       tree.write(

--- a/packages/nx-plugin/src/connection/serve-local.ts
+++ b/packages/nx-plugin/src/connection/serve-local.ts
@@ -8,7 +8,10 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { applyGritQL } from '../utils/ast';
-import { readProjectConfigurationUnqualified } from '../utils/nx';
+import {
+  addDependencyToTargetIfNotPresent,
+  readProjectConfigurationUnqualified,
+} from '../utils/nx';
 import { toClassName } from '../utils/names';
 
 export interface ServeLocalOptions {
@@ -47,14 +50,13 @@ export const addTargetToServeLocal = async (
   }
 
   // Add a dependency on the serve-local target
-  sourceProject.targets['serve-local'].dependsOn = [
-    ...(sourceProject.targets['serve-local'].dependsOn ?? []),
-    {
-      projects: [targetProject.name],
-      target: 'serve-local',
-    },
-    ...(options.additionalDependencyTargets ?? []),
-  ];
+  addDependencyToTargetIfNotPresent(sourceProject, 'serve-local', {
+    projects: [targetProject.name],
+    target: 'serve-local',
+  });
+  for (const additional of options.additionalDependencyTargets ?? []) {
+    addDependencyToTargetIfNotPresent(sourceProject, 'serve-local', additional);
+  }
   updateProjectConfiguration(tree, sourceProject.name, sourceProject);
 
   // Add an override to runtime-config.json for the serve-local target to use the local url

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -31,6 +31,7 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { sortObjectKeys } from '../../utils/object';
 import {
   NxGeneratorInfo,
+  addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
 } from '../../utils/nx';
@@ -105,11 +106,8 @@ export async function tsInfraGenerator(
     `${libraryRoot}/project.json`,
     (config: ProjectConfiguration) => {
       config.projectType = 'application';
-      config.targets.build.dependsOn = [
-        ...(config.targets.build.dependsOn ?? []),
-        'synth',
-        'checkov',
-      ];
+      addDependencyToTargetIfNotPresent(config, 'build', 'synth');
+      addDependencyToTargetIfNotPresent(config, 'build', 'checkov');
       config.targets.compile.outputs = [
         '{workspaceRoot}/dist/{projectRoot}/tsc',
       ];

--- a/packages/nx-plugin/src/py/strands-agent/a2a-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/strands-agent/a2a-connection/generator.spec.ts
@@ -340,6 +340,12 @@ def get_agent(session_id: str):
     const toolsListMatch = agent.match(/tools=\[([^\]]*)\]/);
     expect(toolsListMatch).toBeTruthy();
     expect((toolsListMatch![1].match(/\bask_remote\b/g) ?? []).length).toBe(1);
+
+    // The host serve-local target has the remote serve-local dep exactly once
+    const host = JSON.parse(tree.read('apps/py-host/project.json', 'utf-8')!);
+    expect(host.targets['host-serve-local'].dependsOn).toEqual([
+      { projects: ['test.py_remote'], target: 'remote-serve-local' },
+    ]);
   });
 
   it('should append to existing tools without dropping prior entries', async () => {

--- a/packages/nx-plugin/src/py/strands-agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/strands-agent/a2a-connection/generator.ts
@@ -14,6 +14,7 @@ import {
 import { PyStrandsAgentA2aConnectionGeneratorSchema } from './schema';
 import {
   NxGeneratorInfo,
+  addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
@@ -180,14 +181,10 @@ export const pyStrandsAgentA2aConnectionGenerator = async (
   const targetServeLocalTargetName = `${targetAgentComponentName}-serve-local`;
 
   if (sourceProject.targets?.[serveLocalTargetName]) {
-    const target = sourceProject.targets[serveLocalTargetName];
-    target.dependsOn = [
-      ...(target.dependsOn ?? []),
-      {
-        projects: [targetProject.name],
-        target: targetServeLocalTargetName,
-      },
-    ];
+    addDependencyToTargetIfNotPresent(sourceProject, serveLocalTargetName, {
+      projects: [targetProject.name],
+      target: targetServeLocalTargetName,
+    });
     updateProjectConfiguration(tree, sourceProject.name, sourceProject);
   }
 

--- a/packages/nx-plugin/src/py/strands-agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/strands-agent/mcp-connection/generator.ts
@@ -14,6 +14,7 @@ import {
 import { PyStrandsAgentMcpConnectionGeneratorSchema } from './schema';
 import {
   NxGeneratorInfo,
+  addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
@@ -172,14 +173,10 @@ export const pyStrandsAgentMcpConnectionGenerator = async (
   const mcpServeLocalTargetName = `${mcpComponentName}-serve-local`;
 
   if (sourceProject.targets?.[serveLocalTargetName]) {
-    const target = sourceProject.targets[serveLocalTargetName];
-    target.dependsOn = [
-      ...(target.dependsOn ?? []),
-      {
-        projects: [targetProject.name],
-        target: mcpServeLocalTargetName,
-      },
-    ];
+    addDependencyToTargetIfNotPresent(sourceProject, serveLocalTargetName, {
+      projects: [targetProject.name],
+      target: mcpServeLocalTargetName,
+    });
     updateProjectConfiguration(tree, sourceProject.name, sourceProject);
   }
 

--- a/packages/nx-plugin/src/ts/strands-agent/a2a-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/a2a-connection/generator.spec.ts
@@ -311,6 +311,12 @@ export const getAgent = async (sessionId: string) =>
     const toolsArrayMatch = agent.match(/tools: \[([^\]]*)\]/);
     expect(toolsArrayMatch).toBeTruthy();
     expect((toolsArrayMatch![1].match(/\bremoteTool\b/g) ?? []).length).toBe(1);
+
+    // The host serve-local target has the remote serve-local dep exactly once
+    const host = JSON.parse(tree.read('apps/ts-host/project.json', 'utf-8')!);
+    expect(host.targets['host-serve-local'].dependsOn).toEqual([
+      { projects: ['@test/ts-remote'], target: 'remote-serve-local' },
+    ]);
   });
 
   it('should transform a block-body arrow function, preserving existing statements', async () => {

--- a/packages/nx-plugin/src/ts/strands-agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/a2a-connection/generator.ts
@@ -15,6 +15,7 @@ import {
 import { TsStrandsAgentA2aConnectionGeneratorSchema } from './schema';
 import {
   NxGeneratorInfo,
+  addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
@@ -172,14 +173,10 @@ export const tsStrandsAgentA2aConnectionGenerator = async (
   const targetServeLocalTargetName = `${targetAgentComponentName}-serve-local`;
 
   if (sourceProject.targets?.[serveLocalTargetName]) {
-    const target = sourceProject.targets[serveLocalTargetName];
-    target.dependsOn = [
-      ...(target.dependsOn ?? []),
-      {
-        projects: [targetProject.name],
-        target: targetServeLocalTargetName,
-      },
-    ];
+    addDependencyToTargetIfNotPresent(sourceProject, serveLocalTargetName, {
+      projects: [targetProject.name],
+      target: targetServeLocalTargetName,
+    });
     updateProjectConfiguration(tree, sourceProject.name, sourceProject);
   }
 

--- a/packages/nx-plugin/src/ts/strands-agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/mcp-connection/generator.ts
@@ -15,6 +15,7 @@ import {
 import { TsStrandsAgentMcpConnectionGeneratorSchema } from './schema';
 import {
   NxGeneratorInfo,
+  addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
@@ -147,14 +148,10 @@ export const tsStrandsAgentMcpConnectionGenerator = async (
   const mcpServeLocalTargetName = `${mcpComponentName}-serve-local`;
 
   if (sourceProject.targets?.[serveLocalTargetName]) {
-    const target = sourceProject.targets[serveLocalTargetName];
-    target.dependsOn = [
-      ...(target.dependsOn ?? []),
-      {
-        projects: [targetProject.name],
-        target: mcpServeLocalTargetName,
-      },
-    ];
+    addDependencyToTargetIfNotPresent(sourceProject, serveLocalTargetName, {
+      projects: [targetProject.name],
+      target: mcpServeLocalTargetName,
+    });
     updateProjectConfiguration(tree, sourceProject.name, sourceProject);
   }
 

--- a/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
@@ -17,6 +17,7 @@ import {
 } from '../shared-constructs-constants';
 import { addStarExport } from '../ast';
 import { IacProvider } from '../iac';
+import { addDependencyToTargetIfNotPresent } from '../nx';
 
 interface BackendOptions {
   type: 'trpc' | 'fastapi' | 'smithy';
@@ -71,16 +72,11 @@ export const addApiGatewayInfra = async (
       'project.json',
     ),
     (config: ProjectConfiguration) => {
-      if (!config.targets) {
-        config.targets = {};
-      }
-      if (!config.targets.build) {
-        config.targets.build = {};
-      }
-      config.targets.build.dependsOn = [
-        ...(config.targets.build.dependsOn ?? []),
+      addDependencyToTargetIfNotPresent(
+        config,
+        'build',
         `${options.apiProjectName}:build`,
-      ];
+      );
       return config;
     },
   );

--- a/packages/nx-plugin/src/utils/api-constructs/open-api-metadata.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/open-api-metadata.ts
@@ -10,6 +10,7 @@ import {
 } from '@nx/devkit';
 import { IacProvider } from '../iac';
 import { updateGitIgnore } from '../git';
+import { addDependencyToTargetIfNotPresent } from '../nx';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
@@ -81,13 +82,7 @@ export const addSharedConstructsOpenApiMetadataGenerateTarget = (
           dependsOn: [specBuildTargetName],
         };
       }
-      if (!config.targets.compile) {
-        config.targets.compile = {};
-      }
-      config.targets.compile.dependsOn = [
-        ...(config.targets.compile.dependsOn ?? []),
-        metadataTargetName,
-      ];
+      addDependencyToTargetIfNotPresent(config, 'compile', metadataTargetName);
       return config;
     },
   );

--- a/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
+++ b/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
@@ -17,6 +17,7 @@ import {
 } from '../shared-constructs-constants';
 import { addStarExport } from '../ast';
 import { IacProvider } from '../iac';
+import { addDependencyToTargetIfNotPresent } from '../nx';
 
 export interface AddLambdaFunctionConstructOptions {
   functionProjectName: string;
@@ -54,16 +55,11 @@ export const addLambdaFunctionInfra = async (
       'project.json',
     ),
     (config: ProjectConfiguration) => {
-      if (!config.targets) {
-        config.targets = {};
-      }
-      if (!config.targets.build) {
-        config.targets.build = {};
-      }
-      config.targets.build.dependsOn = [
-        ...(config.targets.build.dependsOn ?? []),
+      addDependencyToTargetIfNotPresent(
+        config,
+        'build',
         `${options.functionProjectName}:build`,
-      ];
+      );
       return config;
     },
   );

--- a/packages/nx-plugin/src/utils/nx.spec.ts
+++ b/packages/nx-plugin/src/utils/nx.spec.ts
@@ -2,13 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Tree } from '@nx/devkit';
+import { ProjectConfiguration, Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from './test';
 import { expect, describe, it, beforeEach } from 'vitest';
 import {
-  readProjectConfigurationUnqualified,
   addComponentGeneratorMetadata,
+  addDependencyToTargetIfNotPresent,
   NxGeneratorInfo,
+  readProjectConfigurationUnqualified,
 } from './nx';
 
 describe('readProjectConfigurationUnqualified', () => {
@@ -347,5 +348,105 @@ describe('addComponentGeneratorMetadata', () => {
       path: 'src/test-component',
       name: 'test-component',
     });
+  });
+});
+
+describe('addDependencyToTargetIfNotPresent', () => {
+  const makeProject = (): ProjectConfiguration => ({
+    name: 'test-project',
+    root: 'apps/test-project',
+  });
+
+  it('should create the target if it does not exist', () => {
+    const project = makeProject();
+    addDependencyToTargetIfNotPresent(project, 'build', 'lint');
+    expect(project.targets?.build?.dependsOn).toEqual(['lint']);
+  });
+
+  it('should add a string dependency to an existing target', () => {
+    const project = makeProject();
+    project.targets = { build: { dependsOn: ['compile'] } };
+    addDependencyToTargetIfNotPresent(project, 'build', 'bundle');
+    expect(project.targets.build.dependsOn).toEqual(['compile', 'bundle']);
+  });
+
+  it('should not duplicate a string dependency', () => {
+    const project = makeProject();
+    project.targets = { build: { dependsOn: ['compile', 'bundle'] } };
+    addDependencyToTargetIfNotPresent(project, 'build', 'bundle');
+    expect(project.targets.build.dependsOn).toEqual(['compile', 'bundle']);
+  });
+
+  it('should add an object dependency', () => {
+    const project = makeProject();
+    addDependencyToTargetIfNotPresent(project, 'serve-local', {
+      projects: ['other-project'],
+      target: 'serve-local',
+    });
+    expect(project.targets?.['serve-local']?.dependsOn).toEqual([
+      { projects: ['other-project'], target: 'serve-local' },
+    ]);
+  });
+
+  it('should not duplicate an object dependency with identical projects/target', () => {
+    const project = makeProject();
+    project.targets = {
+      'serve-local': {
+        dependsOn: [{ projects: ['other-project'], target: 'serve-local' }],
+      },
+    };
+    addDependencyToTargetIfNotPresent(project, 'serve-local', {
+      projects: ['other-project'],
+      target: 'serve-local',
+    });
+    expect(project.targets['serve-local'].dependsOn).toEqual([
+      { projects: ['other-project'], target: 'serve-local' },
+    ]);
+  });
+
+  it('should treat string-projects and single-element-array-projects as equivalent', () => {
+    const project = makeProject();
+    project.targets = {
+      'serve-local': {
+        dependsOn: [{ projects: 'other-project', target: 'serve-local' }],
+      },
+    };
+    addDependencyToTargetIfNotPresent(project, 'serve-local', {
+      projects: ['other-project'],
+      target: 'serve-local',
+    });
+    expect(project.targets['serve-local'].dependsOn).toHaveLength(1);
+  });
+
+  it('should consider object dependencies with different targets as distinct', () => {
+    const project = makeProject();
+    project.targets = {
+      'serve-local': {
+        dependsOn: [{ projects: ['api'], target: 'serve-local' }],
+      },
+    };
+    addDependencyToTargetIfNotPresent(project, 'serve-local', {
+      projects: ['api'],
+      target: 'serve-watch',
+    });
+    expect(project.targets['serve-local'].dependsOn).toEqual([
+      { projects: ['api'], target: 'serve-local' },
+      { projects: ['api'], target: 'serve-watch' },
+    ]);
+  });
+
+  it('should be idempotent when called repeatedly with the same inputs', () => {
+    const project = makeProject();
+    for (let i = 0; i < 5; i++) {
+      addDependencyToTargetIfNotPresent(project, 'build', 'compile');
+      addDependencyToTargetIfNotPresent(project, 'build', {
+        projects: ['other'],
+        target: 'build',
+      });
+    }
+    expect(project.targets?.build?.dependsOn).toEqual([
+      'compile',
+      { projects: ['other'], target: 'build' },
+    ]);
   });
 });

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -133,19 +133,58 @@ export const addComponentGeneratorMetadata = (
 };
 
 /**
+ * A single entry in an Nx `dependsOn` array.
+ * Matches the shape accepted by Nx without requiring a devkit type import.
+ */
+export type TargetDependency =
+  | string
+  | {
+      projects?: string | string[];
+      target: string;
+      params?: 'ignore' | 'forward';
+    };
+
+const targetDependencyEquals = (a: TargetDependency, b: TargetDependency) => {
+  if (typeof a === 'string' || typeof b === 'string') {
+    return a === b;
+  }
+  if (a.target !== b.target || a.params !== b.params) {
+    return false;
+  }
+  const aProjects = Array.isArray(a.projects)
+    ? a.projects
+    : a.projects !== undefined
+      ? [a.projects]
+      : [];
+  const bProjects = Array.isArray(b.projects)
+    ? b.projects
+    : b.projects !== undefined
+      ? [b.projects]
+      : [];
+  if (aProjects.length !== bProjects.length) {
+    return false;
+  }
+  return aProjects.every((p, i) => p === bProjects[i]);
+};
+
+/**
  * Mutate the project to add the dependency to the target if not already present
  * Adds the target if not present.
+ *
+ * Accepts either a string target name (e.g. `'build'`) or a dependency config
+ * object (e.g. `{ projects: ['foo'], target: 'serve-local' }`). Deduplicates
+ * using deep equality so re-running a generator does not grow `dependsOn`.
  */
 export const addDependencyToTargetIfNotPresent = (
   project: ProjectConfiguration,
   target: string,
-  dependency: string,
+  dependency: TargetDependency,
 ) => {
   project.targets ??= {};
   project.targets[target] ??= {};
   project.targets[target].dependsOn = [
     ...(project.targets[target].dependsOn ?? []).filter(
-      (d) => d !== dependency,
+      (d) => !targetDependencyEquals(d, dependency),
     ),
     dependency,
   ];

--- a/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
+++ b/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
@@ -17,6 +17,7 @@ import {
 } from '../shared-constructs-constants';
 import { addStarExport } from '../ast';
 import { IacProvider } from '../iac';
+import { addDependencyToTargetIfNotPresent } from '../nx';
 
 export interface AddWebsiteInfraOptions {
   websiteProjectName: string;
@@ -51,16 +52,11 @@ export const addWebsiteInfra = async (
       'project.json',
     ),
     (config: ProjectConfiguration) => {
-      if (!config.targets) {
-        config.targets = {};
-      }
-      if (!config.targets.build) {
-        config.targets.build = {};
-      }
-      config.targets.build.dependsOn = [
-        ...(config.targets.build.dependsOn ?? []),
+      addDependencyToTargetIfNotPresent(
+        config,
+        'build',
         `${options.websiteProjectName}:build`,
-      ];
+      );
       return config;
     },
   );


### PR DESCRIPTION
### Reason for this change

Several generators append to `target.dependsOn` arrays without checking for duplicates. Running the same generator twice with the same inputs (common when iterating, or when a downstream generator re-invokes a helper) grows the array on every run. Over time `project.json` targets accumulate duplicate entries, bloating build logs and muddying the dependency graph.

### Description of changes

Route all affected mutation sites through the existing `addDependencyToTargetIfNotPresent` helper, and extend that helper to accept object dependencies (`{ projects, target }`) with deep-equal dedup (previously string-only).

Sites updated:
- `connection/serve-local`, `connection/agent-serve-local`
- `ts/strands-agent/{a2a,mcp}-connection`
- `py/strands-agent/{a2a,mcp}-connection`
- `utils/api-constructs`, `utils/function-constructs`, `utils/website-constructs`
- `utils/api-constructs/open-api-metadata`
- `infra/app`

### Description of how you validated changes

- New unit tests on `addDependencyToTargetIfNotPresent` covering: string dedup, object dedup, array/string `projects` equivalence, different targets remain distinct, repeated-call idempotency.
- Extended existing "idempotent tool" tests on the ts/py a2a-connection generators to also assert the serve-local target's `dependsOn` stays deduplicated after a second run.
- New "run twice" test in `serve-local.spec.ts` exercising `addTargetToServeLocal` directly.
- Full test suite passes: `pnpm nx run @aws/nx-plugin:test` → 1771 passed.
- Build + lint pass: `pnpm nx run-many --target build --all`, `pnpm nx run-many --target lint --all`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*