### PR TITLE
ci(e2e): pre-create RDS service-linked role in deploy smoke tests

### DIFF
--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -307,6 +307,8 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "rdb" {
+  #checkov:skip=CKV2_AWS_11:Flow logs are not required for ephemeral e2e test infrastructure
+  #checkov:skip=CKV2_AWS_12:Default security group restrictions are not required for ephemeral e2e test infrastructure
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -7,6 +7,7 @@ import { ensureDirSync } from 'fs-extra';
 import { runCLI, tmpProjPath } from '../utils';
 import { join } from 'path';
 import { CloudFormation, StackStatus } from '@aws-sdk/client-cloudformation';
+import { ensureRdsServiceLinkedRole } from './deploy-prerequisites';
 import { runSmokeTest } from './smoke-test';
 import {
   invokeAgentCoreA2a,
@@ -94,6 +95,8 @@ describe('smoke test - cdk-deploy', () => {
     writeFileSync(`${opts.cwd}/packages/infra/src/main.ts`, mainContent);
 
     const cdkStageName = `e2e-test-infra-sandbox-${testRunId}`;
+
+    ensureRdsServiceLinkedRole();
 
     try {
       // Deploy the e2e test resources

--- a/e2e/src/smoke-tests/deploy-prerequisites.ts
+++ b/e2e/src/smoke-tests/deploy-prerequisites.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync } from 'child_process';
+
+// Create the RDS service-linked role required by RDS Proxy if it doesn't exist yet.
+// https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.ServiceLinkedRoles.html
+export function ensureRdsServiceLinkedRole(): void {
+  try {
+    execSync(
+      'aws iam create-service-linked-role --aws-service-name rds.amazonaws.com',
+      { stdio: 'pipe' },
+    );
+  } catch (e: unknown) {
+    const stderr = (e as { stderr?: Buffer }).stderr?.toString() ?? '';
+    if (stderr.includes('has been taken in this account')) {
+      return;
+    }
+    throw e;
+  }
+}

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -8,6 +8,7 @@ import { ensureDirSync } from 'fs-extra';
 import { join } from 'path';
 
 import { runCLI, tmpProjPath } from '../utils';
+import { ensureRdsServiceLinkedRole } from './deploy-prerequisites';
 import { runTerraformSmokeTest } from './terraform-smoke-test';
 import {
   invokeAgentCoreA2a,
@@ -99,6 +100,8 @@ describe('smoke test - terraform-deploy', () => {
         'deletion_protection = "INACTIVE"',
       ),
     );
+
+    ensureRdsServiceLinkedRole();
 
     try {
       await runCLI(`sync`, opts);


### PR DESCRIPTION
### Reason for this change

After PR #552 merged, the `Smoke Tests - cdk-deploy` CI job began failing with:

> RDS is not authorized to assume service-linked role arn:aws:iam::...:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS

`RDS::DBProxy` needs `AWSServiceRoleForRDS` to exist before creation. On fresh accounts, RDS has not yet auto-created the role when CloudFormation starts provisioning the proxy, and the deploy fails. The failure blocked the `Release` job, so the `ts#rdb` generator and the idempotency fix from #650 never published.

The same CI run also tripped two checkov checks on the ephemeral helper VPC in the terraform-deploy smoke test.

### Description of changes

- Added `e2e/src/smoke-tests/deploy-prerequisites.ts` with a shared `ensureRdsServiceLinkedRole()` helper that invokes `aws iam create-service-linked-role --aws-service-name rds.amazonaws.com` and treats the "already exists" error as success.
- Call the helper from both `cdk-deploy.spec.ts` and `terraform-deploy.spec.ts` before the deploy step. Even though `terraform-deploy`'s main.tf currently sets `enable_rds_proxy = false`, keeping both tests bootstrapping the same way avoids silent breakage if that flag ever flips.
- Added `CKV2_AWS_11` and `CKV2_AWS_12` suppressions to the e2e `terraform-deploy` helper VPC — flow logs and default security group restrictions are not applicable to throwaway test infra.

SLR management is deliberately kept out of the generator template: CDK itself does not manage service-linked roles (see aws/aws-cdk#14258), AWS docs say *"You don't need to manually create a service-linked role"* for RDS, and real accounts almost never hit this race because any prior RDS provisioning already created the SLR. The failure is specific to greenfield CI accounts, so the bootstrap lives in the test harness.

### Description of how you validated changes

- Ran the e2e build + lint locally, both green.
- Confirmed `aws iam create-service-linked-role` error handling against a real account — the "has been taken in this account" steady-state path is exercised.
- Relying on PR CI to exercise both deploy smoke tests end-to-end.

### Issue # (if applicable)

Follow-up to #552. Unblocks the release that #552 + #650 would have cut.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*