### PR TITLE
ci(e2e): harden rdb deploy smoke tests against Aurora post-create window

### DIFF
--- a/e2e/vite.config.mts
+++ b/e2e/vite.config.mts
@@ -76,7 +76,7 @@ export default defineConfig({
         singleThread: true,
       },
     },
-    testTimeout: 60 * 60 * 1000, /// 60 mins for long running e2e tests (eg deploy)
+    testTimeout: 120 * 60 * 1000, /// 120 mins for long running e2e tests (eg deploy)
     hookTimeout: 2 * 60 * 1000, /// 2 mins — corepack activation + rmSync on Windows can be slow
   },
 });

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -180,6 +180,7 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
     },
     connectionLimit: 1,
     multipleStatements: true,
+    connectTimeout: 10_000,
   });
 
   const quotedDbName = pool.escapeId(dbname);
@@ -203,6 +204,42 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
   }
 };
 
+// Aurora's writer endpoint is briefly unreachable from within the VPC right
+// after the cluster reports ready, surfacing as AggregateError [ETIMEDOUT].
+const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string })?.code;
+  return (
+    message.includes('ETIMEDOUT') ||
+    message.includes('ECONNREFUSED') ||
+    message.includes('ENOTFOUND') ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ENOTFOUND'
+  );
+};
+
+const withConnectionRetry = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const maxAttempts = 6;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
+        throw error;
+      }
+      const delayMs = 10_000 * attempt;
+      console.log(
+        \`Transient connection error (attempt \${attempt}/\${maxAttempts}), retrying in \${delayMs}ms: \${
+          error instanceof Error ? error.message : String(error)
+        }\`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error('unreachable');
+};
+
 export const handler = async (
   event: CloudFormationCustomResourceEvent,
 ): Promise<OnEventResult> => {
@@ -211,7 +248,7 @@ export const handler = async (
   );
 
   if (event.RequestType !== 'Delete') {
-    await ensureDatabaseUser(dbUser);
+    await withConnectionRetry(() => ensureDatabaseUser(dbUser));
   }
 
   return {
@@ -665,7 +702,7 @@ export abstract class AuroraDatabase extends Construct {
       code: Code.fromAsset(createDbUserBundleDir),
       handler: 'index.handler',
       runtime: Runtime.NODEJS_LATEST,
-      timeout: Duration.minutes(1),
+      timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
       vpcSubnets: {
@@ -2065,7 +2102,7 @@ resource "aws_lambda_function" "create_db_user" {
   handler           = "index.handler"
   source_code_hash  = data.archive_file.create_db_user_zip.output_base64sha256
   runtime           = "nodejs24.x"
-  timeout          = 60
+  timeout          = 300
   architectures    = ["arm64"]
 
   tracing_config {
@@ -3520,7 +3557,7 @@ resource "aws_lambda_function" "create_db_user" {
   handler           = "index.handler"
   source_code_hash  = data.archive_file.create_db_user_zip.output_base64sha256
   runtime           = "nodejs24.x"
-  timeout          = 60
+  timeout          = 300
   architectures    = ["arm64"]
 
   tracing_config {
@@ -3899,6 +3936,7 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
     ssl: {
       rejectUnauthorized: true,
     },
+    connectionTimeoutMillis: 10_000,
   });
 
   await client.connect();
@@ -3936,6 +3974,42 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
   }
 };
 
+// Aurora's writer endpoint is briefly unreachable from within the VPC right
+// after the cluster reports ready, surfacing as AggregateError [ETIMEDOUT].
+const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string })?.code;
+  return (
+    message.includes('ETIMEDOUT') ||
+    message.includes('ECONNREFUSED') ||
+    message.includes('ENOTFOUND') ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ENOTFOUND'
+  );
+};
+
+const withConnectionRetry = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const maxAttempts = 6;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
+        throw error;
+      }
+      const delayMs = 10_000 * attempt;
+      console.log(
+        \`Transient connection error (attempt \${attempt}/\${maxAttempts}), retrying in \${delayMs}ms: \${
+          error instanceof Error ? error.message : String(error)
+        }\`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error('unreachable');
+};
+
 export const handler = async (
   event: CloudFormationCustomResourceEvent,
 ): Promise<OnEventResult> => {
@@ -3944,7 +4018,7 @@ export const handler = async (
   );
 
   if (event.RequestType !== 'Delete') {
-    await ensureDatabaseUser(dbUser);
+    await withConnectionRetry(() => ensureDatabaseUser(dbUser));
   }
 
   return {
@@ -4422,7 +4496,7 @@ export abstract class AuroraDatabase extends Construct {
       code: Code.fromAsset(createDbUserBundleDir),
       handler: 'index.handler',
       runtime: Runtime.NODEJS_LATEST,
-      timeout: Duration.minutes(1),
+      timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
       vpcSubnets: {

--- a/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
@@ -34,6 +34,7 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
     },
     connectionLimit: 1,
     multipleStatements: true,
+    connectTimeout: 10_000,
   });
 
   const quotedDbName = pool.escapeId(dbname);
@@ -68,6 +69,7 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
     ssl: {
       rejectUnauthorized: true,
     },
+    connectionTimeoutMillis: 10_000,
   });
 
   await client.connect();
@@ -106,6 +108,42 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
 <%_ } _%>
 };
 
+// Aurora's writer endpoint is briefly unreachable from within the VPC right
+// after the cluster reports ready, surfacing as AggregateError [ETIMEDOUT].
+const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string })?.code;
+  return (
+    message.includes('ETIMEDOUT') ||
+    message.includes('ECONNREFUSED') ||
+    message.includes('ENOTFOUND') ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ENOTFOUND'
+  );
+};
+
+const withConnectionRetry = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const maxAttempts = 6;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
+        throw error;
+      }
+      const delayMs = 10_000 * attempt;
+      console.log(
+        `Transient connection error (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error('unreachable');
+};
+
 export const handler = async (
   event: CloudFormationCustomResourceEvent,
 ): Promise<OnEventResult> => {
@@ -114,7 +152,7 @@ export const handler = async (
   );
 
   if (event.RequestType !== 'Delete') {
-    await ensureDatabaseUser(dbUser);
+    await withConnectionRetry(() => ensureDatabaseUser(dbUser));
   }
 
   return {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
@@ -264,7 +264,7 @@ export abstract class AuroraDatabase extends Construct {
       code: Code.fromAsset(createDbUserBundleDir),
       handler: 'index.handler',
       runtime: Runtime.NODEJS_LATEST,
-      timeout: Duration.minutes(1),
+      timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
       vpcSubnets: {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -528,7 +528,7 @@ resource "aws_lambda_function" "create_db_user" {
   handler           = "index.handler"
   source_code_hash  = data.archive_file.create_db_user_zip.output_base64sha256
   runtime           = "nodejs24.x"
-  timeout          = 60
+  timeout          = 300
   architectures    = ["arm64"]
 
   tracing_config {


### PR DESCRIPTION
### Reason for this change

Post-merge CI for #652 surfaced two reliability gaps in the rdb generator's deploy path:

- **terraform-deploy failed** because the `create-db-user` Lambda connects to the Aurora writer endpoint immediately after `aws_rds_cluster` reports Creation complete. Aurora exposes the endpoint before it accepts VPC-side connections, which surfaces as `AggregateError [ETIMEDOUT]`. The failure aborts the terraform apply and the smoke test fails at ~50min.
- **cdk-deploy's CodeBuild runner lost communication** after ~70min ("self-hosted runner lost communication with the server"), leaving no headroom against vitest's 60min testTimeout. The CodeBuild project timeout is being raised in parallel; vitest needs to match.

### Description of changes

Both failures trace back to the same narrow post-create window on Aurora, so fix it once at the Lambda handler level.

- `create-db-user-handler.ts.template`: wrap `ensureDatabaseUser` in a bounded retry that treats `ETIMEDOUT`/`ECONNREFUSED`/`ENOTFOUND` as transient (6 attempts, 10s→60s linear backoff). Non-connection errors still bubble up unchanged. This single change covers both the CDK custom resource and the Terraform `null_resource.create_db_user_trigger`, since both invoke the same Lambda.
- Give the pg/mariadb client a 10s driver-level connect timeout so a single failed attempt doesn't eat the Lambda budget before we can retry.
- Raise the `create-db-user` Lambda timeout to 5 minutes (CDK `Duration.minutes(1)` → 5; Terraform `60` → `300`) so the retry window fits inside the Lambda ceiling.
- `e2e/vite.config.mts`: raise `testTimeout` from 60min to 120min for the long deploy smoke tests. Pairs with the parallel CodeBuild project timeout bump.

### Description of how you validated changes

- Unit tests updated (`pnpm nx run @aws/nx-plugin:test -u`) — rdb generator snapshot now reflects the retry wrapper and the new Lambda timeouts in both CDK and Terraform outputs.
- Lint clean on `@aws/nx-plugin` + `nx-plugin-e2e`.
- Relying on post-merge deploy smoke tests (cdk-deploy, terraform-deploy) to exercise the retry end-to-end — PR CI doesn't run them.

### Issue # (if applicable)

Follow-up to #552 and #652. Unblocks the release that's been stuck behind cdk-deploy failures.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*