### PR TITLE
ci(e2e): unblock cdk-deploy teardown, cap EIPs, and retry migrations

### DIFF
--- a/e2e/src/files/application-stack.ts.template
+++ b/e2e/src/files/application-stack.ts.template
@@ -25,7 +25,9 @@ export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const vpc = new Vpc(this, 'Vpc');
+    // Single NAT gateway keeps the test run under the default per-region
+    // EIP quota when both cdk-deploy and terraform-deploy run in parallel.
+    const vpc = new Vpc(this, 'Vpc', { natGateways: 1 });
 
     new PostgresDb(this, 'PostgresDb', {
       vpc,

--- a/e2e/src/files/cdk-deploy/main.ts.template
+++ b/e2e/src/files/cdk-deploy/main.ts.template
@@ -4,6 +4,7 @@ import { Aspects, IAspect, RemovalPolicy } from 'aws-cdk-lib';
 import { IConstruct } from 'constructs';
 import { CfnResource } from 'aws-cdk-lib';
 import { CfnUserPool, CfnUserPoolDomain } from 'aws-cdk-lib/aws-cognito';
+import { CfnDBCluster, CfnDBInstance } from 'aws-cdk-lib/aws-rds';
 
 /**
  * Aspect to augment resources for integration tests
@@ -23,6 +24,16 @@ class IntegrationTestAspect implements IAspect {
     // Ensure unique user pool domain name
     if (node instanceof CfnUserPoolDomain) {
       node.domain = `${node.domain}-<% TEST_RUN_ID %>`;
+    }
+
+    // Disable RDS deletion protection and skip final snapshots so destroy
+    // can tear the cluster and its instances down in one pass.
+    if (node instanceof CfnDBCluster) {
+      node.deletionProtection = false;
+      node.skipFinalSnapshot = true;
+    }
+    if (node instanceof CfnDBInstance) {
+      node.deletionProtection = false;
     }
   }
 }

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -153,7 +153,7 @@ exports[`ts#rdb generator > should add mysql prisma dependencies when engine is 
 "import type { CloudFormationCustomResourceEvent } from 'aws-lambda';
 import { randomBytes } from 'node:crypto';
 import { createPool, type PoolConnection } from 'mariadb';
-import { getDatabaseSecret } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 
 type OnEventResult = {
   PhysicalResourceId: string;
@@ -204,42 +204,6 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
   }
 };
 
-// Aurora's writer endpoint is briefly unreachable from within the VPC right
-// after the cluster reports ready, surfacing as AggregateError [ETIMEDOUT].
-const isTransientConnectionError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message : String(error);
-  const code = (error as { code?: string })?.code;
-  return (
-    message.includes('ETIMEDOUT') ||
-    message.includes('ECONNREFUSED') ||
-    message.includes('ENOTFOUND') ||
-    code === 'ETIMEDOUT' ||
-    code === 'ECONNREFUSED' ||
-    code === 'ENOTFOUND'
-  );
-};
-
-const withConnectionRetry = async <T>(fn: () => Promise<T>): Promise<T> => {
-  const maxAttempts = 6;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
-        throw error;
-      }
-      const delayMs = 10_000 * attempt;
-      console.log(
-        \`Transient connection error (attempt \${attempt}/\${maxAttempts}), retrying in \${delayMs}ms: \${
-          error instanceof Error ? error.message : String(error)
-        }\`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
-  throw new Error('unreachable');
-};
-
 export const handler = async (
   event: CloudFormationCustomResourceEvent,
 ): Promise<OnEventResult> => {
@@ -270,23 +234,29 @@ export { getPrisma } from './prisma.js';
 exports[`ts#rdb generator > should add mysql prisma dependencies when engine is MySQL > packages/db/src/migration-handler.ts 1`] = `
 "import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { getDatabaseSecret } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 
-export const handler = async () => {
+const buildDatabaseUrl = async (): Promise<string> => {
   const { host, port, dbname, username, password } = await getDatabaseSecret();
 
-  const databaseUrl =
+  return (
     \`mysql://\${encodeURIComponent(username)}\` +
     \`:\${encodeURIComponent(password)}\` +
     \`@\${host}:\${port}/\${dbname}\` +
-    \`?sslaccept=strict\`;
+    \`?sslaccept=strict\`
+  );
+};
 
-  await promisify(execFile)('npx', ['prisma', 'migrate', 'deploy'], {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      DATABASE_URL: databaseUrl,
-    },
+export const handler = async () => {
+  await withConnectionRetry(async () => {
+    const databaseUrl = await buildDatabaseUrl();
+    await promisify(execFile)('npx', ['prisma', 'migrate', 'deploy'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        DATABASE_URL: databaseUrl,
+      },
+    });
   });
 };
 "
@@ -431,6 +401,60 @@ export const getDatabaseConfig = (
   databaseConfigPromises[runtimeConfigKey] ??=
     loadDatabaseConfig(runtimeConfigKey);
   return databaseConfigPromises[runtimeConfigKey];
+};
+
+// Aurora's writer endpoint is briefly unreachable from within the VPC right
+// after the cluster reports ready, and IAM policy attachments can take tens
+// of seconds to propagate before RDS accepts an IAM auth token. Both surface
+// as errors that resolve on retry.
+const transientErrorPatterns = [
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'P1000', // Prisma: authentication failed
+  'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
+];
+
+export const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string })?.code ?? '';
+  const stderr =
+    (error as { stderr?: Buffer | string })?.stderr?.toString() ?? '';
+  const stdout =
+    (error as { stdout?: Buffer | string })?.stdout?.toString() ?? '';
+  return transientErrorPatterns.some(
+    (p) =>
+      message.includes(p) ||
+      code.includes(p) ||
+      stderr.includes(p) ||
+      stdout.includes(p),
+  );
+};
+
+export const withConnectionRetry = async <T>(
+  fn: () => Promise<T>,
+  {
+    maxAttempts = 6,
+    delayMs = 10_000,
+  }: { maxAttempts?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
+        throw error;
+      }
+      const wait = delayMs * attempt;
+      console.log(
+        \`Transient connection error (attempt \${attempt}/\${maxAttempts}), retrying in \${wait}ms: \${
+          error instanceof Error ? error.message : String(error)
+        }\`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, wait));
+    }
+  }
+  throw new Error('unreachable');
 };
 "
 `;
@@ -3909,7 +3933,7 @@ exports[`ts#rdb generator > should generate the aurora shared construct > packag
 "import type { CloudFormationCustomResourceEvent } from 'aws-lambda';
 import { randomBytes } from 'node:crypto';
 import { Client, escapeIdentifier } from 'pg';
-import { getDatabaseSecret } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 
 type OnEventResult = {
   PhysicalResourceId: string;
@@ -3974,42 +3998,6 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
   }
 };
 
-// Aurora's writer endpoint is briefly unreachable from within the VPC right
-// after the cluster reports ready, surfacing as AggregateError [ETIMEDOUT].
-const isTransientConnectionError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message : String(error);
-  const code = (error as { code?: string })?.code;
-  return (
-    message.includes('ETIMEDOUT') ||
-    message.includes('ECONNREFUSED') ||
-    message.includes('ENOTFOUND') ||
-    code === 'ETIMEDOUT' ||
-    code === 'ECONNREFUSED' ||
-    code === 'ENOTFOUND'
-  );
-};
-
-const withConnectionRetry = async <T>(fn: () => Promise<T>): Promise<T> => {
-  const maxAttempts = 6;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
-        throw error;
-      }
-      const delayMs = 10_000 * attempt;
-      console.log(
-        \`Transient connection error (attempt \${attempt}/\${maxAttempts}), retrying in \${delayMs}ms: \${
-          error instanceof Error ? error.message : String(error)
-        }\`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
-  throw new Error('unreachable');
-};
-
 export const handler = async (
   event: CloudFormationCustomResourceEvent,
 ): Promise<OnEventResult> => {
@@ -4041,8 +4029,9 @@ exports[`ts#rdb generator > should generate the aurora shared construct > packag
 "import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { Signer } from '@aws-sdk/rds-signer';
+import { withConnectionRetry } from './utils.js';
 
-export const handler = async () => {
+const buildDatabaseUrl = async (): Promise<string> => {
   const hostname = process.env.HOSTNAME!;
   const port = process.env.PORT!;
   const database = process.env.DATABASE!;
@@ -4056,18 +4045,24 @@ export const handler = async () => {
     username: dbUser,
   }).getAuthToken();
 
-  const databaseUrl =
+  return (
     \`postgresql://\${encodeURIComponent(dbUser)}\` +
     \`:\${encodeURIComponent(iamAuthToken)}\` +
     \`@\${hostname}:\${port}/\${database}\` +
-    \`?sslaccept=strict\`; // \`sslaccept\` is the correct parameter here for postgresql. The Prisma CLI Rust engine does not use the standard libpq \`sslmode\` option.
+    \`?sslaccept=strict\` // \`sslaccept\` is the correct parameter here for postgresql. The Prisma CLI Rust engine does not use the standard libpq \`sslmode\` option.
+  );
+};
 
-  await promisify(execFile)('npx', ['prisma', 'migrate', 'deploy'], {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      DATABASE_URL: databaseUrl,
-    },
+export const handler = async () => {
+  await withConnectionRetry(async () => {
+    const databaseUrl = await buildDatabaseUrl();
+    await promisify(execFile)('npx', ['prisma', 'migrate', 'deploy'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        DATABASE_URL: databaseUrl,
+      },
+    });
   });
 };
 "
@@ -4225,6 +4220,60 @@ export const getDatabaseConfig = (
   databaseConfigPromises[runtimeConfigKey] ??=
     loadDatabaseConfig(runtimeConfigKey);
   return databaseConfigPromises[runtimeConfigKey];
+};
+
+// Aurora's writer endpoint is briefly unreachable from within the VPC right
+// after the cluster reports ready, and IAM policy attachments can take tens
+// of seconds to propagate before RDS accepts an IAM auth token. Both surface
+// as errors that resolve on retry.
+const transientErrorPatterns = [
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'P1000', // Prisma: authentication failed
+  'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
+];
+
+export const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string })?.code ?? '';
+  const stderr =
+    (error as { stderr?: Buffer | string })?.stderr?.toString() ?? '';
+  const stdout =
+    (error as { stdout?: Buffer | string })?.stdout?.toString() ?? '';
+  return transientErrorPatterns.some(
+    (p) =>
+      message.includes(p) ||
+      code.includes(p) ||
+      stderr.includes(p) ||
+      stdout.includes(p),
+  );
+};
+
+export const withConnectionRetry = async <T>(
+  fn: () => Promise<T>,
+  {
+    maxAttempts = 6,
+    delayMs = 10_000,
+  }: { maxAttempts?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
+        throw error;
+      }
+      const wait = delayMs * attempt;
+      console.log(
+        \`Transient connection error (attempt \${attempt}/\${maxAttempts}), retrying in \${wait}ms: \${
+          error instanceof Error ? error.message : String(error)
+        }\`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, wait));
+    }
+  }
+  throw new Error('unreachable');
 };
 "
 `;

--- a/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
@@ -2,10 +2,10 @@ import type { CloudFormationCustomResourceEvent } from 'aws-lambda';
 import { randomBytes } from 'node:crypto';
 <%_ if (engine === 'MySQL') { _%>
 import { createPool, type PoolConnection } from 'mariadb';
-import { getDatabaseSecret } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 <%_ } else { _%>
 import { Client, escapeIdentifier } from 'pg';
-import { getDatabaseSecret } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 <%_ } _%>
 
 type OnEventResult = {
@@ -106,42 +106,6 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
     await client.end();
   }
 <%_ } _%>
-};
-
-// Aurora's writer endpoint is briefly unreachable from within the VPC right
-// after the cluster reports ready, surfacing as AggregateError [ETIMEDOUT].
-const isTransientConnectionError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message : String(error);
-  const code = (error as { code?: string })?.code;
-  return (
-    message.includes('ETIMEDOUT') ||
-    message.includes('ECONNREFUSED') ||
-    message.includes('ENOTFOUND') ||
-    code === 'ETIMEDOUT' ||
-    code === 'ECONNREFUSED' ||
-    code === 'ENOTFOUND'
-  );
-};
-
-const withConnectionRetry = async <T>(fn: () => Promise<T>): Promise<T> => {
-  const maxAttempts = 6;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
-        throw error;
-      }
-      const delayMs = 10_000 * attempt;
-      console.log(
-        `Transient connection error (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
-  throw new Error('unreachable');
 };
 
 export const handler = async (

--- a/packages/nx-plugin/src/ts/rdb/files/src/migration-handler.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/migration-handler.ts.template
@@ -1,20 +1,22 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 <%_ if (engine === 'MySQL') { _%>
-import { getDatabaseSecret } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 <%_ } else { _%>
 import { Signer } from '@aws-sdk/rds-signer';
+import { withConnectionRetry } from './utils.js';
 <%_ } _%>
 
-export const handler = async () => {
+const buildDatabaseUrl = async (): Promise<string> => {
 <%_ if (engine === 'MySQL') { _%>
   const { host, port, dbname, username, password } = await getDatabaseSecret();
 
-  const databaseUrl =
+  return (
     `mysql://${encodeURIComponent(username)}` +
     `:${encodeURIComponent(password)}` +
     `@${host}:${port}/${dbname}` +
-    `?sslaccept=strict`;
+    `?sslaccept=strict`
+  );
 <%_ } else { _%>
   const hostname = process.env.HOSTNAME!;
   const port = process.env.PORT!;
@@ -29,18 +31,24 @@ export const handler = async () => {
     username: dbUser,
   }).getAuthToken();
 
-  const databaseUrl =
+  return (
     `postgresql://${encodeURIComponent(dbUser)}` +
     `:${encodeURIComponent(iamAuthToken)}` +
     `@${hostname}:${port}/${database}` +
-    `?sslaccept=strict`; // `sslaccept` is the correct parameter here for postgresql. The Prisma CLI Rust engine does not use the standard libpq `sslmode` option.
+    `?sslaccept=strict` // `sslaccept` is the correct parameter here for postgresql. The Prisma CLI Rust engine does not use the standard libpq `sslmode` option.
+  );
 <%_ } _%>
+};
 
-  await promisify(execFile)('npx', ['prisma', 'migrate', 'deploy'], {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      DATABASE_URL: databaseUrl,
-    },
+export const handler = async () => {
+  await withConnectionRetry(async () => {
+    const databaseUrl = await buildDatabaseUrl();
+    await promisify(execFile)('npx', ['prisma', 'migrate', 'deploy'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        DATABASE_URL: databaseUrl,
+      },
+    });
   });
 };

--- a/packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template
@@ -85,3 +85,52 @@ export const getDatabaseConfig = (
     loadDatabaseConfig(runtimeConfigKey);
   return databaseConfigPromises[runtimeConfigKey];
 };
+
+// Aurora's writer endpoint is briefly unreachable from within the VPC right
+// after the cluster reports ready, and IAM policy attachments can take tens
+// of seconds to propagate before RDS accepts an IAM auth token. Both surface
+// as errors that resolve on retry.
+const transientErrorPatterns = [
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'P1000', // Prisma: authentication failed
+  'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
+];
+
+export const isTransientConnectionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string })?.code ?? '';
+  const stderr = (error as { stderr?: Buffer | string })?.stderr?.toString() ?? '';
+  const stdout = (error as { stdout?: Buffer | string })?.stdout?.toString() ?? '';
+  return transientErrorPatterns.some(
+    (p) =>
+      message.includes(p) ||
+      code.includes(p) ||
+      stderr.includes(p) ||
+      stdout.includes(p),
+  );
+};
+
+export const withConnectionRetry = async <T>(
+  fn: () => Promise<T>,
+  { maxAttempts = 6, delayMs = 10_000 }: { maxAttempts?: number; delayMs?: number } = {},
+): Promise<T> => {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxAttempts || !isTransientConnectionError(error)) {
+        throw error;
+      }
+      const wait = delayMs * attempt;
+      console.log(
+        `Transient connection error (attempt ${attempt}/${maxAttempts}), retrying in ${wait}ms: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, wait));
+    }
+  }
+  throw new Error('unreachable');
+};


### PR DESCRIPTION
### Reason for this change

The main CI run after #653 turned up three separate deploy reliability issues:

- **EIP quota on cdk-deploy.** CDK's default `Vpc` creates one NAT gateway per AZ — 3 EIPs in us-west-2. `terraform-deploy` adds 1 more. A single main CI run asks for 4 EIPs concurrently and leaves no headroom against the default per-region quota of 5 once NAT gateway teardown lag or orphans from prior failed runs are in the mix.
- **RDS deletion protection wedges cdk destroy.** The `AuroraDatabase` construct defaults `deletionProtection: true`, which is the right default for users but means `cdk destroy` at the end of a run fails with `"Cannot delete protected Cluster … please disable deletion protection and try again"`, leaving clusters in `DELETE_FAILED` and accumulating orphans across runs.
- **Migration handler fails on transient errors.** Two distinct failures:
  - postgres: `Error P1000: Authentication failed ... credentials for dbUser are not valid`. The IAM auth token is minted fresh per invocation, but `rds-db:connect` on the migration Lambda role hadn't yet propagated through IAM when Prisma connected. Inline policies don't dodge this — it's IAM eventual consistency, independent of policy type.
  - mysql: `AggregateError [ETIMEDOUT]`. Same Aurora post-create writer-endpoint window that bit create-db-user in #653, but on the migration Lambda (which #653's retry didn't cover).

### Description of changes

Two commits on the branch:

1. `ci(e2e): unblock cdk-deploy teardown + stay inside EIP quota`
   - `e2e/src/files/application-stack.ts.template`: pass `natGateways: 1` to the e2e `Vpc`.
   - `e2e/src/files/cdk-deploy/main.ts.template` `IntegrationTestAspect`: flip `CfnDBCluster.deletionProtection` + `skipFinalSnapshot` and `CfnDBInstance.deletionProtection` off. These are the only L1 properties still keeping teardown wedged; the aspect already flips `RemovalPolicy.DESTROY` everywhere and disables Cognito user-pool deletion protection.
2. `fix(ts#rdb): retry migration handler on transient DB connection errors`
   - Extract the retry helper #653 added inline into `create-db-user-handler.ts` into a shared `withConnectionRetry` in `utils.ts`, and expand its classifier to also treat Prisma `P1000` and MySQL `ER_ACCESS_DENIED_ERROR` as transient.
   - Wrap the migration handler's `prisma migrate deploy` invocation in `withConnectionRetry`, rebuilding the `DATABASE_URL` inside each attempt so postgres IAM auth tokens stay fresh.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — green, rdb generator snapshot reflects the refactored retry helper and the retried migration handler for both engines.
- `pnpm nx run-many --target lint --all --fix --projects=@aws/nx-plugin,nx-plugin-e2e` — green.
- Relying on post-merge main CI (cdk-deploy + terraform-deploy) to exercise the full deploy + destroy end-to-end; PR CI doesn't include those.

### Issue # (if applicable)

Follow-up to #653. Unblocks the release that's been stuck behind cdk-deploy and terraform-deploy failures.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*