### PR TITLE
chore(ci): upgrade to pnpm 11 and action-setup v6

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -20,10 +20,8 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: public.ecr.aws
-    - name: Use PNPM 10.x
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10
+    - name: Use PNPM
+      uses: pnpm/action-setup@v6
     - uses: oven-sh/setup-bun@v2
       if: ${{ runner.os != 'Windows' }}
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,7 @@ jobs:
           role-to-assume: ${{ secrets.DEPLOY_INTEG_TESTS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        run: |
-          $PSNativeCommandArgumentPassing = 'Standard'
-          pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
+        run: pnpm nx run @aws/nx-plugin-e2e:test --args="-t 'smoke test - ${{ matrix.smoke_test }} '"
   release:
     name: Release
     needs: [build, smoke_tests, smoke_tests_windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,9 @@ jobs:
           role-to-assume: ${{ secrets.DEPLOY_INTEG_TESTS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        shell: bash
-        run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
+        run: |
+          $PSNativeCommandArgumentPassing = 'Standard'
+          pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
   release:
     name: Release
     needs: [build, smoke_tests, smoke_tests_windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
           role-to-assume: ${{ secrets.DEPLOY_INTEG_TESTS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
+        shell: bash
         run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
   release:
     name: Release

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,10 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Use PNPM 10.x
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Use PNPM
+        uses: pnpm/action-setup@v6
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,6 +108,4 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        run: |
-          $PSNativeCommandArgumentPassing = 'Standard'
-          pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
+        run: pnpm nx run @aws/nx-plugin-e2e:test --args="-t 'smoke test - ${{ matrix.smoke_test }} '"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,5 +108,6 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        shell: bash
-        run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
+        run: |
+          $PSNativeCommandArgumentPassing = 'Standard'
+          pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,4 +108,5 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
+        shell: bash
         run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
+  "packageManager": "pnpm@11.1.1",
   "scripts": {
     "prepare": "husky || true",
     "build:all": "nx run-many --target build"

--- a/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
@@ -154,7 +154,7 @@ RUN smithy-install/smithy/install
 
 # Add node dependencies for bundling
 WORKDIR /project
-RUN npm i -g pnpm@10.15.1 rolldown@1.0.0-beta.38
+RUN npm i -g pnpm@11.1.1 rolldown@1.0.0-beta.38
 
 # Copy project files
 COPY smithy-build.json .
@@ -395,7 +395,7 @@ RUN smithy-install/smithy/install
 
 # Add node dependencies for bundling
 WORKDIR /project
-RUN npm i -g pnpm@10.15.1 rolldown@1.0.0-beta.38
+RUN npm i -g pnpm@11.1.1 rolldown@1.0.0-beta.38
 
 # Copy project files
 COPY smithy-build.json .

--- a/packages/nx-plugin/src/smithy/project/files/build.Dockerfile.template
+++ b/packages/nx-plugin/src/smithy/project/files/build.Dockerfile.template
@@ -16,7 +16,7 @@ RUN smithy-install/smithy/install
 
 # Add node dependencies for bundling
 WORKDIR /project
-RUN npm i -g pnpm@10.15.1 rolldown@1.0.0-beta.38
+RUN npm i -g pnpm@11.1.1 rolldown@1.0.0-beta.38
 
 # Copy project files
 COPY smithy-build.json .


### PR DESCRIPTION
### Reason for this change

The repo has shipped pnpm 11 support for generated projects (#633) and for the `preset` generator, but CI still pins `pnpm/action-setup@v4` with `version: 10` in both `init-monorepo` (used by all CI workflows) and `on-release`. That keeps our build / smoke-test matrix on a pnpm version we no longer develop against, and blocks Dependabot #599 which is trying to bump `pnpm/action-setup` v4 → v6.

Dependabot's attempted bump is safe now that the preset supports pnpm 11. PR #572 previously had to revert a similar bump because `action-setup@v6` with `version: 10` installed a pnpm 10 binary with a pnpm **11** store, which then tripped `ERR_PNPM_IGNORED_BUILDS`. Moving the whole repo to pnpm 11 resolves that mismatch.

`pnpm/action-setup@v6` reads the pnpm version from `package.json`'s `packageManager` field when no `version` input is passed, so this PR also wires that up.

### Description of changes

- Bump `pnpm/action-setup` v4 → v6 in `.github/actions/init-monorepo/action.yml` and `.github/workflows/on-release.yml`.
- Drop the `version: 10` input and add `"packageManager": "pnpm@11.1.1"` to the root `package.json` so the action installs pnpm 11.
- Bump `pnpm@10.15.1` → `pnpm@11.1.1` in `packages/nx-plugin/src/smithy/project/files/build.Dockerfile.template` (used by generated Smithy projects) and refresh the corresponding generator snapshot.

Out of scope (left intact): the `pnpm-10` smoke tests in `ci.yml` / `pr.yml` continue to run via corepack so we still validate that generated projects work under pnpm 10 for downstream users. `packages/nx-plugin/src/utils/pnpm-workspace.ts` keeps writing both `allowBuilds` (pnpm 11) and `onlyBuiltDependencies` (pnpm 10) keys.

### Description of how you validated changes

- `pnpm i` under pnpm 11.1.1 with no lockfile changes required.
- `pnpm nx run-many --target build --all` — 5 projects, 14 dependent tasks, all green.
- `pnpm nx run @aws/nx-plugin:test` — 1790 tests across 86 files, all pass. Smithy Dockerfile snapshot regenerated.
- `pnpm nx run-many --target lint --all` — all green (pre-existing warnings only).

### Issue # (if applicable)

Supersedes Dependabot PR #599 for the `pnpm/action-setup` bump.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*