### PR TITLE
fix(ts#react-website): shadcn component installation with pnpm 11

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -742,23 +742,25 @@ describe('react-website generator uxProvider tests', () => {
       expect(tree.exists('components.json')).toBeTruthy();
     });
 
-    it('should ensure .npmrc ignores workspace root check when using Shadcn', async () => {
+    it('should ensure pnpm-workspace.yaml ignores workspace root check when using Shadcn', async () => {
       await tsReactWebsiteGenerator(tree, options);
 
-      const npmrc = tree.read('.npmrc', 'utf-8') ?? '';
-      const npmrcLines = npmrc.split(/\r?\n/);
-      expect(npmrcLines).toContain('ignore-workspace-root-check=true');
+      const workspaceYaml = tree.read('pnpm-workspace.yaml', 'utf-8') ?? '';
+      expect(workspaceYaml).toMatch(/ignoreWorkspaceRootCheck:\s*true/);
     });
 
-    it('should append ignore-workspace-root-check to existing .npmrc', async () => {
-      tree.write('.npmrc', 'strict-peer-dependencies=false\n');
+    it('should preserve existing pnpm-workspace.yaml entries when enabling ignoreWorkspaceRootCheck', async () => {
+      tree.write(
+        'pnpm-workspace.yaml',
+        "packages:\n  - packages/*\nallowBuilds:\n  '@swc/core': true\n",
+      );
 
       await tsReactWebsiteGenerator(tree, options);
 
-      const npmrc = tree.read('.npmrc', 'utf-8') ?? '';
-      const npmrcLines = npmrc.split(/\r?\n/).filter(Boolean);
-      expect(npmrcLines).toContain('strict-peer-dependencies=false');
-      expect(npmrcLines).toContain('ignore-workspace-root-check=true');
+      const workspaceYaml = tree.read('pnpm-workspace.yaml', 'utf-8') ?? '';
+      expect(workspaceYaml).toMatch(/ignoreWorkspaceRootCheck:\s*true/);
+      expect(workspaceYaml).toMatch(/packages:/);
+      expect(workspaceYaml).toMatch(/@swc\/core/);
     });
 
     it('should use shared Shadcn components when uxProvider is Shadcn', async () => {

--- a/packages/nx-plugin/src/utils/pnpm-workspace.ts
+++ b/packages/nx-plugin/src/utils/pnpm-workspace.ts
@@ -10,6 +10,7 @@ const WORKSPACE_FILE = 'pnpm-workspace.yaml';
 interface PnpmWorkspaceYaml {
   allowBuilds?: Record<string, boolean>;
   onlyBuiltDependencies?: string[];
+  ignoreWorkspaceRootCheck?: boolean;
   [key: string]: unknown;
 }
 
@@ -66,4 +67,34 @@ export const registerPnpmBuiltDependencies = (
   parsed.onlyBuiltDependencies = [...onlyBuiltDependencies];
 
   tree.write(WORKSPACE_FILE, yaml.dump(parsed, { quotingType: "'" }));
+};
+
+/**
+ * Set `ignoreWorkspaceRootCheck: true` in `pnpm-workspace.yaml` so `pnpm add`
+ * from the workspace root does not error with `ERR_PNPM_ADDING_TO_ROOT`.
+ *
+ * pnpm 11 no longer honours `ignore-workspace-root-check=true` in `.npmrc`;
+ * it must live in `pnpm-workspace.yaml` as the camelCased key. pnpm 10 also
+ * accepts the yaml form, so writing it here works for both majors.
+ *
+ * No-op for non-pnpm workspaces or when `pnpm-workspace.yaml` is absent.
+ */
+export const ensurePnpmIgnoresWorkspaceRootCheck = (tree: Tree): boolean => {
+  if (detectPackageManager(tree.root) !== 'pnpm') {
+    return false;
+  }
+  if (!tree.exists(WORKSPACE_FILE)) {
+    return false;
+  }
+
+  const original = tree.read(WORKSPACE_FILE, 'utf-8') ?? '';
+  const parsed = (yaml.load(original) as PnpmWorkspaceYaml | null) ?? {};
+
+  if (parsed.ignoreWorkspaceRootCheck === true) {
+    return false;
+  }
+
+  parsed.ignoreWorkspaceRootCheck = true;
+  tree.write(WORKSPACE_FILE, yaml.dump(parsed, { quotingType: "'" }));
+  return true;
 };

--- a/packages/nx-plugin/src/utils/shared-shadcn.ts
+++ b/packages/nx-plugin/src/utils/shared-shadcn.ts
@@ -21,6 +21,7 @@ import {
   SHARED_SHADCN_NAME,
 } from './shared-constructs-constants';
 import { ITsDepVersion, withVersions } from './versions';
+import { ensurePnpmIgnoresWorkspaceRootCheck } from './pnpm-workspace';
 
 const SHADCN_DEPS = [
   'class-variance-authority',
@@ -30,33 +31,6 @@ const SHADCN_DEPS = [
   'tw-animate-css',
   'radix-ui',
 ] as const satisfies ITsDepVersion[];
-
-const NPMRC_IGNORE_WORKSPACE_ROOT_CHECK = 'ignore-workspace-root-check=true';
-
-const ensureNpmrcIgnoresWorkspaceRoot = (tree: Tree): boolean => {
-  const npmrcPath = '.npmrc';
-  if (tree.exists(npmrcPath)) {
-    const npmrcContent = tree.read(npmrcPath, 'utf-8');
-    const alreadyConfigured = npmrcContent
-      .split(/\r?\n/)
-      .some((line) => line.trim() === NPMRC_IGNORE_WORKSPACE_ROOT_CHECK);
-
-    if (alreadyConfigured) {
-      return false;
-    }
-
-    const needsTrailingNewline =
-      npmrcContent.length > 0 && !npmrcContent.endsWith('\n');
-    tree.write(
-      npmrcPath,
-      `${npmrcContent}${needsTrailingNewline ? '\n' : ''}${NPMRC_IGNORE_WORKSPACE_ROOT_CHECK}\n`,
-    );
-    return true;
-  }
-
-  tree.write(npmrcPath, `${NPMRC_IGNORE_WORKSPACE_ROOT_CHECK}\n`);
-  return true;
-};
 
 const addSharedShadcnEslintRules = async (
   tree: Tree,
@@ -85,7 +59,7 @@ export async function sharedShadcnGenerator(tree: Tree) {
   const shadcnSrcRoot = joinPathFragments(libraryRoot, 'src');
   const eslintConfigPath = joinPathFragments(libraryRoot, 'eslint.config.mjs');
 
-  ensureNpmrcIgnoresWorkspaceRoot(tree);
+  ensurePnpmIgnoresWorkspaceRootCheck(tree);
 
   if (!tree.exists(joinPathFragments(libraryRoot, 'project.json'))) {
     await tsProjectGenerator(tree, {


### PR DESCRIPTION
### Reason for this change

When generating a Shadcn-based React website, the generator wrote `ignore-workspace-root-check=true` to `.npmrc` so that running `pnpm add <pkg>` from the workspace root would not fail with `ERR_PNPM_ADDING_TO_ROOT`.

pnpm 11 dropped support for that key in `.npmrc` — the same setting now lives in `pnpm-workspace.yaml` as `ignoreWorkspaceRootCheck: true`. As a result, on pnpm 11 the existing `.npmrc` write was a no-op, and any user running `pnpm add <pkg>` from the workspace root (e.g. when following the dungeon adventure tutorial's `<InstallCommand>` snippet without `-w`) hit `ERR_PNPM_ADDING_TO_ROOT`.

### Description of changes

- Added `ensurePnpmIgnoresWorkspaceRootCheck(tree)` to `packages/nx-plugin/src/utils/pnpm-workspace.ts`. It writes `ignoreWorkspaceRootCheck: true` into `pnpm-workspace.yaml` idempotently. pnpm 10 and pnpm 11 both honour this form, so no separate compatibility handling is required.
- Updated `packages/nx-plugin/src/utils/shared-shadcn.ts` to call the new helper instead of writing `.npmrc`. Removed the unused `NPMRC_IGNORE_WORKSPACE_ROOT_CHECK` constant and the local `ensureNpmrcIgnoresWorkspaceRoot` function.
- Updated the two `should ensure ... ignores workspace root check ...` cases in `packages/nx-plugin/src/ts/react-website/app/generator.spec.ts` to assert on `pnpm-workspace.yaml` instead of `.npmrc`, including a case that confirms existing entries (`packages`, `allowBuilds`, …) are preserved.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test` — all 1,790 tests pass, including the two updated `react-website generator › Shadcn` cases.
- End-to-end on the generated workspace:
  - With pnpm **11.1.1**, `pnpm add electrodb` from the workspace root previously errored with `ERR_PNPM_ADDING_TO_ROOT`; with this change it succeeds and writes the dep to the root `package.json` (single-version policy preserved).
  - With pnpm **10.33.4**, the same command also succeeds, confirming the yaml form works for both majors.
  - Generated `pnpm-workspace.yaml` contains `ignoreWorkspaceRootCheck: true`; no `.npmrc` is created.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*