### PR TITLE
ci: extend smoke test IAM session duration to 3 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEPLOY_INTEG_TESTS_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 10800
       - name: Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
   smoke_tests_windows:
@@ -124,6 +125,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEPLOY_INTEG_TESTS_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 10800
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:test --args="-t 'smoke test - ${{ matrix.smoke_test }} '"
   release:


### PR DESCRIPTION
### Reason for this change

The latest CI run on `main` ([run #25847370222](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/25847370222)) failed in the `cdk-deploy` smoke test job with:

```
❌  e2e-test-infra-sandbox-qhgxc551-Application failed: ExpiredToken: The security token included in the request is expired
AssumeRoleExpiredToken: Assuming role failed: ExpiredToken
```

The job started assuming the role at `07:41:21Z` and the token expired around `08:57:05Z` — ~1h16m into the run. `aws-actions/configure-aws-credentials@v6` defaults to a 1-hour session, which is shorter than several of the long-running deploy smoke tests (full CI typically takes ~1h40m, and individual deploy smoke tests can run >1h on their own).

### Description of changes

- Set `role-duration-seconds: 10800` (3 hours) on the AWS credentials step for both the Linux (`smoke_tests`) and Windows (`smoke_tests_windows`) smoke test jobs in `.github/workflows/ci.yml`.

3 hours gives comfortable headroom over the longest current smoke test runs while remaining well below the 12-hour STS maximum.

> [!IMPORTANT]
> The `DEPLOY_INTEG_TESTS_ROLE_ARN` IAM role's `MaxSessionDuration` must also be updated to at least 10800 seconds (out-of-band, in the AWS account that owns the role). If the role's `MaxSessionDuration` remains at the default 3600, the credentials step will fail when the action attempts to request a longer session.

### Description of how you validated changes

This is a workflow-only change. Validation will come from observing the next CI run on `main` (or a `workflow_dispatch` trigger) once the IAM role's `MaxSessionDuration` is also raised.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*