### PR TITLE
ci(e2e): split deploy smoke tests into rdb / non-rdb variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
           - smithy-api
           - react-website
           - cdk-deploy
+          - cdk-deploy-rdb
           - terraform-deploy
+          - terraform-deploy-rdb
           - license-sync
           - mcp-server
     steps:

--- a/e2e/src/files/application-stack-rdb.ts.template
+++ b/e2e/src/files/application-stack-rdb.ts.template
@@ -1,0 +1,17 @@
+import * as cdk from 'aws-cdk-lib';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Construct } from 'constructs';
+import { PostgresDb, MySqlDb } from ':e2e-test/common-constructs';
+
+export class ApplicationStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Single NAT gateway keeps the test run under the default per-region
+    // EIP quota when both deploy variants run in parallel.
+    const vpc = new Vpc(this, 'Vpc', { natGateways: 1 });
+
+    new PostgresDb(this, 'PostgresDb', { vpc });
+    new MySqlDb(this, 'MySqlDb', { vpc });
+  }
+}

--- a/e2e/src/files/application-stack.ts.template
+++ b/e2e/src/files/application-stack.ts.template
@@ -1,5 +1,4 @@
 import * as cdk from 'aws-cdk-lib';
-import { Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import {
   UserIdentity,
@@ -17,25 +16,11 @@ import {
   MyTsA2aAgent,
   HostedMcpServer,
   MySmithyApi,
-  PostgresDb,
-  MySqlDb,
 } from ':e2e-test/common-constructs';
 
 export class ApplicationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-
-    // Single NAT gateway keeps the test run under the default per-region
-    // EIP quota when both cdk-deploy and terraform-deploy run in parallel.
-    const vpc = new Vpc(this, 'Vpc', { natGateways: 1 });
-
-    new PostgresDb(this, 'PostgresDb', {
-      vpc,
-    });
-
-    new MySqlDb(this, 'MySqlDb', {
-      vpc,
-    });
 
     const identity = new UserIdentity(this, 'UserIdentity');
     const myapi = new MyApi(this, 'MyApi', {

--- a/e2e/src/files/terraform-deploy/main-rdb.tf.template
+++ b/e2e/src/files/terraform-deploy/main-rdb.tf.template
@@ -1,0 +1,124 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# RDB-only wiring for the terraform-deploy-rdb smoke test. Provisions a
+# minimal VPC plus the two Aurora databases (PostgreSQL + MySQL) generated
+# by the rdb generator. Splitting these resources into their own variant
+# keeps the main terraform-deploy variant under the IAM session limit.
+
+# Shared asset bucket — stages the migration + create-db-user Lambda zips.
+module "asset_bucket" {
+  source = "../../common/terraform/src/core/asset-bucket"
+
+  bucket_name_prefix = "e2e-rdb-assets-<% TEST_RUN_ID %>"
+}
+
+# ---------------------------------------------------------------------------
+# VPC (shared by both relational database modules)
+# ---------------------------------------------------------------------------
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "rdb" {
+  #checkov:skip=CKV2_AWS_11:Flow logs are not required for ephemeral e2e test infrastructure
+  #checkov:skip=CKV2_AWS_12:Default security group restrictions are not required for ephemeral e2e test infrastructure
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = { Name = "e2e-rdb-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_subnet" "rdb_a" {
+  vpc_id            = aws_vpc.rdb.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  tags = { Name = "e2e-rdb-a-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_subnet" "rdb_b" {
+  vpc_id            = aws_vpc.rdb.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+  tags = { Name = "e2e-rdb-b-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_internet_gateway" "rdb" {
+  vpc_id = aws_vpc.rdb.id
+  tags   = { Name = "e2e-rdb-igw-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_subnet" "rdb_public_a" {
+  vpc_id            = aws_vpc.rdb.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  tags = { Name = "e2e-rdb-public-a-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_eip" "rdb_nat" {
+  domain = "vpc"
+  tags   = { Name = "e2e-rdb-nat-eip-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_nat_gateway" "rdb" {
+  allocation_id = aws_eip.rdb_nat.id
+  subnet_id     = aws_subnet.rdb_public_a.id
+  tags          = { Name = "e2e-rdb-nat-<% TEST_RUN_ID %>" }
+  depends_on    = [aws_internet_gateway.rdb]
+}
+
+resource "aws_route_table" "rdb_private" {
+  vpc_id = aws_vpc.rdb.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.rdb.id
+  }
+  tags = { Name = "e2e-rdb-private-rt-<% TEST_RUN_ID %>" }
+}
+
+resource "aws_route_table_association" "rdb_a" {
+  subnet_id      = aws_subnet.rdb_a.id
+  route_table_id = aws_route_table.rdb_private.id
+}
+
+resource "aws_route_table_association" "rdb_b" {
+  subnet_id      = aws_subnet.rdb_b.id
+  route_table_id = aws_route_table.rdb_private.id
+}
+
+# ---------------------------------------------------------------------------
+# Relational databases (Aurora + Prisma) — PostgreSQL and MySQL
+# ---------------------------------------------------------------------------
+
+module "postgres_db" {
+  source = "../../common/terraform/src/app/dbs/postgres-db"
+
+  vpc_id              = aws_vpc.rdb.id
+  database_subnet_ids = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
+  lambda_subnet_ids   = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
+  asset_bucket_name   = module.asset_bucket.bucket_name
+
+  deletion_protection        = false
+  skip_final_snapshot        = true
+  enable_rds_proxy           = false
+  enable_credential_rotation = false
+  enable_backup              = false
+}
+
+module "my_sql_db" {
+  source = "../../common/terraform/src/app/dbs/my-sql-db"
+
+  vpc_id              = aws_vpc.rdb.id
+  database_subnet_ids = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
+  lambda_subnet_ids   = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
+  asset_bucket_name   = module.asset_bucket.bucket_name
+
+  deletion_protection        = false
+  skip_final_snapshot        = true
+  enable_rds_proxy           = false
+  enable_credential_rotation = false
+  enable_backup              = false
+}

--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -298,114 +298,6 @@ resource "aws_iam_role_policy_attachment" "authenticated_agent_access" {
   policy_arn = aws_iam_policy.agent_invoke_policy.arn
 }
 
-# ---------------------------------------------------------------------------
-# VPC (shared by both relational database modules)
-# ---------------------------------------------------------------------------
-
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-resource "aws_vpc" "rdb" {
-  #checkov:skip=CKV2_AWS_11:Flow logs are not required for ephemeral e2e test infrastructure
-  #checkov:skip=CKV2_AWS_12:Default security group restrictions are not required for ephemeral e2e test infrastructure
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = { Name = "e2e-rdb-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_subnet" "rdb_a" {
-  vpc_id            = aws_vpc.rdb.id
-  cidr_block        = "10.0.0.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
-  tags = { Name = "e2e-rdb-a-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_subnet" "rdb_b" {
-  vpc_id            = aws_vpc.rdb.id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = data.aws_availability_zones.available.names[1]
-  tags = { Name = "e2e-rdb-b-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_internet_gateway" "rdb" {
-  vpc_id = aws_vpc.rdb.id
-  tags   = { Name = "e2e-rdb-igw-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_subnet" "rdb_public_a" {
-  vpc_id            = aws_vpc.rdb.id
-  cidr_block        = "10.0.2.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
-  tags = { Name = "e2e-rdb-public-a-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_eip" "rdb_nat" {
-  domain = "vpc"
-  tags   = { Name = "e2e-rdb-nat-eip-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_nat_gateway" "rdb" {
-  allocation_id = aws_eip.rdb_nat.id
-  subnet_id     = aws_subnet.rdb_public_a.id
-  tags          = { Name = "e2e-rdb-nat-<% TEST_RUN_ID %>" }
-  depends_on    = [aws_internet_gateway.rdb]
-}
-
-resource "aws_route_table" "rdb_private" {
-  vpc_id = aws_vpc.rdb.id
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.rdb.id
-  }
-  tags = { Name = "e2e-rdb-private-rt-<% TEST_RUN_ID %>" }
-}
-
-resource "aws_route_table_association" "rdb_a" {
-  subnet_id      = aws_subnet.rdb_a.id
-  route_table_id = aws_route_table.rdb_private.id
-}
-
-resource "aws_route_table_association" "rdb_b" {
-  subnet_id      = aws_subnet.rdb_b.id
-  route_table_id = aws_route_table.rdb_private.id
-}
-
-# ---------------------------------------------------------------------------
-# Relational databases (Aurora + Prisma) — PostgreSQL and MySQL
-# ---------------------------------------------------------------------------
-
-module "postgres_db" {
-  source = "../../common/terraform/src/app/dbs/postgres-db"
-
-  vpc_id             = aws_vpc.rdb.id
-  database_subnet_ids = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
-  lambda_subnet_ids   = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
-  asset_bucket_name  = module.asset_bucket.bucket_name
-
-  deletion_protection        = false
-  skip_final_snapshot        = true
-  enable_rds_proxy           = false
-  enable_credential_rotation = false
-  enable_backup              = false
-}
-
-module "my_sql_db" {
-  source = "../../common/terraform/src/app/dbs/my-sql-db"
-
-  vpc_id             = aws_vpc.rdb.id
-  database_subnet_ids = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
-  lambda_subnet_ids   = [aws_subnet.rdb_a.id, aws_subnet.rdb_b.id]
-  asset_bucket_name  = module.asset_bucket.bucket_name
-
-  deletion_protection        = false
-  skip_final_snapshot        = true
-  enable_rds_proxy           = false
-  enable_credential_rotation = false
-  enable_backup              = false
-}
-
 # Shared runtime-config AppConfig deployment — aggregates every contributed
 # entry and creates the hosted configuration version + deployment per
 # namespace against the shared application.
@@ -435,8 +327,6 @@ module "runtime_config_appconfig_deployment" {
     module.py_agui_agent,
     module.py_agent,
     module.ts_agent,
-    module.postgres_db,
-    module.my_sql_db,
   ]
 }
 

--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -63,7 +63,15 @@ async function deleteLeftoverStacks(cdkStageName: string): Promise<void> {
 }
 
 /**
- * A test which deploys the smoke test resources to aws
+ * cdk-deploy smoke test — deploys the non-RDB application stack (APIs,
+ * agents, MCP servers, Lambda functions, website), exercises every
+ * invocation surface, and tears down.
+ *
+ * The relational database constructs (`PostgresDb`, `MySqlDb`) are
+ * exercised by the separate `cdk-deploy-rdb` variant — Aurora cluster
+ * create + destroy plus VPC ENI cleanup for the rotation Lambdas
+ * dominate the runtime, so isolating them keeps both variants under the
+ * IAM session limit.
  */
 describe('smoke test - cdk-deploy', () => {
   const pkgMgr = 'npm';
@@ -95,8 +103,6 @@ describe('smoke test - cdk-deploy', () => {
     writeFileSync(`${opts.cwd}/packages/infra/src/main.ts`, mainContent);
 
     const cdkStageName = `e2e-test-infra-sandbox-${testRunId}`;
-
-    ensureRdsServiceLinkedRole();
 
     try {
       // Deploy the e2e test resources
@@ -207,6 +213,74 @@ describe('smoke test - cdk-deploy', () => {
       }
       // cdk destroy skips cross-region stacks (e.g. WAF in us-east-1) when
       // the main stack is in ROLLBACK_COMPLETE. Clean up any leftovers.
+      await deleteLeftoverStacks(cdkStageName);
+    }
+  });
+});
+
+/**
+ * cdk-deploy-rdb smoke test — deploys only the relational database stack
+ * (PostgreSQL + MySQL Aurora clusters with a dedicated VPC). The full
+ * generator matrix is still scaffolded and built so the rdb generator's
+ * coexistence with the rest of the matrix is verified, but only the
+ * database constructs are deployed to AWS.
+ */
+describe('smoke test - cdk-deploy-rdb', () => {
+  const pkgMgr = 'npm';
+  const targetDir = `${tmpProjPath()}/cdk-deploy-rdb-${pkgMgr}`;
+
+  beforeEach(() => {
+    console.log(`Cleaning target directory ${targetDir}`);
+    if (existsSync(targetDir)) {
+      rmSync(targetDir, { force: true, recursive: true });
+    }
+    ensureDirSync(targetDir);
+  });
+
+  it('should generate and build', async () => {
+    const { opts } = await runSmokeTest(targetDir, pkgMgr);
+
+    const testRunId = Math.random().toString(36).substring(2, 10);
+
+    // Swap in the rdb-only application stack — same workspace, smaller
+    // deploy surface. Deletion-aspects in main.ts.template still apply.
+    const rdbStackContent = readFileSync(
+      join(__dirname, '../files/application-stack-rdb.ts.template'),
+      'utf-8',
+    );
+    writeFileSync(
+      `${opts.cwd}/packages/infra/src/stacks/application-stack.ts`,
+      rdbStackContent,
+    );
+
+    const templateContent = readFileSync(
+      join(__dirname, '../files/cdk-deploy/main.ts.template'),
+      'utf-8',
+    );
+    const mainContent = templateContent.replace(
+      /<% TEST_RUN_ID %>/g,
+      testRunId,
+    );
+    writeFileSync(`${opts.cwd}/packages/infra/src/main.ts`, mainContent);
+
+    const cdkStageName = `e2e-test-rdb-sandbox-${testRunId}`;
+
+    ensureRdsServiceLinkedRole();
+
+    try {
+      await runCLI(
+        `deploy infra ${cdkStageName}/* --output-style=stream`,
+        opts,
+      );
+    } finally {
+      try {
+        await runCLI(
+          `destroy infra ${cdkStageName}/* --output-style=stream --force`,
+          opts,
+        );
+      } catch (e) {
+        console.warn(`cdk destroy failed (will still clean up): ${e}`);
+      }
       await deleteLeftoverStacks(cdkStageName);
     }
   });

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -37,150 +37,194 @@ function readTerraformOutputs(projectRoot: string): Record<string, string> {
   );
 }
 
-describe('smoke test - terraform-deploy', () => {
+interface TerraformDeployVariant {
+  /** Suffix appended to the smoke-test name and target directory. */
+  variant: 'terraform-deploy' | 'terraform-deploy-rdb';
+  /** Path (relative to e2e/src/files) of the main.tf template to use. */
+  mainTfTemplate: string;
+  /** Whether the variant requires the RDS service-linked role. */
+  requiresRdsServiceLinkedRole: boolean;
+}
+
+const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
   const pkgMgr = 'pnpm';
-  const targetDir = `${tmpProjPath()}/terraform-deploy-${pkgMgr}`;
+  const targetDir = `${tmpProjPath()}/${config.variant}-${pkgMgr}`;
 
-  beforeEach(() => {
-    console.log(`Cleaning target directory ${targetDir}`);
-    if (existsSync(targetDir)) {
-      rmSync(targetDir, { force: true, recursive: true });
-    }
-    ensureDirSync(targetDir);
-  });
-
-  it('should generate, deploy, exercise and destroy', async () => {
-    const { opts } = await runTerraformSmokeTest(targetDir, pkgMgr);
-
-    // Per-run suffix used in the Terraform state key so concurrent runs
-    // don't share state.
-    const testRunId = Math.random().toString(36).substring(2, 10);
-
-    // Overwrite the scaffolded main.tf with the wiring template (Terraform
-    // analogue of the `application-stack.ts.template` cdk-deploy uses).
-    const mainTfTemplate = readFileSync(
-      join(__dirname, '../files/terraform-deploy/main.tf.template'),
-      'utf-8',
-    );
-    writeFileSync(
-      `${opts.cwd}/packages/infra/src/main.tf`,
-      mainTfTemplate.replace(/<% TEST_RUN_ID %>/g, testRunId),
-    );
-
-    // Per-run Terraform state key — the generated `init.ts` uses the
-    // `TF_ENV` env var as the state-key leaf, so giving each run a
-    // distinct TF_ENV value isolates its state from concurrent runs.
-    const infraProjectJsonPath = `${opts.cwd}/packages/infra/project.json`;
-    const infraProjectJson = JSON.parse(
-      readFileSync(infraProjectJsonPath, 'utf-8'),
-    );
-    infraProjectJson.targets.init.configurations.dev.env = {
-      ...(infraProjectJson.targets.init.configurations.dev.env ?? {}),
-      TF_ENV: `dev-${testRunId}`,
-    };
-    writeFileSync(
-      infraProjectJsonPath,
-      JSON.stringify(infraProjectJson, null, 2),
-    );
-
-    // Auto-apply sync so the main.tf + project.json rewrites don't block
-    // `apply` with a fatal "workspace is out of sync" error.
-    const nxJsonPath = `${opts.cwd}/nx.json`;
-    const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
-    nxJson.sync = { ...(nxJson.sync ?? {}), applyChanges: true };
-    writeFileSync(nxJsonPath, JSON.stringify(nxJson, null, 2));
-
-    // Cognito deletion_protection = INACTIVE so `terraform destroy` can
-    // remove the user pool in one pass.
-    const identityTfPath = `${opts.cwd}/packages/common/terraform/src/core/user-identity/identity/identity.tf`;
-    writeFileSync(
-      identityTfPath,
-      readFileSync(identityTfPath, 'utf-8').replace(
-        /deletion_protection\s*=\s*"ACTIVE"/,
-        'deletion_protection = "INACTIVE"',
-      ),
-    );
-
-    ensureRdsServiceLinkedRole();
-
-    try {
-      await runCLI(`sync`, opts);
-      await runCLI(`bootstrap infra --output-style=stream`, opts);
-      await runCLI(`apply infra --output-style=stream`, opts);
-
-      const outputs = readTerraformOutputs(opts.cwd);
-      console.log('Terraform outputs:', outputs);
-
-      // tRPC
-      await invokeTrpcApi(outputs.my_api_endpoint, 'tRPC REST API');
-      await invokeTrpcApi(outputs.my_api_http_endpoint, 'tRPC HTTP API');
-
-      // FastAPI
-      await invokeRestApi(outputs.py_api_endpoint, 'FastAPI REST');
-      await invokeRestApi(outputs.py_api_http_endpoint, 'FastAPI HTTP');
-
-      // Smithy
-      await invokeRestApi(outputs.my_smithy_api_endpoint, 'Smithy REST');
-
-      // MCP
-      await invokeAgentCoreMcp(
-        outputs.ts_mcp_server_arn,
-        'TypeScript MCP Server',
-      );
-      await invokeAgentCoreMcp(outputs.py_mcp_server_arn, 'Python MCP Server');
-
-      // Strands agents — direct invocation. The TypeScript strands agent
-      // serves tRPC on AgentCore, so invoke it via the tRPC helper.
-      await invokeAgentCoreAgent(outputs.strands_agent_arn, 'Strands Agent');
-      await invokeTrpcAgentCoreAgent(
-        outputs.ts_strands_agent_arn,
-        'TypeScript Strands Agent',
-      );
-
-      // A2A (direct)
-      await invokeAgentCoreA2a(
-        outputs.ts_a2a_agent_arn,
-        'TypeScript A2A Agent',
-      );
-      await invokeAgentCoreA2a(outputs.py_a2a_agent_arn, 'Python A2A Agent');
-
-      // A2A via delegate tool (host agent -> A2A target)
-      await invokeTrpcAgentCoreAgent(
-        outputs.ts_strands_agent_arn,
-        'TS Agent -> TS A2A (via askMyTsA2aAgent)',
-        'Use the askMyTsA2aAgent tool to ask the remote agent what 5 * 4 is. Return just the answer.',
-      );
-      await invokeTrpcAgentCoreAgent(
-        outputs.ts_strands_agent_arn,
-        'TS Agent -> PY A2A (via askMyPyA2aAgent)',
-        'Use the askMyPyA2aAgent tool to ask the remote agent what 11 + 2 is. Return just the answer.',
-      );
-      await invokeAgentCoreAgent(
-        outputs.strands_agent_arn,
-        'PY Agent -> TS A2A (via ask_my_ts_a2a_agent)',
-        'Use the ask_my_ts_a2a_agent tool to ask the remote agent what 9 - 3 is. Return just the answer.',
-      );
-      await invokeAgentCoreAgent(
-        outputs.strands_agent_arn,
-        'PY Agent -> PY A2A (via ask_my_py_a2a_agent)',
-        'Use the ask_my_py_a2a_agent tool to ask the remote agent what 7 + 8 is. Return just the answer.',
-      );
-
-      // Lambda functions
-      await invokeLambda(outputs.py_function_arn, 'Python Function');
-      await invokeLambda(outputs.ts_function_arn, 'TypeScript Function');
-
-      // Website
-      await pingWebsite(outputs.website_distribution_domain_name);
-    } finally {
-      try {
-        await runCLI(
-          `destroy infra --output-style=stream -- -auto-approve`,
-          opts,
-        );
-      } catch (e) {
-        console.warn(`terraform destroy failed (will still clean up): ${e}`);
+  describe(`smoke test - ${config.variant}`, () => {
+    beforeEach(() => {
+      console.log(`Cleaning target directory ${targetDir}`);
+      if (existsSync(targetDir)) {
+        rmSync(targetDir, { force: true, recursive: true });
       }
-    }
+      ensureDirSync(targetDir);
+    });
+
+    it('should generate, deploy, exercise and destroy', async () => {
+      const { opts } = await runTerraformSmokeTest(targetDir, pkgMgr);
+
+      // Per-run suffix used in the Terraform state key so concurrent runs
+      // don't share state.
+      const testRunId = Math.random().toString(36).substring(2, 10);
+
+      // Overwrite the scaffolded main.tf with the wiring template (Terraform
+      // analogue of the `application-stack.ts.template` cdk-deploy uses).
+      const mainTfTemplate = readFileSync(
+        join(__dirname, '../files', config.mainTfTemplate),
+        'utf-8',
+      );
+      writeFileSync(
+        `${opts.cwd}/packages/infra/src/main.tf`,
+        mainTfTemplate.replace(/<% TEST_RUN_ID %>/g, testRunId),
+      );
+
+      // Per-run Terraform state key — the generated `init.ts` uses the
+      // `TF_ENV` env var as the state-key leaf, so giving each run a
+      // distinct TF_ENV value isolates its state from concurrent runs.
+      const infraProjectJsonPath = `${opts.cwd}/packages/infra/project.json`;
+      const infraProjectJson = JSON.parse(
+        readFileSync(infraProjectJsonPath, 'utf-8'),
+      );
+      infraProjectJson.targets.init.configurations.dev.env = {
+        ...(infraProjectJson.targets.init.configurations.dev.env ?? {}),
+        TF_ENV: `${config.variant}-${testRunId}`,
+      };
+      writeFileSync(
+        infraProjectJsonPath,
+        JSON.stringify(infraProjectJson, null, 2),
+      );
+
+      // Auto-apply sync so the main.tf + project.json rewrites don't block
+      // `apply` with a fatal "workspace is out of sync" error.
+      const nxJsonPath = `${opts.cwd}/nx.json`;
+      const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
+      nxJson.sync = { ...(nxJson.sync ?? {}), applyChanges: true };
+      writeFileSync(nxJsonPath, JSON.stringify(nxJson, null, 2));
+
+      // Cognito deletion_protection = INACTIVE so `terraform destroy` can
+      // remove the user pool in one pass.
+      const identityTfPath = `${opts.cwd}/packages/common/terraform/src/core/user-identity/identity/identity.tf`;
+      if (existsSync(identityTfPath)) {
+        writeFileSync(
+          identityTfPath,
+          readFileSync(identityTfPath, 'utf-8').replace(
+            /deletion_protection\s*=\s*"ACTIVE"/,
+            'deletion_protection = "INACTIVE"',
+          ),
+        );
+      }
+
+      if (config.requiresRdsServiceLinkedRole) {
+        ensureRdsServiceLinkedRole();
+      }
+
+      try {
+        await runCLI(`sync`, opts);
+        await runCLI(`bootstrap infra --output-style=stream`, opts);
+        await runCLI(`apply infra --output-style=stream`, opts);
+
+        if (config.variant === 'terraform-deploy') {
+          const outputs = readTerraformOutputs(opts.cwd);
+          console.log('Terraform outputs:', outputs);
+
+          // tRPC
+          await invokeTrpcApi(outputs.my_api_endpoint, 'tRPC REST API');
+          await invokeTrpcApi(outputs.my_api_http_endpoint, 'tRPC HTTP API');
+
+          // FastAPI
+          await invokeRestApi(outputs.py_api_endpoint, 'FastAPI REST');
+          await invokeRestApi(outputs.py_api_http_endpoint, 'FastAPI HTTP');
+
+          // Smithy
+          await invokeRestApi(outputs.my_smithy_api_endpoint, 'Smithy REST');
+
+          // MCP
+          await invokeAgentCoreMcp(
+            outputs.ts_mcp_server_arn,
+            'TypeScript MCP Server',
+          );
+          await invokeAgentCoreMcp(
+            outputs.py_mcp_server_arn,
+            'Python MCP Server',
+          );
+
+          // Strands agents — direct invocation. The TypeScript strands agent
+          // serves tRPC on AgentCore, so invoke it via the tRPC helper.
+          await invokeAgentCoreAgent(
+            outputs.strands_agent_arn,
+            'Strands Agent',
+          );
+          await invokeTrpcAgentCoreAgent(
+            outputs.ts_strands_agent_arn,
+            'TypeScript Strands Agent',
+          );
+
+          // A2A (direct)
+          await invokeAgentCoreA2a(
+            outputs.ts_a2a_agent_arn,
+            'TypeScript A2A Agent',
+          );
+          await invokeAgentCoreA2a(
+            outputs.py_a2a_agent_arn,
+            'Python A2A Agent',
+          );
+
+          // A2A via delegate tool (host agent -> A2A target)
+          await invokeTrpcAgentCoreAgent(
+            outputs.ts_strands_agent_arn,
+            'TS Agent -> TS A2A (via askMyTsA2aAgent)',
+            'Use the askMyTsA2aAgent tool to ask the remote agent what 5 * 4 is. Return just the answer.',
+          );
+          await invokeTrpcAgentCoreAgent(
+            outputs.ts_strands_agent_arn,
+            'TS Agent -> PY A2A (via askMyPyA2aAgent)',
+            'Use the askMyPyA2aAgent tool to ask the remote agent what 11 + 2 is. Return just the answer.',
+          );
+          await invokeAgentCoreAgent(
+            outputs.strands_agent_arn,
+            'PY Agent -> TS A2A (via ask_my_ts_a2a_agent)',
+            'Use the ask_my_ts_a2a_agent tool to ask the remote agent what 9 - 3 is. Return just the answer.',
+          );
+          await invokeAgentCoreAgent(
+            outputs.strands_agent_arn,
+            'PY Agent -> PY A2A (via ask_my_py_a2a_agent)',
+            'Use the ask_my_py_a2a_agent tool to ask the remote agent what 7 + 8 is. Return just the answer.',
+          );
+
+          // Lambda functions
+          await invokeLambda(outputs.py_function_arn, 'Python Function');
+          await invokeLambda(outputs.ts_function_arn, 'TypeScript Function');
+
+          // Website
+          await pingWebsite(outputs.website_distribution_domain_name);
+        }
+      } finally {
+        try {
+          await runCLI(
+            `destroy infra --output-style=stream -- -auto-approve`,
+            opts,
+          );
+        } catch (e) {
+          console.warn(`terraform destroy failed (will still clean up): ${e}`);
+        }
+      }
+    });
   });
+};
+
+// terraform-deploy — application surface (APIs, agents, MCP, lambdas, website).
+runTerraformDeployVariant({
+  variant: 'terraform-deploy',
+  mainTfTemplate: 'terraform-deploy/main.tf.template',
+  requiresRdsServiceLinkedRole: false,
+});
+
+// terraform-deploy-rdb — relational databases only (PostgreSQL + MySQL
+// Aurora clusters with a dedicated VPC). Splitting these out keeps the
+// main terraform-deploy variant under the IAM session limit, since
+// Aurora cluster create + destroy plus VPC ENI cleanup for the
+// migration/credential Lambdas dominates the runtime.
+runTerraformDeployVariant({
+  variant: 'terraform-deploy-rdb',
+  mainTfTemplate: 'terraform-deploy/main-rdb.tf.template',
+  requiresRdsServiceLinkedRole: true,
 });


### PR DESCRIPTION
### Reason for this change

The Aurora RDS clusters dominate the runtime of the `cdk-deploy` and `terraform-deploy` smoke tests on both create and destroy. From the latest successful CI run ([#25797626070](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/25797626070)):

| Phase | cdk-deploy | terraform-deploy |
| --- | --- | --- |
| Workspace + matrix + build | ~12 min | ~10 min |
| Bootstrap + apply / deploy | ~21 min | ~21 min |
| Exercise | ~1 min | ~2 min |
| **Destroy** | **~41 min** | **~24 min** |
| **Total** | **~78 min** | **~57 min** |

The slowest individual resources, in both providers, are RDS-related:

- Aurora MySQL writer DBInstance: **460s** create / **610s** destroy
- Aurora PostgreSQL writer DBInstance: **336s** create / **427s** destroy
- Secrets-Manager rotation Lambdas (VPC ENI detach): **~1170s** destroy each
- Migration / create-db-user Lambdas (VPC ENI detach): **~1140s** destroy each
- Terraform `aws_security_group` for the migration handlers: **~1400s** destroy waiting on ENI dependencies

Splitting these into a dedicated matrix variant lets the two halves run in parallel and keeps each well under the IAM session limit (which #666 just bumped to 3 hours).

### Description of changes

- Added `cdk-deploy-rdb` and `terraform-deploy-rdb` matrix entries in `.github/workflows/ci.yml`. Each new variant scaffolds the **full generator matrix** (so coexistence is still verified), but deploys only the relational database constructs (PostgreSQL + MySQL Aurora clusters) plus a minimal dedicated VPC.
- Removed the rdb constructs (and the VPC + NAT gateway that only existed for them) from the existing `cdk-deploy` and `terraform-deploy` templates.
- Refactored `terraform-deploy.spec.ts` so both variants share the wiring helper, parameterized by template path + whether the RDS service-linked role is required + whether the Application surface should be exercised.
- Added `application-stack-rdb.ts.template` (CDK) and `terraform-deploy/main-rdb.tf.template` (TF) holding only the RDB wiring.

Expected duration after split: ~30-40 min for the application variant, ~50 min for the rdb variant — both running in parallel, replacing a single ~80 min critical-path job with a ~50 min one.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin-e2e:lint` — clean.
- `pnpm nx run @aws/nx-plugin-e2e:build` — clean.
- I'll also run both new variants end-to-end against my own AWS account (`AWS_REGION=us-west-2`) while the PR workflows execute, and post results in a follow-up comment.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*