### PR TITLE
ci(e2e): use correct stage name prefix in cdk-deploy-rdb spec

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -263,7 +263,8 @@ describe('smoke test - cdk-deploy-rdb', () => {
     );
     writeFileSync(`${opts.cwd}/packages/infra/src/main.ts`, mainContent);
 
-    const cdkStageName = `e2e-test-rdb-sandbox-${testRunId}`;
+    // Stage name is set by main.ts.template (`e2e-test-infra-sandbox-…`).
+    const cdkStageName = `e2e-test-infra-sandbox-${testRunId}`;
 
     ensureRdsServiceLinkedRole();
 


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy-rdb` smoke test job introduced in #667 fails immediately on `nx run @e2e-test/infra:deploy` with:

```
@e2e-test/infra: No stacks match the name(s) e2e-test-rdb-sandbox-20ive8iw/*
```

(See [run #25861782344](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/25861782344/job/75995770457).)

The spec passed `e2e-test-rdb-sandbox-${testRunId}/*` to `cdk deploy`, but the shared `main.ts.template` synthesizes the stage as `e2e-test-infra-sandbox-${testRunId}` — so CDK had no matching stack to deploy. My local validation manually substituted the right prefix into `main.ts`, which is why I never hit this. Sloppy on my part.

### Description of changes

Use `e2e-test-infra-sandbox-${testRunId}` (matches what `main.ts.template` actually emits). The two cdk-deploy variants run in parallel jobs with unique `testRunId`s, so sharing the prefix doesn't cause collisions; the existing `deleteLeftoverStacks` cleanup is per-run-id-prefixed and continues to work.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin-e2e:lint` — clean. The fix is a one-line stage-name correction; the deploy / destroy plumbing around it is unchanged from #667 (which I did exercise end-to-end against AWS).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*