### PR TITLE
fix(strands-agent): propagate AgentCore session ID through TS HTTP and Py AG-UI servers

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -458,12 +458,18 @@ This creates an example Strands agent and defines a subtraction tool.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -475,11 +481,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-This is the entrypoint for the agent. Because we selected `--protocol=AG-UI`, the generator wraps our Strands `Agent` with `StrandsAgent` from [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) and mounts it on a FastAPI app that speaks the [AG-UI protocol](https://docs.copilotkit.ai/aws-strands/protocol) — this is what CopilotKit will talk to from the React website. In <Link path="get_started/tutorials/dungeon-game/3">Module 3</Link> we'll add a `session_manager_provider` so each thread id gets its own `S3SessionManager` and conversation history persists across turns.
+This is the entrypoint for the agent. Because we selected `--protocol=AG-UI`, the generator wraps our Strands `Agent` with `StrandsAgent` from [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) and mounts it on a FastAPI app that speaks the [AG-UI protocol](https://docs.copilotkit.ai/aws-strands/protocol) — this is what CopilotKit will talk to from the React website. The `_SessionIdMiddleware` binds the inbound AgentCore runtime session ID onto a `ContextVar` so any downstream MCP/A2A client we wire up later (e.g. the Inventory MCP server in <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) automatically forwards it on its outbound calls. In <Link path="get_started/tutorials/dungeon-game/3">Module 3</Link> we'll also add a `session_manager_provider` so each thread id gets its own `S3SessionManager` and conversation history persists across turns.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -458,12 +458,18 @@ Esto crea un agente Strands de ejemplo y define una herramienta de resta.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -475,11 +481,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-Este es el punto de entrada para el agente. Debido a que seleccionamos `--protocol=AG-UI`, el generador envuelve nuestro `Agent` de Strands con `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) y lo monta en una aplicación FastAPI que habla el [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — esto es con lo que CopilotKit hablará desde el sitio web React. En el <Link path="get_started/tutorials/dungeon-game/3">Módulo 3</Link> agregaremos un `session_manager_provider` para que cada thread id obtenga su propio `S3SessionManager` y el historial de conversación persista entre turnos.
+Este es el punto de entrada para el agente. Debido a que seleccionamos `--protocol=AG-UI`, el generador envuelve nuestro `Agent` de Strands con `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) y lo monta en una aplicación FastAPI que habla el [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — esto es con lo que CopilotKit hablará desde el sitio web React. El `_SessionIdMiddleware` vincula el ID de sesión de runtime de AgentCore entrante a un `ContextVar` para que cualquier cliente MCP/A2A descendente que conectemos más adelante (por ejemplo, el servidor MCP de Inventario en el <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) lo reenvíe automáticamente en sus llamadas salientes. En el <Link path="get_started/tutorials/dungeon-game/3">Módulo 3</Link> también agregaremos un `session_manager_provider` para que cada thread id obtenga su propio `S3SessionManager` y el historial de conversación persista entre turnos.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -459,12 +459,18 @@ Cela crée un exemple d'agent Strands et définit un outil de soustraction.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -476,11 +482,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-C'est le point d'entrée de l'agent. Parce que nous avons sélectionné `--protocol=AG-UI`, le générateur enveloppe notre `Agent` Strands avec `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) et le monte sur une application FastAPI qui parle le [protocole AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — c'est ce à quoi CopilotKit parlera depuis le site web React. Dans le <Link path="get_started/tutorials/dungeon-game/3">Module 3</Link>, nous ajouterons un `session_manager_provider` pour que chaque thread id obtienne son propre `S3SessionManager` et que l'historique de conversation persiste entre les tours.
+C'est le point d'entrée de l'agent. Parce que nous avons sélectionné `--protocol=AG-UI`, le générateur enveloppe notre `Agent` Strands avec `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) et le monte sur une application FastAPI qui parle le [protocole AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — c'est ce à quoi CopilotKit parlera depuis le site web React. Le `_SessionIdMiddleware` lie l'ID de session du runtime AgentCore entrant à un `ContextVar` afin que tout client MCP/A2A en aval que nous connecterons plus tard (par exemple, le serveur MCP d'inventaire dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) le transmette automatiquement lors de ses appels sortants. Dans le <Link path="get_started/tutorials/dungeon-game/3">Module 3</Link>, nous ajouterons également un `session_manager_provider` pour que chaque thread id obtienne son propre `S3SessionManager` et que l'historique de conversation persiste entre les tours.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -458,12 +458,18 @@ Questo crea un agente Strands di esempio e definisce uno strumento di sottrazion
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -475,11 +481,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-Questo è l'entrypoint dell'agente. Poiché abbiamo selezionato `--protocol=AG-UI`, il generatore avvolge il nostro `Agent` Strands con `StrandsAgent` da [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e lo monta su un'app FastAPI che parla il [protocollo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — questo è ciò con cui CopilotKit comunicherà dal sito web React. Nel <Link path="get_started/tutorials/dungeon-game/3">Modulo 3</Link> aggiungeremo un `session_manager_provider` in modo che ogni thread id ottenga il proprio `S3SessionManager` e la cronologia delle conversazioni persista tra i turni.
+Questo è l'entrypoint dell'agente. Poiché abbiamo selezionato `--protocol=AG-UI`, il generatore avvolge il nostro `Agent` Strands con `StrandsAgent` da [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e lo monta su un'app FastAPI che parla il [protocollo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — questo è ciò con cui CopilotKit comunicherà dal sito web React. Il `_SessionIdMiddleware` collega l'ID di sessione del runtime AgentCore in entrata a un `ContextVar` in modo che qualsiasi client MCP/A2A downstream che colleghiamo successivamente (ad es. il server MCP Inventory nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>) lo inoltri automaticamente nelle sue chiamate in uscita. Nel <Link path="get_started/tutorials/dungeon-game/3">Modulo 3</Link> aggiungeremo anche un `session_manager_provider` in modo che ogni thread id ottenga il proprio `S3SessionManager` e la cronologia delle conversazioni persista tra i turni.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -458,12 +458,18 @@ Refer to tools as your 'spellbook'.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -475,11 +481,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-これはエージェントのエントリーポイントです。`--protocol=AG-UI`を選択したため、ジェネレーターはStrandsの`Agent`を[`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)の`StrandsAgent`でラップし、[AG-UIプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すFastAPIアプリにマウントします。これがReactウェブサイトからCopilotKitが通信する相手です。<Link path="get_started/tutorials/dungeon-game/3">モジュール3</Link>では、各スレッドIDが独自の`S3SessionManager`を取得し、会話履歴がターン間で永続化されるように`session_manager_provider`を追加します。
+これはエージェントのエントリーポイントです。`--protocol=AG-UI`を選択したため、ジェネレーターはStrandsの`Agent`を[`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)の`StrandsAgent`でラップし、[AG-UIプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すFastAPIアプリにマウントします。これがReactウェブサイトからCopilotKitが通信する相手です。`_SessionIdMiddleware`は、インバウンドのAgentCoreランタイムセッションIDを`ContextVar`にバインドするため、後で配線する下流のMCP/A2Aクライアント(例えば<Link path="get_started/tutorials/dungeon-game/2">モジュール2</Link>のインベントリMCPサーバー)が、アウトバウンド呼び出しで自動的にそれを転送します。<Link path="get_started/tutorials/dungeon-game/3">モジュール3</Link>では、各スレッドIDが独自の`S3SessionManager`を取得し、会話履歴がターン間で永続化されるように`session_manager_provider`も追加します。
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -455,12 +455,18 @@ Refer to tools as your 'spellbook'.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -472,11 +478,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-이 파일은 에이전트의 진입점입니다. `--protocol=AG-UI`를 선택했기 때문에 생성기는 Strands `Agent`를 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)의 `StrandsAgent`로 래핑하고 [AG-UI 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하는 FastAPI 앱에 마운트합니다. 이것이 React 웹사이트에서 CopilotKit이 통신할 대상입니다. <Link path="get_started/tutorials/dungeon-game/3">모듈 3</Link>에서는 각 스레드 ID가 자체 `S3SessionManager`를 갖고 대화 기록이 턴 간에 유지되도록 `session_manager_provider`를 추가할 것입니다.
+이 파일은 에이전트의 진입점입니다. `--protocol=AG-UI`를 선택했기 때문에 생성기는 Strands `Agent`를 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)의 `StrandsAgent`로 래핑하고 [AG-UI 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하는 FastAPI 앱에 마운트합니다. 이것이 React 웹사이트에서 CopilotKit이 통신할 대상입니다. `_SessionIdMiddleware`는 인바운드 AgentCore 런타임 세션 ID를 `ContextVar`에 바인딩하여 나중에 연결할 다운스트림 MCP/A2A 클라이언트(예: <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>의 인벤토리 MCP 서버)가 아웃바운드 호출 시 자동으로 이를 전달하도록 합니다. <Link path="get_started/tutorials/dungeon-game/3">모듈 3</Link>에서는 각 스레드 ID가 자체 `S3SessionManager`를 갖고 대화 기록이 턴 간에 유지되도록 `session_manager_provider`도 추가할 것입니다.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -458,12 +458,18 @@ Isso cria um agente Strands de exemplo e define uma ferramenta de subtração.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -475,11 +481,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-Este é o ponto de entrada do agente. Como selecionamos `--protocol=AG-UI`, o gerador envolve nosso `Agent` Strands com `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e o monta em uma aplicação FastAPI que fala o [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — é isso que o CopilotKit conversará a partir do website React. No <Link path="get_started/tutorials/dungeon-game/3">Módulo 3</Link> adicionaremos um `session_manager_provider` para que cada thread id obtenha seu próprio `S3SessionManager` e o histórico de conversação persista entre turnos.
+Este é o ponto de entrada do agente. Como selecionamos `--protocol=AG-UI`, o gerador envolve nosso `Agent` Strands com `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e o monta em uma aplicação FastAPI que fala o [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — é isso que o CopilotKit conversará a partir do website React. O `_SessionIdMiddleware` vincula o session ID de runtime do AgentCore de entrada a um `ContextVar` para que qualquer cliente MCP/A2A downstream que conectarmos posteriormente (por exemplo, o servidor MCP de Inventário no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) o encaminhe automaticamente em suas chamadas de saída. No <Link path="get_started/tutorials/dungeon-game/3">Módulo 3</Link> também adicionaremos um `session_manager_provider` para que cada thread id obtenha seu próprio `S3SessionManager` e o histórico de conversação persista entre turnos.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -458,12 +458,18 @@ Refer to tools as your 'spellbook'.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -475,11 +481,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-Đây là điểm vào cho agent. Vì chúng ta đã chọn `--protocol=AG-UI`, trình tạo bọc Strands `Agent` của chúng ta với `StrandsAgent` từ [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) và gắn nó vào một ứng dụng FastAPI giao tiếp bằng [giao thức AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — đây là thứ mà CopilotKit sẽ giao tiếp từ website React. Trong <Link path="get_started/tutorials/dungeon-game/3">Module 3</Link>, chúng ta sẽ thêm một `session_manager_provider` để mỗi thread id có `S3SessionManager` riêng và lịch sử hội thoại được duy trì qua các lượt.
+Đây là điểm vào cho agent. Vì chúng ta đã chọn `--protocol=AG-UI`, trình tạo bọc Strands `Agent` của chúng ta với `StrandsAgent` từ [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) và gắn nó vào một ứng dụng FastAPI giao tiếp bằng [giao thức AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — đây là thứ mà CopilotKit sẽ giao tiếp từ website React. `_SessionIdMiddleware` liên kết session ID của AgentCore runtime đến vào một `ContextVar` để bất kỳ MCP/A2A client downstream nào mà chúng ta kết nối sau này (ví dụ: máy chủ MCP Inventory trong <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) tự động chuyển tiếp nó trên các cuộc gọi đi ra. Trong <Link path="get_started/tutorials/dungeon-game/3">Module 3</Link>, chúng ta cũng sẽ thêm một `session_manager_provider` để mỗi thread id có `S3SessionManager` riêng và lịch sử hội thoại được duy trì qua các lượt.
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -455,12 +455,18 @@ Refer to tools as your 'spellbook'.
 ```python
 # agent/main.py
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -472,11 +478,22 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)
 ```
 
-这是代理的入口点。因为我们选择了 `--protocol=AG-UI`,生成器将我们的 Strands `Agent` 用 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) 的 `StrandsAgent` 包装,并将其挂载到使用 [AG-UI 协议](https://docs.copilotkit.ai/aws-strands/protocol)的 FastAPI 应用上 — 这就是 CopilotKit 从 React 网站与之通信的方式。在<Link path="get_started/tutorials/dungeon-game/3">模块 3</Link> 中,我们将添加 `session_manager_provider`,使每个线程 id 获得自己的 `S3SessionManager`,对话历史在多轮对话中持久化。
+这是代理的入口点。因为我们选择了 `--protocol=AG-UI`,生成器将我们的 Strands `Agent` 用 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) 的 `StrandsAgent` 包装,并将其挂载到使用 [AG-UI 协议](https://docs.copilotkit.ai/aws-strands/protocol)的 FastAPI 应用上 — 这就是 CopilotKit 从 React 网站与之通信的方式。`_SessionIdMiddleware` 将入站的 AgentCore 运行时会话 ID 绑定到 `ContextVar` 上,这样我们稍后连接的任何下游 MCP/A2A 客户端(例如<Link path="get_started/tutorials/dungeon-game/2">模块 2</Link> 中的库存 MCP 服务器)都会在其出站调用中自动转发该 ID。在<Link path="get_started/tutorials/dungeon-game/3">模块 3</Link> 中,我们还将添加 `session_manager_provider`,使每个线程 id 获得自己的 `S3SessionManager`,对话历史在多轮对话中持久化。
 
 ```ts
 // common/constructs/src/app/agents/story-agent.ts

--- a/e2e/src/files/dungeon-adventure/3/main.py.old.template
+++ b/e2e/src/files/dungeon-adventure/3/main.py.old.template
@@ -1,10 +1,16 @@
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -16,5 +22,16 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)

--- a/e2e/src/files/dungeon-adventure/3/main.py.template
+++ b/e2e/src/files/dungeon-adventure/3/main.py.template
@@ -1,16 +1,22 @@
 import logging
 import os
+import uuid
 from functools import cache
 from typing import Any, cast
 
 from ag_ui.core import RunAgentInput
 from ag_ui_strands import StrandsAgent, StrandsAgentConfig, create_strands_app
 from aws_lambda_powertools.utilities import parameters
+from dungeon_adventure_agent_connection import session_id_context
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 from strands.session import FileSessionManager, S3SessionManager, SessionManager
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @cache
@@ -58,4 +64,15 @@ agui_agent = StrandsAgent(
     config=StrandsAgentConfig(session_manager_provider=_session_manager_provider),
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)

--- a/packages/nx-plugin/src/py/strands-agent/files/ag-ui/main.py.template
+++ b/packages/nx-plugin/src/py/strands-agent/files/ag-ui/main.py.template
@@ -1,10 +1,16 @@
 import logging
+import uuid
 
 from ag_ui_strands import StrandsAgent, create_strands_app
+from fastapi import Request
+from <%- agentConnectionModuleName %> import session_id_context
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
 
 logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 # Create AG-UI agent wrapper
 _agent_ctx = get_agent()
@@ -16,5 +22,16 @@ agui_agent = StrandsAgent(
     description="A Strands Agent exposed via the AG-UI protocol.",
 )
 
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
 # Create FastAPI app with AG-UI endpoint and health check
 app = create_strands_app(agui_agent, path="/invocations")
+app.add_middleware(_SessionIdMiddleware)

--- a/packages/nx-plugin/src/py/strands-agent/generator.spec.ts
+++ b/packages/nx-plugin/src/py/strands-agent/generator.spec.ts
@@ -1150,6 +1150,16 @@ dev-dependencies = []
     expect(mainContent).toContain('create_strands_app');
     expect(mainContent).toContain('StrandsAgent');
 
+    // AG-UI must bind the inbound AgentCore session ID into the ContextVar
+    // so downstream MCP / A2A connection clients forward it on outbound
+    // calls. (AG-UI handles its own per-thread conversation isolation, so
+    // we don't wrap the agent in `with_session_id` here — only the
+    // downstream forwarding path matters.)
+    expect(mainContent).toContain('session_id_context');
+    expect(mainContent).toContain(
+      'x-amzn-bedrock-agentcore-runtime-session-id',
+    );
+
     // AG-UI should not generate init.py (HTTP-only)
     expect(
       tree.exists('apps/test-project/proj_test_project/agent/init.py'),

--- a/packages/nx-plugin/src/ts/strands-agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/strands-agent/__snapshots__/generator.spec.ts.snap
@@ -913,7 +913,6 @@ console.log(\`TRPC server listening on port \${PORT}\`);
 
 exports[`ts#strands-agent generator > should match snapshot for generated files > strands-agent-init.ts 1`] = `
 "import { initTRPC } from '@trpc/server';
-import { enterSessionContext } from ':proj/agent-connection';
 
 export interface Context {
   sessionId: string;
@@ -921,17 +920,7 @@ export interface Context {
 
 export const t = initTRPC.context<Context>().create();
 
-/**
- * Bind the inbound session onto the current async flow so downstream MCP /
- * A2A clients forward it on outbound calls. Uses \`enterWith\` so the binding
- * persists across subscription iterations.
- */
-const sessionMiddleware = t.middleware(({ ctx, next }) => {
-  enterSessionContext(ctx.sessionId);
-  return next();
-});
-
-export const publicProcedure = t.procedure.use(sessionMiddleware);
+export const publicProcedure = t.procedure;
 "
 `;
 
@@ -939,7 +928,7 @@ exports[`ts#strands-agent generator > should match snapshot for generated files 
 "import { publicProcedure, t } from './init.js';
 import { z } from 'zod';
 import { zAsyncIterable } from './schema/z-async-iterable.js';
-import { withSessionId } from ':proj/agent-connection';
+import { enterSessionContext, withSessionId } from ':proj/agent-connection';
 import { getAgent } from './agent.js';
 
 export const router = t.router;
@@ -956,6 +945,8 @@ export const appRouter = router({
       }),
     )
     .subscription(async function* (opts) {
+      // Bind the session ID for this subscription so downstream MCP / A2A clients forward it on outbound calls.
+      enterSessionContext(opts.ctx.sessionId);
       for await (const event of agent.stream(opts.input.message)) {
         if (
           event.type === 'modelStreamUpdateEvent' &&

--- a/packages/nx-plugin/src/ts/strands-agent/files/http/init.ts.template
+++ b/packages/nx-plugin/src/ts/strands-agent/files/http/init.ts.template
@@ -1,5 +1,4 @@
 import { initTRPC } from '@trpc/server';
-import { enterSessionContext } from '<%- agentConnectionImport %>';
 
 export interface Context {
   sessionId: string;
@@ -7,14 +6,4 @@ export interface Context {
 
 export const t = initTRPC.context<Context>().create();
 
-/**
- * Bind the inbound session onto the current async flow so downstream MCP /
- * A2A clients forward it on outbound calls. Uses `enterWith` so the binding
- * persists across subscription iterations.
- */
-const sessionMiddleware = t.middleware(({ ctx, next }) => {
-  enterSessionContext(ctx.sessionId);
-  return next();
-});
-
-export const publicProcedure = t.procedure.use(sessionMiddleware);
+export const publicProcedure = t.procedure;

--- a/packages/nx-plugin/src/ts/strands-agent/files/http/router.ts.template
+++ b/packages/nx-plugin/src/ts/strands-agent/files/http/router.ts.template
@@ -1,7 +1,7 @@
 import { publicProcedure, t } from './init.js';
 import { z } from 'zod';
 import { zAsyncIterable } from './schema/z-async-iterable.js';
-import { withSessionId } from '<%- agentConnectionImport %>';
+import { enterSessionContext, withSessionId } from '<%- agentConnectionImport %>';
 import { getAgent } from './agent.js';
 
 export const router = t.router;
@@ -18,6 +18,8 @@ export const appRouter = router({
       }),
     )
     .subscription(async function* (opts) {
+      // Bind the session ID for this subscription so downstream MCP / A2A clients forward it on outbound calls.
+      enterSessionContext(opts.ctx.sessionId);
       for await (const event of agent.stream(opts.input.message)) {
         if (
           event.type === 'modelStreamUpdateEvent' &&


### PR DESCRIPTION
### Reason for this change

Both `Smoke Tests - cdk-deploy` and `Smoke Tests - terraform-deploy` have been failing intermittently on `main` (most recently CI run [25905712783](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/25905712783)) with:

```
TRPCClientError: Agent is already processing an invocation.
Wait for the current invoke() or stream() call to complete before invoking again.
```

(and occasionally `TRPCClientError: Too many connections, please wait before trying again.` for the `terraform-deploy` variant).

#### Root cause

`init.ts.template` for `ts#strands-agent` HTTP wraps every procedure with a tRPC middleware that calls `enterSessionContext(ctx.sessionId)`. The intent (per #657) was to bind the inbound `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` onto `AsyncLocalStorage` so that:

1. `withSessionId.forSession()` reads the session, looks up / creates a per-session cached Strands `Agent`, and isolates conversation state and `_isInvoking` lock per caller.
2. Downstream MCP / A2A connection clients read the session and forward it on outbound `fetch` calls.

In practice, the middleware runs while the subscription handler is being _set up_ — but tRPC's WebSocket layer iterates the resulting `async function*` generator from a fresh async context, so `AsyncLocalStorage.enterWith` from the middleware was already gone by the time the generator's first `next()` ran.

I confirmed this end-to-end on real AWS by deploying a freshly-generated `ts#strands-agent` HTTP runtime with a probe inside the subscription generator. `getCurrentSessionId()` consistently returned `null` regardless of the inbound header. As a result every caller hashed to `withSessionId`'s `'default'` key — one shared Strands `Agent` with one shared `_isInvoking` lock per microVM. Two concurrent or rapidly-sequential calls that AgentCore happened to route to the same microVM collided with the error above.

I then probed all five protocols on real AWS to look for the same bug pattern:

| Protocol | Server-side context bound during agent.stream()? |
| --- | --- |
| TS HTTP (tRPC/WS) | **NO** — fixed by commit 1 |
| TS A2A (Express + `runWithSessionId`) | yes |
| Py HTTP (FastAPI + ContextVar middleware) | yes |
| Py A2A (Starlette + ContextVar middleware) | yes |
| Py AG-UI | **No middleware at all** — fixed by commit 2 |

### Description of changes

**Commit 1 — `fix(ts#strands-agent)`**: Move the `enterSessionContext(ctx.sessionId)` call into the subscription generator body. The generator runs in the async context that drives `agent.stream(...)` and the downstream MCP / A2A connection clients, so the binding is now in scope when those reads happen. The now-pointless tRPC middleware in `init.ts` is dropped.

**Commit 2 — `fix(py#strands-agent)`**: Add a `BaseHTTPMiddleware` to the Py AG-UI `main.py` template that reads the AgentCore session header and binds it via `session_id_context`. AG-UI itself isolates conversation state per `thread_id`, so we don't need `with_session_id` here — only the downstream forwarding path was missing. Mirrors the middleware already vended for Py HTTP and Py A2A.

Snapshots updated to match.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — 1823/1823 pass.
- Real AWS, freshly-deployed `ts#strands-agent` HTTP runtime:
  - Pre-fix: probe yielded `als=null` inside the generator. 6 concurrent distinct-session calls collapsed onto one cached `Agent` and surfaced the CI failure.
  - Post-fix: probe yielded the correct session ID. 6/6 concurrent distinct-session calls succeeded; same-session sequential calls correctly preserved conversation history.
- Real AWS, freshly-deployed `py#strands-agent` AG-UI runtime: a probe tool injected into the agent reported the inbound session ID inside its tool call (the same context downstream MCP/A2A fetches run in), and three calls with two distinct sessions and two distinct threads each correctly observed their own session.

### Issue # (if applicable)

n/a

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
