### PR TITLE
fix(terraform): use hex sha256 in lambda S3 keys

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -2275,7 +2275,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -2936,7 +2936,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -3584,7 +3584,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -4249,7 +4249,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -5065,7 +5065,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -5883,7 +5883,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -188,7 +188,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "lambdas/test-project-test-function/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "lambdas/test-project-test-function/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -369,7 +369,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "lambdas/test-project-snapshot-function/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "lambdas/test-project-snapshot-function/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -776,7 +776,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -1970,7 +1970,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -2755,7 +2755,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -3276,7 +3276,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/custom-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/custom-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3279,7 +3279,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -3922,7 +3922,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -4552,7 +4552,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -5199,7 +5199,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -5985,7 +5985,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -6773,7 +6773,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/test-api/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -257,7 +257,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "lambdas/test-project-test-function/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "lambdas/test-project-test-function/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5
@@ -438,7 +438,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "lambdas/test-project-snapshot-function/\${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "lambdas/test-project-snapshot-function/\${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -108,7 +108,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/<%- apiNameKebabCase %>/${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/<%- apiNameKebabCase %>/${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -98,7 +98,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "apis/<%- apiNameKebabCase %>/${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "apis/<%- apiNameKebabCase %>/${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5

--- a/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__functionNameKebabCase__/__functionNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__functionNameKebabCase__/__functionNameKebabCase__.tf.template
@@ -120,7 +120,7 @@ data "archive_file" "lambda_zip" {
 
 resource "aws_s3_object" "lambda_zip" {
   bucket      = var.asset_bucket_name
-  key         = "lambdas/<%- functionNameKebabCase %>/${data.archive_file.lambda_zip.output_base64sha256}.zip"
+  key         = "lambdas/<%- functionNameKebabCase %>/${data.archive_file.lambda_zip.output_sha256}.zip"
   source      = data.archive_file.lambda_zip.output_path
   source_hash = data.archive_file.lambda_zip.output_base64sha256
   etag        = data.archive_file.lambda_zip.output_md5


### PR DESCRIPTION
### Reason for this change

`Smoke Tests - terraform-deploy` started failing reproducibly on `main`:

```
Error: creating Lambda Function (PyApiHandler-...):
InvalidParameterValueException: Error occurred while GetObjectVersion.
S3 Error Code: NoSuchVersion. The specified version does not exist.
```

Two reruns hit the same error on different generated suffixes — not a transient flake.

#### Root cause

The S3 keys used to stage Lambda zips embedded `data.archive_file.lambda_zip.output_base64sha256`. That output uses Go's `base64.StdEncoding` whose alphabet is `[A-Za-z0-9+/=]` — a hash that happens to start with `/` (~1/64 chance per Lambda) produces a key like `apis/py-api//RDR…zip` with a **literal double slash**.

In the failing CI run the offending key was logged verbatim:
- `apis/py-api-http/tNjZqK2u…zip` ✓ (single slash)
- `apis/py-api//RDRxN7FH…zip` ❌ (double slash — hash starts with `/`)

S3 stores the key verbatim and assigns a real `version_id`, but Lambda's `CreateFunction` URL-encodes the key when calling S3 `GetObjectVersion`, the empty path segment between the two slashes is normalised away, and S3 rejects the resulting different key as `NoSuchVersion`.

The `rdb-constructs` template was already using `output_sha256` (hex) for the same reason — see [#640](https://github.com/awslabs/nx-plugin-for-aws/pull/640) — but the API and function constructs hadn't been updated.

### Description of changes

Switch the S3 keys to `output_sha256` (hex, `[0-9a-f]{64}`, guaranteed path-safe) in:
- `api-constructs/files/terraform/app/apis/rest/...`
- `api-constructs/files/terraform/app/apis/http/...`
- `function-constructs/files/terraform/app/lambda-functions/...`

Keep `output_base64sha256` for `source_code_hash` / `source_hash` attributes on the Lambda and S3 object resources, where the value is an opaque comparison token (Lambda expects base64) and not part of any URL path.

Snapshots updated to match.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — 1823/1823 pass.
- Confirmed the CI failure mode by inspecting the failing terraform plan output: the only differing characteristic between the failing `module.py_api` and the succeeding sibling modules was the literal `//` in the S3 key, derived from a base64sha256 starting with `/`.
- End-to-end will be confirmed by `Smoke Tests - terraform-deploy` on this PR's CI matrix.

### Issue # (if applicable)

n/a (regression that surfaced on `main` after PR #670 merged; this PR is a follow-up fix).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
