### PR TITLE
fix(ts#rdb): use correct path to mount data volume for Postgres 17

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -3858,6 +3858,7 @@ try {
       \`POSTGRES_DB=\${dbName}\`,
       \`POSTGRES_USER=\${dbUser}\`,
       \`POSTGRES_PASSWORD=\${dbPassword}\`,
+      \`PGDATA=/var/lib/postgresql/17/docker\`,
     ],
     ExposedPorts: { '5432/tcp': {} },
     HostConfig: {

--- a/packages/nx-plugin/src/ts/rdb/files/scripts/docker-start.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/scripts/docker-start.ts.template
@@ -41,6 +41,7 @@ try {
       `POSTGRES_DB=${dbName}`,
       `POSTGRES_USER=${dbUser}`,
       `POSTGRES_PASSWORD=${dbPassword}`,
+      `PGDATA=/var/lib/postgresql/17/docker`,
     ],
     ExposedPorts: { '5432/tcp': {} },
     HostConfig: {


### PR DESCRIPTION
### Reason for this change

Earlier versions of `ts#rdb` used the `postgres` docker image without specifying a version tag, which pulled the latest image: version 18. The volume mount path was set to `/var/lib/postgresql`, which is correct for version 18.

The image version was later pinned to 17 to match the latest PostgreSQL version supported by AWS Aurora. However, the mount path was not updated. For PostgreSQL 17, the correct mount path is `/var/lib/postgresql/data`, not `/var/lib/postgresql` as documented [here](https://hub.docker.com/_/postgres#pgdata) .

According to Postgres docker documentation:

> (for PostgreSQL 17 and below) Mount the data volume at /var/lib/postgresql/data and not at /var/lib/postgresql because mounts at the latter path WILL NOT PERSIST database data when the container is re-created. The Dockerfile that builds the image declares a volume at /var/lib/postgresql/data and if no data volume is mounted at that path then the container runtime will automatically create an [anonymous volume](https://docs.docker.com/engine/storage/#volumes) that is not reused across container re-creations. Data will be written to the anonymous volume rather than your intended data volume and won't persist when the container is deleted and re-created.

> Users who wish to opt-in to this change on older releases can do so by setting PGDATA explicitly (--env PGDATA=/var/lib/postgresql/17/docker --volume some-postgres:/var/lib/postgresql). To migrate pre-existing data, adjust the volume's folder structure appropriately first (moving all database files into a PG_MAJOR/docker subdirectory).

### Description of changes

Option 2 is prefered i.e. opt-in to the latest change by Postgres 18 by setting `PGDATA` explicitly to make it easier to upgrade to Postgres 18 or later.

### Description of how you validated changes

Unit tests
Manually test the generated project can start and persist data correctly. 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*