### PR TITLE
fix(ts#identity): skip updating smsRole if MFA is set to off

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -196,11 +196,13 @@ export class UserIdentity extends Construct {
     });
     // Retain the SMS role alongside the pool so the pool can still be updated and deleted manually
     const poolCfn = userPool.node.defaultChild as CfnResource;
-    const smsRoleCfn = userPool.node.findChild('smsRole').node
-      .defaultChild as CfnResource;
-    smsRoleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
-    smsRoleCfn.cfnOptions.updateReplacePolicy =
-      poolCfn.cfnOptions.updateReplacePolicy;
+    const smsRoleNode = userPool.node.tryFindChild('smsRole');
+    if (smsRoleNode) {
+      const smsRoleCfn = smsRoleNode.node.defaultChild as CfnResource;
+      smsRoleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
+      smsRoleCfn.cfnOptions.updateReplacePolicy =
+        poolCfn.cfnOptions.updateReplacePolicy;
+    }
     return userPool;
   };
 

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -108,12 +108,13 @@ export class UserIdentity extends Construct {
     });
     // Retain the SMS role alongside the pool so the pool can still be updated and deleted manually
     const poolCfn = userPool.node.defaultChild as CfnResource;
-    const smsRoleCfn = userPool.node
-      .findChild('smsRole')
-      .node.defaultChild as CfnResource;
-    smsRoleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
-    smsRoleCfn.cfnOptions.updateReplacePolicy =
-      poolCfn.cfnOptions.updateReplacePolicy;
+    const smsRoleNode = userPool.node.tryFindChild('smsRole');
+    if (smsRoleNode) {
+      const smsRoleCfn = smsRoleNode.node.defaultChild as CfnResource;
+      smsRoleCfn.cfnOptions.deletionPolicy = poolCfn.cfnOptions.deletionPolicy;
+      smsRoleCfn.cfnOptions.updateReplacePolicy =
+        poolCfn.cfnOptions.updateReplacePolicy;
+    }
     return userPool;
   };
 


### PR DESCRIPTION
### Reason for this change

When MFA is set to off, `cdk synth` will fail at `userPool.node.findChild('smsRole')` with error `Child node with id smsRole not found`. 

### Description of changes

Use `tryFindNode` to skip updating `smsRole` when MFA is disabled and the SMS role is not created.

### Description of how you validated changes

* Unit tests
* Generate and build a project with MFA off

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*