### PR TITLE
fix(ts#rdb): prismaClient for Postgres should be module-level singleton

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4099,9 +4099,13 @@ import {
 } from './constants.js';
 import { getDatabaseConfig } from './utils.js';
 
+let prismaClient: PrismaClient<Prisma.LogLevel> | undefined;
+
 export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
   log: LogOpts[] = ['warn', 'error'] as LogOpts[],
 ): Promise<PrismaClient<LogOpts>> => {
+  if (prismaClient) return prismaClient;
+
   if (process.env.SERVE_LOCAL === 'true') {
     const adapter = new PrismaPg(
       new Pool({
@@ -4113,10 +4117,11 @@ export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
         allowExitOnIdle: true,
       }),
     );
-    return new PrismaClient({
+    prismaClient = new PrismaClient({
       adapter,
       log,
-    }) as unknown as PrismaClient<LogOpts>;
+    }) as unknown as PrismaClient<Prisma.LogLevel>;
+    return prismaClient;
   }
 
   const { hostname, port, database, dbUser, region } =
@@ -4143,10 +4148,11 @@ export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
     }),
   );
 
-  return new PrismaClient({
+  prismaClient = new PrismaClient({
     adapter,
     log,
-  }) as unknown as PrismaClient<LogOpts>;
+  }) as unknown as PrismaClient<Prisma.LogLevel>;
+  return prismaClient;
 };
 "
 `;

--- a/packages/nx-plugin/src/ts/rdb/files/src/prisma.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/prisma.ts.template
@@ -60,9 +60,13 @@ export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
 };
 <%_ } else { _%>
 
+let prismaClient: PrismaClient<Prisma.LogLevel> | undefined;
+
 export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
   log: LogOpts[] = ['warn', 'error'] as LogOpts[],
 ): Promise<PrismaClient<LogOpts>> => {
+  if (prismaClient) return prismaClient;
+
   if (process.env.SERVE_LOCAL === 'true') {
     const adapter = new PrismaPg(
       new Pool({
@@ -74,10 +78,11 @@ export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
         allowExitOnIdle: true,
       }),
     );
-    return new PrismaClient({
+    prismaClient = new PrismaClient({
       adapter,
       log,
-    }) as unknown as PrismaClient<LogOpts>;
+    }) as unknown as PrismaClient<Prisma.LogLevel>;
+    return prismaClient;
   }
 
   const { hostname, port, database, dbUser, region } =
@@ -104,9 +109,10 @@ export const getPrisma = async <LogOpts extends Prisma.LogLevel>(
     }),
   );
 
-  return new PrismaClient({
+  prismaClient = new PrismaClient({
     adapter,
     log,
-  }) as unknown as PrismaClient<LogOpts>;
+  }) as unknown as PrismaClient<Prisma.LogLevel>;
+  return prismaClient;
 };
 <%_ } _%>


### PR DESCRIPTION
### Reason for this change

`prismaClient` for Postgres used to be module level singleton but at some point the singleton was removed. I think Claude attempted to make the Postgres and MySQL block consistent during the introduction of the generic `<LogOpts extends Prisma.LogLevel>` to the `getPrisma()` function.

### Description of changes

Reintroduce `prismaClient` var at module level and `getPrisma`  lazily instantiates one if not defined.

### Description of how you validated changes
* Unit tests
* Manually test by generating a new Postgres project. 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*