### PR TITLE
fix(ts#react-website): re-enable pointer events on CopilotKit chat input

### DIFF
--- a/e2e/src/files/dungeon-adventure/4/styles.css.template
+++ b/e2e/src/files/dungeon-adventure/4/styles.css.template
@@ -47,13 +47,3 @@ body {
 h1, h2, h3 {
   letter-spacing: 0.05em;
 }
-
-/* CopilotChat positions its sticky input wrapper with
- * `pointer-events: none` (so scroll events can pass through to the message
- * list behind it). That inherits into the input too, which means users can't
- * click the chat input. Re-enable pointer events for every direct child of
- * the sticky wrapper — the input itself, its buttons, and anything else the
- * chat surface might render there. */
-.copilotKitChat > .cpk\:pointer-events-none > * {
-  pointer-events: auto;
-}

--- a/packages/nx-plugin/src/py/strands-agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/strands-agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -421,7 +421,9 @@ export {
 `;
 
 exports[`py strands agent react connection generator - AG-UI themed CopilotKit > should vend the default (unstyled) copilot theme when uxProvider is None > default-theme-index.tsx 1`] = `
-"export {
+"import './copilot.css';
+
+export {
   CopilotChat,
   CopilotSidebar,
   CopilotPopup,

--- a/packages/nx-plugin/src/py/strands-agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/strands-agent/react-connection/generator.spec.ts
@@ -926,6 +926,17 @@ export function Main() {
         'apps/frontend/src/components/copilot/ShadcnAssistantMessage.tsx',
       ),
     ).toBeFalsy();
+    // copilot.css is vended (carrying the pointer-events fix) and imported
+    expect(
+      tree.exists('apps/frontend/src/components/copilot/copilot.css'),
+    ).toBeTruthy();
+    expect(themeIndex).toContain(`import './copilot.css'`);
+    const css = tree.read(
+      'apps/frontend/src/components/copilot/copilot.css',
+      'utf-8',
+    ) as string;
+    expect(css).toContain(`.copilotKitChat > .cpk\\:pointer-events-none > * {`);
+    expect(css).toContain('pointer-events: auto;');
   });
 
   it('should vend the cloudscape-themed copilot components when uxProvider is Cloudscape', async () => {
@@ -962,6 +973,14 @@ export function Main() {
       'utf-8',
     ) as string;
     expect(assistant).toContain('@cloudscape-design');
+
+    // copilot.css carries the pointer-events fix
+    const css = tree.read(
+      'apps/frontend/src/components/copilot/copilot.css',
+      'utf-8',
+    ) as string;
+    expect(css).toContain(`.copilotKitChat > .cpk\\:pointer-events-none > * {`);
+    expect(css).toContain('pointer-events: auto;');
   });
 
   it('should vend the shadcn-themed copilot components and shared shadcn primitives when uxProvider is Shadcn', async () => {
@@ -999,6 +1018,14 @@ export function Main() {
     ) as string;
     expect(themeIndex).toMatchSnapshot('shadcn-theme-index.tsx');
     expect(themeIndex).toContain('ShadcnAssistantMessage');
+
+    // copilot.css carries the pointer-events fix
+    const css = tree.read(
+      'apps/frontend/src/components/copilot/copilot.css',
+      'utf-8',
+    ) as string;
+    expect(css).toContain(`.copilotKitChat > .cpk\\:pointer-events-none > * {`);
+    expect(css).toContain('pointer-events: auto;');
 
     const packageJson = JSON.parse(tree.read('package.json', 'utf-8'));
     expect(packageJson.dependencies['lucide-react']).toBeDefined();

--- a/packages/nx-plugin/src/ts/react-website/agui/files/cloudscape/src/components/copilot/copilot.css.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/cloudscape/src/components/copilot/copilot.css.template
@@ -1,3 +1,13 @@
+/* CopilotChat positions its sticky input wrapper with
+ * `pointer-events: none` (so scroll events can pass through to the message
+ * list behind it). That inherits into the input too, which means users can't
+ * click the chat input. Re-enable pointer events for every direct child of
+ * the sticky wrapper — the input itself, its buttons, and anything else the
+ * chat surface might render there. */
+.copilotKitChat > .cpk\:pointer-events-none > * {
+  pointer-events: auto;
+}
+
 /* Explicit styles for the Streamdown markdown output (CopilotKit emits
  * unprefixed Tailwind utilities that the website's Tailwind build can't see). */
 

--- a/packages/nx-plugin/src/ts/react-website/agui/files/default/src/components/copilot/copilot.css.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/default/src/components/copilot/copilot.css.template
@@ -1,0 +1,9 @@
+/* CopilotChat positions its sticky input wrapper with
+ * `pointer-events: none` (so scroll events can pass through to the message
+ * list behind it). That inherits into the input too, which means users can't
+ * click the chat input. Re-enable pointer events for every direct child of
+ * the sticky wrapper — the input itself, its buttons, and anything else the
+ * chat surface might render there. */
+.copilotKitChat > .cpk\:pointer-events-none > * {
+  pointer-events: auto;
+}

--- a/packages/nx-plugin/src/ts/react-website/agui/files/default/src/components/copilot/index.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/default/src/components/copilot/index.tsx.template
@@ -1,3 +1,5 @@
+import './copilot.css';
+
 export {
   CopilotChat,
   CopilotSidebar,

--- a/packages/nx-plugin/src/ts/react-website/agui/files/shadcn/src/components/copilot/copilot.css.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/shadcn/src/components/copilot/copilot.css.template
@@ -1,3 +1,13 @@
+/* CopilotChat positions its sticky input wrapper with
+ * `pointer-events: none` (so scroll events can pass through to the message
+ * list behind it). That inherits into the input too, which means users can't
+ * click the chat input. Re-enable pointer events for every direct child of
+ * the sticky wrapper — the input itself, its buttons, and anything else the
+ * chat surface might render there. */
+.copilotKitChat > .cpk\:pointer-events-none > * {
+  pointer-events: auto;
+}
+
 /* Explicit styles for the Streamdown markdown output (CopilotKit emits
  * unprefixed Tailwind utilities that the website's Tailwind build can't see). */
 


### PR DESCRIPTION
### Reason for this change

CopilotKit's sticky chat input wrapper uses `pointer-events: none` (so scroll events fall through to the message list behind it). That property inherits into the input itself, which means users couldn't click the chat input on any website that the AG-UI generator wired up.

The dungeon adventure tutorial had its own copy of the workaround in `styles.css.template`, but every site that the AG-UI generator vends hit the same bug — so the fix needs to be vended by the generator itself, not copy-pasted by tutorial authors.

### Description of changes

- Add the `pointer-events: auto` override to the existing themed `copilot.css.template` files (cloudscape, shadcn).
- Add a new `copilot.css.template` for the default (unstyled) theme and import it from that theme's `index.tsx` so the fix lands regardless of the website's `uxProvider`.
- Drop the now-redundant copy of the override from the dungeon adventure tutorial's `styles.css.template`.

### Description of how you validated changes

- Extended the existing `py strands agent react connection generator - AG-UI themed CopilotKit` suite with assertions that each theme (default / cloudscape / shadcn) vends a `copilot.css` containing the pointer-events override.
- `pnpm nx run @aws/nx-plugin:test -u` (1830 tests pass; one snapshot updated for the default theme's new `import './copilot.css'`).
- `pnpm nx run @aws/nx-plugin:build` passes.
- `pnpm nx run @aws/nx-plugin:lint --fix` passes.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*