### PR TITLE
ci(windows): use dedicated nx smoke-test target with embedded -t pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: 10800
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        run: pnpm nx run @aws/nx-plugin-e2e:test --args="-t 'smoke test - ${{ matrix.smoke_test }} '"
+        run: pnpm nx run @aws/nx-plugin-e2e:test --args='-t "smoke test - ${{ matrix.smoke_test }} "'
   release:
     name: Release
     needs: [build, smoke_tests, smoke_tests_windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: 10800
       - name: Smoke Test - ${{ matrix.smoke_test }}
-        run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
+        run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}
     runs-on: windows-latest
@@ -129,7 +129,7 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: 10800
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        run: pnpm nx run @aws/nx-plugin-e2e:test --args='-t "smoke test - ${{ matrix.smoke_test }} "'
+        run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
   release:
     name: Release
     needs: [build, smoke_tests, smoke_tests_windows]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,4 +108,4 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        run: pnpm nx run @aws/nx-plugin-e2e:test --args="-t 'smoke test - ${{ matrix.smoke_test }} '"
+        run: pnpm nx run @aws/nx-plugin-e2e:test --args='-t "smoke test - ${{ matrix.smoke_test }} "'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Smoke Test - ${{ matrix.smoke_test }}
-        run: pnpm nx run @aws/nx-plugin-e2e:test -- -t "smoke test - ${{ matrix.smoke_test }} "
+        run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}
     runs-on: windows-latest
@@ -108,4 +108,4 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
-        run: pnpm nx run @aws/nx-plugin-e2e:test --args='-t "smoke test - ${{ matrix.smoke_test }} "'
+        run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,11 @@ The end to end tests run our generators and check that generated projects functi
 
 First ensure you have at least compiled the Nx Plugin (`pnpm nx compile nx-plugin`)
 
-You can run them using `pnpm nx test nx-plugin-e2e -- -t 'smoke test - xxx'` (replacing xxx with the test to run). The `--` separator forwards the `-t` flag to Vitest (Nx consumes a bare `-t` as its own `--target` option).
+You can run them using `pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=xxx` (replacing xxx with the test to run, e.g. `pnpm-10`, `dungeon-adventure`). The `smoke-test` target wraps Vitest with the correct `-t` pattern so the same invocation works on Windows (where shell quoting via `--args` is unreliable).
 
 Note that we have a test which runs through our main tutorial (the Dungeon Adventure Game). If you have updated generators which affect files which we show the contents of in the tutorial, you will need to update this test. You can update the "before" files automatically by running:
 
-`pnpm nx test nx-plugin-e2e -- -t 'dungeon-adventure' -u`
+`pnpm nx run @aws/nx-plugin-e2e:smoke-test:update-snapshot --name=dungeon-adventure`
 
 However you will still need to make changes to any "after" files manually to ensure the tutorial works end to end. You can also use `pnpm nx start docs` to run the docs site locally and follow the tutorial yourself.
 

--- a/e2e/project.json
+++ b/e2e/project.json
@@ -15,6 +15,18 @@
           "fix": true
         }
       }
+    },
+    "smoke-test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "e2e",
+        "command": "vitest -t \"smoke test - {args.name} \""
+      },
+      "configurations": {
+        "update-snapshot": {
+          "command": "vitest -t \"smoke test - {args.name} \" --update"
+        }
+      }
     }
   },
   "implicitDependencies": ["@aws/nx-plugin", "@aws/nx-plugin-mcp"]


### PR DESCRIPTION
### Reason for this change

The Windows smoke test matrix entries were running every smoke test instead of just their assigned variant — the dungeon-adventure Windows job ran for ~1h45m before timing out and failing.

The previous fix used `--args='-t "smoke test - <name> "'`. This preserved the inner double quotes correctly through pwsh, pnpm, and nx — but `nx run-commands` then spawns vitest via `child_process.spawn(cmd, [], { shell: true })`, which on Windows is `cmd.exe`. cmd.exe stripped the inner double quotes during argv parsing, so vitest received `-t smoke test - <name>` as four separate args. That filtered by `-t smoke` (matches every `smoke test - X` describe block) and silently treated `test`, `-`, and `<name>` as nonexistent file path filters.

Log evidence from a previous run on this PR:
```
> nx run @aws/nx-plugin-e2e:test --args=-t smoke test - dungeon-adventure
> vitest -t smoke test - dungeon-adventure
```

### Description of changes

Add a dedicated `smoke-test` target on `@aws/nx-plugin-e2e`. The quoted `-t` pattern is baked directly into the target's `command` template, and the matrix value flows in as `{args.name}` interpolation:

```json
"smoke-test": {
  "executor": "nx:run-commands",
  "options": {
    "cwd": "e2e",
    "command": "vitest -t \"smoke test - {args.name} \""
  },
  "configurations": {
    "update-snapshot": {
      "command": "vitest -t \"smoke test - {args.name} \" --update"
    }
  }
}
```

Because the quotes are part of the static template (not passed as `--args`), cmd.exe parses them correctly. Workflows now invoke:

```yaml
run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
```

This works identically on Linux and Windows with no `--args`/shell-quoting plumbing. Both `pr.yml` and `ci.yml` (Linux + Windows matrices) are updated, plus `CONTRIBUTING.md` to document the new invocation.

### Description of how you validated changes

- Ran `pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=this-doesnt-exist` locally and confirmed nx logs the resolved command as `vitest -t "smoke test - this-doesnt-exist "` with quotes intact.
- The pre-commit hook ran the full nx-plugin test suite (1830/1830 passing).
- Will monitor the Windows smoke test jobs on this PR to confirm the matrix entries now run only their assigned variant.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
