### PR TITLE
fix(ts#react-website): import fromCognitoIdentityPool from cognito-identity package

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -285,7 +285,7 @@ export function Main() {
     expect(packageJson.dependencies['oidc-client-ts']).toBeDefined();
     expect(packageJson.dependencies['react-oidc-context']).toBeDefined();
     expect(
-      packageJson.dependencies['@aws-sdk/credential-providers'],
+      packageJson.dependencies['@aws-sdk/credential-provider-cognito-identity'],
     ).toBeDefined();
     expect(packageJson.dependencies['aws4fetch']).toBeDefined();
 

--- a/packages/nx-plugin/src/py/strands-agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/strands-agent/react-connection/generator.spec.ts
@@ -253,7 +253,7 @@ export function Main() {
     expect(packageJson.dependencies['oidc-client-ts']).toBeDefined();
     expect(packageJson.dependencies['react-oidc-context']).toBeDefined();
     expect(
-      packageJson.dependencies['@aws-sdk/credential-providers'],
+      packageJson.dependencies['@aws-sdk/credential-provider-cognito-identity'],
     ).toBeDefined();
     expect(packageJson.dependencies['aws4fetch']).toBeDefined();
 

--- a/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
@@ -329,7 +329,9 @@ export function Main() {
       expect(packageJson.dependencies['oidc-client-ts']).toBeDefined();
       expect(packageJson.dependencies['react-oidc-context']).toBeDefined();
       expect(
-        packageJson.dependencies['@aws-sdk/credential-providers'],
+        packageJson.dependencies[
+          '@aws-sdk/credential-provider-cognito-identity'
+        ],
       ).toBeDefined();
       expect(packageJson.dependencies['aws4fetch']).toBeDefined();
 
@@ -1104,7 +1106,9 @@ export function Main() {
       const packageJson = JSON.parse(tree.read('package.json', 'utf-8'));
       expect(packageJson.dependencies['aws4fetch']).toBeDefined();
       expect(
-        packageJson.dependencies['@aws-sdk/credential-providers'],
+        packageJson.dependencies[
+          '@aws-sdk/credential-provider-cognito-identity'
+        ],
       ).toBeDefined();
 
       // Verify that the runtime config includes the correct API

--- a/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
@@ -422,7 +422,7 @@ export default TestApiClientProvider;
 
 exports[`trpc react generator > should handle IAM auth option > useSigV4.tsx 1`] = `
 "import { AwsClient } from 'aws4fetch';
-import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers';
+import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
 import { useCallback, useRef } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { useRuntimeConfig } from './useRuntimeConfig';

--- a/packages/nx-plugin/src/trpc/react/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.spec.ts
@@ -139,7 +139,7 @@ export function Main() {
     expect(packageJson.dependencies['oidc-client-ts']).toBeDefined();
     expect(packageJson.dependencies['react-oidc-context']).toBeDefined();
     expect(
-      packageJson.dependencies['@aws-sdk/credential-providers'],
+      packageJson.dependencies['@aws-sdk/credential-provider-cognito-identity'],
     ).toBeDefined();
     expect(packageJson.dependencies['aws4fetch']).toBeDefined();
   });

--- a/packages/nx-plugin/src/trpc/react/generator.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.ts
@@ -154,7 +154,7 @@ export async function reactGenerator(
         ? [
             'oidc-client-ts',
             'aws4fetch',
-            '@aws-sdk/credential-providers',
+            '@aws-sdk/credential-provider-cognito-identity',
             'react-oidc-context',
           ]
         : []) as any),

--- a/packages/nx-plugin/src/ts/react-website/agui/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/agui/generator.ts
@@ -141,7 +141,7 @@ export const addAgUiReactConnection = async (
         ? [
             'oidc-client-ts',
             'aws4fetch',
-            '@aws-sdk/credential-providers',
+            '@aws-sdk/credential-provider-cognito-identity',
             'react-oidc-context',
             'rxjs',
           ]

--- a/packages/nx-plugin/src/ts/strands-agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/react-connection/generator.spec.ts
@@ -167,7 +167,7 @@ export function Main() {
     expect(packageJson.dependencies['oidc-client-ts']).toBeDefined();
     expect(packageJson.dependencies['react-oidc-context']).toBeDefined();
     expect(
-      packageJson.dependencies['@aws-sdk/credential-providers'],
+      packageJson.dependencies['@aws-sdk/credential-provider-cognito-identity'],
     ).toBeDefined();
     expect(packageJson.dependencies['aws4fetch']).toBeDefined();
   });

--- a/packages/nx-plugin/src/ts/strands-agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/strands-agent/react-connection/generator.ts
@@ -182,7 +182,7 @@ export async function tsStrandsAgentReactConnectionGenerator(
         ? [
             'oidc-client-ts',
             'aws4fetch',
-            '@aws-sdk/credential-providers',
+            '@aws-sdk/credential-provider-cognito-identity',
             'react-oidc-context',
           ]
         : []) as any),

--- a/packages/nx-plugin/src/utils/connection/open-api/react.ts
+++ b/packages/nx-plugin/src/utils/connection/open-api/react.ts
@@ -262,7 +262,7 @@ export const addOpenApiReactClient = async (
         ? [
             'oidc-client-ts',
             'react-oidc-context',
-            '@aws-sdk/credential-providers',
+            '@aws-sdk/credential-provider-cognito-identity',
             'aws4fetch',
           ]
         : []) as any),

--- a/packages/nx-plugin/src/utils/files/website/hooks/sigv4/useSigV4.tsx.template
+++ b/packages/nx-plugin/src/utils/files/website/hooks/sigv4/useSigV4.tsx.template
@@ -1,5 +1,5 @@
 import { AwsClient } from 'aws4fetch';
-import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers';
+import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
 import { useCallback, useRef } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { useRuntimeConfig } from './useRuntimeConfig';

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -14,6 +14,7 @@ export const TS_VERSIONS = {
   '@aws-sdk/client-s3': '3.1048.0',
   '@aws-sdk/client-sts': '3.1048.0',
   '@aws-sdk/credential-providers': '3.1048.0',
+  '@aws-sdk/credential-provider-cognito-identity': '3.972.35',
   '@aws-sdk/client-secrets-manager': '3.1048.0',
   '@aws-sdk/rds-signer': '3.1048.0',
   '@aws-smithy/server-apigateway': '1.0.0-alpha.10',


### PR DESCRIPTION
### Reason for this change

After the dep update in #672 (`@aws-sdk/credential-providers` 3.1039.0 → 3.1048.0), `pnpm nx run @e2e-test/website:serve-local` fails to bundle when the website is generated with IAM auth — the `useSigV4` hook imports `fromCognitoIdentityPool` from `@aws-sdk/credential-providers`, and the new release of that umbrella package picked up transitive deps (e.g. `@aws-sdk/nested-clients`, `@aws-sdk/credential-provider-login`) that drag Node-only modules into the browser bundle.

Reproduction:
```sh
cd /tmp && pnpm create @aws/nx-workspace test --no-interactive
cd test
pnpm nx g @aws/nx-plugin:ts#react-website --name=website --no-interactive
pnpm nx g @aws/nx-plugin:ts#trpc-api --name=api --auth=IAM --no-interactive
pnpm nx run @e2e-test/website:serve-local   # fails to bundle
```

### Description of changes

The `@aws-sdk/credential-provider-cognito-identity` package only exposes `fromCognitoIdentityPool` and avoids the umbrella package's Node-only entries. Update the shared sigv4 hook template and the four generators that emit it to depend on the focused package instead:

- `utils/files/website/hooks/sigv4/useSigV4.tsx.template` — switch the import.
- `trpc/react/generator.ts`, `utils/connection/open-api/react.ts` (used by smithy#react-connection and py#fast-api#react), `ts/react-website/agui/generator.ts`, `ts/strands-agent/react-connection/generator.ts` — replace the IAM-auth website dep `@aws-sdk/credential-providers` with `@aws-sdk/credential-provider-cognito-identity`.
- `utils/versions.ts` — add a version pin for the new package.

Server-side imports of `@aws-sdk/credential-providers` (used for `fromNodeProviderChain` / `fromIni` in Lambda handlers, scripts, and Node clients) are unchanged — only the browser-bound sigv4 hook needed to switch.

Snapshots and dep assertions in the affected `*.spec.ts` files updated to match.

### Description of how you validated changes

- `pnpm nx test @aws/nx-plugin` — 1830 tests pass (including the regenerated trpc-react useSigV4 snapshot).
- Manual repro on a fresh workspace: with the patched local plugin linked, `serve-local` now bundles cleanly under IAM auth.

### Issue # (if applicable)

n/a

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*