### PR TITLE
feat(ts#react-website#auth): make cognitoDomain optional with derived default

### DIFF
--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -965,7 +965,7 @@
       "vi": "Thư mục gốc của website React."
     },
     "cognitoDomain": {
-      "en": "The cognito domain prefix to use",
+      "en": "The cognito domain prefix to use. If omitted, a value is derived from the npm scope and website project name.",
       "jp": "使用するCognitoドメインのプレフィックス",
       "es": "El prefijo del dominio de Cognito a utilizar",
       "ko": "사용할 Cognito 도메인 접두사입니다.",

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
@@ -425,7 +425,7 @@ describe('cognito-auth generator', () => {
     });
   });
 
-  it('should throw when cognito domain is empty', async () => {
+  it('should derive a cognito domain from the scope and project name when not provided', async () => {
     // Setup main.tsx with RuntimeConfigProvider
     tree.write(
       'packages/test-project/src/main.tsx',
@@ -446,12 +446,117 @@ describe('cognito-auth generator', () => {
     `,
     );
 
-    await expect(() =>
-      tsReactWebsiteAuthGenerator(tree, {
-        ...options,
-        cognitoDomain: '',
+    // Use a scoped workspace and a fully-qualified project name
+    updateJson(tree, 'package.json', (packageJson) => ({
+      ...packageJson,
+      name: '@my-scope/source',
+    }));
+    tree.write(
+      'packages/test-project/project.json',
+      JSON.stringify({
+        name: '@my-scope/test-project',
+        sourceRoot: 'packages/test-project/src',
+        metadata: { uxProvider },
       }),
-    ).rejects.toThrow(/A Cognito domain must be specified/);
+    );
+
+    await tsReactWebsiteAuthGenerator(tree, {
+      ...options,
+      project: '@my-scope/test-project',
+      cognitoDomain: undefined,
+    });
+
+    const userIdentity = tree
+      .read('packages/common/constructs/src/core/user-identity.ts', 'utf-8')
+      ?.toString();
+    expect(userIdentity).toContain('my-scope-test-project');
+  });
+
+  it('should strip reserved words from a derived cognito domain', async () => {
+    // Setup main.tsx with RuntimeConfigProvider
+    tree.write(
+      'packages/test-project/src/main.tsx',
+      `
+      import { RuntimeConfigProvider } from './components/RuntimeConfig';
+      import { RouterProvider, createRouter } from '@tanstack/react-router';
+
+      export function App() {
+
+        const App = () => <RouterProvider router={router} />;
+
+        return (
+          <RuntimeConfigProvider>
+            <App/>
+          </RuntimeConfigProvider>
+        );
+      }
+    `,
+    );
+
+    // Use a scope that contains the reserved word "cognito" and a project name with "aws"
+    updateJson(tree, 'package.json', (packageJson) => ({
+      ...packageJson,
+      name: '@cognito-test/source',
+    }));
+    tree.write(
+      'packages/test-project/project.json',
+      JSON.stringify({
+        name: '@cognito-test/aws-project',
+        sourceRoot: 'packages/test-project/src',
+        metadata: { uxProvider },
+      }),
+    );
+
+    await tsReactWebsiteAuthGenerator(tree, {
+      ...options,
+      project: '@cognito-test/aws-project',
+      cognitoDomain: undefined,
+    });
+
+    const userIdentity = tree
+      .read('packages/common/constructs/src/core/user-identity.ts', 'utf-8')
+      ?.toString();
+    // Reserved words "cognito" and "aws" should be stripped, leaving collapsed hyphens
+    expect(userIdentity).not.toMatch(/domain: `[^`]*cognito[^`]*`/i);
+    expect(userIdentity).not.toMatch(/domain: `[^`]*aws[^`]*`/i);
+    expect(userIdentity).not.toMatch(/domain: `[^`]*amazon[^`]*`/i);
+    // The remaining derived prefix should still match the Cognito pattern.
+    const match = userIdentity?.match(/domain: `([^`$]+?)-\$\{/);
+    expect(match).toBeTruthy();
+    expect(match![1]).toMatch(/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/);
+  });
+
+  it('should treat an empty cognito domain as not provided and derive a value', async () => {
+    // Setup main.tsx with RuntimeConfigProvider
+    tree.write(
+      'packages/test-project/src/main.tsx',
+      `
+      import { RuntimeConfigProvider } from './components/RuntimeConfig';
+      import { RouterProvider, createRouter } from '@tanstack/react-router';
+
+      export function App() {
+
+        const App = () => <RouterProvider router={router} />;
+
+        return (
+          <RuntimeConfigProvider>
+            <App/>
+          </RuntimeConfigProvider>
+        );
+      }
+    `,
+    );
+
+    await tsReactWebsiteAuthGenerator(tree, {
+      ...options,
+      cognitoDomain: '',
+    });
+
+    const userIdentity = tree
+      .read('packages/common/constructs/src/core/user-identity.ts', 'utf-8')
+      ?.toString();
+    // The default empty workspace uses scope "@proj/source"
+    expect(userIdentity).toContain('proj-test-project');
   });
 
   it('should add generator metric to app.ts', async () => {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -36,8 +36,10 @@ import {
   addCloudscapeAuthMenu,
   addNoneAuthMenu,
   addShadcnAuthMenu,
+  deriveCognitoDomainPrefix,
 } from './utils';
 import { toProjectRelativePath } from '../../../utils/paths';
+import { getNpmScope } from '../../../utils/npm-scope';
 
 const readGritPattern = (name: string): string =>
   readFileSync(join(__dirname, 'grit', `${name}.grit`), 'utf-8').trim();
@@ -62,9 +64,10 @@ export async function tsReactWebsiteAuthGenerator(
     );
   }
 
-  if (!options.cognitoDomain) {
-    throw new Error('A Cognito domain must be specified!');
-  }
+  const cognitoDomain =
+    options.cognitoDomain && options.cognitoDomain.length > 0
+      ? options.cognitoDomain
+      : deriveCognitoDomainPrefix(getNpmScope(tree), projectConfig.name!);
 
   await runtimeConfigGenerator(tree, {
     project: options.project,
@@ -79,7 +82,7 @@ export async function tsReactWebsiteAuthGenerator(
   await addIdentityInfra(tree, {
     iacProvider,
     allowSignup: options.allowSignup,
-    cognitoDomain: options.cognitoDomain,
+    cognitoDomain,
   });
 
   generateFiles(

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.d.ts
@@ -8,6 +8,6 @@ import { IacProviderOption } from '../../../utils/iac';
 export interface TsReactWebsiteAuthGeneratorSchema {
   project: string;
   allowSignup: boolean;
-  cognitoDomain: string;
+  cognitoDomain?: string;
   iacProvider: IacProviderOption;
 }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.json
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.json
@@ -25,10 +25,10 @@
       "x-dropdown": "projects"
     },
     "cognitoDomain": {
-      "description": "The cognito domain prefix to use",
+      "description": "The cognito domain prefix to use. If omitted, a value is derived from the npm scope and website project name.",
       "type": "string",
       "x-priority": "important",
-      "x-prompt": "the cognito domain prefix to use i.e: https://{{cognitoDomain}}-123456789.auth.ap-southeast-2.amazoncognito.com"
+      "x-prompt": "the cognito domain prefix to use i.e: https://{{cognitoDomain}}-123456789.auth.ap-southeast-2.amazoncognito.com (leave blank to derive from scope and project name)"
     },
     "allowSignup": {
       "description": "Whether to allow self-signup",
@@ -46,5 +46,5 @@
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: Inherit)"
     }
   },
-  "required": ["project", "cognitoDomain"]
+  "required": ["project"]
 }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
@@ -6,9 +6,58 @@ import { Tree } from '@nx/devkit';
 import { addDestructuredImport, applyGritQL } from '../../../utils/ast';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { kebabCase } from '../../../utils/names';
 
 const readGritPattern = (name: string): string =>
   readFileSync(join(__dirname, 'grit', `${name}.grit`), 'utf-8').trim();
+
+// The Cognito hosted prefix domain pattern is ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$ with a max length of 63.
+// Both CDK and Terraform templates append a suffix (account id, optional random hex) to the prefix when
+// creating the user pool domain. We cap derived prefixes at 41 characters to leave room for the longest
+// suffix used by the Terraform template ("-<12-digit account id>-<8-char hex>" = 22 characters).
+const MAX_DERIVED_DOMAIN_PREFIX_LENGTH = 41;
+
+// Cognito rejects prefixes that contain any of these case-insensitive substrings with
+// "Domain cannot contain reserved word".
+const COGNITO_DOMAIN_RESERVED_WORDS = ['aws', 'amazon', 'cognito'];
+
+/**
+ * Derive a Cognito-compatible hosted-domain prefix from the npm scope and the website project name.
+ *
+ * Cognito domain prefixes must:
+ * - Match `^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`
+ * - Be 1-63 characters in total
+ * - Not contain the reserved words `aws`, `amazon`, or `cognito` as substrings
+ *
+ * The plugin appends an account id (and a random suffix for Terraform) when actually creating the
+ * user pool domain, so the derived value is conservatively truncated to leave room for those suffixes.
+ */
+export const deriveCognitoDomainPrefix = (
+  npmScope: string | undefined,
+  projectName: string,
+): string => {
+  const projectNameWithoutScope = projectName.includes('/')
+    ? projectName.split('/').pop()!
+    : projectName;
+  const parts = [npmScope, projectNameWithoutScope].filter(
+    (p): p is string => !!p,
+  );
+  let candidate = kebabCase(parts.join('-'));
+  for (const reserved of COGNITO_DOMAIN_RESERVED_WORDS) {
+    candidate = candidate.replace(new RegExp(reserved, 'gi'), '');
+  }
+  candidate = candidate
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_DERIVED_DOMAIN_PREFIX_LENGTH)
+    .replace(/-+$/g, '');
+  if (!candidate) {
+    throw new Error(
+      `Unable to derive a valid Cognito domain prefix from scope "${npmScope ?? ''}" and project "${projectName}". Please specify a cognitoDomain explicitly.`,
+    );
+  }
+  return candidate;
+};
 
 // Adds a user greeting and sign-out button to the default AppLayout header when using the None UX provider.
 export async function addNoneAuthMenu(tree: Tree, appLayoutTsxPath: string) {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
@@ -11,46 +11,31 @@ import { kebabCase } from '../../../utils/names';
 const readGritPattern = (name: string): string =>
   readFileSync(join(__dirname, 'grit', `${name}.grit`), 'utf-8').trim();
 
-// The Cognito hosted prefix domain pattern is ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$ with a max length of 63.
-// Both CDK and Terraform templates append a suffix (account id, optional random hex) to the prefix when
-// creating the user pool domain. We cap derived prefixes at 41 characters to leave room for the longest
-// suffix used by the Terraform template ("-<12-digit account id>-<8-char hex>" = 22 characters).
+// Leaves room for the IaC suffix (Terraform: `-<12-digit account>-<8-char hex>` = 22 chars) inside Cognito's 63-char limit.
 const MAX_DERIVED_DOMAIN_PREFIX_LENGTH = 41;
 
-// Cognito rejects prefixes that contain any of these case-insensitive substrings with
-// "Domain cannot contain reserved word".
+// Cognito rejects domains containing these substrings ("Domain cannot contain reserved word").
 const COGNITO_DOMAIN_RESERVED_WORDS = ['aws', 'amazon', 'cognito'];
 
-/**
- * Derive a Cognito-compatible hosted-domain prefix from the npm scope and the website project name.
- *
- * Cognito domain prefixes must:
- * - Match `^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`
- * - Be 1-63 characters in total
- * - Not contain the reserved words `aws`, `amazon`, or `cognito` as substrings
- *
- * The plugin appends an account id (and a random suffix for Terraform) when actually creating the
- * user pool domain, so the derived value is conservatively truncated to leave room for those suffixes.
- */
 export const deriveCognitoDomainPrefix = (
   npmScope: string | undefined,
   projectName: string,
 ): string => {
-  const projectNameWithoutScope = projectName.includes('/')
+  const projectWithoutScope = projectName.includes('/')
     ? projectName.split('/').pop()!
     : projectName;
-  const parts = [npmScope, projectNameWithoutScope].filter(
-    (p): p is string => !!p,
+  const kebab = kebabCase(
+    [npmScope, projectWithoutScope].filter(Boolean).join('-'),
   );
-  let candidate = kebabCase(parts.join('-'));
-  for (const reserved of COGNITO_DOMAIN_RESERVED_WORDS) {
-    candidate = candidate.replace(new RegExp(reserved, 'gi'), '');
-  }
-  candidate = candidate
+  const stripped = COGNITO_DOMAIN_RESERVED_WORDS.reduce(
+    (s, word) => s.replaceAll(word, ''),
+    kebab,
+  );
+  const candidate = stripped
     .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/^-|-$/g, '')
     .slice(0, MAX_DERIVED_DOMAIN_PREFIX_LENGTH)
-    .replace(/-+$/g, '');
+    .replace(/-$/, '');
   if (!candidate) {
     throw new Error(
       `Unable to derive a valid Cognito domain prefix from scope "${npmScope ?? ''}" and project "${projectName}". Please specify a cognitoDomain explicitly.`,


### PR DESCRIPTION
### Reason for this change

The `ts#react-website#auth` generator currently requires the user to pass an explicit `cognitoDomain`, which is unnecessary friction for the common case where any unique-per-account, deploy-friendly prefix would do. The CDK template already appends `-${Stack.of(this).account}` (and Terraform appends an account id + random suffix) to whatever value the user supplies, so the user-chosen part is rarely meaningful.

### Description of changes

- Marked `cognitoDomain` as optional in `schema.json` / `schema.d.ts` and tweaked the schema description (and the i18n English source string) so docs reflect the new behavior.
- When `cognitoDomain` is missing or empty, the generator now derives a Cognito-compatible hosted prefix from the npm scope and the website project name. The new `deriveCognitoDomainPrefix` helper:
  - Kebab-cases the scope + project name (using the existing `kebabCase` util).
  - Strips Cognito's reserved words (`aws`, `amazon`, `cognito`) — verified by hitting `cognito-idp create-user-pool-domain` against a real account, which rejects them with `Domain cannot contain reserved word`.
  - Caps the result at 41 characters so the longest IaC-appended suffix (Terraform's `-<12-digit account id>-<8-char hex>` = 22 chars) still fits inside Cognito's 63-character `Domain` limit.
- Removed the existing "must be specified" error path and replaced it with two unit tests: one that confirms a derived value when scope and project are supplied, and one that confirms an empty string is treated like an omitted value. Added a third test that exercises the reserved-word stripping (scope `@cognito-test`, project `aws-project`).

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -t cognito-auth -u` — 1832/1832 passing.
- `pnpm nx run-many --target build --all` — green.
- End-to-end deploy in `us-west-2` against a fresh `pnpm create @aws/nx-workspace cognito-test` workspace with the linked plugin: generated two react websites (`demo-website`, `second-website`), ran the auth generator on both with no `cognitoDomain`, generated a CDK infra app wiring both websites + `UserIdentity`, and `cdk deploy`'d. The resulting `AWS::Cognito::UserPoolDomain` came up `ACTIVE` with `Domain = test-demo-website-597088032894` (note "cognito" stripped from the `cognito-test` scope). Stack was `cdk destroy`'d and the orphan resources (deletion-protected user pool + SMS role) were cleaned up manually.
- Confirmed the reserved-word constraint by calling `aws cognito-idp create-user-pool-domain` against a throwaway pool with prefixes containing `aws`, `amazon`, `cognito`, `amazonaws` — all four were rejected with `InvalidParameterException: Domain cannot contain reserved word`.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*