### PR TITLE
feat(agent): log clear error when a model invocation fails

### DIFF
--- a/e2e/src/files/dungeon-adventure/3/agent.py.old.template
+++ b/e2e/src/files/dungeon-adventure/3/agent.py.old.template
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 
-from dungeon_adventure_agent_connection import InventoryMcpServerClient
+from dungeon_adventure_agent_connection import InventoryMcpServerClient, log_model_errors
 from strands import Agent, tool
 from strands_tools import current_time
 
@@ -25,4 +25,5 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
             tools=[subtract, current_time, *inventory_mcp_server.list_tools_sync()],
+            hooks=[log_model_errors],
         )

--- a/e2e/src/files/dungeon-adventure/3/agent.py.template
+++ b/e2e/src/files/dungeon-adventure/3/agent.py.template
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 
-from dungeon_adventure_agent_connection import InventoryMcpServerClient
+from dungeon_adventure_agent_connection import InventoryMcpServerClient, log_model_errors
 from strands import Agent
 
 
@@ -27,4 +27,5 @@ Items should be a key part of the narrative.
 Keep responses under 100 words.
 """,
             tools=[*inventory_mcp_server.list_tools_sync()],
+            hooks=[log_model_errors],
         )

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -633,6 +633,7 @@ exports[`py#agent generator > should match snapshot for generated files > agent-
 
 from strands import Agent, tool
 from strands_tools import current_time
+from proj_agent_connection import log_model_errors
 
 
 @tool
@@ -651,6 +652,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
+        hooks=[log_model_errors],
     )
 "
 `;

--- a/packages/nx-plugin/src/py/agent/files/common/agent.py.template
+++ b/packages/nx-plugin/src/py/agent/files/common/agent.py.template
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 from strands import Agent, tool
 from strands_tools import current_time
+from <%- agentConnectionModuleName %> import log_model_errors
 
 
 @tool
@@ -20,4 +21,5 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
+        hooks=[log_model_errors],
     )

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -7,6 +7,9 @@ from .core.session_context import get_current_session_id, session_id_context
 
 from .app.inventory_mcp_client import InventoryMcpClient
 
+from .core.model_errors import log_model_errors
+
+
 from .core.with_session_id import with_session_id
 
 
@@ -14,6 +17,7 @@ __all__ = [
     "get_current_session_id",
     "session_id_context",
     "with_session_id",
+    "log_model_errors",
     "InventoryMcpClient",
 ]
 "

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -629,6 +629,7 @@ output "agent_runtime_version" {
 
 exports[`ts#agent generator > should match snapshot for generated files > agent-agent.ts 1`] = `
 "import { Agent, tool } from '@strands-agents/sdk';
+import { logModelErrors } from ':proj/agent-connection';
 import { z } from 'zod';
 
 const multiply = tool({
@@ -641,13 +642,16 @@ const multiply = tool({
   callback: ({ a, b }) => a * b,
 });
 
-export const getAgent = async () =>
-  new Agent({
+export const getAgent = async () => {
+  const agent = new Agent({
     systemPrompt: \`You are a mathematical wizard.
   Use your tools for mathematical tasks.
   Refer to tools as your 'spellbook'.\`,
     tools: [multiply],
   });
+  logModelErrors(agent);
+  return agent;
+};
 "
 `;
 

--- a/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
@@ -1,4 +1,5 @@
 import { Agent, tool } from '@strands-agents/sdk';
+import { logModelErrors } from '<%- agentConnectionImport %>';
 import { z } from 'zod';
 
 const multiply = tool({
@@ -11,10 +12,13 @@ const multiply = tool({
   callback: ({ a, b }) => a * b,
 });
 
-export const getAgent = async () =>
-  new Agent({
+export const getAgent = async () => {
+  const agent = new Agent({
     systemPrompt: `You are a mathematical wizard.
   Use your tools for mathematical tasks.
   Refer to tools as your 'spellbook'.`,
     tools: [multiply],
   });
+  logModelErrors(agent);
+  return agent;
+};

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agent-connection-index.ts 1`] = `
 "export * from './app/inventory-mcp-client.js';
+export * from './core/model-errors.js';
 export * from './core/with-session-id.js';
 export * from './core/session-context.js';
 // Export your library code here

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -122,6 +122,11 @@ export async function ensureTypeScriptAgentConnectionProject(
     joinPathFragments(AGENT_CONNECTION_PROJECT_DIR, 'src', 'index.ts'),
     './core/with-session-id.js',
   );
+  await addStarExport(
+    tree,
+    joinPathFragments(AGENT_CONNECTION_PROJECT_DIR, 'src', 'index.ts'),
+    './core/model-errors.js',
+  );
 }
 
 /**
@@ -209,9 +214,19 @@ export async function ensurePythonAgentConnectionProject(
     '.core.with_session_id',
     'with_session_id',
   );
+  await addPythonReExport(
+    tree,
+    moduleInitPath,
+    '.core.model_errors',
+    'log_model_errors',
+  );
 
-  // Shared core helpers depend on aws-lambda-powertools for AppConfig access.
-  addDependenciesToPyProjectToml(tree, projectDir, ['aws-lambda-powertools']);
+  // Shared core helpers depend on aws-lambda-powertools for AppConfig access
+  // and strands-agents for the model error-logging hook.
+  addDependenciesToPyProjectToml(tree, projectDir, [
+    'aws-lambda-powertools',
+    'strands-agents',
+  ]);
 }
 
 /**

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/model-errors.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/model-errors.ts.template
@@ -1,0 +1,36 @@
+import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';
+
+const NO_CREDENTIALS =
+  'Unable to invoke the model: no AWS credentials found. Configure credentials ' +
+  '(e.g. run `aws configure`, set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / ' +
+  'AWS_SESSION_TOKEN, or assume a role) before running the agent.';
+const ACCESS_DENIED =
+  'Unable to invoke the model: access denied. Grant your AWS principal permission ' +
+  'to call bedrock:InvokeModelWithResponseStream for your model.';
+
+// AWS SDK v3 errors are identified by their `name` rather than `instanceof`,
+// since the SDK may be loaded from more than one place. Strands wraps them in a
+// ModelError, so we check the error and its `cause` chain.
+const hasErrorNamed = (error: unknown, name: string): boolean => {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    if (current.name === name) return true;
+    current = current.cause;
+  }
+  return false;
+};
+
+/** Logs model invocation errors, calling out missing credentials or denied permissions. */
+export const logModelErrors = (agent: LocalAgent): void => {
+  agent.addHook(AfterModelCallEvent, (event) => {
+    const error = event.error;
+    if (!error) return;
+    if (hasErrorNamed(error, 'CredentialsProviderError')) {
+      console.error(NO_CREDENTIALS);
+    } else if (hasErrorNamed(error, 'AccessDeniedException')) {
+      console.error(ACCESS_DENIED);
+    } else {
+      console.error(`Model invocation failed: ${error.message}`);
+    }
+  });
+};

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/model_errors.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/model_errors.py.template
@@ -1,0 +1,40 @@
+import logging
+
+from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
+from strands.hooks import AfterModelCallEvent, HookRegistry
+
+logger = logging.getLogger(__name__)
+
+_NO_CREDENTIALS = (
+    "Unable to invoke the model: no AWS credentials found. Configure credentials "
+    "(e.g. run `aws configure`, set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / "
+    "AWS_SESSION_TOKEN, or assume a role) before running the agent."
+)
+_ACCESS_DENIED = (
+    "Unable to invoke the model: access denied. Grant your AWS principal permission "
+    "to call bedrock:InvokeModelWithResponseStream for your model."
+)
+
+
+def _is_access_denied(error: BaseException) -> bool:
+    return isinstance(error, ClientError) and error.response.get("Error", {}).get("Code") == "AccessDeniedException"
+
+
+class _LogModelErrors:
+    def register_hooks(self, registry: HookRegistry, **_kwargs) -> None:
+        registry.add_callback(AfterModelCallEvent, self._on_after_model_call)
+
+    @staticmethod
+    def _on_after_model_call(event: AfterModelCallEvent) -> None:
+        error = event.exception
+        if error is None:
+            return
+        if isinstance(error, (NoCredentialsError, PartialCredentialsError)):
+            logger.error(_NO_CREDENTIALS)
+        elif _is_access_denied(error):
+            logger.error(_ACCESS_DENIED)
+        else:
+            logger.error("Model invocation failed: %s", error)
+
+
+log_model_errors = _LogModelErrors()


### PR DESCRIPTION
### Reason for this change

When a generated Strands Agent failed to invoke its model — most commonly because AWS credentials were missing or lacked permission to call Amazon Bedrock — the failure surfaced as an opaque transport error with no indication of the cause or the fix:

- **Py HTTP**: `200 OK` with an empty stream.
- **Py A2A**: task `failed` with the SDK's generic `"Agent execution failed"`.
- **Py AG-UI**: a silent `RUN_FINISHED` with no assistant output.
- **TS HTTP / A2A**: a raw `Could not load credentials from any providers` error.

None of these told the developer what was wrong or how to fix it.

### Description of changes

Every protocol (HTTP, A2A, AG-UI) for a given language shares a single agent factory (`agent.py` / `agent.ts`), and both Strands SDKs fire an `AfterModelCallEvent` carrying the model-call exception on failure. So rather than adding per-protocol middleware, a **single error-logging hook registered at agent construction** covers all three protocols.

The shared `agent-connection` library vends `log_model_errors` (Python) / `logModelErrors` (TypeScript). The hook classifies the failure **by exception type — not string matching** — and logs a specific, actionable message:

| Failure | Python detection | TypeScript detection | Logged message |
|---|---|---|---|
| Missing credentials | `isinstance(NoCredentialsError \| PartialCredentialsError)` | `CredentialsProviderError` in the error's `cause` chain (matched by `name`) | "no AWS credentials found. Configure credentials…" |
| Access denied | botocore `ClientError` with `Error.Code == "AccessDeniedException"` | `AccessDeniedException` in the `cause` chain | "access denied. Grant your AWS principal permission to call `bedrock:InvokeModelWithResponseStream`…" |
| Any other model error | — | — | logged verbatim |

AWS SDK v3 (TS) errors are matched on their stable `name` discriminant walked through the `cause` chain (the SDK can be loaded from more than one place, so `instanceof` is unreliable); botocore (Python) is matched with `isinstance` and the error code.

The generated agent registers the hook in a single line:

```python
# agent.py
yield Agent(..., hooks=[log_model_errors])
```

```typescript
// agent.ts
const agent = new Agent({ ... });
logModelErrors(agent);
```

The per-protocol server entry points (`main.py` / `init.ts` / `index.ts`) are **unchanged from main** — no middleware, executor subclasses, protected-field casts, or AG-UI endpoint rewrites.

### Description of how you validated changes

Verified **end-to-end in a generated workspace** (TS and Python HTTP agents run locally):

- **No credentials** (`AWS_EC2_METADATA_DISABLED=true`, creds unset): both log the *"no AWS credentials found"* message.
- **No permissions** (credentials from an IAM role lacking Bedrock access): both log the *"access denied"* message.
- **Valid credentials**: both stream a normal model response with no error logged.

Also:
- `pnpm nx run @aws/nx-plugin:test -u` — all 2010 tests passing.
- `pnpm nx run-many --target build --all` — passes.
- `pnpm nx run-many --target lint --all --fix` — passes.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
