### PR TITLE
fix(ast): contain GritQL stdlib download to workspace .grit directory

### DIFF
--- a/packages/nx-plugin/src/connection/generator.ts
+++ b/packages/nx-plugin/src/connection/generator.ts
@@ -435,7 +435,7 @@ const isTrpcApi = async (
   }
 
   // If the index file exports an AppRouter, it's a trpc api
-  if (await hasExportDeclaration(indexTs, 'AppRouter')) {
+  if (await hasExportDeclaration(tree, indexTs, 'AppRouter')) {
     return true;
   }
 
@@ -458,7 +458,7 @@ const isTrpcApi = async (
     return false;
   }
 
-  if (await hasExportDeclaration(trpcRouter, 'AppRouter')) {
+  if (await hasExportDeclaration(tree, trpcRouter, 'AppRouter')) {
     return true;
   }
 

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`preset generator > should run successfully > .gitignore 1`] = `".grit"`;
+
 exports[`preset generator > should run successfully > .prettierignore 1`] = `
 "# Add files here to ignore them from prettier formatting
 /dist

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -1,7 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`preset generator > should run successfully > .gitignore 1`] = `".grit"`;
-
 exports[`preset generator > should run successfully > .prettierignore 1`] = `
 "# Add files here to ignore them from prettier formatting
 /dist

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -900,7 +900,6 @@ output "cloudfront_domain_name" {
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > .gitignore 1`] = `
 "vite.config.*.timestamp*
 vitest.config.*.timestamp*
-.grit
 
 runtime-config.json"
 `;
@@ -2521,7 +2520,6 @@ exports[`react-website generator > Tanstack router integration > should generate
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > .gitignore 1`] = `
 "vite.config.*.timestamp*
 vitest.config.*.timestamp*
-.grit
 
 runtime-config.json"
 `;

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -900,6 +900,7 @@ output "cloudfront_domain_name" {
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > .gitignore 1`] = `
 "vite.config.*.timestamp*
 vitest.config.*.timestamp*
+.grit
 
 runtime-config.json"
 `;
@@ -2520,6 +2521,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > .gitignore 1`] = `
 "vite.config.*.timestamp*
 vitest.config.*.timestamp*
+.grit
 
 runtime-config.json"
 `;

--- a/packages/nx-plugin/src/utils/ast.spec.ts
+++ b/packages/nx-plugin/src/utils/ast.spec.ts
@@ -170,12 +170,12 @@ describe('ast utils', () => {
   describe('hasExportDeclaration', () => {
     it('should return true for exported type alias declarations', async () => {
       const source = `export type MyType = string;`;
-      expect(await hasExportDeclaration(source, 'MyType')).toBe(true);
+      expect(await hasExportDeclaration(tree, source, 'MyType')).toBe(true);
     });
 
     it('should return false for non-exported type alias declarations', async () => {
       const source = `type MyType = string;`;
-      expect(await hasExportDeclaration(source, 'MyType')).toBe(false);
+      expect(await hasExportDeclaration(tree, source, 'MyType')).toBe(false);
     });
 
     it('should return true for export declarations', async () => {
@@ -183,17 +183,17 @@ describe('ast utils', () => {
         type MyType = string;
         export { MyType };
       `;
-      expect(await hasExportDeclaration(source, 'MyType')).toBe(true);
+      expect(await hasExportDeclaration(tree, source, 'MyType')).toBe(true);
     });
 
     it('should return false when type alias does not exist', async () => {
       const source = `type OtherType = string;`;
-      expect(await hasExportDeclaration(source, 'MyType')).toBe(false);
+      expect(await hasExportDeclaration(tree, source, 'MyType')).toBe(false);
     });
 
     it('should return true for re-exported types', async () => {
       const source = `export type { AppRouter } from "./router";`;
-      expect(await hasExportDeclaration(source, 'AppRouter')).toBe(true);
+      expect(await hasExportDeclaration(tree, source, 'AppRouter')).toBe(true);
     });
   });
 

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -4,31 +4,15 @@
  */
 import { Tree } from '@nx/devkit';
 import { QueryBuilder } from '@getgrit/gritql';
-import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { updateGitIgnore } from './git';
 
 const GRIT_DIR = '.grit';
 
-// The native gritql library unconditionally initializes a "global" .grit
-// directory the first time a QueryBuilder is used. By default it derives
-// the path from the running node binary (e.g. `/usr/local/.grit` for system-
-// installed node), which is typically not writable and causes generators to
-// fail or pollute system directories. Pin it to a `.grit` directory at the
-// workspace root and ensure it is gitignored. For virtual test trees whose
-// root does not exist on disk, fall back to a path under the OS tempdir
-// so the native fetcher has somewhere writable. Respect any explicit
-// override by the user.
-const ensureGritGlobalDir = (tree: Tree) => {
-  if (!process.env.GRIT_GLOBAL_DIR) {
-    process.env.GRIT_GLOBAL_DIR = fs.existsSync(tree.root)
-      ? path.join(tree.root, GRIT_DIR)
-      : path.join(os.tmpdir(), '.aws-nx-plugin-grit');
-  }
-  if (fs.existsSync(tree.root)) {
-    updateGitIgnore(tree, '.', (patterns) => [...patterns, GRIT_DIR]);
-  }
+// Pin the gritql native library's "global" stdlib directory to <workspace>/.grit so it doesn't try to write to /usr/local/.grit (or wherever node's grandparent resolves to).
+const ensureGritDir = (tree: Tree) => {
+  process.env.GRIT_GLOBAL_DIR ??= path.join(tree.root, GRIT_DIR);
+  updateGitIgnore(tree, '.', (patterns) => [...patterns, GRIT_DIR]);
 };
 
 const assertFilePath = (tree: Tree, filePath: string) => {
@@ -212,7 +196,7 @@ export const hasExportDeclaration = async (
   source: string,
   identifierName: string,
 ): Promise<boolean> => {
-  ensureGritGlobalDir(tree);
+  ensureGritDir(tree);
   const patterns = [
     `\`export type ${identifierName} = $_\``,
     `\`export { ${identifierName} }\``,
@@ -244,7 +228,7 @@ export const applyGritQL = async (
   pattern: string,
 ): Promise<boolean> => {
   if (!tree.exists(filePath)) throw new Error(`No file at ${filePath}`);
-  ensureGritGlobalDir(tree);
+  ensureGritDir(tree);
   const source = tree.read(filePath)!.toString();
   const query = new QueryBuilder(pattern);
   const result = await query.applyToFile({ path: filePath, content: source });
@@ -269,7 +253,7 @@ export const matchGritQL = async (
   pattern: string,
 ): Promise<boolean> => {
   if (!tree.exists(filePath)) return false;
-  ensureGritGlobalDir(tree);
+  ensureGritDir(tree);
   const source = tree.read(filePath)!.toString();
   let matched = false;
   try {

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -4,6 +4,24 @@
  */
 import { Tree } from '@nx/devkit';
 import { QueryBuilder } from '@getgrit/gritql';
+import * as path from 'path';
+import { updateGitIgnore } from './git';
+
+const GRIT_DIR = '.grit';
+
+// The native gritql library unconditionally initializes a "global" .grit
+// directory the first time a QueryBuilder is used. By default it derives
+// the path from the running node binary (e.g. `/usr/local/.grit` for system-
+// installed node), which is typically not writable and causes generators to
+// fail or pollute system directories. Pin it to a `.grit` directory at the
+// workspace root and ensure it is gitignored. Respect any explicit override
+// by the user.
+const ensureGritGlobalDir = (tree: Tree) => {
+  if (!process.env.GRIT_GLOBAL_DIR) {
+    process.env.GRIT_GLOBAL_DIR = path.join(tree.root, GRIT_DIR);
+  }
+  updateGitIgnore(tree, '.', (patterns) => [...patterns, GRIT_DIR]);
+};
 
 const assertFilePath = (tree: Tree, filePath: string) => {
   if (!tree.exists(filePath)) {
@@ -182,9 +200,11 @@ export const addStarExport = async (
  * Checks for both `export { Identifier }` and `export type Identifier = ...`.
  */
 export const hasExportDeclaration = async (
+  tree: Tree,
   source: string,
   identifierName: string,
 ): Promise<boolean> => {
+  ensureGritGlobalDir(tree);
   const patterns = [
     `\`export type ${identifierName} = $_\``,
     `\`export { ${identifierName} }\``,
@@ -216,6 +236,7 @@ export const applyGritQL = async (
   pattern: string,
 ): Promise<boolean> => {
   if (!tree.exists(filePath)) throw new Error(`No file at ${filePath}`);
+  ensureGritGlobalDir(tree);
   const source = tree.read(filePath)!.toString();
   const query = new QueryBuilder(pattern);
   const result = await query.applyToFile({ path: filePath, content: source });
@@ -240,6 +261,7 @@ export const matchGritQL = async (
   pattern: string,
 ): Promise<boolean> => {
   if (!tree.exists(filePath)) return false;
+  ensureGritGlobalDir(tree);
   const source = tree.read(filePath)!.toString();
   let matched = false;
   try {

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -4,6 +4,8 @@
  */
 import { Tree } from '@nx/devkit';
 import { QueryBuilder } from '@getgrit/gritql';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { updateGitIgnore } from './git';
 
@@ -14,13 +16,19 @@ const GRIT_DIR = '.grit';
 // the path from the running node binary (e.g. `/usr/local/.grit` for system-
 // installed node), which is typically not writable and causes generators to
 // fail or pollute system directories. Pin it to a `.grit` directory at the
-// workspace root and ensure it is gitignored. Respect any explicit override
-// by the user.
+// workspace root and ensure it is gitignored. For virtual test trees whose
+// root does not exist on disk, fall back to a path under the OS tempdir
+// so the native fetcher has somewhere writable. Respect any explicit
+// override by the user.
 const ensureGritGlobalDir = (tree: Tree) => {
   if (!process.env.GRIT_GLOBAL_DIR) {
-    process.env.GRIT_GLOBAL_DIR = path.join(tree.root, GRIT_DIR);
+    process.env.GRIT_GLOBAL_DIR = fs.existsSync(tree.root)
+      ? path.join(tree.root, GRIT_DIR)
+      : path.join(os.tmpdir(), '.aws-nx-plugin-grit');
   }
-  updateGitIgnore(tree, '.', (patterns) => [...patterns, GRIT_DIR]);
+  if (fs.existsSync(tree.root)) {
+    updateGitIgnore(tree, '.', (patterns) => [...patterns, GRIT_DIR]);
+  }
 };
 
 const assertFilePath = (tree: Tree, filePath: string) => {

--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
     env: {
       NX_DAEMON: 'false',
       NX_NATIVE_LOGGING: 'error',
+      GRIT_GLOBAL_DIR: '/tmp/.grit',
     },
     watch: false,
     globals: true,

--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -23,7 +23,6 @@ export default defineConfig({
     env: {
       NX_DAEMON: 'false',
       NX_NATIVE_LOGGING: 'error',
-      GRIT_GLOBAL_DIR: '/tmp/.grit',
     },
     watch: false,
     globals: true,


### PR DESCRIPTION
### Reason for this change

The native `@getgrit/gritql` library unconditionally downloads the GritQL standard library (~2.2MB) into a "global" `.grit` directory the first time a `QueryBuilder` is used. By default it derives the path from the running node binary's grandparent (e.g. `/usr/local/.grit` for system-installed node), which is typically not writable.

This caused generators that use GritQL (notably `ts#react-website` and `ts#react-website#auth`) to fail with errors like:

```
Failed to fetch standard library grit module getgrit/stdlib. Try running `grit init` first to create a local .grit directory.
Original error: Failed to clone repo getgrit/stdlib: failed to make directory '/usr/local/.grit': Permission denied
```

…and even when the path was writable, it polluted system directories with a hidden `.grit` folder.

A previous workaround in `vite.config.mts` set `GRIT_GLOBAL_DIR=/tmp/.grit` for the unit-test environment only, leaving the issue unresolved for actual users.

### Description of changes

- Added `ensureGritGlobalDir(tree)` in `packages/nx-plugin/src/utils/ast.ts` that pins `GRIT_GLOBAL_DIR` to `<workspace-root>/.grit` and adds `.grit` to the workspace `.gitignore` (via the existing idempotent `updateGitIgnore` helper). The user can still override with their own `GRIT_GLOBAL_DIR`.
- Called `ensureGritGlobalDir` from every `QueryBuilder` entry point: `applyGritQL`, `matchGritQL`, and `hasExportDeclaration`.
- Added `tree: Tree` as the first parameter of `hasExportDeclaration` (and updated its callers in `connection/generator.ts` and the spec) so it can access the workspace.
- Removed the now-redundant `GRIT_GLOBAL_DIR: '/tmp/.grit'` test workaround from `packages/nx-plugin/vite.config.mts`.
- Updated affected snapshots reflecting the new `.grit` `.gitignore` entry.

### Description of how you validated changes

- All 1830 unit tests pass (`pnpm nx run @aws/nx-plugin:test`).
- Lint passes (`pnpm nx run @aws/nx-plugin:lint`).
- End-to-end: created a fresh workspace via `pnpm create @aws/nx-workspace`, linked the local plugin, then ran `ts#react-website` followed by `ts#react-website#auth` with `GRIT_GLOBAL_DIR` unset. The stdlib was downloaded to `<workspace>/.grit` (not `/usr/local/.grit` or `/tmp/.grit`), and a single `.grit` entry was added to `.gitignore` — re-running the generator did not duplicate the entry.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*