### PR TITLE
feat(preset): add opt-in finch container engine support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           - license-sync
           - mcp-server
           - git-secrets
+          - finch
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,6 +71,7 @@ jobs:
           - license-sync
           - mcp-server
           - git-secrets
+          - finch
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/src/content/docs/en/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/en/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Several generators (such as <Link path="/guides/ts-agent">`ts#agent`</Link> and <Link path="/guides/py-agent">`py#agent`</Link>) produce a Docker image that is pushed to Amazon ECR and consumed by AWS infrastructure. This guide describes the pattern they follow so that you can apply it to other use cases — for example, running a <Link path="/guides/fastapi">`py#fast-api`</Link> project on Amazon ECS, or deploying a containerised Express server.
 
+:::tip[Docker or Finch]
+The container engine used to build images is chosen at workspace creation time via the `--containerEngine` flag (`docker`, `finch`, or `infer` — the default — which auto-detects what's installed). [Finch](https://runfinch.com/) is an open-source, drop-in alternative to Docker. The selection is recorded in `aws-nx-plugin.config.mts` and applied to every generator that emits container build commands. CDK image asset builds honour the choice via the `CDK_DOCKER` environment variable.
+:::
+
 ## The Pattern
 
 ```d2

--- a/docs/src/content/docs/en/guides/workspace.mdx
+++ b/docs/src/content/docs/en/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 For full details on managing patterns, see the [git-secrets documentation](https://github.com/awslabs/git-secrets#readme).
+
+## Nx Plugin for AWS Configuration
+
+The workspace ships with an `aws-nx-plugin.config.mts` file at the root. Generators read this file to pick sensible defaults so you don't have to pass the same flags every time. Two settings are particularly useful:
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — the default infrastructure-as-code provider (`CDK` or `Terraform`) used by generators that emit infrastructure (e.g. `ts#infra`, `ts#trpc-api`, `py#fast-api`). Generators that accept an `--iacProvider` flag default to `Inherit`, which reads this value.
+- **`containers.engine`** — the container CLI (`docker` or `finch`) baked into generated build/push/login commands. CDK image-asset builds also pick this up via the `CDK_DOCKER` environment variable. See the <Link path="guides/docker-bundling">Docker bundling guide</Link> for details.
+
+You can edit either setting at any time — subsequent generator runs will pick up the new value.

--- a/docs/src/content/docs/es/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/es/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Varios generadores (como <Link path="/guides/ts-agent">`ts#agent`</Link> y <Link path="/guides/py-agent">`py#agent`</Link>) producen una imagen Docker que se envía a Amazon ECR y es consumida por la infraestructura de AWS. Esta guía describe el patrón que siguen para que puedas aplicarlo a otros casos de uso — por ejemplo, ejecutar un proyecto <Link path="/guides/fastapi">`py#fast-api`</Link> en Amazon ECS, o desplegar un servidor Express en contenedor.
 
+:::tip[Docker o Finch]
+El motor de contenedores utilizado para construir imágenes se elige en el momento de creación del espacio de trabajo mediante la bandera `--containerEngine` (`docker`, `finch`, o `infer` — el valor predeterminado — que detecta automáticamente lo que está instalado). [Finch](https://runfinch.com/) es una alternativa de código abierto y compatible con Docker. La selección se registra en `aws-nx-plugin.config.mts` y se aplica a cada generador que emite comandos de construcción de contenedores. Las construcciones de activos de imagen de CDK respetan la elección a través de la variable de entorno `CDK_DOCKER`.
+:::
+
 ## El Patrón
 
 ```d2

--- a/docs/src/content/docs/es/guides/workspace.mdx
+++ b/docs/src/content/docs/es/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 Para detalles completos sobre la gestión de patrones, consulta la [documentación de git-secrets](https://github.com/awslabs/git-secrets#readme).
+
+## Configuración del Nx Plugin for AWS
+
+El espacio de trabajo incluye un archivo `aws-nx-plugin.config.mts` en la raíz. Los generadores leen este archivo para elegir valores predeterminados sensatos, de modo que no tengas que pasar las mismas banderas cada vez. Dos configuraciones son particularmente útiles:
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — el proveedor de infraestructura como código predeterminado (`CDK` o `Terraform`) utilizado por los generadores que emiten infraestructura (por ejemplo, `ts#infra`, `ts#trpc-api`, `py#fast-api`). Los generadores que aceptan una bandera `--iacProvider` tienen como valor predeterminado `Inherit`, que lee este valor.
+- **`containers.engine`** — la CLI de contenedores (`docker` o `finch`) integrada en los comandos generados de build/push/login. Las construcciones de image-asset de CDK también toman esto a través de la variable de entorno `CDK_DOCKER`. Consulta la <Link path="guides/docker-bundling">guía de empaquetado de Docker</Link> para más detalles.
+
+Puedes editar cualquiera de estas configuraciones en cualquier momento — las ejecuciones posteriores del generador tomarán el nuevo valor.

--- a/docs/src/content/docs/fr/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/fr/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Plusieurs générateurs (tels que <Link path="/guides/ts-agent">`ts#agent`</Link> et <Link path="/guides/py-agent">`py#agent`</Link>) produisent une image Docker qui est poussée vers Amazon ECR et consommée par l'infrastructure AWS. Ce guide décrit le modèle qu'ils suivent afin que vous puissiez l'appliquer à d'autres cas d'usage — par exemple, exécuter un projet <Link path="/guides/fastapi">`py#fast-api`</Link> sur Amazon ECS, ou déployer un serveur Express conteneurisé.
 
+:::tip[Docker ou Finch]
+Le moteur de conteneurs utilisé pour construire les images est choisi au moment de la création de l'espace de travail via le flag `--containerEngine` (`docker`, `finch`, ou `infer` — la valeur par défaut — qui détecte automatiquement ce qui est installé). [Finch](https://runfinch.com/) est une alternative open-source et compatible avec Docker. La sélection est enregistrée dans `aws-nx-plugin.config.mts` et appliquée à chaque générateur qui émet des commandes de construction de conteneurs. Les constructions d'assets d'image CDK respectent ce choix via la variable d'environnement `CDK_DOCKER`.
+:::
+
 ## Le Modèle
 
 ```d2

--- a/docs/src/content/docs/fr/guides/workspace.mdx
+++ b/docs/src/content/docs/fr/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 Pour tous les détails sur la gestion des modèles, consultez la [documentation git-secrets](https://github.com/awslabs/git-secrets#readme).
+
+## Configuration Nx Plugin for AWS
+
+L'espace de travail est livré avec un fichier `aws-nx-plugin.config.mts` à la racine. Les générateurs lisent ce fichier pour choisir des valeurs par défaut sensées afin que vous n'ayez pas à passer les mêmes flags à chaque fois. Deux paramètres sont particulièrement utiles :
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — le fournisseur d'infrastructure-as-code par défaut (`CDK` ou `Terraform`) utilisé par les générateurs qui émettent de l'infrastructure (par exemple `ts#infra`, `ts#trpc-api`, `py#fast-api`). Les générateurs qui acceptent un flag `--iacProvider` utilisent par défaut `Inherit`, qui lit cette valeur.
+- **`containers.engine`** — le CLI de conteneur (`docker` ou `finch`) intégré dans les commandes de build/push/login générées. Les builds d'image-asset CDK récupèrent également cette valeur via la variable d'environnement `CDK_DOCKER`. Consultez le <Link path="guides/docker-bundling">guide de bundling Docker</Link> pour plus de détails.
+
+Vous pouvez modifier l'un ou l'autre paramètre à tout moment — les exécutions ultérieures du générateur récupéreront la nouvelle valeur.

--- a/docs/src/content/docs/it/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/it/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Diversi generatori (come <Link path="/guides/ts-agent">`ts#agent`</Link> e <Link path="/guides/py-agent">`py#agent`</Link>) producono un'immagine Docker che viene caricata su Amazon ECR e utilizzata dall'infrastruttura AWS. Questa guida descrive il pattern che seguono in modo da poterlo applicare ad altri casi d'uso — ad esempio, eseguire un progetto <Link path="/guides/fastapi">`py#fast-api`</Link> su Amazon ECS o distribuire un server Express containerizzato.
 
+:::tip[Docker o Finch]
+Il motore di container utilizzato per costruire le immagini viene scelto al momento della creazione del workspace tramite il flag `--containerEngine` (`docker`, `finch`, o `infer` — il valore predefinito — che rileva automaticamente ciò che è installato). [Finch](https://runfinch.com/) è un'alternativa open-source e drop-in a Docker. La selezione viene registrata in `aws-nx-plugin.config.mts` e applicata a ogni generatore che emette comandi di build dei container. Le build degli asset immagine CDK rispettano la scelta tramite la variabile d'ambiente `CDK_DOCKER`.
+:::
+
 ## Il Pattern
 
 ```d2

--- a/docs/src/content/docs/it/guides/workspace.mdx
+++ b/docs/src/content/docs/it/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 Per dettagli completi sulla gestione dei pattern, consulta la [documentazione di git-secrets](https://github.com/awslabs/git-secrets#readme).
+
+## Configurazione Nx Plugin for AWS
+
+Il workspace include un file `aws-nx-plugin.config.mts` nella radice. I generatori leggono questo file per scegliere impostazioni predefinite sensate in modo da non dover passare gli stessi flag ogni volta. Due impostazioni sono particolarmente utili:
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — il provider infrastructure-as-code predefinito (`CDK` o `Terraform`) utilizzato dai generatori che emettono infrastruttura (ad es. `ts#infra`, `ts#trpc-api`, `py#fast-api`). I generatori che accettano un flag `--iacProvider` hanno come valore predefinito `Inherit`, che legge questo valore.
+- **`containers.engine`** — la CLI dei container (`docker` o `finch`) integrata nei comandi generati di build/push/login. Anche le build di image-asset CDK utilizzano questo valore tramite la variabile d'ambiente `CDK_DOCKER`. Consulta la <Link path="guides/docker-bundling">guida al bundling Docker</Link> per i dettagli.
+
+Puoi modificare entrambe le impostazioni in qualsiasi momento — le successive esecuzioni dei generatori utilizzeranno il nuovo valore.

--- a/docs/src/content/docs/jp/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/jp/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 いくつかのジェネレーター(<Link path="/guides/ts-agent">`ts#agent`</Link>や<Link path="/guides/py-agent">`py#agent`</Link>など)は、Amazon ECRにプッシュされ、AWSインフラストラクチャによって使用されるDockerイメージを生成します。このガイドでは、これらのジェネレーターが従うパターンについて説明し、他のユースケースに適用できるようにします。例えば、Amazon ECS上で<Link path="/guides/fastapi">`py#fast-api`</Link>プロジェクトを実行したり、コンテナ化されたExpressサーバーをデプロイしたりする場合などです。
 
+:::tip[DockerまたはFinch]
+イメージのビルドに使用されるコンテナエンジンは、ワークスペース作成時に`--containerEngine`フラグ(`docker`、`finch`、または`infer` — デフォルト — インストールされているものを自動検出)を介して選択されます。[Finch](https://runfinch.com/)は、Dockerのオープンソースのドロップイン代替品です。選択は`aws-nx-plugin.config.mts`に記録され、コンテナビルドコマンドを出力するすべてのジェネレーターに適用されます。CDKイメージアセットビルドは、`CDK_DOCKER`環境変数を介してこの選択を尊重します。
+:::
+
 ## パターン
 
 ```d2

--- a/docs/src/content/docs/jp/guides/workspace.mdx
+++ b/docs/src/content/docs/jp/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 パターン管理の詳細については、[git-secretsドキュメント](https://github.com/awslabs/git-secrets#readme)を参照してください。
+
+## Nx Plugin for AWS設定
+
+ワークスペースには、ルートに`aws-nx-plugin.config.mts`ファイルが付属しています。ジェネレーターはこのファイルを読み取って適切なデフォルト値を選択するため、毎回同じフラグを渡す必要がありません。特に便利な2つの設定があります：
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — インフラストラクチャを生成するジェネレーター（例：`ts#infra`、`ts#trpc-api`、`py#fast-api`）で使用されるデフォルトのInfrastructure as Codeプロバイダー（`CDK`または`Terraform`）。`--iacProvider`フラグを受け入れるジェネレーターは、デフォルトで`Inherit`に設定されており、この値を読み取ります。
+- **`containers.engine`** — 生成されたビルド/プッシュ/ログインコマンドに組み込まれるコンテナCLI（`docker`または`finch`）。CDKイメージアセットのビルドも、`CDK_DOCKER`環境変数を介してこれを取得します。詳細については、<Link path="guides/docker-bundling">Dockerバンドリングガイド</Link>を参照してください。
+
+いずれの設定もいつでも編集できます — 以降のジェネレーター実行で新しい値が適用されます。

--- a/docs/src/content/docs/ko/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/ko/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 여러 제너레이터(예: <Link path="/guides/ts-agent">`ts#agent`</Link> 및 <Link path="/guides/py-agent">`py#agent`</Link>)는 Amazon ECR로 푸시되고 AWS 인프라에서 사용되는 Docker 이미지를 생성합니다. 이 가이드는 이들이 따르는 패턴을 설명하므로 다른 사용 사례에 적용할 수 있습니다. 예를 들어 Amazon ECS에서 <Link path="/guides/fastapi">`py#fast-api`</Link> 프로젝트를 실행하거나 컨테이너화된 Express 서버를 배포하는 경우입니다.
 
+:::tip[Docker 또는 Finch]
+이미지를 빌드하는 데 사용되는 컨테이너 엔진은 워크스페이스 생성 시 `--containerEngine` 플래그(`docker`, `finch` 또는 `infer` — 기본값 — 설치된 것을 자동 감지)를 통해 선택됩니다. [Finch](https://runfinch.com/)는 Docker의 오픈 소스, 드롭인 대체 솔루션입니다. 선택 사항은 `aws-nx-plugin.config.mts`에 기록되며 컨테이너 빌드 명령을 생성하는 모든 제너레이터에 적용됩니다. CDK 이미지 자산 빌드는 `CDK_DOCKER` 환경 변수를 통해 선택 사항을 존중합니다.
+:::
+
 ## 패턴
 
 ```d2

--- a/docs/src/content/docs/ko/guides/workspace.mdx
+++ b/docs/src/content/docs/ko/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 패턴 관리에 대한 전체 세부 정보는 [git-secrets 문서](https://github.com/awslabs/git-secrets#readme)를 참조하세요.
+
+## Nx Plugin for AWS 구성
+
+워크스페이스는 루트에 `aws-nx-plugin.config.mts` 파일과 함께 제공됩니다. 생성기는 이 파일을 읽어 합리적인 기본값을 선택하므로 매번 동일한 플래그를 전달할 필요가 없습니다. 특히 유용한 두 가지 설정이 있습니다:
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — 인프라를 생성하는 생성기(예: `ts#infra`, `ts#trpc-api`, `py#fast-api`)에서 사용하는 기본 infrastructure-as-code 공급자(`CDK` 또는 `Terraform`). `--iacProvider` 플래그를 허용하는 생성기는 기본적으로 `Inherit`로 설정되며, 이 값을 읽습니다.
+- **`containers.engine`** — 생성된 빌드/푸시/로그인 명령에 포함되는 컨테이너 CLI(`docker` 또는 `finch`). CDK 이미지 에셋 빌드도 `CDK_DOCKER` 환경 변수를 통해 이를 사용합니다. 자세한 내용은 <Link path="guides/docker-bundling">Docker 번들링 가이드</Link>를 참조하세요.
+
+언제든지 두 설정을 편집할 수 있으며, 이후 생성기 실행 시 새 값이 적용됩니다.

--- a/docs/src/content/docs/pt/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/pt/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Vários geradores (como <Link path="/guides/ts-agent">`ts#agent`</Link> e <Link path="/guides/py-agent">`py#agent`</Link>) produzem uma imagem Docker que é enviada para o Amazon ECR e consumida pela infraestrutura AWS. Este guia descreve o padrão que eles seguem para que você possa aplicá-lo a outros casos de uso — por exemplo, executar um projeto <Link path="/guides/fastapi">`py#fast-api`</Link> no Amazon ECS, ou implantar um servidor Express containerizado.
 
+:::tip[Docker ou Finch]
+O motor de container usado para construir imagens é escolhido no momento da criação do workspace através da flag `--containerEngine` (`docker`, `finch`, ou `infer` — o padrão — que detecta automaticamente o que está instalado). [Finch](https://runfinch.com/) é uma alternativa open-source e drop-in para o Docker. A seleção é registrada em `aws-nx-plugin.config.mts` e aplicada a todos os geradores que emitem comandos de construção de container. As construções de assets de imagem do CDK respeitam a escolha através da variável de ambiente `CDK_DOCKER`.
+:::
+
 ## O Padrão
 
 ```d2

--- a/docs/src/content/docs/pt/guides/workspace.mdx
+++ b/docs/src/content/docs/pt/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 Para detalhes completos sobre gerenciamento de padrões, consulte a [documentação do git-secrets](https://github.com/awslabs/git-secrets#readme).
+
+## Configuração do Nx Plugin for AWS
+
+O workspace vem com um arquivo `aws-nx-plugin.config.mts` na raiz. Os geradores leem este arquivo para escolher padrões sensatos, para que você não precise passar as mesmas flags toda vez. Duas configurações são particularmente úteis:
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — o provedor de infraestrutura como código padrão (`CDK` ou `Terraform`) usado por geradores que emitem infraestrutura (por exemplo, `ts#infra`, `ts#trpc-api`, `py#fast-api`). Geradores que aceitam uma flag `--iacProvider` têm como padrão `Inherit`, que lê este valor.
+- **`containers.engine`** — a CLI de contêiner (`docker` ou `finch`) incorporada nos comandos de build/push/login gerados. Builds de image-asset do CDK também capturam isso através da variável de ambiente `CDK_DOCKER`. Consulte o <Link path="guides/docker-bundling">guia de bundling Docker</Link> para detalhes.
+
+Você pode editar qualquer uma das configurações a qualquer momento — execuções subsequentes do gerador irão capturar o novo valor.

--- a/docs/src/content/docs/vi/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/vi/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Một số generator (như <Link path="/guides/ts-agent">`ts#agent`</Link> và <Link path="/guides/py-agent">`py#agent`</Link>) tạo ra Docker image được đẩy lên Amazon ECR và được sử dụng bởi hạ tầng AWS. Hướng dẫn này mô tả mẫu thiết kế mà chúng tuân theo để bạn có thể áp dụng cho các trường hợp sử dụng khác — ví dụ, chạy dự án <Link path="/guides/fastapi">`py#fast-api`</Link> trên Amazon ECS, hoặc triển khai máy chủ Express được container hóa.
 
+:::tip[Docker hoặc Finch]
+Container engine được sử dụng để build image được chọn tại thời điểm tạo workspace thông qua flag `--containerEngine` (`docker`, `finch`, hoặc `infer` — mặc định — tự động phát hiện những gì đã được cài đặt). [Finch](https://runfinch.com/) là một giải pháp thay thế mã nguồn mở, thay thế trực tiếp cho Docker. Lựa chọn được ghi lại trong `aws-nx-plugin.config.mts` và áp dụng cho mọi generator phát ra các lệnh build container. CDK image asset builds tôn trọng lựa chọn này thông qua biến môi trường `CDK_DOCKER`.
+:::
+
 ## Mẫu Thiết Kế
 
 ```d2

--- a/docs/src/content/docs/vi/guides/workspace.mdx
+++ b/docs/src/content/docs/vi/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 Để biết đầy đủ chi tiết về quản lý các mẫu, xem [tài liệu git-secrets](https://github.com/awslabs/git-secrets#readme).
+
+## Cấu Hình Nx Plugin for AWS
+
+Workspace đi kèm với một tệp `aws-nx-plugin.config.mts` ở thư mục gốc. Các trình tạo đọc tệp này để chọn các giá trị mặc định hợp lý để bạn không phải truyền cùng các flag mỗi lần. Hai cài đặt đặc biệt hữu ích:
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — nhà cung cấp infrastructure-as-code mặc định (`CDK` hoặc `Terraform`) được sử dụng bởi các trình tạo phát ra cơ sở hạ tầng (ví dụ: `ts#infra`, `ts#trpc-api`, `py#fast-api`). Các trình tạo chấp nhận flag `--iacProvider` mặc định là `Inherit`, đọc giá trị này.
+- **`containers.engine`** — container CLI (`docker` hoặc `finch`) được tích hợp vào các lệnh build/push/login được tạo ra. Các bản build CDK image-asset cũng sử dụng giá trị này thông qua biến môi trường `CDK_DOCKER`. Xem <Link path="guides/docker-bundling">hướng dẫn Docker bundling</Link> để biết chi tiết.
+
+Bạn có thể chỉnh sửa bất kỳ cài đặt nào bất cứ lúc nào — các lần chạy trình tạo tiếp theo sẽ sử dụng giá trị mới.

--- a/docs/src/content/docs/zh/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/zh/guides/docker-bundling.mdx
@@ -10,6 +10,10 @@ import Infrastructure from '@components/infrastructure.astro';
 
 多个生成器(例如 <Link path="/guides/ts-agent">`ts#agent`</Link> 和 <Link path="/guides/py-agent">`py#agent`</Link>)会生成一个 Docker 镜像,该镜像被推送到 Amazon ECR 并由 AWS 基础设施使用。本指南描述了它们遵循的模式,以便您可以将其应用于其他用例——例如,在 Amazon ECS 上运行 <Link path="/guides/fastapi">`py#fast-api`</Link> 项目,或部署容器化的 Express 服务器。
 
+:::tip[Docker 或 Finch]
+用于构建镜像的容器引擎在工作空间创建时通过 `--containerEngine` 标志选择(`docker`、`finch` 或 `infer`——默认值——会自动检测已安装的引擎)。[Finch](https://runfinch.com/) 是 Docker 的开源即插即用替代方案。该选择记录在 `aws-nx-plugin.config.mts` 中,并应用于每个生成容器构建命令的生成器。CDK 镜像资产构建通过 `CDK_DOCKER` 环境变量遵循该选择。
+:::
+
 ## 模式
 
 ```d2

--- a/docs/src/content/docs/zh/guides/workspace.mdx
+++ b/docs/src/content/docs/zh/guides/workspace.mdx
@@ -156,3 +156,26 @@ EXAMPLE[A-Z]{16}
 ```
 
 有关管理模式的完整详细信息，请参阅 [git-secrets 文档](https://github.com/awslabs/git-secrets#readme)。
+
+## Nx Plugin for AWS 配置
+
+工作空间在根目录附带一个 `aws-nx-plugin.config.mts` 文件。生成器读取此文件以选择合理的默认值，这样您就不必每次都传递相同的标志。有两个设置特别有用：
+
+```typescript
+// aws-nx-plugin.config.mts
+import { AwsNxPluginConfig } from '@aws/nx-plugin';
+
+export default {
+  iac: {
+    provider: 'CDK', // or 'Terraform'
+  },
+  containers: {
+    engine: 'docker', // or 'finch'
+  },
+} satisfies AwsNxPluginConfig;
+```
+
+- **`iac.provider`** — 生成基础设施的生成器（例如 `ts#infra`、`ts#trpc-api`、`py#fast-api`）使用的默认基础设施即代码提供商（`CDK` 或 `Terraform`）。接受 `--iacProvider` 标志的生成器默认为 `Inherit`，它会读取此值。
+- **`containers.engine`** — 嵌入到生成的构建/推送/登录命令中的容器 CLI（`docker` 或 `finch`）。CDK 镜像资产构建也会通过 `CDK_DOCKER` 环境变量获取此值。有关详细信息，请参阅 <Link path="guides/docker-bundling">Docker 打包指南</Link>。
+
+您可以随时编辑任一设置——后续的生成器运行将获取新值。

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -174,6 +174,17 @@
       "it": "Se configurare git-secrets per impedire il commit di credenziali AWS.",
       "zh": "是否配置 git-secrets 以防止提交 AWS 凭证。",
       "vi": "Có cấu hình git-secrets để ngăn chặn commit thông tin xác thực AWS hay không."
+    },
+    "containerEngine": {
+      "en": "The container engine to use for build/push/login. 'infer' picks docker if installed, otherwise finch (falling back to docker when neither is installed).",
+      "es": "El motor de contenedores a utilizar para build/push/login. 'infer' selecciona docker si está instalado, de lo contrario finch (recurriendo a docker cuando ninguno está instalado).",
+      "fr": "Le moteur de conteneurs à utiliser pour build/push/login. 'infer' choisit docker s'il est installé, sinon finch (avec repli sur docker si aucun des deux n'est installé).",
+      "pt": "O motor de contêiner a ser usado para build/push/login. 'infer' escolhe docker se instalado, caso contrário finch (voltando para docker quando nenhum estiver instalado).",
+      "jp": "ビルド/プッシュ/ログインに使用するコンテナエンジン。'infer'はdockerがインストールされている場合はdockerを選択し、それ以外の場合はfinchを選択します（どちらもインストールされていない場合はdockerにフォールバックします）。",
+      "ko": "빌드/푸시/로그인에 사용할 컨테이너 엔진입니다. 'infer'는 docker가 설치되어 있으면 docker를 선택하고, 그렇지 않으면 finch를 선택합니다(둘 다 설치되지 않은 경우 docker로 폴백).",
+      "zh": "用于构建/推送/登录的容器引擎。'infer' 会在已安装 docker 时选择 docker，否则选择 finch（当两者都未安装时回退到 docker）。",
+      "vi": "Container engine được sử dụng để build/push/login. 'infer' sẽ chọn docker nếu đã cài đặt, nếu không sẽ dùng finch (quay lại docker khi cả hai đều chưa được cài đặt).",
+      "it": "Il motore di container da utilizzare per build/push/login. 'infer' seleziona docker se installato, altrimenti finch (con fallback a docker quando nessuno dei due è installato)."
     }
   },
   "py#fast-api": {

--- a/e2e/src/smoke-tests/finch-install.ts
+++ b/e2e/src/smoke-tests/finch-install.ts
@@ -1,0 +1,324 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync, spawn, spawnSync } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const FINCH_VERSION = '1.17.0';
+
+const sh = (cmd: string): void => {
+  console.log(`[finch-install] $ ${cmd}`);
+  execSync(cmd, { stdio: 'inherit' });
+};
+
+const isOnPath = (binary: string): boolean => {
+  try {
+    execSync(`command -v ${binary}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const hasRunningSystemd = (): boolean => {
+  // Canonical sd_booted(3) check: systemd PID 1 always exposes
+  // /run/systemd/system. CodeBuild container runners ship the systemctl
+  // binary (so wrapping execs around it succeeds in surprising ways) but
+  // do not have an init bus, hence checking the marker directly.
+  return existsSync('/run/systemd/system');
+};
+
+const waitForSocket = (
+  path: string,
+  timeoutMs = 60_000,
+  logPaths: string[] = [],
+): void => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (existsSync(path)) return;
+    execSync('sleep 1');
+  }
+  // Surface daemon logs to make timeouts diagnosable on CI.
+  for (const logPath of logPaths) {
+    if (existsSync(logPath)) {
+      console.error(`[finch-install] ----- ${logPath} -----`);
+      try {
+        console.error(readFileSync(logPath, 'utf-8'));
+      } catch (e) {
+        console.error(`(failed to read: ${(e as Error).message})`);
+      }
+    }
+  }
+  throw new Error(`Timed out waiting for socket ${path}`);
+};
+
+const startDaemonsViaSystemd = (): void => {
+  sh('sudo systemctl daemon-reload');
+  sh('sudo systemctl enable --now containerd');
+  sh(
+    'sudo systemctl enable --now finch-buildkit.socket finch-buildkit.service',
+  );
+  sh('sudo systemctl enable --now finch-soci.socket finch-soci.service');
+  sh('sudo systemctl enable --now finch.socket finch.service');
+  waitForSocket('/run/finch.sock');
+};
+
+const startDaemonsManually = (): void => {
+  // Mirror the systemd unit invocations shipped by the deb (see
+  // /etc/systemd/system/finch*.service) so callers get the same daemon
+  // topology on hosts without an active init system — e.g. CodeBuild
+  // container-based runners.
+  const logDir = join(tmpdir(), 'nx-plugin-for-aws', 'finch-logs');
+  sh(`mkdir -p "${logDir}"`);
+  sh('sudo mkdir -p /var/lib/finch /var/lib/containerd /run/finch');
+  // CodeBuild GHA runners are containers whose rootfs is overlayfs on a
+  // 4.14 Amazon Linux 2 kernel. BuildKit's cache mounts then try to
+  // overlay-mount on top of that, which the kernel rejects with EINVAL.
+  // Mount tmpfs on the dirs containerd/buildkit write to so their
+  // overlay mounts have a non-overlay filesystem to anchor on.
+  sh('sudo mount -t tmpfs -o size=8g tmpfs /var/lib/containerd || true');
+  sh('sudo mount -t tmpfs -o size=8g tmpfs /var/lib/finch || true');
+  sh('sudo mkdir -p /var/lib/finch/buildkit');
+
+  // sudo strips PATH via secure_path, so set the daemons' env explicitly
+  // via `sudo env VAR=...` rather than relying on spawn's `env` option
+  // (which only affects sudo itself, not its child).
+  const launch = (name: string, cmd: string[]): void => {
+    const out = openSync(join(logDir, `${name}.log`), 'a');
+    console.log(`[finch-install] starting ${name}: ${cmd.join(' ')}`);
+    const env = [
+      `PATH=/usr/libexec/finch:/usr/libexec/finch/cni/bin:${process.env.PATH ?? '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'}`,
+    ];
+    const child = spawn('sudo', ['env', ...env, ...cmd], {
+      stdio: ['ignore', out, out],
+      detached: true,
+    });
+    child.unref();
+  };
+
+  launch('containerd', ['containerd']);
+  waitForSocket('/run/containerd/containerd.sock', 60_000, [
+    join(logDir, 'containerd.log'),
+  ]);
+
+  // Bind buildkitd to the socket path the finch CLI hard-codes
+  // (pkg/path/finch_linux.go BuildkitSocketPath -> /var/lib/finch/buildkit).
+  // The finch wrapper sets BUILDKIT_HOST for nerdctl from this path, so a
+  // mismatch here causes finch build to silently fail to dial buildkit.
+  launch('finch-buildkit', [
+    '/usr/libexec/finch/buildkitd',
+    '--config',
+    '/etc/finch/buildkit/buildkitd.toml',
+    '--addr',
+    'unix:///var/lib/finch/buildkit/buildkitd.sock',
+  ]);
+  launch('finch-soci', [
+    '/usr/libexec/finch/soci-snapshotter-grpc',
+    '--config',
+    '/etc/finch/soci/soci-snapshotter-grpc.toml',
+    '--root',
+    '/var/lib/finch/soci',
+  ]);
+  launch('finch-daemon', [
+    '/usr/libexec/finch/finch-daemon',
+    '--debug',
+    '--config-file',
+    '/etc/finch/nerdctl/nerdctl.toml',
+    '--socket-addr',
+    '/run/finch.sock',
+  ]);
+  waitForSocket('/run/finch.sock', 60_000, [
+    join(logDir, 'finch-daemon.log'),
+    join(logDir, 'finch-buildkit.log'),
+    join(logDir, 'finch-soci.log'),
+  ]);
+  waitForSocket('/var/lib/finch/buildkit/buildkitd.sock', 60_000, [
+    join(logDir, 'finch-buildkit.log'),
+  ]);
+  // The daemon sockets default to mode 0600 owned by root. The smoke-test
+  // process runs unprivileged, but `finch build` dials buildkit directly
+  // (via nerdctl's BUILDKIT_HOST resolution) — so both sockets need to be
+  // reachable by the calling user.
+  sh('sudo chmod 666 /run/finch.sock');
+  sh('sudo chmod 666 /var/lib/finch/buildkit/buildkitd.sock');
+  sh('sudo chmod 666 /run/containerd/containerd.sock');
+};
+
+/**
+ * Install Finch on Linux from the upstream .deb package, pull in its
+ * containerd/runc dependencies, and start the finch-daemon so the
+ * Docker-compatible socket is ready before any generator tries to
+ * invoke `finch build` / `finch push` / etc.
+ *
+ * Uses systemd when the runner has a live dbus; otherwise launches the
+ * daemon binaries directly (CodeBuild container runners have systemctl
+ * on PATH but no init system actually running).
+ */
+export const installFinch = (): void => {
+  if (process.platform !== 'linux') {
+    throw new Error(
+      `installFinch is only supported on Linux (got ${process.platform})`,
+    );
+  }
+  if (!isOnPath('sudo') || !isOnPath('dpkg') || !isOnPath('apt-get')) {
+    throw new Error(
+      'installFinch requires sudo, dpkg, and apt-get — only Debian/Ubuntu hosts are supported',
+    );
+  }
+
+  if (isOnPath('finch')) {
+    console.log('[finch-install] finch already on PATH, skipping install');
+  } else {
+    const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+    const url = `https://github.com/runfinch/finch/releases/download/v${FINCH_VERSION}/runfinch-finch_${FINCH_VERSION}_${arch}.deb`;
+    const debPath = join(tmpdir(), `finch-${FINCH_VERSION}-${arch}.deb`);
+    sh(`curl -fsSL -o "${debPath}" "${url}"`);
+    sh('sudo apt-get update -y');
+    // The deb depends on containerd >= 1.7.24 and runc >= 1.1.5; let
+    // dpkg pull them in via apt-get -f after the unsatisfied install.
+    sh(`sudo dpkg -i "${debPath}" || sudo apt-get install -fy`);
+  }
+
+  if (hasRunningSystemd()) {
+    console.log('[finch-install] systemd is active, using systemctl');
+    startDaemonsViaSystemd();
+  } else {
+    console.log(
+      '[finch-install] no live systemd bus, launching daemons directly',
+    );
+    startDaemonsManually();
+  }
+
+  // finch CLI execs /usr/libexec/finch/nerdctl, which then forks buildctl
+  // via PATH lookup. /usr/libexec/finch isn't on the default PATH, so any
+  // downstream invocation (smoke test, generator targets) needs it added.
+  const finchLibexec = '/usr/libexec/finch';
+  if (!process.env.PATH?.split(':').includes(finchLibexec)) {
+    process.env.PATH = `${finchLibexec}:${process.env.PATH ?? ''}`;
+  }
+
+  // Smoke-check the daemon is reachable before handing back to the test.
+  sh('finch version');
+  sh('finch info');
+
+  // Run a real `finch build` to surface daemon/buildkit/binfmt issues here
+  // rather than burying them inside the silent nx:run-commands docker target.
+  // The generated targets pass `--platform linux/arm64`, which on x86_64
+  // CodeBuild runners requires QEMU binfmt_misc registration in the kernel.
+  smokeCheckFinchBuild();
+};
+
+const smokeCheckFinchBuild = (): void => {
+  const buildDir = join(tmpdir(), 'finch-smoke-build');
+  mkdirSync(buildDir, { recursive: true });
+  writeFileSync(
+    join(buildDir, 'Dockerfile'),
+    'FROM --platform=$TARGETPLATFORM public.ecr.aws/docker/library/alpine:3.20\nRUN echo hi\n',
+  );
+  runFinchAndReport(['images']);
+  runFinchAndReport(['pull', 'public.ecr.aws/docker/library/alpine:3.20']);
+  const buildResult = runFinchAndReport(
+    ['build', '--progress=plain', '-t', 'finch-smoke:native', '.'],
+    buildDir,
+  );
+  if (buildResult.status !== 0) {
+    dumpFinchLogs();
+    throw new Error(
+      `finch build smoke check failed with exit ${buildResult.status}`,
+    );
+  }
+};
+
+const runFinchAndReport = (
+  args: string[],
+  cwd?: string,
+): { status: number | null; stdout: string; stderr: string } => {
+  return runAndReport('finch', args, cwd);
+};
+
+const runAndReport = (
+  bin: string,
+  args: string[],
+  cwd?: string,
+): { status: number | null; stdout: string; stderr: string } => {
+  console.log(`[finch-install] $ ${bin} ${args.join(' ')}`);
+  const result = spawnSync(bin, args, {
+    cwd,
+    encoding: 'utf-8',
+  });
+  const tag = `${bin} ${args[0] ?? ''}`.trim();
+  console.log(
+    `[finch-install] ${tag} exit code: ${result.status} signal: ${result.signal}`,
+  );
+  console.log(
+    `[finch-install] ${tag} STDOUT (${(result.stdout ?? '').length} bytes):`,
+  );
+  console.log(result.stdout ?? '<null>');
+  console.log(
+    `[finch-install] ${tag} STDERR (${(result.stderr ?? '').length} bytes):`,
+  );
+  console.log(result.stderr ?? '<null>');
+  if (result.error) {
+    console.log('[finch-install] spawn error:', result.error);
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+};
+
+const dumpFinchLogs = (): void => {
+  const logDir = join(tmpdir(), 'nx-plugin-for-aws', 'finch-logs');
+  for (const name of [
+    'finch-daemon',
+    'finch-buildkit',
+    'finch-soci',
+    'containerd',
+  ]) {
+    const logPath = join(logDir, `${name}.log`);
+    if (existsSync(logPath)) {
+      console.error(`[finch-install] ----- ${logPath} -----`);
+      try {
+        console.error(readFileSync(logPath, 'utf-8'));
+      } catch (re) {
+        console.error(`(failed to read: ${(re as Error).message})`);
+      }
+    }
+  }
+};
+
+/**
+ * onProjectCreate hook for the finch smoke test: switches the workspace's
+ * container engine to finch by editing aws-nx-plugin.config.mts in place.
+ * The preset writes `containers: { engine: 'docker' }` (or whatever was
+ * inferred at create time) — we replace that with finch so every generator
+ * downstream sees the override.
+ */
+export const setFinchAsContainerEngine = (projectRoot: string): void => {
+  const configPath = join(projectRoot, 'aws-nx-plugin.config.mts');
+  if (!existsSync(configPath)) {
+    throw new Error(`Expected ${configPath} to exist after workspace creation`);
+  }
+  const original = readFileSync(configPath, 'utf-8');
+  const updated = original.replace(
+    /containers:\s*\{\s*engine:\s*'[^']*'\s*\}/,
+    "containers: { engine: 'finch' }",
+  );
+  if (updated === original) {
+    throw new Error(
+      `Failed to rewrite containers.engine in ${configPath}:\n${original}`,
+    );
+  }
+  writeFileSync(configPath, updated, { encoding: 'utf-8' });
+  console.log(`[finch-install] set containers.engine=finch in ${configPath}`);
+};

--- a/e2e/src/smoke-tests/finch.spec.ts
+++ b/e2e/src/smoke-tests/finch.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { smokeTest } from './smoke-test';
+import { installFinch, setFinchAsContainerEngine } from './finch-install';
+
+// Runs the full generator matrix with `containers.engine: finch` to verify
+// every generator that ships container tooling honours the workspace
+// override end-to-end. Linux only — installs the upstream Finch .deb and
+// runs the finch-daemon (containerd-backed Docker-compatible socket).
+smokeTest('pnpm', {
+  variant: 'finch',
+  setup: () => {
+    installFinch();
+  },
+  onProjectCreate: setFinchAsContainerEngine,
+});

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -39,6 +39,7 @@ import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
 import { uvxCommand } from '../../utils/py';
+import { resolveContainerEngine } from '../../utils/containers';
 
 export const INFRA_APP_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -49,6 +50,18 @@ export async function tsInfraGenerator(
 ): Promise<GeneratorCallback> {
   const lib = getTsLibDetails(tree, schema);
   await tsProjectGenerator(tree, schema);
+
+  // CDK shells out to a container engine to build image assets. Default
+  // (docker) needs no env override; finch is set via CDK_DOCKER per
+  // https://docs.aws.amazon.com/cdk/v2/guide/build-containers.html#build-container-replace.
+  const containerEngine = await resolveContainerEngine(tree, 'Inherit');
+  const cdkEnv: Record<string, string> | undefined =
+    containerEngine === 'docker' ? undefined : { CDK_DOCKER: containerEngine };
+  const withCdkEnv = <T extends Record<string, unknown>>(opts: T): T => {
+    if (!cdkEnv) return opts;
+    const existingEnv = (opts.env as Record<string, string> | undefined) ?? {};
+    return { ...opts, env: { ...existingEnv, ...cdkEnv } } as T;
+  };
 
   addGeneratorMetadata(tree, lib.fullyQualifiedName, INFRA_APP_GENERATOR_INFO);
 
@@ -117,10 +130,10 @@ export async function tsInfraGenerator(
         inputs: ['default'],
         outputs: ['{workspaceRoot}/dist/{projectRoot}/cdk.out'],
         dependsOn: ['^build', 'compile'], // compile clobbers dist directory, so ensure synth runs afterwards
-        options: {
+        options: withCdkEnv({
           cwd: '{projectRoot}',
           command: 'cdk synth',
-        },
+        }),
       };
       config.targets.checkov = {
         cache: true,
@@ -139,53 +152,53 @@ export async function tsInfraGenerator(
         executor: 'nx:run-commands',
         dependsOn: ['^build', 'compile'],
         options: enableStageConfig
-          ? {
+          ? withCdkEnv({
               command: `tsx packages/common/scripts/src/infra-deploy.ts ${libraryRoot}`,
-            }
-          : {
+            })
+          : withCdkEnv({
               cwd: '{projectRoot}',
               command: 'cdk deploy --require-approval=never',
-            },
+            }),
       };
       config.targets['deploy-ci'] = {
         executor: 'nx:run-commands',
-        options: {
+        options: withCdkEnv({
           cwd: '{projectRoot}',
           command: `cdk deploy --require-approval=never --app ${distDirFromProjectRoot}`,
-        },
+        }),
       };
       config.targets.destroy = {
         executor: 'nx:run-commands',
         dependsOn: ['^build', 'compile'],
         options: enableStageConfig
-          ? {
+          ? withCdkEnv({
               command: `tsx packages/common/scripts/src/infra-destroy.ts ${libraryRoot}`,
-            }
-          : {
+            })
+          : withCdkEnv({
               cwd: '{projectRoot}',
               command: 'cdk destroy --require-approval=never',
-            },
+            }),
       };
       config.targets['destroy-ci'] = {
         executor: 'nx:run-commands',
-        options: {
+        options: withCdkEnv({
           cwd: '{projectRoot}',
           command: `cdk destroy --require-approval=never --app ${distDirFromProjectRoot}`,
-        },
+        }),
       };
       config.targets.cdk = {
         executor: 'nx:run-commands',
-        options: {
+        options: withCdkEnv({
           cwd: '{projectRoot}',
           command: 'cdk',
-        },
+        }),
       };
       config.targets.bootstrap = {
         executor: 'nx:run-commands',
-        options: {
+        options: withCdkEnv({
           cwd: '{projectRoot}',
           command: 'cdk bootstrap',
-        },
+        }),
       };
       config.targets = sortObjectKeys(config.targets);
       return config;

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -168,7 +168,10 @@ Learn more:
 exports[`preset generator > should run successfully > aws-nx-plugin.config.mts 1`] = `
 "import { AwsNxPluginConfig } from '@aws/nx-plugin';
 
-export default { iac: { provider: 'CDK' } } satisfies AwsNxPluginConfig;
+export default {
+  iac: { provider: 'CDK' },
+  containers: { engine: 'docker' },
+} satisfies AwsNxPluginConfig;
 "
 `;
 

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -40,6 +40,7 @@ describe('preset generator', () => {
       addTsPlugin: false,
       iacProvider: 'CDK',
       gitSecrets: false,
+      containerEngine: 'docker',
     });
 
     snapshotTreeDir(tree, '.');
@@ -49,13 +50,28 @@ describe('preset generator', () => {
     await presetGenerator(tree, {
       addTsPlugin: false,
       iacProvider: 'Terraform',
+      containerEngine: 'docker',
     });
 
     expect((await readAwsNxPluginConfig(tree)).iac.provider).toBe('Terraform');
   });
 
+  it('should store container engine in config', async () => {
+    await presetGenerator(tree, {
+      addTsPlugin: false,
+      iacProvider: 'CDK',
+      containerEngine: 'finch',
+    });
+
+    expect((await readAwsNxPluginConfig(tree)).containers.engine).toBe('finch');
+  });
+
   it('should store Terraform iac provider in config', async () => {
-    await presetGenerator(tree, { addTsPlugin: false, iacProvider: 'CDK' });
+    await presetGenerator(tree, {
+      addTsPlugin: false,
+      iacProvider: 'CDK',
+      containerEngine: 'docker',
+    });
 
     expect((await readAwsNxPluginConfig(tree)).iac.provider).toBe('CDK');
   });
@@ -88,13 +104,21 @@ describe('preset generator', () => {
   });
 
   it('should disable analytics in nx.json', async () => {
-    await presetGenerator(tree, { addTsPlugin: false, iacProvider: 'CDK' });
+    await presetGenerator(tree, {
+      addTsPlugin: false,
+      iacProvider: 'CDK',
+      containerEngine: 'docker',
+    });
 
     expect(readNxJson(tree).analytics).toBe(false);
   });
 
   it('should register the TypeScript sync generators for compile targets', async () => {
-    await presetGenerator(tree, { addTsPlugin: false, iacProvider: 'CDK' });
+    await presetGenerator(tree, {
+      addTsPlugin: false,
+      iacProvider: 'CDK',
+      containerEngine: 'docker',
+    });
 
     const syncGenerators =
       readNxJson(tree).targetDefaults?.compile?.syncGenerators;

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -33,6 +33,7 @@ import {
   updateAwsNxPluginConfig,
 } from '../utils/config/utils';
 import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
+import { inferContainerEngine } from '../utils/containers';
 import yaml from 'js-yaml';
 
 const WORKSPACES = ['packages/*'];
@@ -157,8 +158,17 @@ const setUpGitSecrets = (tree: Tree) => {
 
 export const presetGenerator = async (
   tree: Tree,
-  { addTsPlugin, iacProvider, gitSecrets }: PresetGeneratorSchema,
+  {
+    addTsPlugin,
+    iacProvider,
+    gitSecrets,
+    containerEngine,
+  }: PresetGeneratorSchema,
 ): Promise<GeneratorCallback> => {
+  const resolvedContainerEngine =
+    !containerEngine || containerEngine === 'infer'
+      ? inferContainerEngine()
+      : containerEngine;
   if (
     isAmazonian() &&
     !process.env.VITEST &&
@@ -181,9 +191,12 @@ export const presetGenerator = async (
     }
   }
 
-  // Write IaC provider to plugin config
+  // Write IaC provider and container engine to plugin config
   await ensureAwsNxPluginConfig(tree);
-  await updateAwsNxPluginConfig(tree, { iac: { provider: iacProvider } });
+  await updateAwsNxPluginConfig(tree, {
+    iac: { provider: iacProvider },
+    containers: { engine: resolvedContainerEngine },
+  });
 
   await initGenerator(tree, {
     formatter: 'prettier',

--- a/packages/nx-plugin/src/preset/schema.d.ts
+++ b/packages/nx-plugin/src/preset/schema.d.ts
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { IacProvider } from '../utils/iac';
+import { ContainerEngine } from '../utils/containers';
+
+export type PresetContainerEngineOption = ContainerEngine | 'infer';
 
 export interface PresetGeneratorSchema {
   readonly addTsPlugin?: boolean;
   readonly iacProvider: IacProvider;
   readonly gitSecrets?: boolean;
+  readonly containerEngine?: PresetContainerEngineOption;
 }

--- a/packages/nx-plugin/src/preset/schema.json
+++ b/packages/nx-plugin/src/preset/schema.json
@@ -22,6 +22,14 @@
       "type": "boolean",
       "description": "Whether to configure git-secrets to prevent committing AWS credentials.",
       "default": true
+    },
+    "containerEngine": {
+      "type": "string",
+      "description": "The container engine to use for build/push/login. 'infer' picks docker if installed, otherwise finch (falling back to docker when neither is installed).",
+      "enum": ["infer", "docker", "finch"],
+      "default": "infer",
+      "x-priority": "important",
+      "x-prompt": "Which container engine would you like to use? (default: infer)"
     }
   }
 }

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -523,12 +523,12 @@ resource "aws_iam_role_policy_attachment" "agent_core_policy" {
   policy_arn = aws_iam_policy.agent_core_runtime_policy.arn
 }
 
-# Data source to get Docker image digest
+# Data source to get container image digest
 data "external" "docker_digest" {
   program = ["sh", "-c", "echo '{\\"digest\\":\\"'$(docker inspect \${var.docker_image_tag} --format '{{.Id}}')'\\"}' "]
 }
 
-# Null resource for Docker publish
+# Null resource for container image publish
 resource "null_resource" "docker_publish" {
   triggers = {
     docker_digest    = data.external.docker_digest.result.digest

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -44,6 +44,7 @@ import { getNpmScope } from '../../utils/npm-scope';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { resolveIacProvider } from '../../utils/iac';
+import { resolveContainerEngine } from '../../utils/containers';
 import { assignPort } from '../../utils/port';
 import { toProjectRelativePath } from '../../utils/paths';
 
@@ -151,6 +152,7 @@ export const pyAgentGenerator = async (
   ]);
 
   if (computeType === 'BedrockAgentCoreRuntime') {
+    const containerEngine = await resolveContainerEngine(tree, 'Inherit');
     const dockerImageTag = `${getNpmScope(tree)}-${name}:latest`;
 
     // Add bundle target
@@ -197,7 +199,7 @@ export const pyAgentGenerator = async (
             `${targetSourceDir}/Dockerfile`,
             `${dockerOutputDir}/Dockerfile`,
           ),
-          `docker build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
+          `${containerEngine} build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
         ],
         parallel: false,
       },
@@ -224,6 +226,7 @@ export const pyAgentGenerator = async (
       projectName: project.name,
       auth,
       serverProtocol: infraProtocol,
+      containerEngine,
     });
   }
 

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -394,12 +394,12 @@ resource "aws_iam_role_policy_attachment" "agent_core_policy" {
   policy_arn = aws_iam_policy.agent_core_runtime_policy.arn
 }
 
-# Data source to get Docker image digest
+# Data source to get container image digest
 data "external" "docker_digest" {
   program = ["sh", "-c", "echo '{\\"digest\\":\\"'$(docker inspect \${var.docker_image_tag} --format '{{.Id}}')'\\"}' "]
 }
 
-# Null resource for Docker publish
+# Null resource for container image publish
 resource "null_resource" "docker_publish" {
   triggers = {
     docker_digest    = data.external.docker_digest.result.digest

--- a/packages/nx-plugin/src/py/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.ts
@@ -32,6 +32,7 @@ import { FsCommands } from '../../utils/fs';
 import { withVersions } from '../../utils/versions';
 import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { resolveIacProvider } from '../../utils/iac';
+import { resolveContainerEngine } from '../../utils/containers';
 import { assignPort } from '../../utils/port';
 import { toProjectRelativePath } from '../../utils/paths';
 
@@ -102,6 +103,7 @@ export const pyMcpServerGenerator = async (
   ]);
 
   if (computeType === 'BedrockAgentCoreRuntime') {
+    const containerEngine = await resolveContainerEngine(tree, 'Inherit');
     const dockerImageTag = `${getNpmScope(tree)}-${name}:latest`;
 
     // Add bundle target
@@ -146,7 +148,7 @@ export const pyMcpServerGenerator = async (
             `${targetSourceDir}/Dockerfile`,
             `${dockerOutputDir}/Dockerfile`,
           ),
-          `docker build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
+          `${containerEngine} build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
         ],
         parallel: false,
       },
@@ -186,6 +188,7 @@ export const pyMcpServerGenerator = async (
       dockerOutputDir,
       iacProvider,
       auth,
+      containerEngine,
     });
   }
 

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -22,6 +22,7 @@ import { getTsLibDetails } from '../../ts/lib/generator';
 import { toClassName, toKebabCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
 import { FsCommands } from '../../utils/fs';
+import { resolveContainerEngine } from '../../utils/containers';
 
 export const SMITHY_PROJECT_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(__filename);
@@ -31,6 +32,7 @@ export const smithyProjectGenerator = async (
   options: SmithyProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const cmd = new FsCommands(tree);
+  const containerEngine = await resolveContainerEngine(tree, 'Inherit');
 
   // Create project.json
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, options);
@@ -51,7 +53,7 @@ export const smithyProjectGenerator = async (
           commands: [
             cmd.rm('dist/{projectRoot}/build'),
             cmd.mkdir('dist/{projectRoot}/build'),
-            'docker build -f {projectRoot}/build.Dockerfile --target export --output type=local,dest=dist/{projectRoot}/build {projectRoot}',
+            `${containerEngine} build -f {projectRoot}/build.Dockerfile --target export --output type=local,dest=dist/{projectRoot}/build {projectRoot}`,
           ],
           parallel: false,
           cwd: '{workspaceRoot}',

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -524,12 +524,12 @@ resource "aws_iam_role_policy_attachment" "agent_core_policy" {
   policy_arn = aws_iam_policy.agent_core_runtime_policy.arn
 }
 
-# Data source to get Docker image digest
+# Data source to get container image digest
 data "external" "docker_digest" {
   program = ["sh", "-c", "echo '{\\"digest\\":\\"'$(docker inspect \${var.docker_image_tag} --format '{{.Id}}')'\\"}' "]
 }
 
-# Null resource for Docker publish
+# Null resource for container image publish
 resource "null_resource" "docker_publish" {
   triggers = {
     docker_digest    = data.external.docker_digest.result.digest

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -27,6 +27,7 @@ import { TS_VERSIONS, withVersions } from '../../utils/versions';
 import { getNpmScope } from '../../utils/npm-scope';
 import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { resolveIacProvider } from '../../utils/iac';
+import { resolveContainerEngine } from '../../utils/containers';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { addAgentInfra } from '../../utils/agent-core-constructs/agent-core-constructs';
 
@@ -100,6 +101,7 @@ export const tsAgentGenerator = async (
   );
 
   if (computeType === 'BedrockAgentCoreRuntime') {
+    const containerEngine = await resolveContainerEngine(tree, 'Inherit');
     const dockerImageTag = `${getNpmScope(tree)}-${name}:latest`;
 
     // Add bundle target
@@ -143,7 +145,7 @@ export const tsAgentGenerator = async (
             `${targetSourceDir}/Dockerfile`,
             `${dockerOutputDir}/Dockerfile`,
           ),
-          `docker build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
+          `${containerEngine} build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
         ],
         parallel: false,
       },
@@ -170,6 +172,7 @@ export const tsAgentGenerator = async (
       iacProvider,
       auth,
       serverProtocol: infraProtocol,
+      containerEngine,
     });
   }
 

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -394,12 +394,12 @@ resource "aws_iam_role_policy_attachment" "agent_core_policy" {
   policy_arn = aws_iam_policy.agent_core_runtime_policy.arn
 }
 
-# Data source to get Docker image digest
+# Data source to get container image digest
 data "external" "docker_digest" {
   program = ["sh", "-c", "echo '{\\"digest\\":\\"'$(docker inspect \${var.docker_image_tag} --format '{{.Id}}')'\\"}' "]
 }
 
-# Null resource for Docker publish
+# Null resource for container image publish
 resource "null_resource" "docker_publish" {
   triggers = {
     docker_digest    = data.external.docker_digest.result.digest

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -33,6 +33,7 @@ import { addMcpServerInfra } from '../../utils/agent-core-constructs/agent-core-
 
 import { getNpmScope } from '../../utils/npm-scope';
 import { resolveIacProvider } from '../../utils/iac';
+import { resolveContainerEngine } from '../../utils/containers';
 import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { assignPort } from '../../utils/port';
 import { FsCommands } from '../../utils/fs';
@@ -128,6 +129,7 @@ export const tsMcpServerGenerator = async (
 
   // Add hosting based on compute type
   if (computeType === 'BedrockAgentCoreRuntime') {
+    const containerEngine = await resolveContainerEngine(tree, 'Inherit');
     const dockerImageTag = `${getNpmScope(tree)}-${name}:latest`;
 
     // Add bundle target
@@ -156,7 +158,7 @@ export const tsMcpServerGenerator = async (
             `${targetSourceDir}/Dockerfile`,
             `${dockerOutputDir}/Dockerfile`,
           ),
-          `docker build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
+          `${containerEngine} build --platform linux/arm64 -t ${dockerImageTag} ${dockerOutputDir}`,
         ],
         parallel: false,
       },
@@ -179,6 +181,7 @@ export const tsMcpServerGenerator = async (
       dockerOutputDir,
       iacProvider,
       auth,
+      containerEngine,
     });
   } else {
     // No Dockerfile needed for non-hosted MCP

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -23,83 +23,94 @@ datasource db {
 `;
 
 exports[`ts#rdb generator > should add mysql prisma dependencies when engine is MySQL > packages/db/scripts/docker-pull.ts 1`] = `
-"import Docker from 'dockerode';
-import { promisify } from 'util';
+"import { spawnSync } from 'child_process';
 
-const docker = new Docker();
+const ENGINE = 'docker';
 const image = process.argv[2];
 
-try {
-  await docker.getImage(image).inspect();
-} catch (e) {
-  if ((e as { statusCode?: number }).statusCode !== 404) throw e;
-  const stream = (await promisify(docker.pull.bind(docker))(
-    image,
-  )) as NodeJS.ReadableStream;
-  await promisify(docker.modem.followProgress.bind(docker.modem))(stream);
+const inspect = spawnSync(ENGINE, ['image', 'inspect', image], {
+  stdio: 'ignore',
+});
+
+if (inspect.status !== 0) {
+  const pull = spawnSync(ENGINE, ['pull', image], { stdio: 'inherit' });
+  if (pull.status !== 0) {
+    process.exit(pull.status ?? 1);
+  }
 }
 "
 `;
 
 exports[`ts#rdb generator > should add mysql prisma dependencies when engine is MySQL > packages/db/scripts/docker-start.ts 1`] = `
-"import Docker from 'dockerode';
+"import { spawn, spawnSync } from 'child_process';
+
+const ENGINE = 'docker';
 
 const [containerName, image, hostPort, dbName, dbPassword] =
   process.argv.slice(2);
 
-const docker = new Docker();
+const containerExists = (): boolean =>
+  spawnSync(ENGINE, ['container', 'inspect', containerName], {
+    stdio: 'ignore',
+  }).status === 0;
 
-let container: Docker.Container;
+const isRunning = (): boolean => {
+  const result = spawnSync(
+    ENGINE,
+    ['container', 'inspect', '-f', '{{.State.Running}}', containerName],
+    { encoding: 'utf-8' },
+  );
+  return result.status === 0 && result.stdout.trim() === 'true';
+};
 
-try {
-  const existing = docker.getContainer(containerName);
-  const info = await existing.inspect();
-  container = existing;
-  if (!info.State.Running) {
-    await container.start();
+if (containerExists()) {
+  if (!isRunning()) {
+    const start = spawnSync(ENGINE, ['start', containerName], {
+      stdio: 'inherit',
+    });
+    if (start.status !== 0) process.exit(start.status ?? 1);
   }
-} catch (e) {
-  if ((e as { statusCode?: number }).statusCode !== 404) throw e;
-  container = await docker.createContainer({
-    name: containerName,
-    Image: image,
-    Env: [\`MYSQL_DATABASE=\${dbName}\`, \`MYSQL_ROOT_PASSWORD=\${dbPassword}\`],
-    ExposedPorts: { '3306/tcp': {} },
-    HostConfig: {
-      AutoRemove: true,
-      PortBindings: { '3306/tcp': [{ HostPort: hostPort }] },
-      Binds: [\`\${containerName}-data:/var/lib/mysql\`],
-    },
-  });
-  await container.start();
+} else {
+  const runArgs = [
+    'run',
+    '--name',
+    containerName,
+    '-e',
+    \`MYSQL_DATABASE=\${dbName}\`,
+    '-e',
+    \`MYSQL_ROOT_PASSWORD=\${dbPassword}\`,
+    '-p',
+    \`\${hostPort}:3306\`,
+    '-v',
+    \`\${containerName}-data:/var/lib/mysql\`,
+    '-d',
+    image,
+  ];
+  const create = spawnSync(ENGINE, runArgs, { stdio: 'inherit' });
+  if (create.status !== 0) process.exit(create.status ?? 1);
 }
 
-const stream = await container.attach({
-  stream: true,
-  stdout: true,
-  stderr: true,
+const logs = spawn(ENGINE, ['logs', '-f', containerName], {
+  stdio: ['ignore', 'inherit', 'inherit'],
 });
-container.modem.demuxStream(stream, process.stdout, process.stderr);
 
 let exiting = false;
 
-async function cleanup() {
+const cleanup = () => {
   if (exiting) return;
   exiting = true;
-  try {
-    await container.stop();
-  } catch (e) {
-    if ((e as { statusCode?: number }).statusCode !== 404) console.error(e);
-  }
+  spawnSync(ENGINE, ['stop', containerName], { stdio: 'ignore' });
+  logs.kill();
   process.exit(0);
-}
+};
 
-process.on('SIGTERM', () => void cleanup());
-process.on('SIGINT', () => void cleanup());
-process.on('SIGHUP', () => void cleanup());
+process.on('SIGTERM', cleanup);
+process.on('SIGINT', cleanup);
+process.on('SIGHUP', cleanup);
 
-const { StatusCode } = await container.wait();
-if (!exiting) process.exit(StatusCode);
+logs.on('exit', (code) => {
+  if (!exiting) process.exit(code ?? 0);
+});
 "
 `;
 
@@ -3814,88 +3825,98 @@ datasource db {
 `;
 
 exports[`ts#rdb generator > should generate the aurora shared construct > packages/db/scripts/docker-pull.ts 1`] = `
-"import Docker from 'dockerode';
-import { promisify } from 'util';
+"import { spawnSync } from 'child_process';
 
-const docker = new Docker();
+const ENGINE = 'docker';
 const image = process.argv[2];
 
-try {
-  await docker.getImage(image).inspect();
-} catch (e) {
-  if ((e as { statusCode?: number }).statusCode !== 404) throw e;
-  const stream = (await promisify(docker.pull.bind(docker))(
-    image,
-  )) as NodeJS.ReadableStream;
-  await promisify(docker.modem.followProgress.bind(docker.modem))(stream);
+const inspect = spawnSync(ENGINE, ['image', 'inspect', image], {
+  stdio: 'ignore',
+});
+
+if (inspect.status !== 0) {
+  const pull = spawnSync(ENGINE, ['pull', image], { stdio: 'inherit' });
+  if (pull.status !== 0) {
+    process.exit(pull.status ?? 1);
+  }
 }
 "
 `;
 
 exports[`ts#rdb generator > should generate the aurora shared construct > packages/db/scripts/docker-start.ts 1`] = `
-"import Docker from 'dockerode';
+"import { spawn, spawnSync } from 'child_process';
+
+const ENGINE = 'docker';
 
 const [containerName, image, hostPort, dbName, dbUser, dbPassword] =
   process.argv.slice(2);
 
-const docker = new Docker();
+const containerExists = (): boolean =>
+  spawnSync(ENGINE, ['container', 'inspect', containerName], {
+    stdio: 'ignore',
+  }).status === 0;
 
-let container: Docker.Container;
+const isRunning = (): boolean => {
+  const result = spawnSync(
+    ENGINE,
+    ['container', 'inspect', '-f', '{{.State.Running}}', containerName],
+    { encoding: 'utf-8' },
+  );
+  return result.status === 0 && result.stdout.trim() === 'true';
+};
 
-try {
-  const existing = docker.getContainer(containerName);
-  const info = await existing.inspect();
-  container = existing;
-  if (!info.State.Running) {
-    await container.start();
+if (containerExists()) {
+  if (!isRunning()) {
+    const start = spawnSync(ENGINE, ['start', containerName], {
+      stdio: 'inherit',
+    });
+    if (start.status !== 0) process.exit(start.status ?? 1);
   }
-} catch (e) {
-  if ((e as { statusCode?: number }).statusCode !== 404) throw e;
-  container = await docker.createContainer({
-    name: containerName,
-    Image: image,
-    Env: [
-      \`POSTGRES_DB=\${dbName}\`,
-      \`POSTGRES_USER=\${dbUser}\`,
-      \`POSTGRES_PASSWORD=\${dbPassword}\`,
-      \`PGDATA=/var/lib/postgresql/17/docker\`,
-    ],
-    ExposedPorts: { '5432/tcp': {} },
-    HostConfig: {
-      AutoRemove: true,
-      PortBindings: { '5432/tcp': [{ HostPort: hostPort }] },
-      Binds: [\`\${containerName}-data:/var/lib/postgresql\`],
-    },
-  });
-  await container.start();
+} else {
+  const runArgs = [
+    'run',
+    '--name',
+    containerName,
+    '-e',
+    \`POSTGRES_DB=\${dbName}\`,
+    '-e',
+    \`POSTGRES_USER=\${dbUser}\`,
+    '-e',
+    \`POSTGRES_PASSWORD=\${dbPassword}\`,
+    '-e',
+    \`PGDATA=/var/lib/postgresql/17/docker\`,
+    '-p',
+    \`\${hostPort}:5432\`,
+    '-v',
+    \`\${containerName}-data:/var/lib/postgresql\`,
+    '-d',
+    image,
+  ];
+  const create = spawnSync(ENGINE, runArgs, { stdio: 'inherit' });
+  if (create.status !== 0) process.exit(create.status ?? 1);
 }
 
-const stream = await container.attach({
-  stream: true,
-  stdout: true,
-  stderr: true,
+const logs = spawn(ENGINE, ['logs', '-f', containerName], {
+  stdio: ['ignore', 'inherit', 'inherit'],
 });
-container.modem.demuxStream(stream, process.stdout, process.stderr);
 
 let exiting = false;
 
-async function cleanup() {
+const cleanup = () => {
   if (exiting) return;
   exiting = true;
-  try {
-    await container.stop();
-  } catch (e) {
-    if ((e as { statusCode?: number }).statusCode !== 404) console.error(e);
-  }
+  spawnSync(ENGINE, ['stop', containerName], { stdio: 'ignore' });
+  logs.kill();
   process.exit(0);
-}
+};
 
-process.on('SIGTERM', () => void cleanup());
-process.on('SIGINT', () => void cleanup());
-process.on('SIGHUP', () => void cleanup());
+process.on('SIGTERM', cleanup);
+process.on('SIGINT', cleanup);
+process.on('SIGHUP', cleanup);
 
-const { StatusCode } = await container.wait();
-if (!exiting) process.exit(StatusCode);
+logs.on('exit', (code) => {
+  if (!exiting) process.exit(code ?? 0);
+});
 "
 `;
 

--- a/packages/nx-plugin/src/ts/rdb/files/scripts/docker-pull.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/scripts/docker-pull.ts.template
@@ -1,15 +1,15 @@
-import Docker from 'dockerode';
-import { promisify } from 'util';
+import { spawnSync } from 'child_process';
 
-const docker = new Docker();
+const ENGINE = '<%= containerEngine %>';
 const image = process.argv[2];
 
-try {
-  await docker.getImage(image).inspect();
-} catch (e) {
-  if ((e as { statusCode?: number }).statusCode !== 404) throw e;
-  const stream = (await promisify(docker.pull.bind(docker))(
-    image,
-  )) as NodeJS.ReadableStream;
-  await promisify(docker.modem.followProgress.bind(docker.modem))(stream);
+const inspect = spawnSync(ENGINE, ['image', 'inspect', image], {
+  stdio: 'ignore',
+});
+
+if (inspect.status !== 0) {
+  const pull = spawnSync(ENGINE, ['pull', image], { stdio: 'inherit' });
+  if (pull.status !== 0) {
+    process.exit(pull.status ?? 1);
+  }
 }

--- a/packages/nx-plugin/src/ts/rdb/files/scripts/docker-start.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/scripts/docker-start.ts.template
@@ -1,4 +1,6 @@
-import Docker from 'dockerode';
+import { spawn, spawnSync } from 'child_process';
+
+const ENGINE = '<%= containerEngine %>';
 
 <%_ if (engine === 'MySQL') { _%>
 const [containerName, image, hostPort, dbName, dbPassword] =
@@ -8,75 +10,75 @@ const [containerName, image, hostPort, dbName, dbUser, dbPassword] =
   process.argv.slice(2);
 <%_ } _%>
 
-const docker = new Docker();
+const containerExists = (): boolean =>
+  spawnSync(ENGINE, ['container', 'inspect', containerName], {
+    stdio: 'ignore',
+  }).status === 0;
 
-let container: Docker.Container;
+const isRunning = (): boolean => {
+  const result = spawnSync(
+    ENGINE,
+    ['container', 'inspect', '-f', '{{.State.Running}}', containerName],
+    { encoding: 'utf-8' },
+  );
+  return result.status === 0 && result.stdout.trim() === 'true';
+};
 
-try {
-  const existing = docker.getContainer(containerName);
-  const info = await existing.inspect();
-  container = existing;
-  if (!info.State.Running) {
-    await container.start();
+if (containerExists()) {
+  if (!isRunning()) {
+    const start = spawnSync(ENGINE, ['start', containerName], {
+      stdio: 'inherit',
+    });
+    if (start.status !== 0) process.exit(start.status ?? 1);
   }
-} catch (e) {
-  if ((e as { statusCode?: number }).statusCode !== 404) throw e;
-  container = await docker.createContainer({
-    name: containerName,
+} else {
 <%_ if (engine === 'MySQL') { _%>
-    Image: image,
-    Env: [
-      `MYSQL_DATABASE=${dbName}`,
-      `MYSQL_ROOT_PASSWORD=${dbPassword}`,
-    ],
-    ExposedPorts: { '3306/tcp': {} },
-    HostConfig: {
-      AutoRemove: true,
-      PortBindings: { '3306/tcp': [{ HostPort: hostPort }] },
-      Binds: [`${containerName}-data:/var/lib/mysql`],
-    },
+  const runArgs = [
+    'run',
+    '--name', containerName,
+    '-e', `MYSQL_DATABASE=${dbName}`,
+    '-e', `MYSQL_ROOT_PASSWORD=${dbPassword}`,
+    '-p', `${hostPort}:3306`,
+    '-v', `${containerName}-data:/var/lib/mysql`,
+    '-d',
+    image,
+  ];
 <%_ } else { _%>
-    Image: image,
-    Env: [
-      `POSTGRES_DB=${dbName}`,
-      `POSTGRES_USER=${dbUser}`,
-      `POSTGRES_PASSWORD=${dbPassword}`,
-      `PGDATA=/var/lib/postgresql/17/docker`,
-    ],
-    ExposedPorts: { '5432/tcp': {} },
-    HostConfig: {
-      AutoRemove: true,
-      PortBindings: { '5432/tcp': [{ HostPort: hostPort }] },
-      Binds: [`${containerName}-data:/var/lib/postgresql`],
-    },
+  const runArgs = [
+    'run',
+    '--name', containerName,
+    '-e', `POSTGRES_DB=${dbName}`,
+    '-e', `POSTGRES_USER=${dbUser}`,
+    '-e', `POSTGRES_PASSWORD=${dbPassword}`,
+    '-e', `PGDATA=/var/lib/postgresql/17/docker`,
+    '-p', `${hostPort}:5432`,
+    '-v', `${containerName}-data:/var/lib/postgresql`,
+    '-d',
+    image,
+  ];
 <%_ } _%>
-  });
-  await container.start();
+  const create = spawnSync(ENGINE, runArgs, { stdio: 'inherit' });
+  if (create.status !== 0) process.exit(create.status ?? 1);
 }
 
-const stream = await container.attach({
-  stream: true,
-  stdout: true,
-  stderr: true,
+const logs = spawn(ENGINE, ['logs', '-f', containerName], {
+  stdio: ['ignore', 'inherit', 'inherit'],
 });
-container.modem.demuxStream(stream, process.stdout, process.stderr);
 
 let exiting = false;
 
-async function cleanup() {
+const cleanup = () => {
   if (exiting) return;
   exiting = true;
-  try {
-    await container.stop();
-  } catch (e) {
-    if ((e as { statusCode?: number }).statusCode !== 404) console.error(e);
-  }
+  spawnSync(ENGINE, ['stop', containerName], { stdio: 'ignore' });
+  logs.kill();
   process.exit(0);
-}
+};
 
-process.on('SIGTERM', () => void cleanup());
-process.on('SIGINT', () => void cleanup());
-process.on('SIGHUP', () => void cleanup());
+process.on('SIGTERM', cleanup);
+process.on('SIGINT', cleanup);
+process.on('SIGHUP', cleanup);
 
-const { StatusCode } = await container.wait();
-if (!exiting) process.exit(StatusCode);
+logs.on('exit', (code) => {
+  if (!exiting) process.exit(code ?? 0);
+});

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -159,8 +159,6 @@ describe('ts#rdb generator', () => {
     expect(packageJson.dependencies.mariadb).toBeUndefined();
     expect(packageJson.dependencies['@prisma/adapter-mariadb']).toBeUndefined();
     expect(packageJson.devDependencies['tsx']).toBeDefined();
-    expect(packageJson.devDependencies['dockerode']).toBeDefined();
-    expect(packageJson.devDependencies['@types/dockerode']).toBeDefined();
     expect(packageJson.devDependencies['@types/aws-lambda']).toBeDefined();
     expect(packageJson.devDependencies['@types/pg']).toBeDefined();
     expect(packageJson.devDependencies.prisma).toBeDefined();

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -32,6 +32,7 @@ import { addIgnoresToEslintConfig } from '../lib/eslint';
 import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { TS_VERSIONS, withVersions } from '../../utils/versions';
 import { resolveIacProvider } from '../../utils/iac';
+import { resolveContainerEngine } from '../../utils/containers';
 import { getNpmScope, toScopeAlias } from '../../utils/npm-scope';
 import { updateGitIgnore } from '../../utils/git';
 import { assignPort } from '../../utils/port';
@@ -49,6 +50,7 @@ export const tsRdbGenerator = async (
   const databaseUser = options.databaseUser ?? 'dbadmin';
   const databaseName = snakeCase(options.databaseName ?? options.name);
   const iacProvider = await resolveIacProvider(tree, options.iacProvider);
+  const containerEngine = await resolveContainerEngine(tree, 'Inherit');
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, {
     name: options.name,
     directory: options.directory,
@@ -97,6 +99,7 @@ export const tsRdbGenerator = async (
     localDbName: databaseName,
     localDbUser,
     localDbPassword,
+    containerEngine,
   };
 
   generateFiles(
@@ -202,7 +205,7 @@ export const tsRdbGenerator = async (
       cache: true,
       executor: 'nx:run-commands',
       options: {
-        command: `docker build --platform linux/arm64 --provenance=false -t ${dockerImageTag} ${migrationBundleDir}`,
+        command: `${containerEngine} build --platform linux/arm64 --provenance=false -t ${dockerImageTag} ${migrationBundleDir}`,
       },
       dependsOn: ['bundle'],
     };
@@ -232,6 +235,7 @@ export const tsRdbGenerator = async (
       'create-db-user',
     ),
     dockerImageTag,
+    containerEngine,
   });
 
   addDependenciesToPackageJson(
@@ -249,8 +253,6 @@ export const tsRdbGenerator = async (
     withVersions([
       'prisma',
       'tsx',
-      'dockerode',
-      '@types/dockerode',
       '@types/aws-lambda',
       ...(options.engine === 'MySQL'
         ? ([] as const)
@@ -261,9 +263,6 @@ export const tsRdbGenerator = async (
   registerPnpmBuiltDependencies(tree, {
     '@prisma/engines': false,
     prisma: false,
-    ssh2: false,
-    'cpu-features': false,
-    protobufjs: false,
   });
 
   await addGeneratorMetricsIfApplicable(tree, [TS_RDB_GENERATOR_INFO]);

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -17,6 +17,7 @@ import {
 } from '../shared-constructs-constants';
 import { addStarExport } from '../ast';
 import { IacProvider } from '../iac';
+import { ContainerEngine } from '../containers';
 
 type IACProvider = { iacProvider: IacProvider };
 
@@ -31,6 +32,7 @@ export interface AddAgentCoreInfraProps {
   appDirectory: string;
   serverProtocol: 'MCP' | 'HTTP' | 'A2A';
   auth: AgentCoreAuth;
+  containerEngine: ContainerEngine;
 }
 
 const addAgentCoreInfra = async (
@@ -136,7 +138,7 @@ const addAgentCoreTerraformInfra = (
       'core',
       'agent-core',
     ),
-    {},
+    { containerEngine: options.containerEngine },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -167,6 +169,7 @@ export interface AddMcpServerInfraProps {
   dockerImageTag: string;
   dockerOutputDir: string;
   auth: AgentCoreAuth;
+  containerEngine: ContainerEngine;
 }
 
 /**
@@ -186,6 +189,7 @@ export const addMcpServerInfra = async (
     serverProtocol: 'MCP',
     iacProvider: options.iacProvider,
     auth: options.auth,
+    containerEngine: options.containerEngine,
   });
 };
 
@@ -197,6 +201,7 @@ export interface AddAgentInfraProps {
   dockerOutputDir: string;
   auth: AgentCoreAuth;
   serverProtocol?: 'HTTP' | 'A2A';
+  containerEngine: ContainerEngine;
 }
 
 /**
@@ -216,5 +221,6 @@ export const addAgentInfra = async (
     serverProtocol: options.serverProtocol ?? 'HTTP',
     iacProvider: options.iacProvider,
     auth: options.auth,
+    containerEngine: options.containerEngine,
   });
 };

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -265,12 +265,12 @@ resource "aws_iam_role_policy_attachment" "agent_core_policy" {
   policy_arn = aws_iam_policy.agent_core_runtime_policy.arn
 }
 
-# Data source to get Docker image digest
+# Data source to get container image digest
 data "external" "docker_digest" {
-  program = ["sh", "-c", "echo '{\"digest\":\"'$(docker inspect ${var.docker_image_tag} --format '{{.Id}}')'\"}' "]
+  program = ["sh", "-c", "echo '{\"digest\":\"'$(<%= containerEngine %> inspect ${var.docker_image_tag} --format '{{.Id}}')'\"}' "]
 }
 
-# Null resource for Docker publish
+# Null resource for container image publish
 resource "null_resource" "docker_publish" {
   triggers = {
     docker_digest    = data.external.docker_digest.result.digest
@@ -281,13 +281,13 @@ resource "null_resource" "docker_publish" {
   provisioner "local-exec" {
     command = <<-EOT
       # Get ECR login token
-      aws ecr get-login-password --region ${local.aws_region} | docker login --username AWS --password-stdin ${self.triggers.repository_url}
+      aws ecr get-login-password --region ${local.aws_region} | <%= containerEngine %> login --username AWS --password-stdin ${self.triggers.repository_url}
 
       # Tag the image
-      docker tag ${self.triggers.docker_image_tag} ${self.triggers.repository_url}:latest
+      <%= containerEngine %> tag ${self.triggers.docker_image_tag} ${self.triggers.repository_url}:latest
 
       # Push the image
-      docker push ${self.triggers.repository_url}:latest
+      <%= containerEngine %> push ${self.triggers.repository_url}:latest
     EOT
   }
 

--- a/packages/nx-plugin/src/utils/config/index.ts
+++ b/packages/nx-plugin/src/utils/config/index.ts
@@ -4,9 +4,11 @@
  */
 import { LicenseConfig } from '../../license/config-types';
 import { IacConfig } from '../iac';
+import { ContainersConfig } from '../containers';
 
 export * from '../../license/config-types';
 export { IacConfig, IacProvider } from '../iac';
+export { ContainersConfig, ContainerEngine } from '../containers';
 
 /**
  * Configuration for the nx plugin
@@ -21,6 +23,11 @@ export interface AwsNxPluginConfig {
    * Configuration for infrastructure as code
    */
   iac?: IacConfig;
+
+  /**
+   * Configuration for container tooling (build/push/login)
+   */
+  containers?: ContainersConfig;
 
   /**
    * List of tags

--- a/packages/nx-plugin/src/utils/containers.spec.ts
+++ b/packages/nx-plugin/src/utils/containers.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from './test';
+import { resolveContainerEngine } from './containers';
+import {
+  ensureAwsNxPluginConfig,
+  updateAwsNxPluginConfig,
+  AWS_NX_PLUGIN_CONFIG_FILE_NAME,
+} from './config/utils';
+
+describe('containers utils', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  describe('resolveContainerEngine', () => {
+    it('should return docker when option is docker', async () => {
+      const result = await resolveContainerEngine(tree, 'docker');
+      expect(result).toBe('docker');
+    });
+
+    it('should return finch when option is finch', async () => {
+      const result = await resolveContainerEngine(tree, 'finch');
+      expect(result).toBe('finch');
+    });
+
+    it('should resolve to configured engine when option is Inherit', async () => {
+      await ensureAwsNxPluginConfig(tree);
+      await updateAwsNxPluginConfig(tree, {
+        containers: { engine: 'finch' },
+      });
+      const result = await resolveContainerEngine(tree, 'Inherit');
+      expect(result).toBe('finch');
+    });
+
+    it('should default to docker when option is Inherit and no config exists', async () => {
+      const result = await resolveContainerEngine(tree, 'Inherit');
+      expect(result).toBe('docker');
+    });
+
+    it('should default to docker when option is Inherit and config has no containers section', async () => {
+      await ensureAwsNxPluginConfig(tree);
+      const result = await resolveContainerEngine(tree, 'Inherit');
+      expect(result).toBe('docker');
+    });
+
+    it('should throw when configured engine is invalid', async () => {
+      await ensureAwsNxPluginConfig(tree);
+      await updateAwsNxPluginConfig(tree, {
+        containers: { engine: 'podman' as any },
+      });
+      await expect(resolveContainerEngine(tree, 'Inherit')).rejects.toThrow(
+        `containers.engine in ${AWS_NX_PLUGIN_CONFIG_FILE_NAME} must be one of docker, finch`,
+      );
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/containers.ts
+++ b/packages/nx-plugin/src/utils/containers.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree } from '@nx/devkit';
+import { execSync } from 'child_process';
+import {
+  AWS_NX_PLUGIN_CONFIG_FILE_NAME,
+  readAwsNxPluginConfig,
+} from './config/utils';
+
+export const CONTAINER_ENGINES = ['docker', 'finch'] as const;
+
+export type ContainerEngine = (typeof CONTAINER_ENGINES)[number];
+
+export type ContainerEngineOption = ContainerEngine | 'Inherit';
+
+/**
+ * Configuration for container tooling
+ */
+export interface ContainersConfig {
+  /**
+   * Container engine used for build/push/login operations
+   */
+  engine: ContainerEngine;
+}
+
+const isOnPath = (binary: string): boolean => {
+  try {
+    const which = process.platform === 'win32' ? 'where' : 'command -v';
+    execSync(`${which} ${binary}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Detect which container engine is available on the host. Prefers docker;
+ * falls back to finch when only finch is installed; defaults to docker
+ * when neither is found.
+ */
+export const inferContainerEngine = (): ContainerEngine => {
+  if (isOnPath('docker')) return 'docker';
+  if (isOnPath('finch')) return 'finch';
+  return 'docker';
+};
+
+/**
+ * Given a container engine option, resolve the actual engine to use.
+ * `Inherit` reads the value from the workspace plugin config, defaulting
+ * to docker when nothing has been configured.
+ */
+export const resolveContainerEngine = async (
+  tree: Tree,
+  option: ContainerEngineOption,
+): Promise<ContainerEngine> => {
+  if (option === 'Inherit') {
+    const pluginConfig = await readAwsNxPluginConfig(tree);
+    const engine = pluginConfig?.containers?.engine ?? 'docker';
+    if (!CONTAINER_ENGINES.includes(engine)) {
+      throw new Error(
+        `containers.engine in ${AWS_NX_PLUGIN_CONFIG_FILE_NAME} must be one of ${CONTAINER_ENGINES.join(
+          ', ',
+        )}`,
+      );
+    }
+    return engine;
+  }
+  return option;
+};

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -273,7 +273,7 @@ resource "aws_ecr_repository_policy" "migration_handler" {
 }
 
 data "external" "docker_digest" {
-  program = ["sh", "-c", "echo '{\"digest\":\"'$(docker inspect ${var.docker_image_tag} --format '{{.Id}}')'\"}' "]
+  program = ["sh", "-c", "echo '{\"digest\":\"'$(<%= containerEngine %> inspect ${var.docker_image_tag} --format '{{.Id}}')'\"}' "]
 }
 
 resource "null_resource" "docker_publish" {
@@ -285,9 +285,9 @@ resource "null_resource" "docker_publish" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      aws ecr get-login-password --region ${data.aws_region.current.region} | docker login --username AWS --password-stdin ${self.triggers.repository_url}
-      docker tag ${self.triggers.docker_image_tag} ${self.triggers.repository_url}:latest
-      docker push ${self.triggers.repository_url}:latest
+      aws ecr get-login-password --region ${data.aws_region.current.region} | <%= containerEngine %> login --username AWS --password-stdin ${self.triggers.repository_url}
+      <%= containerEngine %> tag ${self.triggers.docker_image_tag} ${self.triggers.repository_url}:latest
+      <%= containerEngine %> push ${self.triggers.repository_url}:latest
     EOT
   }
 

--- a/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
+++ b/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
@@ -17,6 +17,7 @@ import {
 } from '../shared-constructs-constants';
 import { addStarExport } from '../ast';
 import { IacProvider } from '../iac';
+import { ContainerEngine } from '../containers';
 
 export interface AddRdbConstructOptions {
   projectName: string;
@@ -29,6 +30,7 @@ export interface AddRdbConstructOptions {
   migrationBundleDir: string;
   createDbUserBundleDir: string;
   dockerImageTag: string;
+  containerEngine: ContainerEngine;
 }
 
 export const addRdbInfra = async (

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -55,8 +55,6 @@ export const TS_VERSIONS = {
   '@trpc/tanstack-react-query': '11.17.0',
   '@trpc/client': '11.17.0',
   '@trpc/server': '11.17.0',
-  dockerode: '5.0.0',
-  '@types/dockerode': '4.0.1',
   '@types/node': '25.9.1',
   '@types/aws-lambda': '8.10.161',
   '@types/cors': '2.8.19',


### PR DESCRIPTION
### Reason for this change

Customers who prefer [Finch](https://runfinch.com/) (an open-source, AWS-developed Docker alternative) currently can't use it cleanly with the plugin because every generator hardcodes `docker` in `project.json` commands, terraform `null_resource` provisioners, the rdb local-dev scripts, and CDK image asset builds.

### Description of changes

Adds a workspace-level container engine setting (mirroring the `iacProvider` pattern):

- **Workspace creation**: new `--containerEngine` flag on the preset (`docker` | `finch` | `infer` — default `infer` checks PATH and falls back to docker). The choice is recorded in `aws-nx-plugin.config.mts` under `containers.engine`.
- **Generators**: 6 docker-emitting generators (`ts#agent`, `py#agent`, `ts#mcp-server`, `py#mcp-server`, `ts#rdb`, `smithy/project`) call `resolveContainerEngine(tree, 'Inherit')` and substitute the engine binary into generated `docker` target commands.
- **Terraform templates**: `runtime.tf.template` and the rdb `<name>.tf.template` use `<%= containerEngine %>` for the 8 hardcoded `docker` invocations (inspect/login/tag/push).
- **CDK**: `ts#infra` sets `CDK_DOCKER=<engine>` on synth/deploy/deploy-ci/destroy/destroy-ci/cdk/bootstrap targets when engine ≠ docker (per [CDK docs](https://docs.aws.amazon.com/cdk/v2/guide/build-containers.html#build-container-replace)).
- **RDB local-dev scripts**: rewrote `docker-pull.ts` and `docker-start.ts` from `dockerode` (Docker socket API — incompatible with Finch) to `spawnSync` shell-outs against the engine baked in at generator time. Removes `dockerode` and `@types/dockerode` from `versions.ts`.
- **Docs**: short tip in `docker-bundling.mdx` pointing at `--containerEngine=finch` and `runfinch.com`.

Existing workspaces require no migration — the absence of `containers.engine` defaults to `docker`, matching prior behaviour.

### Description of how you validated changes

- Unit tests: 1839/1839 pass (`pnpm nx run @aws/nx-plugin:test`). Added `containers.spec.ts` covering resolver/inferrer; updated 7 snapshots.
- Build + lint: `pnpm nx run-many --target build --all` and `--target lint --all --fix` pass on the rebased branch.
- End-to-end: created a fresh workspace with `containers.engine: 'finch'`, generated `ts#project` + `ts#mcp-server` + `ts#agent` + `ts#infra`, and ran `nx run :infra:synth` through a `finch` shim that forwards to `docker`. Confirmed the shim was invoked for both image-asset builds during synth and that `CDK_DOCKER=finch` was honoured on the synth target. Verified the rdb scripts emit `finch image inspect` / `finch pull` / `finch run` correctly.
- CI: new `Smoke Tests - finch` job installs the upstream Finch v1.17.0 .deb on the Linux runner, launches the daemon stack manually (CodeBuild containers have no PID 1 systemd), and runs the full generator matrix end-to-end with `containers.engine: 'finch'`.

### Issue # (if applicable)

Fixes #160.
Closes #714.
Contributes to #718 (v1.0 roadmap).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*