### PR TITLE
chore(ts#agent): initialize agent before StrandsAgent for MCP tool discovery

### DIFF
--- a/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
@@ -13,6 +13,9 @@ const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
 void (async () => {
   const agent = await getAgent();
 
+  // Connect MCP clients and register their tools so StrandsAgent can discover them.
+  await agent.initialize();
+
   const aguiAgent = new StrandsAgent({
     agent,
     name: '<%= agentNameClassName %>',


### PR DESCRIPTION
### Reason for this change

When an AG-UI TypeScript agent is connected to an MCP server via the connection generator, the MCP tools are not visible to the AG-UI adapter. The `@ag-ui/aws-strands` `StrandsAgent` reads `agent.tools` at construction time, but the Strands SDK only resolves MCP clients into their individual tools during `Agent.initialize()`.

### Description of changes

Adds `await agent.initialize()` in the AG-UI template before constructing `StrandsAgent`. This connects MCP clients and registers their tools in the agent's tool registry so they're visible when the AG-UI adapter reads them.

### Description of how you validated changes

- Tested locally with an MCP server exposing a `divide` tool connected to an AG-UI agent
- Without `initialize()`: agent only sees local tools (e.g. `Multiply`)
- With `initialize()`: agent sees both local tools AND MCP tools (e.g. `Multiply` + `divide`)
- All 1837 unit tests pass

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*