### PR TITLE
fix(preset): ignore git-secrets script in scan and initialize git repo in create-nx-workspace

### DIFF
--- a/e2e/src/smoke-tests/git-secrets.spec.ts
+++ b/e2e/src/smoke-tests/git-secrets.spec.ts
@@ -18,7 +18,6 @@ describe('smoke test - git-secrets', () => {
       rmSync(targetDir, { force: true, recursive: true });
     }
     ensureDirSync(targetDir);
-    // Git user config needed for Nx's initial commit and test commits
     execSync('git config --global user.email "test@example.com"', {
       stdio: 'pipe',
     });
@@ -27,7 +26,7 @@ describe('smoke test - git-secrets', () => {
 
   it('should block commits containing AWS access keys', async () => {
     await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'gs-test', 'CDK')} --interactive=false --skipGit=false`,
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'gs-test', 'CDK')} --interactive=false`,
       {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,
@@ -42,14 +41,6 @@ describe('smoke test - git-secrets', () => {
       true,
     );
     expect(existsSync(join(projectRoot, '.husky/pre-commit'))).toBe(true);
-
-    // Simulate cloning: delete node_modules and reinstall. This triggers
-    // prepare -> husky which sets up hooks now that .git exists.
-    rmSync(join(projectRoot, 'node_modules'), { recursive: true, force: true });
-    execSync('pnpm install --no-frozen-lockfile', {
-      cwd: projectRoot,
-      stdio: 'pipe',
-    });
 
     // git commit should fail — the pre-commit hook blocks the secret
     writeFileSync(

--- a/packages/create-nx-workspace/src/create-nx-workspace.spec.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.spec.ts
@@ -7,6 +7,7 @@ import {
   buildArgs,
   createNxWorkspace,
   detectPackageManager,
+  shouldSkipGit,
 } from './create-nx-workspace';
 
 describe('create-nx-workspace', () => {
@@ -54,13 +55,32 @@ describe('create-nx-workspace', () => {
     });
   });
 
+  describe('shouldSkipGit', () => {
+    it('should return true for bare --skipGit', () => {
+      expect(shouldSkipGit(['--skipGit'])).toBe(true);
+    });
+
+    it('should return true for --skipGit=true', () => {
+      expect(shouldSkipGit(['--skipGit=true'])).toBe(true);
+    });
+
+    it('should return false for --skipGit=false', () => {
+      expect(shouldSkipGit(['--skipGit=false'])).toBe(false);
+    });
+
+    it('should return false when --skipGit is not present', () => {
+      expect(shouldSkipGit(['--no-interactive'])).toBe(false);
+    });
+  });
+
   describe('buildArgs', () => {
-    it('should add --preset and default flags for a simple workspace name', () => {
+    it('should add --preset, default flags, and --skipGit for a simple workspace name', () => {
       expect(buildArgs(['my-project'])).toEqual([
         'my-project',
         '--preset=@aws/nx-plugin',
         '--ci=skip',
         '--analytics=false',
+        '--skipGit',
       ]);
     });
 
@@ -129,6 +149,7 @@ describe('create-nx-workspace', () => {
         '--preset=@aws/nx-plugin',
         '--ci=skip',
         '--analytics=false',
+        '--skipGit',
       ]);
     });
 
@@ -139,68 +160,38 @@ describe('create-nx-workspace', () => {
       expect(result[2]).toBe('--preset=@aws/nx-plugin');
     });
 
-    it('should preserve all user flags', () => {
+    it('should always pass --skipGit to nx regardless of user flags', () => {
+      const result = buildArgs(['my-project', '--no-interactive']);
+      expect(result).toContain('--skipGit');
+    });
+
+    it('should strip user --skipGit flag and still include our --skipGit', () => {
+      const result = buildArgs(['my-project', '--skipGit']);
+      expect(result.filter((a) => a === '--skipGit')).toHaveLength(1);
+    });
+
+    it('should strip user --skipGit=true flag', () => {
+      const result = buildArgs(['my-project', '--skipGit=true']);
+      expect(result).not.toContain('--skipGit=true');
+      expect(result).toContain('--skipGit');
+    });
+
+    it('should strip user --skipGit=false flag', () => {
+      const result = buildArgs(['my-project', '--skipGit=false']);
+      expect(result).not.toContain('--skipGit=false');
+      expect(result).toContain('--skipGit');
+    });
+
+    it('should preserve other user flags', () => {
       const result = buildArgs([
         'my-project',
         '--iacProvider=CDK',
         '--interactive=false',
-        '--skipGit',
         '--pm=pnpm',
       ]);
       expect(result).toContain('--iacProvider=CDK');
       expect(result).toContain('--interactive=false');
-      expect(result).toContain('--skipGit');
       expect(result).toContain('--pm=pnpm');
-    });
-
-    it('should auto-add --skipGit with --no-interactive on the default path', () => {
-      const result = buildArgs(['my-project', '--no-interactive']);
-      expect(result).toContain('--no-interactive');
-      expect(result).toContain('--skipGit');
-    });
-
-    it('should auto-add --skipGit with --interactive=false on the default path', () => {
-      const result = buildArgs(['my-project', '--interactive=false']);
-      expect(result).toContain('--interactive=false');
-      expect(result).toContain('--skipGit');
-    });
-
-    it('should not auto-add --skipGit when running interactively', () => {
-      const result = buildArgs(['my-project']);
-      expect(result).not.toContain('--skipGit');
-    });
-
-    it('should NOT auto-add --skipGit when the user overrides --ci', () => {
-      const result = buildArgs([
-        'my-project',
-        '--no-interactive',
-        '--ci=github',
-      ]);
-      expect(result).not.toContain('--skipGit');
-    });
-
-    it('should NOT auto-add --skipGit when the user overrides --nxCloud', () => {
-      const result = buildArgs([
-        'my-project',
-        '--no-interactive',
-        '--nxCloud=yes',
-      ]);
-      expect(result).not.toContain('--skipGit');
-    });
-
-    it('should not duplicate --skipGit if the user already passed it', () => {
-      const result = buildArgs(['my-project', '--no-interactive', '--skipGit']);
-      expect(result.filter((a) => a.startsWith('--skipGit'))).toHaveLength(1);
-    });
-
-    it('should respect explicit --skipGit=false even with --no-interactive', () => {
-      const result = buildArgs([
-        'my-project',
-        '--no-interactive',
-        '--skipGit=false',
-      ]);
-      expect(result).toContain('--skipGit=false');
-      expect(result).not.toContain('--skipGit');
     });
 
     it('should match the expected e2e arg order', () => {

--- a/packages/create-nx-workspace/src/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { spawnSync } from 'child_process';
+import { resolve } from 'path';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { TS_VERSIONS } from '../../nx-plugin/src/utils/versions';
 
@@ -24,41 +25,51 @@ export const detectPackageManager = (): string | undefined => {
   return undefined;
 };
 
-const isNonInteractive = (flagArgs: string[]): boolean =>
-  flagArgs.some((a) => a === '--no-interactive' || a === '--interactive=false');
-
-const hasSkipGitFlag = (flagArgs: string[]): boolean =>
-  flagArgs.some((a) => a === '--skipGit' || a.startsWith('--skipGit='));
-
-const hasCiOverride = (flagArgs: string[]): boolean =>
-  flagArgs.some((a) => a.startsWith('--ci') || a.startsWith('--nxCloud'));
+export const shouldSkipGit = (flagArgs: string[]): boolean =>
+  flagArgs.some((a) => a === '--skipGit' || a === '--skipGit=true');
 
 export const buildArgs = (args: string[]): string[] => {
   const positionalArgs = args.filter((a) => !a.startsWith('-'));
   const flagArgs = args.filter((a) => a.startsWith('-'));
 
-  const defaultFlags = [...DEFAULT_FLAGS];
+  const defaultFlags = [...DEFAULT_FLAGS, '--skipGit'];
 
   if (!flagArgs.some((a) => a.startsWith('--pm'))) {
     const pm = detectPackageManager();
     if (pm) defaultFlags.push(`--pm=${pm}`);
   }
 
-  // Under `--no-interactive` with our default `--ci=skip`, nx still hits
-  // GitHub prompts that aren't gated on the interactive flag.
-  if (
-    isNonInteractive(flagArgs) &&
-    !hasCiOverride(flagArgs) &&
-    !hasSkipGitFlag(flagArgs)
-  ) {
-    defaultFlags.push('--skipGit');
-  }
-
-  const flagsToAdd = defaultFlags.filter(
-    (flag) => !flagArgs.some((a) => a.startsWith(flag.split('=')[0])),
+  const userFlagsWithoutSkipGit = flagArgs.filter(
+    (a) => !a.startsWith('--skipGit'),
   );
 
-  return [...positionalArgs, `--preset=${PRESET}`, ...flagsToAdd, ...flagArgs];
+  const flagsToAdd = defaultFlags.filter(
+    (flag) =>
+      !userFlagsWithoutSkipGit.some((a) => a.startsWith(flag.split('=')[0])),
+  );
+
+  return [
+    ...positionalArgs,
+    `--preset=${PRESET}`,
+    ...flagsToAdd,
+    ...userFlagsWithoutSkipGit,
+  ];
+};
+
+const initGitRepo = (dir: string): void => {
+  const shell = process.platform === 'win32';
+
+  spawnSync('git', ['init'], { cwd: dir, stdio: 'pipe' });
+
+  // Run the prepare script (husky) to configure git hooks now that .git exists
+  const pm = detectPackageManager() ?? 'npm';
+  spawnSync(pm, ['run', 'prepare'], { cwd: dir, stdio: 'pipe', shell });
+
+  spawnSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' });
+  spawnSync('git', ['commit', '-m', 'Initial commit'], {
+    cwd: dir,
+    stdio: 'pipe',
+  });
 };
 
 /**
@@ -76,6 +87,9 @@ export const createNxWorkspace = (args: string[]): number => {
     );
     return 1;
   }
+
+  const flagArgs = args.filter((a) => a.startsWith('-'));
+  const skipGit = shouldSkipGit(flagArgs);
 
   const allArgs = buildArgs(args);
 
@@ -100,5 +114,17 @@ export const createNxWorkspace = (args: string[]): number => {
     },
   );
 
-  return result.status ?? 1;
+  if (result.status !== 0) {
+    return result.status ?? 1;
+  }
+
+  if (!skipGit) {
+    const positionalArgs = args.filter((a) => !a.startsWith('-'));
+    const workspaceName = positionalArgs[0];
+    if (workspaceName) {
+      initGitRepo(resolve(workspaceName));
+    }
+  }
+
+  return 0;
 };

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -85,6 +85,7 @@ describe('preset generator', () => {
 
     expect(tree.exists('.git-secrets/git-secrets')).toBe(false);
     expect(tree.exists('.husky/pre-commit')).toBe(false);
+    expect(tree.exists('.gitallowed')).toBe(false);
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.scripts?.prepare).toBeUndefined();
     expect(packageJson.devDependencies?.husky).toBeUndefined();
@@ -95,6 +96,9 @@ describe('preset generator', () => {
 
     expect(tree.exists('.git-secrets/git-secrets')).toBe(true);
     expect(tree.exists('.husky/pre-commit')).toBe(true);
+    expect(tree.exists('.gitallowed')).toBe(true);
+    const gitallowed = tree.read('.gitallowed', 'utf-8');
+    expect(gitallowed).toContain('.git-secrets/git-secrets:');
     const preCommit = tree.read('.husky/pre-commit', 'utf-8');
     expect(preCommit).toContain('--register-aws');
     expect(preCommit).toContain('--pre_commit_hook');

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -144,6 +144,7 @@ const setUpGitSecrets = (tree: Tree) => {
     '.husky/pre-commit',
     readFileSync(joinPathFragments(huskyDir, 'pre-commit'), 'utf-8'),
   );
+  tree.write('.gitallowed', '\\.git-secrets/git-secrets:\n');
 
   updateJson(tree, 'package.json', (json) => ({
     ...json,


### PR DESCRIPTION
### Reason for this change

Previously, `create-nx-workspace` delegated git initialization to the upstream Nx `create-nx-workspace` tool conditionally (only skipping it in non-interactive mode). This meant git-secrets hooks set up by the preset generator weren't active until a separate `npm install` re-triggered husky setup. Now the wrapper always controls git initialization itself, ensuring hooks are active from the first commit.

### Description of changes

- Always pass `--skipGit` to upstream `create-nx-workspace` so we control git initialization
- After a successful workspace creation, run `git init`, the prepare script (husky), then `git add .` + `git commit -m "Initial commit"` (matching the same message Nx uses)
- Skip git init only when the user explicitly passes `--skipGit` (bare) or `--skipGit=true`
- Add `.gitallowed` with a pattern to suppress false positives from the git-secrets script file itself (which contains pattern definitions that would otherwise trigger the pre-commit hook)
- Export `shouldSkipGit` helper for determining whether the user requested skipping git
- Strip any user-provided `--skipGit` variants from the args forwarded to Nx (since we always pass our own `--skipGit`)
- Remove the `rmSync(node_modules)` + `pnpm install` workaround from the git-secrets e2e test since husky hooks are now active immediately after workspace creation
- Use `shell: true` on Windows for the prepare script invocation (package manager bins are .cmd files)

### Description of how you validated changes

- All 29 unit tests in `@aws/create-nx-workspace` pass
- All 1846 unit tests in `@aws/nx-plugin` pass
- Build passes across all projects
- Lint passes
- Linux and Windows git-secrets e2e tests pass in CI

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*