### PR TITLE
chore(git-secrets): add symlink so pre-commit hook resolves correctly

### DIFF
--- a/.git-secrets/git-secrets
+++ b/.git-secrets/git-secrets
@@ -1,0 +1,1 @@
+../packages/nx-plugin/src/preset/git-secrets-files/git-secrets-dir/git-secrets


### PR DESCRIPTION
### Reason for this change

Running `git commit` in the plugin repo produces:
```
bash: .git-secrets/git-secrets: No such file or directory
```

The pre-commit hook calls `--register-aws`, which hardcodes the secrets provider as `bash .git-secrets/git-secrets --aws-provider`. Generated projects have that file at the repo root, but the plugin repo itself does not — the script lives deep in the source tree.

### Description of changes

Added a `.git-secrets/git-secrets` symlink pointing to `packages/nx-plugin/src/preset/git-secrets-files/git-secrets-dir/git-secrets`. This lets the hardcoded provider path resolve correctly without modifying the hook or the git-secrets script.

### Description of how you validated changes

- Cleared `secrets.*` git config, ran `git commit` — confirmed the error no longer appears and the pre-commit hook passes cleanly.
- Verified generated projects are unaffected (they already have `.git-secrets/git-secrets` as a real file).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*