### PR TITLE
fix(e2e): correct CloudFormation output key prefixes for Custom auth REST APIs

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -144,7 +144,7 @@ describe('smoke test - cdk-deploy', () => {
 
       // Custom auth APIs — should deny unauthenticated requests
       await invokeCustomAuthTrpcApi(
-        findOutput('MyApiCustomEndpoint'),
+        findOutput('MyApiCustomApiEndpoint'),
         'tRPC REST Custom Auth',
       );
       await invokeCustomAuthTrpcApi(
@@ -152,7 +152,7 @@ describe('smoke test - cdk-deploy', () => {
         'tRPC HTTP Custom Auth',
       );
       await invokeCustomAuthApi(
-        findOutput('PyApiCustomEndpoint'),
+        findOutput('PyApiCustomApiEndpoint'),
         'FastAPI REST Custom Auth',
       );
       await invokeCustomAuthApi(


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` smoke test fails because it looks up CloudFormation stack outputs using incorrect key prefixes for the Custom auth REST API constructs (`MyApiCustomEndpoint` and `PyApiCustomEndpoint`). CDK's unique-ID algorithm includes the child construct name (`Api`) in the logical ID when the parent name doesn't already end with `Api` — so `MyApiCustom/Api` produces the output key `MyApiCustomApiEndpoint...`, not `MyApiCustomEndpoint...`.

This was introduced in #720 (feat: replace auth=None with auth=Custom).

### Description of changes

Updated the `findOutput()` prefixes in `cdk-deploy.spec.ts`:
- `MyApiCustomEndpoint` → `MyApiCustomApiEndpoint`
- `PyApiCustomEndpoint` → `PyApiCustomApiEndpoint`

### Description of how you validated changes

- Verified the correct output key names from the CI deployment logs (run 26639602956 and 26634773214)
- Build passes locally (`pnpm nx run @aws/nx-plugin-e2e:build`)
- Unit tests pass locally (`pnpm nx run @aws/nx-plugin:test`)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*