### PR TITLE
feat(ts#docs): rename ts#astro-docs to ts#docs with framework option

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -337,7 +337,7 @@ export default defineConfig({
               label: 'ts#react-website#auth',
               link: '/guides/react-website-auth',
             },
-            { label: 'ts#astro-docs', link: '/guides/astro-docs' },
+            { label: 'ts#docs', link: '/guides/astro-docs' },
             { label: 'ts#lambda-function', link: '/guides/ts-lambda-function' },
             { label: 'ts#nx-plugin', link: '/guides/ts-nx-plugin' },
             { label: 'ts#nx-generator', link: '/guides/nx-generator' },

--- a/docs/src/content/docs/en/guides/astro-docs.mdx
+++ b/docs/src/content/docs/en/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Reference documentation for an Astro + Starlight documentation site
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,11 +25,11 @@ By default it also scaffolds an automated translation pipeline powered by a
 
 You can generate a new Astro docs site in two ways:
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### Options
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## Generator Output
 

--- a/docs/src/content/docs/en/guides/docs.mdx
+++ b/docs/src/content/docs/en/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: Documentation Site
+description: Reference documentation for the ts#docs generator
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+This generator creates a documentation site for your project. Use the `framework`
+option to select which documentation framework to use.
+
+## Usage
+
+### Generate a documentation site
+
+You can generate a new documentation site in two ways:
+
+<RunGenerator generator="ts#docs" />
+
+### Options
+
+<GeneratorParameters generator="ts#docs" />
+
+## Frameworks
+
+<LinkCard
+  title="Astro + Starlight"
+  description="Documentation site powered by Astro and the Starlight docs theme with localisation, snippets, blog, and automated translation."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/es/guides/astro-docs.mdx
+++ b/docs/src/content/docs/es/guides/astro-docs.mdx
@@ -16,7 +16,7 @@ localización, fragmentos de contenido reutilizables, enlaces internos conscient
 plugin [`starlight-blog`](https://starlight-blog-docs.vercel.app/) por defecto.
 
 Por defecto, también crea un pipeline de traducción automatizado impulsado por un
-[Agent](https://strandsagents.com/) en
+[Strands Agent](https://strandsagents.com/) en
 [Amazon Bedrock](https://aws.amazon.com/bedrock/).
 
 ## Uso

--- a/docs/src/content/docs/es/guides/astro-docs.mdx
+++ b/docs/src/content/docs/es/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Documentación de referencia para un sitio de documentación Astro + Starlight
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,11 +25,11 @@ Por defecto, también crea un pipeline de traducción automatizado impulsado por
 
 Puedes generar un nuevo sitio de documentación Astro de dos maneras:
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### Opciones
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## Salida del Generador
 

--- a/docs/src/content/docs/es/guides/docs.mdx
+++ b/docs/src/content/docs/es/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: Sitio de Documentación
+description: Documentación de referencia para el generador ts#docs
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+Este generador crea un sitio de documentación para tu proyecto. Usa la opción `framework`
+para seleccionar qué framework de documentación utilizar.
+
+## Uso
+
+### Generar un sitio de documentación
+
+Puedes generar un nuevo sitio de documentación de dos maneras:
+
+<RunGenerator generator="ts#docs" />
+
+### Opciones
+
+<GeneratorParameters generator="ts#docs" />
+
+## Frameworks
+
+<LinkCard
+  title="Astro + Starlight"
+  description="Sitio de documentación impulsado por Astro y el tema de documentación Starlight con localización, fragmentos, blog y traducción automatizada."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/fr/guides/astro-docs.mdx
+++ b/docs/src/content/docs/fr/guides/astro-docs.mdx
@@ -16,7 +16,7 @@ la localisation, les extraits de contenu réutilisables, les liens internes sens
 plugin [`starlight-blog`](https://starlight-blog-docs.vercel.app/) par défaut.
 
 Par défaut, il crée également un pipeline de traduction automatisé propulsé par un
-[Agent](https://strandsagents.com/) sur
+[Agent Strands](https://strandsagents.com/) sur
 [Amazon Bedrock](https://aws.amazon.com/bedrock/).
 
 ## Utilisation
@@ -141,3 +141,4 @@ Aucun workflow CI n'est généré par défaut — ajoutez-en un qui :
    `scripts/translate.config.json` (par défaut `docs: update translations`) afin que
    les exécutions incrémentielles ultérieures puissent détecter le commit de base et ne
    retraduire que les fichiers qui ont changé depuis.
+

--- a/docs/src/content/docs/fr/guides/astro-docs.mdx
+++ b/docs/src/content/docs/fr/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Documentation de référence pour un site de documentation Astro + Starlight
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,11 +25,11 @@ Par défaut, il crée également un pipeline de traduction automatisé propulsé
 
 Vous pouvez générer un nouveau site de documentation Astro de deux manières :
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### Options
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## Sortie du générateur
 

--- a/docs/src/content/docs/fr/guides/docs.mdx
+++ b/docs/src/content/docs/fr/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: Site de documentation
+description: Documentation de référence pour le générateur ts#docs
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+Ce générateur crée un site de documentation pour votre projet. Utilisez l'option `framework`
+pour sélectionner le framework de documentation à utiliser.
+
+## Utilisation
+
+### Générer un site de documentation
+
+Vous pouvez générer un nouveau site de documentation de deux manières :
+
+<RunGenerator generator="ts#docs" />
+
+### Options
+
+<GeneratorParameters generator="ts#docs" />
+
+## Frameworks
+
+<LinkCard
+  title="Astro + Starlight"
+  description="Site de documentation propulsé par Astro et le thème de documentation Starlight avec localisation, extraits de code, blog et traduction automatisée."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/it/guides/astro-docs.mdx
+++ b/docs/src/content/docs/it/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Documentazione di riferimento per un sito di documentazione Astro + Starlight
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -23,11 +25,11 @@ Per impostazione predefinita, crea anche una pipeline di traduzione automatizzat
 
 Puoi generare un nuovo sito di documentazione Astro in due modi:
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### Opzioni
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## Output del generatore
 

--- a/docs/src/content/docs/it/guides/docs.mdx
+++ b/docs/src/content/docs/it/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: Sito di Documentazione
+description: Documentazione di riferimento per il generatore ts#docs
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+Questo generatore crea un sito di documentazione per il tuo progetto. Usa l'opzione `framework`
+per selezionare quale framework di documentazione utilizzare.
+
+## Utilizzo
+
+### Generare un sito di documentazione
+
+Puoi generare un nuovo sito di documentazione in due modi:
+
+<RunGenerator generator="ts#docs" />
+
+### Opzioni
+
+<GeneratorParameters generator="ts#docs" />
+
+## Framework
+
+<LinkCard
+  title="Astro + Starlight"
+  description="Sito di documentazione basato su Astro e il tema docs Starlight con localizzazione, snippet, blog e traduzione automatizzata."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/jp/guides/astro-docs.mdx
+++ b/docs/src/content/docs/jp/guides/astro-docs.mdx
@@ -122,3 +122,4 @@ import Snippet from '@components/snippet.astro';
    <NxCommands commands={['translate docs']} />
 
 3. 結果の翻訳を PR ブランチにコミットバックします。コミットメッセージは `scripts/translate.config.json` の `translationCommitMessage` 値（デフォルトは `docs: update translations`）と一致する必要があります。これにより、後続の増分実行がベースラインコミットを検出し、それ以降に変更されたファイルのみを再翻訳できます。
+

--- a/docs/src/content/docs/jp/guides/astro-docs.mdx
+++ b/docs/src/content/docs/jp/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Astro + Starlight ドキュメントサイトのリファレンスドキュメント
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -10,7 +12,7 @@ import NxCommands from '@components/nx-commands.astro';
 
 このジェネレーターは、[Astro](https://astro.build/) と [Starlight](https://starlight.astro.build/) ドキュメントテーマを使用したドキュメントサイトをスキャフォールドします。デフォルトで、ローカライゼーション、再利用可能なコンテンツスニペット、ロケール対応の内部リンク、および [`starlight-blog`](https://starlight-blog-docs.vercel.app/) プラグインを設定します。
 
-また、デフォルトで [Amazon Bedrock](https://aws.amazon.com/bedrock/) 上の [Agent](https://strandsagents.com/) を使用した自動翻訳パイプラインもスキャフォールドします。
+また、デフォルトで [Amazon Bedrock](https://aws.amazon.com/bedrock/) 上の [Strands Agent](https://strandsagents.com/) を使用した自動翻訳パイプラインもスキャフォールドします。
 
 ## 使用方法
 
@@ -18,11 +20,11 @@ import NxCommands from '@components/nx-commands.astro';
 
 新しい Astro ドキュメントサイトは2つの方法で生成できます：
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### オプション
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## ジェネレーターの出力
 

--- a/docs/src/content/docs/jp/guides/docs.mdx
+++ b/docs/src/content/docs/jp/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: ドキュメントサイト
+description: ts#docs ジェネレーターのリファレンスドキュメント
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+このジェネレーターは、プロジェクト用のドキュメントサイトを作成します。`framework`
+オプションを使用して、使用するドキュメントフレームワークを選択してください。
+
+## 使用方法
+
+### ドキュメントサイトを生成する
+
+新しいドキュメントサイトは2つの方法で生成できます：
+
+<RunGenerator generator="ts#docs" />
+
+### オプション
+
+<GeneratorParameters generator="ts#docs" />
+
+## フレームワーク
+
+<LinkCard
+  title="Astro + Starlight"
+  description="ローカライゼーション、スニペット、ブログ、自動翻訳機能を備えた Astro と Starlight ドキュメントテーマで構築されたドキュメントサイト。"
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/ko/guides/astro-docs.mdx
+++ b/docs/src/content/docs/ko/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Astro + Starlight 문서 사이트에 대한 참조 문서
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -10,7 +12,7 @@ import NxCommands from '@components/nx-commands.astro';
 
 이 생성기는 [Astro](https://astro.build/)와 [Starlight](https://starlight.astro.build/) 문서 테마로 구동되는 문서 사이트를 스캐폴딩합니다. 기본적으로 로컬라이제이션, 재사용 가능한 콘텐츠 스니펫, 로케일 인식 내부 링크 및 [`starlight-blog`](https://starlight-blog-docs.vercel.app/) 플러그인을 연결합니다.
 
-기본적으로 [Amazon Bedrock](https://aws.amazon.com/bedrock/)의 [Agent](https://strandsagents.com/)로 구동되는 자동화된 번역 파이프라인도 스캐폴딩합니다.
+기본적으로 [Amazon Bedrock](https://aws.amazon.com/bedrock/)의 [Strands Agent](https://strandsagents.com/)로 구동되는 자동화된 번역 파이프라인도 스캐폴딩합니다.
 
 ## 사용법
 
@@ -18,11 +20,11 @@ import NxCommands from '@components/nx-commands.astro';
 
 두 가지 방법으로 새로운 Astro 문서 사이트를 생성할 수 있습니다:
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### 옵션
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## 생성기 출력
 

--- a/docs/src/content/docs/ko/guides/astro-docs.mdx
+++ b/docs/src/content/docs/ko/guides/astro-docs.mdx
@@ -122,3 +122,4 @@ import Snippet from '@components/snippet.astro';
    <NxCommands commands={['translate docs']} />
 
 3. 결과 번역을 PR 브랜치에 다시 커밋합니다. 커밋 메시지는 `scripts/translate.config.json`의 `translationCommitMessage` 값(기본값 `docs: update translations`)과 일치해야 하므로 후속 증분 실행이 기준 커밋을 감지하고 그 이후 변경된 파일만 다시 번역할 수 있습니다.
+

--- a/docs/src/content/docs/ko/guides/docs.mdx
+++ b/docs/src/content/docs/ko/guides/docs.mdx
@@ -30,3 +30,4 @@ import Link from '@components/link.astro';
   description="현지화, 스니펫, 블로그 및 자동 번역 기능을 갖춘 Astro와 Starlight 문서 테마로 구동되는 문서 사이트입니다."
   href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
 />
+

--- a/docs/src/content/docs/ko/guides/docs.mdx
+++ b/docs/src/content/docs/ko/guides/docs.mdx
@@ -1,0 +1,32 @@
+---
+title: 문서 사이트
+description: ts#docs 생성기에 대한 참조 문서
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+이 생성기는 프로젝트를 위한 문서 사이트를 생성합니다. `framework` 옵션을 사용하여 사용할 문서 프레임워크를 선택하세요.
+
+## 사용법
+
+### 문서 사이트 생성
+
+두 가지 방법으로 새로운 문서 사이트를 생성할 수 있습니다:
+
+<RunGenerator generator="ts#docs" />
+
+### 옵션
+
+<GeneratorParameters generator="ts#docs" />
+
+## 프레임워크
+
+<LinkCard
+  title="Astro + Starlight"
+  description="현지화, 스니펫, 블로그 및 자동 번역 기능을 갖춘 Astro와 Starlight 문서 테마로 구동되는 문서 사이트입니다."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/pt/guides/astro-docs.mdx
+++ b/docs/src/content/docs/pt/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Documentação de referência para um site de documentação Astro + Starlight
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -14,7 +16,7 @@ localização, snippets de conteúdo reutilizáveis, links internos com reconhec
 plugin [`starlight-blog`](https://starlight-blog-docs.vercel.app/) por padrão.
 
 Por padrão, ele também cria um pipeline de tradução automatizado alimentado por um
-[Agent](https://strandsagents.com/) no
+[Strands Agent](https://strandsagents.com/) no
 [Amazon Bedrock](https://aws.amazon.com/bedrock/).
 
 ## Uso
@@ -23,11 +25,11 @@ Por padrão, ele também cria um pipeline de tradução automatizado alimentado 
 
 Você pode gerar um novo site de documentação Astro de duas maneiras:
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### Opções
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## Saída do Gerador
 

--- a/docs/src/content/docs/pt/guides/astro-docs.mdx
+++ b/docs/src/content/docs/pt/guides/astro-docs.mdx
@@ -141,3 +141,4 @@ Nenhum workflow de CI é gerado por padrão — adicione um que:
    `scripts/translate.config.json` (padrão `docs: update translations`) para que
    execuções incrementais subsequentes possam detectar o commit de linha de base e apenas
    retraduzir os arquivos que mudaram desde então.
+

--- a/docs/src/content/docs/pt/guides/docs.mdx
+++ b/docs/src/content/docs/pt/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: Site de Documentação
+description: Documentação de referência para o gerador ts#docs
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+Este gerador cria um site de documentação para o seu projeto. Use a opção `framework`
+para selecionar qual framework de documentação usar.
+
+## Uso
+
+### Gerar um site de documentação
+
+Você pode gerar um novo site de documentação de duas maneiras:
+
+<RunGenerator generator="ts#docs" />
+
+### Opções
+
+<GeneratorParameters generator="ts#docs" />
+
+## Frameworks
+
+<LinkCard
+  title="Astro + Starlight"
+  description="Site de documentação alimentado por Astro e o tema de documentação Starlight com localização, snippets, blog e tradução automatizada."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/pt/guides/docs.mdx
+++ b/docs/src/content/docs/pt/guides/docs.mdx
@@ -31,3 +31,4 @@ Você pode gerar um novo site de documentação de duas maneiras:
   description="Site de documentação alimentado por Astro e o tema de documentação Starlight com localização, snippets, blog e tradução automatizada."
   href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
 />
+

--- a/docs/src/content/docs/vi/guides/astro-docs.mdx
+++ b/docs/src/content/docs/vi/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro Docs
 description: Tài liệu tham khảo cho trang tài liệu Astro + Starlight
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -14,7 +16,7 @@ bản địa hóa, các đoạn nội dung có thể tái sử dụng, liên k�
 plugin [`starlight-blog`](https://starlight-blog-docs.vercel.app/) theo mặc định.
 
 Theo mặc định, nó cũng tạo khung cho một pipeline dịch tự động được hỗ trợ bởi một
-[Agent](https://strandsagents.com/) trên
+[Strands Agent](https://strandsagents.com/) trên
 [Amazon Bedrock](https://aws.amazon.com/bedrock/).
 
 ## Cách sử dụng
@@ -23,11 +25,11 @@ Theo mặc định, nó cũng tạo khung cho một pipeline dịch tự động
 
 Bạn có thể tạo một trang tài liệu Astro mới theo hai cách:
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### Tùy chọn
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## Kết quả của Generator
 

--- a/docs/src/content/docs/vi/guides/astro-docs.mdx
+++ b/docs/src/content/docs/vi/guides/astro-docs.mdx
@@ -142,3 +142,4 @@ Không có workflow CI nào được tạo sẵn — hãy thêm một workflow:
    `scripts/translate.config.json` (mặc định `docs: update translations`) để
    các lần chạy tăng dần tiếp theo có thể phát hiện commit cơ sở và chỉ
    dịch lại các tệp đã thay đổi kể từ đó.
+

--- a/docs/src/content/docs/vi/guides/docs.mdx
+++ b/docs/src/content/docs/vi/guides/docs.mdx
@@ -1,0 +1,33 @@
+---
+title: Trang Tài Liệu
+description: Tài liệu tham khảo cho trình tạo ts#docs
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+Trình tạo này tạo ra một trang tài liệu cho dự án của bạn. Sử dụng tùy chọn `framework`
+để chọn framework tài liệu nào sẽ được sử dụng.
+
+## Cách Sử Dụng
+
+### Tạo một trang tài liệu
+
+Bạn có thể tạo một trang tài liệu mới theo hai cách:
+
+<RunGenerator generator="ts#docs" />
+
+### Tùy Chọn
+
+<GeneratorParameters generator="ts#docs" />
+
+## Frameworks
+
+<LinkCard
+  title="Astro + Starlight"
+  description="Trang tài liệu được hỗ trợ bởi Astro và theme tài liệu Starlight với bản địa hóa, đoạn mã, blog và dịch tự động."
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/content/docs/zh/guides/astro-docs.mdx
+++ b/docs/src/content/docs/zh/guides/astro-docs.mdx
@@ -1,7 +1,9 @@
 ---
 title: Astro 文档
 description: Astro + Starlight 文档站点的参考文档
-generator: ts#astro-docs
+when:
+  framework:
+    - astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import RunGenerator from '@components/run-generator.astro';
@@ -18,11 +20,11 @@ import NxCommands from '@components/nx-commands.astro';
 
 您可以通过两种方式生成新的 Astro 文档站点：
 
-<RunGenerator generator="ts#astro-docs" />
+<RunGenerator generator="ts#docs" />
 
 ### 选项
 
-<GeneratorParameters generator="ts#astro-docs" />
+<GeneratorParameters generator="ts#docs" />
 
 ## 生成器输出
 

--- a/docs/src/content/docs/zh/guides/astro-docs.mdx
+++ b/docs/src/content/docs/zh/guides/astro-docs.mdx
@@ -12,7 +12,7 @@ import NxCommands from '@components/nx-commands.astro';
 
 此生成器搭建了一个由 [Astro](https://astro.build/) 和 [Starlight](https://starlight.astro.build/) 文档主题驱动的文档站点。它默认配置了本地化、可重用内容片段、区域感知内部链接以及 [`starlight-blog`](https://starlight-blog-docs.vercel.app/) 插件。
 
-默认情况下，它还会搭建一个由 [Amazon Bedrock](https://aws.amazon.com/bedrock/) 上的 [Agent](https://strandsagents.com/) 驱动的自动翻译管道。
+默认情况下，它还会搭建一个由 [Amazon Bedrock](https://aws.amazon.com/bedrock/) 上的 [Strands Agent](https://strandsagents.com/) 驱动的自动翻译管道。
 
 ## 使用方法
 

--- a/docs/src/content/docs/zh/guides/docs.mdx
+++ b/docs/src/content/docs/zh/guides/docs.mdx
@@ -1,0 +1,32 @@
+---
+title: 文档站点
+description: ts#docs 生成器的参考文档
+generator: ts#docs
+---
+import Astro from '@astrojs/react';
+import { LinkCard } from '@astrojs/starlight/components';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import Link from '@components/link.astro';
+
+此生成器为您的项目创建文档站点。使用 `framework` 选项来选择要使用的文档框架。
+
+## 用法
+
+### 生成文档站点
+
+您可以通过两种方式生成新的文档站点：
+
+<RunGenerator generator="ts#docs" />
+
+### 选项
+
+<GeneratorParameters generator="ts#docs" />
+
+## 框架
+
+<LinkCard
+  title="Astro + Starlight"
+  description="由 Astro 和 Starlight 文档主题驱动的文档站点，支持本地化、代码片段、博客和自动翻译。"
+  href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/astro-docs`}
+/>

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -1854,5 +1854,84 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
     }
+  },
+  "ts#docs": {
+    "name": {
+      "en": "The name of the docs project.",
+      "pt": "O nome do projeto de documentação.",
+      "fr": "Le nom du projet de documentation.",
+      "ko": "문서 프로젝트의 이름입니다.",
+      "es": "El nombre del proyecto de documentación.",
+      "jp": "ドキュメントプロジェクトの名前。",
+      "it": "Il nome del progetto di documentazione.",
+      "zh": "文档项目的名称。",
+      "vi": "Tên của dự án tài liệu."
+    },
+    "directory": {
+      "en": "The parent directory the docs project is placed in.",
+      "pt": "O diretório pai onde o projeto de documentação é colocado.",
+      "fr": "Le répertoire parent dans lequel le projet de documentation est placé.",
+      "ko": "문서 프로젝트가 배치될 상위 디렉토리입니다.",
+      "es": "El directorio padre donde se coloca el proyecto de documentación.",
+      "jp": "ドキュメントプロジェクトが配置される親ディレクトリ。",
+      "it": "La directory principale in cui viene posizionato il progetto di documentazione.",
+      "zh": "文档项目所在的父目录。",
+      "vi": "Thư mục cha mà dự án tài liệu được đặt trong đó."
+    },
+    "subDirectory": {
+      "en": "The sub directory the docs project is placed in. Defaults to the kebab-case project name.",
+      "pt": "O subdiretório onde o projeto de documentação é colocado. O padrão é o nome do projeto em kebab-case.",
+      "fr": "Le sous-répertoire dans lequel le projet de documentation est placé. Par défaut, le nom du projet en kebab-case.",
+      "ko": "문서 프로젝트가 배치될 하위 디렉토리입니다. 기본값은 케밥 케이스 프로젝트 이름입니다.",
+      "es": "El subdirectorio donde se coloca el proyecto de documentación. Por defecto es el nombre del proyecto en formato kebab-case.",
+      "jp": "ドキュメントプロジェクトが配置されるサブディレクトリ。デフォルトはケバブケースのプロジェクト名。",
+      "it": "La sottodirectory in cui viene posizionato il progetto di documentazione. Per impostazione predefinita, il nome del progetto in formato kebab-case.",
+      "zh": "文档项目所在的子目录。默认为 kebab-case 格式的项目名称。",
+      "vi": "Thư mục con mà dự án tài liệu được đặt trong đó. Mặc định là tên dự án dạng kebab-case."
+    },
+    "framework": {
+      "en": "The documentation framework to use.",
+      "pt": "O framework de documentação a ser usado.",
+      "fr": "Le framework de documentation à utiliser.",
+      "ko": "사용할 문서 프레임워크입니다.",
+      "es": "El framework de documentación a utilizar.",
+      "jp": "使用するドキュメントフレームワーク。",
+      "it": "Il framework di documentazione da utilizzare.",
+      "zh": "要使用的文档框架。",
+      "vi": "Framework tài liệu sẽ sử dụng."
+    },
+    "noTranslation": {
+      "en": "Opt out of the automated documentation translation pipeline (Strands Agent on Amazon Bedrock + a `translate` project target).",
+      "pt": "Desativar o pipeline automatizado de tradução de documentação (Strands Agent no Amazon Bedrock + um target de projeto `translate`).",
+      "fr": "Désactiver le pipeline de traduction automatique de la documentation (Strands Agent sur Amazon Bedrock + une cible de projet `translate`).",
+      "ko": "자동화된 문서 번역 파이프라인(Amazon Bedrock의 Strands Agent + `translate` 프로젝트 타겟)을 사용하지 않습니다.",
+      "es": "Excluirse del pipeline automatizado de traducción de documentación (Strands Agent en Amazon Bedrock + un target de proyecto `translate`).",
+      "jp": "自動ドキュメント翻訳パイプライン（Strands Agent on Amazon Bedrock + `translate` プロジェクトターゲット）をオプトアウトする。",
+      "it": "Rinuncia alla pipeline di traduzione automatica della documentazione (Strands Agent su Amazon Bedrock + un target di progetto `translate`).",
+      "zh": "选择退出自动文档翻译管道（Amazon Bedrock 上的 Strands Agent + `translate` 项目目标）。",
+      "vi": "Từ chối quy trình dịch tài liệu tự động (Strands Agent trên Amazon Bedrock + target dự án `translate`)."
+    },
+    "noBlog": {
+      "en": "Opt out of the `starlight-blog` plugin and the sample blog post.",
+      "pt": "Desativar o plugin `starlight-blog` e o post de blog de exemplo.",
+      "fr": "Désactiver le plugin `starlight-blog` et l'article de blog exemple.",
+      "ko": "`starlight-blog` 플러그인과 샘플 블로그 게시물을 사용하지 않습니다.",
+      "es": "Excluirse del plugin `starlight-blog` y de la entrada de blog de ejemplo.",
+      "jp": "`starlight-blog` プラグインとサンプルブログ投稿をオプトアウトする。",
+      "it": "Rinuncia al plugin `starlight-blog` e al post di blog di esempio.",
+      "zh": "选择退出 `starlight-blog` 插件和示例博客文章。",
+      "vi": "Từ chối plugin `starlight-blog` và bài viết blog mẫu."
+    },
+    "skipInstall": {
+      "en": "Skip installing dependencies after the generator runs.",
+      "pt": "Pular a instalação de dependências após a execução do gerador.",
+      "fr": "Ignorer l'installation des dépendances après l'exécution du générateur.",
+      "ko": "생성기 실행 후 의존성 설치를 건너뜁니다.",
+      "es": "Omitir la instalación de dependencias después de ejecutar el generador.",
+      "jp": "ジェネレーター実行後の依存関係のインストールをスキップする。",
+      "it": "Salta l'installazione delle dipendenze dopo l'esecuzione del generatore.",
+      "zh": "生成器运行后跳过安装依赖项。",
+      "vi": "Bỏ qua cài đặt dependencies sau khi generator chạy."
+    }
   }
 }

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -142,12 +142,20 @@
       "metric": "g23",
       "guidePages": ["terraform-project"]
     },
+    "ts#docs": {
+      "factory": "./src/ts/docs/generator",
+      "schema": "./src/ts/docs/schema.json",
+      "description": "Generates a documentation site",
+      "metric": "g43",
+      "guidePages": ["docs", "astro-docs"]
+    },
     "ts#astro-docs": {
       "factory": "./src/ts/astro-docs/generator",
       "schema": "./src/ts/astro-docs/schema.json",
       "description": "Generates an Astro + Starlight documentation site with localisation, snippets, blog, and optional automated documentation translation",
       "metric": "g37",
-      "guidePages": ["astro-docs"]
+      "guidePages": ["astro-docs"],
+      "hidden": true
     },
     "ts#infra": {
       "factory": "./src/infra/app/generator",

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -644,6 +644,91 @@ REACT_PY_STRANDS_BODY`,
     });
   });
 
+  describe('ts#docs framework filtering', () => {
+    const variants: Record<string, string> = {
+      'docs.mdx': `---
+title: Documentation Site
+---
+DOCS_OVERVIEW`,
+      'astro-docs.mdx': `---
+title: Astro Docs
+when:
+  framework:
+    - astro
+---
+ASTRO_DOCS_BODY`,
+    };
+
+    const docsInfo: NxGeneratorInfo = {
+      id: 'ts#docs',
+      description: 'Generates a documentation site',
+      resolvedSchemaPath: '/fake/schema.json',
+      resolvedFactoryPath: '/fake/factory',
+      metric: 'g43',
+      guidePages: ['docs', 'astro-docs'],
+    };
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      vi.spyOn(fs, 'existsSync').mockImplementation(
+        (p) =>
+          typeof p === 'string' &&
+          (p.endsWith('/docs.mdx') || p.endsWith('/astro-docs.mdx')),
+      );
+      vi.spyOn(fs, 'readFileSync').mockImplementation(
+        (p: any, ...rest: any[]) => {
+          if (typeof p === 'string' && p.endsWith('/docs.mdx')) {
+            return variants['docs.mdx'];
+          }
+          if (typeof p === 'string' && p.endsWith('/astro-docs.mdx')) {
+            return variants['astro-docs.mdx'];
+          }
+          const realReadFileSync =
+            (fs.readFileSync as any).wrappedMethod ?? fs.readFileSync;
+          return realReadFileSync.call(fs, p, ...rest);
+        },
+      );
+    });
+
+    it('returns both pages when no options supplied', async () => {
+      const result = await fetchGuidePagesForGenerator(docsInfo, [docsInfo]);
+      expect(result.kind).toBe('ok');
+      expect(result.content).toMatch(/DOCS\\?_OVERVIEW/);
+      expect(result.content).toMatch(/ASTRO\\?_DOCS\\?_BODY/);
+    });
+
+    it('narrows to astro page when framework=astro', async () => {
+      const result = await fetchGuidePagesForGenerator(
+        docsInfo,
+        [docsInfo],
+        undefined,
+        undefined,
+        { framework: 'astro' },
+      );
+      expect(result.kind).toBe('ok');
+      expect(result.content).toMatch(/DOCS\\?_OVERVIEW/);
+      expect(result.content).toMatch(/ASTRO\\?_DOCS\\?_BODY/);
+    });
+
+    it('returns unsupported for unknown framework', async () => {
+      const result = await fetchGuidePagesForGenerator(
+        docsInfo,
+        [docsInfo],
+        undefined,
+        undefined,
+        { framework: 'docusaurus' },
+      );
+      expect(result.kind).toBe('unsupported');
+      expect(result.content).toContain('Unsupported combination');
+    });
+
+    it('surfaces framework in filterable options', async () => {
+      const rendered = await renderFilterableOptionsAsync(docsInfo);
+      expect(rendered).toContain('framework:');
+      expect(rendered).toContain('astro');
+    });
+  });
+
   describe('local-file fallback for guide pages', () => {
     const info: NxGeneratorInfo = {
       id: 'ts#trpc-api',

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -48,7 +48,7 @@ The following list of generators are what is currently available in the \`@aws/n
 
 - **terraform#project**: Generates a Terraform project
 
-- **ts#astro-docs**: Generates an Astro + Starlight documentation site with localisation, snippets, blog, and optional automated documentation translation
+- **ts#docs**: Generates a documentation site
 
 - **ts#infra**: Generates a cdk application
 

--- a/packages/nx-plugin/src/ts/astro-docs/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/astro-docs/__snapshots__/generator.spec.ts.snap
@@ -161,6 +161,7 @@ exports[`ts#astro-docs generator > should generate a docs site with default opti
   },
   "metadata": {
     "generator": "ts#astro-docs",
+    "framework": "astro",
     "includeTranslation": true,
     "includeBlog": true
   }

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -194,6 +194,7 @@ describe('ts#astro-docs generator', () => {
       'generator',
       TS_ASTRO_DOCS_GENERATOR_INFO.id,
     );
+    expect(projectConfig.metadata).toHaveProperty('framework', 'astro');
     expect(projectConfig.metadata).toHaveProperty('includeTranslation', true);
     expect(projectConfig.metadata).toHaveProperty('includeBlog', true);
   });

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -138,6 +138,7 @@ export const tsAstroDocsGenerator = async (
   }
 
   addGeneratorMetadata(tree, fullyQualifiedName, TS_ASTRO_DOCS_GENERATOR_INFO, {
+    framework: 'astro',
     includeTranslation,
     includeBlog,
   });

--- a/packages/nx-plugin/src/ts/docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/docs/generator.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readJson, Tree } from '@nx/devkit';
+import { tsDocsGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+
+describe('ts#docs generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should delegate to tsAstroDocsGenerator and produce a docs site', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'docs',
+      skipInstall: true,
+    });
+
+    expect(tree.exists('docs/project.json')).toBeTruthy();
+    expect(tree.exists('docs/astro.config.mjs')).toBeTruthy();
+    expect(tree.exists('docs/tsconfig.json')).toBeTruthy();
+    expect(tree.exists('docs/src/content/docs/en/index.mdx')).toBeTruthy();
+  });
+
+  it('should set generator metadata to ts#docs with framework field', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'docs',
+      skipInstall: true,
+    });
+
+    const projectConfig = readJson(tree, 'docs/project.json');
+    expect(projectConfig.metadata).toHaveProperty('generator', 'ts#astro-docs');
+    expect(projectConfig.metadata).toHaveProperty('framework', 'astro');
+  });
+
+  it('should default framework to astro', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'docs',
+      skipInstall: true,
+    });
+
+    const projectConfig = readJson(tree, 'docs/project.json');
+    expect(projectConfig.metadata.framework).toBe('astro');
+  });
+
+  it('should pass framework=astro explicitly', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'docs',
+      framework: 'astro',
+      skipInstall: true,
+    });
+
+    const projectConfig = readJson(tree, 'docs/project.json');
+    expect(projectConfig.metadata.framework).toBe('astro');
+    expect(projectConfig.metadata.generator).toBe('ts#astro-docs');
+  });
+
+  it('should pass through noTranslation option', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'docs',
+      noTranslation: true,
+      skipInstall: true,
+    });
+
+    expect(tree.exists('docs/scripts/translate.ts')).toBeFalsy();
+    const projectConfig = readJson(tree, 'docs/project.json');
+    expect(projectConfig.targets.translate).toBeUndefined();
+  });
+
+  it('should pass through noBlog option', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'docs',
+      noBlog: true,
+      skipInstall: true,
+    });
+
+    expect(
+      tree.exists('docs/src/content/docs/en/blog/welcome.mdx'),
+    ).toBeFalsy();
+  });
+
+  it('should respect custom directory and subDirectory', async () => {
+    await tsDocsGenerator(tree, {
+      name: 'my-docs',
+      directory: 'sites',
+      subDirectory: 'docs-site',
+      skipInstall: true,
+    });
+
+    expect(tree.exists('sites/docs-site/project.json')).toBeTruthy();
+    expect(tree.exists('sites/docs-site/astro.config.mjs')).toBeTruthy();
+  });
+});

--- a/packages/nx-plugin/src/ts/docs/generator.ts
+++ b/packages/nx-plugin/src/ts/docs/generator.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { GeneratorCallback, Tree } from '@nx/devkit';
+import { TsDocsGeneratorSchema } from './schema';
+import { NxGeneratorInfo, getGeneratorInfo } from '../../utils/nx';
+import { tsAstroDocsGenerator } from '../astro-docs/generator';
+
+export const TS_DOCS_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
+
+export const tsDocsGenerator = async (
+  tree: Tree,
+  schema: TsDocsGeneratorSchema,
+): Promise<GeneratorCallback> => {
+  const { framework: _framework, ...rest } = schema;
+  return tsAstroDocsGenerator(tree, rest);
+};
+
+export default tsDocsGenerator;

--- a/packages/nx-plugin/src/ts/docs/schema.d.ts
+++ b/packages/nx-plugin/src/ts/docs/schema.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export interface TsDocsGeneratorSchema {
+  /**
+   * The name of the docs project. Defaults to 'docs'.
+   */
+  name: string;
+  /**
+   * The parent directory the docs project is placed in. Defaults to '.' (workspace root).
+   */
+  directory?: string;
+  /**
+   * The sub directory the docs project is placed in. Defaults to the kebab-case project name.
+   */
+  subDirectory?: string;
+  /**
+   * The documentation framework to use. Defaults to 'astro'.
+   */
+  framework?: 'astro';
+  /**
+   * Opt out of the automated documentation translation pipeline.
+   */
+  noTranslation?: boolean;
+  /**
+   * Opt out of the starlight-blog plugin and sample blog post.
+   */
+  noBlog?: boolean;
+  /**
+   * Skip installing dependencies after the generator runs.
+   */
+  skipInstall?: boolean;
+}

--- a/packages/nx-plugin/src/ts/docs/schema.json
+++ b/packages/nx-plugin/src/ts/docs/schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "ts#docs",
+  "title": "Create a documentation site",
+  "description": "Generates a documentation site. Use the `framework` option to select the underlying docs framework.",
+  "examples": [
+    {
+      "command": "nx g ts#docs",
+      "description": "Generate a docs site using Astro (default framework)"
+    },
+    {
+      "command": "nx g ts#docs --framework=astro --noTranslation",
+      "description": "Generate an Astro docs site without the automated translation pipeline"
+    }
+  ],
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the docs project.",
+      "type": "string",
+      "default": "docs",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the docs project?",
+      "pattern": "^[a-zA-Z][^:]*$"
+    },
+    "directory": {
+      "description": "The parent directory the docs project is placed in.",
+      "type": "string",
+      "alias": "dir",
+      "x-priority": "important",
+      "default": ".",
+      "x-prompt": "Which parent directory would you like to place the docs project in?"
+    },
+    "subDirectory": {
+      "type": "string",
+      "description": "The sub directory the docs project is placed in. Defaults to the kebab-case project name.",
+      "x-prompt": "Which sub directory should the docs project be created in? (default: kebab-case of the name)"
+    },
+    "framework": {
+      "description": "The documentation framework to use.",
+      "type": "string",
+      "enum": ["astro"],
+      "default": "astro",
+      "x-priority": "important",
+      "x-prompt": "Which documentation framework would you like to use?"
+    },
+    "noTranslation": {
+      "description": "Opt out of the automated documentation translation pipeline (Strands Agent on Amazon Bedrock + a `translate` project target).",
+      "type": "boolean",
+      "default": false,
+      "x-prompt": "Would you like to opt out of automated documentation translation?"
+    },
+    "noBlog": {
+      "description": "Opt out of the `starlight-blog` plugin and the sample blog post.",
+      "type": "boolean",
+      "default": false,
+      "x-prompt": "Would you like to opt out of the blog?"
+    },
+    "skipInstall": {
+      "description": "Skip installing dependencies after the generator runs.",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["name"]
+}

--- a/powers/nx-plugin-for-aws/POWER.md
+++ b/powers/nx-plugin-for-aws/POWER.md
@@ -119,29 +119,29 @@ Add capabilities to existing projects:
 
 ## Available Generators
 
-| Generator               | Description                                                                                                                           |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `connection`            | Integrates a source project with a target project                                                                                     |
-| `license`               | Add LICENSE files and configure source code licence headers                                                                           |
-| `py#fast-api`           | Generates a FastAPI Python project                                                                                                    |
-| `py#lambda-function`    | Adds a lambda function to a python project                                                                                            |
-| `py#mcp-server`         | Generate a Python Model Context Protocol (MCP) server for providing context to Large Language Models                                  |
-| `py#project`            | Generates a Python project                                                                                                            |
-| `py#agent`              | Add an AI Agent to a Python project                                                                                                   |
-| `terraform#project`     | Generates a Terraform project                                                                                                         |
-| `ts#astro-docs`         | Generates an Astro + Starlight documentation site with localisation, snippets, blog, and optional automated documentation translation |
-| `ts#infra`              | Generates a cdk application                                                                                                           |
-| `ts#lambda-function`    | Generate a TypeScript lambda function                                                                                                 |
-| `ts#mcp-server`         | Generate a TypeScript Model Context Protocol (MCP) server for providing context to Large Language Models                              |
-| `ts#nx-generator`       | Generator for adding an Nx Generator to an existing TypeScript project                                                                |
-| `ts#nx-plugin`          | Generate an Nx Plugin of your own! Build custom generators automatically made available for AI vibe-coding via MCP                    |
-| `ts#project`            | Generates a TypeScript project                                                                                                        |
-| `ts#react-website`      | Generates a React static website                                                                                                      |
-| `ts#react-website#auth` | Adds auth to an existing React website                                                                                                |
-| `ts#smithy-api`         | Create an API using Smithy and the Smithy TypeScript Server SDK                                                                       |
-| `ts#agent`              | Add an AI Agent to a TypeScript project                                                                                               |
-| `ts#trpc-api`           | creates a trpc backend                                                                                                                |
-| `ts#rdb`                | Create a relational database project                                                                                                  |
+| Generator               | Description                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `connection`            | Integrates a source project with a target project                                                                  |
+| `license`               | Add LICENSE files and configure source code licence headers                                                        |
+| `py#fast-api`           | Generates a FastAPI Python project                                                                                 |
+| `py#lambda-function`    | Adds a lambda function to a python project                                                                         |
+| `py#mcp-server`         | Generate a Python Model Context Protocol (MCP) server for providing context to Large Language Models               |
+| `py#project`            | Generates a Python project                                                                                         |
+| `py#agent`              | Add an AI Agent to a Python project                                                                                |
+| `terraform#project`     | Generates a Terraform project                                                                                      |
+| `ts#docs`               | Generates a documentation site                                                                                     |
+| `ts#infra`              | Generates a cdk application                                                                                        |
+| `ts#lambda-function`    | Generate a TypeScript lambda function                                                                              |
+| `ts#mcp-server`         | Generate a TypeScript Model Context Protocol (MCP) server for providing context to Large Language Models           |
+| `ts#nx-generator`       | Generator for adding an Nx Generator to an existing TypeScript project                                             |
+| `ts#nx-plugin`          | Generate an Nx Plugin of your own! Build custom generators automatically made available for AI vibe-coding via MCP |
+| `ts#project`            | Generates a TypeScript project                                                                                     |
+| `ts#react-website`      | Generates a React static website                                                                                   |
+| `ts#react-website#auth` | Adds auth to an existing React website                                                                             |
+| `ts#smithy-api`         | Create an API using Smithy and the Smithy TypeScript Server SDK                                                    |
+| `ts#agent`              | Add an AI Agent to a TypeScript project                                                                            |
+| `ts#trpc-api`           | creates a trpc backend                                                                                             |
+| `ts#rdb`                | Create a relational database project                                                                               |
 
 ## Best Practices
 

--- a/skills/nx-plugin-for-aws/SKILL.md
+++ b/skills/nx-plugin-for-aws/SKILL.md
@@ -118,29 +118,29 @@ Add capabilities to existing projects:
 
 ## Available Generators
 
-| Generator               | Description                                                                                                                           |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `connection`            | Integrates a source project with a target project                                                                                     |
-| `license`               | Add LICENSE files and configure source code licence headers                                                                           |
-| `py#fast-api`           | Generates a FastAPI Python project                                                                                                    |
-| `py#lambda-function`    | Adds a lambda function to a python project                                                                                            |
-| `py#mcp-server`         | Generate a Python Model Context Protocol (MCP) server for providing context to Large Language Models                                  |
-| `py#project`            | Generates a Python project                                                                                                            |
-| `py#agent`              | Add an AI Agent to a Python project                                                                                                   |
-| `terraform#project`     | Generates a Terraform project                                                                                                         |
-| `ts#astro-docs`         | Generates an Astro + Starlight documentation site with localisation, snippets, blog, and optional automated documentation translation |
-| `ts#infra`              | Generates a cdk application                                                                                                           |
-| `ts#lambda-function`    | Generate a TypeScript lambda function                                                                                                 |
-| `ts#mcp-server`         | Generate a TypeScript Model Context Protocol (MCP) server for providing context to Large Language Models                              |
-| `ts#nx-generator`       | Generator for adding an Nx Generator to an existing TypeScript project                                                                |
-| `ts#nx-plugin`          | Generate an Nx Plugin of your own! Build custom generators automatically made available for AI vibe-coding via MCP                    |
-| `ts#project`            | Generates a TypeScript project                                                                                                        |
-| `ts#react-website`      | Generates a React static website                                                                                                      |
-| `ts#react-website#auth` | Adds auth to an existing React website                                                                                                |
-| `ts#smithy-api`         | Create an API using Smithy and the Smithy TypeScript Server SDK                                                                       |
-| `ts#agent`              | Add an AI Agent to a TypeScript project                                                                                               |
-| `ts#trpc-api`           | creates a trpc backend                                                                                                                |
-| `ts#rdb`                | Create a relational database project                                                                                                  |
+| Generator               | Description                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `connection`            | Integrates a source project with a target project                                                                  |
+| `license`               | Add LICENSE files and configure source code licence headers                                                        |
+| `py#fast-api`           | Generates a FastAPI Python project                                                                                 |
+| `py#lambda-function`    | Adds a lambda function to a python project                                                                         |
+| `py#mcp-server`         | Generate a Python Model Context Protocol (MCP) server for providing context to Large Language Models               |
+| `py#project`            | Generates a Python project                                                                                         |
+| `py#agent`              | Add an AI Agent to a Python project                                                                                |
+| `terraform#project`     | Generates a Terraform project                                                                                      |
+| `ts#docs`               | Generates a documentation site                                                                                     |
+| `ts#infra`              | Generates a cdk application                                                                                        |
+| `ts#lambda-function`    | Generate a TypeScript lambda function                                                                              |
+| `ts#mcp-server`         | Generate a TypeScript Model Context Protocol (MCP) server for providing context to Large Language Models           |
+| `ts#nx-generator`       | Generator for adding an Nx Generator to an existing TypeScript project                                             |
+| `ts#nx-plugin`          | Generate an Nx Plugin of your own! Build custom generators automatically made available for AI vibe-coding via MCP |
+| `ts#project`            | Generates a TypeScript project                                                                                     |
+| `ts#react-website`      | Generates a React static website                                                                                   |
+| `ts#react-website#auth` | Adds auth to an existing React website                                                                             |
+| `ts#smithy-api`         | Create an API using Smithy and the Smithy TypeScript Server SDK                                                    |
+| `ts#agent`              | Add an AI Agent to a TypeScript project                                                                            |
+| `ts#trpc-api`           | creates a trpc backend                                                                                             |
+| `ts#rdb`                | Create a relational database project                                                                               |
 
 ## Best Practices
 


### PR DESCRIPTION
### Reason for this change

Users think "I want a docs site", not "I want an Astro docs site". This follows the same pattern as other generators (`ts#rdb` with `service`/`engine` options) and enables future documentation frameworks without new generator IDs.

Closes #710.

### Description of changes

- **New `ts#docs` generator** — a thin wrapper that accepts a `framework` option (default: `astro`) and delegates to the existing `ts#astro-docs` generator internally. The `framework` choice is persisted in project metadata.
- **`ts#astro-docs` marked hidden** — still works as-is, just not shown in the generator list or MCP server output.
- **Documentation** — new `docs.mdx` guide page with a card linking to the existing Astro docs page. The `astro-docs.mdx` page now uses `when: { framework: [astro] }` frontmatter for MCP guide filtering.
- **MCP server** — `ts#docs` is now listed by `list-generators` with `framework` as a filterable option. The guide tool returns narrowed content based on the selected framework.

### Description of how you validated changes

- All 1855 unit tests pass (`pnpm nx run @aws/nx-plugin:test -u`)
- Full build passes (`pnpm nx run-many --target build --all`)
- Lint passes (`pnpm nx run-many --target lint --all --fix`)
- Snapshot updated for preset README listing

### Issue # (if applicable)

Closes #710.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*