### PR TITLE
feat(mcp): bundle documentation into published MCP server package

### DIFF
--- a/packages/nx-plugin-mcp/project.json
+++ b/packages/nx-plugin-mcp/project.json
@@ -30,7 +30,10 @@
           "cp packages/nx-plugin-mcp/README.md dist/packages/nx-plugin-mcp/README.md",
           "test -f packages/nx-plugin-mcp/LICENSE && cp packages/nx-plugin-mcp/LICENSE dist/packages/nx-plugin-mcp/LICENSE || true",
           "cp packages/nx-plugin/generators.json dist/packages/nx-plugin-mcp/generators.json",
-          "cd packages/nx-plugin && find src -name 'schema.json' -exec sh -c 'mkdir -p ../../dist/packages/nx-plugin-mcp/$(dirname $1) && cp $1 ../../dist/packages/nx-plugin-mcp/$1' _ {} \\;"
+          "cd packages/nx-plugin && find src -name 'schema.json' -exec sh -c 'mkdir -p ../../dist/packages/nx-plugin-mcp/$(dirname $1) && cp $1 ../../dist/packages/nx-plugin-mcp/$1' _ {} \\;",
+          "mkdir -p dist/packages/nx-plugin-mcp/docs",
+          "cp -r docs/src/content/docs/en/guides dist/packages/nx-plugin-mcp/docs/",
+          "cp -r docs/src/content/docs/en/snippets dist/packages/nx-plugin-mcp/docs/"
         ],
         "parallel": false
       },

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -246,11 +246,10 @@ Here are the parameters for the generator:
   });
 
   it('should replace Snippet tags with fetched snippet content', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('This is shared content about constructs.', {
-        status: 200,
-      }),
-    );
+    const snippetProvider = async (name: string) =>
+      name === 'shared-constructs'
+        ? 'This is shared content about constructs.'
+        : '';
 
     const input = `
 # Test Guide
@@ -261,67 +260,75 @@ Some intro text.
 More text after.
 `;
 
-    const result = await postProcessGuide(input, generators);
+    const result = await postProcessGuide(
+      input,
+      generators,
+      undefined,
+      snippetProvider,
+    );
     expect(result).toContain('<Snippet name="shared-constructs">');
     expect(result).toContain('This is shared content about constructs.');
     expect(result).toContain('</Snippet>');
     expect(result).toContain('More text after.');
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/snippets/shared-constructs.mdx'),
-    );
   });
 
   it('should replace Snippet tags with nested path names', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('Consider your API choice carefully.', { status: 200 }),
-    );
+    const snippetProvider = async (name: string) =>
+      name === 'api/api-choice-note'
+        ? 'Consider your API choice carefully.'
+        : '';
 
     const input = `
 # Test Guide
 <Snippet name="api/api-choice-note" />
 `;
 
-    const result = await postProcessGuide(input, generators);
+    const result = await postProcessGuide(
+      input,
+      generators,
+      undefined,
+      snippetProvider,
+    );
     expect(result).toContain('<Snippet name="api/api-choice-note">');
     expect(result).toContain('Consider your API choice carefully.');
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/snippets/api/api-choice-note.mdx'),
-    );
   });
 
-  it('should leave Snippet tags unchanged when fetch fails', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('', { status: 404 }),
-    );
+  it('should leave Snippet tags unchanged when snippet not found', async () => {
+    const snippetProvider = async () => '';
 
     const input = `
 # Test Guide
 <Snippet name="non-existent-snippet" />
 `;
 
-    const result = await postProcessGuide(input, generators);
+    const result = await postProcessGuide(
+      input,
+      generators,
+      undefined,
+      snippetProvider,
+    );
     expect(result).toContain('<Snippet name="non-existent-snippet"');
   });
 
   it('should post-process NxCommands within fetched snippet content', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        `The generator configures a bundle target:
-
-<NxCommands commands={['run <project-name>:bundle']} />`,
-        { status: 200 },
-      ),
-    );
+    const snippetProvider = async (name: string) =>
+      name === 'ts-bundle'
+        ? `The generator configures a bundle target:\n\n<NxCommands commands={['run <project-name>:bundle']} />`
+        : '';
 
     const input = `
 # Test Guide
 <Snippet name="ts-bundle" />
 `;
 
-    const result = await postProcessGuide(input, generators, 'pnpm');
+    const result = await postProcessGuide(
+      input,
+      generators,
+      'pnpm',
+      snippetProvider,
+    );
     expect(result).toContain('<Snippet name="ts-bundle">');
     expect(result).toContain('The generator configures a bundle target:');
-    // remark-stringify indents nested fenced-code blocks inside JSX children.
     expect(result).toMatch(
       /```bash\n\s*pnpm nx run <project-name>:bundle\n\s*```/,
     );
@@ -329,14 +336,11 @@ More text after.
   });
 
   it('should handle multiple Snippet tags in a single guide', async () => {
-    let callCount = 0;
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
-      callCount++;
-      if (callCount === 1) {
-        return new Response('Shared constructs content.', { status: 200 });
-      }
-      return new Response('Bundle content.', { status: 200 });
-    });
+    const snippetProvider = async (name: string) => {
+      if (name === 'shared-constructs') return 'Shared constructs content.';
+      if (name === 'ts-bundle') return 'Bundle content.';
+      return '';
+    };
 
     const input = `
 # Test Guide
@@ -348,7 +352,12 @@ Some middle text.
 <Snippet name="ts-bundle" />
 `;
 
-    const result = await postProcessGuide(input, generators);
+    const result = await postProcessGuide(
+      input,
+      generators,
+      undefined,
+      snippetProvider,
+    );
     expect(result).toContain('<Snippet name="shared-constructs">');
     expect(result).toContain('Shared constructs content.');
     expect(result).toContain('<Snippet name="ts-bundle">');
@@ -357,25 +366,26 @@ Some middle text.
   });
 
   it('should handle Snippet tags with parentHeading attribute', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('Deploy instructions here.', { status: 200 }),
-    );
+    const snippetProvider = async (name: string) =>
+      name === 'lambda-function/deploying-your-function'
+        ? 'Deploy instructions here.'
+        : '';
 
     const input = `
 # Test Guide
 <Snippet name="lambda-function/deploying-your-function" parentHeading="Deploying your Function" />
 `;
 
-    const result = await postProcessGuide(input, generators);
+    const result = await postProcessGuide(
+      input,
+      generators,
+      undefined,
+      snippetProvider,
+    );
     expect(result).toContain(
       '<Snippet name="lambda-function/deploying-your-function">',
     );
     expect(result).toContain('Deploy instructions here.');
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining(
-        '/snippets/lambda-function/deploying-your-function.mdx',
-      ),
-    );
   });
 
   describe('option filtering', () => {
@@ -508,19 +518,25 @@ REACT_PY_STRANDS_BODY`,
 
     beforeEach(() => {
       vi.restoreAllMocks();
-      // Force fetchLocalGuide to miss so we exercise the fetch() fallback,
-      // then return per-URL content from the `variants` table.
-      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-      vi.spyOn(globalThis, 'fetch').mockImplementation((url: any) => {
-        const match = /\/guides\/(.+)\.mdx/.exec(String(url));
-        if (!match) return Promise.resolve(new Response('', { status: 404 }));
-        const key = `${match[1]}.mdx`;
-        const body = variants[key];
-        if (body === undefined) {
-          return Promise.resolve(new Response('', { status: 404 }));
-        }
-        return Promise.resolve(new Response(body));
+      // Mock local file resolution to return variant content from the table.
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        const s = String(p);
+        if (s.endsWith('schema.json')) return true;
+        const match = /\/guides\/(.+)\.mdx/.exec(s);
+        if (match) return variants[`${match[1]}.mdx`] !== undefined;
+        return false;
       });
+      const realReadFileSync = fs.readFileSync;
+      vi.spyOn(fs, 'readFileSync').mockImplementation(
+        (p: any, ...rest: any[]) => {
+          const s = String(p);
+          const match = /\/guides\/(.+)\.mdx/.exec(s);
+          if (match && variants[`${match[1]}.mdx`] !== undefined) {
+            return variants[`${match[1]}.mdx`];
+          }
+          return (realReadFileSync as any)(p, ...rest);
+        },
+      );
     });
 
     // remark-stringify escapes `_` in plain text, so these tests match
@@ -675,17 +691,12 @@ REACT_PY_STRANDS_BODY`,
       fetchSpy.mockRestore();
     });
 
-    it('falls back to the GitHub fetch when no local copy exists', async () => {
+    it('returns empty content when no local copy exists', async () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-      const fetchSpy = vi
-        .spyOn(globalThis, 'fetch')
-        .mockImplementation(() =>
-          Promise.resolve(new Response('REMOTE CONTENT')),
-        );
 
       const result = await fetchGuidePagesForGenerator(info, [info]);
-      expect(result.content).toContain('REMOTE CONTENT');
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result.kind).toBe('ok');
+      expect(result.content).toBe('');
     });
   });
 });

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -331,15 +331,12 @@ export const fetchGuideFrontmatters = async (
 };
 
 /**
- * Read a guide's raw MDX, local filesystem first, GitHub fallback.
+ * Read a guide's raw MDX from the local filesystem (bundled or monorepo).
  */
 const fetchGuideRaw = async (page: string): Promise<string> => {
   const local = fetchLocalGuide(page);
   if (local !== undefined) return local;
-  const response = await fetch(
-    `https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/guides/${page}.mdx`,
-  );
-  return await response.text();
+  return '';
 };
 
 /**
@@ -373,15 +370,10 @@ const parseGuide = async (
 };
 
 /**
- * Search the monorepo-relative guides directory for a page before falling
- * back to GitHub. This is the common case during local development
- * (`pnpm nx mcp-inspect @aws/nx-plugin`), and it also means test workspaces
- * that link the built plugin read the guides they're actually iterating on
- * instead of whatever is currently on `main`.
- *
- * When running as the published `@aws/nx-plugin-mcp` package, `__dirname`
- * resolves somewhere inside `node_modules/@aws/nx-plugin-mcp`, the local
- * probe misses, and we fall back to GitHub.
+ * Probe paths for finding guide MDX files locally. Checked in order:
+ * 1. Bundled docs in the published @aws/nx-plugin-mcp package
+ * 2. Source checkout when running from the monorepo (dev/test)
+ * 3. Rolldown-bundled binary in dist/ (monorepo layout)
  */
 const GUIDES_RELATIVE_PROBES = [
   // Bundled docs inside published @aws/nx-plugin-mcp package (bin/ → ../docs/guides)
@@ -407,9 +399,7 @@ const fetchLocalGuide = (guide: string): string | undefined => {
 };
 
 /**
- * Fetch markdown guide pages. Prefers local files (see `fetchLocalGuide`)
- * and falls back to fetching from the repo on `main` when no local copy
- * is available.
+ * Fetch markdown guide pages from the local filesystem (bundled or monorepo).
  */
 export const fetchGuidePages = async (
   guidePages: string[],
@@ -418,21 +408,13 @@ export const fetchGuidePages = async (
   snippetContentProvider?: SnippetContentProvider,
   options?: Record<string, string>,
 ): Promise<string> => {
-  const guides = await Promise.allSettled(
-    guidePages.map(async (guide) => {
-      const local = fetchLocalGuide(guide);
-      if (local !== undefined) return local;
-      const response = await fetch(
-        `https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/guides/${guide}.mdx`,
-      );
-      return await response.text();
-    }),
-  );
-  const fulfilled = guides.filter((result) => result.status === 'fulfilled');
+  const guides = guidePages
+    .map((guide) => fetchLocalGuide(guide))
+    .filter((content): content is string => content !== undefined);
   const processed = await Promise.all(
-    fulfilled.map((result) =>
+    guides.map((content) =>
       postProcessGuide(
-        result.value,
+        content,
         generators,
         packageManager,
         snippetContentProvider,
@@ -457,13 +439,8 @@ const SNIPPETS_RELATIVE_PROBES = [
   '../../../../docs/src/content/docs/en/snippets',
 ];
 
-const SNIPPET_BASE_URL =
-  'https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/snippets';
-
 /**
- * Fetch a snippet's content. Tries the local repo checkout first (when
- * running under `mcp-inspect` or a linked test workspace) before falling
- * back to the copy on `main`.
+ * Fetch a snippet's content from the local filesystem (bundled or monorepo).
  */
 export const fetchSnippet: SnippetContentProvider = async (
   snippetName: string,
@@ -475,18 +452,10 @@ export const fetchSnippet: SnippetContentProvider = async (
         return fs.readFileSync(candidate, 'utf-8');
       }
     } catch {
-      // Probe failure — try next fallback.
+      // Probe failure — try next path.
     }
   }
-  try {
-    const response = await fetch(`${SNIPPET_BASE_URL}/${snippetName}.mdx`);
-    if (!response.ok) {
-      return '';
-    }
-    return await response.text();
-  } catch {
-    return '';
-  }
+  return '';
 };
 
 /**

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -384,9 +384,11 @@ const parseGuide = async (
  * probe misses, and we fall back to GitHub.
  */
 const GUIDES_RELATIVE_PROBES = [
+  // Bundled docs inside published @aws/nx-plugin-mcp package (bin/ → ../docs/guides)
+  '../docs/guides',
   // nx-plugin package compiled from source (src/mcp-server/…)
   '../../../docs/src/content/docs/en/guides',
-  // rolldown-bundled `@aws/nx-plugin-mcp` binary in dist
+  // rolldown-bundled `@aws/nx-plugin-mcp` binary in dist (monorepo layout)
   '../../../../docs/src/content/docs/en/guides',
 ];
 
@@ -449,6 +451,8 @@ export type SnippetContentProvider = (
 ) => Promise<string> | string;
 
 const SNIPPETS_RELATIVE_PROBES = [
+  // Bundled docs inside published @aws/nx-plugin-mcp package (bin/ → ../docs/snippets)
+  '../docs/snippets',
   '../../../docs/src/content/docs/en/snippets',
   '../../../../docs/src/content/docs/en/snippets',
 ];

--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -35,12 +35,6 @@ describe('MCP Server', () => {
       client.connect(clientTransport),
       server.connect(serverTransport),
     ]);
-
-    global.fetch = vi.fn().mockImplementation(() =>
-      Promise.resolve({
-        text: () => Promise.resolve('Mocked guide content'),
-      }),
-    );
   });
 
   it('should initialize with the correct server information', async () => {
@@ -116,7 +110,6 @@ describe('MCP Server', () => {
   });
 
   it('should execute generator-guide tool with valid generator', async () => {
-    // Call the tool using client
     const result = await client.callTool({
       name: 'generator-guide',
       arguments: {
@@ -125,25 +118,13 @@ describe('MCP Server', () => {
       },
     });
 
-    // Verify result
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toContain('Guide');
-    expect(result.content[0].text).toContain('Mocked guide content');
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      `https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/refs/heads/main/docs/src/content/docs/en/guides/typescript-project.mdx`,
-    );
+    expect(result.content[0].text).toContain('ts#project');
+    expect(result.content[0].text).toContain('Description:');
   });
 
   it('should post process guide pages fetched by the generator-guide tool', async () => {
-    global.fetch = vi.fn().mockImplementation(() =>
-      Promise.resolve({
-        text: () => Promise.resolve('<NxCommands commands={["foo"]} />'),
-      }),
-    );
-
-    // Call the tool using client
     const result = await client.callTool({
       name: 'generator-guide',
       arguments: {
@@ -152,10 +133,10 @@ describe('MCP Server', () => {
       },
     });
 
-    // Verify result
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toContain('pnpm nx foo');
+    // Verify NxCommands are post-processed into code blocks with the package manager prefix
+    expect(result.content[0].text).toContain('pnpm nx');
   });
 
   it('should throw an error when generator-guide is called with an invalid generator', async () => {


### PR DESCRIPTION
## Summary

- Copies guide and snippet MDX files into `@aws/nx-plugin-mcp` dist at build time
- Adds a bundled-docs probe path (`../docs/guides`, `../docs/snippets`) as highest priority in the local resolution chain
- **Removes the remote GitHub fetch fallback entirely** — docs are served exclusively from bundled local files
- This guarantees version-consistent documentation and eliminates network dependencies

The MCP server now operates fully offline: each published version serves its own documentation without any runtime network calls.

## Test plan

- [x] `pnpm nx run @aws/nx-plugin-mcp:build` succeeds and produces `dist/packages/nx-plugin-mcp/docs/{guides,snippets}/`
- [x] MCP server unit tests pass (all 1848 tests green)
- [x] Bundled docs resolve correctly from `bin/` relative path (`../docs/guides`)
- [x] Tested with network blocked: 69KB guide content served from local bundled files
- [x] Headless Claude CLI test confirms `generator-guide` and `general-guidance` tools work correctly
- [ ] CI smoke tests pass (mcp-server smoke test already passed)

Closes #735.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*