### PR TITLE
chore(release): set up prerelease CI for 1.0 release candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           HUSKY: '0'
         run: |
-          pnpm nx release --yes
+          if [ "${{ github.ref }}" = "refs/heads/release/0.x" ]; then
+            pnpm nx release --yes
+          else
+            pnpm nx release --yes --preid rc
+          fi
   deploy_docs:
     name: Deploy Docs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,12 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/release/0.x" ]; then
             pnpm nx release --yes
           else
-            pnpm nx release --yes --preid rc
+            CURRENT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+            if echo "$CURRENT_VERSION" | grep -q "rc"; then
+              pnpm nx release --yes --preid rc
+            else
+              pnpm nx release --yes --specifier premajor --preid rc
+            fi
           fi
   deploy_docs:
     name: Deploy Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
 concurrency:
-  group: 'ci'
+  group: ci-${{ github.ref }}
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/0.x']
   workflow_dispatch:
 
 env:
@@ -163,7 +163,7 @@ jobs:
         env:
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_DIST_TAG: latest
+          NPM_DIST_TAG: ${{ github.ref == 'refs/heads/release/0.x' && 'latest' || 'next' }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           HUSKY: '0'
         run: |
@@ -171,7 +171,7 @@ jobs:
   deploy_docs:
     name: Deploy Docs
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && needs.release.outputs.latest_commit == github.sha }}
+    if: ${{ github.ref == 'refs/heads/release/0.x' && github.event_name == 'push' && needs.release.outputs.latest_commit == github.sha }}
     needs: [release]
     steps:
       - name: Download docs artifact

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,6 +12,7 @@ jobs:
   slack-notification:
     name: Share recent changes with a channel
     runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release/0.x']
 
 env:
   CI: 'true'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,8 +11,8 @@ This repository uses a dual-branch release strategy to support parallel developm
 
 ## How It Works
 
-- **`main`** has `"preid": "rc"` in `nx.json`, so conventional-commit-driven bumps produce prerelease versions (e.g., a `feat:` becomes `1.0.0-rc.1` instead of `0.121.0`). These publish to the `next` dist-tag.
-- **`release/0.x`** uses the original `nx.json` without `preid`, producing normal semver bumps. These publish to the `latest` dist-tag.
+- **`main`** CI passes `--preid rc` to `nx release`, so conventional-commit-driven bumps produce prerelease versions (e.g., a `feat:` becomes `0.121.0-rc.0` instead of `0.121.0`). These publish to the `next` dist-tag.
+- **`release/0.x`** CI runs `nx release` without `--preid`, producing normal semver bumps. These publish to the `latest` dist-tag.
 - **Docs** deploy only from `release/0.x`, keeping the public site on stable content.
 - **Slack notifications** skip prerelease versions.
 
@@ -92,7 +92,7 @@ pnpm nx release --yes
 
 When all v1.0 workstreams are complete (see #718):
 
-1. Remove `"preid": "rc"` from `nx.json` on `main`
+1. Remove the `--preid rc` flag from the `main` branch release step in `ci.yml`
 2. Change `NPM_DIST_TAG` condition in `ci.yml` back to unconditional `latest`
 3. Remove the `release/0.x` branch condition from `deploy_docs`
 4. Publish `1.0.0` to `latest`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ This repository uses a dual-branch release strategy to support parallel developm
 
 ## How It Works
 
-- **`main`** CI passes `--preid rc` to `nx release`, so conventional-commit-driven bumps produce prerelease versions (e.g., a `feat:` becomes `0.121.0-rc.0` instead of `0.121.0`). These publish to the `next` dist-tag.
+- **`main`** CI uses `--specifier premajor --preid rc` for the first RC (producing `1.0.0-rc.0`), then `--preid rc` for subsequent RCs (auto-incrementing to `1.0.0-rc.1`, `1.0.0-rc.2`, etc.). These publish to the `next` dist-tag.
 - **`release/0.x`** CI runs `nx release` without `--preid`, producing normal semver bumps. These publish to the `latest` dist-tag.
 - **Docs** deploy only from `release/0.x`, keeping the public site on stable content.
 - **Slack notifications** skip prerelease versions.
@@ -74,10 +74,17 @@ The default `npm install @aws/nx-plugin` always resolves to the stable 0.x versi
 
 ### Manual release (if needed)
 
-On `main` (prerelease):
+On `main` (first prerelease):
 
 ```bash
-pnpm nx release --yes
+pnpm nx release --yes --specifier premajor --preid rc
+# Publishes 1.0.0-rc.0 to "next" dist-tag
+```
+
+On `main` (subsequent prereleases, after v1.0.0-rc.0 tag exists):
+
+```bash
+pnpm nx release --yes --preid rc
 # Publishes 1.0.0-rc.N to "next" dist-tag
 ```
 
@@ -92,7 +99,7 @@ pnpm nx release --yes
 
 When all v1.0 workstreams are complete (see #718):
 
-1. Remove the `--preid rc` flag from the `main` branch release step in `ci.yml`
+1. Remove the `--specifier premajor --preid rc` logic from the `main` branch release step in `ci.yml`
 2. Change `NPM_DIST_TAG` condition in `ci.yml` back to unconditional `latest`
 3. Remove the `release/0.x` branch condition from `deploy_docs`
 4. Publish `1.0.0` to `latest`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,101 @@
+# Release Strategy
+
+This repository uses a dual-branch release strategy to support parallel development of 1.0 release candidates alongside stable 0.x patches.
+
+## Branches
+
+| Branch        | Purpose                            | npm dist-tag | Version format             |
+| ------------- | ---------------------------------- | ------------ | -------------------------- |
+| `main`        | 1.0 development (breaking changes) | `next`       | `1.0.0-rc.N`               |
+| `release/0.x` | Stable patches for current users   | `latest`     | `0.121.x`, `0.122.x`, etc. |
+
+## How It Works
+
+- **`main`** has `"preid": "rc"` in `nx.json`, so conventional-commit-driven bumps produce prerelease versions (e.g., a `feat:` becomes `1.0.0-rc.1` instead of `0.121.0`). These publish to the `next` dist-tag.
+- **`release/0.x`** uses the original `nx.json` without `preid`, producing normal semver bumps. These publish to the `latest` dist-tag.
+- **Docs** deploy only from `release/0.x`, keeping the public site on stable content.
+- **Slack notifications** skip prerelease versions.
+
+## For Contributors
+
+### New features and breaking changes (targeting 1.0)
+
+Target `main` as usual:
+
+```bash
+git checkout main
+git checkout -b feat/my-feature
+# ... make changes ...
+git commit -m "feat(ts#api): consolidate API generators"
+gh pr create --base main
+```
+
+### Bug fixes for current stable users
+
+Target `release/0.x`:
+
+```bash
+git checkout release/0.x
+git checkout -b fix/my-bugfix
+# ... make changes ...
+git commit -m "fix(ts#trpc-api): correct router import path"
+gh pr create --base release/0.x
+```
+
+### Cherry-picking fixes between branches
+
+If a fix applies to both branches:
+
+```bash
+# Fix on release/0.x first (since it's simpler)
+git checkout release/0.x
+git checkout -b fix/my-bugfix
+# ... commit and merge via PR ...
+
+# Then cherry-pick to main
+git checkout main
+git cherry-pick <commit-sha>
+git push origin main
+```
+
+## For Maintainers
+
+### Consuming prereleases
+
+Users opt into release candidates explicitly:
+
+```bash
+npm install @aws/nx-plugin@next
+# or pin a specific RC:
+npm install @aws/nx-plugin@1.0.0-rc.1
+```
+
+The default `npm install @aws/nx-plugin` always resolves to the stable 0.x version.
+
+### Manual release (if needed)
+
+On `main` (prerelease):
+
+```bash
+pnpm nx release --yes
+# Publishes 1.0.0-rc.N to "next" dist-tag
+```
+
+On `release/0.x` (stable):
+
+```bash
+pnpm nx release --yes
+# Publishes 0.x.y to "latest" dist-tag
+```
+
+### Final cutover to 1.0
+
+When all v1.0 workstreams are complete (see #718):
+
+1. Remove `"preid": "rc"` from `nx.json` on `main`
+2. Change `NPM_DIST_TAG` condition in `ci.yml` back to unconditional `latest`
+3. Remove the `release/0.x` branch condition from `deploy_docs`
+4. Publish `1.0.0` to `latest`
+5. Archive `release/0.x`
+
+See #737 for the full cutover checklist.

--- a/nx.json
+++ b/nx.json
@@ -107,7 +107,8 @@
     "version": {
       "manifestRootsToUpdate": ["dist/{projectRoot}"],
       "specifierSource": "conventional-commits",
-      "currentVersionResolver": "git-tag"
+      "currentVersionResolver": "git-tag",
+      "preid": "rc"
     },
     "changelog": {
       "workspaceChangelog": {

--- a/nx.json
+++ b/nx.json
@@ -107,8 +107,7 @@
     "version": {
       "manifestRootsToUpdate": ["dist/{projectRoot}"],
       "specifierSource": "conventional-commits",
-      "currentVersionResolver": "git-tag",
-      "preid": "rc"
+      "currentVersionResolver": "git-tag"
     },
     "changelog": {
       "workspaceChangelog": {


### PR DESCRIPTION
## Summary

- CI uses `--specifier premajor --preid rc` for the first RC release (producing `1.0.0-rc.0`), then `--preid rc` for subsequent (auto-incrementing `1.0.0-rc.1`, etc.)
- On `release/0.x`, `nx release` runs without `--preid`, producing stable `0.x.y` versions on `latest`
- Docs deploy is gated to `release/0.x` branch only
- PR workflow accepts PRs targeting either branch
- Slack release notifications skip prereleases
- CI concurrency is branch-scoped to avoid cross-branch cancellation
- Adds `RELEASE.md` documenting the dual-branch workflow for contributors

## Merge and activation plan

> **IMPORTANT:** This PR uses `chore:` commit prefix. This prevents CI from triggering a release on merge — giving time to create `release/0.x` before any RC is published.

**Sequence:**
1. Merge #738 (MCP bundling) — triggers normal `0.x` release
2. Merge #740 (create-nx-workspace version pinning) — triggers normal `0.x` release
3. **Wait for both release tags** to be created by CI
4. Merge this PR (#739) — `chore:` prefix means no release is triggered
5. **Immediately** create `release/0.x` from `main`:
   ```bash
   git checkout main && git pull
   git branch release/0.x
   git push origin release/0.x
   ```
6. Set up branch protection on `release/0.x` (same rules as `main`)
7. The next `feat:` or `fix:` commit on `main` produces `1.0.0-rc.0`

## Verified with dry-runs

**First RC from main** (`--specifier premajor --preid rc`): `0.120.0` -> `1.0.0-rc.0`

**Subsequent RC** (`--preid rc`, after v1.0.0-rc.0 tag): `1.0.0-rc.0` -> `1.0.0-rc.1`

**Stable from release/0.x** (no preid): `0.120.0` -> `0.121.0`

## Test plan

- [x] `nx release --dry-run --specifier premajor --preid rc` produces `1.0.0-rc.0`
- [x] Subsequent RC increments correctly: `1.0.0-rc.0` -> `1.0.0-rc.1`
- [x] `nx release --dry-run --yes` (no preid) produces `0.121.0`
- [x] GitHub Release is created with prerelease tag
- [x] `feat!:` commits handled correctly (premajor overrides, then prerelease auto-detects)
- [x] Full test suite passes (1848 tests)
- [ ] CI smoke tests pass

Closes #736.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*