### PR TITLE
feat(create-nx-workspace): pin preset to own package version

### DIFF
--- a/docs/src/components/create-nx-workspace-command.astro
+++ b/docs/src/components/create-nx-workspace-command.astro
@@ -2,7 +2,7 @@
 import PackageManagerCommand from './package-manager-command.astro';
 import { buildCreateNxWorkspaceCommand } from '../../../packages/nx-plugin/src/utils/commands';
 
-const { workspace, iacProvider } = Astro.props;
-const buildCommand = (pm) => buildCreateNxWorkspaceCommand(pm, workspace, iacProvider);
+const { workspace, iacProvider, tag } = Astro.props;
+const buildCommand = (pm) => buildCreateNxWorkspaceCommand(pm, workspace, iacProvider, tag);
 ---
 <PackageManagerCommand buildCommand={buildCommand} />

--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -31,6 +31,12 @@ Run the following command to create an <Link path="guides/workspace">Nx workspac
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[Trying the latest release candidate]
+To try the latest pre-release version, append `@next` to the package name:
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[Choosing an IaC Provider]
 You will be prompted for your preferred infrastructure as code (IaC) provider, either [CDK](https://docs.aws.amazon.com/cdk/) or [Terraform](https://developer.hashicorp.com/terraform). You can skip the prompt by running the command with `--iacProvider`, ie:
 

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ Ejecuta el siguiente comando para crear un <Link path="guides/workspace">espacio
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[Probar la última versión candidata]
+Para probar la última versión preliminar, agrega `@next` al nombre del paquete:
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[Elegir un proveedor de IaC]
 Se te pedirá que elijas tu proveedor de infraestructura como código (IaC), ya sea [CDK](https://docs.aws.amazon.com/cdk/) o [Terraform](https://developer.hashicorp.com/terraform). Puedes omitir esta pregunta ejecutando el comando con `--iacProvider`, por ejemplo:
 

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ Exécutez la commande suivante pour créer un <Link path="guides/workspace">espa
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[Essayer la dernière version candidate]
+Pour essayer la dernière version pré-release, ajoutez `@next` au nom du paquet :
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[Choix d'un fournisseur IaC]
 Vous serez invité à choisir votre fournisseur d'infrastructure as code (IaC), soit [CDK](https://docs.aws.amazon.com/cdk/) soit [Terraform](https://developer.hashicorp.com/terraform). Vous pouvez ignorer cette étape en ajoutant `--iacProvider` à la commande, par exemple :
 

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ Esegui il seguente comando per creare una <Link path="guides/workspace">workspac
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[Provare l'ultima release candidate]
+Per provare l'ultima versione pre-release, aggiungi `@next` al nome del pacchetto:
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[Scegliere un provider IaC]
 Ti verrà chiesto di selezionare un provider per l'infrastruttura as code (IaC), [CDK](https://docs.aws.amazon.com/cdk/) o [Terraform](https://developer.hashicorp.com/terraform). Puoi saltare la selezione aggiungendo `--iacProvider` al comando, ad esempio:
 

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ import Infrastructure from '@components/infrastructure.astro';
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[最新リリース候補版を試す]
+最新のプレリリースバージョンを試すには、パッケージ名に`@next`を追加します：
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[IaCプロバイダーの選択]
 IaC（Infrastructure as Code）プロバイダーとして[CDK](https://docs.aws.amazon.com/cdk/)または[Terraform](https://developer.hashicorp.com/terraform)を選択するプロンプトが表示されます。`--iacProvider`オプションを付けて実行することでプロンプトをスキップできます：
 

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ import Infrastructure from '@components/infrastructure.astro';
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[최신 릴리스 후보 버전 사용해보기]
+최신 프리릴리스 버전을 사용하려면 패키지 이름에 `@next`를 추가하세요:
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[IaC 프로바이더 선택]
 인프라스트럭처 코드(IaC) 제공자로 [CDK](https://docs.aws.amazon.com/cdk/) 또는 [Terraform](https://developer.hashicorp.com/terraform)을 선택할 수 있습니다. `--iacProvider` 플래그를 사용하면 프롬프트를 건너뛸 수 있습니다:
 

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ Execute o seguinte comando para criar um <Link path="guides/workspace">workspace
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[Experimentando a versão release candidate mais recente]
+Para experimentar a versão de pré-lançamento mais recente, adicione `@next` ao nome do pacote:
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[Escolhendo um provedor IaC]
 Você será questionado sobre seu provedor de infraestrutura como código (IaC) preferido, [CDK](https://docs.aws.amazon.com/cdk/) ou [Terraform](https://developer.hashicorp.com/terraform). Você pode pular a pergunta executando o comando com `--iacProvider`, ex:
 

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ Chạy lệnh sau để tạo một <Link path="guides/workspace">Nx workspace</
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[Thử phiên bản release candidate mới nhất]
+Để thử phiên bản pre-release mới nhất, hãy thêm `@next` vào tên package:
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[Chọn nhà cung cấp IaC]
 Bạn sẽ được nhắc chọn nhà cung cấp infrastructure as code (IaC) ưa thích, có thể là [CDK](https://docs.aws.amazon.com/cdk/) hoặc [Terraform](https://developer.hashicorp.com/terraform). Bạn có thể bỏ qua lời nhắc bằng cách chạy lệnh với `--iacProvider`, ví dụ:
 

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -32,6 +32,12 @@ import Infrastructure from '@components/infrastructure.astro';
 <CreateNxWorkspaceCommand workspace="my-project" />
 
 
+:::tip[尝试最新候选版本]
+要尝试最新的预发布版本，请在包名后添加 `@next`：
+
+<CreateNxWorkspaceCommand workspace="my-project" tag="next" />
+:::
+
 :::tip[选择IaC提供者]
 系统会提示您选择基础设施即代码（IaC）提供商，可选 [CDK](https://docs.aws.amazon.com/cdk/) 或 [Terraform](https://developer.hashicorp.com/terraform)。您可以通过添加 `--iacProvider` 参数跳过提示：
 

--- a/packages/create-nx-workspace/src/create-nx-workspace.spec.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.spec.ts
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import {
   buildArgs,
   createNxWorkspace,
   detectPackageManager,
   shouldSkipGit,
 } from './create-nx-workspace';
+
+const OWN_VERSION: string = JSON.parse(
+  readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'),
+).version;
 
 describe('create-nx-workspace', () => {
   let originalUserAgent: string | undefined;
@@ -77,7 +83,7 @@ describe('create-nx-workspace', () => {
     it('should add --preset, default flags, and --skipGit for a simple workspace name', () => {
       expect(buildArgs(['my-project'])).toEqual([
         'my-project',
-        '--preset=@aws/nx-plugin',
+        `--preset=@aws/nx-plugin@${OWN_VERSION}`,
         '--ci=skip',
         '--analytics=false',
         '--skipGit',
@@ -104,7 +110,7 @@ describe('create-nx-workspace', () => {
         '--interactive=false',
       ]);
       expect(result[0]).toBe('my-project');
-      expect(result[1]).toBe('--preset=@aws/nx-plugin');
+      expect(result[1]).toBe(`--preset=@aws/nx-plugin@${OWN_VERSION}`);
     });
 
     it('should place --preset before user flags', () => {
@@ -113,7 +119,9 @@ describe('create-nx-workspace', () => {
         '--iacProvider=CDK',
         '--interactive=false',
       ]);
-      const presetIndex = result.indexOf('--preset=@aws/nx-plugin');
+      const presetIndex = result.indexOf(
+        `--preset=@aws/nx-plugin@${OWN_VERSION}`,
+      );
       const iacIndex = result.indexOf('--iacProvider=CDK');
       expect(presetIndex).toBeLessThan(iacIndex);
     });
@@ -146,7 +154,7 @@ describe('create-nx-workspace', () => {
 
     it('should handle no args', () => {
       expect(buildArgs([])).toEqual([
-        '--preset=@aws/nx-plugin',
+        `--preset=@aws/nx-plugin@${OWN_VERSION}`,
         '--ci=skip',
         '--analytics=false',
         '--skipGit',
@@ -157,7 +165,7 @@ describe('create-nx-workspace', () => {
       const result = buildArgs(['my-project', 'extra-arg']);
       expect(result[0]).toBe('my-project');
       expect(result[1]).toBe('extra-arg');
-      expect(result[2]).toBe('--preset=@aws/nx-plugin');
+      expect(result[2]).toBe(`--preset=@aws/nx-plugin@${OWN_VERSION}`);
     });
 
     it('should always pass --skipGit to nx regardless of user flags', () => {
@@ -202,7 +210,7 @@ describe('create-nx-workspace', () => {
       ]);
       expect(result).toEqual([
         'e2e-test',
-        '--preset=@aws/nx-plugin',
+        `--preset=@aws/nx-plugin@${OWN_VERSION}`,
         '--ci=skip',
         '--analytics=false',
         '--skipGit',

--- a/packages/create-nx-workspace/src/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.ts
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { spawnSync } from 'child_process';
+import { readFileSync } from 'fs';
 import { resolve } from 'path';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { TS_VERSIONS } from '../../nx-plugin/src/utils/versions';
 
 const NX_VERSION = TS_VERSIONS['create-nx-workspace'];
-const PRESET = '@aws/nx-plugin';
+const OWN_VERSION: string = JSON.parse(
+  readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'),
+).version;
+const PRESET = `@aws/nx-plugin@${OWN_VERSION}`;
 const DEFAULT_FLAGS = ['--ci=skip', '--analytics=false'];
 
 /**
@@ -81,7 +85,7 @@ export const createNxWorkspace = (args: string[]): number => {
   if (hasPreset) {
     console.error(
       `Error: --preset cannot be used with @aws/create-nx-workspace.\n` +
-        `This package always creates a workspace with the ${PRESET} preset.\n` +
+        `This package always creates a workspace with the @aws/nx-plugin preset.\n` +
         `To use a different preset, run create-nx-workspace directly:\n\n` +
         `  npx create-nx-workspace <name> --preset=<your-preset>\n`,
     );

--- a/packages/nx-plugin/src/utils/commands.ts
+++ b/packages/nx-plugin/src/utils/commands.ts
@@ -83,11 +83,13 @@ export const buildCreateNxWorkspaceCommand = (
   pm: string,
   workspace: string,
   iacProvider?: 'CDK' | 'Terraform',
+  tag?: string,
 ) => {
   const createPrefix = PACKAGE_MANAGER_COMMANDS[pm]?.create ?? `${pm} create`;
+  const pkgName = tag ? `@aws/nx-workspace@${tag}` : '@aws/nx-workspace';
   const parts = [
     createPrefix,
-    '@aws/nx-workspace',
+    pkgName,
     // npm requires '--' to stop interpreting subsequent flags as npm config
     ...(pm === 'npm' ? ['--'] : []),
     workspace,


### PR DESCRIPTION
## Summary

- `@aws/create-nx-workspace` now reads its own version from `package.json` at runtime and passes `--preset=@aws/nx-plugin@<version>` instead of bare `--preset=@aws/nx-plugin`
- This ensures the preset version always matches the `create-nx-workspace` version (they share a fixed release group)
- Adds a `tag` prop to the `CreateNxWorkspaceCommand` docs component
- Adds a tip to the quick start guide showing how to use `@next`

## Why this matters

Once 1.0 release candidates exist on the `next` dist-tag:

```bash
pnpm create @aws/nx-workspace my-project        # → uses @aws/nx-plugin@0.x (stable)
pnpm create @aws/nx-workspace@next my-project   # → uses @aws/nx-plugin@1.0.0-rc.N (RC)
```

Without this change, both commands would resolve the preset to whatever `latest` points to, making it impossible to create a workspace using the RC.

## Test plan

- [x] All 29 create-nx-workspace tests pass with versioned preset assertions
- [x] Docs build succeeds with new `tag` prop on component
- [ ] CI smoke tests pass (the `no-interactive` smoke test exercises create-nx-workspace)

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*