### PR TITLE
chore: point power/skill URLs at release/0.x branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,8 @@
       "name": "nx-plugin-for-aws",
       "source": {
         "source": "github",
-        "repo": "awslabs/nx-plugin-for-aws"
+        "repo": "awslabs/nx-plugin-for-aws",
+        "ref": "release/0.x"
       },
       "description": "Scaffold and build cloud-native applications on AWS using @aws/nx-plugin generators.",
       "version": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Install the [Kiro Power](https://kiro.dev/docs/powers/) for the best experience 
 
 1. Open the Kiro Powers panel from the sidebar
 2. Click `+` to add a custom power
-3. Paste: `https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws`
+3. Paste: `https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws`
 4. Click install
 
 Or add the MCP server manually in `.kiro/mcp.json`:

--- a/docs/src/content/docs/en/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/en/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ Install the [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
     2. Enter the following URL:
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. Click **Install**

--- a/docs/src/content/docs/es/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/es/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ Instala el [Plugin de Claude](https://code.claude.com/docs/en/plugins), [Kiro Po
     2. Ingresa la siguiente URL:
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. Haz clic en **Install**

--- a/docs/src/content/docs/fr/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/fr/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ Installez le [plugin Claude](https://code.claude.com/docs/en/plugins), le [Kiro 
     2. Entrez l'URL suivante :
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. Cliquez sur **Install**

--- a/docs/src/content/docs/it/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/it/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ Installa il [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
     2. Inserisci il seguente URL:
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. Clicca su **Install**

--- a/docs/src/content/docs/jp/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/jp/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     2. 以下のURLを入力：
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. **Install**をクリック

--- a/docs/src/content/docs/ko/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/ko/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     2. 다음 URL 입력:
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. **Install** 클릭

--- a/docs/src/content/docs/pt/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/pt/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ Instale o [Plugin Claude](https://code.claude.com/docs/en/plugins), [Kiro Power]
     2. Digite a seguinte URL:
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. Clique em **Install**

--- a/docs/src/content/docs/vi/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/vi/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ Cài đặt [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
     2. Nhập URL sau:
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. Nhấp vào **Install**

--- a/docs/src/content/docs/zh/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/zh/get_started/building-with-ai.mdx
@@ -20,7 +20,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     2. 输入以下 URL：
 
        ```
-       https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws
+       https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws
        ```
 
     3. 点击 **Install**

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -45,7 +45,7 @@ Install the [Kiro Power](https://kiro.dev/docs/powers/) for the best experience 
 
 1. Open the Kiro Powers panel from the sidebar
 2. Click `+` to add a custom power
-3. Paste: `https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws`
+3. Paste: `https://github.com/awslabs/nx-plugin-for-aws/tree/release/0.x/powers/nx-plugin-for-aws`
 4. Click install
 
 Or add the MCP server manually in `.kiro/mcp.json`:


### PR DESCRIPTION
### Reason for this change

Now that `main` is the 1.0 release candidate, the Kiro Power URL and Claude Code plugin marketplace `ref` on the `release/0.x` branch still point to `main`. This means 0.x users installing the Power or plugin will get 1.0 RC content (which may reference generators or features that don't exist in 0.x).

### Description of changes

- **README.md** / **packages/nx-plugin/README.md**: Updated the Kiro Power install URL from `tree/main/powers/...` to `tree/release/0.x/powers/...`
- **docs/.../building-with-ai.mdx**: Same URL fix in the English docs
- **.claude-plugin/marketplace.json**: Added `"ref": "release/0.x"` to the source config so the Claude Code plugin marketplace resolves against this branch

### Description of how you validated changes

Documentation-only changes — verified no build impact. URLs resolve correctly to the `release/0.x` branch on GitHub.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*