### PR TITLE
chore: add stable and next plugin entries to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,26 @@
       "name": "nx-plugin-for-aws",
       "source": {
         "source": "github",
-        "repo": "awslabs/nx-plugin-for-aws"
+        "repo": "awslabs/nx-plugin-for-aws",
+        "ref": "release/0.x"
       },
       "description": "Scaffold and build cloud-native applications on AWS using @aws/nx-plugin generators.",
+      "version": "1.0.0",
+      "author": {
+        "name": "AWS"
+      },
+      "homepage": "https://awslabs.github.io/nx-plugin-for-aws",
+      "repository": "https://github.com/awslabs/nx-plugin-for-aws",
+      "license": "Apache-2.0",
+      "keywords": ["aws", "nx", "cdk", "terraform", "agent", "mcp-server"]
+    },
+    {
+      "name": "nx-plugin-for-aws-next",
+      "source": {
+        "source": "github",
+        "repo": "awslabs/nx-plugin-for-aws"
+      },
+      "description": "[Pre-release] Scaffold and build cloud-native applications on AWS using @aws/nx-plugin generators (1.0 release candidate).",
       "version": "1.0.0",
       "author": {
         "name": "AWS"

--- a/docs/src/content/docs/en/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/en/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ Install the [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
     ```
 
     Then run `/reload-plugins` to activate the plugin.
+
+    :::tip
+    To try the 1.0 release candidate, install `nx-plugin-for-aws-next@nx-plugin-for-aws` instead.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     Add the following to `~/.cursor/mcp.json` (or `.cursor/mcp.json` in your project):

--- a/docs/src/content/docs/es/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/es/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ Instala el [Plugin de Claude](https://code.claude.com/docs/en/plugins), [Kiro Po
     ```
 
     Luego ejecuta `/reload-plugins` para activar el plugin.
+
+    :::tip
+    Para probar la versión candidata 1.0, instala `nx-plugin-for-aws-next@nx-plugin-for-aws` en su lugar.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     Agrega lo siguiente a `~/.cursor/mcp.json` (o `.cursor/mcp.json` en tu proyecto):

--- a/docs/src/content/docs/fr/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/fr/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ Installez le [plugin Claude](https://code.claude.com/docs/en/plugins), le [Kiro 
     ```
 
     Ensuite, exécutez `/reload-plugins` pour activer le plugin.
+
+    :::tip
+    Pour essayer la version candidate 1.0, installez plutôt `nx-plugin-for-aws-next@nx-plugin-for-aws`.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     Ajoutez ce qui suit à `~/.cursor/mcp.json` (ou `.cursor/mcp.json` dans votre projet) :

--- a/docs/src/content/docs/it/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/it/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ Installa il [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
     ```
 
     Quindi esegui `/reload-plugins` per attivare il plugin.
+
+    :::tip
+    Per provare la release candidate 1.0, installa invece `nx-plugin-for-aws-next@nx-plugin-for-aws`.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     Aggiungi quanto segue a `~/.cursor/mcp.json` (o `.cursor/mcp.json` nel tuo progetto):

--- a/docs/src/content/docs/jp/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/jp/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     ```
 
     その後、`/reload-plugins`を実行してプラグインを有効化します。
+
+    :::tip
+    1.0リリース候補を試すには、代わりに`nx-plugin-for-aws-next@nx-plugin-for-aws`をインストールしてください。
+    :::
   </TabItem>
   <TabItem label="Cursor">
     `~/.cursor/mcp.json`（またはプロジェクト内の`.cursor/mcp.json`）に以下を追加してください：

--- a/docs/src/content/docs/ko/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/ko/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     ```
 
     그런 다음 `/reload-plugins`를 실행하여 플러그인을 활성화하세요.
+
+    :::tip
+    1.0 릴리스 후보를 사용해보려면 대신 `nx-plugin-for-aws-next@nx-plugin-for-aws`를 설치하세요.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     `~/.cursor/mcp.json` (또는 프로젝트의 `.cursor/mcp.json`)에 다음을 추가하세요:

--- a/docs/src/content/docs/pt/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/pt/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ Instale o [Plugin Claude](https://code.claude.com/docs/en/plugins), [Kiro Power]
     ```
 
     Em seguida, execute `/reload-plugins` para ativar o plugin.
+
+    :::tip
+    Para experimentar o candidato a lançamento 1.0, instale `nx-plugin-for-aws-next@nx-plugin-for-aws` em vez disso.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     Adicione o seguinte a `~/.cursor/mcp.json` (ou `.cursor/mcp.json` no seu projeto):

--- a/docs/src/content/docs/vi/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/vi/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ Cài đặt [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
     ```
 
     Sau đó chạy `/reload-plugins` để kích hoạt plugin.
+
+    :::tip
+    Để thử phiên bản release candidate 1.0, hãy cài đặt `nx-plugin-for-aws-next@nx-plugin-for-aws` thay thế.
+    :::
   </TabItem>
   <TabItem label="Cursor">
     Thêm nội dung sau vào `~/.cursor/mcp.json` (hoặc `.cursor/mcp.json` trong dự án của bạn):

--- a/docs/src/content/docs/zh/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/zh/get_started/building-with-ai.mdx
@@ -56,6 +56,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     ```
 
     然后运行 `/reload-plugins` 来激活插件。
+
+    :::tip
+    要尝试 1.0 候选版本，请改为安装 `nx-plugin-for-aws-next@nx-plugin-for-aws`。
+    :::
   </TabItem>
   <TabItem label="Cursor">
     将以下内容添加到 `~/.cursor/mcp.json`（或项目中的 `.cursor/mcp.json`）：


### PR DESCRIPTION
### Reason for this change

The Claude Code plugin marketplace is always cloned from the repo's default branch (`main`). Now that `main` is the 1.0 release candidate, the existing single plugin entry pulls content from `main` — which has 1.x-only generators (e.g. `ts#docs`) that don't exist in the published stable release.

Users running `/plugin install nx-plugin-for-aws@nx-plugin-for-aws` should get the stable 0.x plugin content.

### Description of changes

- **`.claude-plugin/marketplace.json`**: Split into two plugin entries:
  - `nx-plugin-for-aws` — stable entry with `"ref": "release/0.x"` so it resolves to the stable branch
  - `nx-plugin-for-aws-next` — 1.0 RC entry with no ref (resolves to `main`)
- **`docs/.../building-with-ai.mdx`**: Updated Claude Code tab to reference the RC plugin name (`nx-plugin-for-aws-next`) with a note about the stable alternative

### Description of how you validated changes

Tested end-to-end with Claude Code CLI:
1. Added the local repo as a marketplace
2. Installed `nx-plugin-for-aws@nx-plugin-for-aws` — confirmed it resolved to `release/0.x` HEAD (commit `63b136ab`) and the SKILL.md lists `ts#astro-docs` (0.x generator)
3. Installed `nx-plugin-for-aws-next@nx-plugin-for-aws` — confirmed it resolved to `main` HEAD and the SKILL.md lists `ts#docs` (1.x generator)
4. Validated marketplace.json passes `claude plugin validate`

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*