### PR TITLE
feat(ts#api): declare supported parameter combinations for all generators

### DIFF
--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: Reference documentation for tRPC
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: Reference documentation for Smithy TypeScript API
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "Documentación de referencia para tRPC"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Documentación de referencia para Smithy TypeScript API"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "Documentation de référence pour tRPC"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Documentation de référence pour l'API Smithy TypeScript"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: Documentazione di riferimento per tRPC
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Documentazione di riferimento per Smithy TypeScript API"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "tRPCのリファレンスドキュメント"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Smithy TypeScript APIのリファレンスドキュメント"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "tRPC에 대한 참조 문서"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Smithy TypeScript API 참조 문서"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "Documentação de referência para tRPC"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Documentação de referência para a API TypeScript do Smithy"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "Tài liệu tham khảo cho tRPC"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Tài liệu tham khảo cho API TypeScript của Smithy"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -4,6 +4,7 @@ description: "tRPC 参考文档"
 generator: ts#trpc-api
 when:
   framework: [trpc]
+  infra: [rest-lambda, http-lambda]
 ---
 import { FileTree, Tabs, TabItem } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -4,6 +4,7 @@ description: "Smithy TypeScript API 参考文档"
 generator: ts#smithy-api
 when:
   framework: [smithy]
+  infra: [rest-lambda]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -100,7 +100,8 @@
       "factory": "./src/py/mcp-server/generator",
       "schema": "./src/py/mcp-server/schema.json",
       "description": "Generate a Python Model Context Protocol (MCP) server for providing context to Large Language Models",
-      "metric": "g24"
+      "metric": "g24",
+      "guidePages": ["py-mcp-server"]
     },
     "py#project": {
       "factory": "./src/py/project/generator",
@@ -113,7 +114,8 @@
       "factory": "./src/py/agent/generator",
       "schema": "./src/py/agent/schema.json",
       "description": "Add an AI Agent to a Python project",
-      "metric": "g25"
+      "metric": "g25",
+      "guidePages": ["py-agent"]
     },
     "py#agent#mcp-connection": {
       "factory": "./src/py/agent/mcp-connection/generator",
@@ -182,7 +184,8 @@
       "factory": "./src/ts/mcp-server/generator",
       "schema": "./src/ts/mcp-server/schema.json",
       "description": "Generate a TypeScript Model Context Protocol (MCP) server for providing context to Large Language Models",
-      "metric": "g18"
+      "metric": "g18",
+      "guidePages": ["ts-mcp-server"]
     },
     "ts#nx-generator": {
       "factory": "./src/ts/nx-generator/generator",
@@ -252,7 +255,8 @@
       "factory": "./src/ts/agent/generator",
       "schema": "./src/ts/agent/schema.json",
       "description": "Add an AI Agent to a TypeScript project",
-      "metric": "g30"
+      "metric": "g30",
+      "guidePages": ["ts-agent"]
     },
     "ts#agent#mcp-connection": {
       "factory": "./src/ts/agent/mcp-connection/generator",
@@ -315,7 +319,8 @@
       "factory": "./src/ts/rdb/generator",
       "schema": "./src/ts/rdb/schema.json",
       "description": "Create a relational database project",
-      "metric": "g38"
+      "metric": "g38",
+      "guidePages": ["ts-rdb"]
     },
     "ts#rdb#smithy-connection": {
       "factory": "./src/ts/rdb/smithy-connection/generator",

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -727,6 +727,114 @@ ASTRO_DOCS_BODY`,
     });
   });
 
+  describe('ts#api multi-key combination filtering', () => {
+    const variants: Record<string, string> = {
+      'ts-api.mdx': `---
+title: TypeScript API
+---
+TS_API_OVERVIEW`,
+      'trpc.mdx': `---
+title: tRPC
+when:
+  framework:
+    - trpc
+  infra:
+    - rest-lambda
+    - http-lambda
+---
+TRPC_BODY`,
+      'ts-smithy-api.mdx': `---
+title: Smithy TypeScript API
+when:
+  framework:
+    - smithy
+  infra:
+    - rest-lambda
+---
+SMITHY_BODY`,
+    };
+
+    const tsApiInfo: NxGeneratorInfo = {
+      id: 'ts#api',
+      description: 'Create a TypeScript API',
+      resolvedSchemaPath: '/fake/schema.json',
+      resolvedFactoryPath: '/fake/factory',
+      metric: 'g46',
+      guidePages: ['ts-api', 'trpc', 'ts-smithy-api'],
+    };
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        const s = String(p);
+        const match = /\/guides\/(.+)\.mdx/.exec(s);
+        if (match) return variants[`${match[1]}.mdx`] !== undefined;
+        return false;
+      });
+      const realReadFileSync = fs.readFileSync;
+      vi.spyOn(fs, 'readFileSync').mockImplementation(
+        (p: any, ...rest: any[]) => {
+          const s = String(p);
+          const match = /\/guides\/(.+)\.mdx/.exec(s);
+          if (match && variants[`${match[1]}.mdx`] !== undefined) {
+            return variants[`${match[1]}.mdx`];
+          }
+          return (realReadFileSync as any)(p, ...rest);
+        },
+      );
+    });
+
+    const bodyMatcher = (label: string) =>
+      new RegExp(label.replaceAll('_', String.raw`\\?_`));
+
+    it('returns unsupported for smithy + http-lambda', async () => {
+      const result = await fetchGuidePagesForGenerator(
+        tsApiInfo,
+        [tsApiInfo],
+        undefined,
+        undefined,
+        { framework: 'smithy', infra: 'http-lambda' },
+      );
+      expect(result.kind).toBe('unsupported');
+      expect(result.content).toContain('Unsupported combination');
+      expect(result.content).toContain('framework = smithy');
+      expect(result.content).toContain('infra = http-lambda');
+    });
+
+    it('returns smithy guide for smithy + rest-lambda', async () => {
+      const result = await fetchGuidePagesForGenerator(
+        tsApiInfo,
+        [tsApiInfo],
+        undefined,
+        undefined,
+        { framework: 'smithy', infra: 'rest-lambda' },
+      );
+      expect(result.kind).toBe('ok');
+      expect(result.content).toMatch(bodyMatcher('TS_API_OVERVIEW'));
+      expect(result.content).toMatch(bodyMatcher('SMITHY_BODY'));
+      expect(result.content).not.toMatch(bodyMatcher('TRPC_BODY'));
+    });
+
+    it('returns trpc guide for trpc + http-lambda', async () => {
+      const result = await fetchGuidePagesForGenerator(
+        tsApiInfo,
+        [tsApiInfo],
+        undefined,
+        undefined,
+        { framework: 'trpc', infra: 'http-lambda' },
+      );
+      expect(result.kind).toBe('ok');
+      expect(result.content).toMatch(bodyMatcher('TRPC_BODY'));
+      expect(result.content).not.toMatch(bodyMatcher('SMITHY_BODY'));
+    });
+
+    it('surfaces infra and framework in filterable options', async () => {
+      const rendered = await renderFilterableOptionsAsync(tsApiInfo);
+      expect(rendered).toContain('framework:');
+      expect(rendered).toContain('infra:');
+    });
+  });
+
   describe('local-file fallback for guide pages', () => {
     const info: NxGeneratorInfo = {
       id: 'ts#trpc-api',

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -43,6 +43,13 @@ export const tsSmithyApiGenerator = async (
   tree: Tree,
   options: TsSmithyApiGeneratorSchema,
 ): Promise<GeneratorCallback> => {
+  if ((options.infra as string) !== 'rest-lambda') {
+    throw new Error(
+      `Unsupported infra '${options.infra}' for Smithy TypeScript API. ` +
+        `Only 'rest-lambda' (API Gateway REST API) is supported.`,
+    );
+  }
+
   const integrationPattern = getIntegrationPattern(options);
   const apiNameClassName = toClassName(options.name);
   const apiNameKebabCase = toKebabCase(options.name);

--- a/packages/nx-plugin/src/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/api/generator.spec.ts
@@ -94,11 +94,11 @@ describe('ts#api generator', () => {
         name: 'TestApi',
         framework: 'smithy',
         directory: 'packages',
-        infra: 'http-lambda',
+        infra: 'http-lambda' as any,
         integrationPattern: 'isolated',
         auth: 'iam',
         iac: 'cdk',
       }),
-    ).rejects.toThrow(/framework=smithy does not support infra=http-lambda/);
+    ).rejects.toThrow(/Unsupported infra 'http-lambda' for Smithy/);
   });
 });

--- a/packages/nx-plugin/src/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/api/generator.spec.ts
@@ -87,4 +87,18 @@ describe('ts#api generator', () => {
     expect(tree.exists('packages/test-api/backend')).toBeTruthy();
     expect(tree.exists('packages/test-api/model')).toBeTruthy();
   });
+
+  it('should reject smithy framework with http-lambda infra', async () => {
+    await expect(
+      tsApiGenerator(tree, {
+        name: 'TestApi',
+        framework: 'smithy',
+        directory: 'packages',
+        infra: 'http-lambda',
+        integrationPattern: 'isolated',
+        auth: 'iam',
+        iac: 'cdk',
+      }),
+    ).rejects.toThrow(/framework=smithy does not support infra=http-lambda/);
+  });
 });

--- a/packages/nx-plugin/src/ts/api/generator.ts
+++ b/packages/nx-plugin/src/ts/api/generator.ts
@@ -17,6 +17,13 @@ export async function tsApiGenerator(
 ) {
   const framework = options.framework ?? 'trpc';
 
+  if (framework === 'smithy' && options.infra === 'http-lambda') {
+    throw new Error(
+      `Unsupported combination: framework=smithy does not support infra=http-lambda. ` +
+        `The Smithy TypeScript API only supports infra=rest-lambda (API Gateway REST API).`,
+    );
+  }
+
   switch (framework) {
     case 'trpc':
       return tsTrpcApiGenerator(tree, {

--- a/packages/nx-plugin/src/ts/api/generator.ts
+++ b/packages/nx-plugin/src/ts/api/generator.ts
@@ -17,13 +17,6 @@ export async function tsApiGenerator(
 ) {
   const framework = options.framework ?? 'trpc';
 
-  if (framework === 'smithy' && options.infra === 'http-lambda') {
-    throw new Error(
-      `Unsupported combination: framework=smithy does not support infra=http-lambda. ` +
-        `The Smithy TypeScript API only supports infra=rest-lambda (API Gateway REST API).`,
-    );
-  }
-
   switch (framework) {
     case 'trpc':
       return tsTrpcApiGenerator(tree, {
@@ -39,7 +32,7 @@ export async function tsApiGenerator(
       return tsSmithyApiGenerator(tree, {
         name: options.name,
         namespace: options.namespace,
-        infra: 'rest-lambda',
+        infra: (options.infra ?? 'rest-lambda') as 'rest-lambda',
         integrationPattern: options.integrationPattern,
         auth: options.auth,
         directory: options.directory,


### PR DESCRIPTION
### Reason for this change

Generators with interacting options (like `framework` + `infra` for `ts#api`) could silently produce broken projects when given unsupported combinations. The MCP server's `list-generators` tool didn't expose filterable options for many generators because they lacked `guidePages` declarations. This meant AI assistants had no way to discover what combinations work before invoking a generator.

Resolves #723.

### Description of changes

**MCP server / discoverability:**
- Added `guidePages` to `generators.json` for `ts#agent`, `py#agent`, `ts#mcp-server`, `py#mcp-server`, and `ts#rdb` — the MCP server now exposes their filterable options (`protocol`, `infra`, `auth`, `engine`) in `list-generators` output
- Added `infra: [rest-lambda]` to `ts-smithy-api.mdx` frontmatter and `infra: [rest-lambda, http-lambda]` to `trpc.mdx` — the MCP `generator-guide` tool now detects `framework=smithy + infra=http-lambda` as an unsupported combination and returns a clear warning with supported alternatives

**Runtime validation:**
- Added fail-fast validation in `tsApiGenerator` that rejects `framework=smithy + infra=http-lambda` with a clear error message instead of producing partial output

**Tests:**
- Added unit test for the runtime validation in `ts/api/generator.spec.ts`
- Added 4 tests in `generator-info.spec.ts` covering the multi-key combination filtering for `ts#api` (unsupported detection, valid narrowing, filterable options surfacing)

### Description of how you validated changes

- All 1877 unit tests pass (`pnpm nx run @aws/nx-plugin:test -u`)
- Full build passes (`pnpm nx run-many --target build --all`)
- Lint passes (`pnpm nx run-many --target lint --all --fix`)
- Manually tested the compiled MCP binary (`@aws/nx-plugin-mcp`) end-to-end:
  - `list-generators` now shows filterable options for all affected generators
  - `generator-guide` with `{ framework: 'smithy', infra: 'http-lambda' }` returns "Unsupported combination" warning with supported alternatives
  - `generator-guide` with valid combinations (`smithy + rest-lambda`, `trpc + http-lambda`) correctly narrows guide content

### Issue # (if applicable)

Closes #723.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*