### PR TITLE
feat(infra): support --infra=none on all infrastructure-vending generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - fast-api
           - smithy-api
           - react-website
+          - infra-none
           - cdk-deploy
           - cdk-deploy-rdb
           - terraform-deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,6 +68,7 @@ jobs:
           - fast-api
           - smithy-api
           - react-website
+          - infra-none
           - license-sync
           - mcp-server
           - git-secrets

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -153,17 +153,6 @@
       "zh": "是否添加 TypeScript 插件。",
       "vi": "Có thêm ts plugin hay không."
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider.",
-      "jp": "優先するIaCプロバイダー。",
-      "ko": "선호하는 IaC 제공자입니다.",
-      "es": "El proveedor de IaC preferido.",
-      "pt": "O provedor de IaC preferido.",
-      "it": "Il provider IaC preferito.",
-      "fr": "Le fournisseur IaC préféré.",
-      "zh": "首选的基础设施即代码（IaC）提供商。",
-      "vi": "Nhà cung cấp IaC ưa thích."
-    },
     "gitSecrets": {
       "en": "Whether to configure git-secrets to prevent committing AWS credentials.",
       "ko": "AWS 자격 증명 커밋을 방지하기 위해 git-secrets를 구성할지 여부입니다.",
@@ -175,16 +164,27 @@
       "zh": "是否配置 git-secrets 以防止提交 AWS 凭证。",
       "vi": "Có cấu hình git-secrets để ngăn chặn commit thông tin xác thực AWS hay không."
     },
-    "containerEngine": {
+    "iac": {
+      "en": "The preferred IaC provider.",
+      "fr": "Le fournisseur IaC préféré.",
+      "es": "El proveedor de IaC preferido.",
+      "ko": "선호하는 IaC 제공자입니다.",
+      "pt": "O provedor de IaC preferido.",
+      "jp": "優先するIaCプロバイダー。",
+      "it": "Il provider IaC preferito.",
+      "vi": "Nhà cung cấp IaC ưa thích.",
+      "zh": "首选的 IaC 提供商。"
+    },
+    "containers": {
       "en": "The container engine to use for build/push/login. 'infer' picks docker if installed, otherwise finch (falling back to docker when neither is installed).",
+      "fr": "Le moteur de conteneurs à utiliser pour build/push/login. 'infer' choisit docker s'il est installé, sinon finch (avec repli sur docker si aucun n'est installé).",
       "es": "El motor de contenedores a utilizar para build/push/login. 'infer' selecciona docker si está instalado, de lo contrario finch (recurriendo a docker cuando ninguno está instalado).",
-      "fr": "Le moteur de conteneurs à utiliser pour build/push/login. 'infer' choisit docker s'il est installé, sinon finch (avec repli sur docker si aucun des deux n'est installé).",
-      "pt": "O motor de contêiner a ser usado para build/push/login. 'infer' escolhe docker se instalado, caso contrário finch (voltando para docker quando nenhum estiver instalado).",
+      "ko": "빌드/푸시/로그인에 사용할 컨테이너 엔진입니다. 'infer'는 설치된 경우 docker를 선택하고, 그렇지 않으면 finch를 선택합니다(둘 다 설치되지 않은 경우 docker로 대체).",
+      "pt": "O motor de contêineres a ser usado para build/push/login. 'infer' escolhe docker se instalado, caso contrário finch (voltando para docker quando nenhum estiver instalado).",
       "jp": "ビルド/プッシュ/ログインに使用するコンテナエンジン。'infer'はdockerがインストールされている場合はdockerを選択し、それ以外の場合はfinchを選択します（どちらもインストールされていない場合はdockerにフォールバックします）。",
-      "ko": "빌드/푸시/로그인에 사용할 컨테이너 엔진입니다. 'infer'는 docker가 설치되어 있으면 docker를 선택하고, 그렇지 않으면 finch를 선택합니다(둘 다 설치되지 않은 경우 docker로 폴백).",
-      "zh": "用于构建/推送/登录的容器引擎。'infer' 会在已安装 docker 时选择 docker，否则选择 finch（当两者都未安装时回退到 docker）。",
-      "vi": "Container engine được sử dụng để build/push/login. 'infer' sẽ chọn docker nếu đã cài đặt, nếu không sẽ dùng finch (quay lại docker khi cả hai đều chưa được cài đặt).",
-      "it": "Il motore di container da utilizzare per build/push/login. 'infer' seleziona docker se installato, altrimenti finch (con fallback a docker quando nessuno dei due è installato)."
+      "it": "Il motore di container da utilizzare per build/push/login. 'infer' seleziona docker se installato, altrimenti finch (con fallback a docker quando nessuno dei due è installato).",
+      "vi": "Công cụ container để sử dụng cho build/push/login. 'infer' chọn docker nếu đã cài đặt, nếu không thì chọn finch (quay lại docker khi cả hai đều chưa cài đặt).",
+      "zh": "用于构建/推送/登录的容器引擎。'infer' 会在已安装 docker 时选择 docker，否则选择 finch（当两者都未安装时回退到 docker）。"
     }
   },
   "py#agent": {
@@ -199,28 +199,6 @@
       "zh": "要添加 Agent 的项目",
       "vi": "Dự án để thêm Agent vào"
     },
-    "sdk": {
-      "en": "The agent SDK to use.",
-      "ko": "사용할 에이전트 SDK.",
-      "jp": "使用するエージェントSDK。",
-      "es": "El SDK de agente a utilizar.",
-      "fr": "Le SDK d'agent à utiliser.",
-      "pt": "O SDK de agente a ser usado.",
-      "it": "L'SDK dell'agente da utilizzare.",
-      "zh": "要使用的代理 SDK。",
-      "vi": "SDK agent để sử dụng."
-    },
-    "computeType": {
-      "en": "The type of compute to host your Agent.",
-      "ko": "Agent를 호스팅할 컴퓨팅 유형",
-      "jp": "Agentをホストするコンピュートのタイプ",
-      "es": "El tipo de cómputo para alojar tu Agent.",
-      "fr": "Le type de calcul pour héberger votre Agent.",
-      "pt": "O tipo de computação para hospedar seu Agent.",
-      "it": "Il tipo di compute per ospitare il tuo Agent.",
-      "zh": "托管 Agent 的计算类型",
-      "vi": "Loại compute để host Agent của bạn."
-    },
     "name": {
       "en": "The name of your Agent (default: agent)",
       "ko": "Agent의 이름 (기본값: agent)",
@@ -232,27 +210,16 @@
       "zh": "Agent 的名称（默认：agent）",
       "vi": "Tên của Agent của bạn (mặc định: agent)"
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "ko": "선호하는 IaC 공급자. 기본적으로 초기 선택에서 상속됩니다.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
-      "es": "El proveedor de IaC preferido. Por defecto, esto se hereda de tu selección inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "auth": {
-      "en": "The method used to authenticate with your Agent. Only applicable when computeType is set (ignored when computeType is None).",
-      "jp": "Agentとの認証に使用する方法。computeTypeが設定されている場合にのみ適用されます（computeTypeがNoneの場合は無視されます）。",
-      "es": "El método utilizado para autenticar con tu Agent. Solo aplicable cuando computeType está configurado (se ignora cuando computeType es None).",
-      "ko": "Agent 인증에 사용되는 방법입니다. computeType이 설정된 경우에만 적용됩니다 (computeType이 None인 경우 무시됨).",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre Agent. Applicable uniquement lorsque computeType est défini (ignoré lorsque computeType est None).",
-      "pt": "O método usado para autenticar com seu Agent. Aplicável apenas quando computeType está definido (ignorado quando computeType é None).",
-      "zh": "用于与 Agent 进行身份验证的方法。仅在设置了 computeType 时适用（当 computeType 为 None 时忽略）。",
-      "it": "Il metodo utilizzato per autenticare con il tuo Agent. Applicabile solo quando computeType è impostato (ignorato quando computeType è None).",
-      "vi": "Phương thức được sử dụng để xác thực với Agent của bạn. Chỉ áp dụng khi computeType được thiết lập (bỏ qua khi computeType là None)."
+      "en": "The method used to authenticate with your Agent. Only applicable when infra is set (ignored when infra is none).",
+      "jp": "エージェントとの認証に使用する方法。infraが設定されている場合にのみ適用されます（infraがnoneの場合は無視されます）。",
+      "es": "El método utilizado para autenticar con tu Agent. Solo aplicable cuando infra está configurado (se ignora cuando infra es none).",
+      "ko": "에이전트 인증에 사용되는 방법입니다. infra가 설정된 경우에만 적용됩니다 (infra가 none일 때는 무시됨).",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre Agent. Applicable uniquement lorsque infra est défini (ignoré lorsque infra est none).",
+      "pt": "O método usado para autenticar com seu Agent. Aplicável apenas quando infra está definido (ignorado quando infra é none).",
+      "zh": "用于对 Agent 进行身份验证的方法。仅在设置了 infra 时适用（当 infra 为 none 时忽略）。",
+      "it": "Il metodo utilizzato per autenticare con il tuo Agent. Applicabile solo quando infra è impostato (ignorato quando infra è none).",
+      "vi": "Phương thức được sử dụng để xác thực với Agent của bạn. Chỉ áp dụng khi infra được thiết lập (bị bỏ qua khi infra là none)."
     },
     "protocol": {
       "en": "The server protocol for your Agent. HTTP exposes a FastAPI HTTP server. A2A exposes an Agent-to-Agent protocol server. AG-UI exposes an Agent-User Interaction protocol server for direct frontend integration.",
@@ -264,6 +231,39 @@
       "it": "Il protocollo server per il tuo Agent. HTTP espone un server HTTP FastAPI. A2A espone un server con protocollo Agent-to-Agent. AG-UI espone un server con protocollo Agent-User Interaction per l'integrazione diretta con il frontend.",
       "zh": "Agent 的服务器协议。HTTP 暴露一个 FastAPI HTTP 服务器。A2A 暴露一个 Agent-to-Agent 协议服务器。AG-UI 暴露一个 Agent-User Interaction 协议服务器，用于直接前端集成。",
       "vi": "Giao thức máy chủ cho Agent của bạn. HTTP cung cấp máy chủ HTTP FastAPI. A2A cung cấp máy chủ giao thức Agent-to-Agent. AG-UI cung cấp máy chủ giao thức Agent-User Interaction để tích hợp trực tiếp với frontend."
+    },
+    "framework": {
+      "en": "The agent SDK to use.",
+      "jp": "使用するエージェントSDK。",
+      "pt": "O SDK do agente a ser usado.",
+      "ko": "사용할 에이전트 SDK입니다.",
+      "es": "El SDK del agente a utilizar.",
+      "fr": "Le SDK d'agent à utiliser.",
+      "vi": "SDK agent cần sử dụng.",
+      "zh": "要使用的 Agent SDK。",
+      "it": "L'SDK dell'agente da utilizzare."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, ceci est hérité de votre sélection initiale.",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale."
+    },
+    "infra": {
+      "en": "The type of infrastructure to host your Agent.",
+      "jp": "エージェントをホストするインフラストラクチャのタイプ。",
+      "pt": "O tipo de infraestrutura para hospedar seu Agent.",
+      "ko": "에이전트를 호스팅할 인프라 유형입니다.",
+      "es": "El tipo de infraestructura para alojar tu Agent.",
+      "fr": "Le type d'infrastructure pour héberger votre Agent.",
+      "vi": "Loại hạ tầng để lưu trữ Agent của bạn.",
+      "zh": "用于托管 Agent 的基础设施类型。",
+      "it": "Il tipo di infrastruttura per ospitare il tuo Agent."
     }
   },
   "py#agent#a2a-connection": {
@@ -416,17 +416,6 @@
       "zh": "要生成的 API 项目名称",
       "vi": "Tên của dự án API cần tạo"
     },
-    "computeType": {
-      "en": "The type of compute to use to deploy this API. Choose between ServerlessApiGatewayRestApi (default) or ServerlessApiGatewayHttpApi.",
-      "jp": "このAPIをデプロイするために使用するコンピュートのタイプ。ServerlessApiGatewayRestApi（デフォルト）またはServerlessApiGatewayHttpApiから選択します。",
-      "ko": "API 배포에 사용할 컴퓨팅 유형입니다. ServerlessApiGatewayRestApi (기본값) 또는 ServerlessApiGatewayHttpApi 중에서 선택하세요.",
-      "es": "El tipo de cómputo a utilizar para desplegar esta API. Elija entre ServerlessApiGatewayRestApi (predeterminado) o ServerlessApiGatewayHttpApi.",
-      "pt": "O tipo de computação a ser usado para implantar esta API. Escolha entre ServerlessApiGatewayRestApi (padrão) ou ServerlessApiGatewayHttpApi.",
-      "fr": "Le type de calcul à utiliser pour déployer cette API. Choisissez entre ServerlessApiGatewayRestApi (par défaut) ou ServerlessApiGatewayHttpApi.",
-      "it": "Il tipo di compute da utilizzare per distribuire questa API. Scegli tra ServerlessApiGatewayRestApi (predefinito) o ServerlessApiGatewayHttpApi.",
-      "zh": "用于部署此 API 的计算类型。可选择 ServerlessApiGatewayRestApi（默认）或 ServerlessApiGatewayHttpApi。",
-      "vi": "Loại compute sử dụng để triển khai API này. Chọn giữa ServerlessApiGatewayRestApi (mặc định) hoặc ServerlessApiGatewayHttpApi."
-    },
     "integrationPattern": {
       "en": "How API Gateway integrations are generated for the API. Choose between isolated (default) and shared.",
       "jp": "API用にAPI Gateway統合を生成する方法。isolated（デフォルト）またはsharedから選択します。",
@@ -439,15 +428,15 @@
       "vi": "Cách thức tạo các integration của API Gateway cho API. Chọn giữa isolated (mặc định) và shared."
     },
     "auth": {
-      "en": "The method used to authenticate with your API. Choose between IAM (default), Cognito or Custom.",
-      "jp": "APIの認証に使用する方法。IAM（デフォルト）、Cognito、またはCustomから選択します。",
-      "ko": "API 인증에 사용할 방법입니다. IAM(기본값), Cognito 또는 Custom 중에서 선택하세요.",
-      "es": "El método utilizado para autenticar con tu API. Elige entre IAM (predeterminado), Cognito o Custom.",
-      "pt": "O método usado para autenticar com sua API. Escolha entre IAM (padrão), Cognito ou Custom.",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre IAM (par défaut), Cognito ou Custom.",
-      "it": "Il metodo utilizzato per autenticarsi con la tua API. Scegli tra IAM (predefinito), Cognito o Custom.",
-      "zh": "用于对 API 进行身份验证的方法。可选择 IAM（默认）、Cognito 或 Custom。",
-      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa IAM (mặc định), Cognito hoặc Custom."
+      "en": "The method used to authenticate with your API. Choose between iam (default), cognito or custom.",
+      "jp": "APIの認証に使用する方法。iam（デフォルト）、cognito、customから選択します。",
+      "ko": "API 인증에 사용할 방법입니다. iam(기본값), cognito 또는 custom 중에서 선택하세요.",
+      "es": "El método utilizado para autenticar con tu API. Elige entre iam (predeterminado), cognito o custom.",
+      "pt": "O método usado para autenticar com sua API. Escolha entre iam (padrão), cognito ou custom.",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre iam (par défaut), cognito ou custom.",
+      "it": "Il metodo utilizzato per autenticare con la tua API. Scegli tra iam (predefinito), cognito o custom.",
+      "zh": "用于对 API 进行身份验证的方法。可选择 iam（默认）、cognito 或 custom。",
+      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa iam (mặc định), cognito hoặc custom."
     },
     "directory": {
       "en": "The directory to store the application in.",
@@ -459,17 +448,6 @@
       "it": "La directory in cui memorizzare l'applicazione.",
       "zh": "存储应用程序的目录。",
       "vi": "Thư mục để lưu trữ ứng dụng."
-    },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 제공자입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, esto se hereda de su selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     },
     "moduleName": {
       "en": "Python module name",
@@ -503,6 +481,28 @@
       "it": "Il framework API da utilizzare.",
       "zh": "要使用的API框架。",
       "vi": "Framework API để sử dụng."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to use to deploy this API.",
+      "ko": "이 API를 배포하는 데 사용할 인프라 유형입니다.",
+      "jp": "このAPIをデプロイするために使用するインフラストラクチャのタイプ。",
+      "es": "El tipo de infraestructura a utilizar para desplegar esta API.",
+      "pt": "O tipo de infraestrutura a ser usado para implantar esta API.",
+      "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
+      "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
+      "zh": "用于部署此 API 的基础设施类型。",
+      "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     }
   },
   "py#fast-api": {
@@ -517,17 +517,6 @@
       "zh": "要生成的 API 项目名称",
       "vi": "Tên của dự án API cần tạo"
     },
-    "computeType": {
-      "en": "The type of compute to use to deploy this API. Choose between ServerlessApiGatewayRestApi (default) or ServerlessApiGatewayHttpApi.",
-      "jp": "このAPIをデプロイするために使用するコンピュートのタイプ。ServerlessApiGatewayRestApi（デフォルト）またはServerlessApiGatewayHttpApiから選択します。",
-      "ko": "API 배포에 사용할 컴퓨팅 유형입니다. ServerlessApiGatewayRestApi (기본값) 또는 ServerlessApiGatewayHttpApi 중에서 선택하세요.",
-      "es": "El tipo de cómputo a utilizar para desplegar esta API. Elija entre ServerlessApiGatewayRestApi (predeterminado) o ServerlessApiGatewayHttpApi.",
-      "pt": "O tipo de computação a ser usado para implantar esta API. Escolha entre ServerlessApiGatewayRestApi (padrão) ou ServerlessApiGatewayHttpApi.",
-      "fr": "Le type de calcul à utiliser pour déployer cette API. Choisissez entre ServerlessApiGatewayRestApi (par défaut) ou ServerlessApiGatewayHttpApi.",
-      "it": "Il tipo di compute da utilizzare per distribuire questa API. Scegli tra ServerlessApiGatewayRestApi (predefinito) o ServerlessApiGatewayHttpApi.",
-      "zh": "用于部署此 API 的计算类型。可选择 ServerlessApiGatewayRestApi（默认）或 ServerlessApiGatewayHttpApi。",
-      "vi": "Loại compute sử dụng để triển khai API này. Chọn giữa ServerlessApiGatewayRestApi (mặc định) hoặc ServerlessApiGatewayHttpApi."
-    },
     "integrationPattern": {
       "en": "How API Gateway integrations are generated for the API. Choose between isolated (default) and shared.",
       "jp": "API用にAPI Gateway統合を生成する方法。isolated（デフォルト）またはsharedから選択します。",
@@ -540,15 +529,15 @@
       "vi": "Cách thức tạo các integration của API Gateway cho API. Chọn giữa isolated (mặc định) và shared."
     },
     "auth": {
-      "en": "The method used to authenticate with your API. Choose between IAM (default), Cognito or Custom.",
-      "jp": "APIの認証に使用する方法。IAM（デフォルト）、Cognito、またはCustomから選択します。",
-      "ko": "API 인증에 사용할 방법입니다. IAM(기본값), Cognito 또는 Custom 중에서 선택하세요.",
-      "es": "El método utilizado para autenticar con tu API. Elige entre IAM (predeterminado), Cognito o Custom.",
-      "pt": "O método usado para autenticar com sua API. Escolha entre IAM (padrão), Cognito ou Custom.",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre IAM (par défaut), Cognito ou Custom.",
-      "it": "Il metodo utilizzato per autenticarsi con la tua API. Scegli tra IAM (predefinito), Cognito o Custom.",
-      "zh": "用于对 API 进行身份验证的方法。可选择 IAM（默认）、Cognito 或 Custom。",
-      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa IAM (mặc định), Cognito hoặc Custom."
+      "en": "The method used to authenticate with your API. Choose between iam (default), cognito or custom.",
+      "jp": "APIの認証に使用する方法。iam（デフォルト）、cognito、customから選択します。",
+      "ko": "API 인증에 사용할 방법입니다. iam(기본값), cognito 또는 custom 중에서 선택하세요.",
+      "es": "El método utilizado para autenticar con tu API. Elige entre iam (predeterminado), cognito o custom.",
+      "pt": "O método usado para autenticar com sua API. Escolha entre iam (padrão), cognito ou custom.",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre iam (par défaut), cognito ou custom.",
+      "it": "Il metodo utilizzato per autenticare con la tua API. Scegli tra iam (predefinito), cognito o custom.",
+      "zh": "用于对 API 进行身份验证的方法。可选择 iam（默认）、cognito 或 custom。",
+      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa iam (mặc định), cognito hoặc custom."
     },
     "directory": {
       "en": "The directory to store the application in.",
@@ -560,17 +549,6 @@
       "it": "La directory in cui memorizzare l'applicazione.",
       "zh": "存储应用程序的目录。",
       "vi": "Thư mục để lưu trữ ứng dụng."
-    },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 제공자입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, esto se hereda de su selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     },
     "moduleName": {
       "en": "Python module name",
@@ -593,6 +571,28 @@
       "it": "La sottodirectory in cui viene posizionato il progetto. Per impostazione predefinita corrisponde al nome del progetto.",
       "zh": "项目所在的子目录。默认情况下为项目名称。",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to use to deploy this API.",
+      "es": "El tipo de infraestructura a utilizar para desplegar esta API.",
+      "jp": "このAPIをデプロイするために使用するインフラストラクチャのタイプ。",
+      "pt": "O tipo de infraestrutura a ser usado para implantar esta API.",
+      "ko": "이 API를 배포하는 데 사용할 인프라 유형입니다.",
+      "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
+      "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
+      "zh": "用于部署此 API 的基础设施类型。",
+      "vi": "Loại cơ sở hạ tầng được sử dụng để triển khai API này."
     }
   },
   "py#lambda-function": {
@@ -607,17 +607,6 @@
       "zh": "要添加 Lambda 函数的项目",
       "vi": "Dự án để thêm hàm lambda vào"
     },
-    "functionName": {
-      "en": "The name of the function to add",
-      "jp": "追加する関数の名前",
-      "ko": "추가할 함수의 이름",
-      "es": "El nombre de la función a agregar",
-      "pt": "O nome da função a adicionar",
-      "fr": "Le nom de la fonction à ajouter",
-      "it": "Il nome della funzione da aggiungere",
-      "zh": "要添加的函数名称",
-      "vi": "Tên của hàm cần thêm"
-    },
     "functionPath": {
       "en": "The path within the project source directory to add the function to",
       "jp": "関数を追加するプロジェクト内のソースディレクトリのパス",
@@ -629,27 +618,49 @@
       "zh": "在项目源代码目录中添加函数的路径",
       "vi": "Đường dẫn trong thư mục nguồn của dự án để thêm hàm vào"
     },
-    "eventSource": {
+    "name": {
+      "en": "The name of the function to add",
+      "jp": "追加する関数の名前",
+      "ko": "추가할 함수의 이름",
+      "es": "El nombre de la función a agregar",
+      "pt": "O nome da função a adicionar",
+      "fr": "Le nom de la fonction à ajouter",
+      "it": "Il nome della funzione da aggiungere",
+      "zh": "要添加的函数名称",
+      "vi": "Tên của hàm cần thêm"
+    },
+    "event": {
       "en": "Optional event source model to use for the lambda function",
       "jp": "Lambda関数に使用するオプションのイベントソースモデル",
-      "ko": "람다 함수에 사용할 선택적 이벤트 소스 모델",
-      "es": "Modelo de fuente de eventos opcional a usar para la función lambda",
-      "pt": "Modelo de origem de evento opcional a usar para a função lambda",
+      "ko": "Lambda 함수에 사용할 선택적 이벤트 소스 모델",
+      "es": "Modelo de origen de evento opcional para usar con la función lambda",
+      "pt": "Modelo de origem de evento opcional para usar na função lambda",
       "fr": "Modèle de source d'événement optionnel à utiliser pour la fonction lambda",
       "it": "Modello di origine evento opzionale da utilizzare per la funzione lambda",
-      "zh": "用于 Lambda 函数的可选事件源模型",
+      "zh": "用于 lambda 函数的可选事件源模型",
       "vi": "Mô hình nguồn sự kiện tùy chọn để sử dụng cho hàm lambda"
     },
-    "iacProvider": {
+    "infra": {
+      "en": "The type of infrastructure to deploy your Lambda function with.",
+      "jp": "Lambda関数をデプロイするインフラストラクチャのタイプ",
+      "ko": "Lambda 함수를 배포할 인프라 유형",
+      "es": "El tipo de infraestructura con la que desplegar tu función Lambda.",
+      "pt": "O tipo de infraestrutura para implantar sua função Lambda.",
+      "fr": "Le type d'infrastructure pour déployer votre fonction Lambda.",
+      "it": "Il tipo di infrastruttura con cui distribuire la tua funzione Lambda.",
+      "zh": "用于部署 Lambda 函数的基础设施类型。",
+      "vi": "Loại hạ tầng để triển khai Lambda function của bạn."
+    },
+    "iac": {
       "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
       "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
-      "ko": "선호하는 IaC 제공자. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, esto se hereda de su selección inicial.",
+      "ko": "선호하는 IaC 공급자. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
       "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
       "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+      "zh": "首选的 IaC 提供商。默认情况下,这继承自您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     }
   },
   "py#mcp-server": {
@@ -664,17 +675,6 @@
       "zh": "要添加 MCP 服务器的项目",
       "vi": "Dự án để thêm MCP server vào"
     },
-    "computeType": {
-      "en": "The type of compute to host your MCP server. Select None for no hosting.",
-      "jp": "MCP サーバーをホストするコンピュートのタイプ。ホスティングなしの場合は None を選択してください。",
-      "ko": "MCP 서버를 호스팅할 컴퓨트 유형입니다. 호스팅하지 않으려면 None을 선택하세요.",
-      "es": "El tipo de cómputo para alojar tu servidor MCP. Selecciona None para no alojar.",
-      "pt": "O tipo de computação para hospedar seu servidor MCP. Selecione None para nenhuma hospedagem.",
-      "fr": "Le type de calcul pour héberger votre serveur MCP. Sélectionnez None pour aucun hébergement.",
-      "it": "Il tipo di compute per ospitare il tuo server MCP. Seleziona None per nessun hosting.",
-      "zh": "托管 MCP 服务器的计算类型。选择 None 表示不托管。",
-      "vi": "Loại compute để host MCP server của bạn. Chọn None nếu không cần hosting."
-    },
     "name": {
       "en": "The name of your MCP server (default: mcp-server)",
       "jp": "MCP サーバーの名前（デフォルト: mcp-server）",
@@ -686,27 +686,38 @@
       "zh": "MCP 服务器的名称（默认：mcp-server）",
       "vi": "Tên của MCP server của bạn (mặc định: mcp-server)"
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先する IaC プロバイダー。デフォルトでは初期選択から継承されます。",
-      "ko": "선호하는 IaC 프로바이더입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, ceci est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "auth": {
-      "en": "The method used to authenticate with your MCP server. Only applicable when computeType is set (ignored when computeType is None).",
-      "jp": "MCP サーバーへの認証に使用する方法。computeType が設定されている場合にのみ適用されます（computeType が None の場合は無視されます）。",
-      "es": "El método utilizado para autenticar con tu servidor MCP. Solo aplicable cuando computeType está configurado (se ignora cuando computeType es None).",
-      "ko": "MCP 서버 인증에 사용되는 방법입니다. computeType이 설정된 경우에만 적용됩니다 (computeType이 None인 경우 무시됨).",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre serveur MCP. Applicable uniquement lorsque computeType est défini (ignoré lorsque computeType est None).",
-      "it": "Il metodo utilizzato per autenticarsi con il server MCP. Applicabile solo quando computeType è impostato (ignorato quando computeType è None).",
-      "pt": "O método usado para autenticar com seu servidor MCP. Aplicável apenas quando computeType está definido (ignorado quando computeType é None).",
-      "zh": "用于向您的 MCP 服务器进行身份验证的方法。仅在设置了 computeType 时适用（当 computeType 为 None 时忽略）。",
-      "vi": "Phương thức được sử dụng để xác thực với MCP server của bạn. Chỉ áp dụng khi computeType được thiết lập (bỏ qua khi computeType là None)."
+      "en": "The method used to authenticate with your MCP server. Only applicable when infra is set (ignored when infra is none).",
+      "jp": "MCPサーバーへの認証に使用する方法。infraが設定されている場合にのみ適用されます（infraがnoneの場合は無視されます）。",
+      "es": "El método utilizado para autenticar con tu servidor MCP. Solo aplicable cuando infra está configurado (se ignora cuando infra es none).",
+      "ko": "MCP 서버 인증에 사용되는 방법입니다. infra가 설정된 경우에만 적용됩니다 (infra가 none일 때는 무시됨).",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre serveur MCP. Applicable uniquement lorsque infra est défini (ignoré lorsque infra est none).",
+      "it": "Il metodo utilizzato per autenticare con il tuo server MCP. Applicabile solo quando infra è impostato (ignorato quando infra è none).",
+      "pt": "O método usado para autenticar com seu servidor MCP. Aplicável apenas quando infra está definido (ignorado quando infra é none).",
+      "zh": "用于对 MCP 服务器进行身份验证的方法。仅在设置了 infra 时适用（当 infra 为 none 时忽略）。",
+      "vi": "Phương thức được sử dụng để xác thực với MCP server của bạn. Chỉ áp dụng khi infra được thiết lập (bị bỏ qua khi infra là none)."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "ko": "선호하는 IaC 프로바이더입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to host your MCP server. Select none for no hosting.",
+      "jp": "MCPサーバーをホストするインフラストラクチャのタイプ。ホスティングが不要な場合はnoneを選択してください。",
+      "es": "El tipo de infraestructura para alojar tu servidor MCP. Selecciona none para no tener alojamiento.",
+      "ko": "MCP 서버를 호스팅할 인프라 유형입니다. 호스팅이 필요 없는 경우 none을 선택하세요.",
+      "pt": "O tipo de infraestrutura para hospedar seu servidor MCP. Selecione none para nenhuma hospedagem.",
+      "fr": "Le type d'infrastructure pour héberger votre serveur MCP. Sélectionnez none pour aucun hébergement.",
+      "it": "Il tipo di infrastruttura per ospitare il tuo server MCP. Seleziona none per nessun hosting.",
+      "zh": "托管 MCP 服务器的基础设施类型。选择 none 表示不托管。",
+      "vi": "Loại hạ tầng để lưu trữ MCP server của bạn. Chọn none để không có lưu trữ."
     }
   },
   "py#project": {
@@ -732,17 +743,6 @@
       "zh": "项目所在的父目录",
       "vi": "Thư mục cha nơi dự án được đặt."
     },
-    "projectType": {
-      "en": "Whether the project is an application or library",
-      "jp": "プロジェクトがアプリケーションかライブラリか",
-      "ko": "프로젝트가 애플리케이션인지 라이브러리인지 여부",
-      "pt": "Se o projeto é uma aplicação ou biblioteca",
-      "fr": "Si le projet est une application ou une bibliothèque",
-      "es": "Si el proyecto es una aplicación o una biblioteca",
-      "it": "Se il progetto è un'applicazione o una libreria",
-      "zh": "项目是应用程序还是库",
-      "vi": "Dự án là ứng dụng hay thư viện"
-    },
     "moduleName": {
       "en": "Python module name",
       "jp": "Pythonモジュール名",
@@ -764,6 +764,17 @@
       "it": "La sottodirectory in cui viene posizionato il progetto. Per impostazione predefinita corrisponde al nome del progetto.",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án.",
       "zh": "项目所在的子目录。默认情况下为项目名称。"
+    },
+    "type": {
+      "en": "Whether the project is an application or library",
+      "ko": "프로젝트가 애플리케이션인지 라이브러리인지 여부",
+      "jp": "プロジェクトが application か library かを指定します",
+      "es": "Si el proyecto es una aplicación o una biblioteca",
+      "zh": "项目是应用程序还是库",
+      "fr": "Indique si le projet est une application ou une bibliothèque",
+      "it": "Se il progetto è un'applicazione o una libreria",
+      "pt": "Se o projeto é uma aplicação ou biblioteca",
+      "vi": "Dự án là ứng dụng hay thư viện"
     }
   },
   "smithy#project": {
@@ -881,28 +892,6 @@
       "it": "Il progetto a cui aggiungere lo Agent",
       "vi": "Dự án để thêm Agent vào"
     },
-    "sdk": {
-      "en": "The agent SDK to use.",
-      "ko": "사용할 에이전트 SDK.",
-      "jp": "使用するエージェントSDK。",
-      "es": "El SDK de agente a utilizar.",
-      "fr": "Le SDK d'agent à utiliser.",
-      "pt": "O SDK de agente a ser usado.",
-      "it": "L'SDK dell'agente da utilizzare.",
-      "zh": "要使用的代理 SDK。",
-      "vi": "SDK agent để sử dụng."
-    },
-    "computeType": {
-      "en": "The type of compute to host your Agent.",
-      "jp": "Agentをホストするコンピュートのタイプ",
-      "ko": "Agent를 호스팅할 컴퓨팅 유형",
-      "pt": "O tipo de computação para hospedar seu Agent.",
-      "es": "El tipo de cómputo para alojar tu Agent.",
-      "fr": "Le type de calcul pour héberger votre Agent.",
-      "zh": "托管 Agent 的计算类型",
-      "it": "Il tipo di compute per ospitare il tuo Agent.",
-      "vi": "Loại compute để lưu trữ Agent của bạn."
-    },
     "name": {
       "en": "The name of your Agent (default: agent)",
       "jp": "Agentの名前（デフォルト: agent）",
@@ -914,27 +903,16 @@
       "it": "Il nome del tuo Agent (predefinito: agent)",
       "vi": "Tên của Agent của bạn (mặc định: agent)"
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
-      "ko": "선호하는 IaC 프로바이더. 기본적으로 초기 선택에서 상속됩니다.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承自您的初始选择。",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "auth": {
-      "en": "The method used to authenticate with your Agent. Only applicable when computeType is set (ignored when computeType is None).",
-      "jp": "エージェントとの認証に使用する方法。computeTypeが設定されている場合にのみ適用されます（computeTypeがNoneの場合は無視されます）。",
-      "ko": "Agent 인증에 사용되는 방법입니다. computeType이 설정된 경우에만 적용됩니다 (computeType이 None인 경우 무시됨).",
-      "es": "El método utilizado para autenticar con tu Agent. Solo aplicable cuando computeType está configurado (se ignora cuando computeType es None).",
-      "pt": "O método usado para autenticar com seu Agent. Aplicável apenas quando computeType está definido (ignorado quando computeType é None).",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre Agent. Applicable uniquement lorsque computeType est défini (ignoré lorsque computeType est None).",
-      "it": "Il metodo utilizzato per autenticare con il tuo Agent. Applicabile solo quando computeType è impostato (ignorato quando computeType è None).",
-      "zh": "用于与您的 Agent 进行身份验证的方法。仅在设置了 computeType 时适用（当 computeType 为 None 时忽略）。",
-      "vi": "Phương thức được sử dụng để xác thực với Agent của bạn. Chỉ áp dụng khi computeType được thiết lập (bị bỏ qua khi computeType là None)."
+      "en": "The method used to authenticate with your Agent. Only applicable when infra is set (ignored when infra is none).",
+      "jp": "エージェントとの認証に使用する方法。infraが設定されている場合にのみ適用されます（infraがnoneの場合は無視されます）。",
+      "ko": "에이전트 인증에 사용되는 방법입니다. infra가 설정된 경우에만 적용됩니다 (infra가 none일 때는 무시됨).",
+      "es": "El método utilizado para autenticar con tu Agent. Solo aplicable cuando infra está configurado (se ignora cuando infra es none).",
+      "pt": "O método usado para autenticar com seu Agent. Aplicável apenas quando infra está definido (ignorado quando infra é none).",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre Agent. Applicable uniquement lorsque infra est défini (ignoré lorsque infra est none).",
+      "it": "Il metodo utilizzato per autenticare con il tuo Agent. Applicabile solo quando infra è impostato (ignorato quando infra è none).",
+      "zh": "用于对 Agent 进行身份验证的方法。仅在设置了 infra 时适用（当 infra 为 none 时忽略）。",
+      "vi": "Phương thức được sử dụng để xác thực với Agent của bạn. Chỉ áp dụng khi infra được thiết lập (bị bỏ qua khi infra là none)."
     },
     "protocol": {
       "en": "The server protocol for your Agent. HTTP exposes a tRPC/WebSocket server. A2A exposes an Agent-to-Agent protocol server. AG-UI exposes an AG-UI protocol server for direct frontend integration with CopilotKit.",
@@ -946,6 +924,39 @@
       "it": "Il protocollo del server per il tuo Agent. HTTP espone un server tRPC/WebSocket. A2A espone un server con protocollo Agent-to-Agent. AG-UI espone un server con protocollo AG-UI per l'integrazione diretta del frontend con CopilotKit.",
       "zh": "Agent 的服务器协议。HTTP 公开 tRPC/WebSocket 服务器。A2A 公开 Agent-to-Agent 协议服务器。AG-UI 公开 AG-UI 协议服务器，用于与 CopilotKit 的前端直接集成。",
       "vi": "Giao thức máy chủ cho Agent của bạn. HTTP cung cấp máy chủ tRPC/WebSocket. A2A cung cấp máy chủ giao thức Agent-to-Agent. AG-UI cung cấp máy chủ giao thức AG-UI để tích hợp trực tiếp frontend với CopilotKit."
+    },
+    "framework": {
+      "en": "The agent SDK to use.",
+      "jp": "使用するエージェントSDK。",
+      "ko": "사용할 에이전트 SDK입니다.",
+      "es": "El SDK del agente a utilizar.",
+      "pt": "O SDK do agente a ser usado.",
+      "fr": "Le SDK d'agent à utiliser.",
+      "it": "L'SDK dell'agente da utilizzare.",
+      "zh": "要使用的 Agent SDK。",
+      "vi": "SDK agent cần sử dụng."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, cela est hérité de votre sélection initiale.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to host your Agent.",
+      "jp": "エージェントをホストするインフラストラクチャのタイプ。",
+      "ko": "에이전트를 호스팅할 인프라 유형입니다.",
+      "es": "El tipo de infraestructura para alojar tu Agent.",
+      "pt": "O tipo de infraestrutura para hospedar seu Agent.",
+      "fr": "Le type d'infrastructure pour héberger votre Agent.",
+      "it": "Il tipo di infrastruttura per ospitare il tuo Agent.",
+      "zh": "用于托管 Agent 的基础设施类型。",
+      "vi": "Loại hạ tầng để lưu trữ Agent của bạn."
     }
   },
   "ts#agent#a2a-connection": {
@@ -1098,17 +1109,6 @@
       "zh": "API 的名称（必填）。用于生成类名和文件路径。",
       "vi": "Tên của API (bắt buộc). Được sử dụng để tạo tên class và đường dẫn file."
     },
-    "computeType": {
-      "en": "The type of compute to use to deploy this API.",
-      "jp": "このAPIをデプロイするために使用するコンピュートのタイプ",
-      "ko": "이 API를 배포하는 데 사용할 컴퓨팅 유형입니다.",
-      "es": "El tipo de cómputo a utilizar para desplegar esta API.",
-      "pt": "O tipo de computação a ser usado para implantar esta API.",
-      "it": "Il tipo di compute da utilizzare per distribuire questa API.",
-      "fr": "Le type de calcul à utiliser pour déployer cette API.",
-      "zh": "用于部署此 API 的计算类型。",
-      "vi": "Loại compute sử dụng để triển khai API này."
-    },
     "integrationPattern": {
       "en": "How API Gateway integrations are generated for the API. Choose between isolated (default) and shared.",
       "jp": "API用にAPI Gateway統合を生成する方法。isolated（デフォルト）またはsharedから選択します。",
@@ -1121,15 +1121,15 @@
       "vi": "Cách thức tạo API Gateway integrations cho API. Chọn giữa isolated (mặc định) và shared."
     },
     "auth": {
-      "en": "The method used to authenticate with your API. Choose between IAM (default), Cognito or Custom.",
-      "jp": "APIの認証に使用する方法。IAM（デフォルト）、Cognito、Customから選択します。",
-      "ko": "API 인증에 사용되는 방법입니다. IAM(기본값), Cognito 또는 Custom 중에서 선택하세요.",
-      "es": "El método utilizado para autenticar con tu API. Elige entre IAM (predeterminado), Cognito o Custom.",
-      "pt": "O método usado para autenticar com sua API. Escolha entre IAM (padrão), Cognito ou Custom.",
-      "it": "Il metodo utilizzato per autenticarsi con la tua API. Scegli tra IAM (predefinito), Cognito o Custom.",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre IAM (par défaut), Cognito ou Custom.",
-      "zh": "用于对 API 进行身份验证的方法。可选择 IAM（默认）、Cognito 或 Custom。",
-      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa IAM (mặc định), Cognito hoặc Custom."
+      "en": "The method used to authenticate with your API. Choose between iam (default), cognito or custom.",
+      "jp": "APIの認証に使用する方法。iam（デフォルト）、cognito、customから選択します。",
+      "ko": "API 인증에 사용할 방법입니다. iam(기본값), cognito 또는 custom 중에서 선택하세요.",
+      "es": "El método utilizado para autenticar con tu API. Elige entre iam (predeterminado), cognito o custom.",
+      "pt": "O método usado para autenticar com sua API. Escolha entre iam (padrão), cognito ou custom.",
+      "it": "Il metodo utilizzato per autenticare con la tua API. Scegli tra iam (predefinito), cognito o custom.",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre iam (par défaut), cognito ou custom.",
+      "zh": "用于对 API 进行身份验证的方法。可选择 iam（默认）、cognito 或 custom。",
+      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa iam (mặc định), cognito hoặc custom."
     },
     "directory": {
       "en": "The directory to store the application in.",
@@ -1141,17 +1141,6 @@
       "fr": "Le répertoire dans lequel stocker l'application.",
       "zh": "存储应用程序的目录。",
       "vi": "Thư mục để lưu trữ ứng dụng."
-    },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de su selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     },
     "subDirectory": {
       "en": "The sub directory the project is placed in. By default this is the project name.",
@@ -1185,6 +1174,28 @@
       "it": "Il namespace per l'API Smithy (applicabile solo per il framework smithy). Il valore predefinito è lo scope del monorepo",
       "zh": "Smithy API 的命名空间（仅适用于 smithy 框架）。默认为您的 monorepo 作用域",
       "vi": "Namespace cho Smithy API (chỉ áp dụng cho framework smithy). Mặc định là scope của monorepo"
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to use to deploy this API.",
+      "jp": "このAPIをデプロイするために使用するインフラストラクチャのタイプ。",
+      "es": "El tipo de infraestructura a utilizar para desplegar esta API.",
+      "ko": "이 API를 배포하는 데 사용할 인프라 유형입니다.",
+      "pt": "O tipo de infraestrutura a ser usado para implantar esta API.",
+      "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
+      "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
+      "zh": "用于部署此 API 的基础设施类型。",
+      "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     }
   },
   "ts#astro-docs": {
@@ -1357,17 +1368,6 @@
       "zh": "新应用程序的目录。",
       "vi": "Thư mục của ứng dụng mới."
     },
-    "enableStageConfig": {
-      "en": "Enable centralized stage configuration (credentials, account, region) for multi-environment CDK deployments.",
-      "jp": "マルチ環境CDKデプロイメント用の集中ステージ設定（認証情報、アカウント、リージョン）を有効にする。",
-      "ko": "다중 환경 CDK 배포를 위한 중앙 집중식 스테이지 구성(자격 증명, 계정, 리전)을 활성화합니다.",
-      "pt": "Habilitar configuração centralizada de estágio (credenciais, conta, região) para implantações CDK em múltiplos ambientes.",
-      "fr": "Activer la configuration centralisée des stages (identifiants, compte, région) pour les déploiements CDK multi-environnements.",
-      "es": "Habilitar configuración centralizada de stage (credenciales, cuenta, región) para despliegues CDK multi-entorno.",
-      "it": "Abilita la configurazione centralizzata degli stage (credenziali, account, region) per deployment CDK multi-ambiente.",
-      "zh": "为多环境 CDK 部署启用集中式阶段配置（凭证、账户、区域）。",
-      "vi": "Bật cấu hình stage tập trung (thông tin xác thực, tài khoản, vùng) cho triển khai CDK đa môi trường."
-    },
     "subDirectory": {
       "en": "The sub directory the project is placed in. By default this is the project name.",
       "jp": "プロジェクトが配置されるサブディレクトリ。デフォルトではプロジェクト名になります。",
@@ -1378,6 +1378,17 @@
       "zh": "项目所在的子目录。默认为项目名称。",
       "it": "La sottodirectory in cui viene posizionato il progetto. Per impostazione predefinita corrisponde al nome del progetto.",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án."
+    },
+    "stageConfig": {
+      "en": "Enable centralized stage configuration (credentials, account, region) for multi-environment CDK deployments.",
+      "jp": "マルチ環境CDKデプロイメント用の集中ステージ設定（認証情報、アカウント、リージョン）を有効にします。",
+      "es": "Habilita la configuración centralizada de etapas (credenciales, cuenta, región) para despliegues CDK multi-entorno.",
+      "pt": "Habilita configuração centralizada de estágio (credenciais, conta, região) para implantações CDK em múltiplos ambientes.",
+      "ko": "다중 환경 CDK 배포를 위한 중앙 집중식 스테이지 구성(자격 증명, 계정, 리전)을 활성화합니다.",
+      "it": "Abilita la configurazione centralizzata degli stage (credenziali, account, regione) per deployment CDK multi-ambiente.",
+      "fr": "Active la configuration centralisée des stages (identifiants, compte, région) pour les déploiements CDK multi-environnements.",
+      "zh": "为多环境 CDK 部署启用集中式阶段配置（凭证、账户、区域）。",
+      "vi": "Bật cấu hình stage tập trung (thông tin xác thực, tài khoản, vùng) cho triển khai CDK đa môi trường."
     }
   },
   "ts#lambda-function": {
@@ -1392,17 +1403,6 @@
       "zh": "要添加 Lambda 函数的项目",
       "vi": "Dự án để thêm hàm lambda vào"
     },
-    "functionName": {
-      "en": "The name of the function to add",
-      "jp": "追加する関数の名前",
-      "es": "El nombre de la función a agregar",
-      "ko": "추가할 함수의 이름",
-      "pt": "O nome da função a adicionar",
-      "fr": "Le nom de la fonction à ajouter",
-      "it": "Il nome della funzione da aggiungere",
-      "zh": "要添加的函数名称",
-      "vi": "Tên của hàm cần thêm"
-    },
     "functionPath": {
       "en": "Optional subdirectory within the project source directory to add the function to",
       "jp": "関数を追加するプロジェクトソースディレクトリ内のオプションのサブディレクトリ",
@@ -1414,27 +1414,49 @@
       "zh": "项目源代码目录中用于添加函数的可选子目录",
       "vi": "Thư mục con tùy chọn trong thư mục nguồn của dự án để thêm hàm vào"
     },
-    "eventSource": {
+    "name": {
+      "en": "The name of the function to add",
+      "jp": "追加する関数の名前",
+      "ko": "추가할 함수의 이름",
+      "es": "El nombre de la función a agregar",
+      "pt": "O nome da função a adicionar",
+      "fr": "Le nom de la fonction à ajouter",
+      "zh": "要添加的函数名称",
+      "it": "Il nome della funzione da aggiungere",
+      "vi": "Tên của function cần thêm"
+    },
+    "event": {
       "en": "Optional event source schema to use for the lambda function",
       "jp": "Lambda関数に使用するオプションのイベントソーススキーマ",
-      "es": "Esquema de origen de eventos opcional para usar en la función lambda",
-      "ko": "람다 함수에 사용할 선택적 이벤트 소스 스키마",
-      "pt": "Esquema de origem de evento opcional a usar para a função lambda",
+      "ko": "Lambda 함수에 사용할 선택적 이벤트 소스 스키마",
+      "es": "Esquema de origen de evento opcional para usar en la función lambda",
+      "pt": "Esquema de origem de evento opcional para usar na função lambda",
       "fr": "Schéma de source d'événement optionnel à utiliser pour la fonction lambda",
+      "zh": "用于 lambda 函数的可选事件源架构",
       "it": "Schema opzionale della sorgente evento da utilizzare per la funzione lambda",
-      "zh": "用于 Lambda 函数的可选事件源架构",
-      "vi": "Schema nguồn sự kiện tùy chọn để sử dụng cho hàm lambda"
+      "vi": "Schema nguồn sự kiện tùy chọn để sử dụng cho lambda function"
     },
-    "iacProvider": {
+    "infra": {
+      "en": "The type of infrastructure to deploy your Lambda function with.",
+      "jp": "Lambda関数をデプロイするインフラストラクチャのタイプ",
+      "ko": "Lambda 함수를 배포할 인프라 유형",
+      "es": "El tipo de infraestructura con la que desplegar tu función Lambda.",
+      "pt": "O tipo de infraestrutura para implantar sua função Lambda.",
+      "fr": "Le type d'infrastructure pour déployer votre fonction Lambda.",
+      "zh": "用于部署 Lambda 函数的基础设施类型。",
+      "it": "Il tipo di infrastruttura con cui distribuire la tua funzione Lambda.",
+      "vi": "Loại hạ tầng để triển khai Lambda function của bạn."
+    },
+    "iac": {
       "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de su selección inicial.",
-      "ko": "선호하는 IaC 제공자. 기본적으로 초기 선택에서 상속됩니다.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
+      "ko": "선호하는 IaC 공급자. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
       "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, ceci est hérité de votre sélection initiale.",
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     }
   },
   "ts#mcp-server": {
@@ -1449,17 +1471,6 @@
       "vi": "Dự án để thêm MCP server vào",
       "zh": "要添加 MCP 服务器的项目"
     },
-    "computeType": {
-      "en": "The type of compute to host your MCP server. Select None for no hosting.",
-      "jp": "MCP サーバーをホストするコンピュートのタイプ。ホスティングなしの場合は None を選択してください。",
-      "ko": "MCP 서버를 호스팅할 컴퓨트 유형입니다. 호스팅하지 않으려면 None을 선택하세요.",
-      "es": "El tipo de cómputo para alojar tu servidor MCP. Selecciona None para no alojar.",
-      "pt": "O tipo de computação para hospedar seu servidor MCP. Selecione None para nenhuma hospedagem.",
-      "fr": "Le type de calcul pour héberger votre serveur MCP. Sélectionnez None pour aucun hébergement.",
-      "it": "Il tipo di compute per ospitare il tuo server MCP. Seleziona None per nessun hosting.",
-      "vi": "Loại compute để host MCP server của bạn. Chọn None nếu không cần hosting.",
-      "zh": "托管 MCP 服务器的计算类型。选择 None 表示不托管。"
-    },
     "name": {
       "en": "The name of your MCP server (default: mcp-server)",
       "jp": "MCP サーバーの名前（デフォルト: mcp-server）",
@@ -1471,27 +1482,38 @@
       "vi": "Tên của MCP server của bạn (mặc định: mcp-server)",
       "zh": "MCP 服务器的名称（默认：mcp-server）"
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先する IaC プロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, ceci est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。"
-    },
     "auth": {
-      "en": "The method used to authenticate with your MCP server. Only applicable when computeType is set (ignored when computeType is None).",
-      "jp": "MCPサーバーへの認証に使用する方法。computeTypeが設定されている場合にのみ適用されます（computeTypeがNoneの場合は無視されます）。",
-      "ko": "MCP 서버 인증에 사용되는 방법입니다. computeType이 설정된 경우에만 적용됩니다(computeType이 None인 경우 무시됨).",
-      "es": "El método utilizado para autenticar con tu servidor MCP. Solo aplicable cuando computeType está configurado (se ignora cuando computeType es None).",
-      "pt": "O método usado para autenticar com seu servidor MCP. Aplicável apenas quando computeType está definido (ignorado quando computeType é None).",
-      "it": "Il metodo utilizzato per autenticarsi con il server MCP. Applicabile solo quando computeType è impostato (ignorato quando computeType è None).",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre serveur MCP. Applicable uniquement lorsque computeType est défini (ignoré lorsque computeType est None).",
-      "zh": "用于向您的 MCP 服务器进行身份验证的方法。仅在设置了 computeType 时适用（当 computeType 为 None 时将被忽略）。",
-      "vi": "Phương thức được sử dụng để xác thực với MCP server của bạn. Chỉ áp dụng khi computeType được thiết lập (bỏ qua khi computeType là None)."
+      "en": "The method used to authenticate with your MCP server. Only applicable when infra is set (ignored when infra is none).",
+      "jp": "MCPサーバーへの認証に使用する方法。infraが設定されている場合にのみ適用されます（infraがnoneの場合は無視されます）。",
+      "ko": "MCP 서버 인증에 사용되는 방법입니다. infra가 설정된 경우에만 적용됩니다 (infra가 none인 경우 무시됨).",
+      "es": "El método utilizado para autenticar con tu servidor MCP. Solo aplicable cuando infra está configurado (se ignora cuando infra es none).",
+      "pt": "O método usado para autenticar com seu servidor MCP. Aplicável apenas quando infra está definido (ignorado quando infra é none).",
+      "it": "Il metodo utilizzato per autenticare con il tuo server MCP. Applicabile solo quando infra è impostato (ignorato quando infra è none).",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre serveur MCP. Applicable uniquement lorsque infra est défini (ignoré lorsque infra est none).",
+      "zh": "用于对 MCP 服务器进行身份验证的方法。仅在设置了 infra 时适用（当 infra 为 none 时忽略）。",
+      "vi": "Phương thức được sử dụng để xác thực với MCP server của bạn. Chỉ áp dụng khi infra được thiết lập (bị bỏ qua khi infra là none)."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, cette valeur est héritée de votre sélection initiale.",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。"
+    },
+    "infra": {
+      "en": "The type of infrastructure to host your MCP server. Select none for no hosting.",
+      "jp": "MCPサーバーをホストするインフラストラクチャのタイプ。ホスティングなしの場合はnoneを選択してください。",
+      "es": "El tipo de infraestructura para alojar tu servidor MCP. Selecciona none para no tener alojamiento.",
+      "pt": "O tipo de infraestrutura para hospedar seu servidor MCP. Selecione none para nenhuma hospedagem.",
+      "ko": "MCP 서버를 호스팅할 인프라 유형입니다. 호스팅이 필요 없는 경우 none을 선택하세요.",
+      "it": "Il tipo di infrastruttura per ospitare il tuo server MCP. Seleziona none per nessun hosting.",
+      "fr": "Le type d'infrastructure pour héberger votre serveur MCP. Sélectionnez none pour aucun hébergement.",
+      "vi": "Loại hạ tầng để lưu trữ MCP server của bạn. Chọn none để không có lưu trữ.",
+      "zh": "托管 MCP 服务器的基础设施类型。选择 none 表示不托管。"
     }
   },
   "ts#nx-generator": {
@@ -1633,17 +1655,6 @@
       "zh": "存储应用程序的目录。",
       "vi": "Thư mục để lưu trữ ứng dụng."
     },
-    "service": {
-      "en": "Relational database service to provision.",
-      "es": "Servicio de base de datos relacional a aprovisionar.",
-      "jp": "プロビジョニングするリレーショナルデータベースサービス",
-      "ko": "프로비저닝할 관계형 데이터베이스 서비스",
-      "fr": "Service de base de données relationnelle à provisionner.",
-      "it": "Servizio di database relazionale da provisioning.",
-      "pt": "Serviço de banco de dados relacional a ser provisionado.",
-      "zh": "要配置的关系型数据库服务。",
-      "vi": "Dịch vụ cơ sở dữ liệu quan hệ cần cung cấp."
-    },
     "engine": {
       "en": "Database engine to use with the selected service.",
       "es": "Motor de base de datos a utilizar con el servicio seleccionado.",
@@ -1677,28 +1688,6 @@
       "zh": "初始数据库名称。默认为项目名称。",
       "vi": "Tên cơ sở dữ liệu ban đầu. Mặc định là tên dự án."
     },
-    "ormFramework": {
-      "en": "ORM framework to use for the generated project.",
-      "es": "Framework ORM a utilizar para el proyecto generado.",
-      "jp": "生成されるプロジェクトで使用するORMフレームワーク",
-      "ko": "생성된 프로젝트에 사용할 ORM 프레임워크",
-      "fr": "Framework ORM à utiliser pour le projet généré.",
-      "it": "Framework ORM da utilizzare per il progetto generato.",
-      "pt": "Framework ORM a ser usado para o projeto gerado.",
-      "zh": "用于生成项目的 ORM 框架。",
-      "vi": "ORM framework sử dụng cho dự án được tạo."
-    },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "es": "El proveedor IaC preferido. Por defecto se hereda de tu selección inicial.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます",
-      "ko": "선호하는 IaC 공급자. 기본적으로 초기 선택에서 상속됩니다.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "pt": "O provedor IaC preferido. Por padrão, este é herdado da sua seleção inicial.",
-      "zh": "首选的 IaC 提供商。默认情况下,这将继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "subDirectory": {
       "en": "The sub directory the project is placed in. By default this is the project name.",
       "es": "El subdirectorio donde se coloca el proyecto. Por defecto es el nombre del proyecto.",
@@ -1709,6 +1698,39 @@
       "zh": "项目所在的子目录。默认为项目名称。",
       "vi": "Thư mục con nơi dự án được đặt. Mặc định là tên dự án.",
       "it": "La sottodirectory in cui viene posizionato il progetto. Per impostazione predefinita corrisponde al nome del progetto."
+    },
+    "infra": {
+      "en": "Relational database service to provision.",
+      "jp": "プロビジョニングするリレーショナルデータベースサービス。",
+      "ko": "프로비저닝할 관계형 데이터베이스 서비스입니다.",
+      "es": "Servicio de base de datos relacional a provisionar.",
+      "fr": "Service de base de données relationnelle à provisionner.",
+      "pt": "Serviço de banco de dados relacional a ser provisionado.",
+      "it": "Servizio di database relazionale da fornire.",
+      "zh": "要配置的关系数据库服务。",
+      "vi": "Dịch vụ cơ sở dữ liệu quan hệ cần cung cấp."
+    },
+    "framework": {
+      "en": "ORM framework to use for the generated project.",
+      "jp": "生成されるプロジェクトで使用するORMフレームワーク。",
+      "ko": "생성된 프로젝트에 사용할 ORM 프레임워크입니다.",
+      "es": "Framework ORM a utilizar para el proyecto generado.",
+      "fr": "Framework ORM à utiliser pour le projet généré.",
+      "pt": "Framework ORM a ser usado para o projeto gerado.",
+      "it": "Framework ORM da utilizzare per il progetto generato.",
+      "zh": "用于生成项目的 ORM 框架。",
+      "vi": "Framework ORM sử dụng cho dự án được tạo."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     }
   },
   "ts#rdb#agent-connection": {
@@ -1852,50 +1874,6 @@
       "zh": "新应用程序的目录。",
       "vi": "Thư mục của ứng dụng mới."
     },
-    "uxProvider": {
-      "en": "The preferred UX provider.",
-      "jp": "優先するUXプロバイダー。",
-      "ko": "선호하는 UX 프로바이더입니다.",
-      "es": "El proveedor de UX preferido.",
-      "pt": "O provedor de UX preferido.",
-      "fr": "Le fournisseur UX préféré.",
-      "it": "Il provider UX preferito.",
-      "zh": "首选的 UX 提供程序。",
-      "vi": "Nhà cung cấp UX ưa thích."
-    },
-    "enableTailwind": {
-      "en": "Enable TailwindCSS for utility-first styling.",
-      "jp": "ユーティリティファーストのスタイリングのためにTailwindCSSを有効にする。",
-      "ko": "유틸리티 우선 스타일링을 위해 TailwindCSS를 활성화합니다.",
-      "es": "Habilitar TailwindCSS para estilos utility-first.",
-      "pt": "Habilitar TailwindCSS para estilização utility-first.",
-      "fr": "Activer TailwindCSS pour un style utilitaire.",
-      "it": "Abilita TailwindCSS per lo styling utility-first.",
-      "zh": "启用 TailwindCSS 以实现实用优先的样式设计。",
-      "vi": "Bật TailwindCSS cho việc styling theo tiện ích."
-    },
-    "enableTanstackRouter": {
-      "en": "Enable Tanstack router for type-safe routing.",
-      "jp": "型安全なルーティングのためにTanstackルーターを有効にする。",
-      "ko": "타입 안전 라우팅을 위해 Tanstack router를 활성화합니다.",
-      "es": "Habilitar Tanstack router para enrutamiento con seguridad de tipos.",
-      "pt": "Habilitar Tanstack router para roteamento type-safe.",
-      "fr": "Activer le routeur Tanstack pour un routage type-safe.",
-      "it": "Abilita Tanstack router per il routing type-safe.",
-      "zh": "启用 Tanstack router 以实现类型安全的路由。",
-      "vi": "Bật Tanstack router cho định tuyến an toàn kiểu."
-    },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 프로바이더입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de su selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, este é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, il est hérité de votre sélection initiale.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供程序。默认情况下,这将继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "subDirectory": {
       "en": "The sub directory the project is placed in. By default this is the project name.",
       "jp": "プロジェクトが配置されるサブディレクトリ。デフォルトではプロジェクト名になります。",
@@ -1906,6 +1884,50 @@
       "it": "La sottodirectory in cui viene posizionato il progetto. Per impostazione predefinita corrisponde al nome del progetto.",
       "zh": "项目所在的子目录。默认情况下为项目名称。",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án."
+    },
+    "ux": {
+      "en": "The preferred UX provider.",
+      "pt": "O provedor de UX preferido.",
+      "jp": "優先するUXプロバイダー。",
+      "es": "El proveedor de UX preferido.",
+      "ko": "선호하는 UX 프레임워크입니다.",
+      "fr": "Le fournisseur UX préféré.",
+      "zh": "首选的 UX 提供程序。",
+      "vi": "Nhà cung cấp UX ưa thích.",
+      "it": "Il provider UX preferito."
+    },
+    "tailwind": {
+      "en": "Enable TailwindCSS for utility-first styling.",
+      "pt": "Ativar TailwindCSS para estilização utility-first.",
+      "jp": "ユーティリティファーストのスタイリングのためにTailwindCSSを有効にします。",
+      "es": "Habilitar TailwindCSS para estilos basados en utilidades.",
+      "ko": "유틸리티 우선 스타일링을 위해 TailwindCSS를 활성화합니다.",
+      "fr": "Activer TailwindCSS pour un style utilitaire.",
+      "zh": "启用 TailwindCSS 以实现实用优先的样式设计。",
+      "vi": "Bật TailwindCSS để tạo kiểu theo tiện ích.",
+      "it": "Abilita TailwindCSS per lo styling utility-first."
+    },
+    "tanstackRouter": {
+      "en": "Enable Tanstack router for type-safe routing.",
+      "pt": "Ativar roteador Tanstack para roteamento type-safe.",
+      "jp": "型安全なルーティングのためにTanstack routerを有効にします。",
+      "es": "Habilitar Tanstack router para enrutamiento con seguridad de tipos.",
+      "ko": "타입 안전 라우팅을 위해 Tanstack router를 활성화합니다.",
+      "fr": "Activer le routeur Tanstack pour un routage type-safe.",
+      "zh": "启用 Tanstack router 以实现类型安全的路由。",
+      "vi": "Bật Tanstack router để định tuyến an toàn kiểu.",
+      "it": "Abilita Tanstack router per il routing type-safe."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "pt": "O provedor de IaC preferido. Por padrão, este é herdado da sua seleção inicial.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "ko": "선호하는 IaC 프레임워크입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "zh": "首选的 IaC 提供程序。默认情况下，这将继承您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale."
     }
   },
   "ts#react-website#auth": {
@@ -1942,16 +1964,16 @@
       "zh": "是否允许自助注册",
       "vi": "Có cho phép tự đăng ký hay không"
     },
-    "iacProvider": {
+    "iac": {
       "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
       "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "es": "El proveedor de IaC preferido. Por defecto, esto se hereda de tu selección inicial.",
       "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
       "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
       "fr": "Le fournisseur IaC préféré. Par défaut, ceci est hérité de votre sélection initiale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     }
   },
   "ts#react-website#runtime-config": {
@@ -1990,17 +2012,6 @@
       "zh": "Smithy API 的命名空间。默认为您的 monorepo 作用域",
       "vi": "Namespace cho Smithy API. Mặc định là scope của monorepo của bạn"
     },
-    "computeType": {
-      "en": "The type of compute to use to deploy this API.",
-      "jp": "このAPIをデプロイするために使用するコンピュートのタイプ",
-      "ko": "이 API를 배포하는 데 사용할 컴퓨트 유형입니다.",
-      "es": "El tipo de cómputo a utilizar para desplegar esta API.",
-      "fr": "Le type de calcul à utiliser pour déployer cette API.",
-      "pt": "O tipo de computação a ser usado para implantar esta API.",
-      "it": "Il tipo di compute da utilizzare per il deployment di questa API.",
-      "zh": "用于部署此 API 的计算类型。",
-      "vi": "Loại compute được sử dụng để triển khai API này."
-    },
     "integrationPattern": {
       "en": "How API Gateway integrations are generated for the API. Choose between isolated (default) and shared.",
       "jp": "API GatewayインテグレーションがAPIに対してどのように生成されるか。isolated（デフォルト）とsharedから選択します。",
@@ -2013,15 +2024,15 @@
       "vi": "Cách thức các integration của API Gateway được tạo ra cho API. Chọn giữa isolated (mặc định) và shared."
     },
     "auth": {
-      "en": "The method used to authenticate with your API. Choose between IAM (default), Cognito or Custom.",
-      "jp": "APIの認証に使用する方法。IAM（デフォルト）、Cognito、Customから選択します。",
-      "ko": "API 인증에 사용되는 방법입니다. IAM(기본값), Cognito 또는 Custom 중에서 선택하세요.",
-      "es": "El método utilizado para autenticar con tu API. Elige entre IAM (predeterminado), Cognito o Custom.",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre IAM (par défaut), Cognito ou Custom.",
-      "pt": "O método usado para autenticar com sua API. Escolha entre IAM (padrão), Cognito ou Custom.",
-      "it": "Il metodo utilizzato per autenticarsi con la tua API. Scegli tra IAM (predefinito), Cognito o Custom.",
-      "zh": "用于对 API 进行身份验证的方法。可选择 IAM（默认）、Cognito 或 Custom。",
-      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa IAM (mặc định), Cognito hoặc Custom."
+      "en": "The method used to authenticate with your API. Choose between iam (default), cognito or custom.",
+      "jp": "APIの認証に使用する方法。iam（デフォルト）、cognito、customから選択します。",
+      "ko": "API 인증에 사용할 방법입니다. iam(기본값), cognito 또는 custom 중에서 선택하세요.",
+      "es": "El método utilizado para autenticar con tu API. Elige entre iam (predeterminado), cognito o custom.",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre iam (par défaut), cognito ou custom.",
+      "pt": "O método usado para autenticar com sua API. Escolha entre iam (padrão), cognito ou custom.",
+      "it": "Il metodo utilizzato per autenticare con la tua API. Scegli tra iam (predefinito), cognito o custom.",
+      "zh": "用于对 API 进行身份验证的方法。可选择 iam（默认）、cognito 或 custom。",
+      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa iam (mặc định), cognito hoặc custom."
     },
     "directory": {
       "en": "The directory to store the application in.",
@@ -2034,17 +2045,6 @@
       "zh": "存储应用程序的目录。",
       "vi": "Thư mục để lưu trữ ứng dụng."
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先されるIaCプロバイダー。デフォルトでは初期選択から継承されます。",
-      "ko": "선호하는 IaC 프로바이더입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto se hereda de tu selección inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "pt": "O provedor IaC preferido. Por padrão, é herdado da sua seleção inicial.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla tua selezione iniziale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "subDirectory": {
       "en": "The sub directory the project is placed in. By default this is the project name.",
       "jp": "プロジェクトが配置されるサブディレクトリ。デフォルトではプロジェクト名になります。",
@@ -2055,6 +2055,28 @@
       "zh": "项目所在的子目录。默认情况下为项目名称。",
       "fr": "Le sous-répertoire dans lequel le projet est placé. Par défaut, il s'agit du nom du projet.",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án."
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这将继承您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to use to deploy this API.",
+      "es": "El tipo de infraestructura a utilizar para desplegar esta API.",
+      "pt": "O tipo de infraestrutura a ser usado para implantar esta API.",
+      "jp": "このAPIをデプロイするために使用するインフラストラクチャのタイプ。",
+      "ko": "이 API를 배포하는 데 사용할 인프라 유형입니다.",
+      "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
+      "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
+      "zh": "用于部署此 API 的基础设施类型。",
+      "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     }
   },
   "ts#trpc-api": {
@@ -2069,17 +2091,6 @@
       "zh": "API 的名称（必填）。用于生成类名和文件路径。",
       "vi": "Tên của API (bắt buộc). Được sử dụng để tạo tên class và đường dẫn file."
     },
-    "computeType": {
-      "en": "The type of compute to use to deploy this API. Choose between ServerlessApiGatewayRestApi (default) or ServerlessApiGatewayHttpApi.",
-      "jp": "このAPIをデプロイするために使用するコンピュートのタイプ。ServerlessApiGatewayRestApi（デフォルト）またはServerlessApiGatewayHttpApiから選択します。",
-      "ko": "이 API를 배포하는 데 사용할 컴퓨팅 유형입니다. ServerlessApiGatewayRestApi (기본값) 또는 ServerlessApiGatewayHttpApi 중에서 선택하세요.",
-      "es": "El tipo de cómputo a utilizar para desplegar esta API. Elija entre ServerlessApiGatewayRestApi (predeterminado) o ServerlessApiGatewayHttpApi.",
-      "pt": "O tipo de computação a ser usado para implantar esta API. Escolha entre ServerlessApiGatewayRestApi (padrão) ou ServerlessApiGatewayHttpApi.",
-      "it": "Il tipo di compute da utilizzare per distribuire questa API. Scegli tra ServerlessApiGatewayRestApi (predefinito) o ServerlessApiGatewayHttpApi.",
-      "fr": "Le type de calcul à utiliser pour déployer cette API. Choisissez entre ServerlessApiGatewayRestApi (par défaut) ou ServerlessApiGatewayHttpApi.",
-      "zh": "用于部署此 API 的计算类型。可选择 ServerlessApiGatewayRestApi（默认）或 ServerlessApiGatewayHttpApi。",
-      "vi": "Loại compute sử dụng để triển khai API này. Chọn giữa ServerlessApiGatewayRestApi (mặc định) hoặc ServerlessApiGatewayHttpApi."
-    },
     "integrationPattern": {
       "en": "How API Gateway integrations are generated for the API. Choose between isolated (default) and shared.",
       "jp": "API用にAPI Gateway統合を生成する方法。isolated（デフォルト）またはsharedから選択します。",
@@ -2092,15 +2103,15 @@
       "vi": "Cách thức tạo API Gateway integrations cho API. Chọn giữa isolated (mặc định) và shared."
     },
     "auth": {
-      "en": "The method used to authenticate with your API. Choose between IAM (default), Cognito or Custom.",
-      "jp": "APIの認証に使用する方法。IAM（デフォルト）、Cognito、Customから選択します。",
-      "ko": "API 인증에 사용되는 방법입니다. IAM(기본값), Cognito 또는 Custom 중에서 선택하세요.",
-      "es": "El método utilizado para autenticar con tu API. Elige entre IAM (predeterminado), Cognito o Custom.",
-      "pt": "O método usado para autenticar com sua API. Escolha entre IAM (padrão), Cognito ou Custom.",
-      "it": "Il metodo utilizzato per autenticarsi con la tua API. Scegli tra IAM (predefinito), Cognito o Custom.",
-      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre IAM (par défaut), Cognito ou Custom.",
-      "zh": "用于对 API 进行身份验证的方法。可选择 IAM（默认）、Cognito 或 Custom。",
-      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa IAM (mặc định), Cognito hoặc Custom."
+      "en": "The method used to authenticate with your API. Choose between iam (default), cognito or custom.",
+      "jp": "APIの認証に使用する方法。iam（デフォルト）、cognito、customから選択します。",
+      "ko": "API 인증에 사용할 방법입니다. iam(기본값), cognito 또는 custom 중에서 선택하세요.",
+      "es": "El método utilizado para autenticar con tu API. Elige entre iam (predeterminado), cognito o custom.",
+      "pt": "O método usado para autenticar com sua API. Escolha entre iam (padrão), cognito ou custom.",
+      "it": "Il metodo utilizzato per autenticare con la tua API. Scegli tra iam (predefinito), cognito o custom.",
+      "fr": "La méthode utilisée pour s'authentifier auprès de votre API. Choisissez entre iam (par défaut), cognito ou custom.",
+      "zh": "用于对 API 进行身份验证的方法。可选择 iam（默认）、cognito 或 custom。",
+      "vi": "Phương thức được sử dụng để xác thực với API của bạn. Chọn giữa iam (mặc định), cognito hoặc custom."
     },
     "directory": {
       "en": "The directory to store the application in.",
@@ -2113,17 +2124,6 @@
       "zh": "存储应用程序的目录。",
       "vi": "Thư mục để lưu trữ ứng dụng."
     },
-    "iacProvider": {
-      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de su selección inicial.",
-      "pt": "O provedor de IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
-      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
-    },
     "subDirectory": {
       "en": "The sub directory the project is placed in. By default this is the project name.",
       "jp": "プロジェクトが配置されるサブディレクトリ。デフォルトではプロジェクト名になります。",
@@ -2134,6 +2134,28 @@
       "it": "La sottodirectory in cui viene posizionato il progetto. Per impostazione predefinita corrisponde al nome del progetto.",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án.",
       "zh": "项目所在的子目录。默认情况下为项目名称。"
+    },
+    "iac": {
+      "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, celui-ci est hérité de votre sélection initiale.",
+      "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
+      "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "infra": {
+      "en": "The type of infrastructure to use to deploy this API.",
+      "jp": "このAPIをデプロイするために使用するインフラストラクチャのタイプ。",
+      "ko": "이 API를 배포하는 데 사용할 인프라 유형입니다.",
+      "es": "El tipo de infraestructura a utilizar para desplegar esta API.",
+      "pt": "O tipo de infraestrutura a ser usado para implantar esta API.",
+      "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
+      "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
+      "zh": "用于部署此 API 的基础设施类型。",
+      "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     }
   },
   "ts#website": {
@@ -2181,49 +2203,60 @@
       "zh": "项目所在的子目录。默认情况下为项目名称。",
       "vi": "Thư mục con nơi dự án được đặt. Mặc định là tên dự án."
     },
-    "uxProvider": {
+    "ux": {
       "en": "The preferred UX provider.",
-      "es": "El proveedor de UX preferido.",
-      "fr": "Le fournisseur UX préféré.",
-      "pt": "O provedor de UX preferido.",
-      "ko": "선호하는 UX 프로바이더입니다.",
       "jp": "優先するUXプロバイダー。",
+      "ko": "선호하는 UX 제공자입니다.",
+      "es": "El proveedor de UX preferido.",
       "it": "Il provider UX preferito.",
-      "zh": "首选的 UX 提供程序。",
-      "vi": "Nhà cung cấp UX ưu tiên."
+      "pt": "O provedor de UX preferido.",
+      "fr": "Le fournisseur UX préféré.",
+      "zh": "首选的 UX 提供商。",
+      "vi": "Nhà cung cấp UX ưa thích."
     },
-    "enableTailwind": {
+    "tailwind": {
       "en": "Enable TailwindCSS for utility-first styling.",
-      "es": "Habilitar TailwindCSS para estilos basados en utilidades.",
-      "fr": "Activer TailwindCSS pour un style utilitaire.",
-      "pt": "Ativar TailwindCSS para estilização utility-first.",
-      "ko": "유틸리티 우선 스타일링을 위해 TailwindCSS를 활성화합니다.",
       "jp": "ユーティリティファーストのスタイリングのためにTailwindCSSを有効にします。",
+      "ko": "유틸리티 우선 스타일링을 위해 TailwindCSS를 활성화합니다.",
+      "es": "Habilitar TailwindCSS para estilos basados en utilidades.",
       "it": "Abilita TailwindCSS per lo styling utility-first.",
+      "pt": "Ativar TailwindCSS para estilização utility-first.",
+      "fr": "Activer TailwindCSS pour un style utilitaire.",
       "zh": "启用 TailwindCSS 以实现实用优先的样式设计。",
       "vi": "Bật TailwindCSS để tạo kiểu theo tiện ích."
     },
-    "enableTanstackRouter": {
+    "tanstackRouter": {
       "en": "Enable Tanstack router for type-safe routing.",
-      "es": "Habilitar Tanstack router para enrutamiento con seguridad de tipos.",
-      "fr": "Activer le routeur Tanstack pour un routage type-safe.",
-      "pt": "Ativar Tanstack router para roteamento type-safe.",
-      "ko": "타입 안전 라우팅을 위해 Tanstack router를 활성화합니다.",
       "jp": "型安全なルーティングのためにTanstackルーターを有効にします。",
+      "ko": "타입 안전 라우팅을 위해 Tanstack router를 활성화합니다.",
+      "es": "Habilitar Tanstack router para enrutamiento con seguridad de tipos.",
       "it": "Abilita Tanstack router per il routing type-safe.",
+      "pt": "Ativar roteador Tanstack para roteamento type-safe.",
+      "fr": "Activer le routeur Tanstack pour un routage type-safe.",
       "zh": "启用 Tanstack router 以实现类型安全的路由。",
       "vi": "Bật Tanstack router để định tuyến an toàn kiểu."
     },
-    "iacProvider": {
+    "infra": {
+      "en": "The type of infrastructure to deploy your website with.",
+      "jp": "ウェブサイトをデプロイするインフラストラクチャのタイプ。",
+      "ko": "웹사이트를 배포할 인프라 유형입니다.",
+      "es": "El tipo de infraestructura con la que desplegar tu sitio web.",
+      "it": "Il tipo di infrastruttura con cui distribuire il tuo sito web.",
+      "pt": "O tipo de infraestrutura para implantar seu website.",
+      "fr": "Le type d'infrastructure pour déployer votre site web.",
+      "zh": "用于部署网站的基础设施类型。",
+      "vi": "Loại hạ tầng để triển khai website của bạn."
+    },
+    "iac": {
       "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "es": "El proveedor de IaC preferido. Por defecto, se hereda de su selección inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, il est hérité de votre sélection initiale.",
-      "pt": "O provedor de IaC preferido. Por padrão, este é herdado da sua seleção inicial.",
-      "ko": "선호하는 IaC 프로바이더입니다. 기본값은 초기 선택에서 상속됩니다.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは初期選択から継承されます。",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "ko": "선호하는 IaC 제공자입니다. 기본적으로 초기 선택에서 상속됩니다.",
+      "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
-      "zh": "首选的 IaC 提供程序。默认情况下,这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+      "pt": "O provedor de IaC preferido. Por padrão, este é herdado da sua seleção inicial.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, il est hérité de votre sélection initiale.",
+      "zh": "首选的 IaC 提供商。默认情况下,这将继承您的初始选择。",
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     }
   },
   "ts#website#auth": {
@@ -2260,16 +2293,16 @@
       "zh": "是否允许自助注册",
       "vi": "Có cho phép tự đăng ký hay không"
     },
-    "iacProvider": {
+    "iac": {
       "en": "The preferred IaC provider. By default this is inherited from your initial selection.",
-      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
-      "ko": "선호하는 IaC 제공자입니다. 기본적으로 초기 선택에서 상속됩니다.",
       "es": "El proveedor de IaC preferido. Por defecto, se hereda de tu selección inicial.",
+      "jp": "優先するIaCプロバイダー。デフォルトでは、初期選択から継承されます。",
+      "ko": "선호하는 IaC 공급자입니다. 기본적으로 초기 선택에서 상속됩니다.",
       "pt": "O provedor IaC preferido. Por padrão, isso é herdado da sua seleção inicial.",
-      "fr": "Le fournisseur IaC préféré. Par défaut, il est hérité de votre sélection initiale.",
+      "fr": "Le fournisseur IaC préféré. Par défaut, cela est hérité de votre sélection initiale.",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
-      "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+      "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     }
   }
 }

--- a/e2e/src/smoke-tests/infra-none.spec.ts
+++ b/e2e/src/smoke-tests/infra-none.spec.ts
@@ -76,21 +76,9 @@ describe('smoke test - infra-none', () => {
       opts,
     );
 
-    // Python agent with infra=none
-    await runCLI(
-      `generate @aws/nx-plugin:py#agent --project=py_project --name=my-agent --infra=none --no-interactive`,
-      opts,
-    );
-
     // TypeScript MCP server with infra=none
     await runCLI(
       `generate @aws/nx-plugin:ts#mcp-server --project=ts-project --name=my-mcp --infra=none --no-interactive`,
-      opts,
-    );
-
-    // Python MCP server with infra=none
-    await runCLI(
-      `generate @aws/nx-plugin:py#mcp-server --project=py_project --name=my-mcp --infra=none --no-interactive`,
       opts,
     );
 

--- a/e2e/src/smoke-tests/infra-none.spec.ts
+++ b/e2e/src/smoke-tests/infra-none.spec.ts
@@ -18,7 +18,7 @@ describe('smoke test - infra-none', () => {
     ensureDirSync(targetDir);
   });
 
-  it('should generate and build all generators with --infra=none', async () => {
+  it('should generate and build all generators with --infra=none, then upgrade to infra', async () => {
     await runCLI(
       `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'cdk')} --interactive=false --skipGit`,
       {
@@ -29,6 +29,8 @@ describe('smoke test - infra-none', () => {
     );
     const projectRoot = `${targetDir}/e2e-test`;
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
+
+    // --- Phase 1: Generate all with infra=none ---
 
     // Website with infra=none
     await runCLI(
@@ -95,6 +97,50 @@ describe('smoke test - infra-none', () => {
     // RDB with infra=none
     await runCLI(
       `generate @aws/nx-plugin:ts#rdb --name=my-db --infra=none --engine=postgres --framework=prisma --no-interactive`,
+      opts,
+    );
+
+    await runCLI(`sync --verbose`, opts);
+    await runCLI(
+      `run-many --target build --all --output-style=stream --verbose`,
+      opts,
+    );
+
+    // --- Phase 2: Re-run with infra to add infrastructure ---
+
+    // Re-run website with infra=cloudfront-s3
+    await runCLI(
+      `generate @aws/nx-plugin:ts#website --name=website --infra=cloudfront-s3 --no-interactive`,
+      opts,
+    );
+
+    // Re-run tRPC API with infra=rest-lambda
+    await runCLI(
+      `generate @aws/nx-plugin:ts#api --name=my-api --infra=rest-lambda --no-interactive`,
+      opts,
+    );
+
+    // Re-run Python FastAPI with infra=rest-lambda
+    await runCLI(
+      `generate @aws/nx-plugin:py#api --name=py-api --infra=rest-lambda --no-interactive`,
+      opts,
+    );
+
+    // Re-run lambda function with infra=lambda
+    await runCLI(
+      `generate @aws/nx-plugin:ts#lambda-function --project=ts-project --name=my-function --event=Any --infra=lambda --no-interactive`,
+      opts,
+    );
+
+    // Re-run Python lambda function with infra=lambda
+    await runCLI(
+      `generate @aws/nx-plugin:py#lambda-function --project=e2e_test.py_project --name=my-function --event=Any --infra=lambda --no-interactive`,
+      opts,
+    );
+
+    // Re-run RDB with infra=aurora
+    await runCLI(
+      `generate @aws/nx-plugin:ts#rdb --name=my-db --infra=aurora --engine=postgres --framework=prisma --no-interactive`,
       opts,
     );
 

--- a/e2e/src/smoke-tests/infra-none.spec.ts
+++ b/e2e/src/smoke-tests/infra-none.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { existsSync, rmSync } from 'fs';
+import { ensureDirSync } from 'fs-extra';
+import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+
+describe('smoke test - infra-none', () => {
+  const pkgMgr = 'pnpm';
+  const targetDir = `${tmpProjPath()}/infra-none-${pkgMgr}`;
+
+  beforeEach(() => {
+    console.log(`Cleaning target directory ${targetDir}`);
+    if (existsSync(targetDir)) {
+      rmSync(targetDir, { force: true, recursive: true });
+    }
+    ensureDirSync(targetDir);
+  });
+
+  it('should generate and build all generators with --infra=none', async () => {
+    await runCLI(
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'cdk')} --interactive=false --skipGit`,
+      {
+        cwd: targetDir,
+        prefixWithPackageManagerCmd: false,
+        redirectStderr: true,
+      },
+    );
+    const projectRoot = `${targetDir}/e2e-test`;
+    const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
+
+    // Website with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:ts#website --name=website --infra=none --no-interactive`,
+      opts,
+    );
+
+    // tRPC API with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:ts#api --name=my-api --infra=none --no-interactive`,
+      opts,
+    );
+
+    // Python FastAPI with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:py#api --name=py-api --infra=none --no-interactive`,
+      opts,
+    );
+
+    // TypeScript project + lambda function with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:ts#project --name=ts-project --no-interactive`,
+      opts,
+    );
+    await runCLI(
+      `generate @aws/nx-plugin:ts#lambda-function --project=ts-project --name=my-function --event=Any --infra=none --no-interactive`,
+      opts,
+    );
+
+    // Python project + lambda function with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:py#project --name=py-project --projectType=application --no-interactive`,
+      opts,
+    );
+    await runCLI(
+      `generate @aws/nx-plugin:py#lambda-function --project=e2e_test.py_project --name=my-function --event=Any --infra=none --no-interactive`,
+      opts,
+    );
+
+    // TypeScript agent with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-agent --infra=none --no-interactive`,
+      opts,
+    );
+
+    // Python agent with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:py#agent --project=py_project --name=my-agent --infra=none --no-interactive`,
+      opts,
+    );
+
+    // TypeScript MCP server with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:ts#mcp-server --project=ts-project --name=my-mcp --infra=none --no-interactive`,
+      opts,
+    );
+
+    // Python MCP server with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:py#mcp-server --project=py_project --name=my-mcp --infra=none --no-interactive`,
+      opts,
+    );
+
+    // RDB with infra=none
+    await runCLI(
+      `generate @aws/nx-plugin:ts#rdb --name=my-db --infra=none --engine=postgres --framework=prisma --no-interactive`,
+      opts,
+    );
+
+    await runCLI(`sync --verbose`, opts);
+    await runCLI(
+      `run-many --target build --all --output-style=stream --verbose`,
+      opts,
+    );
+  });
+});

--- a/packages/nx-plugin/src/py/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.spec.ts
@@ -1345,4 +1345,29 @@ dev-dependencies = []
       'my-custom-agent-serve-local',
     ]);
   });
+
+  it('should generate with infra=none then upgrade to infra=agentcore', async () => {
+    await pyAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-agent',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists(
+        'apps/test-project/proj_test_project/upgrade_agent/__init__.py',
+      ),
+    ).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await pyAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-agent',
+      infra: 'agentcore',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/py/api/schema.d.ts
+++ b/packages/nx-plugin/src/py/api/schema.d.ts
@@ -7,7 +7,7 @@ import { IacOption } from '../../utils/iac';
 export interface PyApiGeneratorSchema {
   readonly name: string;
   readonly framework?: 'fastapi';
-  readonly infra: 'rest-lambda' | 'http-lambda';
+  readonly infra: 'rest-lambda' | 'http-lambda' | 'none';
   readonly integrationPattern?: 'isolated' | 'shared';
   readonly auth: 'iam' | 'cognito' | 'custom';
   readonly directory?: string;

--- a/packages/nx-plugin/src/py/api/schema.json
+++ b/packages/nx-plugin/src/py/api/schema.json
@@ -89,9 +89,9 @@
     },
     "infra": {
       "type": "string",
-      "description": "The type of infrastructure to use to deploy this API. Choose between rest-lambda (default) or http-lambda.",
+      "description": "The type of infrastructure to use to deploy this API.",
       "default": "rest-lambda",
-      "enum": ["rest-lambda", "http-lambda"],
+      "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
     }

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -908,4 +908,29 @@ describe('fastapi project generator', () => {
     expect(tree.exists('packages/apis')).toBeTruthy();
     expect(tree.exists('packages/apis/pyproject.toml')).toBeTruthy();
   });
+
+  it('should generate with infra=none then upgrade to infra=rest-lambda', async () => {
+    await pyFastApiProjectGenerator(tree, {
+      name: 'upgrade-api',
+      directory: 'apps',
+      infra: 'none',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists('apps/upgrade_api/proj_upgrade_api/main.py'),
+    ).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await pyFastApiProjectGenerator(tree, {
+      name: 'upgrade-api',
+      directory: 'apps',
+      infra: 'rest-lambda',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -62,13 +62,23 @@ export const pyFastApiProjectGenerator = async (
   const apiNameKebabCase = toKebabCase(schema.name);
   const apiNameClassName = toClassName(schema.name);
 
-  await pyProjectGenerator(tree, {
-    name: schema.name,
-    directory: schema.directory,
-    subDirectory: schema.subDirectory,
-    moduleName: normalizedModuleName,
-    type: 'application',
-  });
+  let projectExists: boolean;
+  try {
+    readProjectConfiguration(tree, fullyQualifiedName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (!projectExists) {
+    await pyProjectGenerator(tree, {
+      name: schema.name,
+      directory: schema.directory,
+      subDirectory: schema.subDirectory,
+      moduleName: normalizedModuleName,
+      type: 'application',
+    });
+  }
 
   const projectConfig = readProjectConfiguration(tree, fullyQualifiedName);
   const port = assignPort(tree, projectConfig, 8000);

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -49,11 +49,6 @@ export const pyFastApiProjectGenerator = async (
   schema: PyFastApiProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const integrationPattern = getIntegrationPattern(schema);
-  const iac = await resolveIac(tree, schema.iac);
-
-  await sharedConstructsGenerator(tree, {
-    iac,
-  });
 
   const { dir, normalizedModuleName, fullyQualifiedName } = getPyProjectDetails(
     tree,
@@ -143,50 +138,58 @@ export const pyFastApiProjectGenerator = async (
     },
   );
 
-  if (schema.auth === 'custom') {
-    const authorizerType = schema.infra === 'http-lambda' ? 'http' : 'rest';
-    generateFiles(
-      tree,
-      joinPathFragments(
-        __dirname,
-        '..',
-        '..',
-        'utils',
-        'api-constructs',
-        'files',
-        'py-authorizer',
-        authorizerType,
-      ),
-      joinPathFragments(dir, normalizedModuleName),
-      {},
-      {
-        overwriteStrategy: OverwriteStrategy.KeepExisting,
+  if (schema.infra !== 'none') {
+    const iac = await resolveIac(tree, schema.iac);
+
+    await sharedConstructsGenerator(tree, {
+      iac,
+    });
+
+    if (schema.auth === 'custom') {
+      const authorizerType = schema.infra === 'http-lambda' ? 'http' : 'rest';
+      generateFiles(
+        tree,
+        joinPathFragments(
+          __dirname,
+          '..',
+          '..',
+          'utils',
+          'api-constructs',
+          'files',
+          'py-authorizer',
+          authorizerType,
+        ),
+        joinPathFragments(dir, normalizedModuleName),
+        {},
+        {
+          overwriteStrategy: OverwriteStrategy.KeepExisting,
+        },
+      );
+    }
+
+    // Add the CDK construct to deploy the FastAPI to shared constructs
+    await addApiGatewayInfra(tree, {
+      apiProjectName: projectConfig.name,
+      apiNameClassName,
+      apiNameKebabCase,
+      constructType: schema.infra === 'http-lambda' ? 'http' : 'rest',
+      backend: {
+        type: 'fastapi',
+        moduleName: normalizedModuleName,
+        bundleOutputDir,
+        integrationPattern,
       },
-    );
+      auth: schema.auth,
+      iac,
+    });
+
+    addSharedConstructsOpenApiMetadataGenerateTarget(tree, {
+      iac,
+      apiNameKebabCase,
+      specPath,
+      specBuildTargetName: `${projectConfig.name}:openapi`,
+    });
   }
-
-  // Add the CDK construct to deploy the FastAPI to shared constructs
-  await addApiGatewayInfra(tree, {
-    apiProjectName: projectConfig.name,
-    apiNameClassName,
-    apiNameKebabCase,
-    constructType: schema.infra === 'http-lambda' ? 'http' : 'rest',
-    backend: {
-      type: 'fastapi',
-      moduleName: normalizedModuleName,
-      bundleOutputDir,
-      integrationPattern,
-    },
-    auth: schema.auth,
-    iac,
-  });
-
-  addSharedConstructsOpenApiMetadataGenerateTarget(tree, {
-    iac,
-    apiNameKebabCase,
-    specPath,
-    specBuildTargetName: `${projectConfig.name}:openapi`,
-  });
 
   addDependenciesToPyProjectToml(tree, dir, [
     'fastapi',

--- a/packages/nx-plugin/src/py/fast-api/schema.d.ts
+++ b/packages/nx-plugin/src/py/fast-api/schema.d.ts
@@ -7,7 +7,7 @@ import { IacOption } from '../../utils/iac';
 
 export interface PyFastApiProjectGeneratorSchema {
   readonly name: string;
-  readonly infra: 'rest-lambda' | 'http-lambda';
+  readonly infra: 'rest-lambda' | 'http-lambda' | 'none';
   readonly integrationPattern?: 'isolated' | 'shared';
   readonly auth: 'iam' | 'cognito' | 'custom';
   readonly directory?: string;

--- a/packages/nx-plugin/src/py/fast-api/schema.json
+++ b/packages/nx-plugin/src/py/fast-api/schema.json
@@ -71,9 +71,9 @@
     },
     "infra": {
       "type": "string",
-      "description": "The type of infrastructure to use to deploy this API. Choose between rest-lambda (default) or http-lambda.",
+      "description": "The type of infrastructure to use to deploy this API.",
       "default": "rest-lambda",
-      "enum": ["rest-lambda", "http-lambda"],
+      "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
     }

--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -1154,4 +1154,47 @@ dev = []
       });
     });
   });
+
+  it('should generate with infra=none then upgrade to infra=lambda', async () => {
+    tree.write(
+      'apps/test_project/project.json',
+      JSON.stringify({
+        name: 'test-project',
+        root: 'apps/test_project',
+        sourceRoot: 'apps/test_project/test_project',
+        targets: {},
+      }),
+    );
+    tree.write(
+      'apps/test_project/pyproject.toml',
+      `[project]\n    dependencies = []\n`,
+    );
+
+    await pyLambdaFunctionGenerator(tree, {
+      project: 'test-project',
+      name: 'test-function',
+      event: 'Any',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists('apps/test_project/test_project/test_function.py'),
+    ).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await pyLambdaFunctionGenerator(tree, {
+      project: 'test-project',
+      name: 'test-function',
+      event: 'Any',
+      infra: 'lambda',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists(
+        'packages/common/constructs/src/app/lambda-functions/test-project-test-function.ts',
+      ),
+    ).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -131,24 +131,28 @@ export const pyLambdaFunctionGenerator = async (
     );
   }
 
-  const iac = await resolveIac(tree, schema.iac);
-
-  await sharedConstructsGenerator(tree, {
-    iac,
-  });
+  const infra = schema.infra ?? 'lambda';
 
   // Check if the project has a bundle target and if not add it
   const { bundleOutputDir } = addPythonBundleTarget(projectConfig);
 
-  await addLambdaFunctionInfra(tree, {
-    functionProjectName: projectConfig.name,
-    nameClassName: constructFunctionClassName,
-    nameKebabCase: constructFunctionKebabCase,
-    handler: normalizedFunctionPath,
-    bundlePathFromRoot: bundleOutputDir,
-    runtime: 'python',
-    iac,
-  });
+  if (infra !== 'none') {
+    const iac = await resolveIac(tree, schema.iac);
+
+    await sharedConstructsGenerator(tree, {
+      iac,
+    });
+
+    await addLambdaFunctionInfra(tree, {
+      functionProjectName: projectConfig.name,
+      nameClassName: constructFunctionClassName,
+      nameKebabCase: constructFunctionKebabCase,
+      handler: normalizedFunctionPath,
+      bundlePathFromRoot: bundleOutputDir,
+      runtime: 'python',
+      iac,
+    });
+  }
 
   const enhancedOptions = {
     ...schema,

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -124,14 +124,14 @@ export const pyLambdaFunctionGenerator = async (
     `${normalizedFunctionName}.py`,
   );
 
-  // Check that the project does not already have a lambda handler
-  if (tree.exists(functionPath)) {
+  const infra = schema.infra ?? 'lambda';
+  const handlerAlreadyExists = tree.exists(functionPath);
+
+  if (handlerAlreadyExists && infra === 'none') {
     throw new Error(
-      `This project already has a a lambda function with the name ${normalizedFunctionName}. Please remove the lambda function before running this generator or use a different name.`,
+      `This project already has a lambda function with the name ${normalizedFunctionName}. Please remove the lambda function before running this generator or use a different name.`,
     );
   }
-
-  const infra = schema.infra ?? 'lambda';
 
   // Check if the project has a bundle target and if not add it
   const { bundleOutputDir } = addPythonBundleTarget(projectConfig);

--- a/packages/nx-plugin/src/py/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/py/lambda-function/schema.d.ts
@@ -47,10 +47,13 @@ type EventSource =
   | 'VpcLatticeModel'
   | 'VpcLatticeV2Model';
 
+export type LambdaInfraOption = 'lambda' | 'none';
+
 export interface PyLambdaFunctionGeneratorSchema {
   readonly project: string;
   readonly name: string;
   readonly functionPath?: string;
   readonly event?: EventSource;
+  readonly infra?: LambdaInfraOption;
   readonly iac: IacOption;
 }

--- a/packages/nx-plugin/src/py/lambda-function/schema.json
+++ b/packages/nx-plugin/src/py/lambda-function/schema.json
@@ -75,6 +75,14 @@
       "default": "Any",
       "x-prompt": "Enter the event source model to use for the lambda function"
     },
+    "infra": {
+      "type": "string",
+      "description": "The type of infrastructure to deploy your Lambda function with.",
+      "enum": ["lambda", "none"],
+      "default": "lambda",
+      "x-priority": "important",
+      "x-prompt": "What infrastructure would you like to deploy your Lambda function with?"
+    },
     "iac": {
       "type": "string",
       "description": "The preferred IaC provider. By default this is inherited from your initial selection.",

--- a/packages/nx-plugin/src/py/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.spec.ts
@@ -971,4 +971,29 @@ dev-dependencies = []
     expect(projectConfig.targets['mcp-server-serve-stdio']).toBeDefined();
     expect(projectConfig.targets['mcp-server-serve']).toBeDefined();
   });
+
+  it('should generate with infra=none then upgrade to infra=agentcore', async () => {
+    await pyMcpServerGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-mcp',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists(
+        'apps/test-project/proj_test_project/upgrade_mcp/__init__.py',
+      ),
+    ).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await pyMcpServerGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-mcp',
+      infra: 'agentcore',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -819,4 +819,25 @@ describe('tsSmithyApiGenerator', () => {
     expect(tree.exists('packages/apis/backend')).toBeTruthy();
     expect(tree.exists('packages/apis/backend/src')).toBeTruthy();
   });
+
+  it('should generate with infra=none then upgrade to infra=rest-lambda', async () => {
+    await tsSmithyApiGenerator(tree, {
+      name: 'upgrade-api',
+      infra: 'none',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('upgrade-api/backend/src')).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await tsSmithyApiGenerator(tree, {
+      name: 'upgrade-api',
+      infra: 'rest-lambda',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -57,14 +57,31 @@ export const tsSmithyApiGenerator = async (
     getTsLibDetails(tree, options);
   const modelProjectName = `${apiNameKebabCase}-model`;
 
-  // Generate the model project
-  await smithyProjectGenerator(tree, {
-    name: modelProjectName,
-    serviceName: apiNameClassName,
-    namespace: options.namespace,
-    directory: dir,
-    subDirectory: 'model',
-  });
+  let projectExists: boolean;
+  try {
+    readProjectConfigurationUnqualified(tree, backendFullyQualifiedName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (!projectExists) {
+    // Generate the model project
+    await smithyProjectGenerator(tree, {
+      name: modelProjectName,
+      serviceName: apiNameClassName,
+      namespace: options.namespace,
+      directory: dir,
+      subDirectory: 'model',
+    });
+
+    // Generate the backend project
+    await tsProjectGenerator(tree, {
+      name: options.name,
+      directory: dir,
+      subDirectory: 'backend',
+    });
+  }
 
   // Add metadata to associate backend project with model project
   const modelProjectConfig = readProjectConfigurationUnqualified(
@@ -77,13 +94,6 @@ export const tsSmithyApiGenerator = async (
       ...modelProjectConfig.metadata,
       backendProject: backendFullyQualifiedName,
     } as any,
-  });
-
-  // Generate the backend project
-  await tsProjectGenerator(tree, {
-    name: options.name,
-    directory: dir,
-    subDirectory: 'backend',
   });
 
   addGeneratorMetadata(

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -43,7 +43,10 @@ export const tsSmithyApiGenerator = async (
   tree: Tree,
   options: TsSmithyApiGeneratorSchema,
 ): Promise<GeneratorCallback> => {
-  if ((options.infra as string) !== 'rest-lambda') {
+  if (
+    (options.infra as string) !== 'rest-lambda' &&
+    (options.infra as string) !== 'none'
+  ) {
     throw new Error(
       `Unsupported infra '${options.infra}' for Smithy TypeScript API. ` +
         `Only 'rest-lambda' (API Gateway REST API) is supported.`,

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -116,84 +116,86 @@ export const tsSmithyApiGenerator = async (
     },
   );
 
-  if (options.auth === 'custom') {
-    generateFiles(
-      tree,
-      joinPathFragments(
-        __dirname,
-        '..',
-        '..',
-        '..',
-        'utils',
-        'api-constructs',
-        'files',
-        'cdk',
-        'authorizer',
-        'rest',
-      ),
-      backendProjectConfig.sourceRoot,
-      {},
-      {
-        overwriteStrategy: OverwriteStrategy.KeepExisting,
-      },
-    );
-  }
+  if (options.infra !== 'none') {
+    if (options.auth === 'custom') {
+      generateFiles(
+        tree,
+        joinPathFragments(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          'utils',
+          'api-constructs',
+          'files',
+          'cdk',
+          'authorizer',
+          'rest',
+        ),
+        backendProjectConfig.sourceRoot,
+        {},
+        {
+          overwriteStrategy: OverwriteStrategy.KeepExisting,
+        },
+      );
+    }
 
-  // Add infrastructure
-  const iac = await resolveIac(tree, options.iac);
-  await sharedConstructsGenerator(tree, {
-    iac,
-  });
-  await addApiGatewayInfra(tree, {
-    iac,
-    apiProjectName: backendFullyQualifiedName,
-    apiNameClassName,
-    apiNameKebabCase,
-    auth: options.auth,
-    constructType: 'rest', // While possible in theory, Smithy doesn't support HTTP APIs
-    backend: {
-      type: 'smithy',
-      bundleOutputDir: joinPathFragments(
-        'dist',
-        backendProjectConfig.root,
-        'bundle',
-      ),
-      integrationPattern,
-      ...(options.auth === 'custom' && {
-        authorizerBundleOutputDir: joinPathFragments(
+    // Add infrastructure
+    const iac = await resolveIac(tree, options.iac);
+    await sharedConstructsGenerator(tree, {
+      iac,
+    });
+    await addApiGatewayInfra(tree, {
+      iac,
+      apiProjectName: backendFullyQualifiedName,
+      apiNameClassName,
+      apiNameKebabCase,
+      auth: options.auth,
+      constructType: 'rest',
+      backend: {
+        type: 'smithy',
+        bundleOutputDir: joinPathFragments(
           'dist',
           backendProjectConfig.root,
           'bundle',
-          'authorizer',
         ),
-      }),
-    },
-  });
-  addSharedConstructsOpenApiMetadataGenerateTarget(tree, {
-    iac,
-    apiNameKebabCase,
-    specPath: joinPathFragments(
-      'dist',
-      modelProjectConfig.root,
-      'build',
-      'openapi',
-      'openapi.json',
-    ),
-    specBuildTargetName: `${modelProjectConfig.name}:build`,
-  });
-
-  // Add bundle target using rolldown
-  await addTypeScriptBundleTarget(tree, backendProjectConfig, {
-    targetFilePath: 'src/handler.ts',
-    external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
-  });
-
-  if (options.auth === 'custom') {
-    await addTypeScriptBundleTarget(tree, backendProjectConfig, {
-      targetFilePath: 'src/authorizer.ts',
-      bundleOutputDir: 'authorizer',
-      external: [/@aws-sdk\/.*/],
+        integrationPattern,
+        ...(options.auth === 'custom' && {
+          authorizerBundleOutputDir: joinPathFragments(
+            'dist',
+            backendProjectConfig.root,
+            'bundle',
+            'authorizer',
+          ),
+        }),
+      },
     });
+    addSharedConstructsOpenApiMetadataGenerateTarget(tree, {
+      iac,
+      apiNameKebabCase,
+      specPath: joinPathFragments(
+        'dist',
+        modelProjectConfig.root,
+        'build',
+        'openapi',
+        'openapi.json',
+      ),
+      specBuildTargetName: `${modelProjectConfig.name}:build`,
+    });
+
+    // Add bundle target using rolldown
+    await addTypeScriptBundleTarget(tree, backendProjectConfig, {
+      targetFilePath: 'src/handler.ts',
+      external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
+    });
+
+    if (options.auth === 'custom') {
+      await addTypeScriptBundleTarget(tree, backendProjectConfig, {
+        targetFilePath: 'src/authorizer.ts',
+        bundleOutputDir: 'authorizer',
+        external: [/@aws-sdk\/.*/],
+      });
+    }
   }
 
   const cmd = new FsCommands(tree);

--- a/packages/nx-plugin/src/smithy/ts/api/schema.d.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/schema.d.ts
@@ -8,7 +8,7 @@ import { IacOption } from '../../../utils/iac';
 export interface TsSmithyApiGeneratorSchema {
   name: string;
   namespace?: string;
-  infra: 'rest-lambda';
+  infra: 'rest-lambda' | 'none';
   integrationPattern?: 'isolated' | 'shared';
   auth: 'iam' | 'cognito' | 'custom';
   directory?: TsProjectGeneratorSchema['directory'];

--- a/packages/nx-plugin/src/smithy/ts/api/schema.json
+++ b/packages/nx-plugin/src/smithy/ts/api/schema.json
@@ -74,7 +74,7 @@
       "type": "string",
       "description": "The type of infrastructure to use to deploy this API.",
       "default": "rest-lambda",
-      "enum": ["rest-lambda"],
+      "enum": ["rest-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "internal"
     }

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -989,4 +989,38 @@ describe('trpc backend generator', () => {
     expect(tree.exists('packages/apis/src')).toBeTruthy();
     expect(tree.exists('packages/apis/src/index.ts')).toBeTruthy();
   });
+
+  it('should generate with infra=none then upgrade to infra=rest-lambda', async () => {
+    await tsTrpcApiGenerator(tree, {
+      name: 'TestApi',
+      directory: 'packages',
+      infra: 'none',
+      integrationPattern: 'isolated',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/test-api/src/router.ts')).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    const projectJson = JSON.parse(
+      tree.read('packages/test-api/project.json', 'utf-8'),
+    );
+    expect(projectJson.targets['bundle']).toBeUndefined();
+
+    await tsTrpcApiGenerator(tree, {
+      name: 'TestApi',
+      directory: 'packages',
+      infra: 'rest-lambda',
+      integrationPattern: 'isolated',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+    const updatedProjectJson = JSON.parse(
+      tree.read('packages/test-api/project.json', 'utf-8'),
+    );
+    expect(updatedProjectJson.targets['bundle']).toBeDefined();
+  });
 });

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -41,19 +41,17 @@ const VALID_TRPC_INTEGRATION_PERMUTATIONS = new Set([
   'rest-lambda::shared',
   'http-lambda::isolated',
   'http-lambda::shared',
+  'none::isolated',
+  'none::shared',
 ]);
 
 export async function tsTrpcApiGenerator(
   tree: Tree,
   options: TsTrpcApiGeneratorSchema,
 ) {
-  validateTrpcInfraAndIntegrationPatternCombination(options);
-
-  const iac = await resolveIac(tree, options.iac);
-
-  await sharedConstructsGenerator(tree, {
-    iac,
-  });
+  if (options.infra !== 'none') {
+    validateTrpcInfraAndIntegrationPatternCombination(options);
+  }
 
   const apiNamespace = getNpmScopePrefix(tree);
   const apiNameKebabCase = kebabCase(options.name);
@@ -88,28 +86,36 @@ export async function tsTrpcApiGenerator(
     ...options,
   };
 
-  await addApiGatewayInfra(tree, {
-    apiProjectName: backendProjectName,
-    apiNameClassName,
-    apiNameKebabCase,
-    constructType: options.infra === 'http-lambda' ? 'http' : 'rest',
-    backend: {
-      type: 'trpc',
-      projectAlias: enhancedOptions.backendProjectAlias,
-      bundleOutputDir: joinPathFragments('dist', backendRoot, 'bundle'),
-      integrationPattern: getIntegrationPattern(options),
-      ...(options.auth === 'custom' && {
-        authorizerBundleOutputDir: joinPathFragments(
-          'dist',
-          backendRoot,
-          'bundle',
-          'authorizer',
-        ),
-      }),
-    },
-    auth: options.auth,
-    iac,
-  });
+  if (options.infra !== 'none') {
+    const iac = await resolveIac(tree, options.iac);
+
+    await sharedConstructsGenerator(tree, {
+      iac,
+    });
+
+    await addApiGatewayInfra(tree, {
+      apiProjectName: backendProjectName,
+      apiNameClassName,
+      apiNameKebabCase,
+      constructType: options.infra === 'http-lambda' ? 'http' : 'rest',
+      backend: {
+        type: 'trpc',
+        projectAlias: enhancedOptions.backendProjectAlias,
+        bundleOutputDir: joinPathFragments('dist', backendRoot, 'bundle'),
+        integrationPattern: getIntegrationPattern(options),
+        ...(options.auth === 'custom' && {
+          authorizerBundleOutputDir: joinPathFragments(
+            'dist',
+            backendRoot,
+            'bundle',
+            'authorizer',
+          ),
+        }),
+      },
+      auth: options.auth,
+      iac,
+    });
+  }
 
   projectConfig.metadata = {
     ...projectConfig.metadata,
@@ -139,20 +145,22 @@ export async function tsTrpcApiGenerator(
     },
   };
 
-  await addTypeScriptBundleTarget(tree, projectConfig, {
-    targetFilePath: 'src/handler.ts',
-    external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
-  });
-
-  if (options.auth === 'custom') {
+  if (options.infra !== 'none') {
     await addTypeScriptBundleTarget(tree, projectConfig, {
-      targetFilePath: 'src/authorizer.ts',
-      bundleOutputDir: 'authorizer',
-      external: [/@aws-sdk\/.*/],
+      targetFilePath: 'src/handler.ts',
+      external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
     });
-  }
 
-  addDependencyToTargetIfNotPresent(projectConfig, 'build', 'bundle');
+    if (options.auth === 'custom') {
+      await addTypeScriptBundleTarget(tree, projectConfig, {
+        targetFilePath: 'src/authorizer.ts',
+        bundleOutputDir: 'authorizer',
+        external: [/@aws-sdk\/.*/],
+      });
+    }
+
+    addDependencyToTargetIfNotPresent(projectConfig, 'build', 'bundle');
+  }
 
   projectConfig.targets = sortObjectKeys(projectConfig.targets);
 
@@ -170,7 +178,7 @@ export async function tsTrpcApiGenerator(
 
   tree.delete(joinPathFragments(backendRoot, 'src', 'lib'));
 
-  if (options.auth === 'custom') {
+  if (options.infra !== 'none' && options.auth === 'custom') {
     const authorizerType = options.infra === 'http-lambda' ? 'http' : 'rest';
     generateFiles(
       tree,
@@ -194,7 +202,7 @@ export async function tsTrpcApiGenerator(
   }
 
   // Remove streaming schema helper for HTTP APIs (API Gateway HTTP API doesn't support streaming)
-  if (options.infra !== 'rest-lambda') {
+  if (options.infra !== 'rest-lambda' && options.infra !== 'none') {
     tree.delete(
       joinPathFragments(backendRoot, 'src', 'schema', 'z-async-iterable.ts'),
     );

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -60,11 +60,21 @@ export async function tsTrpcApiGenerator(
   const backendName = apiNameKebabCase;
   const backendProjectName = `${apiNamespace}${backendName}`;
 
-  await tsProjectGenerator(tree, {
-    name: backendName,
-    directory: options.directory,
-    subDirectory: options.subDirectory,
-  });
+  let projectExists: boolean;
+  try {
+    readProjectConfigurationUnqualified(tree, backendProjectName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (!projectExists) {
+    await tsProjectGenerator(tree, {
+      name: backendName,
+      directory: options.directory,
+      subDirectory: options.subDirectory,
+    });
+  }
 
   const projectConfig = readProjectConfigurationUnqualified(
     tree,

--- a/packages/nx-plugin/src/trpc/backend/schema.d.ts
+++ b/packages/nx-plugin/src/trpc/backend/schema.d.ts
@@ -8,7 +8,7 @@ import { TsProjectGeneratorSchema } from '../../ts/lib/schema';
 
 export interface TsTrpcApiGeneratorSchema {
   name: string;
-  infra: 'rest-lambda' | 'http-lambda';
+  infra: 'rest-lambda' | 'http-lambda' | 'none';
   integrationPattern?: 'isolated' | 'shared';
   auth: 'iam' | 'cognito' | 'custom';
   directory?: TsProjectGeneratorSchema['directory'];

--- a/packages/nx-plugin/src/trpc/backend/schema.json
+++ b/packages/nx-plugin/src/trpc/backend/schema.json
@@ -66,9 +66,9 @@
     },
     "infra": {
       "type": "string",
-      "description": "The type of infrastructure to use to deploy this API. Choose between rest-lambda (default) or http-lambda.",
+      "description": "The type of infrastructure to use to deploy this API.",
       "default": "rest-lambda",
-      "enum": ["rest-lambda", "http-lambda"],
+      "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
     }

--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -1128,4 +1128,33 @@ describe('ts#agent generator', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('should generate with infra=none then upgrade to infra=agentcore', async () => {
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-agent',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists('apps/test-project/src/upgrade-agent/index.ts'),
+    ).toBeTruthy();
+    expect(
+      tree.exists('apps/test-project/src/upgrade-agent/Dockerfile'),
+    ).toBeFalsy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-agent',
+      infra: 'agentcore',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists('apps/test-project/src/upgrade-agent/Dockerfile'),
+    ).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/ts/api/generator.ts
+++ b/packages/nx-plugin/src/ts/api/generator.ts
@@ -32,7 +32,10 @@ export async function tsApiGenerator(
       return tsSmithyApiGenerator(tree, {
         name: options.name,
         namespace: options.namespace,
-        infra: options.infra === 'none' ? 'none' : 'rest-lambda',
+        infra:
+          options.infra === 'none'
+            ? 'none'
+            : ((options.infra ?? 'rest-lambda') as 'rest-lambda'),
         integrationPattern: options.integrationPattern,
         auth: options.auth,
         directory: options.directory,

--- a/packages/nx-plugin/src/ts/api/generator.ts
+++ b/packages/nx-plugin/src/ts/api/generator.ts
@@ -32,7 +32,7 @@ export async function tsApiGenerator(
       return tsSmithyApiGenerator(tree, {
         name: options.name,
         namespace: options.namespace,
-        infra: (options.infra ?? 'rest-lambda') as 'rest-lambda',
+        infra: options.infra === 'none' ? 'none' : 'rest-lambda',
         integrationPattern: options.integrationPattern,
         auth: options.auth,
         directory: options.directory,

--- a/packages/nx-plugin/src/ts/api/schema.d.ts
+++ b/packages/nx-plugin/src/ts/api/schema.d.ts
@@ -9,7 +9,7 @@ export interface TsApiGeneratorSchema {
   name: string;
   framework?: 'trpc' | 'smithy';
   namespace?: string;
-  infra: 'rest-lambda' | 'http-lambda';
+  infra: 'rest-lambda' | 'http-lambda' | 'none';
   integrationPattern?: 'isolated' | 'shared';
   auth: 'iam' | 'cognito' | 'custom';
   directory?: TsProjectGeneratorSchema['directory'];

--- a/packages/nx-plugin/src/ts/api/schema.json
+++ b/packages/nx-plugin/src/ts/api/schema.json
@@ -96,7 +96,7 @@
       "type": "string",
       "description": "The type of infrastructure to use to deploy this API.",
       "default": "rest-lambda",
-      "enum": ["rest-lambda", "http-lambda"],
+      "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
     }

--- a/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
@@ -296,6 +296,36 @@ describe('ts-lambda-function generator', () => {
     );
   });
 
+  it('should generate with infra=none then upgrade to infra=lambda', async () => {
+    await tsLambdaFunctionGenerator(tree, { ...options, infra: 'none' });
+
+    expect(
+      tree.exists('packages/test-project/src/test-function.ts'),
+    ).toBeTruthy();
+
+    const projectJson = JSON.parse(
+      tree.read('packages/test-project/project.json', 'utf-8'),
+    );
+    expect(projectJson.targets['bundle']).toBeUndefined();
+    expect(
+      tree.exists(
+        'packages/common/constructs/src/app/lambda-functions/test-project-test-function.ts',
+      ),
+    ).toBeFalsy();
+
+    await tsLambdaFunctionGenerator(tree, { ...options, infra: 'lambda' });
+
+    const updatedProjectJson = JSON.parse(
+      tree.read('packages/test-project/project.json', 'utf-8'),
+    );
+    expect(updatedProjectJson.targets['bundle']).toBeDefined();
+    expect(
+      tree.exists(
+        'packages/common/constructs/src/app/lambda-functions/test-project-test-function.ts',
+      ),
+    ).toBeTruthy();
+  });
+
   it('should throw error if project has no tsconfig.json', async () => {
     // Remove tsconfig.json
     tree.delete('packages/test-project/tsconfig.json');

--- a/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
@@ -282,14 +282,16 @@ describe('ts-lambda-function generator', () => {
     );
   });
 
-  it('should throw error if lambda function already exists', async () => {
+  it('should throw error if lambda function already exists and infra is none', async () => {
     // Create the lambda function file first
     tree.write(
       'packages/test-project/src/test-function.ts',
       '// existing file',
     );
 
-    await expect(tsLambdaFunctionGenerator(tree, options)).rejects.toThrow(
+    await expect(
+      tsLambdaFunctionGenerator(tree, { ...options, infra: 'none' }),
+    ).rejects.toThrow(
       'This project already has a lambda function with the name test-function',
     );
   });

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -126,12 +126,14 @@ export const tsLambdaFunctionGenerator = async (
     returnType: TS_HANDLER_RETURN_TYPES[schema.event],
   };
 
-  // Add a bundle target for the function
-  await addTypeScriptBundleTarget(tree, projectConfig, {
-    targetFilePath: functionPathFromProjectRoot,
-    bundleOutputDir,
-    external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
-  });
+  if (infra !== 'none') {
+    // Add a bundle target for the function
+    await addTypeScriptBundleTarget(tree, projectConfig, {
+      targetFilePath: functionPathFromProjectRoot,
+      bundleOutputDir,
+      external: [/@aws-sdk\/.*/], // lambda runtime provides aws sdk
+    });
+  }
 
   projectConfig.targets = sortObjectKeys(projectConfig.targets);
   updateProjectConfiguration(tree, projectConfig.name, projectConfig);

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -84,14 +84,14 @@ export const tsLambdaFunctionGenerator = async (
     functionPathFromProjectRoot,
   );
 
-  // Check that the project does not already have a lambda handler
-  if (tree.exists(functionPath)) {
+  const infra = schema.infra ?? 'lambda';
+  const handlerAlreadyExists = tree.exists(functionPath);
+
+  if (handlerAlreadyExists && infra === 'none') {
     throw new Error(
       `This project already has a lambda function with the name ${nameKebabCase}. Please remove the lambda function before running this generator or use a different name.`,
     );
   }
-
-  const infra = schema.infra ?? 'lambda';
 
   const bundleOutputDir = joinPathFragments('lambda', lambdaFunctionKebabCase);
 

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -91,28 +91,32 @@ export const tsLambdaFunctionGenerator = async (
     );
   }
 
-  const iac = await resolveIac(tree, schema.iac);
-
-  await sharedConstructsGenerator(tree, {
-    iac,
-  });
+  const infra = schema.infra ?? 'lambda';
 
   const bundleOutputDir = joinPathFragments('lambda', lambdaFunctionKebabCase);
 
-  await addLambdaFunctionInfra(tree, {
-    functionProjectName: projectConfig.name,
-    nameClassName: constructFunctionClassName,
-    nameKebabCase: constructFunctionNameKebabCase,
-    handler: 'index.handler',
-    runtime: 'node',
-    bundlePathFromRoot: joinPathFragments(
-      'dist',
-      dir,
-      'bundle',
-      bundleOutputDir,
-    ),
-    iac,
-  });
+  if (infra !== 'none') {
+    const iac = await resolveIac(tree, schema.iac);
+
+    await sharedConstructsGenerator(tree, {
+      iac,
+    });
+
+    await addLambdaFunctionInfra(tree, {
+      functionProjectName: projectConfig.name,
+      nameClassName: constructFunctionClassName,
+      nameKebabCase: constructFunctionNameKebabCase,
+      handler: 'index.handler',
+      runtime: 'node',
+      bundlePathFromRoot: joinPathFragments(
+        'dist',
+        dir,
+        'bundle',
+        bundleOutputDir,
+      ),
+      iac,
+    });
+  }
 
   const enhancedOptions = {
     ...schema,

--- a/packages/nx-plugin/src/ts/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/schema.d.ts
@@ -49,10 +49,13 @@ export type EventSource =
   | 'VpcLatticeSchema'
   | 'VpcLatticeV2Schema';
 
+export type LambdaInfraOption = 'lambda' | 'none';
+
 export interface TsLambdaFunctionGeneratorSchema {
   readonly project: string;
   readonly name: string;
   readonly functionPath?: string;
   readonly event?: EventSource;
+  readonly infra?: LambdaInfraOption;
   readonly iac: IacOption;
 }

--- a/packages/nx-plugin/src/ts/lambda-function/schema.json
+++ b/packages/nx-plugin/src/ts/lambda-function/schema.json
@@ -77,6 +77,14 @@
       "default": "Any",
       "x-prompt": "Enter the event source schema to use for the lambda function"
     },
+    "infra": {
+      "type": "string",
+      "description": "The type of infrastructure to deploy your Lambda function with.",
+      "enum": ["lambda", "none"],
+      "default": "lambda",
+      "x-priority": "important",
+      "x-prompt": "What infrastructure would you like to deploy your Lambda function with?"
+    },
     "iac": {
       "type": "string",
       "description": "The preferred IaC provider. By default this is inherited from your initial selection.",

--- a/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
@@ -1097,4 +1097,27 @@ describe('ts#mcp-server generator', () => {
     expect(projectConfig.targets['mcp-server-serve-stdio']).toBeDefined();
     expect(projectConfig.targets['mcp-server-serve']).toBeDefined();
   });
+
+  it('should generate with infra=none then upgrade to infra=agentcore', async () => {
+    await tsMcpServerGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-mcp',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    expect(
+      tree.exists('apps/test-project/src/upgrade-mcp/index.ts'),
+    ).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    await tsMcpServerGenerator(tree, {
+      project: 'test-project',
+      name: 'upgrade-mcp',
+      infra: 'agentcore',
+      iac: 'cdk',
+    });
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+  });
 });

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -283,4 +283,24 @@ describe('ts#rdb generator', () => {
       tree.read('packages/common/terraform/src/app/dbs/db/db.tf', 'utf-8'),
     ).toMatchSnapshot();
   });
+
+  it('should generate with infra=none then upgrade to infra=aurora', async () => {
+    await tsRdbGenerator(tree, { ...defaultOptions, infra: 'none' });
+
+    expect(tree.exists('packages/db/prisma')).toBeTruthy();
+    expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+    const projectJson = JSON.parse(
+      tree.read('packages/db/project.json', 'utf-8'),
+    );
+    expect(projectJson.targets['bundle']).toBeUndefined();
+
+    await tsRdbGenerator(tree, defaultOptions);
+
+    expect(tree.exists('packages/common/constructs')).toBeTruthy();
+    const updatedProjectJson = JSON.parse(
+      tree.read('packages/db/project.json', 'utf-8'),
+    );
+    expect(updatedProjectJson.targets['bundle']).toBeDefined();
+  });
 });

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -56,10 +56,20 @@ export const tsRdbGenerator = async (
     subDirectory: options.subDirectory,
   });
 
-  await tsProjectGenerator(tree, {
-    name: options.name,
-    directory: options.directory,
-  });
+  let projectExists: boolean;
+  try {
+    readProjectConfiguration(tree, fullyQualifiedName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (!projectExists) {
+    await tsProjectGenerator(tree, {
+      name: options.name,
+      directory: options.directory,
+    });
+  }
 
   updateJson(tree, joinPathFragments(dir, 'tsconfig.lib.json'), (tsConfig) => ({
     ...tsConfig,

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -49,7 +49,6 @@ export const tsRdbGenerator = async (
   const nameClassName = toClassName(options.name);
   const databaseUser = options.databaseUser ?? 'dbadmin';
   const databaseName = snakeCase(options.databaseName ?? options.name);
-  const iac = await resolveIac(tree, options.iac);
   const containers = await resolveContainers(tree, 'inherit');
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, {
     name: options.name,
@@ -113,38 +112,49 @@ export const tsRdbGenerator = async (
     projectConfig.root,
   );
   const fs = new FsCommands(tree);
-  await addTypeScriptBundleTarget(tree, projectConfig, {
-    targetFilePath: 'src/migration-handler.ts',
-    bundleOutputDir: 'migration',
-  });
-  await addTypeScriptBundleTarget(tree, projectConfig, {
-    targetFilePath: 'src/create-db-user-handler.ts',
-    bundleOutputDir: 'create-db-user',
-  });
-  const bundleTarget = projectConfig.targets['bundle'];
-  const rolldownCommand = bundleTarget.options.command;
-  delete bundleTarget.options.command;
-  bundleTarget.options = {
-    ...bundleTarget.options,
-    commands: [
-      fs.rm(`${relativePathToRoot}dist/{projectRoot}/bundle/migration`),
-      fs.mkdir(`${relativePathToRoot}dist/{projectRoot}/bundle/migration`),
-      fs.cp(
-        'prisma',
-        `${relativePathToRoot}dist/{projectRoot}/bundle/migration/prisma`,
-      ),
-      fs.cp(
-        'prisma.config.ts',
-        `${relativePathToRoot}dist/{projectRoot}/bundle/migration/prisma.config.ts`,
-      ),
-      fs.cp(
-        'Dockerfile',
-        `${relativePathToRoot}dist/{projectRoot}/bundle/migration/Dockerfile`,
-      ),
-      rolldownCommand,
-    ],
-    parallel: false,
-  };
+  const migrationBundleDir = joinPathFragments(
+    'dist',
+    projectConfig.root,
+    'bundle',
+    'migration',
+  );
+  const dockerImageTag = `${getNpmScope(tree)}-${kebabCase(options.name)}-migration:latest`;
+
+  if (options.infra !== 'none') {
+    await addTypeScriptBundleTarget(tree, projectConfig, {
+      targetFilePath: 'src/migration-handler.ts',
+      bundleOutputDir: 'migration',
+    });
+    await addTypeScriptBundleTarget(tree, projectConfig, {
+      targetFilePath: 'src/create-db-user-handler.ts',
+      bundleOutputDir: 'create-db-user',
+    });
+    const bundleTarget = projectConfig.targets['bundle'];
+    const rolldownCommand = bundleTarget.options.command;
+    delete bundleTarget.options.command;
+    bundleTarget.options = {
+      ...bundleTarget.options,
+      commands: [
+        fs.rm(`${relativePathToRoot}dist/{projectRoot}/bundle/migration`),
+        fs.mkdir(`${relativePathToRoot}dist/{projectRoot}/bundle/migration`),
+        fs.cp(
+          'prisma',
+          `${relativePathToRoot}dist/{projectRoot}/bundle/migration/prisma`,
+        ),
+        fs.cp(
+          'prisma.config.ts',
+          `${relativePathToRoot}dist/{projectRoot}/bundle/migration/prisma.config.ts`,
+        ),
+        fs.cp(
+          'Dockerfile',
+          `${relativePathToRoot}dist/{projectRoot}/bundle/migration/Dockerfile`,
+        ),
+        rolldownCommand,
+      ],
+      parallel: false,
+    };
+  }
+
   projectConfig.targets.generate = {
     executor: 'nx:run-commands',
     outputs: ['{projectRoot}/generated/prisma'],
@@ -193,23 +203,20 @@ export const tsRdbGenerator = async (
       },
     },
   };
-  const migrationBundleDir = joinPathFragments(
-    'dist',
-    projectConfig.root,
-    'bundle',
-    'migration',
-  );
-  const dockerImageTag = `${getNpmScope(tree)}-${kebabCase(options.name)}-migration:latest`;
-  if (iac === 'terraform') {
-    projectConfig.targets['docker'] = {
-      cache: true,
-      executor: 'nx:run-commands',
-      options: {
-        command: `${containers} build --platform linux/arm64 --provenance=false -t ${dockerImageTag} ${migrationBundleDir}`,
-      },
-      dependsOn: ['bundle'],
-    };
-    addDependencyToTargetIfNotPresent(projectConfig, 'build', 'docker');
+  if (options.infra !== 'none') {
+    const iac = await resolveIac(tree, options.iac);
+    if (iac === 'terraform') {
+      projectConfig.targets['docker'] = {
+        cache: true,
+        executor: 'nx:run-commands',
+        options: {
+          command: `${containers} build --platform linux/arm64 --provenance=false -t ${dockerImageTag} ${migrationBundleDir}`,
+        },
+        dependsOn: ['bundle'],
+      };
+      addDependencyToTargetIfNotPresent(projectConfig, 'build', 'docker');
+    }
+    addDependencyToTargetIfNotPresent(projectConfig, 'build', 'bundle');
   }
   addDependencyToTargetIfNotPresent(projectConfig, 'compile', 'generate');
   updateProjectConfiguration(tree, fullyQualifiedName, projectConfig);
@@ -217,26 +224,29 @@ export const tsRdbGenerator = async (
     engine: options.engine,
   });
 
-  await sharedConstructsGenerator(tree, { iac });
-  await addRdbInfra(tree, {
-    iac,
-    projectName: fullyQualifiedName,
-    nameClassName,
-    nameKebabCase,
-    databasePackageAlias: toScopeAlias(fullyQualifiedName),
-    databaseName,
-    adminUser: databaseUser,
-    engine: options.engine === 'mysql' ? 'mysql' : 'postgres',
-    migrationBundleDir,
-    createDbUserBundleDir: joinPathFragments(
-      'dist',
-      projectConfig.root,
-      'bundle',
-      'create-db-user',
-    ),
-    dockerImageTag,
-    containers,
-  });
+  if (options.infra !== 'none') {
+    const iac = await resolveIac(tree, options.iac);
+    await sharedConstructsGenerator(tree, { iac });
+    await addRdbInfra(tree, {
+      iac,
+      projectName: fullyQualifiedName,
+      nameClassName,
+      nameKebabCase,
+      databasePackageAlias: toScopeAlias(fullyQualifiedName),
+      databaseName,
+      adminUser: databaseUser,
+      engine: options.engine === 'mysql' ? 'mysql' : 'postgres',
+      migrationBundleDir,
+      createDbUserBundleDir: joinPathFragments(
+        'dist',
+        projectConfig.root,
+        'bundle',
+        'create-db-user',
+      ),
+      dockerImageTag,
+      containers,
+    });
+  }
 
   addDependenciesToPackageJson(
     tree,

--- a/packages/nx-plugin/src/ts/rdb/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/schema.d.ts
@@ -8,7 +8,7 @@ export interface TsRdbGeneratorSchema {
   name: string;
   directory?: string;
   subDirectory?: string;
-  infra: 'aurora';
+  infra: 'aurora' | 'none';
   engine: 'postgres' | 'mysql';
   databaseUser?: string;
   databaseName?: string;

--- a/packages/nx-plugin/src/ts/rdb/schema.json
+++ b/packages/nx-plugin/src/ts/rdb/schema.json
@@ -29,7 +29,7 @@
     },
     "infra": {
       "type": "string",
-      "enum": ["aurora"],
+      "enum": ["aurora", "none"],
       "default": "aurora",
       "description": "Relational database service to provision.",
       "x-priority": "important",

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -2030,7 +2030,8 @@ exports[`react-website generator > Tanstack router integration > should generate
   "metadata": {
     "generator": "ts#react-website",
     "ux": "cloudscape",
-    "framework": "react"
+    "framework": "react",
+    "infra": "cloudfront-s3"
   },
   "targets": {
     "build": {
@@ -3657,7 +3658,8 @@ exports[`react-website generator > Tanstack router integration > should generate
   "metadata": {
     "generator": "ts#react-website",
     "ux": "cloudscape",
-    "framework": "react"
+    "framework": "react",
+    "infra": "cloudfront-s3"
   },
   "targets": {
     "build": {

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -424,9 +424,7 @@ describe('react-website generator', () => {
             ...options,
             iac: 'InvalidProvider' as any,
           }),
-        ).rejects.toThrow(
-          'Unknown iac: InvalidProvider. Supported providers are: cdk, terraform',
-        );
+        ).rejects.toThrow('Unsupported iac InvalidProvider');
       });
 
       it('should handle terraform with different directory structures', async () => {
@@ -594,9 +592,7 @@ describe('react-website generator', () => {
           ...options,
           iac: 'UnknownProvider' as any,
         }),
-      ).rejects.toThrow(
-        'Unknown iac: UnknownProvider. Supported providers are: cdk, terraform',
-      );
+      ).rejects.toThrow('Unsupported iac UnknownProvider');
     });
 
     it('should configure load:runtime-config target with custom directory for Terraform', async () => {

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -678,6 +678,29 @@ describe('react-website generator', () => {
     expect(tree.exists('packages/websites/src')).toBeTruthy();
     expect(tree.exists('packages/websites/src/main.tsx')).toBeTruthy();
   });
+
+  describe('infra=none idempotency', () => {
+    it('should generate with infra=none then upgrade to infra=cloudfront-s3', async () => {
+      await tsReactWebsiteGenerator(tree, { ...options, infra: 'none' });
+
+      const projectJson = JSON.parse(
+        tree.read('test-app/project.json', 'utf-8'),
+      );
+      expect(projectJson.targets['load:runtime-config']).toBeUndefined();
+      expect(tree.exists('packages/common/constructs')).toBeFalsy();
+
+      await tsReactWebsiteGenerator(tree, {
+        ...options,
+        infra: 'cloudfront-s3',
+      });
+
+      const updatedProjectJson = JSON.parse(
+        tree.read('test-app/project.json', 'utf-8'),
+      );
+      expect(updatedProjectJson.targets['load:runtime-config']).toBeDefined();
+      expect(tree.exists('packages/common/constructs')).toBeTruthy();
+    });
+  });
 });
 
 describe('react-website generator ux tests', () => {

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -142,53 +142,55 @@ export async function tsReactWebsiteGenerator(
     };
   }
 
-  const buildTarget = targets['build'];
-  targets['compile'] = {
-    dependsOn: ['bundle'],
-    executor: 'nx:run-commands',
-    outputs: ['{workspaceRoot}/dist/{projectRoot}/tsc'],
-    options: {
-      command: 'tsc --build tsconfig.app.json',
-      cwd: '{projectRoot}',
-    },
-  };
-  targets['bundle'] = {
-    ...buildTarget,
-    options: {
-      ...buildTarget.options,
-      outputPath: 'dist/{projectRoot}/bundle',
-    },
-  };
-  targets['build'] = {
-    dependsOn: [
-      'lint',
-      'compile',
-      'bundle',
-      'test',
-      ...(buildTarget.dependsOn ?? []),
-    ],
-    options: {
-      outputPath: 'dist/{projectRoot}/bundle',
-    },
-  };
-  targets['test'] = {
-    ...targets['test'],
-    options: {
-      ...(targets['test']?.options ?? {}),
-      reportsDirectory: '{workspaceRoot}/coverage/{projectRoot}',
-    },
-  };
+  if (!projectAlreadyExists) {
+    const buildTarget = targets['build'];
+    targets['compile'] = {
+      dependsOn: ['bundle'],
+      executor: 'nx:run-commands',
+      outputs: ['{workspaceRoot}/dist/{projectRoot}/tsc'],
+      options: {
+        command: 'tsc --build tsconfig.app.json',
+        cwd: '{projectRoot}',
+      },
+    };
+    targets['bundle'] = {
+      ...buildTarget,
+      options: {
+        ...buildTarget.options,
+        outputPath: 'dist/{projectRoot}/bundle',
+      },
+    };
+    targets['build'] = {
+      dependsOn: [
+        'lint',
+        'compile',
+        'bundle',
+        'test',
+        ...(buildTarget.dependsOn ?? []),
+      ],
+      options: {
+        outputPath: 'dist/{projectRoot}/bundle',
+      },
+    };
+    targets['test'] = {
+      ...targets['test'],
+      options: {
+        ...(targets['test']?.options ?? {}),
+        reportsDirectory: '{workspaceRoot}/coverage/{projectRoot}',
+      },
+    };
 
-  // Add a serve-local target for running the website and its dependencies locally
-  targets['serve-local'] = {
-    executor: '@nx/vite:dev-server',
-    options: {
-      buildTarget: `${fullyQualifiedName}:build:development`,
-      hmr: true,
-      mode: 'serve-local',
-    },
-    continuous: true,
-  };
+    // Add a serve-local target for running the website and its dependencies locally
+    targets['serve-local'] = {
+      executor: '@nx/vite:dev-server',
+      options: {
+        buildTarget: `${fullyQualifiedName}:build:development`,
+        hmr: true,
+        mode: 'serve-local',
+      },
+      continuous: true,
+    };
+  }
 
   projectConfiguration.targets = sortObjectKeys(targets);
 

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -100,8 +100,10 @@ export async function tsReactWebsiteGenerator(
 
   const targets = projectConfiguration.targets;
 
-  // Configure load:runtime-config target based on IaC provider
-  const iac = await resolveIac(tree, schema.iac);
+  const infra = schema.infra ?? 'cloudfront-s3';
+
+  // Configure load:runtime-config target based on IaC provider (only when infra is not none)
+  const iac = infra !== 'none' ? await resolveIac(tree, schema.iac) : undefined;
 
   if (iac === 'cdk') {
     targets['load:runtime-config'] = {
@@ -130,10 +132,6 @@ export async function tsReactWebsiteGenerator(
         },
       },
     };
-  } else {
-    throw new Error(
-      `Unknown iac: ${iac}. Supported providers are: cdk, terraform`,
-    );
   }
 
   const buildTarget = targets['build'];
@@ -194,6 +192,7 @@ export async function tsReactWebsiteGenerator(
     {
       ux,
       framework: 'react',
+      infra,
     },
   );
 
@@ -206,18 +205,20 @@ export async function tsReactWebsiteGenerator(
     await sharedShadcnGenerator(tree);
   }
 
-  await sharedConstructsGenerator(tree, {
-    iac,
-  });
+  if (iac) {
+    await sharedConstructsGenerator(tree, {
+      iac,
+    });
 
-  await addWebsiteInfra(tree, {
-    iac,
-    websiteProjectName: fullyQualifiedName,
-    scopeAlias,
-    websiteContentPath: joinPathFragments('dist', websiteContentPath),
-    websiteNameKebabCase,
-    websiteNameClassName,
-  });
+    await addWebsiteInfra(tree, {
+      iac,
+      websiteProjectName: fullyQualifiedName,
+      scopeAlias,
+      websiteContentPath: joinPathFragments('dist', websiteContentPath),
+      websiteNameKebabCase,
+      websiteNameClassName,
+    });
+  }
 
   const projectConfig = readProjectConfiguration(tree, fullyQualifiedName);
   const libraryRoot = projectConfig.root;

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -75,23 +75,31 @@ export async function tsReactWebsiteGenerator(
     schema.directory || '.',
     schema.subDirectory || websiteNameKebabCase,
   );
+
+  const projectAlreadyExists = tree.exists(
+    joinPathFragments(websiteContentPath, 'project.json'),
+  );
+
   // TODO: consider exposing and supporting e2e tests
   const e2eTestRunner = 'none';
-  await applicationGenerator(tree, {
-    ...schema,
-    name: fullyQualifiedName,
-    directory: websiteContentPath,
-    routing: false,
-    e2eTestRunner,
-    linter: 'eslint',
-    bundler: 'vite',
-    unitTestRunner: 'vitest',
-    useProjectJson: true,
-    style: 'css',
-  });
 
-  // Replace with simpler sample source code
-  tree.delete(joinPathFragments(websiteContentPath, 'src'));
+  if (!projectAlreadyExists) {
+    await applicationGenerator(tree, {
+      ...schema,
+      name: fullyQualifiedName,
+      directory: websiteContentPath,
+      routing: false,
+      e2eTestRunner,
+      linter: 'eslint',
+      bundler: 'vite',
+      unitTestRunner: 'vitest',
+      useProjectJson: true,
+      style: 'css',
+    });
+
+    // Replace with simpler sample source code
+    tree.delete(joinPathFragments(websiteContentPath, 'src'));
+  }
 
   const projectConfiguration = readProjectConfiguration(
     tree,

--- a/packages/nx-plugin/src/ts/react-website/app/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/schema.d.ts
@@ -5,6 +5,8 @@
 import { IacOption } from '../../../utils/iac';
 import { UxOption } from './generator';
 
+export type WebsiteInfraOption = 'cloudfront-s3' | 'none';
+
 export interface TsReactWebsiteGeneratorSchema {
   name: string;
   directory?: string;
@@ -13,5 +15,6 @@ export interface TsReactWebsiteGeneratorSchema {
   tanstackRouter?: boolean;
   tailwind?: boolean;
   ux?: UxOption;
+  infra?: WebsiteInfraOption;
   iac: IacOption;
 }

--- a/packages/nx-plugin/src/ts/website/app/schema.d.ts
+++ b/packages/nx-plugin/src/ts/website/app/schema.d.ts
@@ -6,6 +6,7 @@ import { IacOption } from '../../../utils/iac';
 import { UxOption } from '../../react-website/app/generator';
 
 export type WebsiteFramework = 'react';
+export type WebsiteInfraOption = 'cloudfront-s3' | 'none';
 
 export interface TsWebsiteGeneratorSchema {
   name: string;
@@ -16,5 +17,6 @@ export interface TsWebsiteGeneratorSchema {
   tanstackRouter?: boolean;
   tailwind?: boolean;
   ux?: UxOption;
+  infra?: WebsiteInfraOption;
   iac: IacOption;
 }

--- a/packages/nx-plugin/src/ts/website/app/schema.json
+++ b/packages/nx-plugin/src/ts/website/app/schema.json
@@ -83,6 +83,14 @@
       "x-priority": "important",
       "x-prompt": "Would you like to enable Tanstack Router for type-safe routing?"
     },
+    "infra": {
+      "type": "string",
+      "description": "The type of infrastructure to deploy your website with.",
+      "enum": ["cloudfront-s3", "none"],
+      "default": "cloudfront-s3",
+      "x-priority": "important",
+      "x-prompt": "What infrastructure would you like to deploy your website with?"
+    },
     "iac": {
       "type": "string",
       "description": "The preferred IaC provider. By default this is inherited from your initial selection.",


### PR DESCRIPTION
### Reason for this change

Implements the `--infra=none` option for all generators that vend infrastructure code (#721). Users who want to manage their own infrastructure (or are evaluating the plugin) can now generate only the application code without any CDK/Terraform resources. They can later re-run the generator with a different `--infra` value to add infrastructure.

### Description of changes

**New `infra` option values added:**

| Generator | New `infra` values | Default |
|-----------|-------------------|---------|
| `ts#website` | `cloudfront-s3`, `none` | `cloudfront-s3` |
| `ts#lambda-function` / `py#lambda-function` | `lambda`, `none` | `lambda` |
| `ts#api` (tRPC) / `py#api` (FastAPI) | `rest-lambda`, `http-lambda`, `none` | `rest-lambda` |
| `ts#api` (Smithy) | `rest-lambda`, `none` | `rest-lambda` |
| `ts#rdb` | `aurora`, `none` | `aurora` |

**When `--infra=none`:**
- No CDK/Terraform constructs are generated
- No `packages/common/constructs` or `packages/common/terraform` project is created
- No Lambda bundle targets are added (for APIs/lambda functions)
- No `load:runtime-config` target is added (for websites)
- Application code, local dev targets (`serve`, `serve-local`), and dependencies are still generated
- The `iac` option is effectively ignored

**Idempotent upgrade path:**
- Generators can be re-run with `--infra=<value>` on an existing project that was created with `--infra=none`
- Project-level generators (website, API, RDB) skip project creation if it already exists and only add infrastructure
- Add-to-project generators (lambda-function) skip handler regeneration but add the infrastructure construct and bundle target

**Design decisions:**
- Each generator wraps its infrastructure generation in an `if (infra !== 'none')` block
- Local development features (serve targets, Docker for RDB) remain available with `infra=none`
- The `infra` value is stored in project metadata for downstream generators to reference

### Description of how you validated changes

- All 1872 unit tests pass
- Full build of the monorepo passes
- Manually tested in a fresh workspace: generated website, tRPC API, and lambda function with `--infra=none` — all build successfully with no infrastructure artifacts
- Added a dedicated `infra-none` e2e smoke test that:
  1. Generates all projects with `--infra=none` and verifies they build
  2. Re-runs generators with `--infra=<value>` to add infrastructure and verifies the workspace still builds

### Issue # (if applicable)

Closes #721

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*