### PR TITLE
feat(docs): add versioned docs with preview subdirectory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Build
+        env:
+          DOCS_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/nx-plugin-for-aws/preview' || '/nx-plugin-for-aws' }}
         run: pnpm nx run-many --target build --all --output-style=stream
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
@@ -180,14 +182,39 @@ jobs:
   deploy_docs:
     name: Deploy Docs
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/release/0.x' && github.event_name == 'push' && needs.release.outputs.latest_commit == github.sha }}
+    if: ${{ (github.ref == 'refs/heads/release/0.x' || github.ref == 'refs/heads/main') && github.event_name == 'push' && needs.release.outputs.latest_commit == github.sha }}
     needs: [release]
     steps:
-      - name: Download docs artifact
+      - name: Download docs artifact (this branch)
         uses: actions/download-artifact@v8
         with:
           name: docs-artifact
-          path: docs-site
+          path: docs-this-branch
+      - name: Download docs artifact (other branch)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: ci.yml
+          branch: ${{ github.ref == 'refs/heads/main' && 'release/0.x' || 'main' }}
+          name: docs-artifact
+          path: docs-other-branch
+          if_no_artifact_found: warn
+        continue-on-error: true
+      - name: Merge docs artifacts
+        run: |
+          mkdir -p docs-site
+          if [ "${{ github.ref }}" = "refs/heads/release/0.x" ]; then
+            cp -r docs-this-branch/* docs-site/
+            if [ -d docs-other-branch ] && [ "$(ls -A docs-other-branch 2>/dev/null)" ]; then
+              mkdir -p docs-site/preview
+              cp -r docs-other-branch/* docs-site/preview/
+            fi
+          else
+            if [ -d docs-other-branch ] && [ "$(ls -A docs-other-branch 2>/dev/null)" ]; then
+              cp -r docs-other-branch/* docs-site/
+            fi
+            mkdir -p docs-site/preview
+            cp -r docs-this-branch/* docs-site/preview/
+          fi
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,12 +29,14 @@ const smithySyntax = () => ({
   name: 'smithy',
 });
 
+const basePath = process.env.DOCS_BASE_PATH || '/nx-plugin-for-aws';
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://awslabs.github.io',
-  base: '/nx-plugin-for-aws',
+  base: basePath,
   redirects: {
-    '/': '/nx-plugin-for-aws/en',
+    '/': `${basePath}/en`,
   },
   image: {
     service: passthroughImageService(),
@@ -66,11 +68,12 @@ export default defineConfig({
           tag: 'meta',
           attrs: {
             property: 'og:image',
-            content: '/nx-plugin-for-aws/favicon.svg',
+            content: `${basePath}/favicon.svg`,
           },
         },
       ],
       components: {
+        Header: './src/components/header.astro',
         PageSidebar: './src/components/page-sidebar.astro',
         MarkdownContent: './src/components/markdown-content.astro',
         PageTitle: './src/components/page-title.astro',

--- a/docs/src/components/header.astro
+++ b/docs/src/components/header.astro
@@ -1,0 +1,91 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import config from 'virtual:starlight/user-config';
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
+import Search from 'virtual:starlight/components/Search';
+import SiteTitle from 'virtual:starlight/components/SiteTitle';
+import SocialIcons from 'virtual:starlight/components/SocialIcons';
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
+import VersionSwitcher from './version-switcher.astro';
+
+const shouldRenderSearch =
+  config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
+---
+
+<div class="header">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle />
+  </div>
+  <div class="sl-flex print:hidden">
+    {shouldRenderSearch && <Search />}
+  </div>
+  <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <div class="sl-flex social-icons">
+      <SocialIcons />
+    </div>
+    <VersionSwitcher />
+    <ThemeSelect />
+    <LanguageSelect />
+  </div>
+</div>
+
+<style>
+  @layer starlight.core {
+    .header {
+      display: flex;
+      gap: var(--sl-nav-gap);
+      justify-content: space-between;
+      align-items: center;
+      height: 100%;
+    }
+
+    .title-wrapper {
+      overflow: clip;
+      padding: 0.25rem;
+      margin: -0.25rem;
+      min-width: 0;
+    }
+
+    .right-group,
+    .social-icons {
+      gap: 1rem;
+      align-items: center;
+    }
+    .social-icons::after {
+      content: '';
+      height: 2rem;
+      border-inline-end: 1px solid var(--sl-color-gray-5);
+    }
+
+    @media (min-width: 50rem) {
+      :global(:root[data-has-sidebar]) {
+        --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+      }
+      :global(:root:not([data-has-toc])) {
+        --__toc-width: 0rem;
+      }
+      .header {
+        --__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
+        --__main-column-fr: calc(
+          (
+              100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
+                (2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
+                var(--sl-content-width)
+            ) / 2
+        );
+        display: grid;
+        grid-template-columns:
+          minmax(
+            calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
+            auto
+          )
+          1fr
+          auto;
+        align-content: center;
+      }
+    }
+  }
+</style>

--- a/docs/src/components/version-switcher.astro
+++ b/docs/src/components/version-switcher.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+const stableBase = '/nx-plugin-for-aws';
+const previewBase = '/nx-plugin-for-aws/preview';
+---
+
+<div class="version-switcher">
+  <select aria-label="Docs version" data-stable-base={stableBase} data-preview-base={previewBase}>
+    <option value="stable">Stable (0.x)</option>
+    <option value="preview">Preview (1.0 RC)</option>
+  </select>
+</div>
+
+<script>
+  function initVersionSwitcher() {
+    document.querySelectorAll('.version-switcher select').forEach((select) => {
+      const el = select as HTMLSelectElement;
+      const stableBase = el.dataset.stableBase!;
+      const previewBase = el.dataset.previewBase!;
+      const currentPath = window.location.pathname;
+
+      const isPreview = currentPath.startsWith(previewBase + '/') || currentPath === previewBase;
+      el.value = isPreview ? 'preview' : 'stable';
+
+      el.addEventListener('change', () => {
+        const currentBase = isPreview ? previewBase : stableBase;
+        const targetBase = el.value === 'preview' ? previewBase : stableBase;
+        const relativePath = currentPath.slice(currentBase.length);
+        window.location.pathname = targetBase + relativePath;
+      });
+    });
+  }
+
+  initVersionSwitcher();
+  document.addEventListener('astro:after-swap', initVersionSwitcher);
+</script>
+
+<style>
+  .version-switcher {
+    display: flex;
+    align-items: center;
+  }
+
+  .version-switcher select {
+    appearance: none;
+    background: var(--sl-color-gray-6, #17191e);
+    color: var(--sl-color-text-accent);
+    border: 1px solid var(--sl-color-accent);
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color 150ms ease, background-color 150ms ease;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.5rem center;
+    padding-right: 1.5rem;
+  }
+
+  .version-switcher select:hover {
+    background-color: var(--sl-color-accent-low);
+    border-color: var(--sl-color-accent-high);
+  }
+
+  .version-switcher select:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+</style>


### PR DESCRIPTION
### Reason for this change

We need the documentation site to support viewing both stable (0.x) and preview (1.0 RC) docs simultaneously, with an easy way to switch between them.

### Description of changes

- **Configurable base path**: `docs/astro.config.mjs` now reads `DOCS_BASE_PATH` env var (defaults to `/nx-plugin-for-aws`). On `main`, CI sets it to `/nx-plugin-for-aws/preview`.
- **Version switcher component**: New `version-switcher.astro` renders a dropdown in the header nav bar ("Stable (0.x)" / "Preview (1.0 RC)") that preserves the current locale and page path when switching.
- **Header override**: Custom `header.astro` extends Starlight's default Header to include the version switcher between social icons and theme toggle.
- **CI deployment**: `deploy_docs` now runs on both `main` and `release/0.x`. Each branch downloads the other's latest docs artifact via `dawidd6/action-download-artifact` and merges them — stable at root, preview in a `preview/` subdirectory.

**Result:**
- Stable docs: `https://awslabs.github.io/nx-plugin-for-aws/en/...`
- Preview docs: `https://awslabs.github.io/nx-plugin-for-aws/preview/en/...`

### Description of how you validated changes

- Built docs with default base path — all links use `/nx-plugin-for-aws/` prefix ✓
- Built docs with `DOCS_BASE_PATH=/nx-plugin-for-aws/preview` — all links use `/nx-plugin-for-aws/preview/` prefix ✓
- Served both builds merged together and verified:
  - Version switcher renders on both versions ✓
  - Sidebar links stay within the current version ✓
  - Locale switching works in both versions ✓
  - No cross-version link contamination ✓

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*