### PR TITLE
fix(release): use npm_config_tag env var for dist-tag control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         env:
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_DIST_TAG: ${{ github.ref == 'refs/heads/release/0.x' && 'latest' || 'next' }}
+          npm_config_tag: ${{ github.ref == 'refs/heads/release/0.x' && 'latest' || 'next' }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           HUSKY: '0'
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -100,7 +100,7 @@ pnpm nx release --yes
 When all v1.0 workstreams are complete (see #718):
 
 1. Remove the `--specifier premajor --preid rc` logic from the `main` branch release step in `ci.yml`
-2. Change `NPM_DIST_TAG` condition in `ci.yml` back to unconditional `latest`
+2. Change `npm_config_tag` condition in `ci.yml` back to unconditional `latest`
 3. Remove the `release/0.x` branch condition from `deploy_docs`
 4. Publish `1.0.0` to `latest`
 5. Archive `release/0.x`


### PR DESCRIPTION
### Reason for this change

The `NPM_DIST_TAG` env var set in CI is not recognized by npm or Nx. The `@nx/js` release-publish executor resolves the npm dist-tag via `npm config get tag`, which only reads env vars with the `npm_config_` prefix (npm's standard override convention). This caused all `1.0.0-rc.x` releases from `main` to be published with the `latest` tag instead of `next`, meaning `npm install @aws/nx-plugin` resolves to `1.0.0-rc.2` rather than the stable `0.121.0`.

### Description of changes

- Rename `NPM_DIST_TAG` to `npm_config_tag` in the Release step env block of `ci.yml`. npm reads `npm_config_*` env vars as config overrides, so `npm_config_tag=next` makes `npm config get tag` return `next`.
- Update `RELEASE.md` reference to match.

This is the `main` branch counterpart of #752 (targeting `release/0.x`). The `release/0.x` PR is the critical one — once it merges, the next 0.x release will reclaim the `latest` dist-tag. This PR ensures future RC releases from `main` correctly publish to `next`.

### Description of how you validated changes

Verified locally:
```bash
$ NPM_DIST_TAG=next npm config get tag
latest  # ← doesn't work

$ npm_config_tag=next npm config get tag
next    # ← works
```

Also confirmed by reading the `@nx/js` source: `parseRegistryOptions()` calls `getNpmTag()` → `npm config get tag` when no `--tag` CLI arg is passed.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*