### PR TITLE
fix(release): publish with nx release publish --tag to set dist-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,20 +166,21 @@ jobs:
         env:
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          npm_config_tag: ${{ github.ref == 'refs/heads/release/0.x' && 'latest' || 'next' }}
+          NPM_DIST_TAG: ${{ github.ref == 'refs/heads/release/0.x' && 'latest' || 'next' }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           HUSKY: '0'
         run: |
           if [ "${{ github.ref }}" = "refs/heads/release/0.x" ]; then
-            pnpm nx release --yes
+            pnpm nx release --yes --skip-publish
           else
             CURRENT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
             if echo "$CURRENT_VERSION" | grep -q "rc"; then
-              pnpm nx release --yes --preid rc
+              pnpm nx release --yes --skip-publish --preid rc
             else
-              pnpm nx release --yes --specifier premajor --preid rc
+              pnpm nx release --yes --skip-publish --specifier premajor --preid rc
             fi
           fi
+          pnpm nx release publish --tag "$NPM_DIST_TAG"
   deploy_docs:
     name: Deploy Docs
     runs-on: ubuntu-latest

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -77,21 +77,24 @@ The default `npm install @aws/nx-plugin` always resolves to the stable 0.x versi
 On `main` (first prerelease):
 
 ```bash
-pnpm nx release --yes --specifier premajor --preid rc
+pnpm nx release --yes --skip-publish --specifier premajor --preid rc
+pnpm nx release publish --tag next
 # Publishes 1.0.0-rc.0 to "next" dist-tag
 ```
 
 On `main` (subsequent prereleases, after v1.0.0-rc.0 tag exists):
 
 ```bash
-pnpm nx release --yes --preid rc
+pnpm nx release --yes --skip-publish --preid rc
+pnpm nx release publish --tag next
 # Publishes 1.0.0-rc.N to "next" dist-tag
 ```
 
 On `release/0.x` (stable):
 
 ```bash
-pnpm nx release --yes
+pnpm nx release --yes --skip-publish
+pnpm nx release publish --tag latest
 # Publishes 0.x.y to "latest" dist-tag
 ```
 
@@ -100,7 +103,7 @@ pnpm nx release --yes
 When all v1.0 workstreams are complete (see #718):
 
 1. Remove the `--specifier premajor --preid rc` logic from the `main` branch release step in `ci.yml`
-2. Change `npm_config_tag` condition in `ci.yml` back to unconditional `latest`
+2. Change the `NPM_DIST_TAG` condition in `ci.yml` back to unconditional `latest`
 3. Remove the `release/0.x` branch condition from `deploy_docs`
 4. Publish `1.0.0` to `latest`
 5. Archive `release/0.x`


### PR DESCRIPTION

### Reason for this change

The rc.3 release (CI run [26850452511](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/26850452511/)) half-completed: the `v1.0.0-rc.3` git tag and GitHub pre-release were created, but **nothing was published to npm**. All three packages (`@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `@aws/create-nx-workspace`) are missing `1.0.0-rc.3`, and there is no `next` dist-tag at all.

Root cause: #752/#753 set `npm_config_tag` as an environment variable to control the npm dist-tag. But nx's `release-publish` executor probes for existing dist-tags by running:

```
npm view @aws/nx-plugin versions dist-tags --json --"@aws:registry=https://registry.npmjs.org/"
```

npm interprets `npm_config_tag` as a **version selector** for `npm view`. With `npm_config_tag=next` and no existing `next` dist-tag, the command resolves `@aws/nx-plugin@next` and fails with `E404`, aborting the publish — *after* the git tag and GitHub release had already been created.

Reproduced locally:
```
$ npm_config_tag=next npm view @aws/nx-plugin versions dist-tags --json
npm error code E404
npm error 404  '@aws/nx-plugin@next' is not in this registry.
```

### Description of changes

- Split the release into two steps: `nx release --yes --skip-publish` (version + changelog + git tag + GitHub release) followed by `nx release publish --tag "$NPM_DIST_TAG"`.
- `nx release publish` accepts `--tag` as a first-class flag, which sets the dist-tag without leaking into the `npm view` dist-tag probe. The aggregate `nx release` command does not accept `--tag`, which is why the env-var workaround was used previously.
- Renamed the env var back to `NPM_DIST_TAG` (it is now consumed explicitly by the publish step rather than implicitly by npm).
- Updated `RELEASE.md` manual-release commands and the cutover checklist to match.

### Description of how you validated changes

- Reproduced the `E404` failure locally with `npm_config_tag=next npm view ...`.
- Confirmed `nx release publish` supports `--tag` (`pnpm nx release publish --help`) whereas the aggregate `nx release` does not.
- Validated `ci.yml` is well-formed YAML.

Note: this is a CI workflow change that can only be fully exercised by a real release on `main`/`release/0.x`. The dangling `v1.0.0-rc.3` tag/release is being recovered separately by publishing the built packages to the `next` dist-tag.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
