### PR TITLE
fix(release): drop --yes from version step to allow --skip-publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,13 +171,13 @@ jobs:
           HUSKY: '0'
         run: |
           if [ "${{ github.ref }}" = "refs/heads/release/0.x" ]; then
-            pnpm nx release --yes --skip-publish
+            pnpm nx release --skip-publish
           else
             CURRENT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
             if echo "$CURRENT_VERSION" | grep -q "rc"; then
-              pnpm nx release --yes --skip-publish --preid rc
+              pnpm nx release --skip-publish --preid rc
             else
-              pnpm nx release --yes --skip-publish --specifier premajor --preid rc
+              pnpm nx release --skip-publish --specifier premajor --preid rc
             fi
           fi
           pnpm nx release publish --tag "$NPM_DIST_TAG"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -77,7 +77,7 @@ The default `npm install @aws/nx-plugin` always resolves to the stable 0.x versi
 On `main` (first prerelease):
 
 ```bash
-pnpm nx release --yes --skip-publish --specifier premajor --preid rc
+pnpm nx release --skip-publish --specifier premajor --preid rc
 pnpm nx release publish --tag next
 # Publishes 1.0.0-rc.0 to "next" dist-tag
 ```
@@ -85,7 +85,7 @@ pnpm nx release publish --tag next
 On `main` (subsequent prereleases, after v1.0.0-rc.0 tag exists):
 
 ```bash
-pnpm nx release --yes --skip-publish --preid rc
+pnpm nx release --skip-publish --preid rc
 pnpm nx release publish --tag next
 # Publishes 1.0.0-rc.N to "next" dist-tag
 ```
@@ -93,7 +93,7 @@ pnpm nx release publish --tag next
 On `release/0.x` (stable):
 
 ```bash
-pnpm nx release --yes --skip-publish
+pnpm nx release --skip-publish
 pnpm nx release publish --tag latest
 # Publishes 0.x.y to "latest" dist-tag
 ```


### PR DESCRIPTION

### Reason for this change

Follow-up to #757. That PR split the release into a version step (`nx release --yes --skip-publish`) and a publish step (`nx release publish --tag`). However nx rejects `--yes` and `--skip-publish` used together:

```
The --yes and --skip-publish options are mutually exclusive, please use one or the other.
```

`--yes` only auto-confirms the **publish** prompt, which `--skip-publish` removes entirely — so combining them is invalid. The Release step failed at argument validation before creating any tag, GitHub release, or publishing (verified: no dangling tag was created), so the failure was clean but the release still did not happen.

### Description of changes

- Removed `--yes` from the `nx release ... --skip-publish` version/changelog commands in `ci.yml` (the command is non-interactive in CI without a publish prompt to confirm).
- The separate `nx release publish --tag "$NPM_DIST_TAG"` step is unchanged and remains non-interactive (`nx release publish` has no confirmation prompt).
- Updated the matching manual-release commands in `RELEASE.md`.

### Description of how you validated changes

- Confirmed nx's mutual-exclusivity error from the failed Release step in CI run [26859838065](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/26859838065).
- Confirmed `nx release publish --help` exposes no `--yes`/confirmation flag (publish is non-interactive).
- Validated `ci.yml` is well-formed YAML.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
