### PR TITLE
feat(preset): configure Nx Plugin for AWS MCP server for coding agents

### DIFF
--- a/docs/src/content/docs/en/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/en/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ Install the [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
 
 ## Configure your AI Assistant
 
+:::tip[Project-level configuration is automatic]
+Workspaces created with the Nx Plugin for AWS preset already include project-level MCP configuration for common coding agents (Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot and OpenAI Codex). Any agent working inside the workspace can use the MCP server without further setup. The steps below configure the MCP server globally for use across all of your projects.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     The Nx Plugin for AWS ships as a [Kiro Power](https://kiro.dev/docs/powers/) that bundles the MCP server with steering documentation and workflow guides.

--- a/docs/src/content/docs/en/guides/workspace.mdx
+++ b/docs/src/content/docs/en/guides/workspace.mdx
@@ -29,6 +29,12 @@ When you create a new workspace with `@aws/nx-plugin`, the preset generator sets
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .husky/ Git hooks
+  - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
+  - .cursor/mcp.json ...and for Cursor
+  - .kiro/settings/mcp.json ...and for Kiro
+  - .gemini/settings.json ...and for Gemini CLI
+  - .vscode/mcp.json ...and for GitHub Copilot
+  - .codex/config.toml ...and for OpenAI Codex
 </FileTree>
 
 ## Nx

--- a/docs/src/content/docs/es/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/es/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ Instala el [Plugin de Claude](https://code.claude.com/docs/en/plugins), [Kiro Po
 
 ## Configura tu Asistente de IA
 
+:::tip[La configuración a nivel de proyecto es automática]
+Los workspaces creados con el preset del Plugin Nx para AWS ya incluyen configuración MCP a nivel de proyecto para agentes de codificación comunes (Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot y OpenAI Codex). Cualquier agente que trabaje dentro del workspace puede usar el servidor MCP sin configuración adicional. Los pasos a continuación configuran el servidor MCP globalmente para su uso en todos tus proyectos.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     El Plugin Nx para AWS se distribuye como un [Kiro Power](https://kiro.dev/docs/powers/) que agrupa el servidor MCP con documentación de orientación y guías de flujo de trabajo.

--- a/docs/src/content/docs/es/guides/workspace.mdx
+++ b/docs/src/content/docs/es/guides/workspace.mdx
@@ -29,6 +29,12 @@ Cuando creas un nuevo espacio de trabajo con `@aws/nx-plugin`, el generador de p
   - aws-nx-plugin.config.mts Configuración del Nx Plugin for AWS
   - .git-secrets/ Script bash de git-secrets incluido para escaneo de credenciales
   - .husky/ Hooks de Git
+  - .mcp.json Configuración del servidor MCP de Nx Plugin for AWS para Claude Code
+  - .cursor/mcp.json ...y para Cursor
+  - .kiro/settings/mcp.json ...y para Kiro
+  - .gemini/settings.json ...y para Gemini CLI
+  - .vscode/mcp.json ...y para GitHub Copilot
+  - .codex/config.toml ...y para OpenAI Codex
 </FileTree>
 
 ## Nx
@@ -167,7 +173,7 @@ import { AwsNxPluginConfig } from '@aws/nx-plugin';
 
 export default {
   iac: {
-    provider: 'CDK', // or 'Terraform'
+    provider: 'cdk', // or 'terraform'
   },
   containers: {
     engine: 'docker', // or 'finch'
@@ -175,7 +181,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-- **`iac.provider`** — el proveedor de infraestructura como código predeterminado (`CDK` o `Terraform`) utilizado por los generadores que emiten infraestructura (por ejemplo, `ts#infra`, `ts#trpc-api`, `py#fast-api`). Los generadores que aceptan una bandera `--iac` tienen como valor predeterminado `Inherit`, que lee este valor.
+- **`iac.provider`** — el proveedor de infraestructura como código predeterminado (`cdk` o `terraform`) utilizado por los generadores que emiten infraestructura (por ejemplo, `ts#infra`, `ts#trpc-api`, `py#fast-api`). Los generadores que aceptan una bandera `--iac` tienen como valor predeterminado `inherit`, que lee este valor.
 - **`containers.engine`** — la CLI de contenedores (`docker` o `finch`) integrada en los comandos generados de build/push/login. Las construcciones de image-asset de CDK también toman esto a través de la variable de entorno `CDK_DOCKER`. Consulta la <Link path="guides/docker-bundling">guía de empaquetado de Docker</Link> para más detalles.
 
 Puedes editar cualquiera de estas configuraciones en cualquier momento — las ejecuciones posteriores del generador tomarán el nuevo valor.

--- a/docs/src/content/docs/fr/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/fr/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ Installez le [plugin Claude](https://code.claude.com/docs/en/plugins), le [Kiro 
 
 ## Configurez votre assistant IA
 
+:::tip[La configuration au niveau du projet est automatique]
+Les espaces de travail créés avec le preset Nx Plugin pour AWS incluent déjà une configuration MCP au niveau du projet pour les agents de codage courants (Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot et OpenAI Codex). Tout agent travaillant à l'intérieur de l'espace de travail peut utiliser le serveur MCP sans configuration supplémentaire. Les étapes ci-dessous configurent le serveur MCP globalement pour une utilisation dans tous vos projets.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     Le Plugin Nx pour AWS est livré sous forme de [Kiro Power](https://kiro.dev/docs/powers/) qui regroupe le serveur MCP avec la documentation de pilotage et les guides de flux de travail.

--- a/docs/src/content/docs/fr/guides/workspace.mdx
+++ b/docs/src/content/docs/fr/guides/workspace.mdx
@@ -29,6 +29,12 @@ Lorsque vous créez un nouvel espace de travail avec `@aws/nx-plugin`, le géné
   - aws-nx-plugin.config.mts Configuration Nx Plugin for AWS
   - .git-secrets/ Script bash git-secrets intégré pour l'analyse des identifiants
   - .husky/ Hooks Git
+  - .mcp.json Configuration du serveur MCP Nx Plugin for AWS pour Claude Code
+  - .cursor/mcp.json ...et pour Cursor
+  - .kiro/settings/mcp.json ...et pour Kiro
+  - .gemini/settings.json ...et pour Gemini CLI
+  - .vscode/mcp.json ...et pour GitHub Copilot
+  - .codex/config.toml ...et pour OpenAI Codex
 </FileTree>
 
 ## Nx
@@ -167,7 +173,7 @@ import { AwsNxPluginConfig } from '@aws/nx-plugin';
 
 export default {
   iac: {
-    provider: 'CDK', // or 'Terraform'
+    provider: 'cdk', // or 'terraform'
   },
   containers: {
     engine: 'docker', // or 'finch'
@@ -175,7 +181,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-- **`iac.provider`** — le fournisseur d'infrastructure-as-code par défaut (`CDK` ou `Terraform`) utilisé par les générateurs qui émettent de l'infrastructure (par exemple `ts#infra`, `ts#trpc-api`, `py#fast-api`). Les générateurs qui acceptent un flag `--iac` utilisent par défaut `Inherit`, qui lit cette valeur.
+- **`iac.provider`** — le fournisseur d'infrastructure-as-code par défaut (`cdk` ou `terraform`) utilisé par les générateurs qui émettent de l'infrastructure (par exemple `ts#infra`, `ts#trpc-api`, `py#fast-api`). Les générateurs qui acceptent un flag `--iac` utilisent par défaut `inherit`, qui lit cette valeur.
 - **`containers.engine`** — le CLI de conteneur (`docker` ou `finch`) intégré dans les commandes de build/push/login générées. Les builds d'image-asset CDK récupèrent également cette valeur via la variable d'environnement `CDK_DOCKER`. Consultez le <Link path="guides/docker-bundling">guide de bundling Docker</Link> pour plus de détails.
 
 Vous pouvez modifier l'un ou l'autre paramètre à tout moment — les exécutions ultérieures du générateur récupéreront la nouvelle valeur.

--- a/docs/src/content/docs/it/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/it/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ Installa il [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
 
 ## Configura il tuo Assistente AI
 
+:::tip[La configurazione a livello di progetto è automatica]
+I workspace creati con il preset Nx Plugin for AWS includono già la configurazione MCP a livello di progetto per gli agenti di codifica comuni (Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot e OpenAI Codex). Qualsiasi agente che lavora all'interno del workspace può utilizzare il server MCP senza ulteriori configurazioni. I passaggi seguenti configurano il server MCP globalmente per l'uso in tutti i tuoi progetti.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     Il Plugin Nx per AWS è distribuito come [Kiro Power](https://kiro.dev/docs/powers/) che raggruppa il MCP server con documentazione di guida e guide per i flussi di lavoro.

--- a/docs/src/content/docs/it/guides/workspace.mdx
+++ b/docs/src/content/docs/it/guides/workspace.mdx
@@ -167,7 +167,7 @@ import { AwsNxPluginConfig } from '@aws/nx-plugin';
 
 export default {
   iac: {
-    provider: 'CDK', // or 'Terraform'
+    provider: 'cdk', // or 'terraform'
   },
   containers: {
     engine: 'docker', // or 'finch'
@@ -175,7 +175,9 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-- **`iac.provider`** — il provider infrastructure-as-code predefinito (`CDK` o `Terraform`) utilizzato dai generatori che emettono infrastruttura (ad es. `ts#infra`, `ts#trpc-api`, `py#fast-api`). I generatori che accettano un flag `--iac` hanno come valore predefinito `Inherit`, che legge questo valore.
+- **`iac.provider`** — il provider infrastructure-as-code predefinito (`cdk` o `terraform`) utilizzato dai generatori che emettono infrastruttura (ad es. `ts#infra`, `ts#trpc-api`, `py#fast-api`). I generatori che accettano un flag `--iac` hanno come valore predefinito `inherit`, che legge questo valore.
 - **`containers.engine`** — la CLI dei container (`docker` o `finch`) integrata nei comandi generati di build/push/login. Anche le build di image-asset CDK utilizzano questo valore tramite la variabile d'ambiente `CDK_DOCKER`. Consulta la <Link path="guides/docker-bundling">guida al bundling Docker</Link> per i dettagli.
+
+Puoi modificare entrambe le impostazioni in qualsiasi momento — le successive esecuzioni dei generatori utilizzeranno il nuovo valore.no questo valore tramite la variabile d'ambiente `CDK_DOCKER`. Consulta la <Link path="guides/docker-bundling">guida al bundling Docker</Link> per i dettagli.
 
 Puoi modificare entrambe le impostazioni in qualsiasi momento — le successive esecuzioni dei generatori utilizzeranno il nuovo valore.

--- a/docs/src/content/docs/jp/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/jp/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## AIアシスタントの設定
 
+:::tip[プロジェクトレベルの設定は自動的に行われます]
+Nx Plugin for AWSプリセットで作成されたワークスペースには、一般的なコーディングエージェント（Claude Code、Cursor、Kiro、Gemini CLI、GitHub Copilot、OpenAI Codex）向けのプロジェクトレベルのMCP設定がすでに含まれています。ワークスペース内で動作するエージェントは、追加のセットアップなしでMCPサーバーを使用できます。以下の手順は、すべてのプロジェクトで使用するためにMCPサーバーをグローバルに設定するものです。
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     Nx Plugin for AWSは[Kiro Power](https://kiro.dev/docs/powers/)として提供されており、MCPサーバーとステアリングドキュメント、ワークフローガイドがバンドルされています。

--- a/docs/src/content/docs/jp/guides/workspace.mdx
+++ b/docs/src/content/docs/jp/guides/workspace.mdx
@@ -29,6 +29,12 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - aws-nx-plugin.config.mts Nx Plugin for AWS設定
   - .git-secrets/ クレデンシャルスキャン用のベンダー化されたgit-secrets bashスクリプト
   - .husky/ Gitフック
+  - .mcp.json Claude Code用のNx Plugin for AWS MCPサーバー設定
+  - .cursor/mcp.json ...およびCursor用
+  - .kiro/settings/mcp.json ...およびKiro用
+  - .gemini/settings.json ...およびGemini CLI用
+  - .vscode/mcp.json ...およびGitHub Copilot用
+  - .codex/config.toml ...およびOpenAI Codex用
 </FileTree>
 
 ## Nx
@@ -167,7 +173,7 @@ import { AwsNxPluginConfig } from '@aws/nx-plugin';
 
 export default {
   iac: {
-    provider: 'CDK', // or 'Terraform'
+    provider: 'cdk', // or 'terraform'
   },
   containers: {
     engine: 'docker', // or 'finch'
@@ -175,7 +181,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-- **`iac.provider`** — インフラストラクチャを生成するジェネレーター（例：`ts#infra`、`ts#trpc-api`、`py#fast-api`）で使用されるデフォルトのInfrastructure as Codeプロバイダー（`CDK`または`Terraform`）。`--iac`フラグを受け入れるジェネレーターは、デフォルトで`Inherit`に設定されており、この値を読み取ります。
+- **`iac.provider`** — インフラストラクチャを生成するジェネレーター（例：`ts#infra`、`ts#trpc-api`、`py#fast-api`）で使用されるデフォルトのInfrastructure as Codeプロバイダー（`cdk`または`terraform`）。`--iac`フラグを受け入れるジェネレーターは、デフォルトで`inherit`に設定されており、この値を読み取ります。
 - **`containers.engine`** — 生成されたビルド/プッシュ/ログインコマンドに組み込まれるコンテナCLI（`docker`または`finch`）。CDKイメージアセットのビルドも、`CDK_DOCKER`環境変数を介してこれを取得します。詳細については、<Link path="guides/docker-bundling">Dockerバンドリングガイド</Link>を参照してください。
 
 いずれの設定もいつでも編集できます — 以降のジェネレーター実行で新しい値が適用されます。

--- a/docs/src/content/docs/ko/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/ko/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## AI 어시스턴트 구성하기
 
+:::tip[프로젝트 수준 구성은 자동입니다]
+Nx Plugin for AWS 프리셋으로 생성된 작업 공간에는 일반적인 코딩 에이전트(Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot 및 OpenAI Codex)를 위한 프로젝트 수준 MCP 구성이 이미 포함되어 있습니다. 작업 공간 내에서 작업하는 모든 에이전트는 추가 설정 없이 MCP 서버를 사용할 수 있습니다. 아래 단계는 모든 프로젝트에서 사용할 수 있도록 MCP 서버를 전역으로 구성합니다.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     Nx Plugin for AWS는 MCP 서버와 가이드 문서 및 워크플로 가이드를 번들로 제공하는 [Kiro Power](https://kiro.dev/docs/powers/)로 제공됩니다.

--- a/docs/src/content/docs/ko/guides/workspace.mdx
+++ b/docs/src/content/docs/ko/guides/workspace.mdx
@@ -29,6 +29,12 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - aws-nx-plugin.config.mts Nx Plugin for AWS 구성
   - .git-secrets/ 자격 증명 스캔을 위한 벤더링된 git-secrets bash 스크립트
   - .husky/ Git 훅
+  - .mcp.json Claude Code를 위한 Nx Plugin for AWS MCP 서버 구성
+  - .cursor/mcp.json ...그리고 Cursor를 위한 구성
+  - .kiro/settings/mcp.json ...그리고 Kiro를 위한 구성
+  - .gemini/settings.json ...그리고 Gemini CLI를 위한 구성
+  - .vscode/mcp.json ...그리고 GitHub Copilot을 위한 구성
+  - .codex/config.toml ...그리고 OpenAI Codex를 위한 구성
 </FileTree>
 
 ## Nx
@@ -167,7 +173,7 @@ import { AwsNxPluginConfig } from '@aws/nx-plugin';
 
 export default {
   iac: {
-    provider: 'CDK', // or 'Terraform'
+    provider: 'cdk', // or 'terraform'
   },
   containers: {
     engine: 'docker', // or 'finch'
@@ -175,7 +181,7 @@ export default {
 } satisfies AwsNxPluginConfig;
 ```
 
-- **`iac.provider`** — 인프라를 생성하는 생성기(예: `ts#infra`, `ts#trpc-api`, `py#fast-api`)에서 사용하는 기본 infrastructure-as-code 공급자(`CDK` 또는 `Terraform`). `--iac` 플래그를 허용하는 생성기는 기본적으로 `Inherit`로 설정되며, 이 값을 읽습니다.
+- **`iac.provider`** — 인프라를 생성하는 생성기(예: `ts#infra`, `ts#trpc-api`, `py#fast-api`)에서 사용하는 기본 infrastructure-as-code 공급자(`cdk` 또는 `terraform`). `--iac` 플래그를 허용하는 생성기는 기본적으로 `inherit`로 설정되며, 이 값을 읽습니다.
 - **`containers.engine`** — 생성된 빌드/푸시/로그인 명령에 포함되는 컨테이너 CLI(`docker` 또는 `finch`). CDK 이미지 에셋 빌드도 `CDK_DOCKER` 환경 변수를 통해 이를 사용합니다. 자세한 내용은 <Link path="guides/docker-bundling">Docker 번들링 가이드</Link>를 참조하세요.
 
 언제든지 두 설정을 편집할 수 있으며, 이후 생성기 실행 시 새 값이 적용됩니다.

--- a/docs/src/content/docs/pt/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/pt/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ Instale o [Plugin Claude](https://code.claude.com/docs/en/plugins), [Kiro Power]
 
 ## Configure seu Assistente de IA
 
+:::tip[Configuração em nível de projeto é automática]
+Workspaces criados com o preset do Plugin Nx para AWS já incluem configuração MCP em nível de projeto para agentes de codificação comuns (Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot e OpenAI Codex). Qualquer agente trabalhando dentro do workspace pode usar o servidor MCP sem configuração adicional. As etapas abaixo configuram o servidor MCP globalmente para uso em todos os seus projetos.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     O Plugin Nx para AWS é distribuído como um [Kiro Power](https://kiro.dev/docs/powers/) que agrupa o servidor MCP com documentação de direcionamento e guias de fluxo de trabalho.

--- a/docs/src/content/docs/pt/guides/workspace.mdx
+++ b/docs/src/content/docs/pt/guides/workspace.mdx
@@ -29,6 +29,12 @@ Quando você cria um novo workspace com `@aws/nx-plugin`, o gerador de preset co
   - aws-nx-plugin.config.mts Configuração do Nx Plugin for AWS
   - .git-secrets/ Script bash do git-secrets vendorizado para verificação de credenciais
   - .husky/ Hooks do Git
+  - .mcp.json Configuração do servidor MCP do Nx Plugin for AWS para Claude Code
+  - .cursor/mcp.json ...e para Cursor
+  - .kiro/settings/mcp.json ...e para Kiro
+  - .gemini/settings.json ...e para Gemini CLI
+  - .vscode/mcp.json ...e para GitHub Copilot
+  - .codex/config.toml ...e para OpenAI Codex
 </FileTree>
 
 ## Nx

--- a/docs/src/content/docs/vi/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/vi/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ Cài đặt [Claude Plugin](https://code.claude.com/docs/en/plugins), [Kiro Powe
 
 ## Cấu hình Trợ lý AI của bạn
 
+:::tip[Cấu hình cấp dự án là tự động]
+Các workspace được tạo với preset Nx Plugin cho AWS đã bao gồm cấu hình MCP cấp dự án cho các coding agent phổ biến (Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot và OpenAI Codex). Bất kỳ agent nào làm việc bên trong workspace đều có thể sử dụng MCP server mà không cần thiết lập thêm. Các bước dưới đây cấu hình MCP server toàn cục để sử dụng trên tất cả các dự án của bạn.
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     Nx Plugin cho AWS được cung cấp dưới dạng một [Kiro Power](https://kiro.dev/docs/powers/) tích hợp MCP server với tài liệu hướng dẫn và hướng dẫn quy trình làm việc.

--- a/docs/src/content/docs/vi/guides/workspace.mdx
+++ b/docs/src/content/docs/vi/guides/workspace.mdx
@@ -29,6 +29,12 @@ Khi bạn tạo một workspace mới với `@aws/nx-plugin`, trình tạo prese
   - aws-nx-plugin.config.mts Cấu hình Nx Plugin for AWS
   - .git-secrets/ Script bash git-secrets được đóng gói để quét thông tin xác thực
   - .husky/ Git hooks
+  - .mcp.json Cấu hình Nx Plugin for AWS MCP server cho Claude Code
+  - .cursor/mcp.json ...và cho Cursor
+  - .kiro/settings/mcp.json ...và cho Kiro
+  - .gemini/settings.json ...và cho Gemini CLI
+  - .vscode/mcp.json ...và cho GitHub Copilot
+  - .codex/config.toml ...và cho OpenAI Codex
 </FileTree>
 
 ## Nx

--- a/docs/src/content/docs/zh/get_started/building-with-ai.mdx
+++ b/docs/src/content/docs/zh/get_started/building-with-ai.mdx
@@ -10,6 +10,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## 配置您的 AI 助手
 
+:::tip[项目级配置是自动的]
+使用 Nx Plugin for AWS 预设创建的工作区已经包含了常见编码代理（Claude Code、Cursor、Kiro、Gemini CLI、GitHub Copilot 和 OpenAI Codex）的项目级 MCP 配置。在工作区内工作的任何代理都可以使用 MCP 服务器，无需进一步设置。以下步骤用于全局配置 MCP 服务器，以便在您的所有项目中使用。
+:::
+
 <Tabs syncKey="ai-assistant">
   <TabItem label="Kiro">
     Nx AWS 插件作为 [Kiro Power](https://kiro.dev/docs/powers/) 发布，它将 MCP 服务器与引导文档和工作流指南打包在一起。

--- a/docs/src/content/docs/zh/guides/workspace.mdx
+++ b/docs/src/content/docs/zh/guides/workspace.mdx
@@ -29,6 +29,12 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .husky/ Git hooks
+  - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
+  - .cursor/mcp.json ...and for Cursor
+  - .kiro/settings/mcp.json ...and for Kiro
+  - .gemini/settings.json ...and for Gemini CLI
+  - .vscode/mcp.json ...and for GitHub Copilot
+  - .codex/config.toml ...and for OpenAI Codex
 </FileTree>
 
 ## Nx

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -185,6 +185,17 @@
       "it": "Il motore di container da utilizzare per build/push/login. 'infer' seleziona docker se installato, altrimenti finch (con fallback a docker quando nessuno dei due è installato).",
       "vi": "Công cụ container để sử dụng cho build/push/login. 'infer' chọn docker nếu đã cài đặt, nếu không thì chọn finch (quay lại docker khi cả hai đều chưa cài đặt).",
       "zh": "用于构建/推送/登录的容器引擎。'infer' 会在已安装 docker 时选择 docker，否则选择 finch（当两者都未安装时回退到 docker）。"
+    },
+    "mcp": {
+      "en": "Whether to configure the Nx Plugin for AWS MCP server for use by coding agents.",
+      "es": "Si se debe configurar el Nx Plugin para el servidor AWS MCP para uso de agentes de codificación.",
+      "fr": "Indique s'il faut configurer le plugin Nx pour le serveur AWS MCP afin qu'il soit utilisé par les agents de codage.",
+      "pt": "Se deve configurar o Nx Plugin para servidor AWS MCP para uso por agentes de codificação.",
+      "jp": "コーディングエージェントが使用するためのAWS MCP サーバー用 Nx Plugin を設定するかどうか。",
+      "ko": "코딩 에이전트가 사용할 수 있도록 AWS MCP 서버용 Nx Plugin을 구성할지 여부입니다.",
+      "zh": "是否配置 Nx Plugin for AWS MCP server 以供编码代理使用。",
+      "it": "Se configurare il Plugin Nx per il server AWS MCP per l'uso da parte di agenti di codifica.",
+      "vi": "Có cấu hình Nx Plugin cho AWS MCP server để sử dụng bởi các coding agent hay không."
     }
   },
   "py#agent": {

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`preset generator > should run successfully > .codex/config.toml 1`] = `
 "[mcp_servers.nx-plugin-for-aws]
 command = "npx"
-args = [ "-y", "@aws/nx-plugin-mcp" ]
+args = [ "-y", "@aws/nx-plugin-mcp@next" ]
 "
 `;
 
@@ -12,7 +12,7 @@ exports[`preset generator > should run successfully > .cursor/mcp.json 1`] = `
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
+      "args": ["-y", "@aws/nx-plugin-mcp@next"]
     }
   }
 }
@@ -24,7 +24,7 @@ exports[`preset generator > should run successfully > .gemini/settings.json 1`] 
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
+      "args": ["-y", "@aws/nx-plugin-mcp@next"]
     }
   }
 }
@@ -38,7 +38,7 @@ exports[`preset generator > should run successfully > .kiro/settings/mcp.json 1`
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
+      "args": ["-y", "@aws/nx-plugin-mcp@next"]
     }
   }
 }
@@ -50,7 +50,7 @@ exports[`preset generator > should run successfully > .mcp.json 1`] = `
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
+      "args": ["-y", "@aws/nx-plugin-mcp@next"]
     }
   }
 }
@@ -76,7 +76,7 @@ exports[`preset generator > should run successfully > .vscode/mcp.json 1`] = `
     "nx-plugin-for-aws": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
+      "args": ["-y", "@aws/nx-plugin-mcp@next"]
     }
   }
 }

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -1,6 +1,61 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`preset generator > should run successfully > .codex/config.toml 1`] = `
+"[mcp_servers.nx-plugin-for-aws]
+command = "npx"
+args = [ "-y", "@aws/nx-plugin-mcp" ]
+"
+`;
+
+exports[`preset generator > should run successfully > .cursor/mcp.json 1`] = `
+"{
+  "mcpServers": {
+    "nx-plugin-for-aws": {
+      "command": "npx",
+      "args": ["-y", "@aws/nx-plugin-mcp"]
+    }
+  }
+}
+"
+`;
+
+exports[`preset generator > should run successfully > .gemini/settings.json 1`] = `
+"{
+  "mcpServers": {
+    "nx-plugin-for-aws": {
+      "command": "npx",
+      "args": ["-y", "@aws/nx-plugin-mcp"]
+    }
+  }
+}
+"
+`;
+
 exports[`preset generator > should run successfully > .gitignore 1`] = `".grit"`;
+
+exports[`preset generator > should run successfully > .kiro/settings/mcp.json 1`] = `
+"{
+  "mcpServers": {
+    "nx-plugin-for-aws": {
+      "command": "npx",
+      "args": ["-y", "@aws/nx-plugin-mcp"]
+    }
+  }
+}
+"
+`;
+
+exports[`preset generator > should run successfully > .mcp.json 1`] = `
+"{
+  "mcpServers": {
+    "nx-plugin-for-aws": {
+      "command": "npx",
+      "args": ["-y", "@aws/nx-plugin-mcp"]
+    }
+  }
+}
+"
+`;
 
 exports[`preset generator > should run successfully > .prettierignore 1`] = `
 "# Add files here to ignore them from prettier formatting
@@ -12,6 +67,19 @@ exports[`preset generator > should run successfully > .prettierignore 1`] = `
 
 exports[`preset generator > should run successfully > .prettierrc 1`] = `
 "{ "singleQuote": true }
+"
+`;
+
+exports[`preset generator > should run successfully > .vscode/mcp.json 1`] = `
+"{
+  "servers": {
+    "nx-plugin-for-aws": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@aws/nx-plugin-mcp"]
+    }
+  }
+}
 "
 `;
 

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -123,7 +123,7 @@ describe('preset generator', () => {
     expect(readJson(tree, '.mcp.json').mcpServers['nx-plugin-for-aws']).toEqual(
       {
         command: 'npx',
-        args: ['-y', '@aws/nx-plugin-mcp'],
+        args: ['-y', '@aws/nx-plugin-mcp@next'],
       },
     );
   });

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -107,6 +107,46 @@ describe('preset generator', () => {
     expect(packageJson.devDependencies.husky).toBeDefined();
   });
 
+  it('should configure MCP servers by default', async () => {
+    await presetGenerator(tree, { addTsPlugin: false, iac: 'cdk' });
+
+    for (const filePath of [
+      '.mcp.json',
+      '.cursor/mcp.json',
+      '.kiro/settings/mcp.json',
+      '.gemini/settings.json',
+      '.vscode/mcp.json',
+      '.codex/config.toml',
+    ]) {
+      expect(tree.exists(filePath)).toBe(true);
+    }
+    expect(readJson(tree, '.mcp.json').mcpServers['nx-plugin-for-aws']).toEqual(
+      {
+        command: 'npx',
+        args: ['-y', '@aws/nx-plugin-mcp'],
+      },
+    );
+  });
+
+  it('should not configure MCP servers when mcp is false', async () => {
+    await presetGenerator(tree, {
+      addTsPlugin: false,
+      iac: 'cdk',
+      mcp: false,
+    });
+
+    for (const filePath of [
+      '.mcp.json',
+      '.cursor/mcp.json',
+      '.kiro/settings/mcp.json',
+      '.gemini/settings.json',
+      '.vscode/mcp.json',
+      '.codex/config.toml',
+    ]) {
+      expect(tree.exists(filePath)).toBe(false);
+    }
+  });
+
   it('should disable analytics in nx.json', async () => {
     await presetGenerator(tree, {
       addTsPlugin: false,

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -34,6 +34,7 @@ import {
 } from '../utils/config/utils';
 import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
 import { inferContainers } from '../utils/containers';
+import { configureMcpServers } from '../utils/mcp';
 import yaml from 'js-yaml';
 
 const WORKSPACES = ['packages/*'];
@@ -159,7 +160,7 @@ const setUpGitSecrets = (tree: Tree) => {
 
 export const presetGenerator = async (
   tree: Tree,
-  { addTsPlugin, iac, gitSecrets, containers }: PresetGeneratorSchema,
+  { addTsPlugin, iac, gitSecrets, mcp, containers }: PresetGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const resolvedContainers =
     !containers || containers === 'infer' ? inferContainers() : containers;
@@ -274,6 +275,10 @@ export const presetGenerator = async (
 
   if (gitSecrets !== false) {
     setUpGitSecrets(tree);
+  }
+
+  if (mcp !== false) {
+    configureMcpServers(tree);
   }
 
   await formatFilesInSubtree(tree);

--- a/packages/nx-plugin/src/preset/schema.d.ts
+++ b/packages/nx-plugin/src/preset/schema.d.ts
@@ -11,5 +11,6 @@ export interface PresetGeneratorSchema {
   readonly addTsPlugin?: boolean;
   readonly iac: Iac;
   readonly gitSecrets?: boolean;
+  readonly mcp?: boolean;
   readonly containers?: PresetContainersOption;
 }

--- a/packages/nx-plugin/src/preset/schema.json
+++ b/packages/nx-plugin/src/preset/schema.json
@@ -23,6 +23,11 @@
       "description": "Whether to configure git-secrets to prevent committing AWS credentials.",
       "default": true
     },
+    "mcp": {
+      "type": "boolean",
+      "description": "Whether to configure the Nx Plugin for AWS MCP server for use by coding agents.",
+      "default": true
+    },
     "containers": {
       "type": "string",
       "description": "The container engine to use for build/push/login. 'infer' picks docker if installed, otherwise finch (falling back to docker when neither is installed).",

--- a/packages/nx-plugin/src/utils/mcp.spec.ts
+++ b/packages/nx-plugin/src/utils/mcp.spec.ts
@@ -25,7 +25,7 @@ describe('mcp utils', () => {
         const config = readJson(tree, filePath);
         expect(config.mcpServers[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
           command: 'npx',
-          args: ['-y', '@aws/nx-plugin-mcp'],
+          args: ['-y', '@aws/nx-plugin-mcp@next'],
         });
       }
 
@@ -34,14 +34,14 @@ describe('mcp utils', () => {
       expect(vscode.servers[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
         type: 'stdio',
         command: 'npx',
-        args: ['-y', '@aws/nx-plugin-mcp'],
+        args: ['-y', '@aws/nx-plugin-mcp@next'],
       });
 
       // OpenAI Codex CLI uses TOML
       const codex = TOML.parse(tree.read('.codex/config.toml', 'utf-8'));
       expect((codex.mcp_servers as any)[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
         command: 'npx',
-        args: ['-y', '@aws/nx-plugin-mcp'],
+        args: ['-y', '@aws/nx-plugin-mcp@next'],
       });
     });
 

--- a/packages/nx-plugin/src/utils/mcp.spec.ts
+++ b/packages/nx-plugin/src/utils/mcp.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createTree } from '@nx/devkit/testing';
+import { readJson, writeJson, Tree } from '@nx/devkit';
+import TOML from '@iarna/toml';
+import { describe, it, expect } from 'vitest';
+import { configureMcpServers, NX_PLUGIN_MCP_SERVER_NAME } from './mcp';
+
+describe('mcp utils', () => {
+  describe('configureMcpServers', () => {
+    it('should configure the MCP server across all agent config locations', () => {
+      const tree = createTree();
+
+      configureMcpServers(tree);
+
+      // Agents using the `mcpServers` config shape
+      for (const filePath of [
+        '.mcp.json',
+        '.cursor/mcp.json',
+        '.kiro/settings/mcp.json',
+        '.gemini/settings.json',
+      ]) {
+        const config = readJson(tree, filePath);
+        expect(config.mcpServers[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
+          command: 'npx',
+          args: ['-y', '@aws/nx-plugin-mcp'],
+        });
+      }
+
+      // GitHub Copilot uses the `servers` key with an explicit type
+      const vscode = readJson(tree, '.vscode/mcp.json');
+      expect(vscode.servers[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@aws/nx-plugin-mcp'],
+      });
+
+      // OpenAI Codex CLI uses TOML
+      const codex = TOML.parse(tree.read('.codex/config.toml', 'utf-8'));
+      expect((codex.mcp_servers as any)[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
+        command: 'npx',
+        args: ['-y', '@aws/nx-plugin-mcp'],
+      });
+    });
+
+    it('should preserve existing servers in JSON configs', () => {
+      const tree = createTree();
+      writeJson(tree, '.mcp.json', {
+        mcpServers: {
+          'existing-server': { command: 'node', args: ['server.js'] },
+        },
+      });
+
+      configureMcpServers(tree);
+
+      const config = readJson(tree, '.mcp.json');
+      expect(config.mcpServers['existing-server']).toEqual({
+        command: 'node',
+        args: ['server.js'],
+      });
+      expect(config.mcpServers[NX_PLUGIN_MCP_SERVER_NAME]).toBeDefined();
+    });
+
+    it('should preserve existing servers in the Copilot config', () => {
+      const tree = createTree();
+      writeJson(tree, '.vscode/mcp.json', {
+        servers: {
+          'existing-server': { type: 'stdio', command: 'node', args: [] },
+        },
+      });
+
+      configureMcpServers(tree);
+
+      const config = readJson(tree, '.vscode/mcp.json');
+      expect(config.servers['existing-server']).toBeDefined();
+      expect(config.servers[NX_PLUGIN_MCP_SERVER_NAME]).toBeDefined();
+    });
+
+    it('should preserve existing servers in the Codex TOML config', () => {
+      const tree = createTree();
+      tree.write(
+        '.codex/config.toml',
+        TOML.stringify({
+          mcp_servers: {
+            'existing-server': { command: 'node', args: ['server.js'] },
+          },
+        }),
+      );
+
+      configureMcpServers(tree);
+
+      const config = TOML.parse(tree.read('.codex/config.toml', 'utf-8'));
+      expect((config.mcp_servers as any)['existing-server']).toBeDefined();
+      expect(
+        (config.mcp_servers as any)[NX_PLUGIN_MCP_SERVER_NAME],
+      ).toBeDefined();
+    });
+
+    it('should be idempotent', () => {
+      const tree: Tree = createTree();
+
+      configureMcpServers(tree);
+      const first = tree.read('.mcp.json', 'utf-8');
+      configureMcpServers(tree);
+      const second = tree.read('.mcp.json', 'utf-8');
+
+      expect(first).toEqual(second);
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/mcp.ts
+++ b/packages/nx-plugin/src/utils/mcp.ts
@@ -18,7 +18,7 @@ export const NX_PLUGIN_MCP_SERVER_COMMAND = 'npx';
 /**
  * Arguments used to launch the Nx Plugin for AWS MCP server.
  */
-export const NX_PLUGIN_MCP_SERVER_ARGS = ['-y', '@aws/nx-plugin-mcp'];
+export const NX_PLUGIN_MCP_SERVER_ARGS = ['-y', '@aws/nx-plugin-mcp@next'];
 
 /**
  * A single stdio MCP server entry, shared by agents that use the `mcpServers` config shape.

--- a/packages/nx-plugin/src/utils/mcp.ts
+++ b/packages/nx-plugin/src/utils/mcp.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Tree, readJson, writeJson } from '@nx/devkit';
+import { updateToml } from './toml';
+
+/**
+ * Name of the Nx Plugin for AWS MCP server, used as the key in each agent's config.
+ */
+export const NX_PLUGIN_MCP_SERVER_NAME = 'nx-plugin-for-aws';
+
+/**
+ * Command used to launch the Nx Plugin for AWS MCP server.
+ */
+export const NX_PLUGIN_MCP_SERVER_COMMAND = 'npx';
+
+/**
+ * Arguments used to launch the Nx Plugin for AWS MCP server.
+ */
+export const NX_PLUGIN_MCP_SERVER_ARGS = ['-y', '@aws/nx-plugin-mcp'];
+
+/**
+ * A single stdio MCP server entry, shared by agents that use the `mcpServers` config shape.
+ */
+const stdioServerEntry = () => ({
+  command: NX_PLUGIN_MCP_SERVER_COMMAND,
+  args: NX_PLUGIN_MCP_SERVER_ARGS,
+});
+
+/**
+ * Merge the Nx Plugin for AWS MCP server into a JSON config file under the given key,
+ * preserving any other servers already configured. Creates the file if it does not exist.
+ */
+const mergeJsonMcpConfig = (
+  tree: Tree,
+  filePath: string,
+  key: 'mcpServers' | 'servers',
+  entry: Record<string, unknown>,
+) => {
+  const config = tree.exists(filePath) ? readJson(tree, filePath) : {};
+  config[key] = {
+    ...config[key],
+    [NX_PLUGIN_MCP_SERVER_NAME]: entry,
+  };
+  writeJson(tree, filePath, config);
+};
+
+/**
+ * Configure the Nx Plugin for AWS MCP server across the project-level config locations
+ * used by common coding agents, so agents working in the workspace can use it to scaffold
+ * AWS projects with the Nx Plugin for AWS.
+ *
+ * Existing servers and unrelated config in each file are preserved.
+ */
+export const configureMcpServers = (tree: Tree) => {
+  // Agents using the `mcpServers` config shape (Claude Code, Cursor, Kiro, Gemini CLI)
+  const mcpServersFiles = [
+    '.mcp.json', // Claude Code
+    '.cursor/mcp.json', // Cursor
+    '.kiro/settings/mcp.json', // Kiro
+    '.gemini/settings.json', // Gemini CLI
+  ];
+  for (const filePath of mcpServersFiles) {
+    mergeJsonMcpConfig(tree, filePath, 'mcpServers', stdioServerEntry());
+  }
+
+  // GitHub Copilot uses the `servers` key with an explicit `type`
+  mergeJsonMcpConfig(tree, '.vscode/mcp.json', 'servers', {
+    type: 'stdio',
+    ...stdioServerEntry(),
+  });
+
+  // OpenAI Codex CLI uses TOML under the `mcp_servers` table
+  const codexConfig = '.codex/config.toml';
+  if (!tree.exists(codexConfig)) {
+    tree.write(codexConfig, '');
+  }
+  updateToml(tree, codexConfig, (prev) => ({
+    ...prev,
+    mcp_servers: {
+      ...(prev.mcp_servers as object),
+      [NX_PLUGIN_MCP_SERVER_NAME]: {
+        command: NX_PLUGIN_MCP_SERVER_COMMAND,
+        args: NX_PLUGIN_MCP_SERVER_ARGS,
+      },
+    },
+  }));
+};


### PR DESCRIPTION
### Reason for this change

Coding agents (Claude Code, Cursor, Kiro, etc.) can use the Nx Plugin for AWS MCP server to scaffold AWS projects with the plugin's generators. Until now, users had to configure this MCP server manually for each agent. Vending project-level MCP configuration as part of the preset means any agent working inside a generated workspace can use it out of the box, without per-developer setup.

### Description of changes

- Added `packages/nx-plugin/src/utils/mcp.ts` with `configureMcpServers(tree)`, which writes/merges the `nx-plugin-for-aws` MCP server (`npx -y @aws/nx-plugin-mcp`) into the project-level config locations used by common coding agents:
  - Claude Code — `.mcp.json`
  - Cursor — `.cursor/mcp.json`
  - Kiro — `.kiro/settings/mcp.json`
  - Gemini CLI — `.gemini/settings.json`
  - GitHub Copilot — `.vscode/mcp.json` (uses the `servers` key with `type: stdio`)
  - OpenAI Codex — `.codex/config.toml` (TOML, `mcp_servers` table)
- The first four share the standard `mcpServers` JSON shape; Copilot and Codex are handled as special cases. Existing servers and unrelated config in each file are preserved (merge, not overwrite), and the operation is idempotent.
- Wired this into the `preset` generator behind a new `mcp` option (boolean, defaults to `true`, mirroring the existing `gitSecrets` option). Disable with `--mcp=false`.
- Updated `schema.json` / `schema.d.ts` accordingly.
- Updated the "Building with AI" docs to note that project-level configuration is now automatic.

### Description of how you validated changes

- Added unit tests in `packages/nx-plugin/src/utils/mcp.spec.ts` covering all config locations, preservation of existing servers (JSON + TOML), and idempotency.
- Added preset generator tests for the default-on and `mcp: false` cases, and updated the preset snapshot.
- Full `@aws/nx-plugin` test suite passes (1895 tests); lint passes with no errors.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*