### PR TITLE
test(ts#dynamodb): don't disable PITR in terraform-deploy e2e test

### DIFF
--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -35,8 +35,7 @@ module "runtime_config_appconfig" {
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 
-  deletion_protection_enabled    = false
-  point_in_time_recovery_enabled = false
+  deletion_protection_enabled = false
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Reason for this change

The `Smoke Tests - terraform-deploy` job in CI on `main` is failing. The DynamoDB table deployed by the test fails the Checkov check `CKV_AWS_28` ("Ensure DynamoDB point in time recovery (backup) is enabled") during `apply`:

```
Check: CKV_AWS_28: "Ensure DynamoDB point in time recovery (backup) is enabled"
	FAILED for resource: module.my_table.module.dynamodb_table.aws_dynamodb_table.table
```

The terraform-deploy test's `main.tf` wiring overrode `point_in_time_recovery_enabled = false` on the table. Point-in-time recovery has no bearing on table teardown (only `deletion_protection_enabled` does), so the override served no purpose — but it diverged from the vended default (PITR enabled) and genuinely tripped `CKV_AWS_28`.

The vended template is correct as-is: it defaults `point_in_time_recovery_enabled` to `true`, so real users get a compliant table.

### Why wasn't this caught at PR time?

Checkov **does** run at build time for both IaC providers, and the fast non-deploy smoke tests run `build` at PR time:

- **CDK** (`infra/app` generator): `build` → `synth` + `checkov` (scans synthesized CloudFormation).
- **Terraform** (`terraform/project` generator): `build` → `test`, where `test` runs Checkov.

The non-deploy `Smoke Tests - terraform` job generates the table with template defaults (PITR = `true`) and **passed**. Only the deploy variant failed, because only its `main.tf` overrode PITR to `false`. Removing that override means the table is now exercised with its real, compliant configuration everywhere — and the build-time Checkov scan continues to guard it at PR time.

### Description of changes

Removed the `point_in_time_recovery_enabled = false` override from the terraform-deploy smoke test's `main.tf` wiring template. No suppression is added anywhere; the table deploys exactly as real users get it.

### Description of how you validated changes

- Confirmed PITR does not affect table teardown — only `deletion_protection_enabled` (retained as `false`) does.
- Confirmed no other references to `point_in_time_recovery` remain in the e2e suite.
- Full validation is via the `Smoke Tests - terraform-deploy` CI job on this PR.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
