### PR TITLE
ci(release): send Slack notifications for all releases and prereleases

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,7 +12,6 @@ jobs:
   slack-notification:
     name: Share recent changes with a channel
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### Reason for this change

Release announcements are posted to Slack via the `Post release announcements` workflow (`.github/workflows/on-release.yml`). The notification job was gated on `if: ${{ !github.event.release.prerelease }}`, which skips **all** GitHub prereleases.

The 0.x releases were published as stable (non-prerelease) GitHub releases, so they triggered Slack notifications. The 1.0 release candidates (e.g. `v1.0.0-rc.4`) are published as **prereleases**, so they were silently skipped — we got no Slack notification for them.

We want Slack notifications for both regular releases and prereleases.

### Description of changes

Removed the `if` condition on the `slack-notification` job in `.github/workflows/on-release.yml` so the job runs for every published release, including prereleases such as 1.0 release candidates.

### Description of how you validated changes

This is a workflow condition change. With the `if` guard removed, the `release: published` trigger fires the notification for all release types (stable and prerelease alike).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*