### PR TITLE
fix(ts#project): format with workspace Biome when biome.json exists on disk

### DIFF
--- a/docs/src/content/docs/en/guides/nx-generator.mdx
+++ b/docs/src/content/docs/en/guides/nx-generator.mdx
@@ -395,6 +395,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree` formats TypeScript, JavaScript, JSON and CSS files with [Biome](https://biomejs.dev/), and Python files with [Ruff](https://docs.astral.sh/ruff/). When the workspace already has a `biome.json` on disk, it uses your workspace's installed version of Biome and its configuration. Otherwise it falls back to a bundled Biome, applying any `biome.json` present in the virtual tree.
+:::
+
 #### Reading and Updating JSON Files
 
 ```typescript

--- a/docs/src/content/docs/es/guides/nx-generator.mdx
+++ b/docs/src/content/docs/es/guides/nx-generator.mdx
@@ -384,6 +384,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'ruta/opcional');
 ```
 
+:::note
+`formatFilesInSubtree` formatea archivos TypeScript, JavaScript, JSON y CSS con [Biome](https://biomejs.dev/), y archivos Python con [Ruff](https://docs.astral.sh/ruff/). Cuando el workspace ya tiene un `biome.json` en disco, utiliza la versión instalada de Biome de tu workspace y su configuración. De lo contrario, recurre a un Biome incluido, aplicando cualquier `biome.json` presente en el árbol virtual.
+:::
+
 #### Leer y actualizar JSON
 
 ```typescript

--- a/docs/src/content/docs/fr/guides/nx-generator.mdx
+++ b/docs/src/content/docs/fr/guides/nx-generator.mdx
@@ -395,6 +395,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree` formate les fichiers TypeScript, JavaScript, JSON et CSS avec [Biome](https://biomejs.dev/), et les fichiers Python avec [Ruff](https://docs.astral.sh/ruff/). Lorsque l'espace de travail possède déjà un fichier `biome.json` sur le disque, il utilise la version installée de Biome dans votre espace de travail ainsi que sa configuration. Sinon, il utilise un Biome intégré, en appliquant tout fichier `biome.json` présent dans l'arborescence virtuelle.
+:::
+
 #### Lecture et mise à jour de fichiers JSON
 
 ```typescript

--- a/docs/src/content/docs/it/guides/nx-generator.mdx
+++ b/docs/src/content/docs/it/guides/nx-generator.mdx
@@ -394,6 +394,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree` formatta i file TypeScript, JavaScript, JSON e CSS con [Biome](https://biomejs.dev/), e i file Python con [Ruff](https://docs.astral.sh/ruff/). Quando il workspace ha già un `biome.json` su disco, utilizza la versione installata di Biome del tuo workspace e la sua configurazione. Altrimenti ricorre a un Biome integrato, applicando qualsiasi `biome.json` presente nell'albero virtuale.
+:::
+
 #### Lettura e Aggiornamento File JSON
 
 ```typescript

--- a/docs/src/content/docs/jp/guides/nx-generator.mdx
+++ b/docs/src/content/docs/jp/guides/nx-generator.mdx
@@ -383,6 +383,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree`は、TypeScript、JavaScript、JSONおよびCSSファイルを[Biome](https://biomejs.dev/)でフォーマットし、Pythonファイルを[Ruff](https://docs.astral.sh/ruff/)でフォーマットします。ワークスペースにすでに`biome.json`がディスク上に存在する場合、ワークスペースにインストールされているバージョンのBiomeとその設定を使用します。それ以外の場合は、バンドルされたBiomeにフォールバックし、仮想ツリーに存在する`biome.json`を適用します。
+:::
+
 #### JSONファイルの操作
 
 ```typescript

--- a/docs/src/content/docs/ko/guides/nx-generator.mdx
+++ b/docs/src/content/docs/ko/guides/nx-generator.mdx
@@ -395,6 +395,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree`는 [Biome](https://biomejs.dev/)을 사용하여 TypeScript, JavaScript, JSON 및 CSS 파일을 포맷하고, [Ruff](https://docs.astral.sh/ruff/)를 사용하여 Python 파일을 포맷합니다. 워크스페이스에 이미 `biome.json`이 디스크에 있는 경우, 워크스페이스에 설치된 Biome 버전과 해당 구성을 사용합니다. 그렇지 않으면 번들된 Biome으로 대체하여 가상 트리에 있는 `biome.json`을 적용합니다.
+:::
+
 #### JSON 파일 읽기/업데이트
 
 ```typescript

--- a/docs/src/content/docs/pt/guides/nx-generator.mdx
+++ b/docs/src/content/docs/pt/guides/nx-generator.mdx
@@ -394,6 +394,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree` formata arquivos TypeScript, JavaScript, JSON e CSS com [Biome](https://biomejs.dev/), e arquivos Python com [Ruff](https://docs.astral.sh/ruff/). Quando o workspace já possui um `biome.json` no disco, ele usa a versão instalada do Biome no seu workspace e sua configuração. Caso contrário, ele recorre a um Biome empacotado, aplicando qualquer `biome.json` presente na árvore virtual.
+:::
+
 #### Lendo e Atualizando JSON
 
 ```typescript

--- a/docs/src/content/docs/vi/guides/nx-generator.mdx
+++ b/docs/src/content/docs/vi/guides/nx-generator.mdx
@@ -395,6 +395,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree` định dạng các tệp TypeScript, JavaScript, JSON và CSS bằng [Biome](https://biomejs.dev/), và các tệp Python bằng [Ruff](https://docs.astral.sh/ruff/). Khi workspace đã có sẵn tệp `biome.json` trên đĩa, nó sẽ sử dụng phiên bản Biome đã cài đặt trong workspace của bạn và cấu hình của nó. Nếu không, nó sẽ quay lại sử dụng Biome đi kèm, áp dụng bất kỳ `biome.json` nào có trong cây ảo.
+:::
+
 #### Đọc và Cập nhật Tệp JSON
 
 ```typescript

--- a/docs/src/content/docs/zh/guides/nx-generator.mdx
+++ b/docs/src/content/docs/zh/guides/nx-generator.mdx
@@ -395,6 +395,10 @@ import { formatFilesInSubtree } from '@aws/nx-plugin/sdk/utils/format';
 await formatFilesInSubtree(tree, 'optional/path/to/format');
 ```
 
+:::note
+`formatFilesInSubtree` 使用 [Biome](https://biomejs.dev/) 格式化 TypeScript、JavaScript、JSON 和 CSS 文件，使用 [Ruff](https://docs.astral.sh/ruff/) 格式化 Python 文件。当工作区磁盘上已有 `biome.json` 时，它会使用工作区安装的 Biome 版本及其配置。否则，它会回退到捆绑的 Biome，并应用虚拟树中存在的任何 `biome.json`。
+:::
+
 #### 读写 JSON 文件
 
 ```typescript

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -4,7 +4,10 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { formatFilesInSubtree } from './format';
 import { createTreeUsingTsSolutionSetup } from './test';
 
@@ -55,6 +58,23 @@ describe('format utils', () => {
         "const x = 1\nconst y = 'hello'\n",
       );
     });
+    it('should apply in-tree config changes without writing a config file', async () => {
+      // Setup - in-memory config change made within this generator run (tabs)
+      tree.write(
+        'biome.json',
+        JSON.stringify({
+          formatter: { indentStyle: 'tab' },
+          javascript: { formatter: { quoteStyle: 'double' } },
+        }),
+      );
+      tree.write('src/test.ts', 'function f(){const x="hi";return x}');
+      // Execute
+      await formatFilesInSubtree(tree, 'src');
+      // Verify - tab indentation and double quotes from the in-tree config
+      expect(tree.read('src/test.ts')?.toString()).toBe(
+        'function f() {\n\tconst x = "hi";\n\treturn x;\n}\n',
+      );
+    });
     it('should not format deleted files', async () => {
       // Setup
       tree.write('src/test.ts', 'const x=1;');
@@ -63,6 +83,63 @@ describe('format utils', () => {
       await formatFilesInSubtree(tree, 'src');
       // Verify
       expect(tree.exists('src/test.ts')).toBe(false);
+    });
+    it('should format all changed files when no directory is given', async () => {
+      // Setup
+      tree.write('src/test.ts', 'const x=1;');
+      tree.write('lib/test.ts', 'const y=2;');
+      // Execute
+      await formatFilesInSubtree(tree);
+      // Verify - both files are formatted
+      expect(tree.read('src/test.ts')?.toString()).toBe('const x = 1;\n');
+      expect(tree.read('lib/test.ts')?.toString()).toBe('const y = 2;\n');
+    });
+    it('should format json and css files', async () => {
+      // Setup
+      tree.write('src/data.json', '{"a":1,"b":2}');
+      tree.write('src/styles.css', '.a{color:red}');
+      // Execute
+      await formatFilesInSubtree(tree, 'src');
+      // Verify
+      expect(tree.read('src/data.json')?.toString()).toBe(
+        '{ "a": 1, "b": 2 }\n',
+      );
+      expect(tree.read('src/styles.css')?.toString()).toBe(
+        '.a {\n  color: red;\n}\n',
+      );
+    });
+  });
+
+  describe('formatFilesInSubtree with an on-disk biome.json', () => {
+    let workspaceDir: string;
+    beforeEach(() => {
+      // Point the tree at a real directory so the on-disk biome.json is used.
+      workspaceDir = mkdtempSync(path.join(tmpdir(), 'nx-plugin-format-'));
+      tree.root = workspaceDir;
+    });
+    afterEach(() => {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    });
+    it("should format using the workspace's on-disk biome config", async () => {
+      // Setup - on-disk config with no semicolons and single quotes
+      writeFileSync(
+        path.join(workspaceDir, 'biome.json'),
+        JSON.stringify({
+          $schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
+          root: true,
+          formatter: { indentStyle: 'space', indentWidth: 2 },
+          javascript: {
+            formatter: { quoteStyle: 'single', semicolons: 'asNeeded' },
+          },
+        }),
+      );
+      tree.write('src/test.ts', 'const x=1;const y="hello";');
+      // Execute
+      await formatFilesInSubtree(tree, 'src');
+      // Verify - respects the on-disk config (no semicolons, single quotes)
+      expect(tree.read('src/test.ts')?.toString()).toBe(
+        "const x = 1\nconst y = 'hello'\n",
+      );
     });
   });
 });

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -5,7 +5,8 @@
 
 import { Biome } from '@biomejs/js-api/nodejs';
 import type { Tree } from '@nx/devkit';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
+import { existsSync } from 'fs';
 import path from 'path';
 
 export const DEFAULT_BIOME_CONFIG = {
@@ -106,10 +107,60 @@ export async function formatFilesInSubtree(
     }
   }
 
-  // Format TS/JS/JSON/CSS files with Biome via its library API, so nothing is
-  // written to the filesystem (the config is applied in-memory).
   if (otherFiles.length === 0) return;
 
+  // Use the workspace's own Biome CLI (its version and config) when biome.json
+  // exists on disk; otherwise format via the bundled library API with the
+  // in-memory tree config. The CLI path does not see in-tree config changes.
+  if (existsSync(path.join(tree.root, 'biome.json'))) {
+    formatWithBiomeCli(tree, otherFiles);
+  } else {
+    formatWithBiomeApi(tree, otherFiles);
+  }
+}
+
+/**
+ * Format files via the workspace's Biome CLI, run from the workspace root so it
+ * discovers the on-disk biome.json.
+ */
+function formatWithBiomeCli(
+  tree: Tree,
+  files: { path: string; content: Buffer | null }[],
+): void {
+  const biome = getBiomeCommand(tree.root);
+  if (!biome) {
+    // Fall back to the library API if the CLI cannot be resolved
+    formatWithBiomeApi(tree, files);
+    return;
+  }
+
+  for (const file of files) {
+    try {
+      const content = execFileSync(
+        biome.command,
+        [...biome.args, 'format', `--stdin-file-path=${file.path}`],
+        {
+          input: file.content?.toString('utf-8') ?? '',
+          encoding: 'utf-8',
+          cwd: tree.root,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      tree.write(file.path, content);
+    } catch {
+      // Leave individual files that fail to format untouched
+    }
+  }
+}
+
+/**
+ * Format files via the bundled Biome library API, applying the in-memory tree
+ * config.
+ */
+function formatWithBiomeApi(
+  tree: Tree,
+  files: { path: string; content: Buffer | null }[],
+): void {
   try {
     const biome = new Biome();
     const { projectKey } = biome.openProject();
@@ -120,11 +171,11 @@ export async function formatFilesInSubtree(
       treeConfig ? JSON.parse(treeConfig) : DEFAULT_BIOME_CONFIG,
     );
 
-    for (const file of otherFiles) {
+    for (const file of files) {
       try {
         const { content } = biome.formatContent(
           projectKey,
-          file.content.toString('utf-8'),
+          file.content?.toString('utf-8') ?? '',
           { filePath: file.path },
         );
         tree.write(file.path, content);
@@ -134,6 +185,53 @@ export async function formatFilesInSubtree(
     }
   } catch {
     // Silently skip formatting failures
+  }
+}
+
+interface BiomeCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Resolve the `@biomejs/biome` CLI from the user's workspace, falling back to a
+ * `biome` binary on the PATH.
+ */
+const _biomeCommands = new Map<string, BiomeCommand | null>();
+function getBiomeCommand(root: string): BiomeCommand | undefined {
+  if (_biomeCommands.has(root)) {
+    return _biomeCommands.get(root) ?? undefined;
+  }
+
+  // Run via node for cross-platform execution of the bin shim.
+  try {
+    const pkgJsonPath = require.resolve('@biomejs/biome/package.json', {
+      paths: [root, __dirname],
+    });
+    const pkgJson = require(pkgJsonPath);
+    const binRelative =
+      typeof pkgJson.bin === 'string' ? pkgJson.bin : pkgJson.bin?.biome;
+    if (binRelative) {
+      const binPath = path.join(path.dirname(pkgJsonPath), binRelative);
+      const command = { command: process.execPath, args: [binPath] };
+      _biomeCommands.set(root, command);
+      return command;
+    }
+  } catch {
+    // Fall back to a biome binary on the PATH
+  }
+
+  try {
+    execSync('biome --version', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const command = { command: 'biome', args: [] };
+    _biomeCommands.set(root, command);
+    return command;
+  } catch {
+    _biomeCommands.set(root, null);
+    return undefined;
   }
 }
 


### PR DESCRIPTION
### Reason for this change

When ESLint and Prettier were replaced with Biome (#754), generator-time formatting (`formatFilesInSubtree`) was implemented using the bundled Biome library API (`@biomejs/js-api` + `@biomejs/wasm-nodejs`). This always formats with the bundled engine and our pinned config defaults, so it does not pick up the user's installed Biome version or their on-disk `biome.json` preferences.

Before the Biome migration, the Prettier-based `format.ts` dynamically imported the user's **own** `prettier`, so generated code matched the user's tooling. This change restores that spirit for Biome where possible.

### Description of changes

`formatFilesInSubtree` now uses a hybrid strategy for TypeScript/JavaScript/JSON/CSS files:

- **When the workspace already has a `biome.json` on disk** -> format with the workspace's **own installed Biome CLI** (resolved from `@biomejs/biome`, run via `node` for cross-platform execution, with a `biome`-on-PATH fallback). The CLI is run from the workspace root so Biome discovers the on-disk `biome.json` - honouring both the user's installed **version** and their **configuration**.
- **Otherwise** (eg a brand new workspace where the config only exists in the virtual tree, or if the CLI can't be resolved) -> fall back to the bundled **Biome library API**, applying the in-memory tree config exactly as before. This keeps formatting working during workspace creation, before anything is flushed to disk.

Python formatting (Ruff) is unchanged.

**Accepted limitation:** the on-disk CLI path does not observe in-memory config changes. So a generator that *modifies* `biome.json` within a run will format using the previous on-disk config during that run. The next run (or a generator that creates a brand new workspace) picks up the change.

`@biomejs/js-api`/`@biomejs/wasm-nodejs` remain dependencies (used by the fallback). No new dependencies are added - the CLI is resolved from the user's workspace at runtime.

### Description of how you validated changes

- Added a test exercising the **on-disk CLI path**: a real temporary workspace directory with a `biome.json` on disk (no semicolons, single quotes) - verifies the output respects the on-disk config, proving the user's CLI + config is used.
- Added tests for the **in-memory library API path**: in-tree `biome.json` config changes, directory-less formatting, and JSON/CSS formatting.
- Ran the full `@aws/nx-plugin` test suite (2010 tests) - all passing.
- Verified `compile` and `lint` pass.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
