### PR TITLE
perf(ci): speed up PR workflow init via cache dedup and tool gating

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -5,6 +5,10 @@ inputs:
   aws-docker-login-role-arn:
     description: 'ARN of the AWS role to assume for Docker login'
     required: false
+  container-tools:
+    description: 'Set up QEMU and Docker Buildx for multi-arch container builds. Disable for jobs that do not build containers.'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -31,18 +35,18 @@ runs:
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
-        cache: 'pnpm'
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v5
       with:
         version: 'latest'
+        enable-cache: true
     - name: Set up QEMU
-      if: ${{ runner.os != 'Windows' }}
+      if: ${{ runner.os != 'Windows' && inputs.container-tools == 'true' }}
       uses: docker/setup-qemu-action@v3
       with:
         image: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
     - name: Set up Docker Buildx
-      if: ${{ runner.os != 'Windows' }}
+      if: ${{ runner.os != 'Windows' && inputs.container-tools == 'true' }}
       uses: docker/setup-buildx-action@v3
     - name: Set up WSL2 Docker for Linux builds (Windows)
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: ./.github/actions/init-monorepo
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
+          container-tools: 'false'
       - name: Build
         env:
           DOCS_BASE_PATH: ${{ github.ref == 'refs/heads/main' && '/nx-plugin-for-aws/preview' || '/nx-plugin-for-aws' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: ./.github/actions/init-monorepo
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
+          container-tools: 'false'
       - name: Build
         run: pnpm nx run-many --target build --all --output-style=stream
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
### Reason for this change

The PR workflow takes ~1 hour wall-clock. Every one of its 24 jobs (Build + 20 Linux + 3 Windows smoke tests) runs the shared `init-monorepo` composite action, which takes **~100s** per job. Profiling a recent run (#765) showed the bulk of that time is environment setup, not the repo's own `pnpm i` (only ~13s):

| init-monorepo step | Time |
|---|---|
| pnpm/action-setup (self-installer) | 16s |
| setup-node — restores 478MB pnpm store (`cache: 'pnpm'`) | **22s** |
| setup-qemu | 13s |
| setup-buildx | 5s |
| **actions/cache — restores the SAME 478MB pnpm store** | **19s** |
| `pnpm i --frozen-lockfile` | 13s |

Two clear inefficiencies:
1. The pnpm store was being **cached and restored twice** — once by `setup-node`'s `cache: 'pnpm'` and again by the explicit `actions/cache` step (identical 478MB content, confirmed in the cache list). This costs a redundant ~19s restore + post-job save per job, and doubles pnpm-store storage. The repo is pinned at the **10GB Actions cache ceiling**, so this duplication accelerates cache eviction → occasional cold installs.
2. The **Build job builds no containers** (verified: zero `docker build`/QEMU activity in its log; the docker/terraform/uv keywords there are only snapshot test names), yet still pays ~18s for QEMU + Buildx setup.

### Description of changes

- **De-duplicate the pnpm store cache**: removed `cache: 'pnpm'` from `setup-node`. The explicit `actions/cache` step remains as the single source of truth — it additionally has `restore-keys` for a warm fallback when the lockfile changes, which `setup-node` lacked.
- **Enable uv's built-in cache** (`enable-cache: true`) so the Python-heavy smoke tests stop re-downloading wheels every run.
- **Gate container tooling**: added a `container-tools` input (default `true`) to `init-monorepo` guarding QEMU + Docker Buildx. Set to `false` for the Build jobs in both `pr.yml` and `ci.yml`, which compile and unit-test only. Smoke test jobs keep the default and still build ARM containers.

### Description of how you validated changes

YAML validated locally. Will observe the actual `init-monorepo` step timings on this PR's own workflow run and compare against the baseline above, iterating if needed.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
