### PR TITLE
perf(ci): decouple smoke tests from full build via fast package job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ permissions:
   id-token: write
 
 jobs:
+  package:
+    name: Package
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
+      - name: Package plugins
+        run: pnpm nx run-many --target compile,post-compile,copy-assets,generate-3p-license --projects @aws/nx-plugin,@aws/nx-plugin-mcp,@aws/create-nx-workspace --output-style=stream
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: build-artifact
+          path: dist
   build:
     name: Build
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -43,11 +60,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Check for mutations
         run: git diff --ignore-space-at-eol --exit-code -- ':!**/LICENSE-THIRD-PARTY'
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: build-artifact
-          path: dist
       - name: Upload docs artifact
         uses: actions/upload-artifact@v7.0.1
         with:
@@ -56,7 +68,7 @@ jobs:
   smoke_tests:
     name: Smoke Tests - ${{matrix.smoke_test}}
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
-    needs: build
+    needs: package
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +120,7 @@ jobs:
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}
     runs-on: windows-latest
-    needs: build
+    needs: package
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +151,7 @@ jobs:
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
   release:
     name: Release
-    needs: [build, smoke_tests, smoke_tests_windows]
+    needs: [package, build, smoke_tests, smoke_tests_windows]
     runs-on: ubuntu-22.04
     outputs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Package plugins
-        run: pnpm nx run-many --target compile,post-compile,copy-assets,generate-3p-license --projects @aws/nx-plugin,@aws/nx-plugin-mcp,@aws/create-nx-workspace --output-style=stream
+        run: pnpm package:all --output-style=stream
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,23 @@ permissions:
   id-token: write
 
 jobs:
+  package:
+    name: Package
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/init-monorepo
+        with:
+          aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
+      - name: Package plugins
+        run: pnpm nx run-many --target compile,post-compile,copy-assets,generate-3p-license --projects @aws/nx-plugin,@aws/nx-plugin-mcp,@aws/create-nx-workspace --output-style=stream
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: build-artifact
+          path: dist
   build:
     name: Build
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -41,15 +58,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Check for mutations
         run: git diff --ignore-space-at-eol --exit-code -- ':!**/LICENSE-THIRD-PARTY'
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: build-artifact
-          path: dist
   smoke_tests:
     name: Smoke Tests - ${{matrix.smoke_test}}
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
-    needs: build
+    needs: package
     strategy:
       fail-fast: false
       matrix:
@@ -92,7 +104,7 @@ jobs:
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}
     runs-on: windows-latest
-    needs: build
+    needs: package
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Package plugins
-        run: pnpm nx run-many --target compile,post-compile,copy-assets,generate-3p-license --projects @aws/nx-plugin,@aws/nx-plugin-mcp,@aws/create-nx-workspace --output-style=stream
+        run: pnpm package:all --output-style=stream
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "packageManager": "pnpm@11.5.0",
   "scripts": {
     "prepare": "husky || true",
-    "build:all": "nx run-many --target build"
+    "build:all": "nx run-many --target build",
+    "package:all": "nx run-many --target package"
   },
   "config": {
     "commitizen": {

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -50,6 +50,9 @@
       },
       "dependsOn": ["compile"]
     },
+    "package": {
+      "dependsOn": ["compile", "post-compile", "copy-assets"]
+    },
     "build": {
       "dependsOn": ["compile", "post-compile", "copy-assets", "lint", "test"]
     }

--- a/packages/nx-plugin-mcp/project.json
+++ b/packages/nx-plugin-mcp/project.json
@@ -39,6 +39,9 @@
       },
       "dependsOn": ["compile"]
     },
+    "package": {
+      "dependsOn": ["compile", "post-compile", "copy-assets"]
+    },
     "build": {
       "dependsOn": ["compile", "post-compile", "copy-assets"]
     }

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -69,6 +69,9 @@
       },
       "dependsOn": ["compile"]
     },
+    "package": {
+      "dependsOn": ["compile", "post-compile", "generate-3p-license"]
+    },
     "build": {
       "dependsOn": [
         "compile",


### PR DESCRIPTION
### Reason for this change

The smoke test jobs (`needs: build`) wait for the entire **Build** job before they can start. Profiling a recent run showed Build takes ~13.5 min, dominated by work the smoke tests don't consume:

| Build sub-task | Time |
|---|---|
| `@aws/nx-plugin:test` (2006 unit tests) | **~472s (8 min)** |
| `docs:build` | ~225s |
| `@aws/nx-plugin:lint` + coverage + codecov | the rest |
| `@aws/nx-plugin:compile` (what smoke actually needs) | **~5s** |

Smoke tests only consume the compiled plugin packages (they publish `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `@aws/create-nx-workspace` to a local verdaccio). Producing exactly that artifact takes **~5s of Nx work**, yet smoke tests wait ~12 min on tests/lint/docs first. Because the smoke fan-out (the ~30 min Windows jobs in particular) is the workflow's critical path, that delay sits directly on the critical path.

### Description of changes

Split the fast packaging step out of the heavy build:

- **New `package` job** runs `nx run-many --target compile,post-compile,copy-assets,generate-3p-license` for the three publishable packages and uploads the `build-artifact` that smoke tests download.
- **`build` job** is unchanged in what it runs (`nx run-many build --all` + coverage + mutation check) but no longer uploads `build-artifact` (in `ci.yml` it still uploads `docs-artifact`). It runs **in parallel** with `package` and smoke, and still gates `release`.
- `smoke_tests` and `smoke_tests_windows` now `needs: package` instead of `needs: build`.
- In `ci.yml`, `release` now `needs: [package, build, smoke_tests, smoke_tests_windows]` — so unit tests/lint must still pass before a publish, and it downloads `build-artifact` from `package`.

Net effect: the smoke fan-out starts after ~init + package (a few minutes) instead of after the full ~13.5 min build, removing ~9–10 min from the critical path. Total wall-clock becomes `max(build, package + slowest-smoke)`.

### Description of how you validated changes

- **Verified the package-only artifact is identical to the full build's output**: ran the `package` command and `nx run-many build --all` separately and diffed `dist/packages` — byte-for-byte identical file set (empty diff both directions). `bin/aws-nx-mcp.js` retains its executable bit from `post-compile`.
- `actionlint` passes clean on both workflow files.
- Will observe the actual PR run to confirm smoke jobs start right after `package`, the `build` job runs in parallel, and everything stays green.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
