### PR TITLE
fix(generators): make IaC and project-creator generators idempotent on re-run

### DIFF
--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -2,7 +2,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readJson, readProjectConfiguration, type Tree } from '@nx/devkit';
+import {
+  getProjects,
+  readJson,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import {
   createTreeUsingTsSolutionSetup,
@@ -448,5 +453,28 @@ describe('infra generator', () => {
     expect(tree.exists('packages/infra')).toBeTruthy();
     expect(tree.exists('packages/infra/src')).toBeTruthy();
     expect(tree.exists('packages/infra/cdk.json')).toBeTruthy();
+  });
+
+  it('should be idempotent when re-run with same options', async () => {
+    await tsInfraGenerator(tree, options);
+
+    const projectCountAfterFirstRun = getProjects(tree).size;
+    const mainTsAfterFirstRun = tree.read('packages/test/src/main.ts', 'utf-8');
+
+    await expect(tsInfraGenerator(tree, options)).resolves.toBeDefined();
+
+    expect(getProjects(tree).size).toBe(projectCountAfterFirstRun);
+    expect(tree.read('packages/test/src/main.ts', 'utf-8')).toEqual(
+      mainTsAfterFirstRun,
+    );
+  });
+
+  it('should create an independent project when run with a different name', async () => {
+    await tsInfraGenerator(tree, options);
+    await tsInfraGenerator(tree, { ...options, name: 'other' });
+
+    expect(readProjectConfiguration(tree, '@proj/test')).toBeDefined();
+    expect(readProjectConfiguration(tree, '@proj/other')).toBeDefined();
+    expect(tree.exists('packages/other/cdk.json')).toBeTruthy();
   });
 });

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -49,7 +49,18 @@ export async function tsInfraGenerator(
   schema: TsInfraGeneratorSchema,
 ): Promise<GeneratorCallback> {
   const lib = getTsLibDetails(tree, schema);
-  await tsProjectGenerator(tree, schema);
+
+  let projectExists: boolean;
+  try {
+    readProjectConfiguration(tree, lib.fullyQualifiedName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (!projectExists) {
+    await tsProjectGenerator(tree, schema);
+  }
 
   // CDK shells out to a container engine to build image assets. Default
   // (docker) needs no env override; finch is set via CDK_DOCKER per

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -26,6 +26,7 @@ import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
+  projectExists,
 } from '../../utils/nx';
 import { sortObjectKeys } from '../../utils/object';
 import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
@@ -50,15 +51,7 @@ export async function tsInfraGenerator(
 ): Promise<GeneratorCallback> {
   const lib = getTsLibDetails(tree, schema);
 
-  let projectExists: boolean;
-  try {
-    readProjectConfiguration(tree, lib.fullyQualifiedName);
-    projectExists = true;
-  } catch {
-    projectExists = false;
-  }
-
-  if (!projectExists) {
+  if (!projectExists(tree, lib.fullyQualifiedName)) {
     await tsProjectGenerator(tree, schema);
   }
 

--- a/packages/nx-plugin/src/smithy/project/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readJson, type Tree } from '@nx/devkit';
+import { getProjects, readJson, type Tree } from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
@@ -252,5 +252,34 @@ describe('smithyProjectGenerator', () => {
     expect(mainSmithy).toContain('service MyService');
     expect(mainSmithy).toContain('@title("MyService")');
     expect(mainSmithy).toMatchSnapshot('default-service-name-main.smithy');
+  });
+
+  it('should be idempotent when re-run with same options', async () => {
+    await smithyProjectGenerator(tree, { name: 'test-api' });
+
+    const projectCountAfterFirstRun = getProjects(tree).size;
+    const mainSmithyAfterFirstRun = tree.read(
+      'test-api/src/main.smithy',
+      'utf-8',
+    );
+
+    await expect(
+      smithyProjectGenerator(tree, { name: 'test-api' }),
+    ).resolves.toBeDefined();
+
+    expect(getProjects(tree).size).toBe(projectCountAfterFirstRun);
+    expect(tree.read('test-api/src/main.smithy', 'utf-8')).toEqual(
+      mainSmithyAfterFirstRun,
+    );
+  });
+
+  it('should create an independent project when run with a different name', async () => {
+    await smithyProjectGenerator(tree, { name: 'test-api' });
+    await smithyProjectGenerator(tree, { name: 'other-api' });
+
+    expect(readJson(tree, 'test-api/project.json').name).toBe('@proj/test-api');
+    expect(readJson(tree, 'other-api/project.json').name).toBe(
+      '@proj/other-api',
+    );
   });
 });

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -8,6 +8,7 @@ import {
   generateFiles,
   installPackagesTask,
   joinPathFragments,
+  readProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
 import { getTsLibDetails } from '../../ts/lib/generator';
@@ -36,31 +37,42 @@ export const smithyProjectGenerator = async (
 
   // Create project.json
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, options);
-  addProjectConfiguration(tree, fullyQualifiedName, {
-    name: fullyQualifiedName,
-    root: dir,
-    sourceRoot: joinPathFragments(dir, 'src'),
-    projectType: 'library',
-    targets: {
-      build: {
-        dependsOn: ['compile'],
-      },
-      compile: {
-        cache: true,
-        outputs: ['{workspaceRoot}/dist/{projectRoot}/build'],
-        executor: 'nx:run-commands',
-        options: {
-          commands: [
-            cmd.rm('dist/{projectRoot}/build'),
-            cmd.mkdir('dist/{projectRoot}/build'),
-            `${containers} build -f {projectRoot}/build.Dockerfile --target export --output type=local,dest=dist/{projectRoot}/build {projectRoot}`,
-          ],
-          parallel: false,
-          cwd: '{workspaceRoot}',
+
+  let projectExists: boolean;
+  try {
+    readProjectConfiguration(tree, fullyQualifiedName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (!projectExists) {
+    addProjectConfiguration(tree, fullyQualifiedName, {
+      name: fullyQualifiedName,
+      root: dir,
+      sourceRoot: joinPathFragments(dir, 'src'),
+      projectType: 'library',
+      targets: {
+        build: {
+          dependsOn: ['compile'],
+        },
+        compile: {
+          cache: true,
+          outputs: ['{workspaceRoot}/dist/{projectRoot}/build'],
+          executor: 'nx:run-commands',
+          options: {
+            commands: [
+              cmd.rm('dist/{projectRoot}/build'),
+              cmd.mkdir('dist/{projectRoot}/build'),
+              `${containers} build -f {projectRoot}/build.Dockerfile --target export --output type=local,dest=dist/{projectRoot}/build {projectRoot}`,
+            ],
+            parallel: false,
+            cwd: '{workspaceRoot}',
+          },
         },
       },
-    },
-  });
+    });
+  }
 
   const serviceName = options.serviceName ?? options.name;
   const serviceNameClassName = toClassName(serviceName);

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -8,7 +8,6 @@ import {
   generateFiles,
   installPackagesTask,
   joinPathFragments,
-  readProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
 import { getTsLibDetails } from '../../ts/lib/generator';
@@ -22,6 +21,7 @@ import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
+  projectExists,
 } from '../../utils/nx';
 import type { SmithyProjectGeneratorSchema } from './schema';
 
@@ -38,15 +38,7 @@ export const smithyProjectGenerator = async (
   // Create project.json
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, options);
 
-  let projectExists: boolean;
-  try {
-    readProjectConfiguration(tree, fullyQualifiedName);
-    projectExists = true;
-  } catch {
-    projectExists = false;
-  }
-
-  if (!projectExists) {
+  if (!projectExists(tree, fullyQualifiedName)) {
     addProjectConfiguration(tree, fullyQualifiedName, {
       name: fullyQualifiedName,
       root: dir,

--- a/packages/nx-plugin/src/terraform/project/generator.spec.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.spec.ts
@@ -7,6 +7,7 @@ import {
   readNxJson,
   readProjectConfiguration,
   type Tree,
+  updateProjectConfiguration,
 } from '@nx/devkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as tsLibGenerator from '../../ts/lib/generator';
@@ -478,6 +479,27 @@ describe('terraformProjectGenerator', () => {
       expect(
         tree.read('packages/my-terraform-project/src/main.tf', 'utf-8'),
       ).toEqual(mainTfAfterFirstRun);
+    });
+
+    it('should preserve project.json customisations when re-run', async () => {
+      await terraformProjectGenerator(tree, applicationSchema);
+
+      const config = readProjectConfiguration(
+        tree,
+        '@proj/my-terraform-project',
+      );
+      config.targets = {
+        ...config.targets,
+        custom: { executor: 'nx:noop' },
+      };
+      updateProjectConfiguration(tree, '@proj/my-terraform-project', config);
+
+      await terraformProjectGenerator(tree, applicationSchema);
+
+      expect(
+        readProjectConfiguration(tree, '@proj/my-terraform-project').targets
+          ?.custom,
+      ).toEqual({ executor: 'nx:noop' });
     });
 
     it('should create an independent project when run with a different name', async () => {

--- a/packages/nx-plugin/src/terraform/project/generator.spec.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.spec.ts
@@ -2,7 +2,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readNxJson, readProjectConfiguration, type Tree } from '@nx/devkit';
+import {
+  getProjects,
+  readNxJson,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as tsLibGenerator from '../../ts/lib/generator';
 import * as gitUtils from '../../utils/git';
@@ -447,6 +452,48 @@ describe('terraformProjectGenerator', () => {
     expect(tree.exists('packages/infra')).toBeTruthy();
     expect(tree.exists('packages/infra/src')).toBeTruthy();
     expect(tree.exists('packages/infra/src/main.tf')).toBeTruthy();
+  });
+
+  describe('idempotency', () => {
+    const applicationSchema: TerraformProjectGeneratorSchema = {
+      name: 'my-terraform-project',
+      type: 'application',
+      directory: 'packages',
+    };
+
+    it('should be idempotent when re-run with same options', async () => {
+      await terraformProjectGenerator(tree, applicationSchema);
+
+      const projectCountAfterFirstRun = getProjects(tree).size;
+      const mainTfAfterFirstRun = tree.read(
+        'packages/my-terraform-project/src/main.tf',
+        'utf-8',
+      );
+
+      await expect(
+        terraformProjectGenerator(tree, applicationSchema),
+      ).resolves.toBeDefined();
+
+      expect(getProjects(tree).size).toBe(projectCountAfterFirstRun);
+      expect(
+        tree.read('packages/my-terraform-project/src/main.tf', 'utf-8'),
+      ).toEqual(mainTfAfterFirstRun);
+    });
+
+    it('should create an independent project when run with a different name', async () => {
+      await terraformProjectGenerator(tree, applicationSchema);
+      await terraformProjectGenerator(tree, {
+        ...applicationSchema,
+        name: 'other-terraform-project',
+      });
+
+      expect(
+        readProjectConfiguration(tree, '@proj/my-terraform-project'),
+      ).toBeDefined();
+      expect(
+        readProjectConfiguration(tree, '@proj/other-terraform-project'),
+      ).toBeDefined();
+    });
   });
 
   describe('error handling', () => {

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -12,7 +12,6 @@ import {
   joinPathFragments,
   OverwriteStrategy,
   readNxJson,
-  readProjectConfiguration,
   type TargetConfiguration,
   type Tree,
   updateJson,
@@ -28,6 +27,7 @@ import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
+  projectExists,
 } from '../../utils/nx';
 import { sortObjectKeys } from '../../utils/object';
 import { uvxCommand } from '../../utils/py';
@@ -241,15 +241,7 @@ export async function terraformProjectGenerator(
     }),
   };
 
-  let projectExists: boolean;
-  try {
-    readProjectConfiguration(tree, lib.fullyQualifiedName);
-    projectExists = true;
-  } catch {
-    projectExists = false;
-  }
-
-  if (projectExists) {
+  if (projectExists(tree, lib.fullyQualifiedName)) {
     updateProjectConfiguration(tree, lib.fullyQualifiedName, {
       ...projectConfiguration,
       name: lib.fullyQualifiedName,

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -16,7 +16,6 @@ import {
   type Tree,
   updateJson,
   updateNxJson,
-  updateProjectConfiguration,
 } from '@nx/devkit';
 import { join, relative } from 'path';
 import { getTsLibDetails } from '../../ts/lib/generator';
@@ -241,12 +240,9 @@ export async function terraformProjectGenerator(
     }),
   };
 
-  if (projectExists(tree, lib.fullyQualifiedName)) {
-    updateProjectConfiguration(tree, lib.fullyQualifiedName, {
-      ...projectConfiguration,
-      name: lib.fullyQualifiedName,
-    });
-  } else {
+  // Only create the project configuration on first run; skip it on re-run so
+  // existing project.json customisations are preserved.
+  if (!projectExists(tree, lib.fullyQualifiedName)) {
     addProjectConfiguration(tree, lib.fullyQualifiedName, projectConfiguration);
   }
   addGeneratorMetadata(

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -12,10 +12,12 @@ import {
   joinPathFragments,
   OverwriteStrategy,
   readNxJson,
+  readProjectConfiguration,
   type TargetConfiguration,
   type Tree,
   updateJson,
   updateNxJson,
+  updateProjectConfiguration,
 } from '@nx/devkit';
 import { join, relative } from 'path';
 import { getTsLibDetails } from '../../ts/lib/generator';
@@ -229,7 +231,7 @@ export async function terraformProjectGenerator(
     },
   };
 
-  addProjectConfiguration(tree, lib.fullyQualifiedName, {
+  const projectConfiguration = {
     root: lib.dir,
     projectType: schema.type,
     sourceRoot: joinPathFragments(lib.dir, 'src'),
@@ -237,7 +239,24 @@ export async function terraformProjectGenerator(
       ...libTargets,
       ...(schema.type === 'application' ? applicationTargets : {}),
     }),
-  });
+  };
+
+  let projectExists: boolean;
+  try {
+    readProjectConfiguration(tree, lib.fullyQualifiedName);
+    projectExists = true;
+  } catch {
+    projectExists = false;
+  }
+
+  if (projectExists) {
+    updateProjectConfiguration(tree, lib.fullyQualifiedName, {
+      ...projectConfiguration,
+      name: lib.fullyQualifiedName,
+    });
+  } else {
+    addProjectConfiguration(tree, lib.fullyQualifiedName, projectConfiguration);
+  }
   addGeneratorMetadata(
     tree,
     lib.fullyQualifiedName,

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -229,6 +229,31 @@ describe('ts#astro-docs generator', () => {
     );
   });
 
+  it('should add the blog when re-run with the blog enabled', async () => {
+    await tsAstroDocsGenerator(tree, {
+      name: 'docs',
+      noBlog: true,
+      skipInstall: true,
+    });
+
+    expect(
+      tree.exists('docs/src/content/docs/en/blog/welcome.mdx'),
+    ).toBeFalsy();
+
+    await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
+
+    expect(
+      tree.exists('docs/src/content/docs/en/blog/welcome.mdx'),
+    ).toBeTruthy();
+
+    const packageJson = readJson(tree, 'package.json');
+    const deps = {
+      ...(packageJson.dependencies ?? {}),
+      ...(packageJson.devDependencies ?? {}),
+    };
+    expect(deps).toHaveProperty('starlight-blog');
+  });
+
   it('should create a second independent project when run with a different name', async () => {
     await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
     await tsAstroDocsGenerator(tree, {

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readJson, type Tree } from '@nx/devkit';
+import { getProjects, readJson, type Tree } from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
@@ -208,5 +208,39 @@ describe('ts#astro-docs generator', () => {
     });
 
     expectHasMetricTags(tree, TS_ASTRO_DOCS_GENERATOR_INFO.metric);
+  });
+
+  it('should be idempotent when re-run with the same options', async () => {
+    await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
+
+    const projectCountAfterFirstRun = getProjects(tree).size;
+    const indexAfterFirstRun = tree.read(
+      'docs/src/content/docs/en/index.mdx',
+      'utf-8',
+    );
+
+    await expect(
+      tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true }),
+    ).resolves.toBeDefined();
+
+    expect(getProjects(tree).size).toBe(projectCountAfterFirstRun);
+    expect(tree.read('docs/src/content/docs/en/index.mdx', 'utf-8')).toEqual(
+      indexAfterFirstRun,
+    );
+  });
+
+  it('should create a second independent project when run with a different name', async () => {
+    await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
+    await tsAstroDocsGenerator(tree, {
+      name: 'other-docs',
+      skipInstall: true,
+    });
+
+    expect(tree.exists('docs/project.json')).toBeTruthy();
+    expect(tree.exists('other-docs/project.json')).toBeTruthy();
+    expect(readJson(tree, 'docs/project.json').name).toBe('@proj/docs');
+    expect(readJson(tree, 'other-docs/project.json').name).toBe(
+      '@proj/other-docs',
+    );
   });
 });

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -7,10 +7,8 @@ import {
   addProjectConfiguration,
   type GeneratorCallback,
   generateFiles,
-  getProjects,
   installPackagesTask,
   joinPathFragments,
-  logger,
   OverwriteStrategy,
   type ProjectConfiguration,
   type Tree,
@@ -23,6 +21,7 @@ import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
+  projectExists,
 } from '../../utils/nx';
 import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
 import { type ITsDepVersion, withVersions } from '../../utils/versions';
@@ -46,12 +45,7 @@ export const tsAstroDocsGenerator = async (
     schema.subDirectory || docsNameKebabCase,
   );
 
-  if (getProjects(tree).has(fullyQualifiedName)) {
-    logger.info(
-      `Project ${fullyQualifiedName} already exists, skipping ts#astro-docs generator.`,
-    );
-    return () => {};
-  }
+  const alreadyExists = projectExists(tree, fullyQualifiedName);
 
   const targets: ProjectConfiguration['targets'] = {
     build: {
@@ -96,13 +90,15 @@ export const tsAstroDocsGenerator = async (
     };
   }
 
-  addProjectConfiguration(tree, fullyQualifiedName, {
-    name: fullyQualifiedName,
-    root: dir,
-    sourceRoot: joinPathFragments(dir, 'src'),
-    projectType: 'application',
-    targets,
-  });
+  if (!alreadyExists) {
+    addProjectConfiguration(tree, fullyQualifiedName, {
+      name: fullyQualifiedName,
+      root: dir,
+      sourceRoot: joinPathFragments(dir, 'src'),
+      projectType: 'application',
+      targets,
+    });
+  }
 
   const templateOptions = {
     fullyQualifiedName,

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -7,8 +7,10 @@ import {
   addProjectConfiguration,
   type GeneratorCallback,
   generateFiles,
+  getProjects,
   installPackagesTask,
   joinPathFragments,
+  logger,
   OverwriteStrategy,
   type ProjectConfiguration,
   type Tree,
@@ -43,6 +45,13 @@ export const tsAstroDocsGenerator = async (
     schema.directory || '.',
     schema.subDirectory || docsNameKebabCase,
   );
+
+  if (getProjects(tree).has(fullyQualifiedName)) {
+    logger.info(
+      `Project ${fullyQualifiedName} already exists, skipping ts#astro-docs generator.`,
+    );
+    return () => {};
+  }
 
   const targets: ProjectConfiguration['targets'] = {
     build: {

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -69,6 +69,19 @@ export const readProjectConfigurationUnqualified = (
 };
 
 /**
+ * Returns whether a project with the given name already exists in the workspace.
+ * The project name may be unqualified (ie may omit the scope prefix).
+ */
+export const projectExists = (tree: Tree, projectName: string): boolean => {
+  try {
+    readProjectConfigurationUnqualified(tree, projectName);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Add metadata about the generator that generated the project to the project.json
  */
 export const addGeneratorMetadata = (


### PR DESCRIPTION
### Reason for this change

Re-running several generators with the same options threw a hard `A project already exists` error (from `addProjectConfiguration`/`libraryGenerator`) instead of being a clean no-op. This is one of the gaps flagged in #124: re-running a generator with the same options should be a graceful no-op (or skip with a log), not a failure.

### Description of changes

Added existing-project guards to the four generators that called `addProjectConfiguration` (directly or via `tsProjectGenerator`) unconditionally. First-run output is unchanged (no snapshots changed); a different name still creates a new independent project.

- **ts#infra** (`infra/app/generator.ts`) — guard `tsProjectGenerator` behind a `readProjectConfiguration` existence check (mirrors the ts#dynamodb / trpc#backend pattern). Downstream `updateJson`/`generateFiles`/`addDependencyToTargetIfNotPresent` were already re-run safe.
- **terraform#project** (`terraform/project/generator.ts`) — when the project already exists, use `updateProjectConfiguration` instead of `addProjectConfiguration`; otherwise add as before. The nx.json plugin add and `generateFiles` (Overwrite) were already safe.
- **smithy#project** (`smithy/project/generator.ts`) — guard `addProjectConfiguration` behind an existence check (the only standalone project generator missing the pattern).
- **ts#astro-docs** (`ts/astro-docs/generator.ts`) — return early with an informative `logger.info` if the project already exists, rather than throwing. Since ts#docs delegates to ts#astro-docs, this fixes both.

### Description of how you validated changes

Added `should be idempotent when re-run with same options` spec tests to each generator (run twice on the same tree, assert no throw, same project count, same file content) plus a `different name creates an independent project` test. `pnpm nx run @aws/nx-plugin:test` passes (2018 tests) with no snapshot changes, confirming first-run output is byte-identical. `build` and `lint` pass.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*