### PR TITLE
fix(generators): make py#lambda-function and ts#nx-generator idempotent on re-run

### DIFF
--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -64,6 +64,51 @@ describe('lambda-handler project generator', () => {
     ).toBeTruthy();
   });
 
+  it('should not overwrite an existing handler when re-run', async () => {
+    tree.write(
+      'apps/test_project/project.json',
+      JSON.stringify({
+        name: 'test-project',
+        root: 'apps/test_project',
+        sourceRoot: 'apps/test_project/test_project',
+        targets: {},
+      }),
+    );
+
+    tree.write(
+      'apps/test_project/pyproject.toml',
+      `[project]
+          dependencies = []
+      `,
+    );
+
+    const options = {
+      project: 'test-project',
+      name: 'test-function',
+      event: 'Any' as const,
+      iac: 'cdk' as const,
+    };
+
+    await pyLambdaFunctionGenerator(tree, options);
+
+    const handlerPath = 'apps/test_project/test_project/test_function.py';
+    const testPath = 'apps/test_project/tests/test_test_function.py';
+
+    // Simulate user edits to the handler and its test
+    const customHandler =
+      '# my custom handler\ndef lambda_handler(event, context):\n    return "custom"\n';
+    const customTest = '# my custom test\n';
+    tree.write(handlerPath, customHandler);
+    tree.write(testPath, customTest);
+
+    // Re-run with the same options
+    await pyLambdaFunctionGenerator(tree, options);
+
+    // User edits should be preserved
+    expect(tree.read(handlerPath, 'utf-8')).toBe(customHandler);
+    expect(tree.read(testPath, 'utf-8')).toBe(customTest);
+  });
+
   it('should set up project configuration with Lambda Function targets', async () => {
     tree.write(
       'apps/test_project/project.json',

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -170,7 +170,7 @@ export const pyLambdaFunctionGenerator = async (
     joinPathFragments(__dirname, 'files', 'handler'), // path to the file templates
     joinPathFragments(projectConfig.sourceRoot, schema.functionPath ?? ''),
     enhancedOptions,
-    { overwriteStrategy: OverwriteStrategy.Overwrite },
+    { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
 
   // Generate the lambda handler test file
@@ -179,7 +179,7 @@ export const pyLambdaFunctionGenerator = async (
     joinPathFragments(__dirname, 'files', 'tests'),
     joinPathFragments(dir, 'tests'),
     enhancedOptions,
-    { overwriteStrategy: OverwriteStrategy.Overwrite },
+    { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
 
   addDependenciesToPyProjectToml(tree, dir, [

--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -207,6 +207,45 @@ describe('nx-generator generator', () => {
       expect(generatorsJson.generators['empty#test'].metric).toBe('g1');
     });
 
+    it('should preserve the metric on same-name re-run', async () => {
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      const generatorsJsonAfterFirstRun = JSON.parse(
+        tree.read('packages/nx-plugin/generators.json', 'utf-8'),
+      );
+      const metricAfterFirstRun =
+        generatorsJsonAfterFirstRun.generators['foo#bar'].metric;
+      expect(metricAfterFirstRun).toBe('g42');
+
+      // Re-run with the same name
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      const generatorsJsonAfterSecondRun = JSON.parse(
+        tree.read('packages/nx-plugin/generators.json', 'utf-8'),
+      );
+
+      // The metric should be unchanged on re-run
+      expect(generatorsJsonAfterSecondRun.generators['foo#bar'].metric).toBe(
+        metricAfterFirstRun,
+      );
+
+      // Other entries should not be corrupted
+      expect(generatorsJsonAfterSecondRun.generators['existing']).toEqual(
+        generatorsJsonAfterFirstRun.generators['existing'],
+      );
+      expect(generatorsJsonAfterSecondRun.generators['another']).toEqual(
+        generatorsJsonAfterFirstRun.generators['another'],
+      );
+    });
+
     it('should support a nested directory', async () => {
       await tsNxGeneratorGenerator(tree, {
         project: NxPluginForAwsProjectJson.name,

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -143,6 +143,12 @@ export const tsNxGeneratorGenerator = async (
   const existingGenerators = Object.values(
     generatorsJson?.generators ?? {},
   ) as any[];
+  // Reuse the existing metric for a same-name re-run, otherwise allocate a new one
+  const metric =
+    generatorsJson?.generators?.[name]?.metric ??
+    (existingGenerators.length > 0
+      ? incrementMetric(existingGenerators.map((g) => g.metric))
+      : 'g1');
   writeJson(tree, generatorsJsonPath, {
     ...generatorsJson,
     generators: sortObjectKeys({
@@ -152,16 +158,7 @@ export const tsNxGeneratorGenerator = async (
         schema: `${factoryBasePath}/schema.json`,
         description:
           description ?? 'TODO: Add short description of the generator',
-        ...(isNxPluginForAws
-          ? {
-              metric:
-                existingGenerators.length > 0
-                  ? incrementMetric(
-                      Object.values(existingGenerators).map((g) => g.metric),
-                    )
-                  : 'g1',
-            }
-          : {}),
+        ...(isNxPluginForAws ? { metric } : {}),
       },
     }),
   });


### PR DESCRIPTION
### Reason for this change

Re-running a scaffolding generator with the same options should not silently clobber user files or churn metadata. Two generators violated this:

- `py#lambda-function` generated the handler file and its test with `OverwriteStrategy.Overwrite`, so a same-options re-run silently overwrote any user edits to the handler/test. The TypeScript equivalent (`ts#lambda-function`) already uses `OverwriteStrategy.KeepExisting`.
- `ts#nx-generator` recomputed the metric id on every run. On a same-name re-run it would allocate `g{max+1}` again, changing the existing generator's metric id each time (metric churn).

### Description of changes

- `py/lambda-function/generator.ts`: switch the handler and test `generateFiles` calls from `OverwriteStrategy.Overwrite` to `OverwriteStrategy.KeepExisting`, matching the `ts#lambda-function` behaviour. A same-options re-run is now a true no-op that preserves user code.
- `ts/nx-generator/generator.ts`: reuse the existing `metric` value from `generators.json` when an entry with the same name already exists, only allocating a fresh metric for a brand-new name. First-run behaviour (new name gets a fresh metric) is unchanged.

First-run output is byte-identical for both generators (no snapshot changes).

### Description of how you validated changes

- Added `py#lambda-function` test: generate, write custom content into the handler and test, re-run with the same options, assert the custom content is preserved.
- Added `ts#nx-generator` test: run twice with the same name, assert the entry's metric is unchanged between runs and other entries are not corrupted.
- `pnpm nx run @aws/nx-plugin:test` passes (2012 tests, no snapshot changes).
- `pnpm nx run-many --target build --all` passes.
- `pnpm nx run-many --target lint --all --fix` passes.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*