### PR TITLE
fix(ts#nx-generator): make generator idempotent on re-run

### DIFF
--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -246,6 +246,29 @@ describe('nx-generator generator', () => {
       );
     });
 
+    it('should preserve user-implemented files on same-name re-run', async () => {
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      // Simulate the user implementing the scaffolded generator
+      const generatorPath = 'packages/nx-plugin/src/foo-bar/generator.ts';
+      const userContent = '// my implemented generator\n';
+      tree.write(generatorPath, userContent);
+
+      // Re-run with the same name
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      // The user's implementation must be preserved, not overwritten by the scaffold
+      expect(tree.read(generatorPath, 'utf-8')).toBe(userContent);
+    });
+
     it('should support a nested directory', async () => {
       await tsNxGeneratorGenerator(tree, {
         project: NxPluginForAwsProjectJson.name,
@@ -618,6 +641,29 @@ describe('nx-generator generator', () => {
       expect(indexContent).toContain(
         "export * from './export-test/generator';",
       );
+    });
+
+    it('should preserve user-implemented files on same-name re-run', async () => {
+      await tsNxGeneratorGenerator(tree, {
+        project: '@test/plugin',
+        name: 'my#generator',
+        description: 'Some description',
+      });
+
+      // Simulate the user implementing the scaffolded generator
+      const generatorPath = 'tools/plugin/src/my-generator/generator.ts';
+      const userContent = '// my implemented generator\n';
+      tree.write(generatorPath, userContent);
+
+      // Re-run with the same name
+      await tsNxGeneratorGenerator(tree, {
+        project: '@test/plugin',
+        name: 'my#generator',
+        description: 'Some description',
+      });
+
+      // The user's implementation must be preserved, not overwritten by the scaffold
+      expect(tree.read(generatorPath, 'utf-8')).toBe(userContent);
     });
 
     it('should add generator metric to app.ts', async () => {

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -7,6 +7,7 @@ import {
   generateFiles,
   installPackagesTask,
   joinPathFragments,
+  OverwriteStrategy,
   readJson,
   type Tree,
   writeJson,
@@ -63,7 +64,7 @@ export const tsNxGeneratorGenerator = async (
     generatorSubDir,
   };
 
-  // Add the common files
+  // Add the common files, preserving any the user has already implemented
   generateFiles(
     tree,
     joinPathFragments(__dirname, 'files', 'common'),
@@ -71,6 +72,7 @@ export const tsNxGeneratorGenerator = async (
     {
       ...enhancedOptions,
     },
+    { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
 
   // Add the files specific to this repo vs a local generator in another project
@@ -90,6 +92,7 @@ export const tsNxGeneratorGenerator = async (
       {
         ...enhancedOptions,
       },
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
     );
 
     // Generate guide page in docs
@@ -100,6 +103,7 @@ export const tsNxGeneratorGenerator = async (
       {
         ...enhancedOptions,
       },
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
     );
 
     // Update the docs config to add the page entry to the Generator guides sidebar section
@@ -117,6 +121,7 @@ export const tsNxGeneratorGenerator = async (
       {
         ...enhancedOptions,
       },
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
     );
 
     const indexPath = joinPathFragments(sourceRoot, 'index.ts');
@@ -140,15 +145,17 @@ export const tsNxGeneratorGenerator = async (
   const generatorsJson = tree.exists(generatorsJsonPath)
     ? readJson(tree, generatorsJsonPath)
     : { generators: {} };
-  const existingGenerators = Object.values(
-    generatorsJson?.generators ?? {},
-  ) as any[];
-  // Reuse the existing metric for a same-name re-run, otherwise allocate a new one
-  const metric =
-    generatorsJson?.generators?.[name]?.metric ??
-    (existingGenerators.length > 0
-      ? incrementMetric(existingGenerators.map((g) => g.metric))
-      : 'g1');
+  // Metrics are only tracked within the @aws/nx-plugin repo. Reuse the existing
+  // metric for a same-name re-run, otherwise allocate a new one.
+  let metric: string | undefined;
+  if (isNxPluginForAws) {
+    const existingMetrics = Object.values(generatorsJson?.generators ?? {})
+      .map((g: any) => g.metric)
+      .filter((m): m is string => typeof m === 'string');
+    metric =
+      generatorsJson?.generators?.[name]?.metric ??
+      (existingMetrics.length > 0 ? incrementMetric(existingMetrics) : 'g1');
+  }
   writeJson(tree, generatorsJsonPath, {
     ...generatorsJson,
     generators: sortObjectKeys({


### PR DESCRIPTION
### Reason for this change

`ts#nx-generator` scaffolds a generator skeleton that the user then implements. Re-running it with the same name **overwrote the user's implemented files** (`generator.ts`, `schema.json`, `schema.d.ts`, spec, docs page) because every `generateFiles` call defaulted to `OverwriteStrategy.Overwrite`. This meant the generator could not be safely re-run — contradicting the goal that all scaffolding generators should be idempotent (no "not idempotent by design" exemption).

A same-name re-run also **crashed in a local (non `@aws/nx-plugin`) workspace**: `incrementMetric` was called unconditionally, but locally-generated `generators.json` entries have no `metric` field, so the re-run fed `undefined` into `m.slice(1)`.

### Description of changes

- Generate all scaffold files with `OverwriteStrategy.KeepExisting`, so a same-name re-run preserves the user's implementation. Framework-owned config still converges: the `generators.json` entry is keyed by name (overwrites, no duplicate), the docs sidebar insertion is GritQL-guarded, and `addStarExport` / `addComponentGeneratorMetadata` dedup.
- Only compute the metric within the `@aws/nx-plugin` repo, and filter to defined metric values, fixing the local-workspace re-run crash.

### Description of how you validated changes

- Added `should preserve user-implemented files on same-name re-run` tests for both the `@aws/nx-plugin` path and the local-workspace path (write user content into the scaffolded `generator.ts`, re-run, assert it survives). The local-path test reproduced the metric crash.
- `pnpm nx run @aws/nx-plugin:test`: 2027 tests pass, no snapshot changes (first-run output unchanged).
- `pnpm nx run-many --target build --all` and lint pass.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*