### PR TITLE
docs: use public generator ids in README and contributing example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Add `generator: <id>` to the page's frontmatter. This wires the page into the op
 ---
 title: tRPC API
 description: Reference documentation for the tRPC API generator
-generator: ts#trpc-api
+generator: ts#api
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,20 +133,20 @@ Create a workspace and start adding components — zero configuration required:
 
 ```bash
 # Create a new workspace
-pnpm create @aws/nx-workspace my-project
+pnpm create @aws/nx-workspace@next my-project
 cd my-project
 
 # Add a tRPC API
-pnpm nx g @aws/nx-plugin:ts#trpc-api
+pnpm nx g @aws/nx-plugin:ts#api --framework=trpc
 
 # Add a Strands AI agent (Python)
 pnpm nx g @aws/nx-plugin:py#agent
 
 # Add a React website
-pnpm nx g @aws/nx-plugin:ts#react-website
+pnpm nx g @aws/nx-plugin:ts#website --framework=react
 
 # Add authentication to your website
-pnpm nx g @aws/nx-plugin:ts#react-website#auth
+pnpm nx g @aws/nx-plugin:ts#website#auth
 
 # Connect your website to your API and agent
 pnpm nx g @aws/nx-plugin:connection
@@ -162,17 +162,17 @@ pnpm nx g @aws/nx-plugin:ts#infra
 | Generator               | Description                                                                                                       |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `ts#project`            | TypeScript library                                                                                                |
-| `ts#trpc-api`           | tRPC API with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
+| `ts#api`                | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
 | `ts#rdb`                | Relational databases with Aurora RDS                                                                              |
-| `ts#react-website`      | React app (Vite)                                                                                                  |
-| `ts#react-website#auth` | Add Cognito auth to a React website                                                                               |
+| `ts#website`            | React app (Vite)                                                                                                  |
+| `ts#website#auth`       | Add Cognito auth to a website                                                                                     |
 | `ts#infra`              | AWS CDK infrastructure project                                                                                    |
 | `ts#lambda-function`    | TypeScript Lambda with type-safe event sources                                                                    |
 | `ts#mcp-server`         | MCP server (TypeScript)                                                                                           |
 | `ts#agent`              | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                          |
 | `ts#nx-generator`       | Nx generator scaffold                                                                                             |
 | `py#project`            | Python project (uv)                                                                                               |
-| `py#fast-api`           | FastAPI with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)      |
+| `py#api`                | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)      |
 | `py#lambda-function`    | Python Lambda with type-safe event sources                                                                        |
 | `py#mcp-server`         | MCP server (Python)                                                                                               |
 | `py#agent`              | [Strands Agent](https://strandsagents.com/) (Python)                                                              |

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -133,20 +133,20 @@ Create a workspace and start adding components — zero configuration required:
 
 ```bash
 # Create a new workspace
-pnpm create @aws/nx-workspace my-project
+pnpm create @aws/nx-workspace@next my-project
 cd my-project
 
 # Add a tRPC API
-pnpm nx g @aws/nx-plugin:ts#trpc-api
+pnpm nx g @aws/nx-plugin:ts#api --framework=trpc
 
 # Add a Strands AI agent (Python)
 pnpm nx g @aws/nx-plugin:py#agent
 
 # Add a React website
-pnpm nx g @aws/nx-plugin:ts#react-website
+pnpm nx g @aws/nx-plugin:ts#website --framework=react
 
 # Add authentication to your website
-pnpm nx g @aws/nx-plugin:ts#react-website#auth
+pnpm nx g @aws/nx-plugin:ts#website#auth
 
 # Connect your website to your API and agent
 pnpm nx g @aws/nx-plugin:connection
@@ -162,17 +162,17 @@ pnpm nx g @aws/nx-plugin:ts#infra
 | Generator               | Description                                                                                                       |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `ts#project`            | TypeScript library                                                                                                |
-| `ts#trpc-api`           | tRPC API with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
+| `ts#api`                | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
 | `ts#rdb`                | Relational databases with Aurora RDS                                                                              |
-| `ts#react-website`      | React app (Vite)                                                                                                  |
-| `ts#react-website#auth` | Add Cognito auth to a React website                                                                               |
+| `ts#website`            | React app (Vite)                                                                                                  |
+| `ts#website#auth`       | Add Cognito auth to a website                                                                                     |
 | `ts#infra`              | AWS CDK infrastructure project                                                                                    |
 | `ts#lambda-function`    | TypeScript Lambda with type-safe event sources                                                                    |
 | `ts#mcp-server`         | MCP server (TypeScript)                                                                                           |
 | `ts#agent`              | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                          |
 | `ts#nx-generator`       | Nx generator scaffold                                                                                             |
 | `py#project`            | Python project (uv)                                                                                               |
-| `py#fast-api`           | FastAPI with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)      |
+| `py#api`                | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)      |
 | `py#lambda-function`    | Python Lambda with type-safe event sources                                                                        |
 | `py#mcp-server`         | MCP server (Python)                                                                                               |
 | `py#agent`              | [Strands Agent](https://strandsagents.com/) (Python)                                                              |


### PR DESCRIPTION

### Reason for this change

Follow-up to #775. That PR switched the documentation site's generator guides to public generator ids (e.g. `py#api` instead of the hidden `py#fast-api`). The repository **README** still pointed users at hidden ids in both its "Build with the CLI" examples and its "Available Generators" table, and the `create-workspace` command didn't use the `@next` tag. A frontmatter example in CONTRIBUTING.md also no longer matched the actual guide page.

### Description of changes

Updated `packages/nx-plugin/README.md` (the source of truth — the root `README.md` is generated from it by the pre-commit hook, so both are updated):

- CLI examples: `ts#trpc-api` → `ts#api --framework=trpc`, `ts#react-website` → `ts#website --framework=react`, `ts#react-website#auth` → `ts#website#auth`, and `create @aws/nx-workspace` → `create @aws/nx-workspace@next`.
- "Available Generators" table: replaced the hidden ids (`ts#trpc-api`, `ts#react-website`, `ts#react-website#auth`, `py#fast-api`) with the public umbrella generators (`ts#api`, `ts#website`, `ts#website#auth`, `py#api`), updating the descriptions to reflect that `ts#api` covers tRPC or Smithy and `py#api` covers FastAPI.

Updated `CONTRIBUTING.md`: the "Linking a guide to its generator" example used `generator: ts#trpc-api`, which is now inconsistent with the actual `trpc.mdx` page — changed to `generator: ts#api`.

**Intentionally left unchanged**: the PDK migration guide (point-in-time, pins a plugin version), the connection `when: sourceType/targetType` taxonomy, the `ts#trpc-api#procedure` tutorial generator, CONTRIBUTING's internal generator-behaviour lists, and the RELEASE.md commit-scope example.

### Description of how you validated changes

- Verified every changed id against `packages/nx-plugin/generators.json` and the relevant `schema.json` files (`ts#api` framework: trpc|smithy; `ts#website` framework: react; `py#api` framework: fastapi).
- Confirmed the root `README.md` is generated from `packages/nx-plugin/README.md` via the pre-commit hook (`cp packages/nx-plugin/README.md README.md`) and that both are in sync.
- Full `@aws/nx-plugin` test suite passes via the pre-commit hook.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
