### PR TITLE
test(e2e): add idempotency smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           - smithy-api
           - react-website
           - infra-none
+          - idempotency
           - cdk-deploy
           - cdk-deploy-rdb
           - terraform-deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,6 +82,7 @@ jobs:
           - smithy-api
           - react-website
           - infra-none
+          - idempotency
           - license-sync
           - license-check
           - mcp-server

--- a/e2e/src/smoke-tests/idempotency.spec.ts
+++ b/e2e/src/smoke-tests/idempotency.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { ensureDirSync } from 'fs-extra';
+import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { runGeneratorMatrix } from './generator-matrix';
+
+/**
+ * idempotency smoke test — runs the full generator matrix, commits the result,
+ * then runs the exact same matrix again and asserts there is no git diff.
+ *
+ * Generators must be idempotent: re-running with the same options must not
+ * overwrite user-touched files, duplicate wiring, or otherwise mutate the
+ * workspace. A non-empty git status after the second pass means some generator
+ * is not idempotent.
+ */
+describe('smoke test - idempotency', () => {
+  const pkgMgr = 'pnpm';
+  const targetDir = `${tmpProjPath()}/idempotency-${pkgMgr}`;
+
+  beforeEach(() => {
+    console.log(`Cleaning target directory ${targetDir}`);
+    if (existsSync(targetDir)) {
+      rmSync(targetDir, { force: true, recursive: true });
+    }
+    ensureDirSync(targetDir);
+  });
+
+  it('should produce no git diff when the generator matrix is re-run', async () => {
+    await runCLI(
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'cdk')} --interactive=false --skipGit`,
+      {
+        cwd: targetDir,
+        prefixWithPackageManagerCmd: false,
+        redirectStderr: true,
+      },
+    );
+    const projectRoot = `${targetDir}/e2e-test`;
+    const opts = {
+      cwd: projectRoot,
+      env: {
+        NX_DAEMON: 'false',
+        NODE_OPTIONS: '--max-old-space-size=8192',
+      },
+    };
+
+    const git = (command: string): string =>
+      execSync(`git ${command}`, {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+        maxBuffer: 50 * 1024 * 1024,
+      });
+
+    // CDK-specific infrastructure projects (mirrors runSmokeTest).
+    await runCLI(
+      `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive`,
+      opts,
+    );
+    await runCLI(
+      `generate @aws/nx-plugin:ts#infra --name=infra-with-stages --enableStageConfig=true --no-interactive`,
+      opts,
+    );
+
+    // First pass — scaffold the full matrix.
+    await runGeneratorMatrix(opts);
+
+    // Terraform project alongside CDK (mirrors runSmokeTest).
+    await runCLI(
+      `generate @aws/nx-plugin:terraform#project --name=tf-infra --no-interactive`,
+      opts,
+    );
+
+    // Commit the generated workspace as the baseline. The workspace was created
+    // with --skipGit, so initialise a repo here. The generated .gitignore keeps
+    // node_modules / build output out of the snapshot.
+    git('init');
+    git('add -A');
+    git('-c user.name=e2e -c user.email=e2e@example.com commit -m baseline --no-verify');
+
+    // Second pass — re-run the exact same matrix on the committed workspace.
+    await runCLI(
+      `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive`,
+      opts,
+    );
+    await runCLI(
+      `generate @aws/nx-plugin:ts#infra --name=infra-with-stages --enableStageConfig=true --no-interactive`,
+      opts,
+    );
+    await runGeneratorMatrix(opts);
+    await runCLI(
+      `generate @aws/nx-plugin:terraform#project --name=tf-infra --no-interactive`,
+      opts,
+    );
+
+    // Any change (modified, added or deleted tracked files) means a generator
+    // mutated the workspace on re-run and is therefore not idempotent.
+    const status = git('status --porcelain').trim();
+    if (status) {
+      // Surface the offending files and the actual diff in the failure output.
+      const diff = git('diff');
+      throw new Error(
+        `Generators were not idempotent — re-running the matrix changed the workspace:\n\n${status}\n\n${diff}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Reason for this change

Issue #124 requires generators to be idempotent — re-running with the same options must not overwrite user-touched files, duplicate wiring, or otherwise mutate the workspace. We had per-generator unit tests but no end-to-end check that the **whole matrix** is idempotent together.

### Description of changes

Adds `e2e/src/smoke-tests/idempotency.spec.ts`: it runs the full generator matrix (`runGeneratorMatrix` plus the CDK `ts#infra` projects and a terraform project), `git init` + commits the result, runs the **exact same matrix again**, and asserts `git status --porcelain` is empty. A non-empty status (modified/added/deleted tracked files) means a generator mutated the workspace on re-run and is therefore not idempotent — the failure surfaces the offending files and the diff.

Registered as `idempotency` in the CI and PR smoke-test matrices.

### Description of how you validated changes

Ran locally. The test **works and currently fails**, surfacing real non-idempotency bugs (react-website overwriting user files, website auth throwing on re-run, shared-config key/order/dup churn, terraform metric-tag growth). Companion PRs fix each of these; this PR adds the guard rail. Once the fixes land, the matrix re-run produces no diff.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*