### PR TITLE
fix(ts#react-website): make generator idempotent (preserve user files on re-run)

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -681,6 +681,45 @@ describe('react-website generator', () => {
     expect(tree.exists('packages/websites/src/main.tsx')).toBeTruthy();
   });
 
+  describe('idempotency', () => {
+    it('should preserve user edits to main.tsx, AppLayout and styles.css on re-run', async () => {
+      await tsReactWebsiteGenerator(tree, options);
+
+      const mainPath = 'test-app/src/main.tsx';
+      const appLayoutPath = 'test-app/src/components/AppLayout/index.tsx';
+      const stylesPath = 'test-app/src/styles.css';
+      const rootRoutePath = 'test-app/src/routes/__root.tsx';
+      const indexRoutePath = 'test-app/src/routes/index.tsx';
+      const configPath = 'test-app/src/config.ts';
+
+      const userMain = '// user edited main\nexport const MAIN = true;\n';
+      const userAppLayout =
+        '// user edited app layout\nexport const LAYOUT = true;\n';
+      const userStyles = "@import 'tailwindcss';\n/* user edited styles */\n";
+      const userRootRoute =
+        '// user edited root route\nexport const ROOT = true;\n';
+      const userIndexRoute =
+        '// user edited index route\nexport const INDEX = true;\n';
+      const userConfig = '// user edited config\nexport const CONFIG = true;\n';
+
+      tree.write(mainPath, userMain);
+      tree.write(appLayoutPath, userAppLayout);
+      tree.write(stylesPath, userStyles);
+      tree.write(rootRoutePath, userRootRoute);
+      tree.write(indexRoutePath, userIndexRoute);
+      tree.write(configPath, userConfig);
+
+      await tsReactWebsiteGenerator(tree, options);
+
+      expect(tree.read(mainPath, 'utf-8')).toBe(userMain);
+      expect(tree.read(appLayoutPath, 'utf-8')).toBe(userAppLayout);
+      expect(tree.read(stylesPath, 'utf-8')).toBe(userStyles);
+      expect(tree.read(rootRoutePath, 'utf-8')).toBe(userRootRoute);
+      expect(tree.read(indexRoutePath, 'utf-8')).toBe(userIndexRoute);
+      expect(tree.read(configPath, 'utf-8')).toBe(userConfig);
+    });
+  });
+
   describe('infra=none idempotency', () => {
     it('should generate with infra=none then upgrade to infra=cloudfront-s3', async () => {
       await tsReactWebsiteGenerator(tree, { ...options, infra: 'none' });

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -280,7 +280,8 @@ export async function tsReactWebsiteGenerator(
     libraryRoot, // destination path of the files
     templateOptions, // config object to replace variable in file templates
     {
-      overwriteStrategy: OverwriteStrategy.Overwrite,
+      // User-editable source - preserve any edits on re-run
+      overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
   );
 
@@ -290,7 +291,8 @@ export async function tsReactWebsiteGenerator(
     libraryRoot, // destination path of the files
     templateOptions, // config object to replace variable in file templates
     {
-      overwriteStrategy: OverwriteStrategy.Overwrite,
+      // User-editable source - preserve any edits on re-run
+      overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
   );
 
@@ -310,7 +312,8 @@ export async function tsReactWebsiteGenerator(
       libraryRoot,
       templateOptions,
       {
-        overwriteStrategy: OverwriteStrategy.Overwrite,
+        // User-editable source (and the TanStack-managed route tree) - preserve on re-run
+        overwriteStrategy: OverwriteStrategy.KeepExisting,
       },
     );
 
@@ -320,7 +323,8 @@ export async function tsReactWebsiteGenerator(
       libraryRoot,
       templateOptions, // config object to replace variable in file templates
       {
-        overwriteStrategy: OverwriteStrategy.Overwrite,
+        // User-editable source - preserve any edits on re-run
+        overwriteStrategy: OverwriteStrategy.KeepExisting,
       },
     );
     tree.delete(joinPathFragments(websiteContentPath, 'src', 'app.tsx'));


### PR DESCRIPTION
### Reason for this change

A new e2e idempotency smoke test runs the full generator matrix, commits, re-runs the same matrix and asserts no git diff. It found that re-running `ts#website` (alias of `ts#react-website`) is destructive.

The generator emitted user-owned source under `src/` with `OverwriteStrategy.Overwrite`. On a second run this regenerated those files back to the bare scaffold, wiping everything later generators (connection, `ts#react-website#auth` / cognito-auth, runtime-config) had added:

- `src/main.tsx` lost all connection providers, the `<CognitoAuth>` wrapper, `RuntimeConfigProvider`, `useRuntimeConfig`/`useAuth`, the `RouterProviderContext` type members and the router `context`.
- `src/components/AppLayout/index.tsx` lost the auth `useAuth()` hook and the sign-out `utilities={[...]}` menu.
- `src/styles.css` flipped quote style (`@import 'tailwindcss';` to `@import "tailwindcss";`) when regenerated and reformatted.

### Description of changes

Generate the user-editable React source with `OverwriteStrategy.KeepExisting` instead of `Overwrite`, for all four `generateFiles` calls that write into the website `src/` (app common, app per-UX, tanstack-router common, tanstack-router per-UX). This covers `main.tsx`, `styles.css`, `config.ts`, `AppLayout`, `__root.tsx`, the routes and the TanStack-managed route tree.

First-run output is unchanged: on a fresh project the `src` directory is deleted and freshly scaffolded before generation, so `KeepExisting` writes the same files as before. Only re-run behaviour changes - existing files are now left alone. Framework-owned config (project targets, tsconfig, vite config via guarded GritQL transforms) continues to update in place.

### Description of how you validated changes

- Added a unit test `should preserve user edits to main.tsx, AppLayout and styles.css on re-run` that runs the generator, writes marker content into `main.tsx`, `AppLayout/index.tsx`, `styles.css`, the routes and `config.ts`, re-runs with the same options and asserts the markers are preserved. Verified this test FAILS on the previous (Overwrite) generator and PASSES with the fix.
- `pnpm nx run @aws/nx-plugin:build` (runs the full unit test suite): 2038 tests pass, no first-run snapshot changes.
- `pnpm nx run-many --target build --all` and `pnpm nx run-many --target lint --all --fix` pass.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*