### PR TITLE
fix(ts#react-website#auth): make generator idempotent on re-run

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -281,8 +281,6 @@ export class UserIdentity extends Construct {
 "
 `;
 
-exports[`cognito-auth generator > should not be able to run the generator multiple times 1`] = `[Error: This generator has already been run on test-project.]`;
-
 exports[`cognito-auth generator > should update main.tsx when RuntimeConfigProvider exists > main-tsx-with-runtime-config 1`] = `
 "import CognitoAuth from './components/CognitoAuth';
 import { RuntimeConfigProvider } from './components/RuntimeConfig';

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.ux-provider.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.ux-provider.spec.ts.snap
@@ -286,26 +286,6 @@ const AppLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
               Sign out
             </button>
           </div>
-          <div className="user-greeting">
-            <span>Hi, {\`\${user?.profile?.['cognito:username']}\`}</span>
-            <button
-              type="button"
-              className="signout-link"
-              onClick={() => {
-                removeUser();
-                signoutRedirect({
-                  post_logout_redirect_uri: window.location.origin,
-                  extraQueryParams: {
-                    redirect_uri: window.location.origin,
-                    response_type: 'code',
-                  },
-                });
-                clearStaleState();
-              }}
-            >
-              Sign out
-            </button>
-          </div>
         </div>
       </header>
       <main className="app-main">

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
@@ -356,7 +356,7 @@ describe('cognito-auth generator', () => {
     });
   });
 
-  it('should not be able to run the generator multiple times', async () => {
+  it('should be idempotent when re-run with same options', async () => {
     // Setup main.tsx with RuntimeConfigProvider
     tree.write(
       'packages/test-project/src/main.tsx',
@@ -378,10 +378,26 @@ describe('cognito-auth generator', () => {
     );
     // First run to create files
     await tsReactWebsiteAuthGenerator(tree, options);
-    // Run generator again
+
+    const mainTsxAfterFirstRun = tree
+      .read('packages/test-project/src/main.tsx')
+      .toString();
+
+    // Re-running with the same options must not throw
     await expect(
-      async () => await tsReactWebsiteAuthGenerator(tree, options),
-    ).rejects.toThrowErrorMatchingSnapshot();
+      tsReactWebsiteAuthGenerator(tree, options),
+    ).resolves.toBeDefined();
+
+    const mainTsxAfterSecondRun = tree
+      .read('packages/test-project/src/main.tsx')
+      .toString();
+
+    // The wiring must be byte-identical after re-run
+    expect(mainTsxAfterSecondRun).toEqual(mainTsxAfterFirstRun);
+
+    // The CognitoAuth wrapper must appear exactly once
+    const wrapperMatches = mainTsxAfterSecondRun.match(/<CognitoAuth>/g) ?? [];
+    expect(wrapperMatches).toHaveLength(1);
   });
 
   it('should allow an unqualified name to be specified', async () => {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -56,13 +56,6 @@ export async function tsReactWebsiteAuthGenerator(
     options.project,
   );
   const srcRoot = projectConfig.sourceRoot;
-  if (
-    tree.exists(joinPathFragments(srcRoot, 'components/CognitoAuth/index.tsx'))
-  ) {
-    throw new Error(
-      `This generator has already been run on ${options.project}.`,
-    );
-  }
 
   const cognitoDomain =
     options.cognitoDomain && options.cognitoDomain.length > 0

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ux-provider.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ux-provider.spec.ts
@@ -244,6 +244,50 @@ export default AppLayout;
       // Create snapshot of the modified AppLayout.tsx
       expect(appLayoutContent).toMatchSnapshot('app-layout-with-auth');
     });
+
+    it('should be idempotent when re-run with same options', async () => {
+      tree.write(
+        'packages/test-project/src/components/AppLayout/index.tsx',
+        `
+        import Config from '../../config';
+
+        const AppLayout = ({ children }: { children: React.ReactNode }) => {
+          return (
+            <div className="app-shell">
+              <header className="app-header">
+                <div className="app-header-inner">
+                  <span className="brand-name">{Config.applicationName}</span>
+                </div>
+              </header>
+              <main className="app-main">{children}</main>
+            </div>
+          );
+        };
+
+        export default AppLayout;
+        `,
+      );
+
+      await tsReactWebsiteAuthGenerator(tree, options);
+      const afterFirstRun = tree
+        .read('packages/test-project/src/components/AppLayout/index.tsx')
+        .toString();
+
+      await expect(
+        tsReactWebsiteAuthGenerator(tree, options),
+      ).resolves.toBeDefined();
+      const afterSecondRun = tree
+        .read('packages/test-project/src/components/AppLayout/index.tsx')
+        .toString();
+
+      // Re-run must leave the file byte-identical
+      expect(afterSecondRun).toEqual(afterFirstRun);
+
+      // The user greeting and sign out wiring must appear exactly once
+      expect(afterSecondRun.match(/className="user-greeting"/g)).toHaveLength(1);
+      expect(afterSecondRun.match(/className="signout-link"/g)).toHaveLength(1);
+      expect(afterSecondRun.match(/= useAuth\(\)/g)).toHaveLength(1);
+    });
   });
 
   describe('Cloudscape', () => {
@@ -443,6 +487,56 @@ export default AppLayout;
       // Create snapshot of the modified AppLayout.tsx
       expect(appLayoutContent).toMatchSnapshot('app-layout-with-auth');
     });
+
+    it('should be idempotent when re-run with same options', async () => {
+      tree.write(
+        'packages/test-project/src/components/AppLayout/index.tsx',
+        `
+        import * as React from 'react';
+        import Config from '../../config';
+        import { TopNavigation } from '@cloudscape-design/components';
+        import { Outlet } from '@tanstack/react-router';
+
+        const AppLayout: React.FC = () => {
+          return (
+            <>
+              <TopNavigation
+                identity={{
+                  href: '/',
+                  title: Config.applicationName,
+                }}
+              />
+              <Outlet />
+            </>
+          );
+        };
+
+        export default AppLayout;
+        `,
+      );
+
+      await tsReactWebsiteAuthGenerator(tree, options);
+      const afterFirstRun = tree
+        .read('packages/test-project/src/components/AppLayout/index.tsx')
+        .toString();
+
+      await expect(
+        tsReactWebsiteAuthGenerator(tree, options),
+      ).resolves.toBeDefined();
+      const afterSecondRun = tree
+        .read('packages/test-project/src/components/AppLayout/index.tsx')
+        .toString();
+
+      // Re-run must leave the file byte-identical
+      expect(afterSecondRun).toEqual(afterFirstRun);
+
+      // The TopNavigation utilities menu and useAuth wiring must appear exactly once
+      expect(
+        afterSecondRun.match(/iconName: 'user-profile-active'/g),
+      ).toHaveLength(1);
+      expect(afterSecondRun.match(/utilities=\{\[/g)).toHaveLength(1);
+      expect(afterSecondRun.match(/= useAuth\(\)/g)).toHaveLength(1);
+    });
   });
 
   describe('Shadcn', () => {
@@ -506,6 +600,55 @@ export default AppLayout;
       expect(appLayoutContent).toContain('clearStaleState()');
 
       expect(appLayoutContent).toMatchSnapshot('app-layout-with-auth');
+    });
+
+    it('should be idempotent when re-run with same options', async () => {
+      tree.write(
+        'packages/test-project/src/components/AppLayout/index.tsx',
+        `
+        import * as React from "react";
+        import Config from "../../config";
+
+        const AppLayout = ({ children }: { children: React.ReactNode }) => {
+          return (
+            <div>
+              <header className="app-header">
+                <span className="text-sm font-semibold">
+                  {Config.applicationName}
+                </span>
+              </header>
+              <div>{children}</div>
+            </div>
+          );
+        };
+
+        export default AppLayout;
+        `,
+      );
+
+      await tsReactWebsiteAuthGenerator(tree, options);
+      const afterFirstRun = tree
+        .read('packages/test-project/src/components/AppLayout/index.tsx')
+        .toString();
+
+      await expect(
+        tsReactWebsiteAuthGenerator(tree, options),
+      ).resolves.toBeDefined();
+      const afterSecondRun = tree
+        .read('packages/test-project/src/components/AppLayout/index.tsx')
+        .toString();
+
+      // Re-run must leave the file byte-identical
+      expect(afterSecondRun).toEqual(afterFirstRun);
+
+      // The user menu, state declarations and useAuth wiring must appear exactly once
+      expect(afterSecondRun.match(/aria-label="Open user menu"/g)).toHaveLength(
+        1,
+      );
+      expect(
+        afterSecondRun.match(/const \[menuOpen, setMenuOpen\] = useState/g),
+      ).toHaveLength(1);
+      expect(afterSecondRun.match(/= useAuth\(\)/g)).toHaveLength(1);
     });
   });
 });

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/cloudscape-auth-menu.grit
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/cloudscape-auth-menu.grit
@@ -16,4 +16,6 @@
     }
   },
   items: [{ id: 'signout', text: 'Sign out' }],
-}]} />`
+}]} />` where {
+  $attrs <: not contains `iconName: 'user-profile-active'`
+}

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/none-auth-menu.grit
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/none-auth-menu.grit
@@ -1,4 +1,5 @@
 `<header className="app-header">$hbody</header>` => `<header className="app-header">$hbody</header>` where {
+  $hbody <: not contains `<button type="button" className="signout-link" $_>$_</button>`,
   $hbody <: contains `<div className="app-header-inner">$inner</div>` => raw`<div className="app-header-inner">$inner
     <div className="user-greeting">
       <span>Hi, {\`\${user?.profile?.['cognito:username']}\`}</span>

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/shadcn-auth-menu.grit
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/shadcn-auth-menu.grit
@@ -36,4 +36,6 @@
     </div>
   )}
 </div>
-</header>`
+</header>` where {
+  $hbody <: not contains `aria-label="Open user menu"`
+}

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/shadcn-state-declarations.grit
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/grit/shadcn-state-declarations.grit
@@ -12,4 +12,6 @@
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
-  $body }`
+  $body }` where {
+  $body <: not contains `const [menuOpen, setMenuOpen] = useState($_)`
+}


### PR DESCRIPTION
### Reason for this change

A new e2e idempotency smoke test (running the full generator matrix, committing, then re-running the same matrix and asserting no git diff) revealed that the `ts#react-website#auth` / `ts#website#auth` generator was not idempotent. Re-running it on a project that already had auth configured threw a hard error:

> This generator has already been run on \<project\>.

Per #124, every generator must be idempotent — a same-options re-run must be a clean no-op, not a hard error. The throw existed only because the downstream menu AST mutators (GritQL transforms) were not individually idempotent and would otherwise append a duplicate user menu / state declarations on a second run.

### Description of changes

- Removed the hard throw guard (the `components/CognitoAuth/index.tsx` existence check) so a re-run naturally no-ops.
- Added idempotency guards (`where { ... <: not contains <stable marker introduced by the transform> }`) to the four previously-unguarded menu GritQL transforms so re-applying them is a no-op:
  - `cloudscape-auth-menu.grit` — guarded on `iconName: 'user-profile-active'`
  - `none-auth-menu.grit` — guarded on the `signout-link` button
  - `shadcn-auth-menu.grit` — guarded on `aria-label="Open user menu"`
  - `shadcn-state-declarations.grit` — guarded on the `menuOpen`/`setMenuOpen` `useState` declaration

All other steps (generateFiles with `KeepExisting`, import helpers, router-context wiring, component metadata, identity infra) were already individually idempotent, so dropping the throw leaves the workspace byte-identical on re-run. First-run output is unchanged.

### Description of how you validated changes

- Replaced the `should not be able to run the generator multiple times` test (which asserted a throw) with `should be idempotent when re-run with same options` in `generator.spec.ts`, asserting no throw, byte-identical output, and the wrapper appears exactly once.
- Added per-ux idempotency tests in `generator.ux-provider.spec.ts` for cloudscape, none and shadcn — each runs the generator twice and asserts the menu utilities / state declarations / user menu and `useAuth()` wiring appear exactly once and the file is byte-identical across runs.
- `pnpm nx run @aws/nx-plugin:test -u`: 2040 tests pass. Only snapshot changes were (a) removal of the obsolete throw snapshot and (b) the "None" ux `should update AppLayout` snapshot losing a previously-duplicated user-greeting block — the test's input AppLayout already contained an auth menu, so the old snapshot had captured the buggy double-append that the guard now correctly prevents. Genuine clean first-run snapshots (Cloudscape/Shadcn) are unchanged.
- `pnpm nx run-many --target build --all` passes.
- `pnpm nx run-many --target lint --all --fix` passes.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*