### PR TITLE
fix(generators): make shared config writes idempotent on re-run

### DIFF
--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -16,6 +16,7 @@ import {
 } from '@nx/devkit';
 import path from 'path';
 import tsProjectGenerator, { getTsLibDetails } from '../../ts/lib/generator';
+import { mergeTsReferences } from '../../ts/lib/ts-project-utils';
 import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
@@ -223,8 +224,7 @@ export async function tsInfraGenerator(
 
   updateJson(tree, `${libraryRoot}/tsconfig.lib.json`, (tsConfig) => ({
     ...tsConfig,
-    references: [
-      ...(tsConfig.references || []),
+    references: mergeTsReferences(tsConfig.references, [
       {
         path: `${path.relative(
           libraryRoot,
@@ -241,7 +241,7 @@ export async function tsInfraGenerator(
             },
           ]
         : []),
-    ],
+    ]),
   }));
 
   await addGeneratorMetricsIfApplicable(tree, [INFRA_APP_GENERATOR_INFO]);

--- a/packages/nx-plugin/src/ts/lib/ts-project-utils.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/ts-project-utils.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { mergeTsReferences } from './ts-project-utils';
+
+describe('mergeTsReferences', () => {
+  it('appends new references to the end', () => {
+    expect(
+      mergeTsReferences([{ path: './a' }], [{ path: './b' }, { path: './c' }]),
+    ).toEqual([{ path: './a' }, { path: './b' }, { path: './c' }]);
+  });
+
+  it('does not duplicate references that already exist', () => {
+    expect(
+      mergeTsReferences(
+        [{ path: './a' }, { path: './b' }],
+        [{ path: './b' }, { path: './c' }],
+      ),
+    ).toEqual([{ path: './a' }, { path: './b' }, { path: './c' }]);
+  });
+
+  it('preserves the order of existing references on re-run', () => {
+    const existing = [{ path: './a' }, { path: './b' }, { path: './c' }];
+    // Re-adding an existing reference must leave the array unchanged
+    expect(mergeTsReferences(existing, [{ path: './a' }])).toEqual(existing);
+  });
+
+  it('is idempotent when applied repeatedly', () => {
+    let references: { path: string }[] | undefined;
+    const toAdd = [{ path: './common/constructs/tsconfig.lib.json' }];
+    references = mergeTsReferences(references, toAdd);
+    const first = references;
+    references = mergeTsReferences(references, toAdd);
+    references = mergeTsReferences(references, toAdd);
+    expect(references).toEqual(first);
+    expect(references).toHaveLength(1);
+  });
+
+  it('handles undefined existing references', () => {
+    expect(mergeTsReferences(undefined, [{ path: './a' }])).toEqual([
+      { path: './a' },
+    ]);
+  });
+});

--- a/packages/nx-plugin/src/ts/lib/ts-project-utils.ts
+++ b/packages/nx-plugin/src/ts/lib/ts-project-utils.ts
@@ -10,6 +10,30 @@ import { configureBiomeLint } from './biome';
 import type { ConfigureProjectOptions } from './types';
 import { configureVitest } from './vitest';
 
+interface TsConfigReference {
+  path: string;
+}
+
+/**
+ * Merges new TypeScript project references into existing ones, deduplicating by
+ * path and preserving the order of existing references so re-running a
+ * generator neither duplicates nor reorders references.
+ */
+export const mergeTsReferences = (
+  existing: TsConfigReference[] | undefined,
+  toAdd: TsConfigReference[],
+): TsConfigReference[] => {
+  const references = [...(existing ?? [])];
+  const existingPaths = new Set(references.map((ref) => ref.path));
+  for (const ref of toAdd) {
+    if (!existingPaths.has(ref.path)) {
+      references.push(ref);
+      existingPaths.add(ref.path);
+    }
+  }
+  return references;
+};
+
 /**
  * Updates typescript projects
  */
@@ -71,15 +95,10 @@ export const configureTsProject = async (
   if (tree.exists('tsconfig.json')) {
     updateJson(tree, 'tsconfig.json', (tsConfig) => ({
       ...tsConfig,
-      references: [
-        // Add project references, ensuring no duplication
-        ...(tsConfig.references ?? []).filter(
-          (ref) => ref.path !== `./${options.dir}`,
-        ),
-        {
-          path: `./${options.dir}`,
-        },
-      ],
+      // Add project references, deduplicating and preserving existing order
+      references: mergeTsReferences(tsConfig.references, [
+        { path: `./${options.dir}` },
+      ]),
     }));
   }
   // Update the root package.json

--- a/packages/nx-plugin/src/utils/metrics.spec.ts
+++ b/packages/nx-plugin/src/utils/metrics.spec.ts
@@ -135,6 +135,30 @@ describe('metrics', () => {
     expectHasMetricTags(tree, 'g1', 'g2', 'g3');
   });
 
+  it('should produce a byte-identical app.ts when re-run with the same generators', async () => {
+    await sharedConstructsGenerator(tree, { iac: 'cdk' });
+
+    const generatorInfo = ['g23', 'g8', 'g5', 'g37'].map((metric, i) => ({
+      id: `gen#${i}`,
+      metric,
+      resolvedFactoryPath: '/path/to/factory',
+      resolvedSchemaPath: '/path/to/schema',
+      description: `Generator ${i}`,
+    }));
+
+    for (const info of generatorInfo) {
+      await addGeneratorMetricsIfApplicable(tree, [info]);
+    }
+    const firstRun = tree.read(METRICS_ASPECT_FILE_PATH, 'utf-8');
+
+    for (const info of generatorInfo) {
+      await addGeneratorMetricsIfApplicable(tree, [info]);
+    }
+    const secondRun = tree.read(METRICS_ASPECT_FILE_PATH, 'utf-8');
+
+    expect(secondRun).toEqual(firstRun);
+  });
+
   it('should not throw when no app.ts exists', async () => {
     await addGeneratorMetricsIfApplicable(tree, [
       {
@@ -355,6 +379,32 @@ describe('metrics', () => {
       expect(result).not.toContain(',,');
       expect(result).toContain('"tf4"');
       expectHasTerraformMetricTags(tree, 'tf1', 'tf2', 'tf3', 'tf4');
+    });
+
+    it('should produce a byte-identical metrics.tf when re-run with the same generators', async () => {
+      await sharedConstructsGenerator(tree, { iac: 'terraform' });
+
+      const generatorInfo = ['g23', 'g8', 'g5', 'g37'].map((metric, i) => ({
+        id: `gen#${i}`,
+        metric,
+        resolvedFactoryPath: '/path/to/factory',
+        resolvedSchemaPath: '/path/to/schema',
+        description: `Generator ${i}`,
+      }));
+
+      // First run: each generator adds its tag individually
+      for (const info of generatorInfo) {
+        await addGeneratorMetricsIfApplicable(tree, [info]);
+      }
+      const firstRun = tree.read(TERRAFORM_METRICS_FILE_PATH, 'utf-8');
+
+      // Re-run with the same generators must not duplicate, reorder or grow tags
+      for (const info of generatorInfo) {
+        await addGeneratorMetricsIfApplicable(tree, [info]);
+      }
+      const secondRun = tree.read(TERRAFORM_METRICS_FILE_PATH, 'utf-8');
+
+      expect(secondRun).toEqual(firstRun);
     });
 
     it('should work with both CDK and Terraform metrics simultaneously', async () => {

--- a/packages/nx-plugin/src/utils/nx.spec.ts
+++ b/packages/nx-plugin/src/utils/nx.spec.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
+  addGeneratorMetadata,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from './nx';
@@ -83,6 +84,78 @@ describe('readProjectConfigurationUnqualified', () => {
     expect(() =>
       readProjectConfigurationUnqualified(tree, 'non-existent-project'),
     ).toThrow(/Cannot find configuration for 'non-existent-project'/);
+  });
+});
+
+describe('addGeneratorMetadata', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+    tree.write(
+      'package.json',
+      JSON.stringify({ name: '@my-scope/monorepo', version: '1.0.0' }),
+    );
+  });
+
+  it('should add generator metadata to the project', () => {
+    tree.write(
+      'apps/test-project/project.json',
+      JSON.stringify({
+        name: 'test-project',
+        root: 'apps/test-project',
+        targets: { build: { executor: 'nx:noop' } },
+      }),
+    );
+
+    addGeneratorMetadata(tree, 'test-project', { id: 'ts#foo' });
+
+    const projectConfig = JSON.parse(
+      tree.read('apps/test-project/project.json', 'utf-8'),
+    );
+    expect(projectConfig.metadata).toEqual({ generator: 'ts#foo' });
+  });
+
+  it('should not rewrite project.json when re-run with the same metadata', () => {
+    tree.write(
+      'apps/test-project/project.json',
+      JSON.stringify({
+        name: 'test-project',
+        root: 'apps/test-project',
+        targets: { build: { executor: 'nx:noop' } },
+      }),
+    );
+
+    addGeneratorMetadata(tree, 'test-project', { id: 'ts#foo' });
+    const first = tree.read('apps/test-project/project.json', 'utf-8');
+
+    addGeneratorMetadata(tree, 'test-project', { id: 'ts#foo' });
+    const second = tree.read('apps/test-project/project.json', 'utf-8');
+
+    // Re-running must leave the file byte-identical (no key reorder)
+    expect(second).toEqual(first);
+  });
+
+  it('should update metadata when additional metadata changes', () => {
+    tree.write(
+      'apps/test-project/project.json',
+      JSON.stringify({
+        name: 'test-project',
+        root: 'apps/test-project',
+        targets: {},
+      }),
+    );
+
+    addGeneratorMetadata(tree, 'test-project', { id: 'ts#foo' });
+    addGeneratorMetadata(tree, 'test-project', { id: 'ts#foo' }, { port: 4200 });
+
+    const projectConfig = JSON.parse(
+      tree.read('apps/test-project/project.json', 'utf-8'),
+    );
+    expect(projectConfig.metadata).toEqual({
+      generator: 'ts#foo',
+      port: 4200,
+    });
   });
 });
 
@@ -447,6 +520,30 @@ describe('addDependencyToTargetIfNotPresent', () => {
     expect(project.targets?.build?.dependsOn).toEqual([
       'compile',
       { projects: ['other'], target: 'build' },
+    ]);
+  });
+
+  it('should not reorder existing dependencies when re-adding one in the middle', () => {
+    const project = makeProject();
+    project.targets = {
+      build: {
+        dependsOn: [
+          '@e2e/website:build',
+          '@e2e/website-no-router:build',
+          '^build',
+        ],
+      },
+    };
+    addDependencyToTargetIfNotPresent(project, 'build', '@e2e/website:build');
+    addDependencyToTargetIfNotPresent(
+      project,
+      'build',
+      '@e2e/website-no-router:build',
+    );
+    expect(project.targets.build.dependsOn).toEqual([
+      '@e2e/website:build',
+      '@e2e/website-no-router:build',
+      '^build',
     ]);
   });
 });

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import PackageJson from '../../package.json';
 import { toSnakeCase } from './names';
 import { getNpmScope, getNpmScopePrefix } from './npm-scope';
+import { deepEquals } from './object';
 
 export type { GeneratorInfo, NxGeneratorInfo } from './generators';
 export { buildGeneratorInfoList } from './generators';
@@ -91,13 +92,19 @@ export const addGeneratorMetadata = (
   additionalMetadata?: { [key: string]: any },
 ) => {
   const config = readProjectConfigurationUnqualified(tree, projectName);
+  const metadata = {
+    ...config?.metadata,
+    generator: info.id,
+    ...additionalMetadata,
+  };
+  // Skip the write entirely when the metadata is unchanged so re-running does
+  // not reorder keys in the serialized project.json.
+  if (deepEquals(config?.metadata, metadata)) {
+    return;
+  }
   updateProjectConfiguration(tree, config.name, {
     ...config,
-    metadata: {
-      ...config?.metadata,
-      generator: info.id,
-      ...additionalMetadata,
-    } as any,
+    metadata: metadata as any,
   });
 };
 
@@ -196,10 +203,11 @@ export const addDependencyToTargetIfNotPresent = (
 ) => {
   project.targets ??= {};
   project.targets[target] ??= {};
-  project.targets[target].dependsOn = [
-    ...(project.targets[target].dependsOn ?? []).filter(
-      (d) => !targetDependencyEquals(d, dependency),
-    ),
-    dependency,
-  ];
+  project.targets[target].dependsOn ??= [];
+  const dependsOn = project.targets[target].dependsOn;
+  // Leave existing dependencies in place so re-running does not reorder them;
+  // only append when the dependency is genuinely absent.
+  if (!dependsOn.some((d) => targetDependencyEquals(d, dependency))) {
+    dependsOn.push(dependency);
+  }
 };

--- a/packages/nx-plugin/src/utils/object.spec.ts
+++ b/packages/nx-plugin/src/utils/object.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { deepEquals, sortObjectKeys } from './object';
+
+describe('sortObjectKeys', () => {
+  it('sorts keys alphabetically', () => {
+    expect(Object.keys(sortObjectKeys({ b: 1, a: 2, c: 3 }))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+});
+
+describe('deepEquals', () => {
+  it('treats objects with different key order as equal', () => {
+    expect(deepEquals({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  it('compares nested objects ignoring key order', () => {
+    expect(
+      deepEquals(
+        { generator: 'ts#foo', nested: { x: 1, y: 2 } },
+        { nested: { y: 2, x: 1 }, generator: 'ts#foo' },
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when values differ', () => {
+    expect(deepEquals({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('returns false when keys differ', () => {
+    expect(deepEquals({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it('compares arrays by order', () => {
+    expect(deepEquals([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEquals([1, 2, 3], [3, 2, 1])).toBe(false);
+  });
+
+  it('handles primitives and null', () => {
+    expect(deepEquals(1, 1)).toBe(true);
+    expect(deepEquals('a', 'a')).toBe(true);
+    expect(deepEquals(null, null)).toBe(true);
+    expect(deepEquals(null, {})).toBe(false);
+    expect(deepEquals(undefined, {})).toBe(false);
+  });
+});

--- a/packages/nx-plugin/src/utils/object.ts
+++ b/packages/nx-plugin/src/utils/object.ts
@@ -12,3 +12,41 @@ export const sortObjectKeys = <T>(object: {
       obj[key] = object[key];
       return obj;
     }, {});
+
+/**
+ * Deep equality check that ignores object key ordering. Useful for determining
+ * whether a config write would be a no-op so it can be skipped to keep output
+ * stable on re-run.
+ */
+export const deepEquals = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (
+    typeof a !== 'object' ||
+    typeof b !== 'object' ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, i) => deepEquals(item, b[i]));
+  }
+  const aKeys = Object.keys(a as Record<string, unknown>);
+  const bKeys = Object.keys(b as Record<string, unknown>);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  return aKeys.every(
+    (key) =>
+      Object.hasOwn(b, key) &&
+      deepEquals(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      ),
+  );
+};


### PR DESCRIPTION
### Reason for this change

A new e2e idempotency smoke test (#124) runs the full generator matrix, commits, re-runs the same matrix and asserts no git diff. It surfaced several shared-config writes that reorder, duplicate or grow on re-run even when the logical content is unchanged.

### Description of changes

Fixes the affected shared-config helpers at their root, keeping first-run output byte-identical and only changing re-run stability:

1. **Project metadata key moves in project.json** (`addGeneratorMetadata` in `utils/nx.ts`): now skips the `updateProjectConfiguration` write entirely when the resulting metadata is unchanged, so re-running no longer reorders keys in the serialized project.json. Backed by a new order-insensitive `deepEquals` helper in `utils/object.ts`.

2. **tsconfig references duplicated and reordered** (`configureTsProject` in `ts/lib/ts-project-utils.ts` and `infra/app/generator.ts`): added a `mergeTsReferences` helper that dedups references by `path` and preserves the order of existing references. The root `tsconfig.json` no longer moves an existing reference to the end, and the infra `tsconfig.lib.json` no longer duplicates the shared-constructs reference on re-run.

3. **`build.dependsOn` reorder** (`addDependencyToTargetIfNotPresent` in `utils/nx.ts`): now a true no-op when the dependency is already present (leaves the array untouched) instead of removing and re-appending, so existing entries keep their position.

4. **Terraform/CDK metric tags** (`utils/metrics.ts`): the dedup guards already in place are correct; added byte-identical re-run unit tests for both the CDK `app.ts` MetricsAspect tags and the Terraform `metrics.tf` `metric_tags` to lock in the no-duplicate / no-reorder / no-growth behaviour.

### Description of how you validated changes

- Added focused unit tests that invoke each helper twice and assert no duplication, reorder, key move or growth:
  - `utils/nx.spec.ts` — `addGeneratorMetadata` byte-identical re-run + `addDependencyToTargetIfNotPresent` no-reorder.
  - `utils/object.spec.ts` — `deepEquals`.
  - `ts/lib/ts-project-utils.spec.ts` — `mergeTsReferences` dedup/order.
  - `utils/metrics.spec.ts` — CDK and Terraform metric tag idempotency.
- Verified first-run output is unchanged: the full `@aws/nx-plugin` test suite shows zero new snapshot changes from these fixes (the only failing snapshots are pre-existing `pnpm`/`npx` environment drift that also fail on a clean checkout of main).
- `@aws/nx-plugin:compile` passes and lint reports no new errors.

### Issue # (if applicable)

Relates to #124.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*