### PR TITLE
fix(dev): add jiti to root devDependencies for pnpm link workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "fs-extra": "11.3.5",
     "github-slugger": "2.0.0",
     "husky": "9.1.7",
+    "jiti": "2.7.0",
     "js-yaml": "4.2.0",
     "jsdom": "29.1.1",
     "license-checker-rseidelsohn": "4.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       husky:
         specifier: 9.1.7
         version: 9.1.7
+      jiti:
+        specifier: 2.7.0
+        version: 2.7.0
       js-yaml:
         specifier: 4.2.0
         version: 4.2.0
@@ -6810,10 +6813,6 @@ packages:
 
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
-    hasBin: true
-
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jiti@2.7.0:
@@ -15237,7 +15236,7 @@ snapshots:
       defu: 6.1.4
       dotenv: 16.6.1
       giget: 1.2.5
-      jiti: 2.6.1
+      jiti: 2.7.0
       mlly: 1.8.0
       ohash: 1.1.6
       pathe: 1.1.2
@@ -17226,8 +17225,6 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.4.2: {}
-
-  jiti@2.6.1: {}
 
   jiti@2.7.0: {}
 


### PR DESCRIPTION
### Reason for this change

When developing locally using `pnpm link dist/packages/nx-plugin`, running any generator fails with:

```Error: Cannot find module 'jiti'```

This happens because the linked dist package resolves its runtime dependencies from the workspace root `node_modules`, not from inside the dist directory. Since jiti was only declared as a dependency in `packages/nx-plugin/package.json` (included in the published package), it is absent from the root workspace `node_modules` and therefore unavailable during the pnpm link dev workflow.

### Description of changes

Add jiti to the root `package.json` devDependencies 

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*