### PR TITLE
fix(ts#rdb): make terraform aurora physical resource names unique

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -1056,10 +1056,19 @@ variable "tags" {
   default     = {}
 }
 
+# Suffix appended to physical resource names so that multiple deployments
+# (e.g. separate environments in the same account and region) don't collide.
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
   default_port           = var.engine == "aurora-mysql" ? 3306 : 5432
   default_engine_version = var.engine == "aurora-mysql" ? "8.0.mysql_aurora.3.12.0" : "17.7"
   parameter_group_family = var.engine == "aurora-mysql" ? "aurora-mysql8.0" : "aurora-postgresql\${split(".", coalesce(var.engine_version, local.default_engine_version))[0]}"
+  cluster_name           = "\${var.name}-aurora-\${random_string.suffix.result}"
 }
 
 resource "aws_rds_cluster_parameter_group" "database" {
@@ -1157,7 +1166,7 @@ resource "aws_security_group" "database" {
 }
 
 resource "aws_db_subnet_group" "database" {
-  name       = "\${var.name}-aurora"
+  name       = local.cluster_name
   subnet_ids = var.subnet_ids
 
   tags = merge(var.tags, {
@@ -1197,7 +1206,7 @@ resource "aws_secretsmanager_secret_version" "credentials" {
 resource "aws_rds_cluster" "database" {
   #checkov:skip=CKV2_AWS_27:Query logging can be enabled with enable_cloudwatch_logs; this module defaults to CDK-equivalent behavior unless logging is requested
   #checkov:skip=CKV_AWS_139:Deletion protection is enabled but checkov is unable to detect it correctly
-  cluster_identifier                  = "\${var.name}-aurora"
+  cluster_identifier                  = local.cluster_name
   engine                              = var.engine
   engine_version                      = coalesce(var.engine_version, local.default_engine_version)
   database_name                       = var.database_name
@@ -1211,7 +1220,7 @@ resource "aws_rds_cluster" "database" {
   kms_key_id                          = aws_kms_key.database.arn
   deletion_protection                 = var.deletion_protection
   skip_final_snapshot                 = var.skip_final_snapshot
-  final_snapshot_identifier           = var.skip_final_snapshot ? null : "\${var.name}-aurora-final-snapshot"
+  final_snapshot_identifier           = var.skip_final_snapshot ? null : "\${local.cluster_name}-final-snapshot"
   iam_database_authentication_enabled = true
   monitoring_interval                 = 5
   monitoring_role_arn                 = aws_iam_role.enhanced_monitoring.arn
@@ -1231,7 +1240,7 @@ resource "aws_rds_cluster" "database" {
 resource "aws_rds_cluster_instance" "database" {
   count = var.instance_count
 
-  identifier           = "\${var.name}-aurora-\${count.index + 1}"
+  identifier           = "\${local.cluster_name}-\${count.index + 1}"
   cluster_identifier   = aws_rds_cluster.database.id
   instance_class       = "db.serverless"
   engine               = aws_rds_cluster.database.engine
@@ -1285,7 +1294,7 @@ resource "aws_vpc_security_group_ingress_rule" "rotation_to_database" {
 resource "aws_cloudformation_stack" "credentials_rotation" {
   #checkov:skip=CKV_AWS_124:SNS event notifications are not required for the credentials rotation stack
   count = var.enable_credential_rotation ? 1 : 0
-  name  = "\${var.name}-aurora-credentials-rotation"
+  name  = "\${local.cluster_name}-credentials-rotation"
 
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"]
 
@@ -1299,7 +1308,7 @@ resource "aws_cloudformation_stack" "credentials_rotation" {
           SecretId = aws_secretsmanager_secret.credentials.arn
           HostedRotationLambda = {
             RotationType        = var.engine == "aurora-mysql" ? "MySQLSingleUser" : "PostgreSQLSingleUser"
-            RotationLambdaName  = "\${var.name}-aurora-credentials-rotation"
+            RotationLambdaName  = "\${local.cluster_name}-credentials-rotation"
             VpcSecurityGroupIds = aws_security_group.rotation[0].id
             VpcSubnetIds        = join(",", var.lambda_subnet_ids)
           }
@@ -1379,7 +1388,7 @@ resource "aws_security_group" "proxy" {
 resource "aws_db_proxy" "aurora" {
   count = var.enable_rds_proxy ? 1 : 0
 
-  name                   = "\${var.name}-proxy"
+  name                   = "\${var.name}-proxy-\${random_string.suffix.result}"
   default_auth_scheme    = "IAM_AUTH"
   engine_family          = var.engine == "aurora-mysql" ? "MYSQL" : "POSTGRESQL"
   role_arn               = aws_iam_role.proxy[0].arn
@@ -1525,7 +1534,7 @@ resource "aws_iam_role_policy_attachment" "backup" {
 resource "aws_backup_vault" "database" {
   count = var.enable_backup ? 1 : 0
 
-  name        = "\${var.name}-aurora-backup"
+  name        = "\${local.cluster_name}-backup"
   kms_key_arn = aws_kms_key.database.arn
   tags        = var.tags
 }
@@ -1533,7 +1542,7 @@ resource "aws_backup_vault" "database" {
 resource "aws_backup_plan" "database" {
   count = var.enable_backup ? 1 : 0
 
-  name = "\${var.name}-aurora-backup"
+  name = "\${local.cluster_name}-backup"
 
   rule {
     rule_name         = "daily-backup"
@@ -2506,10 +2515,19 @@ variable "tags" {
   default     = {}
 }
 
+# Suffix appended to physical resource names so that multiple deployments
+# (e.g. separate environments in the same account and region) don't collide.
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
   default_port           = var.engine == "aurora-mysql" ? 3306 : 5432
   default_engine_version = var.engine == "aurora-mysql" ? "8.0.mysql_aurora.3.12.0" : "17.7"
   parameter_group_family = var.engine == "aurora-mysql" ? "aurora-mysql8.0" : "aurora-postgresql\${split(".", coalesce(var.engine_version, local.default_engine_version))[0]}"
+  cluster_name           = "\${var.name}-aurora-\${random_string.suffix.result}"
 }
 
 resource "aws_rds_cluster_parameter_group" "database" {
@@ -2607,7 +2625,7 @@ resource "aws_security_group" "database" {
 }
 
 resource "aws_db_subnet_group" "database" {
-  name       = "\${var.name}-aurora"
+  name       = local.cluster_name
   subnet_ids = var.subnet_ids
 
   tags = merge(var.tags, {
@@ -2647,7 +2665,7 @@ resource "aws_secretsmanager_secret_version" "credentials" {
 resource "aws_rds_cluster" "database" {
   #checkov:skip=CKV2_AWS_27:Query logging can be enabled with enable_cloudwatch_logs; this module defaults to CDK-equivalent behavior unless logging is requested
   #checkov:skip=CKV_AWS_139:Deletion protection is enabled but checkov is unable to detect it correctly
-  cluster_identifier                  = "\${var.name}-aurora"
+  cluster_identifier                  = local.cluster_name
   engine                              = var.engine
   engine_version                      = coalesce(var.engine_version, local.default_engine_version)
   database_name                       = var.database_name
@@ -2661,7 +2679,7 @@ resource "aws_rds_cluster" "database" {
   kms_key_id                          = aws_kms_key.database.arn
   deletion_protection                 = var.deletion_protection
   skip_final_snapshot                 = var.skip_final_snapshot
-  final_snapshot_identifier           = var.skip_final_snapshot ? null : "\${var.name}-aurora-final-snapshot"
+  final_snapshot_identifier           = var.skip_final_snapshot ? null : "\${local.cluster_name}-final-snapshot"
   iam_database_authentication_enabled = true
   monitoring_interval                 = 5
   monitoring_role_arn                 = aws_iam_role.enhanced_monitoring.arn
@@ -2681,7 +2699,7 @@ resource "aws_rds_cluster" "database" {
 resource "aws_rds_cluster_instance" "database" {
   count = var.instance_count
 
-  identifier           = "\${var.name}-aurora-\${count.index + 1}"
+  identifier           = "\${local.cluster_name}-\${count.index + 1}"
   cluster_identifier   = aws_rds_cluster.database.id
   instance_class       = "db.serverless"
   engine               = aws_rds_cluster.database.engine
@@ -2735,7 +2753,7 @@ resource "aws_vpc_security_group_ingress_rule" "rotation_to_database" {
 resource "aws_cloudformation_stack" "credentials_rotation" {
   #checkov:skip=CKV_AWS_124:SNS event notifications are not required for the credentials rotation stack
   count = var.enable_credential_rotation ? 1 : 0
-  name  = "\${var.name}-aurora-credentials-rotation"
+  name  = "\${local.cluster_name}-credentials-rotation"
 
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"]
 
@@ -2749,7 +2767,7 @@ resource "aws_cloudformation_stack" "credentials_rotation" {
           SecretId = aws_secretsmanager_secret.credentials.arn
           HostedRotationLambda = {
             RotationType        = var.engine == "aurora-mysql" ? "MySQLSingleUser" : "PostgreSQLSingleUser"
-            RotationLambdaName  = "\${var.name}-aurora-credentials-rotation"
+            RotationLambdaName  = "\${local.cluster_name}-credentials-rotation"
             VpcSecurityGroupIds = aws_security_group.rotation[0].id
             VpcSubnetIds        = join(",", var.lambda_subnet_ids)
           }
@@ -2829,7 +2847,7 @@ resource "aws_security_group" "proxy" {
 resource "aws_db_proxy" "aurora" {
   count = var.enable_rds_proxy ? 1 : 0
 
-  name                   = "\${var.name}-proxy"
+  name                   = "\${var.name}-proxy-\${random_string.suffix.result}"
   default_auth_scheme    = "IAM_AUTH"
   engine_family          = var.engine == "aurora-mysql" ? "MYSQL" : "POSTGRESQL"
   role_arn               = aws_iam_role.proxy[0].arn
@@ -2975,7 +2993,7 @@ resource "aws_iam_role_policy_attachment" "backup" {
 resource "aws_backup_vault" "database" {
   count = var.enable_backup ? 1 : 0
 
-  name        = "\${var.name}-aurora-backup"
+  name        = "\${local.cluster_name}-backup"
   kms_key_arn = aws_kms_key.database.arn
   tags        = var.tags
 }
@@ -2983,7 +3001,7 @@ resource "aws_backup_vault" "database" {
 resource "aws_backup_plan" "database" {
   count = var.enable_backup ? 1 : 0
 
-  name = "\${var.name}-aurora-backup"
+  name = "\${local.cluster_name}-backup"
 
   rule {
     rule_name         = "daily-backup"

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -159,10 +159,19 @@ variable "tags" {
   default     = {}
 }
 
+# Suffix appended to physical resource names so that multiple deployments
+# (e.g. separate environments in the same account and region) don't collide.
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
   default_port           = var.engine == "aurora-mysql" ? 3306 : 5432
   default_engine_version = var.engine == "aurora-mysql" ? "8.0.mysql_aurora.3.12.0" : "17.7"
   parameter_group_family = var.engine == "aurora-mysql" ? "aurora-mysql8.0" : "aurora-postgresql${split(".", coalesce(var.engine_version, local.default_engine_version))[0]}"
+  cluster_name           = "${var.name}-aurora-${random_string.suffix.result}"
 }
 
 resource "aws_rds_cluster_parameter_group" "database" {
@@ -260,7 +269,7 @@ resource "aws_security_group" "database" {
 }
 
 resource "aws_db_subnet_group" "database" {
-  name       = "${var.name}-aurora"
+  name       = local.cluster_name
   subnet_ids = var.subnet_ids
 
   tags = merge(var.tags, {
@@ -300,7 +309,7 @@ resource "aws_secretsmanager_secret_version" "credentials" {
 resource "aws_rds_cluster" "database" {
   #checkov:skip=CKV2_AWS_27:Query logging can be enabled with enable_cloudwatch_logs; this module defaults to CDK-equivalent behavior unless logging is requested
   #checkov:skip=CKV_AWS_139:Deletion protection is enabled but checkov is unable to detect it correctly
-  cluster_identifier                  = "${var.name}-aurora"
+  cluster_identifier                  = local.cluster_name
   engine                              = var.engine
   engine_version                      = coalesce(var.engine_version, local.default_engine_version)
   database_name                       = var.database_name
@@ -314,7 +323,7 @@ resource "aws_rds_cluster" "database" {
   kms_key_id                          = aws_kms_key.database.arn
   deletion_protection                 = var.deletion_protection
   skip_final_snapshot                 = var.skip_final_snapshot
-  final_snapshot_identifier           = var.skip_final_snapshot ? null : "${var.name}-aurora-final-snapshot"
+  final_snapshot_identifier           = var.skip_final_snapshot ? null : "${local.cluster_name}-final-snapshot"
   iam_database_authentication_enabled = true
   monitoring_interval                 = 5
   monitoring_role_arn                 = aws_iam_role.enhanced_monitoring.arn
@@ -334,7 +343,7 @@ resource "aws_rds_cluster" "database" {
 resource "aws_rds_cluster_instance" "database" {
   count = var.instance_count
 
-  identifier           = "${var.name}-aurora-${count.index + 1}"
+  identifier           = "${local.cluster_name}-${count.index + 1}"
   cluster_identifier   = aws_rds_cluster.database.id
   instance_class       = "db.serverless"
   engine               = aws_rds_cluster.database.engine
@@ -388,7 +397,7 @@ resource "aws_vpc_security_group_ingress_rule" "rotation_to_database" {
 resource "aws_cloudformation_stack" "credentials_rotation" {
   #checkov:skip=CKV_AWS_124:SNS event notifications are not required for the credentials rotation stack
   count = var.enable_credential_rotation ? 1 : 0
-  name  = "${var.name}-aurora-credentials-rotation"
+  name  = "${local.cluster_name}-credentials-rotation"
 
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"]
 
@@ -402,7 +411,7 @@ resource "aws_cloudformation_stack" "credentials_rotation" {
           SecretId = aws_secretsmanager_secret.credentials.arn
           HostedRotationLambda = {
             RotationType        = var.engine == "aurora-mysql" ? "MySQLSingleUser" : "PostgreSQLSingleUser"
-            RotationLambdaName  = "${var.name}-aurora-credentials-rotation"
+            RotationLambdaName  = "${local.cluster_name}-credentials-rotation"
             VpcSecurityGroupIds = aws_security_group.rotation[0].id
             VpcSubnetIds        = join(",", var.lambda_subnet_ids)
           }
@@ -482,7 +491,7 @@ resource "aws_security_group" "proxy" {
 resource "aws_db_proxy" "aurora" {
   count = var.enable_rds_proxy ? 1 : 0
 
-  name                   = "${var.name}-proxy"
+  name                   = "${var.name}-proxy-${random_string.suffix.result}"
   default_auth_scheme    = "IAM_AUTH"
   engine_family          = var.engine == "aurora-mysql" ? "MYSQL" : "POSTGRESQL"
   role_arn               = aws_iam_role.proxy[0].arn
@@ -628,7 +637,7 @@ resource "aws_iam_role_policy_attachment" "backup" {
 resource "aws_backup_vault" "database" {
   count = var.enable_backup ? 1 : 0
 
-  name        = "${var.name}-aurora-backup"
+  name        = "${local.cluster_name}-backup"
   kms_key_arn = aws_kms_key.database.arn
   tags        = var.tags
 }
@@ -636,7 +645,7 @@ resource "aws_backup_vault" "database" {
 resource "aws_backup_plan" "database" {
   count = var.enable_backup ? 1 : 0
 
-  name = "${var.name}-aurora-backup"
+  name = "${local.cluster_name}-backup"
 
   rule {
     rule_name         = "daily-backup"


### PR DESCRIPTION

### Reason for this change

The `terraform-deploy-rdb` smoke test has been failing on every `main` CI run since 2026-06-08 (including a manual re-run, so not transient). Root cause chain:

1. CI run [27167663167](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/27167663167) was **cancelled mid-`terraform apply`**. The job was killed (`Terminate orphan process: terraform-provider-aws`) with no destroy, leaking the `postgres-db-aurora` and `my-sql-db-aurora` DB subnet groups (among other resources).
2. The smoke test isolates Terraform state per run (random `TF_ENV` state key), so subsequent runs could neither adopt nor destroy the leaked resources.
3. The vended terraform aurora module names its DB subnet group (and several other resources) **statically** from the database name (`${var.name}-aurora`), so every following run failed with `DBSubnetGroupAlreadyExists: The DB subnet group 'postgres-db-aurora' already exists`.

Beyond CI, this is a real user-facing bug: two deployments of the same generated database project in one account/region (e.g. dev + staging environments, which the generated `TF_ENV`-based state isolation explicitly supports) collide on these static physical names.

### Description of changes

In `rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template`, append a `random_string` suffix to all statically-named physical resources:

- DB subnet group, cluster identifier, instance identifiers, final snapshot identifier (via a shared `local.cluster_name`)
- credentials rotation CloudFormation stack + hosted rotation Lambda name
- RDS proxy name
- backup vault + plan names

This matches the approach already used by the app-level terraform rdb module (`random_string.suffix` for migration/create-db-user function names, ECR repo and IAM roles) and the CDK construct (which relies on CloudFormation's unique physical name generation). Resources already using `name_prefix` (security groups, IAM roles, secrets) are unaffected as Terraform makes those unique itself.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — all 2154 tests pass; rdb generator snapshots updated.
- `pnpm nx run-many --target build --all` and `pnpm nx run-many --target lint --all --fix` pass with no mutations.
- The `terraform-deploy-rdb` smoke test only runs in the post-merge CI workflow (the PR workflow runs the non-deploy matrix incl. `terraform` and `rdb`), so the end-to-end deploy validation happens on the main CI run after merge — I will monitor it. New deploys use suffixed names so they no longer collide with the leaked `postgres-db-aurora`/`my-sql-db-aurora` subnet groups; those leftovers from the cancelled run still need a one-off manual cleanup in the test account.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*