### PR TITLE
fix(ts#smithy-api): add tsx as a dev dependency

### DIFF
--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -387,6 +387,8 @@ describe('tsSmithyApiGenerator', () => {
 
     // Verify dev dependencies
     expect(packageJson.devDependencies).toHaveProperty('@types/aws-lambda');
+    // tsx is used by the serve and serve-local targets to run the local server
+    expect(packageJson.devDependencies).toHaveProperty('tsx');
   });
 
   it('should configure git ignores for generated code', async () => {

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -315,7 +315,7 @@ export const tsSmithyApiGenerator = async (
         ? (['@aws-lambda-powertools/parser'] as const)
         : []),
     ]),
-    withVersions(['@types/aws-lambda']),
+    withVersions(['@types/aws-lambda', 'tsx']),
   );
 
   await addGeneratorMetricsIfApplicable(tree, [TS_SMITHY_API_GENERATOR_INFO]);


### PR DESCRIPTION
### Reason for this change

The `ts#smithy-api` generator creates `serve` and `serve-local` targets which run the local server with `tsx` (`tsx --watch src/local-server.ts`). However, the generator did not declare `tsx` as a dependency.

On a fresh workspace, this means running `serve`/`serve-local` fails with `tsx: not found` until some other generator (e.g. `ts#infra`) happens to install `tsx` as a transitive effect. This was surfaced while validating the PDK migration guide, where `serve-local` is used during the website migration step (before any infrastructure generator has run).

### Description of changes

- Add `tsx` to the backend project's dev dependencies in the `ts#smithy-api` generator (`tsx` already has a pinned version in `versions.ts`).
- Add a unit test assertion verifying `tsx` is added to `devDependencies`.

### Description of how you validated changes

- Updated and ran the `ts#smithy-api` generator unit tests (`generator.spec.ts`) — all 43 pass.
- Manually verified end-to-end: generated a Smithy API in a fresh `1.0.0-rc.10` workspace and confirmed `serve-local` now starts the local server without needing any other generator to run first.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*