### PR TITLE
feat(docs): add ephemeral per-PR documentation previews

### DIFF
--- a/.github/workflows/pr-docs-preview-cleanup.yml
+++ b/.github/workflows/pr-docs-preview-cleanup.yml
@@ -1,0 +1,67 @@
+name: PR Docs Preview - Cleanup
+
+# Removes a PR's docs preview from S3 when the PR is closed. Deletes only the
+# prefix derived from the PR number; performs no checkout.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+concurrency:
+  group: pr-docs-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write # OIDC for AWS
+  pull-requests: write # update the preview comment
+
+jobs:
+  cleanup:
+    name: Cleanup Docs Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.DOCS_PREVIEW_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Remove preview from S3
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          aws s3 rm "s3://${{ secrets.DOCS_PREVIEW_BUCKET }}/pr-${PR_NUMBER}/" --recursive
+
+      - name: Invalidate CloudFront
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.DOCS_PREVIEW_DISTRIBUTION_ID }}" \
+            --paths "/pr-${PR_NUMBER}/*"
+
+      - name: Update preview comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const marker = '<!-- docs-preview -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: `${marker}\n### 📖 Documentation preview\n\nThis PR is closed - the documentation preview has been removed.`,
+              });
+            }

--- a/.github/workflows/pr-docs-preview-deploy.yml
+++ b/.github/workflows/pr-docs-preview-deploy.yml
@@ -1,0 +1,120 @@
+name: PR Docs Preview - Deploy
+
+# Publishes the docs artifact produced by the "Build" workflow to S3/CloudFront
+# and comments the preview link on the PR. Runs via workflow_run so its
+# definition always comes from the default branch.
+#
+# The deploy job uses the "docs-preview" environment, which is configured with
+# required reviewers: a maintainer approves the deployment before the preview is
+# published.
+
+on:
+  workflow_run:
+    workflows: ['PR Docs Preview - Build']
+    types:
+      - completed
+
+concurrency:
+  group: pr-docs-preview-deploy-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read # download artifacts from the triggering run
+  pull-requests: write # comment the preview link
+  id-token: write # OIDC for AWS
+
+jobs:
+  deploy:
+    name: Deploy Docs Preview
+    runs-on: ubuntu-latest
+    environment: docs-preview
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        with:
+          script: |
+            // Look the PR up by its head SHA via the API rather than trusting
+            // anything from the build artifact. workflow_run.pull_requests is
+            // empty for forks, so query by head ref.
+            const { data } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}`,
+            });
+            const pr = data.find(
+              (p) => p.head.sha === process.env.HEAD_SHA,
+            );
+            if (!pr) {
+              core.setFailed('Could not resolve a PR for this run.');
+              return;
+            }
+            core.setOutput('number', String(pr.number));
+
+      - name: Download docs artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-preview
+          path: docs-dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.DOCS_PREVIEW_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync docs-dist "s3://${{ secrets.DOCS_PREVIEW_BUCKET }}/pr-${{ steps.pr.outputs.number }}/" \
+            --delete --cache-control "public, max-age=300"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.DOCS_PREVIEW_DISTRIBUTION_ID }}" \
+            --paths "/pr-${{ steps.pr.outputs.number }}/*"
+
+      - name: Comment preview link
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PREVIEW_DOMAIN: ${{ secrets.DOCS_PREVIEW_DOMAIN }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const url = `https://${process.env.PREVIEW_DOMAIN}/pr-${prNumber}/`;
+            const marker = '<!-- docs-preview -->';
+            const body = `${marker}\n### 📖 Documentation preview\n\nYour documentation preview for this PR is ready:\n\n**${url}**\n\n_Updated for commit ${context.payload.workflow_run.head_sha.slice(0, 7)}. This preview is removed when the PR is closed._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -1,0 +1,45 @@
+name: PR Docs Preview - Build
+
+# Builds the documentation site for a pull request and uploads it as an
+# artifact. The companion "Deploy" workflow publishes the artifact and comments
+# the preview link on the PR.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pr-docs-preview.yml'
+
+concurrency:
+  group: pr-docs-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Docs Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use PNPM
+        uses: pnpm/action-setup@v6
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile --prefer-offline
+      - name: Build docs
+        env:
+          # Scope every asset and link to this PR's preview subpath.
+          DOCS_BASE_PATH: /pr-${{ github.event.pull_request.number }}
+        run: pnpm nx run docs:build --output-style=stream
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: docs-preview
+          path: docs/dist
+          retention-days: 1

--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -36,7 +36,9 @@ jobs:
         env:
           # Scope every asset and link to this PR's preview subpath.
           DOCS_BASE_PATH: /pr-${{ github.event.pull_request.number }}
-        run: pnpm nx run docs:build --output-style=stream
+        # The docs site is self-contained Astro content; exclude the upstream
+        # build graph so the preview does not run the full plugin build/test.
+        run: pnpm nx run docs:build --exclude-task-dependencies --output-style=stream
       - name: Upload docs artifact
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -2,7 +2,7 @@ name: PR Docs Preview - Build
 
 # Builds the documentation site for a pull request and uploads it as an
 # artifact. The companion "Deploy" workflow publishes the artifact and comments
-# the preview link on the PR.
+# the preview link on the PR. This job is not given AWS credentials.
 
 on:
   pull_request:
@@ -20,18 +20,12 @@ permissions:
 jobs:
   build:
     name: Build Docs Preview
-    runs-on: ubuntu-latest
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v6
-      - name: Use PNPM
-        uses: pnpm/action-setup@v6
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v6
+      - uses: ./.github/actions/init-monorepo
         with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile --prefer-offline
+          container-tools: 'false'
       - name: Build docs
         env:
           # Scope every asset and link to this PR's preview subpath.

--- a/docs-preview-infra/.gitignore
+++ b/docs-preview-infra/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+cdk.out/
+package-lock.json

--- a/docs-preview-infra/README.md
+++ b/docs-preview-infra/README.md
@@ -1,0 +1,63 @@
+# Docs PR Preview Infrastructure
+
+CDK app for the ephemeral per-PR documentation preview system. It provisions a
+single private S3 bucket, a CloudFront distribution, and a GitHub Actions OIDC
+deploy role. Every PR's preview is served from the same distribution under a
+`pr-<number>/` key prefix.
+
+This app is **deployed manually by maintainers** and is intentionally separate
+from the Nx workspace - it is not part of `pnpm nx run-many --target build`.
+
+## Architecture
+
+```
+pull_request                                  workflow_run
+┌─────────────────────────────┐               ┌──────────────────────────────────┐
+│ pr-docs-preview.yml         │   artifact    │ pr-docs-preview-deploy.yml         │
+│  • astro build              │ ────────────► │  • maintainer approves (env gate)  │
+│    DOCS_BASE_PATH=/pr-<n>   │  (docs-dist)  │  • OIDC assume DeployRole          │
+│  • upload artifact          │               │  • s3 sync → pr-<n>/               │
+└─────────────────────────────┘               │  • cloudfront invalidation         │
+                                               │  • comment preview link on PR      │
+                                               └──────────────────────────────────┘
+                                                              │
+                          pull_request_target (closed)        ▼
+                          ┌──────────────────────────┐   S3 bucket  ◄── CloudFront
+                          │ pr-docs-preview-cleanup   │   pr-1/...       (OAC + URL
+                          │  • s3 rm pr-<n>/          │   pr-2/...        rewrite fn)
+                          └──────────────────────────┘   pr-N/...
+```
+
+## Deploy
+
+```bash
+cd docs-preview-infra
+npm install
+npx cdk bootstrap         # once per account/region, if not already bootstrapped
+npx cdk deploy
+# Override the allowed repo if forked:
+#   npx cdk deploy -c githubRepo=my-org/my-fork
+```
+
+Deploy to `us-east-1` (the workflows assume this region).
+
+> **Prerequisite:** the account must already have a GitHub Actions OIDC provider
+> (`token.actions.githubusercontent.com`). The stack references it rather than
+> creating it, to avoid clashing with one that may already exist. If absent,
+> create it once (`aws iam create-open-id-connect-provider ...`) before deploying.
+
+## Wire up GitHub
+
+After `cdk deploy`, take the stack outputs and set these **repository secrets**:
+
+| Secret                         | From output              |
+| ------------------------------ | ------------------------ |
+| `DOCS_PREVIEW_DEPLOY_ROLE_ARN` | `DeployRoleArn`          |
+| `DOCS_PREVIEW_BUCKET`          | `PreviewBucketName`      |
+| `DOCS_PREVIEW_DISTRIBUTION_ID` | `DistributionId`         |
+| `DOCS_PREVIEW_DOMAIN`          | `DistributionDomainName` |
+
+Then create a repository **environment** named `docs-preview` with **required
+reviewers** set to the maintainer team. The deploy workflow references this
+environment, so a maintainer approves each preview deployment before it is
+published.

--- a/docs-preview-infra/cdk.json
+++ b/docs-preview-infra/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "tsx src/main.ts"
+}

--- a/docs-preview-infra/package.json
+++ b/docs-preview-infra/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "docs-preview-infra",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CDK app for the ephemeral per-PR documentation preview infrastructure (S3 + CloudFront + GitHub OIDC role). Deployed manually by maintainers - not part of the Nx workspace build.",
+  "scripts": {
+    "deploy": "cdk deploy",
+    "diff": "cdk diff",
+    "synth": "cdk synth"
+  },
+  "devDependencies": {
+    "aws-cdk": "^2.1000.0",
+    "aws-cdk-lib": "^2.160.0",
+    "constructs": "^10.3.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/docs-preview-infra/src/docs-preview-stack.ts
+++ b/docs-preview-infra/src/docs-preview-stack.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  Stack,
+  StackProps,
+  Duration,
+  RemovalPolicy,
+  CfnOutput,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export interface DocsPreviewStackProps extends StackProps {
+  /** GitHub repository allowed to assume the deploy role, in "owner/repo" form. */
+  readonly githubRepo: string;
+}
+
+/**
+ * Infrastructure for ephemeral per-PR documentation previews.
+ *
+ * A single private S3 bucket and CloudFront distribution serve every PR. Each
+ * PR's site lives under its own `pr-<number>/` key prefix, so previews are
+ * isolated from one another and from the production docs (which are hosted
+ * separately on GitHub Pages).
+ */
+export class DocsPreviewStack extends Stack {
+  constructor(scope: Construct, id: string, props: DocsPreviewStackProps) {
+    super(scope, id, props);
+
+    const bucket = new s3.Bucket(this, 'PreviewBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      // Sweep up any preview prefixes that outlive their PR (e.g. if a cleanup
+      // run was missed) so the bucket does not grow unbounded.
+      lifecycleRules: [{ expiration: Duration.days(30) }],
+    });
+
+    // Astro builds directory-style routes (e.g. `/guides/` served by
+    // `guides/index.html`). Rewrite directory and extensionless requests to the
+    // corresponding `index.html` so deep links resolve under each PR prefix.
+    const rewriteFunction = new cloudfront.Function(this, 'RewriteFunction', {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  if (uri.endsWith('/')) {
+    request.uri = uri + 'index.html';
+  } else if (!uri.includes('.')) {
+    request.uri = uri + '/index.html';
+  }
+  return request;
+}
+`),
+    });
+
+    const distribution = new cloudfront.Distribution(this, 'Distribution', {
+      comment: 'Nx Plugin for AWS - PR docs previews',
+      defaultBehavior: {
+        origin:
+          origins.S3BucketOrigin.withOriginAccessControl(bucket),
+        viewerProtocolPolicy:
+          cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        functionAssociations: [
+          {
+            function: rewriteFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          },
+        ],
+      },
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+    });
+
+    // GitHub Actions OIDC provider (created once per account; reuse if present).
+    const oidcProvider =
+      iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
+        this,
+        'GitHubOidcProvider',
+        `arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
+      );
+
+    // The deploy role is assumable only from workflows running on this repo's
+    // default branch. The deploy workflow runs via `workflow_run`, so its ref is
+    // always `refs/heads/main`.
+    const deployRole = new iam.Role(this, 'DeployRole', {
+      assumedBy: new iam.WebIdentityPrincipal(
+        oidcProvider.openIdConnectProviderArn,
+        {
+          StringEquals: {
+            'token.actions.githubusercontent.com:aud':
+              'sts.amazonaws.com',
+          },
+          StringLike: {
+            'token.actions.githubusercontent.com:sub': `repo:${props.githubRepo}:ref:refs/heads/main`,
+          },
+        },
+      ),
+      description:
+        'Assumed by GitHub Actions to publish ephemeral PR docs previews',
+      maxSessionDuration: Duration.hours(1),
+    });
+
+    bucket.grantReadWrite(deployRole);
+    deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['cloudfront:CreateInvalidation'],
+        resources: [
+          `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+        ],
+      }),
+    );
+
+    new CfnOutput(this, 'PreviewBucketName', { value: bucket.bucketName });
+    new CfnOutput(this, 'DistributionId', {
+      value: distribution.distributionId,
+    });
+    new CfnOutput(this, 'DistributionDomainName', {
+      value: distribution.distributionDomainName,
+    });
+    new CfnOutput(this, 'DeployRoleArn', { value: deployRole.roleArn });
+  }
+}

--- a/docs-preview-infra/src/main.ts
+++ b/docs-preview-infra/src/main.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { App } from 'aws-cdk-lib';
+import { DocsPreviewStack } from './docs-preview-stack.js';
+
+const app = new App();
+
+new DocsPreviewStack(app, 'NxPluginForAwsDocsPreview', {
+  // The GitHub repository allowed to assume the deploy role, in "owner/repo" form.
+  githubRepo: app.node.tryGetContext('githubRepo') ?? 'awslabs/nx-plugin-for-aws',
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});

--- a/docs-preview-infra/tsconfig.json
+++ b/docs-preview-infra/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Reason for this change

Reviewers currently have to build the documentation site locally to see how doc changes render. This adds an automatic, isolated preview of the docs site for every pull request that touches `docs/**`, with the link commented back on the PR.

### Description of changes

Adds a per-PR documentation preview system:

- **`pr-docs-preview.yml`** (`pull_request`) — builds the docs site with `DOCS_BASE_PATH=/pr-<n>` so all assets and links resolve under the PR's preview subpath, and uploads the result as an artifact.
- **`pr-docs-preview-deploy.yml`** (`workflow_run`) — downloads the artifact, syncs it to an S3 prefix (`pr-<n>/`), invalidates CloudFront, and posts/updates a comment with the preview link. The deploy job uses a `docs-preview` environment with required reviewers, so a maintainer approves each preview deployment before it is published.
- **`pr-docs-preview-cleanup.yml`** (`pull_request_target` on close) — removes the PR's preview prefix from S3.
- **`docs-preview-infra/`** — a standalone CDK app (deployed manually by maintainers, separate from the Nx workspace) that provisions a private S3 bucket, a CloudFront distribution with Origin Access Control and a URL-rewrite function for Astro's directory-style routes, and a GitHub OIDC deploy role scoped to this repo's default branch.

Each PR's preview is isolated under its own `pr-<n>/` key prefix on a single shared distribution. Previews are ephemeral — removed when the PR closes, with an S3 lifecycle rule expiring any stragglers. Production docs on GitHub Pages are unaffected; this is purely additive.

One-time maintainer setup is documented in `docs-preview-infra/README.md`: deploy the CDK app, set the four repository secrets from the stack outputs, and create the `docs-preview` environment with required reviewers.

### Description of how you validated changes

- Verified the docs build with a PR-scoped base path (`DOCS_BASE_PATH=/pr-786 nx run docs:build`) produces output with the correct subpath baked into asset URLs and links, and a root redirect to `/pr-<n>/en`.
- Validated all three workflow YAML files parse correctly.
- Confirmed the CDK app synthesizes and produces the expected S3 bucket, CloudFront distribution + function + OAC, and an OIDC role with a default-branch-scoped trust policy and least-privilege permissions.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*