### PR TITLE
fix(ts#project): add passWithNoTests via structural grit rewrite

### DIFF
--- a/packages/nx-plugin/src/ts/lib/grit/vitest-pass-with-no-tests.grit
+++ b/packages/nx-plugin/src/ts/lib/grit/vitest-pass-with-no-tests.grit
@@ -1,7 +1,4 @@
-`test: { $props }` => raw`test: {
-    passWithNoTests: true,
-    $props
-  }` where {
+`test: { $props }` => `test: { passWithNoTests: true, $props }` where {
   $props <: within `defineConfig($_)`,
   $props <: not some `passWithNoTests: $_`
 }

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -3,25 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import * as ts from 'typescript';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
 import tsProjectGenerator from './generator';
 import { configureVitest } from './vitest';
 
-// Returns the syntax errors produced when parsing the given TypeScript source.
-const syntaxErrors = (content: string): string[] => {
-  const sourceFile = ts.createSourceFile(
-    'vitest.config.mts',
-    content,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  return (
-    (sourceFile as unknown as { parseDiagnostics?: ts.Diagnostic[] })
-      .parseDiagnostics ?? []
-  ).map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
-};
+// A local defineConfig stub keeps the generated config self-contained so it can
+// be type-checked without loading the vite/vitest dependencies. The grit
+// transform only requires the test block to be within a `defineConfig(...)`
+// call, so this exercises the same code path as a real vite config.
+const wrapConfig = (testBlock: string) =>
+  `const defineConfig = (fn: () => unknown): unknown => fn();
+export default defineConfig(() => ({
+  ${testBlock}
+}));
+`;
 
 describe('vitest utils', () => {
   let tree: Tree;
@@ -52,73 +48,56 @@ describe('vitest utils', () => {
   });
 
   // The grit transform splices `passWithNoTests` into the existing `test`
-  // block. Appending it after the final property only stays valid when that
-  // property has a trailing comma, so verify the result parses cleanly across
-  // a variety of test block shapes regardless of trailing commas.
+  // block. Verify the result still compiles across a variety of test block
+  // shapes regardless of trailing commas — a missing comma between properties
+  // would not produce a double comma, so it could otherwise slip through.
   it.each([
     {
       name: 'trailing comma on last property',
-      config: `import { defineConfig } from 'vitest/config';
-export default defineConfig(() => ({
-  test: {
+      testBlock: `test: {
     name: '@proj/test',
     watch: false,
-  },
-}));
-`,
+  },`,
     },
     {
       name: 'no trailing comma on last property',
-      config: `import { defineConfig } from 'vitest/config';
-export default defineConfig(() => ({
-  test: {
+      testBlock: `test: {
     name: '@proj/test',
     watch: false
-  },
-}));
-`,
+  },`,
     },
     {
       name: 'single line test block',
-      config: `import { defineConfig } from 'vitest/config';
-export default defineConfig(() => ({
-  test: { globals: true },
-}));
-`,
+      testBlock: `test: { globals: true },`,
     },
     {
       name: 'empty test block',
-      config: `import { defineConfig } from 'vitest/config';
-export default defineConfig(() => ({
-  test: {},
-}));
-`,
+      testBlock: `test: {},`,
     },
-  ])('should add passWithNoTests producing valid syntax: $name', async ({
-    config,
-  }) => {
-    tree.write('test/vitest.config.mts', config);
+  ])(
+    'should add passWithNoTests producing compilable config: $name',
+    async ({ testBlock }) => {
+      tree.write('test/vitest.config.mts', wrapConfig(testBlock));
 
-    await configureVitest(tree, {
-      dir: 'test',
-      fullyQualifiedName: 'test',
-    });
+      await configureVitest(tree, {
+        dir: 'test',
+        fullyQualifiedName: 'test',
+      });
 
-    const content = tree.read('test/vitest.config.mts', 'utf8')!;
-    expect(content).toContain('passWithNoTests: true');
-    expect(syntaxErrors(content)).toEqual([]);
-  });
+      const content = tree.read('test/vitest.config.mts', 'utf8')!;
+      expect(content).toContain('passWithNoTests: true');
+      expectTypeScriptToCompile(tree, ['test/vitest.config.mts']);
+    },
+  );
 
   it('should not add passWithNoTests when it is already present', async () => {
-    const config = `import { defineConfig } from 'vitest/config';
-export default defineConfig(() => ({
-  test: {
+    tree.write(
+      'test/vitest.config.mts',
+      wrapConfig(`test: {
     passWithNoTests: true,
     name: '@proj/test',
-  },
-}));
-`;
-    tree.write('test/vitest.config.mts', config);
+  },`),
+    );
 
     await configureVitest(tree, {
       dir: 'test',
@@ -127,6 +106,6 @@ export default defineConfig(() => ({
 
     const content = tree.read('test/vitest.config.mts', 'utf8')!;
     expect(content.match(/passWithNoTests/g)).toHaveLength(1);
-    expect(syntaxErrors(content)).toEqual([]);
+    expectTypeScriptToCompile(tree, ['test/vitest.config.mts']);
   });
 });

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -3,9 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
+import * as ts from 'typescript';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
 import tsProjectGenerator from './generator';
 import { configureVitest } from './vitest';
+
+// Returns the syntax errors produced when parsing the given TypeScript source.
+const syntaxErrors = (content: string): string[] => {
+  const sourceFile = ts.createSourceFile(
+    'vitest.config.mts',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  return (
+    (sourceFile as unknown as { parseDiagnostics?: ts.Diagnostic[] })
+      .parseDiagnostics ?? []
+  ).map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+};
 
 describe('vitest utils', () => {
   let tree: Tree;
@@ -33,5 +49,84 @@ describe('vitest utils', () => {
     // properties already end with a trailing comma.
     expect(content).not.toMatch(/,\s*,/);
     expect(content).toMatchSnapshot('vitest.config.mts');
+  });
+
+  // The grit transform splices `passWithNoTests` into the existing `test`
+  // block. Appending it after the final property only stays valid when that
+  // property has a trailing comma, so verify the result parses cleanly across
+  // a variety of test block shapes regardless of trailing commas.
+  it.each([
+    {
+      name: 'trailing comma on last property',
+      config: `import { defineConfig } from 'vitest/config';
+export default defineConfig(() => ({
+  test: {
+    name: '@proj/test',
+    watch: false,
+  },
+}));
+`,
+    },
+    {
+      name: 'no trailing comma on last property',
+      config: `import { defineConfig } from 'vitest/config';
+export default defineConfig(() => ({
+  test: {
+    name: '@proj/test',
+    watch: false
+  },
+}));
+`,
+    },
+    {
+      name: 'single line test block',
+      config: `import { defineConfig } from 'vitest/config';
+export default defineConfig(() => ({
+  test: { globals: true },
+}));
+`,
+    },
+    {
+      name: 'empty test block',
+      config: `import { defineConfig } from 'vitest/config';
+export default defineConfig(() => ({
+  test: {},
+}));
+`,
+    },
+  ])('should add passWithNoTests producing valid syntax: $name', async ({
+    config,
+  }) => {
+    tree.write('test/vitest.config.mts', config);
+
+    await configureVitest(tree, {
+      dir: 'test',
+      fullyQualifiedName: 'test',
+    });
+
+    const content = tree.read('test/vitest.config.mts', 'utf8')!;
+    expect(content).toContain('passWithNoTests: true');
+    expect(syntaxErrors(content)).toEqual([]);
+  });
+
+  it('should not add passWithNoTests when it is already present', async () => {
+    const config = `import { defineConfig } from 'vitest/config';
+export default defineConfig(() => ({
+  test: {
+    passWithNoTests: true,
+    name: '@proj/test',
+  },
+}));
+`;
+    tree.write('test/vitest.config.mts', config);
+
+    await configureVitest(tree, {
+      dir: 'test',
+      fullyQualifiedName: 'test',
+    });
+
+    const content = tree.read('test/vitest.config.mts', 'utf8')!;
+    expect(content.match(/passWithNoTests/g)).toHaveLength(1);
+    expect(syntaxErrors(content)).toEqual([]);
   });
 });


### PR DESCRIPTION
### Reason for this change

The grit transform that inserts `passWithNoTests: true` into a generated vitest config's `test` block used a `raw` string splice:

```grit
`test: { $props }` => raw`test: {
    passWithNoTests: true,
    $props
  }` where { ... }
```

Because the inserted text is a raw splice around the captured `$props`, the result is only valid when the surrounding properties carry the expected trailing commas. If the matched `test` block has a final property with **no trailing comma** (e.g. `watch: false` with no comma), or is written on a **single line** (`test: { globals: true }`), the splice yields invalid syntax — a missing comma between properties — which fails to compile.

The current generated config happens to always emit a trailing comma, so the real generator output is valid today. But the transform is fragile: any future config shape (or a reordering of the splice that puts `passWithNoTests` last) silently produces a broken config, and the existing unit test could not catch it. That test only asserted (a) `passWithNoTests: true` is present and (b) there is no double comma (`/,\s*,/`). A *missing* comma has no double comma, so it sailed straight through.

### Description of changes

- **Make the transform robust.** Replace the `raw` string splice with a structural (non-`raw`) rewrite so GritQL handles comma insertion itself:

  ```grit
  `test: { $props }` => `test: { passWithNoTests: true, $props }` where {
    $props <: within `defineConfig($_)`,
    $props <: not some `passWithNoTests: $_`
  }
  ```

  This stays syntactically valid regardless of property ordering, trailing commas, single-line vs multi-line blocks, or an empty `test: {}`. `formatFilesInSubtree` (prettier) then normalises the layout, so committed snapshots are unchanged.

- **Close the test gap.** Add unit tests that run `configureVitest` against a range of `test` block shapes (trailing comma / no trailing comma / single-line / empty / already-present) and assert the output **parses with zero TypeScript syntax errors**, rather than only checking for a double comma.

### Description of how you validated changes

- Verified with the real `@getgrit/gritql` engine + the TypeScript parser that the previous `raw` splice produces `',' expected` for no-trailing-comma and single-line blocks, while the structural rewrite is valid in all cases.
- Confirmed the new unit tests **fail** (`',' expected`) against the old splice and **pass** against the structural rewrite — proving they close the gap.
- Ran the full `@aws/nx-plugin` unit suite (2159 tests) with `-u`: all pass, **no snapshot changes**.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*