### PR TITLE
fix(format): apply ruff isort during generation regardless of in-tree state

### DIFF
--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -692,12 +692,7 @@ async def handle_invoke(input: InvokeInput):
     """Streaming handler for agent invocation"""
     stream = _agent.stream_async(input.message)
     async for event in stream:
-        text = (
-            event.get("event", {})
-            .get("contentBlockDelta", {})
-            .get("delta", {})
-            .get("text")
-        )
+        text = event.get("event", {}).get("contentBlockDelta", {}).get("delta", {}).get("text")
         if text is not None:
             yield StreamChunk(content=text)
         elif event.get("event", {}).get("messageStop") is not None:
@@ -707,11 +702,7 @@ async def handle_invoke(input: InvokeInput):
 @app.post(
     "/invocations",
     response_class=JsonStreamingResponse,
-    responses={
-        200: JsonStreamingResponse.openapi_response(
-            StreamChunk, "Stream of agent response chunks"
-        )
-    },
+    responses={200: JsonStreamingResponse.openapi_response(StreamChunk, "Stream of agent response chunks")},
 )
 async def invoke(input: InvokeInput) -> JsonStreamingResponse:
     """Entry point for agent invocation"""

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -9,17 +9,17 @@ from .app.inventory_mcp_client import InventoryMcpClient
 
 from .core.model_errors import log_model_errors
 
+from .app.inventory_mcp_client import InventoryMcpClient
 
 from .core.with_session_id import with_session_id
 
+from .app.inventory_mcp_client import InventoryMcpClient
 
-__all__ = [
-    "get_current_session_id",
-    "session_id_context",
-    "with_session_id",
-    "log_model_errors",
-    "InventoryMcpClient",
-]
+from .core.model_errors import log_model_errors
+
+from .app.inventory_mcp_client import InventoryMcpClient
+
+__all__ = ["get_current_session_id", "session_id_context", "with_session_id", "log_model_errors", "InventoryMcpClient"]
 "
 `;
 
@@ -133,7 +133,9 @@ class InventoryMcpClient:
     @staticmethod
     def create() -> MCPClient:
         if os.environ.get("SERVE_LOCAL") == "true":
-            return AgentCoreMCPClient.without_auth("http://localhost:8082/mcp")
+            return AgentCoreMCPClient.without_auth(
+                "http://localhost:8082/mcp"
+            )
         return AgentCoreMCPClient.with_iam_auth(
             get_connected_agent_runtime_arn("InventoryMcp")
         )

--- a/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -2,13 +2,11 @@
 
 exports[`py strands agent react connection generator > should generate OpenAPI spec script scoped to the agent > agent_openapi.py 1`] = `
 "from agent_project.agent.main import app
-import json
-import os
-import sys
+import json, os, sys
 
 os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True)
-with open(sys.argv[1], "w") as f:
-    json.dump(app.openapi(), f)
+with open(sys.argv[1], 'w') as f:
+  json.dump(app.openapi(), f)
 "
 `;
 

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -71,9 +71,7 @@ class JsonStreamingResponse(StreamingResponse):
             "description": description,
             "content": {
                 "application/jsonl": {
-                    "itemSchema": {
-                        "$ref": f"#/components/schemas/{item_model.__name__}"
-                    },
+                    "itemSchema": {"$ref": f"#/components/schemas/{item_model.__name__}"},
                 }
             },
             # Include the model so FastAPI registers the schema in components/schemas
@@ -90,11 +88,7 @@ async def cors_middleware(request: Request, call_next):
     response = await call_next(request)
 
     origin = request.headers.get("origin")
-    allowed_origins = (
-        os.environ.get("ALLOWED_ORIGINS", "").split(",")
-        if os.environ.get("ALLOWED_ORIGINS")
-        else []
-    )
+    allowed_origins = os.environ.get("ALLOWED_ORIGINS", "").split(",") if os.environ.get("ALLOWED_ORIGINS") else []
 
     is_localhost = origin and urlparse(origin).hostname in ["localhost", "127.0.0.1"]
     is_allowed_origin = origin and origin in allowed_origins
@@ -121,8 +115,7 @@ async def unhandled_exception_handler(request, err):
     metrics.add_metric(name="Failure", unit=MetricUnit.Count, value=1)
 
     return JSONResponse(
-        status_code=500,
-        content=InternalServerErrorDetails(detail="Internal Server Error").model_dump(),
+        status_code=500, content=InternalServerErrorDetails(detail="Internal Server Error").model_dump()
     )
 
 
@@ -228,22 +221,20 @@ if __name__ == "__main__":
     uvicorn.run("proj_test_api.main:app", port=8000)
 ",
   "apps/test_api/scripts/generate_open_api.py": "from proj_test_api.main import app
-import json
-import os
-import sys
+import json, os, sys
 
 os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True)
-with open(sys.argv[1], "w") as f:
-    json.dump(app.openapi(), f)
+with open(sys.argv[1], 'w') as f:
+  json.dump(app.openapi(), f)
 ",
   "apps/test_api/tests/__init__.py": """"unit tests."""
 ",
   "apps/test_api/tests/conftest.py": """"Unit tests configuration module."""
 ",
-  "apps/test_api/tests/test_main.py": "#
+  "apps/test_api/tests/test_main.py": "# 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
+# 
 
 
 def test_main():

--- a/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
@@ -2,13 +2,11 @@
 
 exports[`fastapi react generator > should generate OpenAPI spec script > generate_open_api.py 1`] = `
 "from src.main import app
-import json
-import os
-import sys
+import json, os, sys
 
 os.makedirs(os.path.dirname(sys.argv[1]), exist_ok=True)
-with open(sys.argv[1], "w") as f:
-    json.dump(app.openapi(), f)
+with open(sys.argv[1], 'w') as f:
+  json.dump(app.openapi(), f)
 "
 `;
 

--- a/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -15,11 +15,10 @@ logger: Logger = Logger()
 metrics: Metrics = Metrics()
 tracer: Tracer = Tracer()
 
-
 @tracer.capture_lambda_handler
 @metrics.log_metrics
 def lambda_handler(event: dict, context: LambdaContext):
-    logger.info("Received event", extra={"event": event})
+    logger.info("Received event", extra={"event": event })
     metrics.add_metric(name="InvocationCount", unit=MetricUnit.Count, value=1)
 
     try:

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -614,7 +614,7 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP(
     name="SnapshotServer",
     host="0.0.0.0",
-    port=int(os.environ.get("PORT", 8000)),
+    port=int(os.environ.get('PORT', 8000)),
     stateless_http=True,
 )
 

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -94,12 +94,16 @@ export async function formatFilesInSubtree(
     BIOME_FORMATTABLE_EXTENSIONS.has(path.extname(file.path)),
   );
 
-  // Format Python files with ruff (lint fixes + formatting)
+  // Format Python files with ruff (lint fixes + formatting). Ruff resolves
+  // its config (and isort defaults like `I`) by walking up from the file
+  // path on disk, and `uv run` resolves the workspace from cwd — both must
+  // be anchored at tree.root for per-project pyproject.toml configs to apply.
   for (const file of pyFiles) {
     try {
       const content = ruffFixAndFormat(
         file.content.toString('utf-8'),
         file.path,
+        tree.root,
       );
       tree.write(file.path, content);
     } catch {
@@ -236,63 +240,94 @@ function getBiomeCommand(root: string): BiomeCommand | undefined {
 }
 
 /**
- * Find the ruff command. Tries 'uv run ruff', then 'uvx ruff'.
- * Matches how @nxlv/python runs ruff via the UV provider.
+ * Run a single ruff stdin invocation. Returns the transformed content on
+ * success, or `undefined` if ruff couldn't run cleanly. `ruff check --fix`
+ * exits non-zero on unfixable findings while still emitting fixed content
+ * on stdout, so we accept that case and treat it as success — but distinguish
+ * it from "ruff itself failed to start" (uv couldn't resolve the workspace
+ * and short-circuited before running ruff, leaving the file unchanged on
+ * stdout while a workspace error is on stderr).
+ *
+ * `cwd` must be the workspace root and `stdinFilename` must be the absolute
+ * path to the file: ruff resolves config (and isort defaults like `I`) by
+ * walking up from the file path on disk, and `uv run` resolves the workspace
+ * from `cwd`. Mismatches between these and the in-memory tree state cause
+ * ruff to fall back to default rules (no import sorting), which silently
+ * leaves I001 in the output.
  */
-let _ruffCommand: string | undefined;
-function getRuffCommand(): string | undefined {
-  if (_ruffCommand !== undefined) {
-    return _ruffCommand || undefined;
+const tryRuff = (
+  cmd: string,
+  args: string,
+  input: string,
+  cwd: string,
+  stdinFilename: string,
+): string | undefined => {
+  let stdout = '';
+  let stderr = '';
+  try {
+    stdout = execSync(`${cmd} ${args} --stdin-filename ${stdinFilename} -`, {
+      input,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+    });
+  } catch (e: any) {
+    stdout = (e.stdout ?? '').toString();
+    stderr = (e.stderr ?? '').toString();
   }
-  for (const cmd of ['uv run ruff', 'uvx ruff']) {
-    try {
-      execSync(`${cmd} --version`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      _ruffCommand = cmd;
-      return cmd;
-    } catch {
-      // Try next command
-    }
+  // `uv run` emits a workspace-resolution error to stderr but still passes
+  // the unmodified input through to stdout; treat this as a failure so the
+  // caller can fall back to a workspace-independent invocation (`uvx`).
+  if (/Failed to (build|parse) `/.test(stderr)) {
+    return undefined;
   }
-  _ruffCommand = '';
-  return undefined;
-}
+  return stdout || undefined;
+};
 
 /**
  * Run ruff check --fix and ruff format on Python file content via stdin.
- * Applies all configured lint fixes (including import sorting) and formatting.
+ * Applies all configured lint fixes (including import sorting) and
+ * formatting.
+ *
+ * Tries `uv run ruff` first so the workspace's installed ruff version is
+ * used; falls back to `uvx ruff@<pinned>` when `uv run` can't resolve the
+ * workspace (transient state during generation: the in-memory tree's
+ * workspace pyproject.toml has not yet been flushed, so `uv run` from the
+ * workspace root sees a stale workspace and emits the file unchanged on
+ * stdout). The fallback pins ruff to a known-good version so generator
+ * output is reproducible regardless of the user's `uvx` cache.
+ *
+ * Both invocations still pick up per-project ruff config — they walk up
+ * from the stdin filename's directory on disk, which is what makes import
+ * sorting (`I`) apply.
  */
-function ruffFixAndFormat(content: string, filePath: string): string {
-  const ruff = getRuffCommand();
-  if (!ruff) return content;
+const PINNED_RUFF = 'ruff@0.15.17';
 
-  // First apply lint fixes (import sorting, unused imports, etc.)
-  try {
-    const result = execSync(
-      `${ruff} check --fix --stdin-filename ${filePath} -`,
-      { input: content, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+function ruffFixAndFormat(
+  content: string,
+  filePath: string,
+  cwd: string,
+): string {
+  const stdinFilename = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
+  // `--extend-select=I` enables the isort rules even when the file's
+  // project pyproject.toml has not yet been written to disk (a freshly
+  // generated project is still only in the in-memory tree at format time,
+  // so ruff falls back to its default ruleset which excludes `I`).
+  for (const cmd of ['uv run ruff', `uvx ${PINNED_RUFF}`]) {
+    // First apply lint fixes (import sorting, unused imports, etc.)
+    const fixed = tryRuff(
+      cmd,
+      'check --fix --extend-select=I',
+      content,
+      cwd,
+      stdinFilename,
     );
-    content = result;
-  } catch (e: any) {
-    // ruff check exits non-zero when it finds unfixable issues,
-    // but stdout still contains the fixed content
-    if (e.stdout) {
-      content = e.stdout;
-    }
+    if (fixed === undefined) continue;
+    // Then apply formatting
+    const formatted = tryRuff(cmd, 'format', fixed, cwd, stdinFilename);
+    return formatted ?? fixed;
   }
-
-  // Then apply formatting
-  try {
-    content = execSync(`${ruff} format --stdin-filename ${filePath} -`, {
-      input: content,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-  } catch {
-    // Fall through with whatever content we have
-  }
-
   return content;
 }


### PR DESCRIPTION
### Reason for this change

Vended Python files ship with unsorted imports that fail `ruff check` (I001) the first time the user lints. Two root causes, both stemming from running ruff against a workspace where the in-memory tree hasn't been flushed to disk yet:

1. `uv run ruff` runs from the workspace root. During generation the in-memory tree's workspace `pyproject.toml` has not yet been flushed, so `uv run` sees a stale workspace listing and fails to resolve sibling project dependencies — emitting the file unchanged on stdout while a workspace-resolution error goes to stderr. The previous error handling treated any non-empty stdout as success and never fell back, silently masking the failure.
2. Even when ruff itself runs, it loads its config (rules like `I`) by walking up from the stdin filename's directory on disk. A freshly-generated project's `pyproject.toml` is also still only in the in-memory tree at format time, so ruff falls back to its default ruleset — which excludes `I`, leaving import sorting off.

### Description of changes

- Detect the workspace-resolution stderr from `uv run ruff` and fall back to a pinned `uvx ruff@0.15.17` (workspace-independent).
- Pass `--extend-select=I` so import sorting always applies even when the project's `pyproject.toml` hasn't reached disk yet.
- Drop the process-wide cache of which ruff command works — ruff availability depends on workspace state at the moment it runs, not at the start of the process.
- Pin the fallback ruff version so generator output is reproducible regardless of the user's `uvx` cache.

### Description of how you validated changes

- Repro: a fresh `agent_connection` project generated by the connection generator chain previously emitted an `__init__.py` with blank lines between sequential `from` imports (a side effect of GritQL's Python printer between AST-driven appends), which `ruff check` flagged as I001 on first lint. With this fix, the same generation produces a clean, sorted `__init__.py`.
- All 2163 unit tests pass with the existing snapshots refreshed: 7 snapshot files had previously-passing-through-generation Python that contained either blank lines between imports or unsorted imports; they now ship correctly sorted.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*