### PR TITLE
docs: show enum values in generator parameter type column

### DIFF
--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -84,7 +84,7 @@ const getDescription = (parameter, fallback) => {
     Object.entries(schema.properties).map(([parameter, parameterSchema]) => (
       <tr>
         <td>{parameter} {(schema.required ?? []).includes(parameter) ? <Badge text={localeString('required')} variant="note" /> : null}</td>
-        <td>{parameterSchema.type}</td>
+        <td>{parameterSchema.enum ? parameterSchema.enum.join(' | ') : parameterSchema.type}</td>
         <td>{parameterSchema.default ?? '-'}</td>
         <td>{getDescription(parameter, parameterSchema.description) ?? '-'}</td>
       </tr>


### PR DESCRIPTION

### Reason for this change

Generator parameter tables in the docs showed `string` as the type for enum parameters, so users couldn't see the valid options (e.g. for `iac` or `infra`) without digging into the generator schema.

### Description of changes

Updated the `generator-parameters.astro` component to render the enum values joined with ` | ` in the Type column when a parameter schema defines an `enum` (e.g. `inherit | cdk | terraform`), falling back to the schema `type` otherwise.

### Description of how you validated changes

Built the docs site (`pnpm nx build docs`) and verified the rendered HTML: enum parameters such as `iac` now show `inherit | cdk | terraform` and `infra` shows `lambda | none`, while non-enum parameters still show `string`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
