### PR TITLE
feat(nx-plugin): backfill missing SDK exports for public generators + auto-export in nx-generator

### DIFF
--- a/docs/src/content/docs/en/guides/nx-generator.mdx
+++ b/docs/src/content/docs/en/guides/nx-generator.mdx
@@ -583,6 +583,7 @@ When this generator is run in our repository, it'll generate the following files
   - docs/src/content/docs/guides/
     - \<name>.mdx Documentation page for your generator
   - packages/nx-plugin/generators.json Updated to include your generator
+  - packages/nx-plugin/sdk/\<prefix>.ts Updated to expose your generator from the SDK (for `ts#` and `py#` generators)
 </FileTree>
 
 You can then start to implement your generator.

--- a/docs/src/content/docs/es/guides/nx-generator.mdx
+++ b/docs/src/content/docs/es/guides/nx-generator.mdx
@@ -516,6 +516,7 @@ Al ejecutarlo en nuestro repositorio, genera:
   - docs/src/content/docs/guides/
     - \<nombre>.mdx
   - packages/nx-plugin/generators.json Actualizado
+  - packages/nx-plugin/sdk/\<prefix>.ts Actualizado para exponer tu generador desde el SDK (para generadores `ts#` y `py#`)
 </FileTree>
 
 :::tip[Contribuir generadores]

--- a/docs/src/content/docs/fr/guides/nx-generator.mdx
+++ b/docs/src/content/docs/fr/guides/nx-generator.mdx
@@ -583,6 +583,7 @@ Lorsque ce générateur est exécuté dans notre dépôt, il générera les fich
   - docs/src/content/docs/guides/
     - \<name>.mdx Page de documentation pour votre générateur
   - packages/nx-plugin/generators.json Mis à jour pour inclure votre générateur
+  - packages/nx-plugin/sdk/\<prefix>.ts Mis à jour pour exposer votre générateur depuis le SDK (pour les générateurs `ts#` et `py#`)
 </FileTree>
 
 Vous pouvez ensuite commencer à implémenter votre générateur.

--- a/docs/src/content/docs/it/guides/nx-generator.mdx
+++ b/docs/src/content/docs/it/guides/nx-generator.mdx
@@ -581,6 +581,7 @@ Quando questo generatore viene eseguito nel nostro repository, genererà i segue
   - docs/src/content/docs/guides/
     - \<name>.mdx Pagina di documentazione per il generatore
   - packages/nx-plugin/generators.json Aggiornato per includere il generatore
+  - packages/nx-plugin/sdk/\<prefix>.ts Aggiornato per esporre il generatore dall'SDK (per generatori `ts#` e `py#`)
 </FileTree>
 
 Potrai quindi iniziare a implementare il tuo generatore.

--- a/docs/src/content/docs/jp/guides/nx-generator.mdx
+++ b/docs/src/content/docs/jp/guides/nx-generator.mdx
@@ -513,6 +513,7 @@ describe('your generator', () => {
   - docs/src/content/docs/guides/
     - \<name>.mdx ドキュメント
   - packages/nx-plugin/generators.json ジェネレータ定義更新
+  - packages/nx-plugin/sdk/\<prefix>.ts SDKからジェネレータを公開するよう更新（`ts#`および`py#`ジェネレータ用）
 </FileTree>
 
 :::tip[ジェネレーターへの貢献]

--- a/docs/src/content/docs/ko/guides/nx-generator.mdx
+++ b/docs/src/content/docs/ko/guides/nx-generator.mdx
@@ -583,6 +583,7 @@ describe('your generator', () => {
   - docs/src/content/docs/guides/
     - \<name>.mdx 제너레이터 문서 페이지
   - packages/nx-plugin/generators.json 제너레이터 포함되도록 업데이트
+  - packages/nx-plugin/sdk/\<prefix>.ts SDK에서 제너레이터를 노출하도록 업데이트 (`ts#` 및 `py#` 제너레이터용)
 </FileTree>
 
 이후 제너레이터 구현을 시작할 수 있습니다.

--- a/docs/src/content/docs/pt/guides/nx-generator.mdx
+++ b/docs/src/content/docs/pt/guides/nx-generator.mdx
@@ -522,17 +522,22 @@ Pontos-chave para testes:
 
 Use `ts#nx-generator` para criar generators dentro de `@aws/nx-plugin`. No nosso repositório, ele gera:
 
+Quando este gerador é executado em nosso repositório, ele gerará os seguintes arquivos para você:
+
 <FileTree>
   - packages/nx-plugin/src/\<name>/
-    - schema.json
-    - schema.d.ts
-    - generator.ts
-    - generator.spec.ts
+    - schema.json Schema para entrada do seu gerador
+    - schema.d.ts Tipos TypeScript para seu schema
+    - generator.ts Implementação do gerador
+    - generator.spec.ts Testes para seu gerador
   - docs/src/content/docs/guides/
-    - \<name>.mdx
-  - packages/nx-plugin/generators.json Atualizado
+    - \<name>.mdx Página de documentação para seu gerador
+  - packages/nx-plugin/generators.json Atualizado para incluir seu gerador
+  - packages/nx-plugin/sdk/\<prefix>.ts Atualizado para expor seu gerador do SDK (para geradores `ts#` e `py#`)
 </FileTree>
 
-:::tip[Contribuindo geradores]
-Para um guia detalhado sobre contribuição, consulte o <Link path="get_started/tutorials/contribute-generator">tutorial aqui</Link>.
+Você pode então começar a implementar seu gerador.
+
+:::tip[Contribuindo Geradores]
+Para um guia mais detalhado sobre contribuição para o Nx Plugin for AWS, consulte o <Link path="get_started/tutorials/contribute-generator">tutorial aqui</Link>.
 :::

--- a/docs/src/content/docs/vi/guides/nx-generator.mdx
+++ b/docs/src/content/docs/vi/guides/nx-generator.mdx
@@ -583,6 +583,7 @@ Khi generator này được chạy trong repository của chúng tôi, nó sẽ 
   - docs/src/content/docs/guides/
     - \<name>.mdx Trang tài liệu cho generator
   - packages/nx-plugin/generators.json Được cập nhật để bao gồm generator của bạn
+  - packages/nx-plugin/sdk/\<prefix>.ts Được cập nhật để expose generator của bạn từ SDK (cho các generator `ts#` và `py#`)
 </FileTree>
 
 Sau đó bạn có thể bắt đầu triển khai generator của mình.

--- a/docs/src/content/docs/zh/guides/nx-generator.mdx
+++ b/docs/src/content/docs/zh/guides/nx-generator.mdx
@@ -580,6 +580,7 @@ describe('生成器测试', () => {
   - docs/src/content/docs/guides/
     - \<name>.mdx 生成器文档页
   - packages/nx-plugin/generators.json 更新包含新生成器
+  - packages/nx-plugin/sdk/\<prefix>.ts 更新以从 SDK 暴露生成器（适用于 `ts#` 和 `py#` 生成器）
 </FileTree>
 
 之后即可开始实现生成器。

--- a/packages/nx-plugin/sdk/agentcore-gateway.ts
+++ b/packages/nx-plugin/sdk/agentcore-gateway.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// AgentCore Gateway Generator
+export { agentcoreGatewayGenerator } from '../src/agentcore-gateway/generator';
+export type { AgentcoreGatewayGeneratorSchema } from '../src/agentcore-gateway/schema';

--- a/packages/nx-plugin/sdk/license.ts
+++ b/packages/nx-plugin/sdk/license.ts
@@ -2,14 +2,17 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export { DEFAULT_LICENSE_ALLOWLIST } from '../src/license/index';
+export { licenseGenerator } from '../src/license/generator';
 export type {
   AllowlistEntry,
+  CollectedDependency,
   DependencyCheckConfig,
   DependencyCheckException,
-} from '../src/license/index';
-export { npmCollector, pythonCollector } from '../src/license/index';
-export type {
   LicenseCollector,
-  CollectedDependency,
 } from '../src/license/index';
+export {
+  DEFAULT_LICENSE_ALLOWLIST,
+  npmCollector,
+  pythonCollector,
+} from '../src/license/index';
+export type { LicenseGeneratorSchema } from '../src/license/schema';

--- a/packages/nx-plugin/sdk/py.ts
+++ b/packages/nx-plugin/sdk/py.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { pyProjectGenerator } from '../src/py/project/generator';
-export { PyProjectGeneratorSchema } from '../src/py/project/schema';
+export { pyAgentGenerator } from '../src/py/agent/generator';
+export { PyAgentGeneratorSchema } from '../src/py/agent/schema';
+
+export { pyApiGenerator } from '../src/py/api/generator';
+export { PyApiGeneratorSchema } from '../src/py/api/schema';
 
 export { pyFastApiProjectGenerator } from '../src/py/fast-api/generator';
 export { PyFastApiProjectGeneratorSchema } from '../src/py/fast-api/schema';
@@ -14,6 +17,5 @@ export { PyLambdaFunctionGeneratorSchema } from '../src/py/lambda-function/schem
 
 export { pyMcpServerGenerator } from '../src/py/mcp-server/generator';
 export { PyMcpServerGeneratorSchema } from '../src/py/mcp-server/schema';
-
-export { pyAgentGenerator } from '../src/py/agent/generator';
-export { PyAgentGeneratorSchema } from '../src/py/agent/schema';
+export { pyProjectGenerator } from '../src/py/project/generator';
+export { PyProjectGeneratorSchema } from '../src/py/project/schema';

--- a/packages/nx-plugin/sdk/py.ts
+++ b/packages/nx-plugin/sdk/py.ts
@@ -9,9 +9,6 @@ export { PyAgentGeneratorSchema } from '../src/py/agent/schema';
 export { pyApiGenerator } from '../src/py/api/generator';
 export { PyApiGeneratorSchema } from '../src/py/api/schema';
 
-export { pyFastApiProjectGenerator } from '../src/py/fast-api/generator';
-export { PyFastApiProjectGeneratorSchema } from '../src/py/fast-api/schema';
-
 export { pyLambdaFunctionGenerator } from '../src/py/lambda-function/generator';
 export { PyLambdaFunctionGeneratorSchema } from '../src/py/lambda-function/schema';
 

--- a/packages/nx-plugin/sdk/ts.ts
+++ b/packages/nx-plugin/sdk/ts.ts
@@ -6,19 +6,12 @@
 // TypeScript Infrastructure
 export { tsInfraGenerator } from '../src/infra/app/generator';
 export type { TsInfraGeneratorSchema } from '../src/infra/app/schema';
-// TypeScript Smithy API
-export { tsSmithyApiGenerator } from '../src/smithy/ts/api/generator';
-export type { TsSmithyApiGeneratorSchema } from '../src/smithy/ts/api/schema';
-// TypeScript tRPC API
-export { tsTrpcApiGenerator } from '../src/trpc/backend/generator';
-export type { TsTrpcApiGeneratorSchema } from '../src/trpc/backend/schema';
 // TypeScript Agent Generator
 export { tsAgentGenerator } from '../src/ts/agent/generator';
 export type { TsAgentGeneratorSchema } from '../src/ts/agent/schema';
 // TypeScript API
 export { tsApiGenerator } from '../src/ts/api/generator';
 export type { TsApiGeneratorSchema } from '../src/ts/api/schema';
-
 // Documentation Site Generator
 export { tsDocsGenerator } from '../src/ts/docs/generator';
 export type { TsDocsGeneratorSchema } from '../src/ts/docs/schema';
@@ -34,23 +27,15 @@ export type { TsProjectGeneratorSchema } from '../src/ts/lib/schema';
 // TypeScript MCP Server Generator
 export { tsMcpServerGenerator } from '../src/ts/mcp-server/generator';
 export type { TsMcpServerGeneratorSchema } from '../src/ts/mcp-server/schema';
-
 // TypeScript Nx Generator Generator
 export { tsNxGeneratorGenerator } from '../src/ts/nx-generator/generator';
 export type { TsNxGeneratorGeneratorSchema } from '../src/ts/nx-generator/schema';
-
 // TypeScript Nx Plugin Generator
 export { tsNxPluginGenerator } from '../src/ts/nx-plugin/generator';
 export type { TsNxPluginGeneratorSchema } from '../src/ts/nx-plugin/schema';
 // Relational Database Generator
 export { tsRdbGenerator } from '../src/ts/rdb/generator';
 export type { TsRdbGeneratorSchema } from '../src/ts/rdb/schema';
-// TypeScript React Website Generator
-export { tsReactWebsiteGenerator } from '../src/ts/react-website/app/generator';
-export type { TsReactWebsiteGeneratorSchema } from '../src/ts/react-website/app/schema';
-// TypeScript React Website Auth Generator
-export { tsReactWebsiteAuthGenerator } from '../src/ts/react-website/cognito-auth/generator';
-export type { TsReactWebsiteAuthGeneratorSchema } from '../src/ts/react-website/cognito-auth/schema';
 // Runtime Config
 export { runtimeConfigGenerator } from '../src/ts/react-website/runtime-config/generator';
 export type { RuntimeConfigGeneratorSchema } from '../src/ts/react-website/runtime-config/schema';

--- a/packages/nx-plugin/sdk/ts.ts
+++ b/packages/nx-plugin/sdk/ts.ts
@@ -3,21 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TypeScript Project Generator
-export { tsProjectGenerator } from '../src/ts/lib/generator';
-export type { TsProjectGeneratorSchema } from '../src/ts/lib/schema';
-
 // TypeScript Infrastructure
 export { tsInfraGenerator } from '../src/infra/app/generator';
 export type { TsInfraGeneratorSchema } from '../src/infra/app/schema';
-
-// TypeScript MCP Server Generator
-export { tsMcpServerGenerator } from '../src/ts/mcp-server/generator';
-export type { TsMcpServerGeneratorSchema } from '../src/ts/mcp-server/schema';
-
+// TypeScript Smithy API
+export { tsSmithyApiGenerator } from '../src/smithy/ts/api/generator';
+export type { TsSmithyApiGeneratorSchema } from '../src/smithy/ts/api/schema';
+// TypeScript tRPC API
+export { tsTrpcApiGenerator } from '../src/trpc/backend/generator';
+export type { TsTrpcApiGeneratorSchema } from '../src/trpc/backend/schema';
 // TypeScript Agent Generator
 export { tsAgentGenerator } from '../src/ts/agent/generator';
 export type { TsAgentGeneratorSchema } from '../src/ts/agent/schema';
+// TypeScript API
+export { tsApiGenerator } from '../src/ts/api/generator';
+export type { TsApiGeneratorSchema } from '../src/ts/api/schema';
+
+// Documentation Site Generator
+export { tsDocsGenerator } from '../src/ts/docs/generator';
+export type { TsDocsGeneratorSchema } from '../src/ts/docs/schema';
+// DynamoDB Generator
+export { tsDynamoDBGenerator } from '../src/ts/dynamodb/generator';
+export type { TsDynamoDBGeneratorSchema } from '../src/ts/dynamodb/schema';
+// TypeScript Lambda Function
+export { tsLambdaFunctionGenerator } from '../src/ts/lambda-function/generator';
+export type { TsLambdaFunctionGeneratorSchema } from '../src/ts/lambda-function/schema';
+// TypeScript Project Generator
+export { tsProjectGenerator } from '../src/ts/lib/generator';
+export type { TsProjectGeneratorSchema } from '../src/ts/lib/schema';
+// TypeScript MCP Server Generator
+export { tsMcpServerGenerator } from '../src/ts/mcp-server/generator';
+export type { TsMcpServerGeneratorSchema } from '../src/ts/mcp-server/schema';
 
 // TypeScript Nx Generator Generator
 export { tsNxGeneratorGenerator } from '../src/ts/nx-generator/generator';
@@ -26,30 +42,24 @@ export type { TsNxGeneratorGeneratorSchema } from '../src/ts/nx-generator/schema
 // TypeScript Nx Plugin Generator
 export { tsNxPluginGenerator } from '../src/ts/nx-plugin/generator';
 export type { TsNxPluginGeneratorSchema } from '../src/ts/nx-plugin/schema';
-
+// Relational Database Generator
+export { tsRdbGenerator } from '../src/ts/rdb/generator';
+export type { TsRdbGeneratorSchema } from '../src/ts/rdb/schema';
 // TypeScript React Website Generator
 export { tsReactWebsiteGenerator } from '../src/ts/react-website/app/generator';
 export type { TsReactWebsiteGeneratorSchema } from '../src/ts/react-website/app/schema';
-
 // TypeScript React Website Auth Generator
 export { tsReactWebsiteAuthGenerator } from '../src/ts/react-website/cognito-auth/generator';
 export type { TsReactWebsiteAuthGeneratorSchema } from '../src/ts/react-website/cognito-auth/schema';
-
 // Runtime Config
 export { runtimeConfigGenerator } from '../src/ts/react-website/runtime-config/generator';
 export type { RuntimeConfigGeneratorSchema } from '../src/ts/react-website/runtime-config/schema';
-
-// TypeScript tRPC API
-export { tsTrpcApiGenerator } from '../src/trpc/backend/generator';
-export type { TsTrpcApiGeneratorSchema } from '../src/trpc/backend/schema';
-
-// TypeScript Smithy API
-export { tsSmithyApiGenerator } from '../src/smithy/ts/api/generator';
-export type { TsSmithyApiGeneratorSchema } from '../src/smithy/ts/api/schema';
-
-// TypeScript Lambda Function
-export { tsLambdaFunctionGenerator } from '../src/ts/lambda-function/generator';
-export type { TsLambdaFunctionGeneratorSchema } from '../src/ts/lambda-function/schema';
+// TypeScript Website Generator
+export { tsWebsiteGenerator } from '../src/ts/website/app/generator';
+export type { TsWebsiteGeneratorSchema } from '../src/ts/website/app/schema';
+// TypeScript Website Auth Generator
+export { tsWebsiteAuthGenerator } from '../src/ts/website/auth/generator';
+export type { TsWebsiteAuthGeneratorSchema } from '../src/ts/website/auth/schema';
 
 // Shared Constructs
 export { sharedConstructsGenerator } from '../src/utils/shared-constructs';

--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -297,6 +297,99 @@ describe('nx-generator generator', () => {
       );
     });
 
+    it('should add a ts# generator to the ts sdk', async () => {
+      tree.write(
+        'packages/nx-plugin/sdk/ts.ts',
+        `export { tsProjectGenerator } from '../src/ts/lib/generator';\n`,
+      );
+
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'ts#cool-thing',
+        description: 'Some description',
+      });
+
+      const sdk = tree.read('packages/nx-plugin/sdk/ts.ts', 'utf-8');
+      expect(sdk).toContain(
+        `export { tsCoolThingGenerator } from '../src/ts-cool-thing/generator';`,
+      );
+      expect(sdk).toContain(
+        `export type { TsCoolThingGeneratorSchema } from '../src/ts-cool-thing/schema';`,
+      );
+      // Existing exports preserved
+      expect(sdk).toContain(
+        `export { tsProjectGenerator } from '../src/ts/lib/generator';`,
+      );
+    });
+
+    it('should add a py# generator to the py sdk', async () => {
+      tree.write('packages/nx-plugin/sdk/py.ts', '');
+
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'py#cool-thing',
+        description: 'Some description',
+      });
+
+      const sdk = tree.read('packages/nx-plugin/sdk/py.ts', 'utf-8');
+      expect(sdk).toContain(
+        `export { pyCoolThingGenerator } from '../src/py-cool-thing/generator';`,
+      );
+      expect(sdk).toContain(
+        `export type { PyCoolThingGeneratorSchema } from '../src/py-cool-thing/schema';`,
+      );
+    });
+
+    it('should add a ts# generator to the ts sdk in a nested directory', async () => {
+      tree.write('packages/nx-plugin/sdk/ts.ts', '');
+
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'ts#cool-thing',
+        directory: 'nested/dir',
+        description: 'Some description',
+      });
+
+      const sdk = tree.read('packages/nx-plugin/sdk/ts.ts', 'utf-8');
+      expect(sdk).toContain(
+        `export { tsCoolThingGenerator } from '../src/nested/dir/generator';`,
+      );
+      expect(sdk).toContain(
+        `export type { TsCoolThingGeneratorSchema } from '../src/nested/dir/schema';`,
+      );
+    });
+
+    it('should not duplicate the sdk export on a same-name re-run', async () => {
+      tree.write('packages/nx-plugin/sdk/ts.ts', '');
+
+      const options = {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'ts#cool-thing',
+        description: 'Some description',
+      };
+      await tsNxGeneratorGenerator(tree, options);
+      await tsNxGeneratorGenerator(tree, options);
+
+      const sdk = tree.read('packages/nx-plugin/sdk/ts.ts', 'utf-8');
+      const occurrences =
+        sdk.split(`from '../src/ts-cool-thing/generator';`).length - 1;
+      expect(occurrences).toBe(1);
+    });
+
+    it('should not add an sdk export for generators without a known prefix', async () => {
+      tree.write('packages/nx-plugin/sdk/ts.ts', '');
+      tree.write('packages/nx-plugin/sdk/py.ts', '');
+
+      await tsNxGeneratorGenerator(tree, {
+        project: NxPluginForAwsProjectJson.name,
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      expect(tree.read('packages/nx-plugin/sdk/ts.ts', 'utf-8')).toBe('');
+      expect(tree.read('packages/nx-plugin/sdk/py.ts', 'utf-8')).toBe('');
+    });
+
     it('should throw if given a project that is not @aws/nx-plugin', async () => {
       // Add a different project configuration
       addProjectConfiguration(tree, 'other-project', {

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -112,6 +112,9 @@ export const tsNxGeneratorGenerator = async (
       joinPathFragments('docs', 'astro.config.mjs'),
       `\`items: [$items]\` where { $items <: within \`sidebar: [$_]\`, $items <: contains \`'ts#project'\`, $items <: not contains \`'/guides/${enhancedOptions.nameKebabCase}'\`, $items += \`, { label: '${name}', link: '/guides/${enhancedOptions.nameKebabCase}' }\` }`,
     );
+
+    // Expose the generator from the SDK for known prefixes (ts# / py#)
+    addSdkExport(tree, plugin.root, name, generatorSubDir, enhancedOptions);
   } else {
     // Local generator in a project other than nx-plugin-for-aws
     generateFiles(
@@ -182,6 +185,51 @@ export const tsNxGeneratorGenerator = async (
 const incrementMetric = (metrics: string[]): string => {
   const maxMetric = Math.max(...metrics.map((m) => Number(m.slice(1))));
   return `g${maxMetric + 1}`;
+};
+
+// Maps a generator name prefix to the SDK entry point that should re-export it
+const SDK_EXPORT_PREFIXES: Record<string, string> = {
+  'ts#': 'ts',
+  'py#': 'py',
+};
+
+// Re-exports a generated generator from the matching SDK entry point so it is
+// available programmatically as part of @aws/nx-plugin's SDK
+const addSdkExport = (
+  tree: Tree,
+  pluginRoot: string,
+  name: string,
+  generatorSubDir: string,
+  options: { nameCamelCase: string; namePascalCase: string },
+): void => {
+  const prefix = Object.keys(SDK_EXPORT_PREFIXES).find((p) =>
+    name.startsWith(p),
+  );
+  if (!prefix) {
+    return;
+  }
+
+  const sdkPath = joinPathFragments(
+    pluginRoot,
+    'sdk',
+    `${SDK_EXPORT_PREFIXES[prefix]}.ts`,
+  );
+  const generatorExport = `${options.nameCamelCase}Generator`;
+  const schemaExport = `${options.namePascalCase}GeneratorSchema`;
+  const moduleBase = `../src/${generatorSubDir}`;
+
+  const contents = tree.exists(sdkPath) ? tree.read(sdkPath).toString() : '';
+  // Idempotent: skip if this generator is already exported
+  if (contents.includes(`${moduleBase}/generator`)) {
+    return;
+  }
+
+  const block = `// ${options.namePascalCase} Generator\nexport { ${generatorExport} } from '${moduleBase}/generator';\nexport type { ${schemaExport} } from '${moduleBase}/schema';\n`;
+
+  const prefixContents = contents.trim()
+    ? `${contents.replace(/\s*$/, '')}\n\n`
+    : '';
+  tree.write(sdkPath, `${prefixContents}${block}`);
 };
 
 export default tsNxGeneratorGenerator;


### PR DESCRIPTION
### Reason for this change

The `@aws/nx-plugin` SDK (the hand-maintained re-export files under `packages/nx-plugin/sdk/*.ts`) is how consumers use generators programmatically. Several **public** (non-hidden) generators were missing from the SDK, so they couldn't be imported and composed. There was also no mechanism keeping the SDK in sync as new generators are added, so it drifted over time.

### Description of changes

**1. Backfill missing public-generator SDK exports**

Audited `generators.json` for every generator without `"hidden": true` and added the missing re-exports (generator function + schema type):

| Generator | SDK file |
| --- | --- |
| `agentcore-gateway` | new `sdk/agentcore-gateway.ts` |
| `license` | `sdk/license.ts` (added `licenseGenerator` + `LicenseGeneratorSchema`) |
| `py#api` | `sdk/py.ts` |
| `ts#api` | `sdk/ts.ts` |
| `ts#docs` | `sdk/ts.ts` |
| `ts#rdb` | `sdk/ts.ts` |
| `ts#dynamodb` | `sdk/ts.ts` |
| `ts#website` | `sdk/ts.ts` |
| `ts#website#auth` | `sdk/ts.ts` |

The new `sdk/agentcore-gateway.ts` is automatically picked up by the build via `tsconfig.lib.json`'s `sdk/**/*.ts` include. Export and schema-type names were verified against each generator's source rather than guessed.

**2. Drop superseded hidden-generator SDK exports**

Several hidden generators were exposed in the SDK but are now fully covered by the public generators added above (which compose them). These have been removed from the SDK in favour of their public equivalents:

| Removed (hidden) | Superseded by |
| --- | --- |
| `ts#trpc-api` (`tsTrpcApiGenerator`) | `ts#api` (`tsApiGenerator`, `framework: 'trpc'`) |
| `ts#smithy-api` (`tsSmithyApiGenerator`) | `ts#api` (`tsApiGenerator`, `framework: 'smithy'`) |
| `ts#react-website` (`tsReactWebsiteGenerator`) | `ts#website` (`tsWebsiteGenerator`) |
| `ts#react-website#auth` (`tsReactWebsiteAuthGenerator`) | `ts#website#auth` (`tsWebsiteAuthGenerator`) |
| `py#fast-api` (`pyFastApiProjectGenerator`) | `py#api` (`pyApiGenerator`) |

`runtimeConfigGenerator` is retained as no public generator supersedes it.

**3. Auto-export from `ts#nx-generator`**

When the `ts#nx-generator` generator runs inside the `@aws/nx-plugin` package itself, a generator whose name has a known prefix (`ts#` or `py#`) is now automatically re-exported from the matching SDK entry point (`sdk/ts.ts` or `sdk/py.ts`). The export is idempotent (no duplication on a same-name re-run), derives the import path from the generator's source location, and uses the same `<nameCamelCase>Generator` / `<namePascalCase>GeneratorSchema` naming convention the scaffold emits. Generators without a known prefix are left untouched. This keeps the SDK in sync going forward.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:compile` passes — all new SDK exports resolve.
- Added 5 unit tests to `src/ts/nx-generator/generator.spec.ts` covering: `ts#` export, `py#` export, nested-directory export path, idempotency on re-run, and that unknown-prefix generators are not exported. The full `nx-generator` suite (46 tests) passes.
- `pnpm nx run-many --target lint --all --fix` is clean.
- Pre-existing full-suite snapshot failures in untouched generators (preset/infra/react-website) were verified to also fail on clean `main` and are unrelated to this change.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
