### PR TITLE
test(agentcore-gateway): use Target-<name> construct id and broaden gateway e2e coverage

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -214,6 +214,42 @@ describe('smoke test - cdk-deploy', () => {
         'Use the ask_my_py_a2a_agent tool to ask the remote agent what 7 + 8 is. Return just the answer.',
       );
 
+      // AgentCore Gateway — both HTTP agents have the gateway's tools wired in
+      // via the gateway-connection generators, and the gateway fronts both the
+      // TypeScript (`hosted-mcp-server`) and Python (`my-mcp-server`) MCP
+      // servers. Prompt each agent to call a gateway-prefixed tool
+      // (`<target>___<tool>`) for each upstream server and assert the result.
+      // A successful round-trip proves agent -> deployed Gateway (Cedar
+      // ENFORCE + SigV4) -> MCP server works end-to-end for both languages.
+      expect(
+        await invokeTrpcAgentCoreAgent(
+          findOutput('TsAgentArn'),
+          'TS Agent -> Gateway -> TS MCP (hosted-mcp-server___divide)',
+          'Use the hosted-mcp-server___divide tool to divide 6 by 2. Return just the number.',
+        ),
+      ).toContain('3');
+      expect(
+        await invokeTrpcAgentCoreAgent(
+          findOutput('TsAgentArn'),
+          'TS Agent -> Gateway -> PY MCP (my-mcp-server___add)',
+          'Use the my-mcp-server___add tool to add 6 and 2. Return just the number.',
+        ),
+      ).toContain('8');
+      expect(
+        await invokeAgentCoreAgent(
+          findOutput('PyAgentArn'),
+          'PY Agent -> Gateway -> TS MCP (hosted-mcp-server___divide)',
+          'Use the hosted-mcp-server___divide tool to divide 6 by 2. Return just the number.',
+        ),
+      ).toContain('3');
+      expect(
+        await invokeAgentCoreAgent(
+          findOutput('PyAgentArn'),
+          'PY Agent -> Gateway -> PY MCP (my-mcp-server___add)',
+          'Use the my-mcp-server___add tool to add 6 and 2. Return just the number.',
+        ),
+      ).toContain('8');
+
       // Lambda functions
       await invokeLambda(findOutput('PyFunctionArn'), 'Python Function');
       await invokeLambda(findOutput('TsFunctionArn'), 'TypeScript Function');

--- a/e2e/src/smoke-tests/serve-local.spec.ts
+++ b/e2e/src/smoke-tests/serve-local.spec.ts
@@ -225,6 +225,10 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
         opts,
       );
       await runCLI(
+        `generate @aws/nx-plugin:py#agent --project=py_project --name=gw-py-agent --infra=none --no-interactive`,
+        opts,
+      );
+      await runCLI(
         `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive`,
         opts,
       );
@@ -254,11 +258,15 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
         `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-agent --targetProject=py_project --targetComponent=my-py-mcp --no-interactive`,
         opts,
       );
-      // Gateway wiring: gw-agent -> gateway -> {my-mcp, my-py-mcp}. The
-      // agent's serve-local boots the local gateway, which aggregates both
-      // MCP servers behind one endpoint.
+      // Gateway wiring: {gw-agent, gw-py-agent} -> gateway -> {my-mcp,
+      // my-py-mcp}. Each agent's serve-local boots the local gateway, which
+      // aggregates both MCP servers behind one endpoint.
       await runCLI(
         `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=gw-agent --targetProject=my-gateway --no-interactive`,
+        opts,
+      );
+      await runCLI(
+        `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=gw-py-agent --targetProject=my-gateway --no-interactive`,
         opts,
       );
       await runCLI(
@@ -303,6 +311,7 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
         'my_py_agent',
         'my_py_a2a_agent',
         'my_py_agui_agent',
+        'gw_py_agent',
       ]) {
         const file = `${projectRoot}/packages/py_project/serve_local_test_py_project/${dir}/agent.py`;
         let content = readFileSync(file, 'utf-8');
@@ -387,6 +396,11 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
           projectRoot,
           'packages/ts-project/project.json',
           'gw-agent-serve-local',
+        ),
+        gwPyAgent: getPortFromProjectJson(
+          projectRoot,
+          'packages/py_project/project.json',
+          'gw-py-agent-serve-local',
         ),
       };
       console.log('Ports discovered:', ports);
@@ -582,6 +596,74 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
     // Python MCP server: add(6, 2) = 8
     const pyResult = await invokeGatewayTool('my-py-mcp___add');
     console.log('Gateway -> Py MCP (add) stream:', pyResult);
+    expect(pyResult).toContain('8');
+
+    await stopLast();
+  });
+
+  it('Python HTTP Agent - AgentCore Gateway local gateway across multiple MCP servers', async () => {
+    // Mirror of the TypeScript gateway test for a Python agent: the
+    // `gw-py-agent` fronts the gateway, which aggregates the TypeScript
+    // `my-mcp` and Python `my-py-mcp` servers. Drive the LLM mock to call a
+    // gateway-prefixed tool (`<target>___<tool>`) from each and echo the
+    // result. A successful round-trip for both proves the Python agent booted
+    // the local gateway under SERVE_LOCAL, aggregated tools from every
+    // attached MCP server, and routed each call to the right upstream server.
+    type MockReq = {
+      lastMessage: string;
+      messages: { role: string; content: string }[];
+    };
+    const resolver = (req: MockReq) => {
+      const toolMsg = [...req.messages]
+        .reverse()
+        .find((m) => m.role === 'tool');
+      if (toolMsg) return { text: `gateway tool returned ${toolMsg.content}` };
+      const tool = req.lastMessage.replace('call ', '').trim();
+      return { tools: [{ name: tool, args: { a: 6, b: 2 } }] };
+    };
+    const isGatewayTurn = (req: MockReq) =>
+      req.lastMessage.startsWith('call my-') ||
+      req.messages.some((m) => m.role === 'tool');
+    llmMock!
+      .when(isGatewayTurn as never)
+      .reply(resolver as never)
+      .first()
+      .times(4);
+
+    // gw-py-agent-serve-local chains the gateway's serve-local, which starts
+    // both attached MCP servers (deduped with any other serve-local chains in
+    // the same task graph).
+    await startAndWait(
+      'serve_local_test.py_project:gw-py-agent-serve-local',
+      ports.gwPyAgent,
+    );
+
+    const invokeGatewayTool = async (tool: string): Promise<string> => {
+      const res = await fetch(
+        `http://127.0.0.1:${ports.gwPyAgent}/invocations`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: `call ${tool}` }),
+        },
+      );
+      const body = await res.text();
+      const chunks = body
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l));
+      return chunks.map((c) => c.content ?? '').join('');
+    };
+
+    // TypeScript MCP server: divide(6, 2) = 3
+    const tsResult = await invokeGatewayTool('my-mcp___divide');
+    console.log('Py Agent Gateway -> TS MCP (divide) stream:', tsResult);
+    expect(tsResult).toContain('3');
+
+    // Python MCP server: add(6, 2) = 8
+    const pyResult = await invokeGatewayTool('my-py-mcp___add');
+    console.log('Py Agent Gateway -> Py MCP (add) stream:', pyResult);
     expect(pyResult).toContain('8');
 
     await stopLast();

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -207,6 +207,42 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
             'Use the ask_my_py_a2a_agent tool to ask the remote agent what 7 + 8 is. Return just the answer.',
           );
 
+          // AgentCore Gateway — both HTTP agents are granted invoke access to
+          // the gateway, which fronts the TypeScript (`hosted-mcp-server`) and
+          // Python (`my-mcp-server`) MCP servers as targets. Prompt each agent
+          // to call a gateway-prefixed tool (`<target>___<tool>`) for each
+          // upstream server. A successful round-trip proves agent -> deployed
+          // Gateway (Cedar ENFORCE + SigV4) -> MCP server works end-to-end for
+          // both languages.
+          expect(
+            await invokeTrpcAgentCoreAgent(
+              outputs.ts_agent_arn,
+              'TS Agent -> Gateway -> TS MCP (hosted-mcp-server___divide)',
+              'Use the hosted-mcp-server___divide tool to divide 6 by 2. Return just the number.',
+            ),
+          ).toContain('3');
+          expect(
+            await invokeTrpcAgentCoreAgent(
+              outputs.ts_agent_arn,
+              'TS Agent -> Gateway -> PY MCP (my-mcp-server___add)',
+              'Use the my-mcp-server___add tool to add 6 and 2. Return just the number.',
+            ),
+          ).toContain('8');
+          expect(
+            await invokeAgentCoreAgent(
+              outputs.py_agent_arn,
+              'PY Agent -> Gateway -> TS MCP (hosted-mcp-server___divide)',
+              'Use the hosted-mcp-server___divide tool to divide 6 by 2. Return just the number.',
+            ),
+          ).toContain('3');
+          expect(
+            await invokeAgentCoreAgent(
+              outputs.py_agent_arn,
+              'PY Agent -> Gateway -> PY MCP (my-mcp-server___add)',
+              'Use the my-mcp-server___add tool to add 6 and 2. Return just the number.',
+            ),
+          ).toContain('8');
+
           // Lambda functions
           await invokeLambda(outputs.py_function_arn, 'Python Function');
           await invokeLambda(outputs.ts_function_arn, 'TypeScript Function');

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -266,6 +266,18 @@ describe('agentcore-gateway generator', () => {
       expect(construct).toContain('public addMcpServerTarget');
     });
 
+    it('derives the gateway target construct id from the target name as Target-<name>', () => {
+      const construct = tree
+        .read(
+          'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts',
+        )!
+        .toString();
+      // Construct ids preserve the kebab-case target name (e.g. `ts-mcp` ->
+      // `Target-ts-mcp`) so the id changes with the target name.
+      expect(construct).toContain('`Target-${props.gatewayTargetName}`');
+      expect(construct).not.toContain('toPascalCase');
+    });
+
     it('URL-encodes the runtime ARN correctly for the MCP target endpoint', () => {
       const construct = tree
         .read(

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
@@ -107,7 +107,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
                 ...props.cedarPolicyVariables,
               }),
           });
-          const policyId = toPascalCase(file.replace(/\.cedar$/, ''));
+          const policyId = `Policy-${file.replace(/\.cedar$/, '').replace(/[\\/]/g, '-')}`;
           const policy = new agentcore.CfnPolicy(this, policyId, {
             name: policyId,
             policyEngineId: this.policyEngine.attrPolicyEngineId,
@@ -192,7 +192,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     // under an unchanged name fails with AlreadyExists.
     const target = new agentcore.CfnGatewayTarget(
       this,
-      `${toPascalCase(props.gatewayTargetName)}Target`,
+      `Target-${props.gatewayTargetName}`,
       {
         gatewayIdentifier: this.gateway.gatewayId,
         name: props.gatewayTargetName,
@@ -290,11 +290,4 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     return this.targetReadinessProbe;
   }
 }
-
-const toPascalCase = (s: string): string =>
-  s
-    .split(/[-_\s/\\]+/)
-    .filter(Boolean)
-    .map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase())
-    .join('');
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -182,9 +182,9 @@ data "external" "rendered_policies" {
 # One Policy per .cedar file in the project's policies/ directory.
 #
 # Policy resource names are derived from the file basename and normalised
-# to PascalCase (matching the CDK template). The AgentCore Policy resource
-# `name` regex requires `^[A-Za-z][A-Za-z0-9_]*$` — no hyphens — so the
-# join() reassembles the basename with each segment Title-cased.
+# to PascalCase. The AgentCore Policy resource `name` regex requires
+# `^[A-Za-z][A-Za-z0-9_]*$` — no hyphens — so the join() reassembles the
+# basename with each segment Title-cased.
 resource "aws_bedrockagentcore_policy" "policies" {
   for_each = fileset(local.policies_dir, "**/*.cedar")
 


### PR DESCRIPTION
### Reason for this change

Follow-up to the AgentCore Gateway generator addressing review feedback:

1. The shared gateway CDK construct derived gateway-target and policy construct ids by `toPascalCase`-ing the target/policy name (e.g. `ts-mcp` → `TsMcpTarget`), so the construct id no longer visually tracked the actual (kebab-case) target name.
2. Gateway coverage in the e2e tests was incomplete: the local serve-local test only exercised a TypeScript agent fronting the gateway, and neither the `cdk-deploy` nor `terraform-deploy` smoke tests actually invoked the deployed gateway through an agent (agent → Gateway → MCP). These deploy tests do not run in PR CI, so they were run manually.

### Description of changes

- **Construct ids:** Replace `toPascalCase(name)` with literal `` `Target-${name}` `` and `` `Policy-${name}` `` ids in `agent-core-constructs/.../agentcore-gateway.ts.template`, and remove the now-unused `toPascalCase` helper. The policy resource `name` continues to be overwritten with `cdk.Names.uniqueResourceName(...)` (account-wide uniqueness), so this only affects the construct id. A unit test locks in the new `Target-<name>` form.
- **serve-local e2e:** Add a Python agent (`gw-py-agent`) connected to the gateway and a `Python HTTP Agent - AgentCore Gateway local gateway across multiple MCP servers` test mirroring the existing TypeScript gateway test (py agent → local gateway → ts/py MCP servers).
- **Deploy e2e (cdk + terraform):** Exercise both the TypeScript and Python agents calling gateway-prefixed tools (`<target>___<tool>`) for each upstream MCP server, asserting the round-trip result. Wire the gateway targets, gateway-role invoke grants, `policy_dependencies`, and agent → gateway grants into the `terraform-deploy` main.tf template (the CDK application-stack template already had the gateway fully wired). A second commit fixes a duplicate `aws_region` data source in that template (the generated infra `providers.tf` already declares it).

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test` — gateway generator unit tests pass, including the new construct-id assertion.
- **`cdk-deploy` smoke test (run manually — does not run in PR CI): PASSED.** All four new agent → Gateway → MCP invocations succeeded end-to-end against AWS (TS & PY agents each calling `hosted-mcp-server___divide` and `my-mcp-server___add` through the deployed Gateway with Cedar ENFORCE + SigV4), and the stack was torn down cleanly. This validates the `Target-<name>` construct-id change deploys correctly.
- **`terraform-deploy` smoke test (run manually):** verified `terraform init`/`plan`/`apply` now proceed past my changes (the duplicate-`aws_region` fix), with the plan correctly creating both gateway targets, the gateway, policy engine and Cedar policy. The run did not reach the gateway invocations because the **core agent-core module's MCP `runtime_ready` readiness probe** timed out waiting for the MCP runtime's DEFAULT endpoint to become invocable in the test account — a pre-existing cold-start flake unrelated to this change (the same MCP containers came up fine in the `cdk-deploy` run, and `terraform-deploy` is independently red on `main`). The gateway wiring itself plans and applies correctly.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
