### PR TITLE
fix(agentcore-gateway): wire gateway targets and invoke grants in terraform-deploy smoke test

### DIFF
--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -207,8 +207,65 @@ module "py_agui_agent" {
 # AgentCore Gateway (Cedar policy engine + IAM-authenticated MCP endpoint)
 # ---------------------------------------------------------------------------
 
+# The gateway signs outbound calls to its MCP server targets with its own
+# role and fetches each target's tools at creation time, so it needs invoke
+# access to both MCP runtimes before the targets are created.
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
+
+  additional_iam_policy_statements = [
+    local.invoke_py_mcp_server_statement,
+    local.invoke_ts_mcp_server_statement,
+  ]
+
+  policy_dependencies = [
+    aws_bedrockagentcore_gateway_target.ts_mcp_server.target_id,
+    aws_bedrockagentcore_gateway_target.py_mcp_server.target_id,
+  ]
+}
+
+# Register both MCP servers as targets of the Gateway — the Terraform
+# analogue of `myGateway.addMcpServer(...)` in the CDK template. Target
+# names match the serve-local registrations (kebab-cased MCP project class
+# name) so Cedar action prefixes are identical locally and deployed. The
+# runtime ARNs flow through each runtime's readiness probe, so targets are
+# created only once the runtimes serve MCP.
+resource "aws_bedrockagentcore_gateway_target" "ts_mcp_server" {
+  gateway_identifier = module.my_gateway.gateway_id
+  name               = "hosted-mcp-server"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = "https://bedrock-agentcore.${data.aws_region.current.id}.amazonaws.com/runtimes/${urlencode(module.ts_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+
+resource "aws_bedrockagentcore_gateway_target" "py_mcp_server" {
+  gateway_identifier = module.my_gateway.gateway_id
+  name               = "my-mcp-server"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = "https://bedrock-agentcore.${data.aws_region.current.id}.amazonaws.com/runtimes/${urlencode(module.py_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -269,6 +326,14 @@ locals {
       "${module.py_a2a_agent.agent_core_runtime_arn}/*",
     ]
   }
+
+  # Terraform analogue of `myGateway.grantInvokeAccess(...)` in the CDK
+  # template — both HTTP agents fetch the gateway's tools at startup.
+  invoke_my_gateway_statement = {
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }
 }
 
 # Python HTTP agent — calls the Python MCP server and both A2A agents.
@@ -282,6 +347,7 @@ module "py_agent" {
     local.invoke_py_mcp_server_statement,
     local.invoke_ts_a2a_agent_statement,
     local.invoke_py_a2a_agent_statement,
+    local.invoke_my_gateway_statement,
   ]
 }
 
@@ -297,6 +363,7 @@ module "ts_agent" {
     local.invoke_ts_mcp_server_statement,
     local.invoke_ts_a2a_agent_statement,
     local.invoke_py_a2a_agent_statement,
+    local.invoke_my_gateway_statement,
   ]
 }
 


### PR DESCRIPTION

### Reason for this change

The `terraform-deploy` smoke test has been failing on main (run [27414807902](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/27414807902) — both the original run and a re-run of the failed jobs) since the AgentCore Gateway was added to the e2e templates in #660. The Python Agent invocation returns HTTP 200 with an **empty stream**, failing `expect(chunks.length).toBeGreaterThan(0)`.

Root cause (reproduced in a local Terraform workspace and confirmed via the AgentCore runtime CloudWatch logs): the agent's `get_agent` factory calls `my_gateway.list_tools_sync()` on first invocation, which raised `403 Forbidden` against the gateway URL because the agent runtime role was never granted `bedrock-agentcore:InvokeGateway`. The vended FastAPI app's exception handler logs the error, but the streaming response has already started, so the client sees a 200 with an empty body.

The CDK e2e template (`application-stack.ts.template`) wires the gateway with `myGateway.addMcpServer(tsMcp/pyMcp)` and `myGateway.grantInvokeAccess(tsAgent/pyAgent)` — the Terraform template instantiated the bare gateway module with neither analogue, so the gateway also had no targets (and the cdk-deploy job passes for exactly this reason).

### Description of changes

In `e2e/src/files/terraform-deploy/main.tf.template`, following the documented Terraform wiring from the gateway connection guides:

- Grant both HTTP agents `bedrock-agentcore:InvokeGateway` on the gateway ARN (analogue of `grantInvokeAccess`)
- Register both MCP servers as `aws_bedrockagentcore_gateway_target` resources (analogue of `addMcpServer`), with target names matching the serve-local registrations (kebab-cased MCP project class name) so Cedar action prefixes are identical locally and deployed
- Grant the gateway role invoke access to both MCP runtimes — target creation fetches the target's tools, which fails with an authorization error without it
- Route `policy_dependencies` through the target ids so Cedar policies are created after targets register their actions

### Description of how you validated changes

Reproduced and verified end-to-end in a local Terraform workspace deployed to a dev account (us-east-1) with a py agent + py MCP server + gateway and the same connection generators as the smoke test:

- **Bare gateway module (as on main):** agent invocation returns 200 with empty body; runtime logs show `httpx.HTTPStatusError: Client error '403 Forbidden' for url 'https://mygateway-....gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp'`
- **With this wiring:** fresh single-shot `terraform apply` succeeds (41 resources), and the agent invocation streams a full response. Stack destroyed cleanly afterwards.

The unrelated `terraform-deploy-rdb` failure in the same run (`VpcLimitExceeded`) passed on re-run — it was capacity contention with a concurrently-running release branch CI run in the same account.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
