### PR TITLE
feat(agentcore-gateway): support connecting gateways to other gateways

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -653,6 +653,10 @@ export default defineConfig({
                   link: '/guides/connection/agentcore-gateway-mcp',
                 },
                 {
+                  label: 'AgentCore Gateway → AgentCore Gateway',
+                  link: '/guides/connection/agentcore-gateway-gateway',
+                },
+                {
                   label: 'TypeScript Agent → AgentCore Gateway',
                   link: '/guides/connection/ts-agent-gateway',
                 },

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -235,5 +235,6 @@ See the connection guide for the full local development story.
 ## Next steps
 
 - Connect an MCP server: <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- Connect another Gateway: <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - Connect a TypeScript Agent: <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Connect a Python Agent: <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/en/guides/connection.mdx
+++ b/docs/src/content/docs/en/guides/connection.mdx
@@ -182,6 +182,13 @@ The Connection generator supports the following connections:
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway to AgentCore Gateway"
+    description="Aggregate an AgentCore Gateway behind another AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="Connect a TypeScript Agent to an AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/en/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway to AgentCore Gateway
+description: Connect an AgentCore Gateway to another AgentCore Gateway
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+The `connection` generator can register an <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> as a target of another AgentCore Gateway. This lets you compose gateways hierarchically — for example a team-level gateway aggregating several domain gateways, each of which fronts its own MCP servers.
+
+Once connected, the source Gateway aggregates the target Gateway's tools into its single MCP endpoint. Since the target Gateway already prefixes its tools with its own target names, tools surface through the source Gateway as `<gateway-target-name>___<target-name>___<tool-name>` — each gateway in the chain adds one prefix. Both gateways evaluate their own Cedar policies: the source Gateway authorizes the caller for the prefixed action, then the target Gateway authorizes the source Gateway's execution role for the inner action.
+
+## Prerequisites
+
+Before using this generator, ensure you have:
+
+1. Two <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> projects
+
+Both gateways must have `protocol: mcp` and `auth: iam` — the generator validates both. The generator also rejects connections that would create a cycle between gateways, which would otherwise recurse infinitely on `tools/list`.
+
+## Usage
+
+### Run the Generator
+
+<RunGenerator generator="connection" />
+
+Select the aggregating Gateway project as the source and the Gateway to be aggregated as the target.
+
+### Options
+
+<GeneratorParameters generator="connection" />
+
+## Generator Output
+
+The generator wires existing projects together rather than emitting new source files. The following files are modified:
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` gains a dependency on the target gateway's `<target-gateway>-serve-local`
+  - serve-local.ts `ATTACHED_MCP_SERVERS` updated so the local gateway aggregates the target gateway
+
+</FileTree>
+
+The source Gateway project's `<source-gateway>-serve-local` target gains a dependency on the target Gateway's `<target-gateway>-serve-local` target, so running the source Gateway locally also starts the target gateway (and, transitively, every MCP server attached to it). The target gateway is also registered in the source Gateway project's `serve-local.ts` so the local gateway aggregates its tools.
+
+## Adding the gateway target to your stack
+
+The generator **cannot** automatically wire the gateway target into your infrastructure because it doesn't know which stack or module instantiates the Gateways. Add a single call to `gateway.addGateway(targetGateway)` yourself.
+
+<Infrastructure>
+<Fragment slot="cdk">
+In the stack where you instantiate the Gateways, register the target gateway as a target of the source gateway:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+The Gateway target name (the target gateway's `gatewayName` by default) prefixes Cedar action names on the source gateway — the action format is ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``. See the <Link path="guides/agentcore-gateway">Writing Policies section</Link>. Keep the target name short and stable; changing it later invalidates any Cedar policies that reference the old name.
+
+To override the default target name, pass `gatewayTargetName`:
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+The construct grants the source gateway's execution role `bedrock-agentcore:InvokeGateway` access to the target gateway, and configures the target with `iamCredentialProvider.service = 'bedrock-agentcore'` so the source gateway signs outbound calls using its own execution role. The target is created after the target gateway and all of its own targets, since AgentCore fetches the target's tools during creation.
+</Fragment>
+<Fragment slot="terraform">
+In the Terraform file where you instantiate the Gateways, wire the gateway target in:
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+The target `name` (`inner-gateway` above) prefixes Cedar action names on the outer gateway — see the <Link path="guides/agentcore-gateway">Writing Policies section</Link>. The `additional_iam_policy_statements` entry grants the outer gateway's execution role invoke access to the inner gateway, which is required both to fetch the inner gateway's tools at target creation time and to route calls at runtime. `policy_dependencies` ensures Cedar policies referencing this target's actions are created after the target has registered them.
+
+:::note[Target ordering]
+AgentCore fetches the inner gateway's tools when the `aws_bedrockagentcore_gateway_target` is created, so any targets of the inner gateway should be created first. Add them to the target's `depends_on` if they are managed in the same configuration.
+:::
+</Fragment>
+</Infrastructure>
+
+## Cedar policies across chained gateways
+
+Each gateway in the chain evaluates its own policy set:
+
+1. The **source gateway** evaluates the original caller (e.g. an agent's execution role) against the prefixed action, e.g. `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. The **target gateway** evaluates the source gateway's execution role against the inner action, e.g. `AgentCore::Action::"my-mcp___add"`.
+
+This means a tool call through a gateway chain must be permitted at every hop. The default `permit-all.cedar` permits any caller in the same AWS account, which includes the source gateway's role; if you write narrower policies on the target gateway, remember that the principal it sees is the *source gateway's* role, not the original caller.
+
+## Local Development
+
+Running the source Gateway locally with:
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+starts the local source gateway, the local target gateway, and every MCP server attached to either, each on its assigned local port. Tool names are prefixed at each hop exactly as deployed (`<gateway-target-name>___<target-name>___<tool-name>`), so agent prompts and Cedar action names remain consistent across local and deployed runs.
+
+:::caution[Local fidelity]
+Local development uses **local stand-in gateways** — lightweight MCP aggregators started by each Gateway project, not the AgentCore Gateway service. As a consequence, **Cedar policies are not evaluated locally** at either hop. To exercise Cedar policies, run the agent's `serve` target instead (see the <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link> agent-connection guides) so the locally-running agent calls the deployed Gateway.
+:::

--- a/docs/src/content/docs/en/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ Before using this generator, ensure you have:
 
 1. Two <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> projects
 
-Both gateways must have `protocol: mcp` and `auth: iam` — the generator validates both. The generator also rejects connections that would create a cycle between gateways, which would otherwise recurse infinitely on `tools/list`.
+Both gateways must have `protocol: mcp`, and the target gateway must have `auth: iam` — the source gateway invokes the target signing with its own execution role, so only the target's inbound auth needs to be IAM. The generator validates this, and also rejects connections that would create a cycle between gateways, which would otherwise recurse infinitely on `tools/list`.
 
 ## Usage
 

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -235,5 +235,6 @@ Consulta la guía de conexión para la historia completa de desarrollo local.
 ## Próximos pasos
 
 - Conectar un servidor MCP: <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- Conectar otro Gateway: <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - Conectar un Agente TypeScript: <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Conectar un Agente Python: <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/es/guides/connection.mdx
+++ b/docs/src/content/docs/es/guides/connection.mdx
@@ -182,6 +182,13 @@ El generador de Conexión admite las siguientes conexiones:
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway a AgentCore Gateway"
+    description="Agrega un AgentCore Gateway detrás de otro AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent a AgentCore Gateway"
     description="Conecta un TypeScript Agent a un AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/es/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ Antes de usar este generador, asegúrate de tener:
 
 1. Dos proyectos <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
 
-Ambos gateways deben tener `protocol: mcp` y `auth: iam` — el generador valida ambos. El generador también rechaza conexiones que crearían un ciclo entre gateways, lo que de otro modo recurriría infinitamente en `tools/list`.
+Ambos gateways deben tener `protocol: mcp`, y el gateway de destino debe tener `auth: iam` — el gateway de origen invoca el destino firmando con su propio rol de ejecución, por lo que solo la autenticación entrante del destino necesita ser IAM. El generador valida esto, y también rechaza conexiones que crearían un ciclo entre gateways, lo que de otro modo recurriría infinitamente en `tools/list`.
 
 ## Uso
 

--- a/docs/src/content/docs/es/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway a AgentCore Gateway
+description: Conectar un AgentCore Gateway a otro AgentCore Gateway
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+El generador `connection` puede registrar un <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> como destino de otro AgentCore Gateway. Esto te permite componer gateways jerárquicamente — por ejemplo, un gateway a nivel de equipo que agrega varios gateways de dominio, cada uno de los cuales sirve de fachada para sus propios servidores MCP.
+
+Una vez conectado, el Gateway de origen agrega las herramientas del Gateway de destino en su único endpoint MCP. Dado que el Gateway de destino ya prefija sus herramientas con sus propios nombres de destino, las herramientas aparecen a través del Gateway de origen como `<gateway-target-name>___<target-name>___<tool-name>` — cada gateway en la cadena agrega un prefijo. Ambos gateways evalúan sus propias políticas Cedar: el Gateway de origen autoriza al llamador para la acción prefijada, luego el Gateway de destino autoriza el rol de ejecución del Gateway de origen para la acción interna.
+
+## Requisitos previos
+
+Antes de usar este generador, asegúrate de tener:
+
+1. Dos proyectos <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
+
+Ambos gateways deben tener `protocol: mcp` y `auth: iam` — el generador valida ambos. El generador también rechaza conexiones que crearían un ciclo entre gateways, lo que de otro modo recurriría infinitamente en `tools/list`.
+
+## Uso
+
+### Ejecutar el generador
+
+<RunGenerator generator="connection" />
+
+Selecciona el proyecto Gateway agregador como origen y el Gateway a agregar como destino.
+
+### Opciones
+
+<GeneratorParameters generator="connection" />
+
+## Salida del generador
+
+El generador conecta proyectos existentes en lugar de emitir nuevos archivos fuente. Los siguientes archivos se modifican:
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` obtiene una dependencia en el `<target-gateway>-serve-local` del gateway de destino
+  - serve-local.ts `ATTACHED_MCP_SERVERS` actualizado para que el gateway local agregue el gateway de destino
+
+</FileTree>
+
+El target `<source-gateway>-serve-local` del proyecto Gateway de origen obtiene una dependencia en el target `<target-gateway>-serve-local` del Gateway de destino, por lo que ejecutar el Gateway de origen localmente también inicia el gateway de destino (y, transitivamente, cada servidor MCP conectado a él). El gateway de destino también se registra en el `serve-local.ts` del proyecto Gateway de origen para que el gateway local agregue sus herramientas.
+
+## Agregar el destino del gateway a tu stack
+
+El generador **no puede** conectar automáticamente el destino del gateway en tu infraestructura porque no sabe qué stack o módulo instancia los Gateways. Agrega una única llamada a `gateway.addGateway(targetGateway)` tú mismo.
+
+<Infrastructure>
+<Fragment slot="cdk">
+En el stack donde instancias los Gateways, registra el gateway de destino como un destino del gateway de origen:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+El nombre del destino del Gateway (el `gatewayName` del gateway de destino por defecto) prefija los nombres de acción Cedar en el gateway de origen — el formato de acción es ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``. Consulta la <Link path="guides/agentcore-gateway">sección Escribir políticas</Link>. Mantén el nombre del destino corto y estable; cambiarlo más tarde invalida cualquier política Cedar que haga referencia al nombre antiguo.
+
+Para anular el nombre de destino predeterminado, pasa `gatewayTargetName`:
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+El constructo otorga al rol de ejecución del gateway de origen acceso `bedrock-agentcore:InvokeGateway` al gateway de destino, y configura el destino con `iamCredentialProvider.service = 'bedrock-agentcore'` para que el gateway de origen firme las llamadas salientes usando su propio rol de ejecución. El destino se crea después del gateway de destino y todos sus propios destinos, ya que AgentCore obtiene las herramientas del destino durante la creación.
+</Fragment>
+<Fragment slot="terraform">
+En el archivo Terraform donde instancias los Gateways, conecta el destino del gateway:
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+El `name` del destino (`inner-gateway` arriba) prefija los nombres de acción Cedar en el gateway externo — consulta la <Link path="guides/agentcore-gateway">sección Escribir políticas</Link>. La entrada `additional_iam_policy_statements` otorga al rol de ejecución del gateway externo acceso de invocación al gateway interno, lo cual es necesario tanto para obtener las herramientas del gateway interno en el momento de creación del destino como para enrutar llamadas en tiempo de ejecución. `policy_dependencies` asegura que las políticas Cedar que hacen referencia a las acciones de este destino se creen después de que el destino las haya registrado.
+
+:::note[Orden de destinos]
+AgentCore obtiene las herramientas del gateway interno cuando se crea el `aws_bedrockagentcore_gateway_target`, por lo que cualquier destino del gateway interno debe crearse primero. Agrégalos al `depends_on` del destino si se administran en la misma configuración.
+:::
+</Fragment>
+</Infrastructure>
+
+## Políticas Cedar a través de gateways encadenados
+
+Cada gateway en la cadena evalúa su propio conjunto de políticas:
+
+1. El **gateway de origen** evalúa al llamador original (por ejemplo, el rol de ejecución de un agente) contra la acción prefijada, por ejemplo `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. El **gateway de destino** evalúa el rol de ejecución del gateway de origen contra la acción interna, por ejemplo `AgentCore::Action::"my-mcp___add"`.
+
+Esto significa que una llamada de herramienta a través de una cadena de gateways debe ser permitida en cada salto. El `permit-all.cedar` predeterminado permite cualquier llamador en la misma cuenta de AWS, lo que incluye el rol del gateway de origen; si escribes políticas más estrictas en el gateway de destino, recuerda que el principal que ve es el rol del *gateway de origen*, no el llamador original.
+
+## Desarrollo local
+
+Ejecutar el Gateway de origen localmente con:
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+inicia el gateway de origen local, el gateway de destino local y cada servidor MCP conectado a cualquiera de ellos, cada uno en su puerto local asignado. Los nombres de herramientas se prefijan en cada salto exactamente como se despliegan (`<gateway-target-name>___<target-name>___<tool-name>`), por lo que los prompts del agente y los nombres de acción Cedar permanecen consistentes entre ejecuciones locales y desplegadas.
+
+:::caution[Fidelidad local]
+El desarrollo local utiliza **gateways locales sustitutos** — agregadores MCP ligeros iniciados por cada proyecto Gateway, no el servicio AgentCore Gateway. Como consecuencia, **las políticas Cedar no se evalúan localmente** en ningún salto. Para ejercitar las políticas Cedar, ejecuta el target `serve` del agente en su lugar (consulta las guías de conexión de agentes <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link>) para que el agente que se ejecuta localmente llame al Gateway desplegado.
+:::

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -232,6 +232,6 @@ Consultez le guide de connexion pour l'histoire complète du développement loca
 ## Prochaines étapes
 
 - Connecter un serveur MCP : <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- Connecter une autre Gateway : <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - Connecter un agent TypeScript : <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
-- Connecter un agent Python : <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>
 - Connecter un agent Python : <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/fr/guides/connection.mdx
+++ b/docs/src/content/docs/fr/guides/connection.mdx
@@ -182,6 +182,13 @@ Le générateur de connexion prend en charge les connexions suivantes :
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway vers AgentCore Gateway"
+    description="Agréger une AgentCore Gateway derrière une autre AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent vers AgentCore Gateway"
     description="Connecter un TypeScript Agent à une AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/fr/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway vers AgentCore Gateway
+description: Connecter une AgentCore Gateway à une autre AgentCore Gateway
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+Le générateur `connection` peut enregistrer une <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> comme cible d'une autre AgentCore Gateway. Cela vous permet de composer des gateways de manière hiérarchique — par exemple une gateway au niveau de l'équipe agrégeant plusieurs gateways de domaine, chacune faisant face à ses propres serveurs MCP.
+
+Une fois connectée, la Gateway source agrège les outils de la Gateway cible dans son point de terminaison MCP unique. Étant donné que la Gateway cible préfixe déjà ses outils avec ses propres noms de cible, les outils apparaissent à travers la Gateway source sous la forme `<gateway-target-name>___<target-name>___<tool-name>` — chaque gateway dans la chaîne ajoute un préfixe. Les deux gateways évaluent leurs propres politiques Cedar : la Gateway source autorise l'appelant pour l'action préfixée, puis la Gateway cible autorise le rôle d'exécution de la Gateway source pour l'action interne.
+
+## Prérequis
+
+Avant d'utiliser ce générateur, assurez-vous d'avoir :
+
+1. Deux projets <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
+
+Les deux gateways doivent avoir `protocol: mcp` et `auth: iam` — le générateur valide les deux. Le générateur rejette également les connexions qui créeraient un cycle entre les gateways, ce qui sinon récurserait infiniment sur `tools/list`.
+
+## Utilisation
+
+### Exécuter le générateur
+
+<RunGenerator generator="connection" />
+
+Sélectionnez le projet Gateway agrégeant comme source et la Gateway à agréger comme cible.
+
+### Options
+
+<GeneratorParameters generator="connection" />
+
+## Sortie du générateur
+
+Le générateur relie les projets existants ensemble plutôt que d'émettre de nouveaux fichiers source. Les fichiers suivants sont modifiés :
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` gagne une dépendance sur le `<target-gateway>-serve-local` de la gateway cible
+  - serve-local.ts `ATTACHED_MCP_SERVERS` mis à jour pour que la gateway locale agrège la gateway cible
+
+</FileTree>
+
+La cible `<source-gateway>-serve-local` du projet Gateway source gagne une dépendance sur la cible `<target-gateway>-serve-local` du projet Gateway cible, de sorte que l'exécution de la Gateway source localement démarre également la gateway cible (et, transitivement, chaque serveur MCP qui y est attaché). La gateway cible est également enregistrée dans le `serve-local.ts` du projet Gateway source afin que la gateway locale agrège ses outils.
+
+## Ajouter la cible gateway à votre stack
+
+Le générateur **ne peut pas** câbler automatiquement la cible gateway dans votre infrastructure car il ne sait pas quelle stack ou quel module instancie les Gateways. Ajoutez vous-même un seul appel à `gateway.addGateway(targetGateway)`.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Dans la stack où vous instanciez les Gateways, enregistrez la gateway cible comme cible de la gateway source :
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+Le nom de cible Gateway (le `gatewayName` de la gateway cible par défaut) préfixe les noms d'action Cedar sur la gateway source — le format d'action est ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``. Voir la <Link path="guides/agentcore-gateway">section Rédaction de politiques</Link>. Gardez le nom de cible court et stable ; le modifier ultérieurement invalide toutes les politiques Cedar qui référencent l'ancien nom.
+
+Pour remplacer le nom de cible par défaut, passez `gatewayTargetName` :
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+Le construct accorde au rôle d'exécution de la gateway source l'accès `bedrock-agentcore:InvokeGateway` à la gateway cible, et configure la cible avec `iamCredentialProvider.service = 'bedrock-agentcore'` afin que la gateway source signe les appels sortants en utilisant son propre rôle d'exécution. La cible est créée après la gateway cible et toutes ses propres cibles, car AgentCore récupère les outils de la cible lors de la création.
+</Fragment>
+<Fragment slot="terraform">
+Dans le fichier Terraform où vous instanciez les Gateways, câblez la cible gateway :
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+Le `name` de la cible (`inner-gateway` ci-dessus) préfixe les noms d'action Cedar sur la gateway externe — voir la <Link path="guides/agentcore-gateway">section Rédaction de politiques</Link>. L'entrée `additional_iam_policy_statements` accorde au rôle d'exécution de la gateway externe l'accès d'invocation à la gateway interne, ce qui est requis à la fois pour récupérer les outils de la gateway interne au moment de la création de la cible et pour router les appels à l'exécution. `policy_dependencies` garantit que les politiques Cedar référençant les actions de cette cible sont créées après que la cible les a enregistrées.
+
+:::note[Ordre des cibles]
+AgentCore récupère les outils de la gateway interne lorsque le `aws_bedrockagentcore_gateway_target` est créé, donc toutes les cibles de la gateway interne doivent être créées en premier. Ajoutez-les au `depends_on` de la cible si elles sont gérées dans la même configuration.
+:::
+</Fragment>
+</Infrastructure>
+
+## Politiques Cedar à travers les gateways chaînées
+
+Chaque gateway dans la chaîne évalue son propre ensemble de politiques :
+
+1. La **gateway source** évalue l'appelant d'origine (par exemple le rôle d'exécution d'un agent) par rapport à l'action préfixée, par exemple `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. La **gateway cible** évalue le rôle d'exécution de la gateway source par rapport à l'action interne, par exemple `AgentCore::Action::"my-mcp___add"`.
+
+Cela signifie qu'un appel d'outil à travers une chaîne de gateway doit être autorisé à chaque saut. Le `permit-all.cedar` par défaut autorise tout appelant dans le même compte AWS, ce qui inclut le rôle de la gateway source ; si vous écrivez des politiques plus restrictives sur la gateway cible, rappelez-vous que le principal qu'elle voit est le rôle de la *gateway source*, et non l'appelant d'origine.
+
+## Développement local
+
+L'exécution de la Gateway source localement avec :
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+démarre la gateway source locale, la gateway cible locale et chaque serveur MCP attaché à l'une ou l'autre, chacun sur son port local assigné. Les noms d'outils sont préfixés à chaque saut exactement comme déployés (`<gateway-target-name>___<target-name>___<tool-name>`), de sorte que les prompts d'agent et les noms d'action Cedar restent cohérents entre les exécutions locales et déployées.
+
+:::caution[Fidélité locale]
+Le développement local utilise des **gateways de substitution locales** — des agrégateurs MCP légers démarrés par chaque projet Gateway, et non le service AgentCore Gateway. En conséquence, **les politiques Cedar ne sont pas évaluées localement** à aucun des deux sauts. Pour exercer les politiques Cedar, exécutez plutôt la cible `serve` de l'agent (voir les guides de connexion d'agent <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link>) afin que l'agent s'exécutant localement appelle la Gateway déployée.
+:::

--- a/docs/src/content/docs/fr/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ Avant d'utiliser ce générateur, assurez-vous d'avoir :
 
 1. Deux projets <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
 
-Les deux gateways doivent avoir `protocol: mcp` et `auth: iam` — le générateur valide les deux. Le générateur rejette également les connexions qui créeraient un cycle entre les gateways, ce qui sinon récurserait infiniment sur `tools/list`.
+Les deux gateways doivent avoir `protocol: mcp`, et la gateway cible doit avoir `auth: iam` — la gateway source invoque la cible en signant avec son propre rôle d'exécution, donc seule l'authentification entrante de la cible doit être IAM. Le générateur valide cela, et rejette également les connexions qui créeraient un cycle entre les gateways, ce qui sinon récurserait infiniment sur `tools/list`.
 
 ## Utilisation
 

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -233,5 +233,6 @@ Consulta la guida alla connessione per la storia completa dello sviluppo locale.
 ## Prossimi passi
 
 - Connetti un server MCP: <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- Connetti un altro Gateway: <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - Connetti un agente TypeScript: <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Connetti un agente Python: <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/it/guides/connection.mdx
+++ b/docs/src/content/docs/it/guides/connection.mdx
@@ -182,6 +182,13 @@ Il generatore di Connessioni supporta le seguenti connessioni:
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway to AgentCore Gateway"
+    description="Aggrega un AgentCore Gateway dietro un altro AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="Collega un TypeScript Agent a un AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/it/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway a AgentCore Gateway
+description: Connetti un AgentCore Gateway a un altro AgentCore Gateway
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+Il generatore `connection` può registrare un <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> come target di un altro AgentCore Gateway. Questo ti permette di comporre gateway gerarchicamente — ad esempio un gateway a livello di team che aggrega diversi gateway di dominio, ognuno dei quali si interfaccia con i propri server MCP.
+
+Una volta connesso, il Gateway sorgente aggrega gli strumenti del Gateway target nel suo singolo endpoint MCP. Poiché il Gateway target aggiunge già un prefisso ai suoi strumenti con i propri nomi di target, gli strumenti emergono attraverso il Gateway sorgente come `<gateway-target-name>___<target-name>___<tool-name>` — ogni gateway nella catena aggiunge un prefisso. Entrambi i gateway valutano le proprie policy Cedar: il Gateway sorgente autorizza il chiamante per l'azione con prefisso, quindi il Gateway target autorizza il ruolo di esecuzione del Gateway sorgente per l'azione interna.
+
+## Prerequisiti
+
+Prima di utilizzare questo generatore, assicurati di avere:
+
+1. Due progetti <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
+
+Entrambi i gateway devono avere `protocol: mcp` e `auth: iam` — il generatore valida entrambi. Il generatore rifiuta anche le connessioni che creerebbero un ciclo tra gateway, che altrimenti ricorrerebbe all'infinito su `tools/list`.
+
+## Utilizzo
+
+### Esegui il Generatore
+
+<RunGenerator generator="connection" />
+
+Seleziona il progetto Gateway aggregante come sorgente e il Gateway da aggregare come target.
+
+### Opzioni
+
+<GeneratorParameters generator="connection" />
+
+## Output del Generatore
+
+Il generatore collega i progetti esistenti insieme piuttosto che emettere nuovi file sorgente. I seguenti file vengono modificati:
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` acquisisce una dipendenza dal `<target-gateway>-serve-local` del gateway target
+  - serve-local.ts `ATTACHED_MCP_SERVERS` aggiornato in modo che il gateway locale aggreghi il gateway target
+
+</FileTree>
+
+Il target `<source-gateway>-serve-local` del progetto Gateway sorgente acquisisce una dipendenza dal target `<target-gateway>-serve-local` del Gateway target, quindi l'esecuzione del Gateway sorgente localmente avvia anche il gateway target (e, transitivamente, ogni server MCP collegato ad esso). Il gateway target viene anche registrato nel `serve-local.ts` del progetto Gateway sorgente in modo che il gateway locale aggreghi i suoi strumenti.
+
+## Aggiungere il target gateway al tuo stack
+
+Il generatore **non può** collegare automaticamente il target gateway alla tua infrastruttura perché non sa quale stack o modulo istanzia i Gateway. Aggiungi tu stesso una singola chiamata a `gateway.addGateway(targetGateway)`.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Nello stack in cui istanzi i Gateway, registra il gateway target come target del gateway sorgente:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+Il nome del target Gateway (il `gatewayName` del gateway target per impostazione predefinita) aggiunge un prefisso ai nomi delle azioni Cedar sul gateway sorgente — il formato dell'azione è ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``. Vedi la <Link path="guides/agentcore-gateway">sezione Writing Policies</Link>. Mantieni il nome del target breve e stabile; modificarlo in seguito invalida qualsiasi policy Cedar che faccia riferimento al vecchio nome.
+
+Per sovrascrivere il nome del target predefinito, passa `gatewayTargetName`:
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+Il costrutto concede al ruolo di esecuzione del gateway sorgente l'accesso `bedrock-agentcore:InvokeGateway` al gateway target e configura il target con `iamCredentialProvider.service = 'bedrock-agentcore'` in modo che il gateway sorgente firmi le chiamate in uscita utilizzando il proprio ruolo di esecuzione. Il target viene creato dopo il gateway target e tutti i suoi target, poiché AgentCore recupera gli strumenti del target durante la creazione.
+</Fragment>
+<Fragment slot="terraform">
+Nel file Terraform in cui istanzi i Gateway, collega il target gateway:
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+Il `name` del target (`inner-gateway` sopra) aggiunge un prefisso ai nomi delle azioni Cedar sul gateway esterno — vedi la <Link path="guides/agentcore-gateway">sezione Writing Policies</Link>. La voce `additional_iam_policy_statements` concede al ruolo di esecuzione del gateway esterno l'accesso invoke al gateway interno, che è richiesto sia per recuperare gli strumenti del gateway interno al momento della creazione del target sia per instradare le chiamate a runtime. `policy_dependencies` garantisce che le policy Cedar che fanno riferimento alle azioni di questo target vengano create dopo che il target le ha registrate.
+
+:::note[Ordinamento dei target]
+AgentCore recupera gli strumenti del gateway interno quando viene creato `aws_bedrockagentcore_gateway_target`, quindi eventuali target del gateway interno dovrebbero essere creati per primi. Aggiungili al `depends_on` del target se sono gestiti nella stessa configurazione.
+:::
+</Fragment>
+</Infrastructure>
+
+## Policy Cedar attraverso gateway concatenati
+
+Ogni gateway nella catena valuta il proprio set di policy:
+
+1. Il **gateway sorgente** valuta il chiamante originale (ad es. il ruolo di esecuzione di un agente) rispetto all'azione con prefisso, ad es. `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. Il **gateway target** valuta il ruolo di esecuzione del gateway sorgente rispetto all'azione interna, ad es. `AgentCore::Action::"my-mcp___add"`.
+
+Ciò significa che una chiamata di strumento attraverso una catena di gateway deve essere consentita ad ogni passaggio. Il `permit-all.cedar` predefinito consente qualsiasi chiamante nello stesso account AWS, che include il ruolo del gateway sorgente; se scrivi policy più restrittive sul gateway target, ricorda che il principale che vede è il ruolo del *gateway sorgente*, non il chiamante originale.
+
+## Sviluppo Locale
+
+Eseguendo il Gateway sorgente localmente con:
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+avvia il gateway sorgente locale, il gateway target locale e ogni server MCP collegato a entrambi, ciascuno sulla propria porta locale assegnata. I nomi degli strumenti hanno un prefisso ad ogni passaggio esattamente come distribuito (`<gateway-target-name>___<target-name>___<tool-name>`), quindi i prompt degli agenti e i nomi delle azioni Cedar rimangono coerenti tra esecuzioni locali e distribuite.
+
+:::caution[Fedeltà locale]
+Lo sviluppo locale utilizza **gateway sostitutivi locali** — aggregatori MCP leggeri avviati da ogni progetto Gateway, non il servizio AgentCore Gateway. Di conseguenza, **le policy Cedar non vengono valutate localmente** in nessuno dei due passaggi. Per esercitare le policy Cedar, esegui invece il target `serve` dell'agente (vedi le guide di connessione agente <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link>) in modo che l'agente in esecuzione locale chiami il Gateway distribuito.
+:::

--- a/docs/src/content/docs/it/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ Prima di utilizzare questo generatore, assicurati di avere:
 
 1. Due progetti <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
 
-Entrambi i gateway devono avere `protocol: mcp` e `auth: iam` — il generatore valida entrambi. Il generatore rifiuta anche le connessioni che creerebbero un ciclo tra gateway, che altrimenti ricorrerebbe all'infinito su `tools/list`.
+Entrambi i gateway devono avere `protocol: mcp`, e il gateway target deve avere `auth: iam` — il gateway sorgente invoca il target firmando con il proprio ruolo di esecuzione, quindi solo l'autenticazione in entrata del target deve essere IAM. Il generatore valida questo, e rifiuta anche le connessioni che creerebbero un ciclo tra gateway, che altrimenti ricorrerebbe all'infinito su `tools/list`.
 
 ## Utilizzo
 

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -235,5 +235,6 @@ forbid (
 ## 次のステップ
 
 - MCPサーバーを接続する：<Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- 別のGatewayを接続する：<Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - TypeScriptエージェントを接続する：<Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Pythonエージェントを接続する：<Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/jp/guides/connection.mdx
+++ b/docs/src/content/docs/jp/guides/connection.mdx
@@ -182,6 +182,13 @@ import ConnectionCard from '@components/connection-card.astro';
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway to AgentCore Gateway"
+    description="別のAgentCore Gatewayの背後にAgentCore Gatewayを集約する"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="TypeScript AgentをAgentCore Gatewayに接続する"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/jp/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway から AgentCore Gateway へ
+description: AgentCore Gateway を別の AgentCore Gateway に接続する
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+`connection` ジェネレーターは、<Link path="guides/agentcore-gateway">AgentCore Gateway</Link> を別の AgentCore Gateway のターゲットとして登録できます。これにより、ゲートウェイを階層的に構成できます。たとえば、チームレベルのゲートウェイが複数のドメインゲートウェイを集約し、各ドメインゲートウェイが独自の MCP サーバーをフロントするような構成が可能です。
+
+接続されると、ソースゲートウェイはターゲットゲートウェイのツールを単一の MCP エンドポイントに集約します。ターゲットゲートウェイは既に独自のターゲット名でツールにプレフィックスを付けているため、ソースゲートウェイを通じてツールは `<gateway-target-name>___<target-name>___<tool-name>` として表示されます。チェーン内の各ゲートウェイが1つのプレフィックスを追加します。両方のゲートウェイは独自の Cedar ポリシーを評価します。ソースゲートウェイはプレフィックス付きアクションに対して呼び出し元を認可し、次にターゲットゲートウェイは内部アクションに対してソースゲートウェイの実行ロールを認可します。
+
+## 前提条件
+
+このジェネレーターを使用する前に、以下を確認してください：
+
+1. 2つの <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
+
+両方のゲートウェイは `protocol: mcp` と `auth: iam` を持つ必要があります。ジェネレーターは両方を検証します。また、ジェネレーターはゲートウェイ間でサイクルを作成する接続を拒否します。サイクルがあると `tools/list` で無限に再帰してしまうためです。
+
+## 使用方法
+
+### ジェネレーターの実行
+
+<RunGenerator generator="connection" />
+
+集約するゲートウェイプロジェクトをソースとして選択し、集約されるゲートウェイをターゲットとして選択します。
+
+### オプション
+
+<GeneratorParameters generator="connection" />
+
+## ジェネレーターの出力
+
+ジェネレーターは、新しいソースファイルを生成するのではなく、既存のプロジェクトを接続します。以下のファイルが変更されます：
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` がターゲットゲートウェイの `<target-gateway>-serve-local` への依存関係を獲得
+  - serve-local.ts `ATTACHED_MCP_SERVERS` が更新され、ローカルゲートウェイがターゲットゲートウェイを集約
+
+</FileTree>
+
+ソースゲートウェイプロジェクトの `<source-gateway>-serve-local` ターゲットは、ターゲットゲートウェイの `<target-gateway>-serve-local` ターゲットへの依存関係を獲得します。そのため、ソースゲートウェイをローカルで実行すると、ターゲットゲートウェイ（および推移的に、それに接続されているすべての MCP サーバー）も起動します。ターゲットゲートウェイは、ソースゲートウェイプロジェクトの `serve-local.ts` にも登録され、ローカルゲートウェイがそのツールを集約します。
+
+## スタックへのゲートウェイターゲットの追加
+
+ジェネレーターは、どのスタックやモジュールがゲートウェイをインスタンス化するかを知らないため、ゲートウェイターゲットをインフラストラクチャに自動的に接続**できません**。`gateway.addGateway(targetGateway)` の呼び出しを1つ自分で追加してください。
+
+<Infrastructure>
+<Fragment slot="cdk">
+ゲートウェイをインスタンス化するスタックで、ターゲットゲートウェイをソースゲートウェイのターゲットとして登録します：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// 内部ゲートウェイを外部ゲートウェイのターゲットとして登録します。ターゲット
+// 名はデフォルトで内部ゲートウェイの `gatewayName`（クラス名をケバブケースに
+// 変換したもの、例：`InnerGateway` -> `inner-gateway`）になります。
+outerGateway.addGateway(innerGateway);
+```
+
+ゲートウェイターゲット名（デフォルトではターゲットゲートウェイの `gatewayName`）は、ソースゲートウェイ上の Cedar アクション名にプレフィックスを付けます。アクション形式は ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"`` です。<Link path="guides/agentcore-gateway">ポリシーの記述セクション</Link>を参照してください。ターゲット名は短く安定したものにしてください。後で変更すると、古い名前を参照する Cedar ポリシーが無効になります。
+
+デフォルトのターゲット名を上書きするには、`gatewayTargetName` を渡します：
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+コンストラクトは、ソースゲートウェイの実行ロールにターゲットゲートウェイへの `bedrock-agentcore:InvokeGateway` アクセスを付与し、ターゲットを `iamCredentialProvider.service = 'bedrock-agentcore'` で構成します。これにより、ソースゲートウェイは独自の実行ロールを使用してアウトバウンド呼び出しに署名します。ターゲットは、ターゲットゲートウェイとそのすべてのターゲットの後に作成されます。これは、AgentCore がターゲットの作成中にターゲットのツールを取得するためです。
+</Fragment>
+<Fragment slot="terraform">
+ゲートウェイをインスタンス化する Terraform ファイルで、ゲートウェイターゲットを接続します：
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# 内部ゲートウェイを外部ゲートウェイのターゲットとして登録
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+ターゲット `name`（上記の `inner-gateway`）は、外部ゲートウェイ上の Cedar アクション名にプレフィックスを付けます。<Link path="guides/agentcore-gateway">ポリシーの記述セクション</Link>を参照してください。`additional_iam_policy_statements` エントリは、外部ゲートウェイの実行ロールに内部ゲートウェイへの呼び出しアクセスを付与します。これは、ターゲット作成時に内部ゲートウェイのツールを取得する場合と、実行時に呼び出しをルーティングする場合の両方で必要です。`policy_dependencies` は、このターゲットのアクションを参照する Cedar ポリシーが、ターゲットがそれらを登録した後に作成されることを保証します。
+
+:::note[ターゲットの順序]
+AgentCore は `aws_bedrockagentcore_gateway_target` が作成されるときに内部ゲートウェイのツールを取得するため、内部ゲートウェイのターゲットは最初に作成される必要があります。同じ構成で管理されている場合は、ターゲットの `depends_on` にそれらを追加してください。
+:::
+</Fragment>
+</Infrastructure>
+
+## チェーンされたゲートウェイ間の Cedar ポリシー
+
+チェーン内の各ゲートウェイは独自のポリシーセットを評価します：
+
+1. **ソースゲートウェイ**は、元の呼び出し元（例：エージェントの実行ロール）をプレフィックス付きアクションに対して評価します。例：`AgentCore::Action::"inner-gateway___my-mcp___add"`
+2. **ターゲットゲートウェイ**は、ソースゲートウェイの実行ロールを内部アクションに対して評価します。例：`AgentCore::Action::"my-mcp___add"`
+
+これは、ゲートウェイチェーンを通じたツール呼び出しが、すべてのホップで許可される必要があることを意味します。デフォルトの `permit-all.cedar` は同じ AWS アカウント内の任意の呼び出し元を許可し、これにはソースゲートウェイのロールが含まれます。ターゲットゲートウェイでより狭いポリシーを記述する場合は、ターゲットゲートウェイが見るプリンシパルは元の呼び出し元ではなく、*ソースゲートウェイの*ロールであることを忘れないでください。
+
+## ローカル開発
+
+ソースゲートウェイをローカルで実行するには：
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+これにより、ローカルソースゲートウェイ、ローカルターゲットゲートウェイ、およびいずれかに接続されているすべての MCP サーバーが、それぞれ割り当てられたローカルポートで起動します。ツール名は、デプロイされた場合とまったく同じように各ホップでプレフィックスが付けられます（`<gateway-target-name>___<target-name>___<tool-name>`）。そのため、エージェントのプロンプトと Cedar アクション名は、ローカル実行とデプロイ実行の間で一貫性が保たれます。
+
+:::caution[ローカルの忠実性]
+ローカル開発では**ローカルスタンドインゲートウェイ**を使用します。これは、各ゲートウェイプロジェクトによって起動される軽量な MCP アグリゲーターであり、AgentCore Gateway サービスではありません。その結果、**Cedar ポリシーはどちらのホップでもローカルで評価されません**。Cedar ポリシーを実行するには、代わりにエージェントの `serve` ターゲットを実行してください（<Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link> エージェント接続ガイドを参照）。これにより、ローカルで実行されているエージェントがデプロイされたゲートウェイを呼び出します。
+:::

--- a/docs/src/content/docs/jp/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 1. 2つの <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
 
-両方のゲートウェイは `protocol: mcp` と `auth: iam` を持つ必要があります。ジェネレーターは両方を検証します。また、ジェネレーターはゲートウェイ間でサイクルを作成する接続を拒否します。サイクルがあると `tools/list` で無限に再帰してしまうためです。
+両方のゲートウェイは `protocol: mcp` を持つ必要があり、ターゲットゲートウェイは `auth: iam` を持つ必要があります。ソースゲートウェイは独自の実行ロールで署名してターゲットを呼び出すため、ターゲットのインバウンド認証のみが IAM である必要があります。ジェネレーターはこれを検証し、また、ゲートウェイ間でサイクルを作成する接続を拒否します。サイクルがあると `tools/list` で無限に再帰してしまうためです。
 
 ## 使用方法
 

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -235,5 +235,6 @@ forbid (
 ## 다음 단계
 
 - MCP 서버 연결: <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- 다른 Gateway 연결: <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - TypeScript Agent 연결: <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Python Agent 연결: <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/ko/guides/connection.mdx
+++ b/docs/src/content/docs/ko/guides/connection.mdx
@@ -182,6 +182,13 @@ import ConnectionCard from '@components/connection-card.astro';
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway to AgentCore Gateway"
+    description="다른 AgentCore Gateway 뒤에 AgentCore Gateway 집계하기"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="TypeScript Agent를 AgentCore Gateway에 연결하기"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/ko/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway에서 AgentCore Gateway로
+description: AgentCore Gateway를 다른 AgentCore Gateway에 연결
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+`connection` 생성기는 <Link path="guides/agentcore-gateway">AgentCore Gateway</Link>를 다른 AgentCore Gateway의 대상으로 등록할 수 있습니다. 이를 통해 게이트웨이를 계층적으로 구성할 수 있습니다. 예를 들어 팀 레벨 게이트웨이가 여러 도메인 게이트웨이를 집계하고, 각 도메인 게이트웨이는 자체 MCP 서버를 프론트할 수 있습니다.
+
+연결되면 소스 Gateway는 대상 Gateway의 도구를 단일 MCP 엔드포인트로 집계합니다. 대상 Gateway는 이미 자체 대상 이름으로 도구에 접두사를 붙이므로, 도구는 소스 Gateway를 통해 `<gateway-target-name>___<target-name>___<tool-name>`으로 표시됩니다. 체인의 각 게이트웨이는 하나의 접두사를 추가합니다. 두 게이트웨이 모두 자체 Cedar 정책을 평가합니다. 소스 Gateway는 접두사가 붙은 작업에 대해 호출자를 인증하고, 대상 Gateway는 내부 작업에 대해 소스 Gateway의 실행 역할을 인증합니다.
+
+## 사전 요구 사항
+
+이 생성기를 사용하기 전에 다음을 확인하세요:
+
+1. 두 개의 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
+
+두 게이트웨이 모두 `protocol: mcp` 및 `auth: iam`이어야 합니다. 생성기는 둘 다 검증합니다. 또한 생성기는 게이트웨이 간에 순환을 생성하는 연결을 거부합니다. 그렇지 않으면 `tools/list`에서 무한 재귀가 발생합니다.
+
+## 사용법
+
+### 생성기 실행
+
+<RunGenerator generator="connection" />
+
+집계하는 Gateway 프로젝트를 소스로 선택하고 집계될 Gateway를 대상으로 선택합니다.
+
+### 옵션
+
+<GeneratorParameters generator="connection" />
+
+## 생성기 출력
+
+생성기는 새 소스 파일을 생성하는 대신 기존 프로젝트를 연결합니다. 다음 파일이 수정됩니다:
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local`이 대상 게이트웨이의 `<target-gateway>-serve-local`에 대한 종속성을 얻습니다
+  - serve-local.ts `ATTACHED_MCP_SERVERS`가 업데이트되어 로컬 게이트웨이가 대상 게이트웨이를 집계합니다
+
+</FileTree>
+
+소스 Gateway 프로젝트의 `<source-gateway>-serve-local` 대상은 대상 Gateway의 `<target-gateway>-serve-local` 대상에 대한 종속성을 얻으므로, 소스 Gateway를 로컬에서 실행하면 대상 게이트웨이(및 전이적으로 연결된 모든 MCP 서버)도 시작됩니다. 대상 게이트웨이는 소스 Gateway 프로젝트의 `serve-local.ts`에도 등록되어 로컬 게이트웨이가 해당 도구를 집계합니다.
+
+## 스택에 게이트웨이 대상 추가
+
+생성기는 Gateway를 인스턴스화하는 스택이나 모듈을 알 수 없기 때문에 게이트웨이 대상을 인프라에 자동으로 연결할 수 **없습니다**. `gateway.addGateway(targetGateway)` 호출을 직접 추가하세요.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Gateway를 인스턴스화하는 스택에서 대상 게이트웨이를 소스 게이트웨이의 대상으로 등록합니다:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+Gateway 대상 이름(기본적으로 대상 게이트웨이의 `gatewayName`)은 소스 게이트웨이의 Cedar 작업 이름에 접두사를 붙입니다. 작업 형식은 ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``입니다. <Link path="guides/agentcore-gateway">정책 작성 섹션</Link>을 참조하세요. 대상 이름을 짧고 안정적으로 유지하세요. 나중에 변경하면 이전 이름을 참조하는 모든 Cedar 정책이 무효화됩니다.
+
+기본 대상 이름을 재정의하려면 `gatewayTargetName`을 전달하세요:
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+구성은 소스 게이트웨이의 실행 역할에 대상 게이트웨이에 대한 `bedrock-agentcore:InvokeGateway` 액세스 권한을 부여하고, 소스 게이트웨이가 자체 실행 역할을 사용하여 아웃바운드 호출에 서명하도록 `iamCredentialProvider.service = 'bedrock-agentcore'`로 대상을 구성합니다. AgentCore는 생성 중에 대상의 도구를 가져오므로 대상은 대상 게이트웨이와 모든 자체 대상 이후에 생성됩니다.
+</Fragment>
+<Fragment slot="terraform">
+Gateway를 인스턴스화하는 Terraform 파일에서 게이트웨이 대상을 연결합니다:
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+대상 `name`(위의 `inner-gateway`)은 외부 게이트웨이의 Cedar 작업 이름에 접두사를 붙입니다. <Link path="guides/agentcore-gateway">정책 작성 섹션</Link>을 참조하세요. `additional_iam_policy_statements` 항목은 외부 게이트웨이의 실행 역할에 내부 게이트웨이에 대한 호출 액세스 권한을 부여합니다. 이는 대상 생성 시 내부 게이트웨이의 도구를 가져오고 런타임에 호출을 라우팅하는 데 모두 필요합니다. `policy_dependencies`는 이 대상의 작업을 참조하는 Cedar 정책이 대상이 등록한 후에 생성되도록 보장합니다.
+
+:::note[대상 순서]
+AgentCore는 `aws_bedrockagentcore_gateway_target`이 생성될 때 내부 게이트웨이의 도구를 가져오므로 내부 게이트웨이의 모든 대상을 먼저 생성해야 합니다. 동일한 구성에서 관리되는 경우 대상의 `depends_on`에 추가하세요.
+:::
+</Fragment>
+</Infrastructure>
+
+## 체인 게이트웨이 간 Cedar 정책
+
+체인의 각 게이트웨이는 자체 정책 세트를 평가합니다:
+
+1. **소스 게이트웨이**는 접두사가 붙은 작업에 대해 원래 호출자(예: 에이전트의 실행 역할)를 평가합니다. 예: `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. **대상 게이트웨이**는 내부 작업에 대해 소스 게이트웨이의 실행 역할을 평가합니다. 예: `AgentCore::Action::"my-mcp___add"`.
+
+즉, 게이트웨이 체인을 통한 도구 호출은 모든 홉에서 허용되어야 합니다. 기본 `permit-all.cedar`는 동일한 AWS 계정의 모든 호출자를 허용하며, 여기에는 소스 게이트웨이의 역할이 포함됩니다. 대상 게이트웨이에 더 좁은 정책을 작성하는 경우 표시되는 주체는 원래 호출자가 아니라 *소스 게이트웨이의* 역할임을 기억하세요.
+
+## 로컬 개발
+
+다음을 사용하여 소스 Gateway를 로컬에서 실행:
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+로컬 소스 게이트웨이, 로컬 대상 게이트웨이 및 둘 중 하나에 연결된 모든 MCP 서버를 각각 할당된 로컬 포트에서 시작합니다. 도구 이름은 배포된 것과 정확히 동일하게 각 홉에서 접두사가 붙으므로(`<gateway-target-name>___<target-name>___<tool-name>`), 에이전트 프롬프트와 Cedar 작업 이름이 로컬 및 배포된 실행 간에 일관성을 유지합니다.
+
+:::caution[로컬 충실도]
+로컬 개발은 **로컬 대체 게이트웨이**를 사용합니다. 이는 각 Gateway 프로젝트에서 시작된 경량 MCP 집계기이며 AgentCore Gateway 서비스가 아닙니다. 결과적으로 **Cedar 정책은 로컬에서 평가되지 않습니다**. Cedar 정책을 실행하려면 에이전트의 `serve` 대상을 대신 실행하세요(<Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link> 에이전트 연결 가이드 참조). 그러면 로컬에서 실행 중인 에이전트가 배포된 Gateway를 호출합니다.
+:::

--- a/docs/src/content/docs/ko/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 1. 두 개의 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
 
-두 게이트웨이 모두 `protocol: mcp` 및 `auth: iam`이어야 합니다. 생성기는 둘 다 검증합니다. 또한 생성기는 게이트웨이 간에 순환을 생성하는 연결을 거부합니다. 그렇지 않으면 `tools/list`에서 무한 재귀가 발생합니다.
+두 게이트웨이 모두 `protocol: mcp`이어야 하며, 대상 게이트웨이는 `auth: iam`이어야 합니다. 소스 게이트웨이는 자체 실행 역할로 서명하여 대상을 호출하므로 대상의 인바운드 인증만 IAM이어야 합니다. 생성기는 이를 검증하며, 게이트웨이 간에 순환을 생성하는 연결도 거부합니다. 그렇지 않으면 `tools/list`에서 무한 재귀가 발생합니다.
 
 ## 사용법
 

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -235,5 +235,6 @@ Consulte o guia de conexão para a história completa de desenvolvimento local.
 ## Próximos passos
 
 - Conectar um servidor MCP: <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- Conectar outro Gateway: <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - Conectar um Agente TypeScript: <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Conectar um Agente Python: <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/pt/guides/connection.mdx
+++ b/docs/src/content/docs/pt/guides/connection.mdx
@@ -182,6 +182,13 @@ O gerador de Conexão suporta as seguintes conexões:
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway para AgentCore Gateway"
+    description="Agregue um AgentCore Gateway atrás de outro AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent para AgentCore Gateway"
     description="Conecte um TypeScript Agent a um AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/pt/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ Antes de usar este gerador, certifique-se de ter:
 
 1. Dois projetos <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
 
-Ambos os gateways devem ter `protocol: mcp` e `auth: iam` — o gerador valida ambos. O gerador também rejeita conexões que criariam um ciclo entre gateways, o que de outra forma recorreria infinitamente em `tools/list`.
+Ambos os gateways devem ter `protocol: mcp`, e o gateway de destino deve ter `auth: iam` — o gateway de origem invoca o destino assinando com sua própria função de execução, então apenas a autenticação de entrada do destino precisa ser IAM. O gerador valida isso, e também rejeita conexões que criariam um ciclo entre gateways, o que de outra forma recorreria infinitamente em `tools/list`.
 
 ## Uso
 

--- a/docs/src/content/docs/pt/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway para AgentCore Gateway
+description: Conectar um AgentCore Gateway a outro AgentCore Gateway
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+O gerador `connection` pode registrar um <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> como destino de outro AgentCore Gateway. Isso permite compor gateways hierarquicamente — por exemplo, um gateway de nível de equipe agregando vários gateways de domínio, cada um dos quais serve seus próprios servidores MCP.
+
+Uma vez conectado, o Gateway de origem agrega as ferramentas do Gateway de destino em seu único endpoint MCP. Como o Gateway de destino já prefixa suas ferramentas com seus próprios nomes de destino, as ferramentas aparecem através do Gateway de origem como `<gateway-target-name>___<target-name>___<tool-name>` — cada gateway na cadeia adiciona um prefixo. Ambos os gateways avaliam suas próprias políticas Cedar: o Gateway de origem autoriza o chamador para a ação prefixada, então o Gateway de destino autoriza a função de execução do Gateway de origem para a ação interna.
+
+## Pré-requisitos
+
+Antes de usar este gerador, certifique-se de ter:
+
+1. Dois projetos <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
+
+Ambos os gateways devem ter `protocol: mcp` e `auth: iam` — o gerador valida ambos. O gerador também rejeita conexões que criariam um ciclo entre gateways, o que de outra forma recorreria infinitamente em `tools/list`.
+
+## Uso
+
+### Executar o Gerador
+
+<RunGenerator generator="connection" />
+
+Selecione o projeto Gateway agregador como origem e o Gateway a ser agregado como destino.
+
+### Opções
+
+<GeneratorParameters generator="connection" />
+
+## Saída do Gerador
+
+O gerador conecta projetos existentes em vez de emitir novos arquivos de origem. Os seguintes arquivos são modificados:
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` ganha uma dependência no `<target-gateway>-serve-local` do gateway de destino
+  - serve-local.ts `ATTACHED_MCP_SERVERS` atualizado para que o gateway local agregue o gateway de destino
+
+</FileTree>
+
+O destino `<source-gateway>-serve-local` do projeto Gateway de origem ganha uma dependência no destino `<target-gateway>-serve-local` do Gateway de destino, então executar o Gateway de origem localmente também inicia o gateway de destino (e, transitivamente, todos os servidores MCP anexados a ele). O gateway de destino também é registrado no `serve-local.ts` do projeto Gateway de origem para que o gateway local agregue suas ferramentas.
+
+## Adicionando o destino do gateway à sua stack
+
+O gerador **não pode** conectar automaticamente o destino do gateway à sua infraestrutura porque não sabe qual stack ou módulo instancia os Gateways. Adicione uma única chamada a `gateway.addGateway(targetGateway)` você mesmo.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Na stack onde você instancia os Gateways, registre o gateway de destino como um destino do gateway de origem:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+O nome do destino do Gateway (o `gatewayName` do gateway de destino por padrão) prefixa os nomes de ação Cedar no gateway de origem — o formato da ação é ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``. Veja a <Link path="guides/agentcore-gateway">seção Escrevendo Políticas</Link>. Mantenha o nome do destino curto e estável; alterá-lo posteriormente invalida quaisquer políticas Cedar que referenciem o nome antigo.
+
+Para substituir o nome do destino padrão, passe `gatewayTargetName`:
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+O construto concede à função de execução do gateway de origem acesso `bedrock-agentcore:InvokeGateway` ao gateway de destino, e configura o destino com `iamCredentialProvider.service = 'bedrock-agentcore'` para que o gateway de origem assine chamadas de saída usando sua própria função de execução. O destino é criado após o gateway de destino e todos os seus próprios destinos, já que o AgentCore busca as ferramentas do destino durante a criação.
+</Fragment>
+<Fragment slot="terraform">
+No arquivo Terraform onde você instancia os Gateways, conecte o destino do gateway:
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+O `name` do destino (`inner-gateway` acima) prefixa os nomes de ação Cedar no gateway externo — veja a <Link path="guides/agentcore-gateway">seção Escrevendo Políticas</Link>. A entrada `additional_iam_policy_statements` concede à função de execução do gateway externo acesso de invocação ao gateway interno, o que é necessário tanto para buscar as ferramentas do gateway interno no momento da criação do destino quanto para rotear chamadas em tempo de execução. `policy_dependencies` garante que as políticas Cedar que referenciam as ações deste destino sejam criadas após o destino ter registrado-as.
+
+:::note[Ordenação de destinos]
+O AgentCore busca as ferramentas do gateway interno quando o `aws_bedrockagentcore_gateway_target` é criado, então quaisquer destinos do gateway interno devem ser criados primeiro. Adicione-os ao `depends_on` do destino se eles forem gerenciados na mesma configuração.
+:::
+</Fragment>
+</Infrastructure>
+
+## Políticas Cedar em gateways encadeados
+
+Cada gateway na cadeia avalia seu próprio conjunto de políticas:
+
+1. O **gateway de origem** avalia o chamador original (por exemplo, a função de execução de um agente) contra a ação prefixada, por exemplo `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. O **gateway de destino** avalia a função de execução do gateway de origem contra a ação interna, por exemplo `AgentCore::Action::"my-mcp___add"`.
+
+Isso significa que uma chamada de ferramenta através de uma cadeia de gateway deve ser permitida em cada salto. O `permit-all.cedar` padrão permite qualquer chamador na mesma conta AWS, o que inclui a função do gateway de origem; se você escrever políticas mais restritas no gateway de destino, lembre-se de que o principal que ele vê é a função do *gateway de origem*, não o chamador original.
+
+## Desenvolvimento Local
+
+Executar o Gateway de origem localmente com:
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+inicia o gateway de origem local, o gateway de destino local e todos os servidores MCP anexados a qualquer um deles, cada um em sua porta local atribuída. Os nomes das ferramentas são prefixados em cada salto exatamente como implantado (`<gateway-target-name>___<target-name>___<tool-name>`), então os prompts do agente e os nomes de ação Cedar permanecem consistentes entre execuções locais e implantadas.
+
+:::caution[Fidelidade local]
+O desenvolvimento local usa **gateways substitutos locais** — agregadores MCP leves iniciados por cada projeto Gateway, não o serviço AgentCore Gateway. Como consequência, **as políticas Cedar não são avaliadas localmente** em nenhum salto. Para exercitar as políticas Cedar, execute o destino `serve` do agente em vez disso (veja os guias de conexão de agente <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link>) para que o agente em execução local chame o Gateway implantado.
+:::

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -233,5 +233,6 @@ Xem hướng dẫn kết nối để biết toàn bộ câu chuyện phát tri�
 ## Các bước tiếp theo
 
 - Kết nối một MCP server: <Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- Kết nối một Gateway khác: <Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - Kết nối một TypeScript Agent: <Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - Kết nối một Python Agent: <Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/vi/guides/connection.mdx
+++ b/docs/src/content/docs/vi/guides/connection.mdx
@@ -182,6 +182,13 @@ Generator Connection hỗ trợ các kết nối sau:
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway to AgentCore Gateway"
+    description="Tổng hợp AgentCore Gateway phía sau một AgentCore Gateway khác"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="Kết nối TypeScript Agent với AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/vi/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway đến AgentCore Gateway
+description: Kết nối một AgentCore Gateway với một AgentCore Gateway khác
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+Trình tạo `connection` có thể đăng ký một <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> làm mục tiêu của một AgentCore Gateway khác. Điều này cho phép bạn kết hợp các gateway theo cấu trúc phân cấp — ví dụ một gateway cấp nhóm tổng hợp nhiều gateway miền, mỗi gateway miền lại đứng trước các MCP server riêng của nó.
+
+Sau khi được kết nối, Gateway nguồn tổng hợp các công cụ của Gateway mục tiêu vào một điểm cuối MCP duy nhất. Vì Gateway mục tiêu đã thêm tiền tố cho các công cụ của nó bằng tên mục tiêu riêng, các công cụ sẽ xuất hiện qua Gateway nguồn dưới dạng `<gateway-target-name>___<target-name>___<tool-name>` — mỗi gateway trong chuỗi thêm một tiền tố. Cả hai gateway đều đánh giá các chính sách Cedar của riêng chúng: Gateway nguồn ủy quyền cho người gọi đối với hành động có tiền tố, sau đó Gateway mục tiêu ủy quyền cho vai trò thực thi của Gateway nguồn đối với hành động bên trong.
+
+## Điều kiện tiên quyết
+
+Trước khi sử dụng trình tạo này, hãy đảm bảo bạn có:
+
+1. Hai dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
+
+Cả hai gateway phải có `protocol: mcp` và `auth: iam` — trình tạo xác thực cả hai. Trình tạo cũng từ chối các kết nối có thể tạo ra chu trình giữa các gateway, điều này sẽ gây đệ quy vô hạn trên `tools/list`.
+
+## Cách sử dụng
+
+### Chạy Trình tạo
+
+<RunGenerator generator="connection" />
+
+Chọn dự án Gateway tổng hợp làm nguồn và Gateway được tổng hợp làm mục tiêu.
+
+### Tùy chọn
+
+<GeneratorParameters generator="connection" />
+
+## Đầu ra của Trình tạo
+
+Trình tạo kết nối các dự án hiện có với nhau thay vì tạo ra các tệp nguồn mới. Các tệp sau được sửa đổi:
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` có thêm phụ thuộc vào `<target-gateway>-serve-local` của gateway mục tiêu
+  - serve-local.ts `ATTACHED_MCP_SERVERS` được cập nhật để gateway cục bộ tổng hợp gateway mục tiêu
+
+</FileTree>
+
+Target `<source-gateway>-serve-local` của dự án Gateway nguồn có thêm phụ thuộc vào target `<target-gateway>-serve-local` của Gateway mục tiêu, vì vậy khi chạy Gateway nguồn cục bộ cũng sẽ khởi động gateway mục tiêu (và theo cách bắc cầu, mọi MCP server được gắn vào nó). Gateway mục tiêu cũng được đăng ký trong `serve-local.ts` của dự án Gateway nguồn để gateway cục bộ tổng hợp các công cụ của nó.
+
+## Thêm gateway target vào stack của bạn
+
+Trình tạo **không thể** tự động kết nối gateway target vào cơ sở hạ tầng của bạn vì nó không biết stack hoặc module nào khởi tạo các Gateway. Hãy tự thêm một lệnh gọi duy nhất `gateway.addGateway(targetGateway)`.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Trong stack nơi bạn khởi tạo các Gateway, hãy đăng ký gateway mục tiêu làm mục tiêu của gateway nguồn:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+Tên gateway target (mặc định là `gatewayName` của gateway mục tiêu) thêm tiền tố cho tên hành động Cedar trên gateway nguồn — định dạng hành động là ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``. Xem <Link path="guides/agentcore-gateway">phần Viết Chính sách</Link>. Giữ tên target ngắn gọn và ổn định; thay đổi nó sau này sẽ làm mất hiệu lực bất kỳ chính sách Cedar nào tham chiếu đến tên cũ.
+
+Để ghi đè tên target mặc định, hãy truyền `gatewayTargetName`:
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+Construct cấp cho vai trò thực thi của gateway nguồn quyền truy cập `bedrock-agentcore:InvokeGateway` vào gateway mục tiêu, và cấu hình mục tiêu với `iamCredentialProvider.service = 'bedrock-agentcore'` để gateway nguồn ký các cuộc gọi đi bằng vai trò thực thi của chính nó. Mục tiêu được tạo sau gateway mục tiêu và tất cả các mục tiêu của chính nó, vì AgentCore tìm nạp các công cụ của mục tiêu trong quá trình tạo.
+</Fragment>
+<Fragment slot="terraform">
+Trong tệp Terraform nơi bạn khởi tạo các Gateway, hãy kết nối gateway target vào:
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+`name` của target (`inner-gateway` ở trên) thêm tiền tố cho tên hành động Cedar trên outer gateway — xem <Link path="guides/agentcore-gateway">phần Viết Chính sách</Link>. Mục `additional_iam_policy_statements` cấp cho vai trò thực thi của outer gateway quyền truy cập invoke vào inner gateway, điều này là bắt buộc cả để tìm nạp các công cụ của inner gateway tại thời điểm tạo target và để định tuyến các cuộc gọi tại runtime. `policy_dependencies` đảm bảo các chính sách Cedar tham chiếu đến các hành động của target này được tạo sau khi target đã đăng ký chúng.
+
+:::note[Thứ tự target]
+AgentCore tìm nạp các công cụ của inner gateway khi `aws_bedrockagentcore_gateway_target` được tạo, vì vậy bất kỳ target nào của inner gateway nên được tạo trước. Thêm chúng vào `depends_on` của target nếu chúng được quản lý trong cùng một cấu hình.
+:::
+</Fragment>
+</Infrastructure>
+
+## Chính sách Cedar qua các gateway được xâu chuỗi
+
+Mỗi gateway trong chuỗi đánh giá tập chính sách của riêng nó:
+
+1. **Gateway nguồn** đánh giá người gọi ban đầu (ví dụ: vai trò thực thi của agent) đối với hành động có tiền tố, ví dụ: `AgentCore::Action::"inner-gateway___my-mcp___add"`.
+2. **Gateway mục tiêu** đánh giá vai trò thực thi của gateway nguồn đối với hành động bên trong, ví dụ: `AgentCore::Action::"my-mcp___add"`.
+
+Điều này có nghĩa là một cuộc gọi công cụ qua chuỗi gateway phải được cho phép tại mọi điểm dừng. `permit-all.cedar` mặc định cho phép bất kỳ người gọi nào trong cùng tài khoản AWS, bao gồm vai trò của gateway nguồn; nếu bạn viết các chính sách hẹp hơn trên gateway mục tiêu, hãy nhớ rằng principal mà nó thấy là vai trò của *gateway nguồn*, không phải người gọi ban đầu.
+
+## Phát triển Cục bộ
+
+Chạy Gateway nguồn cục bộ với:
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+khởi động gateway nguồn cục bộ, gateway mục tiêu cục bộ và mọi MCP server được gắn vào một trong hai, mỗi cái trên cổng cục bộ được chỉ định của nó. Tên công cụ được thêm tiền tố tại mỗi điểm dừng chính xác như khi triển khai (`<gateway-target-name>___<target-name>___<tool-name>`), vì vậy các lời nhắc của agent và tên hành động Cedar vẫn nhất quán giữa các lần chạy cục bộ và triển khai.
+
+:::caution[Độ trung thực cục bộ]
+Phát triển cục bộ sử dụng **gateway thay thế cục bộ** — các bộ tổng hợp MCP nhẹ được khởi động bởi mỗi dự án Gateway, không phải dịch vụ AgentCore Gateway. Do đó, **các chính sách Cedar không được đánh giá cục bộ** tại cả hai điểm dừng. Để thực thi các chính sách Cedar, hãy chạy target `serve` của agent thay thế (xem hướng dẫn kết nối agent <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link>) để agent chạy cục bộ gọi Gateway đã triển khai.
+:::

--- a/docs/src/content/docs/vi/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ Trước khi sử dụng trình tạo này, hãy đảm bảo bạn có:
 
 1. Hai dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link>
 
-Cả hai gateway phải có `protocol: mcp` và `auth: iam` — trình tạo xác thực cả hai. Trình tạo cũng từ chối các kết nối có thể tạo ra chu trình giữa các gateway, điều này sẽ gây đệ quy vô hạn trên `tools/list`.
+Cả hai gateway phải có `protocol: mcp`, và gateway mục tiêu phải có `auth: iam` — gateway nguồn gọi mục tiêu bằng cách ký với vai trò thực thi của chính nó, vì vậy chỉ xác thực đầu vào của mục tiêu cần phải là IAM. Trình tạo xác thực điều này, và cũng từ chối các kết nối có thể tạo ra chu trình giữa các gateway, điều này sẽ gây đệ quy vô hạn trên `tools/list`.
 
 ## Cách sử dụng
 

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -234,5 +234,6 @@ forbid (
 ## 后续步骤
 
 - 连接 MCP 服务器：<Link path="guides/connection/agentcore-gateway-mcp">`agentcore-gateway#mcp-connection`</Link>
+- 连接另一个 Gateway：<Link path="guides/connection/agentcore-gateway-gateway">`agentcore-gateway#gateway-connection`</Link>
 - 连接 TypeScript 代理：<Link path="guides/connection/ts-agent-gateway">`ts#agent#gateway-connection`</Link>
 - 连接 Python 代理：<Link path="guides/connection/py-agent-gateway">`py#agent#gateway-connection`</Link>

--- a/docs/src/content/docs/zh/guides/connection.mdx
+++ b/docs/src/content/docs/zh/guides/connection.mdx
@@ -182,6 +182,13 @@ import ConnectionCard from '@components/connection-card.astro';
     target="mcp"
   />
   <ConnectionCard
+    title="AgentCore Gateway to AgentCore Gateway"
+    description="在另一个 AgentCore Gateway 后聚合 AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="将 TypeScript Agent 连接到 AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}

--- a/docs/src/content/docs/zh/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/agentcore-gateway-gateway.mdx
@@ -22,7 +22,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 1. 两个 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
 
-两个网关都必须具有 `protocol: mcp` 和 `auth: iam` ——生成器会验证这两者。生成器还会拒绝会在网关之间创建循环的连接，否则会在 `tools/list` 上无限递归。
+两个网关都必须具有 `protocol: mcp`，并且目标网关必须具有 `auth: iam` ——源网关使用自己的执行角色对目标进行签名调用，因此只有目标的入站身份验证需要是 IAM。生成器会验证这一点，并且还会拒绝会在网关之间创建循环的连接，否则会在 `tools/list` 上无限递归。
 
 ## 使用方法
 

--- a/docs/src/content/docs/zh/guides/connection/agentcore-gateway-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/agentcore-gateway-gateway.mdx
@@ -1,0 +1,150 @@
+---
+title: AgentCore Gateway 到 AgentCore Gateway
+description: 将一个 AgentCore Gateway 连接到另一个 AgentCore Gateway
+when:
+  sourceType: agentcore-gateway
+  targetType: agentcore-gateway
+---
+import { FileTree } from '@astrojs/starlight/components';
+import Link from '@components/link.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
+import NxCommands from '@components/nx-commands.astro';
+import Infrastructure from '@components/infrastructure.astro';
+
+`connection` 生成器可以将一个 <Link path="guides/agentcore-gateway">AgentCore Gateway</Link> 注册为另一个 AgentCore Gateway 的目标。这使您可以分层组合网关——例如，一个团队级网关聚合多个域网关，每个域网关都有自己的 MCP 服务器。
+
+连接后，源网关将目标网关的工具聚合到其单一的 MCP 端点中。由于目标网关已经使用自己的目标名称为其工具添加了前缀，因此工具通过源网关显示为 `<gateway-target-name>___<target-name>___<tool-name>` ——链中的每个网关都会添加一个前缀。两个网关都会评估自己的 Cedar 策略：源网关为调用者授权前缀操作，然后目标网关为源网关的执行角色授权内部操作。
+
+## 前提条件
+
+在使用此生成器之前，请确保您拥有：
+
+1. 两个 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
+
+两个网关都必须具有 `protocol: mcp` 和 `auth: iam` ——生成器会验证这两者。生成器还会拒绝会在网关之间创建循环的连接，否则会在 `tools/list` 上无限递归。
+
+## 使用方法
+
+### 运行生成器
+
+<RunGenerator generator="connection" />
+
+选择聚合网关项目作为源，选择要聚合的网关作为目标。
+
+### 选项
+
+<GeneratorParameters generator="connection" />
+
+## 生成器输出
+
+生成器将现有项目连接在一起，而不是生成新的源文件。以下文件将被修改：
+
+<FileTree>
+
+- packages/\<source-gateway>
+  - project.json `<source-gateway>-serve-local` 获得对目标网关的 `<target-gateway>-serve-local` 的依赖
+  - serve-local.ts `ATTACHED_MCP_SERVERS` 更新，使本地网关聚合目标网关
+
+</FileTree>
+
+源网关项目的 `<source-gateway>-serve-local` 目标获得对目标网关的 `<target-gateway>-serve-local` 目标的依赖，因此在本地运行源网关也会启动目标网关（以及传递地启动附加到它的每个 MCP 服务器）。目标网关也会在源网关项目的 `serve-local.ts` 中注册，以便本地网关聚合其工具。
+
+## 将网关目标添加到您的堆栈
+
+生成器**无法**自动将网关目标连接到您的基础设施中，因为它不知道哪个堆栈或模块实例化了网关。请自行添加对 `gateway.addGateway(targetGateway)` 的单个调用。
+
+<Infrastructure>
+<Fragment slot="cdk">
+在实例化网关的堆栈中，将目标网关注册为源网关的目标：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {5-6}
+const innerGateway = new InnerGateway(this, 'InnerGateway');
+const outerGateway = new OuterGateway(this, 'OuterGateway');
+
+// Register the inner gateway as a target of the outer gateway. The target
+// name defaults to the inner gateway's `gatewayName` (its class name in
+// kebab-case, e.g. `InnerGateway` -> `inner-gateway`).
+outerGateway.addGateway(innerGateway);
+```
+
+网关目标名称（默认为目标网关的 `gatewayName`）为源网关上的 Cedar 操作名称添加前缀——操作格式为 ``AgentCore::Action::"<gatewayTargetName>___<targetName>___<toolName>"``。请参阅<Link path="guides/agentcore-gateway">编写策略部分</Link>。保持目标名称简短且稳定；稍后更改它会使引用旧名称的任何 Cedar 策略失效。
+
+要覆盖默认目标名称，请传递 `gatewayTargetName`：
+
+```ts
+outerGateway.addGateway(innerGateway, { gatewayTargetName: 'inner' });
+```
+
+该构造授予源网关的执行角色对目标网关的 `bedrock-agentcore:InvokeGateway` 访问权限，并使用 `iamCredentialProvider.service = 'bedrock-agentcore'` 配置目标，以便源网关使用自己的执行角色对出站调用进行签名。目标在目标网关及其所有自己的目标之后创建，因为 AgentCore 在创建期间获取目标的工具。
+</Fragment>
+<Fragment slot="terraform">
+在实例化网关的 Terraform 文件中，连接网关目标：
+
+```hcl title="packages/infra/src/main.tf" {5-9,12-30}
+module "inner_gateway" {
+  source = "../../common/terraform/src/app/gateways/inner-gateway"
+}
+
+module "outer_gateway" {
+  source              = "../../common/terraform/src/app/gateways/outer-gateway"
+  policy_dependencies = [aws_bedrockagentcore_gateway_target.inner_gateway.target_id]
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.inner_gateway.gateway_arn]
+    }
+  ]
+}
+
+# Register the inner gateway as a target of the outer gateway
+resource "aws_bedrockagentcore_gateway_target" "inner_gateway" {
+  gateway_identifier = module.outer_gateway.gateway_id
+  name               = "inner-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.inner_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+}
+```
+
+目标 `name`（上面的 `inner-gateway`）为外部网关上的 Cedar 操作名称添加前缀——请参阅<Link path="guides/agentcore-gateway">编写策略部分</Link>。`additional_iam_policy_statements` 条目授予外部网关的执行角色对内部网关的调用访问权限，这在目标创建时获取内部网关的工具以及在运行时路由调用时都是必需的。`policy_dependencies` 确保引用此目标操作的 Cedar 策略在目标注册它们之后创建。
+
+:::note[目标排序]
+AgentCore 在创建 `aws_bedrockagentcore_gateway_target` 时获取内部网关的工具，因此应首先创建内部网关的任何目标。如果它们在同一配置中管理，请将它们添加到目标的 `depends_on` 中。
+:::
+</Fragment>
+</Infrastructure>
+
+## 跨链式网关的 Cedar 策略
+
+链中的每个网关都会评估自己的策略集：
+
+1. **源网关**根据前缀操作评估原始调用者（例如代理的执行角色），例如 `AgentCore::Action::"inner-gateway___my-mcp___add"`。
+2. **目标网关**根据内部操作评估源网关的执行角色，例如 `AgentCore::Action::"my-mcp___add"`。
+
+这意味着通过网关链的工具调用必须在每一跳都被允许。默认的 `permit-all.cedar` 允许同一 AWS 账户中的任何调用者，其中包括源网关的角色；如果您在目标网关上编写更窄的策略，请记住它看到的主体是*源网关的*角色，而不是原始调用者。
+
+## 本地开发
+
+使用以下命令在本地运行源网关：
+
+<NxCommands commands={["<source-gateway-name>-serve-local"]} />
+
+启动本地源网关、本地目标网关以及附加到任一网关的每个 MCP 服务器，每个都在其分配的本地端口上。工具名称在每一跳都会像部署时一样添加前缀（`<gateway-target-name>___<target-name>___<tool-name>`），因此代理提示和 Cedar 操作名称在本地和部署运行中保持一致。
+
+:::caution[本地保真度]
+本地开发使用**本地替代网关**——由每个网关项目启动的轻量级 MCP 聚合器，而不是 AgentCore Gateway 服务。因此，**Cedar 策略不会在本地的任一跳进行评估**。要执行 Cedar 策略，请改为运行代理的 `serve` 目标（请参阅 <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link> 代理连接指南），以便本地运行的代理调用已部署的网关。
+:::

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -2924,5 +2924,51 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
     }
+  },
+  "agentcore-gateway#gateway-connection": {
+    "sourceProject": {
+      "en": "The gateway project to add the target gateway to",
+      "pt": "O projeto gateway ao qual adicionar o gateway de destino",
+      "es": "El proyecto gateway al que se agregará el gateway de destino",
+      "jp": "ターゲットゲートウェイを追加するゲートウェイプロジェクト",
+      "fr": "Le projet gateway auquel ajouter le gateway cible",
+      "ko": "대상 게이트웨이를 추가할 게이트웨이 프로젝트",
+      "zh": "要添加目标网关的网关项目",
+      "it": "Il progetto gateway a cui aggiungere il gateway di destinazione",
+      "vi": "Dự án gateway để thêm gateway đích vào"
+    },
+    "targetProject": {
+      "en": "The gateway project to register as a target",
+      "pt": "O projeto gateway a registrar como destino",
+      "es": "El proyecto gateway a registrar como destino",
+      "jp": "ターゲットとして登録するゲートウェイプロジェクト",
+      "fr": "Le projet gateway à enregistrer comme cible",
+      "ko": "대상으로 등록할 게이트웨이 프로젝트",
+      "zh": "要注册为目标的网关项目",
+      "it": "Il progetto gateway da registrare come destinazione",
+      "vi": "Dự án gateway để đăng ký làm đích"
+    },
+    "sourceComponent": {
+      "en": "The gateway component in the source project",
+      "pt": "O componente gateway no projeto de origem",
+      "es": "El componente gateway en el proyecto de origen",
+      "jp": "ソースプロジェクト内のゲートウェイコンポーネント",
+      "fr": "Le composant gateway dans le projet source",
+      "ko": "소스 프로젝트의 게이트웨이 컴포넌트",
+      "zh": "源项目中的网关组件",
+      "it": "Il componente gateway nel progetto sorgente",
+      "vi": "Component gateway trong dự án nguồn"
+    },
+    "targetComponent": {
+      "en": "The gateway component in the target project",
+      "pt": "O componente gateway no projeto de destino",
+      "es": "El componente gateway en el proyecto de destino",
+      "jp": "ターゲットプロジェクト内のゲートウェイコンポーネント",
+      "fr": "Le composant gateway dans le projet cible",
+      "ko": "대상 프로젝트의 게이트웨이 컴포넌트",
+      "zh": "目标项目中的网关组件",
+      "it": "Il componente gateway nel progetto di destinazione",
+      "vi": "Component gateway trong dự án đích"
+    }
   }
 }

--- a/e2e/src/files/application-stack.ts.template
+++ b/e2e/src/files/application-stack.ts.template
@@ -22,6 +22,7 @@ import {
   MySmithyApi,
   MyTable,
   MyGateway,
+  ParentGateway,
 } from ':e2e-test/common-constructs';
 
 export class ApplicationStack extends cdk.Stack {
@@ -118,6 +119,14 @@ export class ApplicationStack extends cdk.Stack {
     myGateway.grantInvokeAccess(pyAgent);
     new cdk.CfnOutput(this, 'MyGatewayUrl', {
       value: myGateway.gateway.gatewayUrl ?? '',
+    });
+
+    // Chained gateways: the parent gateway fronts MyGateway, re-exposing its
+    // tools under `my-gateway___<target>___<tool>` (gateway -> gateway edge).
+    const parentGateway = new ParentGateway(this, 'ParentGateway');
+    parentGateway.addGateway(myGateway);
+    new cdk.CfnOutput(this, 'ParentGatewayUrl', {
+      value: parentGateway.gateway.gatewayUrl ?? '',
     });
   }
 }

--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -268,6 +268,55 @@ resource "aws_bedrockagentcore_gateway_target" "py_mcp_server" {
   }
 }
 
+# Chained gateways: the parent gateway fronts my_gateway via the
+# gateway -> gateway connection, re-exposing its tools under
+# `my-gateway___<target>___<tool>`. The parent signs outbound calls to
+# my_gateway with its own role and fetches its tools at target creation
+# time, so it needs InvokeGateway access before the target is created.
+module "parent_gateway" {
+  source = "../../common/terraform/src/app/gateways/parent-gateway"
+
+  additional_iam_policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["bedrock-agentcore:InvokeGateway"]
+      Resource = [module.my_gateway.gateway_arn]
+    }
+  ]
+
+  policy_dependencies = [
+    aws_bedrockagentcore_gateway_target.my_gateway.target_id,
+  ]
+}
+
+# Register my_gateway as a target of the parent gateway — the Terraform
+# analogue of `parentGateway.addGateway(myGateway)` in the CDK template.
+# AgentCore fetches my_gateway's tools when this target is created, so
+# my_gateway's own targets must exist first.
+resource "aws_bedrockagentcore_gateway_target" "my_gateway" {
+  gateway_identifier = module.parent_gateway.gateway_id
+  name               = "my-gateway"
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = module.my_gateway.gateway_url
+      }
+    }
+  }
+
+  credential_provider_configuration {
+    gateway_iam_role {
+      service = "bedrock-agentcore"
+    }
+  }
+
+  depends_on = [
+    aws_bedrockagentcore_gateway_target.ts_mcp_server,
+    aws_bedrockagentcore_gateway_target.py_mcp_server,
+  ]
+}
+
 # ---------------------------------------------------------------------------
 # HTTP agents (Bedrock AgentCore runtimes)
 # ---------------------------------------------------------------------------
@@ -442,6 +491,7 @@ module "runtime_config_appconfig_deployment" {
     module.ts_agent,
     module.my_table,
     module.my_gateway,
+    module.parent_gateway,
   ]
 }
 
@@ -553,4 +603,8 @@ output "website_distribution_domain_name" {
 
 output "my_gateway_url" {
   value = module.my_gateway.gateway_url
+}
+
+output "parent_gateway_url" {
+  value = module.parent_gateway.gateway_url
 }

--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -11,6 +11,7 @@ import { runCLI, tmpProjPath } from '../utils';
 import {
   invokeAgentCoreA2a,
   invokeAgentCoreAgent,
+  invokeAgentCoreGatewayTool,
   invokeAgentCoreMcp,
   invokeCustomAuthApi,
   invokeCustomAuthTrpcApi,
@@ -249,6 +250,19 @@ describe('smoke test - cdk-deploy', () => {
           'Use the my-mcp-server___add tool to add 6 and 2. Return just the number.',
         ),
       ).toContain('8');
+
+      // Chained gateways — the parent gateway fronts MyGateway via the
+      // gateway -> gateway connection, re-exposing its tools under a second
+      // prefix. Listing tools on the parent and calling one proves the
+      // parent -> MyGateway (SigV4 + Cedar at both hops) -> MCP server chain
+      // works end-to-end.
+      await invokeAgentCoreGatewayTool(
+        findOutput('ParentGatewayUrl'),
+        'Parent Gateway -> Gateway -> TS MCP',
+        'my-gateway___hosted-mcp-server___divide',
+        { a: 6, b: 2 },
+        '3',
+      );
 
       // Lambda functions
       await invokeLambda(findOutput('PyFunctionArn'), 'Python Function');

--- a/e2e/src/smoke-tests/deploy-invocations.ts
+++ b/e2e/src/smoke-tests/deploy-invocations.ts
@@ -105,6 +105,43 @@ export async function invokeAgentCoreMcp(
   }
 }
 
+/**
+ * List tools on a deployed AgentCore Gateway over SigV4 and call one,
+ * asserting the result contains the expected text. Used to exercise
+ * chained gateways (gateway -> gateway -> MCP server) directly, without
+ * an agent in front.
+ */
+export async function invokeAgentCoreGatewayTool(
+  gatewayUrl: string,
+  gatewayName: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  expected: string,
+): Promise<void> {
+  const aws = await createAwsClient('bedrock-agentcore');
+  console.log(`Testing ${gatewayName} at ${gatewayUrl}`);
+
+  const transport = new StreamableHTTPClientTransport(new URL(gatewayUrl), {
+    fetch: aws.fetch.bind(aws),
+  });
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(transport);
+  try {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    console.log(`${gatewayName} tools:`, names);
+    expect(names).toContain(toolName);
+
+    const result = await client.callTool({ name: toolName, arguments: args });
+    const resultText = JSON.stringify(result.content);
+    console.log(`${gatewayName} ${toolName} result:`, resultText);
+    expect(resultText).toContain(expected);
+  } finally {
+    await client.close();
+  }
+}
+
 export async function invokeAgentCoreAgent(
   arn: string,
   agentName: string,

--- a/e2e/src/smoke-tests/generator-matrix.ts
+++ b/e2e/src/smoke-tests/generator-matrix.ts
@@ -244,6 +244,17 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
     opts,
   );
 
+  // A parent gateway fronting my-gateway, exercising the
+  // gateway -> gateway connection edge (chained gateways).
+  await runCLI(
+    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive`,
+    opts,
+  );
+  await runCLI(
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/parent-gateway --targetProject=@e2e-test/my-gateway --no-interactive`,
+    opts,
+  );
+
   // Website -> agent connections (TypeScript HTTP, TypeScript AG-UI, Python HTTP, Python AG-UI/CopilotKit)
   await runCLI(
     `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=ts-project --targetComponent=agent --no-interactive`,

--- a/e2e/src/smoke-tests/serve-local.spec.ts
+++ b/e2e/src/smoke-tests/serve-local.spec.ts
@@ -344,6 +344,12 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
         `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive`,
         opts,
       );
+      // A second gateway fronting my-gateway, to exercise the
+      // gateway -> gateway connection (chained local gateways).
+      await runCLI(
+        `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive`,
+        opts,
+      );
 
       // Connections
       await runCLI(
@@ -391,6 +397,12 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
       );
       await runCLI(
         `generate @aws/nx-plugin:connection --sourceProject=my-gateway --targetProject=py_project --targetComponent=my-py-mcp --no-interactive`,
+        opts,
+      );
+      // parent-gateway -> my-gateway: the parent's local gateway aggregates
+      // my-gateway's (already prefixed) tools under a second prefix.
+      await runCLI(
+        `generate @aws/nx-plugin:connection --sourceProject=parent-gateway --targetProject=my-gateway --no-interactive`,
         opts,
       );
 
@@ -561,6 +573,16 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
           projectRoot,
           'packages/py_project/project.json',
           'gw-py-agent-serve-local',
+        ),
+        gateway: getPortFromProjectJson(
+          projectRoot,
+          'packages/my-gateway/project.json',
+          'my-gateway-serve-local',
+        ),
+        parentGateway: getPortFromProjectJson(
+          projectRoot,
+          'packages/parent-gateway/project.json',
+          'parent-gateway-serve-local',
         ),
       };
       console.log('Ports discovered:', ports);
@@ -885,6 +907,64 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     console.log('Py Agent Gateway -> Py MCP (add) stream:', pyResult);
     expect(pyResult).toContain('8');
 
+    await stopLast();
+  });
+
+  it('AgentCore Gateway - chained local gateways (gateway -> gateway -> MCP servers)', async () => {
+    // parent-gateway fronts my-gateway, which fronts the TypeScript `my-mcp`
+    // and Python `my-py-mcp` servers. Starting the parent's serve-local boots
+    // the whole chain. Listing tools on the parent must surface my-gateway's
+    // (already prefixed) tools under a second prefix
+    // (`my-gateway___<target>___<tool>`), and calling one must route
+    // parent -> my-gateway -> the right upstream MCP server.
+    const { Client } = await import(
+      '@modelcontextprotocol/sdk/client/index.js'
+    );
+    const { StreamableHTTPClientTransport } = await import(
+      '@modelcontextprotocol/sdk/client/streamableHttp.js'
+    );
+
+    await startAndWait(
+      '@serve-local-test/parent-gateway:parent-gateway-serve-local',
+      ports.parentGateway,
+    );
+    // The chain is started in dependency order; wait for the inner gateway
+    // and MCP servers too so list/call below cannot race their startup.
+    await waitForPort(ports.gateway, STARTUP_TIMEOUT_MS);
+    await waitForPort(ports.tsMcp, STARTUP_TIMEOUT_MS);
+    await waitForPort(ports.pyMcp, STARTUP_TIMEOUT_MS);
+
+    const client = new Client({ name: 'e2e-test', version: '1.0.0' });
+    await client.connect(
+      new StreamableHTTPClientTransport(
+        new URL(`http://127.0.0.1:${ports.parentGateway}/mcp`),
+      ),
+    );
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      console.log('Parent gateway aggregated tools:', names);
+      expect(names).toContain('my-gateway___my-mcp___divide');
+      expect(names).toContain('my-gateway___my-py-mcp___add');
+
+      // TypeScript MCP server through both gateways: divide(6, 2) = 3
+      const divide = await client.callTool({
+        name: 'my-gateway___my-mcp___divide',
+        arguments: { a: 6, b: 2 },
+      });
+      console.log('Chained gateway divide result:', JSON.stringify(divide));
+      expect(JSON.stringify(divide)).toContain('3');
+
+      // Python MCP server through both gateways: add(6, 2) = 8
+      const add = await client.callTool({
+        name: 'my-gateway___my-py-mcp___add',
+        arguments: { a: 6, b: 2 },
+      });
+      console.log('Chained gateway add result:', JSON.stringify(add));
+      expect(JSON.stringify(add)).toContain('8');
+    } finally {
+      await client.close();
+    }
     await stopLast();
   });
 

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -11,6 +11,7 @@ import { runCLI, tmpProjPath } from '../utils';
 import {
   invokeAgentCoreA2a,
   invokeAgentCoreAgent,
+  invokeAgentCoreGatewayTool,
   invokeAgentCoreMcp,
   invokeCustomAuthApi,
   invokeCustomAuthTrpcApi,
@@ -242,6 +243,19 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
               'Use the my-mcp-server___add tool to add 6 and 2. Return just the number.',
             ),
           ).toContain('8');
+
+          // Chained gateways — the parent gateway fronts my_gateway via the
+          // gateway -> gateway connection, re-exposing its tools under a
+          // second prefix. Listing tools on the parent and calling one proves
+          // the parent -> my_gateway (SigV4 + Cedar at both hops) -> MCP
+          // server chain works end-to-end.
+          await invokeAgentCoreGatewayTool(
+            outputs.parent_gateway_url,
+            'Parent Gateway -> Gateway -> TS MCP',
+            'my-gateway___hosted-mcp-server___divide',
+            { a: 6, b: 2 },
+            '3',
+          );
 
           // Lambda functions
           await invokeLambda(outputs.py_function_arn, 'Python Function');

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -16,6 +16,13 @@
       "metric": "g49",
       "hidden": true
     },
+    "agentcore-gateway#gateway-connection": {
+      "factory": "./src/agentcore-gateway/gateway-connection/generator",
+      "schema": "./src/agentcore-gateway/gateway-connection/schema.json",
+      "description": "Connect an AgentCore Gateway to another AgentCore Gateway",
+      "metric": "g52",
+      "hidden": true
+    },
     "connection": {
       "factory": "./src/connection/generator",
       "schema": "./src/connection/schema.json",
@@ -39,7 +46,8 @@
         "connection/ts-agent-rdb",
         "connection/ts-agent-gateway",
         "connection/py-agent-gateway",
-        "connection/agentcore-gateway-mcp"
+        "connection/agentcore-gateway-mcp",
+        "connection/agentcore-gateway-gateway"
       ]
     },
     "license": {

--- a/packages/nx-plugin/src/agentcore-gateway/attach-upstream.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/attach-upstream.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type ProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { applyGritQL } from '../utils/ast';
+import { addDependencyToTargetIfNotPresent } from '../utils/nx';
+
+export interface LocalGatewayUpstream {
+  /**
+   * Gateway target name for the upstream — prefixes its tools as
+   * `<targetName>___<toolName>` both locally and deployed.
+   */
+  targetName: string;
+  /**
+   * Local port the upstream MCP endpoint listens on.
+   */
+  port: number;
+  /**
+   * Project providing the upstream's serve-local target.
+   */
+  upstreamProjectName: string;
+  /**
+   * Name of the upstream's serve-local target.
+   */
+  upstreamServeLocalTargetName: string;
+}
+
+/**
+ * Attach an upstream MCP endpoint (an MCP server or another gateway's local
+ * gateway) to a gateway's local gateway.
+ *
+ * Chains the gateway's serve-local target onto the upstream's serve-local
+ * target, and registers the upstream in the gateway's serve-local.ts so the
+ * local gateway aggregates its tools.
+ */
+export const attachUpstreamToLocalGateway = async (
+  tree: Tree,
+  gatewayProject: ProjectConfiguration,
+  gatewayServeLocalTargetName: string,
+  upstream: LocalGatewayUpstream,
+): Promise<void> => {
+  // 1. Wire serve-local chain
+  if (gatewayProject.targets?.[gatewayServeLocalTargetName]) {
+    addDependencyToTargetIfNotPresent(
+      gatewayProject,
+      gatewayServeLocalTargetName,
+      {
+        projects: [upstream.upstreamProjectName],
+        target: upstream.upstreamServeLocalTargetName,
+      },
+    );
+    updateProjectConfiguration(tree, gatewayProject.name, gatewayProject);
+  }
+
+  // 2. Register the upstream in the gateway's local serve-local.ts
+  const serveTsPath = joinPathFragments(gatewayProject.root, 'serve-local.ts');
+  if (tree.exists(serveTsPath)) {
+    const entry = `{ name: '${upstream.targetName}', url: 'http://localhost:${upstream.port}/mcp' }`;
+    await applyGritQL(
+      tree,
+      serveTsPath,
+      `or {
+  \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = []\` => \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [${entry}]\`,
+  \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [$items]\` => \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [${entry}, $items]\` where {
+    $items <: not contains \`'${upstream.targetName}'\`
+  }
+}`,
+    );
+  }
+};

--- a/packages/nx-plugin/src/agentcore-gateway/files/project/serve-local.ts.template
+++ b/packages/nx-plugin/src/agentcore-gateway/files/project/serve-local.ts.template
@@ -18,8 +18,9 @@ interface AttachedMcpServer {
   url: string;
 }
 
-// MCP servers attached to this gateway, maintained by the
-// `agentcore-gateway#mcp-connection` generator.
+// Upstream MCP endpoints attached to this gateway (MCP servers and other
+// gateways), maintained by the `agentcore-gateway#mcp-connection` and
+// `agentcore-gateway#gateway-connection` generators.
 const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [<% attachedMcpServers.forEach((s) => { %>
   { name: '<%- s.name %>', url: 'http://localhost:<%- s.port %>/mcp' },<% }); %>
 ];

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.spec.ts
@@ -274,7 +274,7 @@ describe('agentcore-gateway#gateway-connection generator', () => {
     ).rejects.toThrow(/MCP-protocol gateways/);
   });
 
-  it('fails when either gateway is not IAM auth', async () => {
+  it('fails when the target gateway is not IAM auth', async () => {
     const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
     const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
     const config = readProjectConfiguration(tree, `@proj/${inner.name}`);
@@ -286,6 +286,20 @@ describe('agentcore-gateway#gateway-connection generator', () => {
         targetProject: `@proj/${inner.name}`,
       }),
     ).rejects.toThrow(/IAM authentication/);
+  });
+
+  it('allows a non-IAM source gateway since it signs the hop with its own role', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    const config = readProjectConfiguration(tree, `@proj/${outer.name}`);
+    (config.metadata as any).auth = 'cognito';
+    updateProjectConfiguration(tree, `@proj/${outer.name}`, config);
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${outer.name}`,
+        targetProject: `@proj/${inner.name}`,
+      }),
+    ).resolves.toBeDefined();
   });
 
   it('adds generator metric tags', async () => {

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.spec.ts
@@ -1,0 +1,315 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import {
+  AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO,
+  agentcoreGatewayGatewayConnectionGenerator,
+} from './generator';
+
+describe('agentcore-gateway#gateway-connection generator', () => {
+  let tree: Tree;
+
+  const addGateway = (name: string, rc: string, port: number) => {
+    addProjectConfiguration(tree, `@proj/${name}`, {
+      name: `@proj/${name}`,
+      root: `packages/${name}`,
+      projectType: 'library',
+      sourceRoot: `packages/${name}`,
+      targets: {
+        [`${name}-serve-local`]: {
+          executor: 'nx:run-commands',
+          continuous: true,
+          options: { commands: ['node -e "setInterval(()=>{}, 1000)"'] },
+          dependsOn: [],
+        },
+      },
+      metadata: {
+        generator: 'agentcore-gateway',
+        name,
+        rc,
+        protocol: 'mcp',
+        auth: 'iam',
+        port,
+      } as any,
+    });
+    return { name, rc, port };
+  };
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('wires serve-local dependency from source gateway to target gateway', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${outer.name}`,
+      targetProject: `@proj/${inner.name}`,
+    });
+
+    const config = readProjectConfiguration(tree, `@proj/${outer.name}`);
+    const deps = config.targets?.[`${outer.name}-serve-local`]
+      .dependsOn as any[];
+    expect(deps).toContainEqual(
+      expect.objectContaining({
+        projects: [`@proj/${inner.name}`],
+        target: `${inner.name}-serve-local`,
+      }),
+    );
+  });
+
+  it('registers the target gateway in the source gateway serve-local.ts', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+
+    tree.write(
+      'packages/outer-gateway/serve-local.ts',
+      `const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [
+  { name: 'already-there', url: 'http://localhost:8000/mcp' },
+];
+`,
+    );
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${outer.name}`,
+      targetProject: `@proj/${inner.name}`,
+    });
+
+    const serveTs = tree
+      .read('packages/outer-gateway/serve-local.ts')!
+      .toString();
+    // Registered under the target gateway's local port, prefixing its
+    // (already-prefixed) tools as <gateway>___<target>___<tool>
+    expect(serveTs).toContain("name: 'inner-gateway'");
+    expect(serveTs).toContain("url: 'http://localhost:8101/mcp'");
+    expect(serveTs).toContain('already-there');
+    expect(serveTs).not.toMatch(/,\s*,/);
+  });
+
+  it('serve-local.ts registration is idempotent for the same gateway', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+
+    tree.write(
+      'packages/outer-gateway/serve-local.ts',
+      `const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [];\n`,
+    );
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${outer.name}`,
+      targetProject: `@proj/${inner.name}`,
+    });
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${outer.name}`,
+      targetProject: `@proj/${inner.name}`,
+    });
+
+    const serveTs = tree
+      .read('packages/outer-gateway/serve-local.ts')!
+      .toString();
+    expect((serveTs.match(/'inner-gateway'/g) ?? []).length).toBe(1);
+
+    const config = readProjectConfiguration(tree, `@proj/${outer.name}`);
+    const deps = config.targets?.[`${outer.name}-serve-local`]
+      .dependsOn as any[];
+    expect(
+      deps.filter((d) => d.target === `${inner.name}-serve-local`).length,
+    ).toBe(1);
+  });
+
+  it('supports chains of three gateways', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const middle = addGateway('middle-gateway', 'MiddleGateway', 8101);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8102);
+    tree.write(
+      'packages/outer-gateway/serve-local.ts',
+      `const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [];\n`,
+    );
+    tree.write(
+      'packages/middle-gateway/serve-local.ts',
+      `const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [];\n`,
+    );
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${outer.name}`,
+      targetProject: `@proj/${middle.name}`,
+    });
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${middle.name}`,
+      targetProject: `@proj/${inner.name}`,
+    });
+
+    expect(
+      tree.read('packages/outer-gateway/serve-local.ts')!.toString(),
+    ).toContain("name: 'middle-gateway'");
+    expect(
+      tree.read('packages/middle-gateway/serve-local.ts')!.toString(),
+    ).toContain("name: 'inner-gateway'");
+  });
+
+  it('fails when connecting a gateway to itself', async () => {
+    const gw = addGateway('my-gateway', 'MyGateway', 8100);
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${gw.name}`,
+        targetProject: `@proj/${gw.name}`,
+      }),
+    ).rejects.toThrow(/itself/);
+  });
+
+  it('fails when the connection would create a cycle', async () => {
+    const a = addGateway('gateway-a', 'GatewayA', 8100);
+    const b = addGateway('gateway-b', 'GatewayB', 8101);
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${a.name}`,
+      targetProject: `@proj/${b.name}`,
+    });
+
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${b.name}`,
+        targetProject: `@proj/${a.name}`,
+      }),
+    ).rejects.toThrow(/cycle/);
+  });
+
+  it('fails when the connection would create a transitive cycle', async () => {
+    const a = addGateway('gateway-a', 'GatewayA', 8100);
+    const b = addGateway('gateway-b', 'GatewayB', 8101);
+    const c = addGateway('gateway-c', 'GatewayC', 8102);
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${a.name}`,
+      targetProject: `@proj/${b.name}`,
+    });
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${b.name}`,
+      targetProject: `@proj/${c.name}`,
+    });
+
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${c.name}`,
+        targetProject: `@proj/${a.name}`,
+      }),
+    ).rejects.toThrow(/cycle/);
+  });
+
+  it('cycle detection ignores non-gateway serve-local dependencies', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    // The inner gateway already fronts an MCP server
+    addProjectConfiguration(tree, '@proj/some-mcp', {
+      name: '@proj/some-mcp',
+      root: 'packages/some-mcp',
+      projectType: 'library',
+      sourceRoot: 'packages/some-mcp',
+      targets: { 'some-mcp-serve-local': {} },
+      metadata: {} as any,
+    });
+    const innerConfig = readProjectConfiguration(tree, `@proj/${inner.name}`);
+    innerConfig.targets![`${inner.name}-serve-local`].dependsOn = [
+      { projects: ['@proj/some-mcp'], target: 'some-mcp-serve-local' },
+    ];
+    updateProjectConfiguration(tree, `@proj/${inner.name}`, innerConfig);
+
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${outer.name}`,
+        targetProject: `@proj/${inner.name}`,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('fails when the source project was not generated by agentcore-gateway', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    const config = readProjectConfiguration(tree, `@proj/${outer.name}`);
+    (config.metadata as any).generator = 'ts#project';
+    updateProjectConfiguration(tree, `@proj/${outer.name}`, config);
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${outer.name}`,
+        targetProject: `@proj/${inner.name}`,
+      }),
+    ).rejects.toThrow(/was not generated by/);
+  });
+
+  it('fails when the target project was not generated by agentcore-gateway', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    const config = readProjectConfiguration(tree, `@proj/${inner.name}`);
+    (config.metadata as any).generator = 'ts#project';
+    updateProjectConfiguration(tree, `@proj/${inner.name}`, config);
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${outer.name}`,
+        targetProject: `@proj/${inner.name}`,
+      }),
+    ).rejects.toThrow(/was not generated by/);
+  });
+
+  it('fails when either gateway is non-MCP protocol', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    const config = readProjectConfiguration(tree, `@proj/${inner.name}`);
+    (config.metadata as any).protocol = 'a2a';
+    updateProjectConfiguration(tree, `@proj/${inner.name}`, config);
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${outer.name}`,
+        targetProject: `@proj/${inner.name}`,
+      }),
+    ).rejects.toThrow(/MCP-protocol gateways/);
+  });
+
+  it('fails when either gateway is not IAM auth', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    const config = readProjectConfiguration(tree, `@proj/${inner.name}`);
+    (config.metadata as any).auth = 'cognito';
+    updateProjectConfiguration(tree, `@proj/${inner.name}`, config);
+    await expect(
+      agentcoreGatewayGatewayConnectionGenerator(tree, {
+        sourceProject: `@proj/${outer.name}`,
+        targetProject: `@proj/${inner.name}`,
+      }),
+    ).rejects.toThrow(/IAM authentication/);
+  });
+
+  it('adds generator metric tags', async () => {
+    const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
+    const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
+    const { sharedConstructsGenerator } = await import(
+      '../../utils/shared-constructs'
+    );
+    await sharedConstructsGenerator(tree, { iac: 'cdk' });
+
+    await agentcoreGatewayGatewayConnectionGenerator(tree, {
+      sourceProject: `@proj/${outer.name}`,
+      targetProject: `@proj/${inner.name}`,
+    });
+
+    expectHasMetricTags(
+      tree,
+      AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO.metric,
+    );
+  });
+
+  it('exposes stable generator info id', () => {
+    expect(AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO.id).toBe(
+      'agentcore-gateway#gateway-connection',
+    );
+  });
+});

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
@@ -64,11 +64,15 @@ export const agentcoreGatewayGatewayConnectionGenerator = async (
         `Gateway '${gateway.name}' has protocol='${gateway.protocol}'. Gateway->Gateway connections are only supported between MCP-protocol gateways.`,
       );
     }
-    if (gateway.auth !== 'iam') {
-      throw new Error(
-        `Gateway '${gateway.name}' uses auth='${gateway.auth}'. Gateway->Gateway connections currently require both gateways to use IAM authentication.`,
-      );
-    }
+  }
+
+  // The source gateway invokes the target signing with its own IAM role, so
+  // only the target's inbound auth must be IAM. The source's inbound auth (how
+  // its own callers reach it) is irrelevant to this hop.
+  if (targetGateway.auth !== 'iam') {
+    throw new Error(
+      `Gateway '${targetGateway.name}' uses auth='${targetGateway.auth}'. Gateway->Gateway connections currently require the target gateway to use IAM authentication.`,
+    );
   }
 
   assertNoCycle(tree, sourceProject.name, targetProject.name);

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type GeneratorCallback,
+  installPackagesTask,
+  type Tree,
+} from '@nx/devkit';
+import { formatFilesInSubtree } from '../../utils/format';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+import { kebabCase } from '../../utils/names';
+import {
+  getGeneratorInfo,
+  type NxGeneratorInfo,
+  readProjectConfigurationUnqualified,
+} from '../../utils/nx';
+import { attachUpstreamToLocalGateway } from '../attach-upstream';
+import {
+  AGENTCORE_GATEWAY_GENERATOR_INFO,
+  readAgentCoreGatewayMetadata,
+} from '../generator';
+import type { AgentcoreGatewayGatewayConnectionGeneratorSchema } from './schema';
+
+export const AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =
+  getGeneratorInfo(__filename);
+
+/**
+ * Connect an AgentCore Gateway to another AgentCore Gateway.
+ *
+ * Chains the source gateway's serve-local target to the target gateway's
+ * serve-local target, and registers the target gateway in the source
+ * gateway's local serve-local.ts so the local gateway aggregates its tools
+ * (already prefixed by the target gateway) under
+ * `<targetGateway>___<targetName>___<toolName>`. Users must still call
+ * `gateway.addGateway(...)` in their application stack to create the
+ * actual CDK/Terraform resource.
+ */
+export const agentcoreGatewayGatewayConnectionGenerator = async (
+  tree: Tree,
+  options: AgentcoreGatewayGatewayConnectionGeneratorSchema,
+): Promise<GeneratorCallback> => {
+  const sourceProject = readProjectConfigurationUnqualified(
+    tree,
+    options.sourceProject,
+  );
+  const targetProject = readProjectConfigurationUnqualified(
+    tree,
+    options.targetProject,
+  );
+
+  const sourceGateway = readAgentCoreGatewayMetadata(sourceProject);
+  const targetGateway = readAgentCoreGatewayMetadata(targetProject);
+
+  if (sourceProject.name === targetProject.name) {
+    throw new Error(
+      `Cannot connect gateway '${sourceGateway.name}' to itself.`,
+    );
+  }
+
+  for (const gateway of [sourceGateway, targetGateway]) {
+    if (gateway.protocol !== 'mcp') {
+      throw new Error(
+        `Gateway '${gateway.name}' has protocol='${gateway.protocol}'. Gateway->Gateway connections are only supported between MCP-protocol gateways.`,
+      );
+    }
+    if (gateway.auth !== 'iam') {
+      throw new Error(
+        `Gateway '${gateway.name}' uses auth='${gateway.auth}'. Gateway->Gateway connections currently require both gateways to use IAM authentication.`,
+      );
+    }
+  }
+
+  assertNoCycle(tree, sourceProject.name, targetProject.name);
+
+  const sourceServeLocalTargetName = `${kebabCase(sourceGateway.rc)}-serve-local`;
+  // The target name must match the deployed Gateway target (`gatewayName` on
+  // the gateway construct, the project's class name in kebab-case) so
+  // `<targetGateway>___<target>___<tool>` resolves identically locally and
+  // deployed.
+  const targetGatewayKebabCase = kebabCase(targetGateway.rc);
+
+  await attachUpstreamToLocalGateway(
+    tree,
+    sourceProject,
+    sourceServeLocalTargetName,
+    {
+      targetName: targetGatewayKebabCase,
+      port: targetGateway.port,
+      upstreamProjectName: targetProject.name,
+      upstreamServeLocalTargetName: `${targetGatewayKebabCase}-serve-local`,
+    },
+  );
+
+  await addGeneratorMetricsIfApplicable(tree, [
+    AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO,
+  ]);
+
+  await formatFilesInSubtree(tree);
+
+  return () => {
+    installPackagesTask(tree);
+  };
+};
+
+/**
+ * Reject connections that would make the local gateway graph cyclic — a
+ * cycle would recurse infinitely on tools/list both locally and deployed.
+ *
+ * Walks gateway serve-local dependsOn edges from the target gateway; the
+ * source gateway must not be reachable.
+ */
+const assertNoCycle = (
+  tree: Tree,
+  sourceProjectName: string,
+  targetProjectName: string,
+) => {
+  const visited = new Set<string>();
+  const stack = [targetProjectName];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === sourceProjectName) {
+      throw new Error(
+        `Connecting '${sourceProjectName}' to '${targetProjectName}' would create a cycle: '${targetProjectName}' already routes to '${sourceProjectName}'.`,
+      );
+    }
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const project = readProjectConfigurationUnqualified(tree, current);
+    if (
+      (project.metadata as any)?.generator !==
+      AGENTCORE_GATEWAY_GENERATOR_INFO.id
+    ) {
+      continue;
+    }
+    const gateway = readAgentCoreGatewayMetadata(project);
+    const serveLocal =
+      project.targets?.[`${kebabCase(gateway.rc)}-serve-local`];
+    for (const dep of serveLocal?.dependsOn ?? []) {
+      if (typeof dep !== 'string') {
+        stack.push(...(dep.projects ?? []));
+      }
+    }
+  }
+};
+
+export default agentcoreGatewayGatewayConnectionGenerator;

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ComponentMetadata } from '../../utils/nx';
+
+export interface AgentcoreGatewayGatewayConnectionGeneratorSchema {
+  sourceProject: string;
+  targetProject: string;
+  sourceComponent?: ComponentMetadata;
+  targetComponent?: ComponentMetadata;
+}

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.json
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "agentcore-gateway#gateway-connection",
+  "title": "agentcore-gateway#gateway-connection",
+  "description": "Connect an AgentCore Gateway to another AgentCore Gateway",
+  "type": "object",
+  "properties": {
+    "sourceProject": {
+      "type": "string",
+      "description": "The gateway project to add the target gateway to"
+    },
+    "targetProject": {
+      "type": "string",
+      "description": "The gateway project to register as a target"
+    },
+    "sourceComponent": {
+      "type": "string",
+      "description": "The gateway component in the source project"
+    },
+    "targetComponent": {
+      "type": "string",
+      "description": "The gateway component in the target project"
+    }
+  },
+  "required": ["sourceProject", "targetProject"]
+}

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -266,6 +266,27 @@ describe('agentcore-gateway generator', () => {
       expect(construct).toContain('public addMcpServerTarget');
     });
 
+    it('exposes addGateway + addGatewayTarget for gateway-to-gateway composition', () => {
+      const construct = tree
+        .read(
+          'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts',
+        )!
+        .toString();
+      expect(construct).toContain('public addGateway');
+      expect(construct).toContain('public addGatewayTarget');
+      // The source gateway's role needs InvokeGateway on the target gateway
+      // to fetch tools at target creation time and route calls at runtime.
+      expect(construct).toContain('bedrock-agentcore:InvokeGateway');
+      // The vended app construct exposes the default gateway target name
+      // used by addGateway.
+      const app = tree
+        .read(
+          'packages/common/constructs/src/app/gateways/my-gateway/my-gateway.ts',
+        )!
+        .toString();
+      expect(app).toContain("public readonly gatewayName = 'my-gateway'");
+    });
+
     it('derives the gateway target construct id from the target name as Target-<name>', () => {
       const construct = tree
         .read(
@@ -274,7 +295,7 @@ describe('agentcore-gateway generator', () => {
         .toString();
       // Construct ids preserve the kebab-case target name (e.g. `ts-mcp` ->
       // `Target-ts-mcp`) so the id changes with the target name.
-      expect(construct).toContain('`Target-${props.gatewayTargetName}`');
+      expect(construct).toContain('`Target-${gatewayTargetName}`');
       expect(construct).not.toContain('toPascalCase');
     });
 

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
@@ -5,20 +5,17 @@
 import {
   type GeneratorCallback,
   installPackagesTask,
-  joinPathFragments,
   type Tree,
-  updateProjectConfiguration,
 } from '@nx/devkit';
-import { applyGritQL } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
-  addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../utils/nx';
+import { attachUpstreamToLocalGateway } from '../attach-upstream';
 import { readAgentCoreGatewayMetadata } from '../generator';
 import type { AgentcoreGatewayMcpConnectionGeneratorSchema } from './schema';
 
@@ -67,8 +64,7 @@ export const agentcoreGatewayMcpConnectionGenerator = async (
     );
   }
 
-  const gatewayKebabCase = kebabCase(gateway.rc);
-  const gatewayServeLocalTargetName = `${gatewayKebabCase}-serve-local`;
+  const gatewayServeLocalTargetName = `${kebabCase(gateway.rc)}-serve-local`;
 
   // The target name must match what the deployed Gateway uses
   // (`mcpServerName` on the MCP construct, derived from the project's class
@@ -77,37 +73,18 @@ export const agentcoreGatewayMcpConnectionGenerator = async (
   // both default to `mcp-server`.
   const mcpTargetName = kebabCase(mcpComponent.rc as string);
   const mcpComponentName = mcpComponent.name ?? 'mcp-server';
-  const mcpServeLocalTargetName = `${mcpComponentName}-serve-local`;
-  const mcpPort = (mcpComponent.port as number | undefined) ?? 8000;
 
-  // 1. Wire serve-local chain
-  if (sourceProject.targets?.[gatewayServeLocalTargetName]) {
-    addDependencyToTargetIfNotPresent(
-      sourceProject,
-      gatewayServeLocalTargetName,
-      {
-        projects: [targetProject.name],
-        target: mcpServeLocalTargetName,
-      },
-    );
-    updateProjectConfiguration(tree, sourceProject.name, sourceProject);
-  }
-
-  // 2. Register the MCP server in the gateway's local serve-local.ts
-  const serveTsPath = joinPathFragments(sourceProject.root, 'serve-local.ts');
-  if (tree.exists(serveTsPath)) {
-    const entry = `{ name: '${mcpTargetName}', url: 'http://localhost:${mcpPort}/mcp' }`;
-    await applyGritQL(
-      tree,
-      serveTsPath,
-      `or {
-  \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = []\` => \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [${entry}]\`,
-  \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [$items]\` => \`const ATTACHED_MCP_SERVERS: AttachedMcpServer[] = [${entry}, $items]\` where {
-    $items <: not contains \`'${mcpTargetName}'\`
-  }
-}`,
-    );
-  }
+  await attachUpstreamToLocalGateway(
+    tree,
+    sourceProject,
+    gatewayServeLocalTargetName,
+    {
+      targetName: mcpTargetName,
+      port: (mcpComponent.port as number | undefined) ?? 8000,
+      upstreamProjectName: targetProject.name,
+      upstreamServeLocalTargetName: `${mcpComponentName}-serve-local`,
+    },
+  );
 
   await addGeneratorMetricsIfApplicable(tree, [
     AGENTCORE_GATEWAY_MCP_CONNECTION_GENERATOR_INFO,

--- a/packages/nx-plugin/src/connection/generator.spec.ts
+++ b/packages/nx-plugin/src/connection/generator.spec.ts
@@ -120,6 +120,18 @@ describe('connection generator', () => {
     );
   };
 
+  // Helper to set up an agentcore-gateway project
+  const setupGatewayProject = (name: string) => {
+    tree.write(
+      `packages/${name}/project.json`,
+      JSON.stringify({
+        name,
+        root: `packages/${name}`,
+        metadata: { generator: 'agentcore-gateway' },
+      }),
+    );
+  };
+
   // Helper to set up an unknown project
   const setupUnknownProject = (name = 'unknown', components?: any[]) => {
     tree.write(
@@ -263,6 +275,21 @@ describe('connection generator', () => {
           source: 'react',
           target: 'smithy',
         });
+      });
+
+      it('should resolve agentcore-gateway -> agentcore-gateway', async () => {
+        setupGatewayProject('outer-gateway');
+        setupGatewayProject('inner-gateway');
+        const result = await resolveConnection(tree, {
+          sourceProject: 'outer-gateway',
+          targetProject: 'inner-gateway',
+        });
+        expect(result.connection).toEqual({
+          source: 'agentcore-gateway',
+          target: 'agentcore-gateway',
+        });
+        expect(result.sourceComponent).toBeUndefined();
+        expect(result.targetComponent).toBeUndefined();
       });
 
       it('should throw for unsupported connection (trpc -> trpc)', async () => {

--- a/packages/nx-plugin/src/connection/generator.ts
+++ b/packages/nx-plugin/src/connection/generator.ts
@@ -7,6 +7,7 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
+import agentcoreGatewayGatewayConnectionGenerator from '../agentcore-gateway/gateway-connection/generator';
 import { AGENTCORE_GATEWAY_GENERATOR_INFO } from '../agentcore-gateway/generator';
 import agentcoreGatewayMcpConnectionGenerator from '../agentcore-gateway/mcp-connection/generator';
 import pyAgentA2aConnectionGenerator from '../py/agent/a2a-connection/generator';
@@ -110,6 +111,7 @@ const SUPPORTED_CONNECTIONS = [
   { source: 'py#agent', target: 'agentcore-gateway' },
   { source: 'agentcore-gateway', target: 'ts#mcp-server' },
   { source: 'agentcore-gateway', target: 'py#mcp-server' },
+  { source: 'agentcore-gateway', target: 'agentcore-gateway' },
   { source: 'py#fast-api', target: 'py#dynamodb' },
   { source: 'py#agent', target: 'py#dynamodb' },
   { source: 'py#mcp-server', target: 'py#dynamodb' },
@@ -194,6 +196,8 @@ const CONNECTION_GENERATORS = {
     agentcoreGatewayMcpConnectionGenerator(tree, options),
   'agentcore-gateway -> py#mcp-server': (tree, options) =>
     agentcoreGatewayMcpConnectionGenerator(tree, options),
+  'agentcore-gateway -> agentcore-gateway': (tree, options) =>
+    agentcoreGatewayGatewayConnectionGenerator(tree, options),
   'py#fast-api -> py#dynamodb': (tree, options) =>
     pyDynamoDBFastApiConnectionGenerator(tree, options),
   'py#agent -> py#dynamodb': (tree, options) =>

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -18,6 +18,9 @@ import { findWorkspaceRoot } from '../../../core/workspace.js';
 <%_ } _%>
  */
 export class <%- nameClassName %> extends AgentCoreGateway {
+  /** Default Gateway target name when added to another Gateway. */
+  public readonly gatewayName = '<%- nameKebabCase %>';
+
   constructor(scope: Construct, id: string) {
     super(scope, id, {
 <%_ if (cedarPolicy) { _%>

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
@@ -187,34 +187,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
       cdk.Fn.split('/', cdk.Fn.join('%3A', cdk.Fn.split(':', arn))),
     );
     const endpoint = `https://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodedArn}/invocations?qualifier=DEFAULT`;
-    // The construct id is derived from the target name so the two change
-    // together — target names are unique per gateway, and replacing a target
-    // under an unchanged name fails with AlreadyExists.
-    const target = new agentcore.CfnGatewayTarget(
-      this,
-      `Target-${props.gatewayTargetName}`,
-      {
-        gatewayIdentifier: this.gateway.gatewayId,
-        name: props.gatewayTargetName,
-        targetConfiguration: {
-          mcp: {
-            mcpServer: {
-              endpoint,
-            },
-          },
-        },
-        credentialProviderConfigurations: [
-          {
-            credentialProviderType: 'GATEWAY_IAM_ROLE',
-            credentialProvider: {
-              iamCredentialProvider: {
-                service: 'bedrock-agentcore',
-              },
-            },
-          },
-        ],
-      },
-    );
+    const target = this.addTarget(props.gatewayTargetName, endpoint);
 
     // Grant the gateway role invoke access to the target runtime before the
     // target is created — AgentCore probes the target during creation, which
@@ -252,6 +225,115 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
       probe.trigger.node.addDependency(probeGrant.policyDependable);
     }
     target.node.addDependency(probe.trigger);
+
+    return target;
+  }
+
+  /**
+   * Add another Gateway as a target of this Gateway, exposing its tools
+   * under `<targetName>___<innerTargetName>___<toolName>` names.
+   *
+   * The target name defaults to the gateway construct's `gatewayName`
+   * (its project's class name in kebab-case, e.g. `MyGateway` ->
+   * `my-gateway`). It prefixes Cedar action names and the gateway's tool
+   * names, so renaming it later is a breaking change for consumers.
+   *
+   * Both gateways evaluate their own Cedar policies: this gateway
+   * authorizes the prefixed action, then the target gateway authorizes the
+   * inner action for this gateway's role.
+   */
+  public addGateway(
+    gateway: Construct & {
+      readonly gateway: agentcore.Gateway;
+      readonly gatewayName: string;
+    },
+    props?: {
+      gatewayTargetName?: string;
+    },
+  ): agentcore.CfnGatewayTarget {
+    const target = this.addGatewayTarget({
+      gatewayTargetName: props?.gatewayTargetName ?? gateway.gatewayName,
+      // The Gateway L2 only populates gatewayUrl when created from its own
+      // props; fall back to the CloudFormation attribute otherwise.
+      gatewayUrl:
+        gateway.gateway.gatewayUrl ??
+        (gateway.gateway.node.defaultChild as agentcore.CfnGateway)
+          .attrGatewayUrl,
+      gatewayArn: gateway.gateway.gatewayArn,
+    });
+    // AgentCore fetches the target gateway's tools during target creation,
+    // so the target gateway and all of its own targets must exist first.
+    // Construct dependencies resolve at synth time, covering targets added
+    // to the target gateway after this call.
+    target.node.addDependency(gateway);
+    return target;
+  }
+
+  /**
+   * Register another Gateway's MCP endpoint as a target of this Gateway.
+   * Prefer {@link addGateway} when the construct is in scope — it also
+   * orders this gateway's target after the target gateway's own targets,
+   * so its tools are registered before they are fetched.
+   */
+  public addGatewayTarget(props: {
+    gatewayTargetName: string;
+    gatewayUrl: string;
+    gatewayArn: string;
+  }): agentcore.CfnGatewayTarget {
+    const target = this.addTarget(props.gatewayTargetName, props.gatewayUrl);
+
+    // Grant the gateway role invoke access to the target gateway before the
+    // target is created — AgentCore fetches the target's tools during
+    // creation, which fails if the permission is not yet in place.
+    const grant = this.gateway.role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        actions: ['bedrock-agentcore:InvokeGateway'],
+        resources: [props.gatewayArn],
+      }),
+    );
+    if (grant.policyDependable) {
+      target.node.addDependency(grant.policyDependable);
+    }
+
+    return target;
+  }
+
+  /**
+   * Create a Gateway target for an MCP endpoint, with outbound calls signed
+   * using this gateway's own execution role.
+   */
+  private addTarget(
+    gatewayTargetName: string,
+    endpoint: string,
+  ): agentcore.CfnGatewayTarget {
+    // The construct id is derived from the target name so the two change
+    // together — target names are unique per gateway, and replacing a target
+    // under an unchanged name fails with AlreadyExists.
+    const target = new agentcore.CfnGatewayTarget(
+      this,
+      `Target-${gatewayTargetName}`,
+      {
+        gatewayIdentifier: this.gateway.gatewayId,
+        name: gatewayTargetName,
+        targetConfiguration: {
+          mcp: {
+            mcpServer: {
+              endpoint,
+            },
+          },
+        },
+        credentialProviderConfigurations: [
+          {
+            credentialProviderType: 'GATEWAY_IAM_ROLE',
+            credentialProvider: {
+              iamCredentialProvider: {
+                service: 'bedrock-agentcore',
+              },
+            },
+          },
+        ],
+      },
+    );
 
     // Policies referencing this target's actions (e.g.
     // AgentCore::Action::"<targetName>___<tool>") only validate once the


### PR DESCRIPTION
### Reason for this change

AgentCore Gateways could aggregate MCP servers, but not other Gateways. Composing gateways hierarchically (e.g. a team-level gateway fronting several domain gateways, each fronting its own MCP servers) had no first-class support — there was no `addGateway(...)` construct method and no connection generator for the `agentcore-gateway -> agentcore-gateway` edge.

### Description of changes

Adds an `agentcore-gateway -> agentcore-gateway` connection so a Gateway can aggregate another Gateway's tools behind its own MCP endpoint. Tools surface through the chain as `<gatewayTarget>___<target>___<tool>` (each gateway adds one prefix), and both gateways evaluate their own Cedar policies — the outer authorizes the original caller for the prefixed action, the inner authorizes the outer gateway's role for the inner action.

- **New `agentcore-gateway#gateway-connection` generator** (hidden, dispatched via the `connection` generator). It chains the source gateway's `serve-local` onto the target gateway's `serve-local`, and registers the target gateway in the source's `serve-local.ts` so the local gateway aggregates its tools. Self-connections and cycles (direct or transitive) are rejected up front, since a cycle would recurse infinitely on `tools/list`.
- **Shared `AgentCoreGateway` CDK construct** gains `addGateway(gateway)` / `addGatewayTarget(props)`: registers the target gateway's MCP endpoint as a gateway target, grants the source gateway's role `bedrock-agentcore:InvokeGateway`, and orders target creation after the target gateway and its own targets (AgentCore fetches a target's tools at creation time). Vended app gateway constructs now expose a `gatewayName` used as the default target name. The existing MCP-target path is refactored to share a private `addTarget(...)` helper.
- **Refactor**: the shared `serve-local` wiring is extracted from the `mcp-connection` generator into `attach-upstream.ts`, reused by both connection generators.
- **Terraform**: documented the analogous `aws_bedrockagentcore_gateway_target` + `InvokeGateway` wiring in the new connection guide; the deployed gateway endpoint is used directly as the target endpoint.

### Description of how you validated changes

- **Unit tests**: new `gateway-connection/generator.spec.ts` (serve-local wiring, three-gateway chains, idempotency, self-connection + direct/transitive cycle rejection, non-gateway/protocol/auth validation, metric tags); new `resolveConnection` case for `agentcore-gateway -> agentcore-gateway`; new assertions in the gateway generator spec for `addGateway`/`addGatewayTarget`/`gatewayName`. Full `@aws/nx-plugin:test` suite passes.
- **Local**: generated two gateways + an MCP server in a test workspace, connected gateway→gateway, and verified the `serve-local` chain (outer :8100 → inner :8101 → MCP :8000) aggregates tools as `inner-gateway___my-mcp___divide` and routes a `callTool` end-to-end. Added a chained-gateways case to the `serve-local` e2e smoke test (passes locally).
- **Deployed**: deployed outer→inner→MCP to AWS via CDK and confirmed listing/calling `inner-gateway___my-mcp___divide` over SigV4 returns the correct result through both gateways (Cedar ENFORCE at each hop), then tore the stack down. Extended the `cdk-deploy` and `terraform-deploy` smoke tests + generator matrix with a parent gateway and an `invokeAgentCoreGatewayTool` helper.
- **Docs**: new `connection/agentcore-gateway-gateway` guide (CDK + Terraform + Cedar-across-chained-gateways + local dev), linked from the connection index, gateway guide next steps, and sidebar.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*