### PR TITLE
fix(py#project): exclude transient pytest dirs from ty type checking

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -87,6 +87,25 @@ describe('python project generator', () => {
     });
   });
 
+  it('should exclude transient and cache directories from ty type checking', async () => {
+    await pyProjectGenerator(tree, {
+      name: 'test-project',
+      directory: 'apps',
+      type: 'application',
+    });
+
+    const pyprojectToml = parse(
+      tree.read('apps/test_project/pyproject.toml', 'utf-8'),
+    );
+
+    // pytest creates and removes `pytest-cache-files-*` directories while the
+    // test and typecheck targets run concurrently, so ty must exclude them to
+    // avoid scanning one mid-deletion and failing with an I/O error.
+    const exclude = (pyprojectToml as any).tool?.ty?.src?.exclude;
+    expect(exclude).toContain('**/pytest-cache-files-*');
+    expect(exclude).toContain('**/.pytest_cache');
+  });
+
   it('should add ty as a dev dependency in the root pyproject.toml', async () => {
     await pyProjectGenerator(tree, {
       name: 'test-project',

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -232,6 +232,26 @@ export const pyProjectGenerator = async (
       if ((pyProjectToml.tool as any)?.ruff) {
         (pyProjectToml.tool as any).ruff['line-length'] = 120;
       }
+      // Exclude transient and cache directories from type checking. pytest
+      // creates and removes temporary `pytest-cache-files-*` directories while
+      // the `test` and `typecheck` targets run concurrently, so without this
+      // `ty` can scan one as it is being deleted and fail with an I/O error.
+      const tool = (pyProjectToml.tool ?? {}) as Record<string, any>;
+      tool.ty = {
+        ...tool.ty,
+        src: {
+          ...tool.ty?.src,
+          exclude: [
+            '**/pytest-cache-files-*',
+            '**/.pytest_cache',
+            '**/__pycache__',
+            '**/.ruff_cache',
+            '.venv',
+            'dist',
+          ],
+        },
+      };
+      pyProjectToml.tool = tool as typeof pyProjectToml.tool;
       return pyProjectToml;
     },
   );


### PR DESCRIPTION
### Reason for this change

The CI run on `main` for the merged `py#dynamodb` generator (#804) failed in the **terraform-deploy** smoke test. The failure was a `typecheck` error during `build --all`, not a deploy problem:

```
e2e_test.py_api_http: error[io]: `.../packages/py_api_http/pytest-cache-files-txn5sw9b`: No such file or directory (os error 2)
Found 1 diagnostic
Failed tasks:
- e2e_test.py_api_http:typecheck
```

The `test` (pytest) and `typecheck` (`ty check`) targets run concurrently in the same project directory. pytest creates and removes temporary `pytest-cache-files-*` directories during a run, so `ty` can scan one as it is being deleted and fail with an I/O error. This was always a latent race; the `py#dynamodb` generator added several more Python projects to the smoke-test matrix, increasing concurrency and making the race surface.

### Description of changes

Configure `[tool.ty.src] exclude` in the generated `pyproject.toml` (in the base `py#project` generator, so every Python generator inherits it — `py#dynamodb`, `py#fast-api`, `py#agent`, `py#mcp-server`, ...) to skip transient and cache directories:

```toml
[tool.ty.src]
exclude = [
  "**/pytest-cache-files-*",
  "**/.pytest_cache",
  "**/__pycache__",
  "**/.ruff_cache",
  ".venv",
  "dist",
]
```

**Why not `.gitignore`?** `ty` does respect `.gitignore` by default, but only inside a git work tree. The e2e smoke tests create workspaces with `--skipGit`, so there is no git repo and `ty` ignores `.gitignore` entirely. I verified that the gitignore approach fails once `.git` is removed, whereas the explicit `[tool.ty.src] exclude` works regardless of git presence — which is exactly the CI condition.

**Caught in PR, not just main:** the same `runGeneratorMatrix` + `build --all` (including `typecheck`) runs in the PR smoke tests (`pnpm-11`, `npm`, `bun`, `terraform`), so the typecheck is exercised on every PR. The race was intermittent, which is why #804 passed in PR but failed later on `main`. This fix makes typecheck deterministic so the same matrix reliably catches type regressions at PR time.

### Description of how you validated changes

- Reproduced the failure: a stray `pytest-cache-files-*` directory containing a syntactically-broken `.py` file makes `ty check` fail; with the exclude config it passes.
- Confirmed real type errors in source are still caught (no over-exclusion).
- Verified end-to-end with the recompiled plugin: generated `py#project`, `py#dynamodb`, and a connected `py#fast-api`, all produce the exclude config and pass `typecheck` with a stray pytest dir present.
- Verified the gitignore-only approach fails under `--skipGit` (no git repo), confirming the explicit exclude is required.
- Added a unit test asserting the exclude config is generated; `src/py/project` (33) and `src/py/dynamodb` (37) test suites pass.

### Issue # (if applicable)

Follow-up to #804 / #809.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*