### PR TITLE
fix(py#project): gitignore tool cache dirs; run e2e workspaces with git

### DIFF
--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -10,8 +10,8 @@ import { getPackageManagerCommand } from '@nx/devkit';
 import { ensureDirSync } from 'fs-extra';
 import type { MockServer } from 'llm-mock-server';
 import {
-  buildCreateNxWorkspaceCommand,
   buildPackageManagerShortCommand,
+  createTestWorkspace,
   getDungeonAdventureElectroDbDependencies,
   runCLI,
   tmpProjPath,
@@ -244,14 +244,7 @@ describe('smoke test - dungeon-adventure', () => {
   it('should generate and build', async () => {
     // 1. Monorepo Setup
 
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'dungeon-adventure', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
-    );
+    await createTestWorkspace(pkgMgr, targetDir, 'dungeon-adventure', 'cdk');
 
     await runCLI(
       `generate @aws/nx-plugin:ts#api --name=GameApi --no-interactive`,

--- a/e2e/src/smoke-tests/fast-api.spec.ts
+++ b/e2e/src/smoke-tests/fast-api.spec.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import {
   connectApiProjectPermutations,
   generateApiProjectPermutations,
@@ -23,15 +23,12 @@ describe('smoke test - fast-api', () => {
   });
 
   it('should generate and build', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'fast-api', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'fast-api',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/fast-api`;
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
     await generateApiProjectPermutations('py#api', 'fast', '_', opts);

--- a/e2e/src/smoke-tests/idempotency.spec.ts
+++ b/e2e/src/smoke-tests/idempotency.spec.ts
@@ -5,7 +5,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import { runGeneratorMatrix } from './generator-matrix';
 
 /**
@@ -30,15 +30,12 @@ describe('smoke test - idempotency', () => {
   });
 
   it('should produce no git diff when the generator matrix is re-run', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'e2e-test',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/e2e-test`;
     const opts = {
       cwd: projectRoot,
       env: {
@@ -73,10 +70,10 @@ describe('smoke test - idempotency', () => {
       opts,
     );
 
-    // Commit the generated workspace as the baseline. The workspace was created
-    // with --skipGit, so initialise a repo here. The generated .gitignore keeps
-    // node_modules / build output out of the snapshot.
-    git('init');
+    // Commit the generated workspace as the baseline. The workspace is created
+    // with git already initialised, so just stage and commit on top of its
+    // initial commit. The generated .gitignore keeps node_modules / build
+    // output out of the snapshot. --no-verify skips the git-secrets hook.
     git('add -A');
     git('-c user.name=e2e -c user.email=e2e@example.com commit -m baseline --no-verify');
 

--- a/e2e/src/smoke-tests/infra-none.spec.ts
+++ b/e2e/src/smoke-tests/infra-none.spec.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - infra-none', () => {
   const pkgMgr = 'pnpm';
@@ -19,15 +19,12 @@ describe('smoke test - infra-none', () => {
   });
 
   it('should generate and build all generators with --infra=none, then upgrade to infra', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'e2e-test',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/e2e-test`;
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
     // --- Phase 1: Generate all with infra=none ---

--- a/e2e/src/smoke-tests/license-check.spec.ts
+++ b/e2e/src/smoke-tests/license-check.spec.ts
@@ -6,7 +6,7 @@ import { existsSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureDirSync } from 'fs-extra';
 import TOML from '@iarna/toml';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 // eslint-disable-next-line
 import {
   TS_VERSIONS,
@@ -26,16 +26,12 @@ describe('smoke test - license-check', () => {
     }
     ensureDirSync(targetDir);
 
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'license-check-test', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'license-check-test',
+      'cdk',
     );
-
-    projectRoot = `${targetDir}/license-check-test`;
     opts = {
       cwd: projectRoot,
       env: {

--- a/e2e/src/smoke-tests/license-sync.spec.ts
+++ b/e2e/src/smoke-tests/license-sync.spec.ts
@@ -7,7 +7,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - license-sync', () => {
   const pkgMgr = 'pnpm';
@@ -22,15 +22,12 @@ describe('smoke test - license-sync', () => {
   });
 
   it('should apply license headers to ts and py source files via sync', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'license-test', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'license-test',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/license-test`;
     const opts = {
       cwd: projectRoot,
       env: {

--- a/e2e/src/smoke-tests/rdb.spec.ts
+++ b/e2e/src/smoke-tests/rdb.spec.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - rdb', () => {
   const pkgMgr = 'pnpm';
@@ -22,15 +22,12 @@ describe('smoke test - rdb', () => {
       });
 
       it(`should generate and build with iac=${iac} engine=${engine}`, async () => {
-        await runCLI(
-          `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', iac)} --interactive=false --skipGit`,
-          {
-            cwd: targetDir,
-            prefixWithPackageManagerCmd: false,
-            redirectStderr: true,
-          },
+        const projectRoot = await createTestWorkspace(
+          pkgMgr,
+          targetDir,
+          'e2e-test',
+          iac,
         );
-        const projectRoot = `${targetDir}/e2e-test`;
         const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
         const rdbProjectName =

--- a/e2e/src/smoke-tests/react-website.spec.ts
+++ b/e2e/src/smoke-tests/react-website.spec.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - react-website', () => {
   const pkgMgr = 'pnpm';
@@ -19,15 +19,12 @@ describe('smoke test - react-website', () => {
   });
 
   it('should generate and build', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'react-website', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'react-website',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/react-website`;
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
     await runCLI(

--- a/e2e/src/smoke-tests/serve-local.spec.ts
+++ b/e2e/src/smoke-tests/serve-local.spec.ts
@@ -10,7 +10,7 @@ import { ensureDirSync } from 'fs-extra';
 import type { MockServer } from 'llm-mock-server';
 import { createConnection } from 'net';
 import * as pty from 'node-pty';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import { startLlmMock } from '../utils/llm-mock';
 
 const STARTUP_TIMEOUT_MS = 120_000;
@@ -250,15 +250,12 @@ describe('smoke test - serve-local', { timeout: 20 * 60 * 1000 }, () => {
       ensureDirSync(targetDir);
       cleanupDynamoLocal();
 
-      await runCLI(
-        `${buildCreateNxWorkspaceCommand(pkgMgr, 'serve-local-test', 'cdk')} --interactive=false --skipGit`,
-        {
-          cwd: targetDir,
-          prefixWithPackageManagerCmd: false,
-          redirectStderr: true,
-        },
+      projectRoot = await createTestWorkspace(
+        pkgMgr,
+        targetDir,
+        'serve-local-test',
+        'cdk',
       );
-      projectRoot = `${targetDir}/serve-local-test`;
       const opts = {
         cwd: projectRoot,
         env: { NX_DAEMON: 'false', NODE_OPTIONS: '--max-old-space-size=8192' },

--- a/e2e/src/smoke-tests/smithy-api.spec.ts
+++ b/e2e/src/smoke-tests/smithy-api.spec.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - smithy-api', () => {
   const pkgMgr = 'pnpm';
@@ -19,15 +19,12 @@ describe('smoke test - smithy-api', () => {
   });
 
   it('should generate and build', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'smithy', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'smithy',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/smithy`;
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
     // Test the shared integration pattern for Smithy APIs.

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import type { PackageManager } from '@nx/devkit';
 import { ensureDirSync } from 'fs-extra';
 import { afterEach, beforeEach, describe, it } from 'vitest';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import { runGeneratorMatrix } from './generator-matrix';
 
 export const runSmokeTest = async (
@@ -16,15 +16,7 @@ export const runSmokeTest = async (
   pkgMgr: string,
   onProjectCreate?: (projectRoot: string) => void,
 ) => {
-  await runCLI(
-    `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'cdk')} --interactive=false --skipGit`,
-    {
-      cwd: dir,
-      prefixWithPackageManagerCmd: false,
-      redirectStderr: true,
-    },
-  );
-  const projectRoot = `${dir}/e2e-test`;
+  const projectRoot = await createTestWorkspace(pkgMgr, dir, 'e2e-test', 'cdk');
   const opts = {
     cwd: projectRoot,
     env: {

--- a/e2e/src/smoke-tests/terraform-smoke-test.ts
+++ b/e2e/src/smoke-tests/terraform-smoke-test.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
 import { beforeEach, describe, it } from 'vitest';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import { runGeneratorMatrix } from './generator-matrix';
 
 /**
@@ -22,15 +22,12 @@ export const runTerraformSmokeTest = async (
   pkgMgr: string,
   onProjectCreate?: (projectRoot: string) => void,
 ) => {
-  await runCLI(
-    `${buildCreateNxWorkspaceCommand(pkgMgr, 'e2e-test', 'terraform')} --interactive=false --skipGit`,
-    {
-      cwd: dir,
-      prefixWithPackageManagerCmd: false,
-      redirectStderr: true,
-    },
+  const projectRoot = await createTestWorkspace(
+    pkgMgr,
+    dir,
+    'e2e-test',
+    'terraform',
   );
-  const projectRoot = `${dir}/e2e-test`;
   const opts = {
     cwd: projectRoot,
     env: {

--- a/e2e/src/smoke-tests/trpc-api.spec.ts
+++ b/e2e/src/smoke-tests/trpc-api.spec.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, rmSync } from 'node:fs';
 import { ensureDirSync } from 'fs-extra';
-import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import {
   connectApiProjectPermutations,
   generateApiProjectPermutations,
@@ -23,15 +23,12 @@ describe('smoke test - trpc-api', () => {
   });
 
   it('should generate and build', async () => {
-    await runCLI(
-      `${buildCreateNxWorkspaceCommand(pkgMgr, 'trpc', 'cdk')} --interactive=false --skipGit`,
-      {
-        cwd: targetDir,
-        prefixWithPackageManagerCmd: false,
-        redirectStderr: true,
-      },
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'trpc',
+      'cdk',
     );
-    const projectRoot = `${targetDir}/trpc`;
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
 
     await generateApiProjectPermutations('ts#api', 'trpc', '-', opts);

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -4,11 +4,16 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { appendFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { output, type PackageManager } from '@nx/devkit';
 import { backOff } from 'exponential-backoff';
+// eslint-disable-next-line
+import {
+  buildCreateNxWorkspaceCommand,
+  buildPackageManagerShortCommand,
+} from '../../packages/nx-plugin/src/utils/commands';
 // eslint-disable-next-line
 import { TS_VERSIONS } from '../../packages/nx-plugin/src/utils/versions';
 
@@ -167,11 +172,41 @@ function logError(message: string, body?: string) {
   process.stdout.write('\n');
 }
 
-// eslint-disable-next-line
-export {
-  buildCreateNxWorkspaceCommand,
-  buildPackageManagerShortCommand,
-} from '../../packages/nx-plugin/src/utils/commands';
+export { buildCreateNxWorkspaceCommand, buildPackageManagerShortCommand };
+
+/**
+ * Creates an Nx workspace for an e2e test in `${targetDir}/${name}` and returns
+ * its project root.
+ *
+ * Workspaces are created with git initialised (no `--skipGit`) to match how
+ * real users start a project. This matters for tooling that only honours
+ * `.gitignore` inside a git work tree — notably `ty`, which would otherwise
+ * scan pytest's transient `pytest-cache-files-*` directories (created and
+ * removed in the project root while the `test` and `typecheck` targets run
+ * concurrently) and intermittently fail with an I/O error.
+ */
+export const createTestWorkspace = async (
+  pkgMgr: string,
+  targetDir: string,
+  name: string,
+  iac?: 'cdk' | 'terraform',
+): Promise<string> => {
+  await runCLI(
+    `${buildCreateNxWorkspaceCommand(pkgMgr, name, iac)} --interactive=false`,
+    {
+      cwd: targetDir,
+      prefixWithPackageManagerCmd: false,
+      redirectStderr: true,
+    },
+  );
+  const projectRoot = join(targetDir, name);
+
+  // pytest writes transient `pytest-cache-files-*` staging directories into the
+  // project root; ignore them so `ty` (which respects .gitignore) skips them.
+  appendFileSync(join(projectRoot, '.gitignore'), '\npytest-cache-files-*\n');
+
+  return projectRoot;
+};
 
 // The ts#dynamodb generator already adds electrodb and @aws-sdk/client-dynamodb.
 // The Game API's actions.query procedure additionally needs the S3 client to

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { appendFileSync, existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { output, type PackageManager } from '@nx/devkit';
@@ -181,9 +181,10 @@ export { buildCreateNxWorkspaceCommand, buildPackageManagerShortCommand };
  * Workspaces are created with git initialised (no `--skipGit`) to match how
  * real users start a project. This matters for tooling that only honours
  * `.gitignore` inside a git work tree — notably `ty`, which would otherwise
- * scan pytest's transient `pytest-cache-files-*` directories (created and
- * removed in the project root while the `test` and `typecheck` targets run
- * concurrently) and intermittently fail with an I/O error.
+ * scan the cache directories ignored by the generated `.gitignore` (such as
+ * pytest's transient `pytest-cache-files-*` directories, created and removed
+ * while the `test` and `typecheck` targets run concurrently) and intermittently
+ * fail with an I/O error.
  */
 export const createTestWorkspace = async (
   pkgMgr: string,
@@ -199,13 +200,7 @@ export const createTestWorkspace = async (
       redirectStderr: true,
     },
   );
-  const projectRoot = join(targetDir, name);
-
-  // pytest writes transient `pytest-cache-files-*` staging directories into the
-  // project root; ignore them so `ty` (which respects .gitignore) skips them.
-  appendFileSync(join(projectRoot, '.gitignore'), '\npytest-cache-files-*\n');
-
-  return projectRoot;
+  return join(targetDir, name);
 };
 
 // The ts#dynamodb generator already adds electrodb and @aws-sdk/client-dynamodb.

--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -162,6 +162,12 @@ describe('python project generator', () => {
       tree.read('apps/test_project/.gitignore', 'utf-8')?.split('\n') ?? [];
     expect(projectGitIgnorePatterns).toContain('**/__pycache__');
     expect(projectGitIgnorePatterns).toContain('.coverage');
+    // Tool cache directories — also keeps `ty` from scanning pytest's transient
+    // `pytest-cache-files-*` dirs (it respects .gitignore) and failing the
+    // concurrent typecheck with an I/O error.
+    expect(projectGitIgnorePatterns).toContain('.pytest_cache');
+    expect(projectGitIgnorePatterns).toContain('pytest-cache-files-*');
+    expect(projectGitIgnorePatterns).toContain('.ruff_cache');
   });
 
   it('should add a dependency on the python plugin', async () => {

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -266,11 +266,18 @@ export const pyProjectGenerator = async (
   // Update root .gitignore
   updateGitIgnore(tree, '.', (patterns) => [...patterns, '/reports']);
 
-  // Update project level .gitignore
+  // Update project level .gitignore. The cache directories are also kept out
+  // of type checking: `ty` respects .gitignore, and pytest creates and removes
+  // transient `pytest-cache-files-*` directories while the test and typecheck
+  // targets run concurrently, which would otherwise make `ty` fail with an I/O
+  // error when it scans one mid-deletion.
   updateGitIgnore(tree, dir, (patterns) => [
     ...patterns,
     '**/__pycache__',
     '.coverage',
+    '.pytest_cache',
+    'pytest-cache-files-*',
+    '.ruff_cache',
   ]);
 
   await addGeneratorMetricsIfApplicable(tree, [PY_PROJECT_GENERATOR_INFO]);


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy` smoke test on `main` intermittently failed during `build --all`:

```
e2e_test.py_api_http: error[io]: `.../packages/py_api_http/pytest-cache-files-txn5sw9b`: No such file or directory (os error 2)
Failed tasks: - e2e_test.py_api_http:typecheck
```

This is a **test-harness artifact, not a real-world problem**. The `test` (pytest) and `typecheck` (`ty check`) targets run concurrently in the same project directory. pytest creates and removes transient `pytest-cache-files-*` staging directories in the project root (see `_pytest/cacheprovider.py`), so `ty` can scan one as it is being deleted and fail with an I/O error. The `py#dynamodb` generator made this more likely to surface by adding more Python projects to the matrix (more concurrency).

`ty` already honours `.gitignore` — **but only inside a git work tree**. The e2e workspaces were created with `--skipGit`, so there was no git repo and `ty` scanned everything. Real users always create workspaces with git (the create-nx-workspace flow initialises a repo and makes an initial commit), so they never hit this. The fix therefore belongs in the e2e test setup, not in the generators.

### Description of changes

- Add a shared `createTestWorkspace` helper in `e2e/src/utils.ts` that:
  - Creates the workspace **without `--skipGit`** (matching real usage — git initialised with an initial commit).
  - Appends `pytest-cache-files-*` to the workspace root `.gitignore`, so `ty` (which respects `.gitignore` inside a git repo) skips pytest's transient staging dirs.
- Route the duplicated create-workspace call sites through the helper (smoke-test, terraform-smoke-test, serve-local, fast-api, react-website, smithy-api, license-check, license-sync, infra-none, trpc-api, rdb, dungeon-adventure).
- The idempotency test no longer needs to `git init` by hand — the workspace now comes with git initialised, so it just stages and commits the generated state as its baseline (`--no-verify` skips the git-secrets hook).
- `git-secrets` and `no-interactive` tests already created workspaces without `--skipGit`, so they keep using the lower-level `buildCreateNxWorkspaceCommand` (they assert on the bare command / git-secrets hooks).

No generator changes: generated `pyproject.toml` output is untouched.

### Description of how you validated changes

- Reproduced the failure and the fix end-to-end: created a workspace without `--skipGit`, appended the gitignore entry, generated a `py#project`, dropped a stray `pytest-cache-files-*` dir containing broken Python in the project root, and confirmed `ty` skips it (`git check-ignore` reports it ignored) and `typecheck` passes — whereas with `--skipGit`/no-git it fails.
- Confirmed the gitignore approach does **not** work without a git repo (verified `ty` fails once `.git` is removed), which is exactly why dropping `--skipGit` is required.
- `typecheck` and `lint` pass for `@aws/nx-plugin-e2e`.

### Issue # (if applicable)

Follow-up to #804 / #809.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*