### PR TITLE
feat(api): add withOperationOptions to integration builder

### DIFF
--- a/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
@@ -172,6 +172,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### Customising Options Per-Operation
+
+<Infrastructure>
+<Fragment slot="cdk">
+To customise the options used to create the default integration for _specific_ operations (without affecting the others), you can use the `withOperationOptions` method. For example, if you would like to increase the Lambda function timeout for just one operation:
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// The selected operations remain default integrations, so they're still typed accordingly:
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+The options you specify are merged with the default integration options (and any options set via `withDefaultOptions`). Note that you cannot specify options for operations which you have replaced via `withOverrides`, since these no longer use the default integration.
+
+</Fragment>
+<Fragment slot="terraform">
+To customise options for specific operations with Terraform, you need to edit the generated Terraform module to configure individual Lambda functions per operation (see the [Explicit Integrations](#explicit-integrations) section below).
+</Fragment>
+</Infrastructure>
+
 #### Overriding Integrations
 
 <Infrastructure>

--- a/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
@@ -195,6 +195,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 The options you specify are merged with the default integration options (and any options set via `withDefaultOptions`). Note that you cannot specify options for operations which you have replaced via `withOverrides`, since these no longer use the default integration.
 
+You will encounter a type error if the same operation is targeted by both `withOperationOptions` and `withOverrides`, regardless of the order in which you call them.
+
 </Fragment>
 <Fragment slot="terraform">
 To customise options for specific operations with Terraform, you need to edit the generated Terraform module to configure individual Lambda functions per operation (see the [Explicit Integrations](#explicit-integrations) section below).

--- a/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 Las opciones que especificas se fusionan con las opciones de integración por defecto (y cualquier opción establecida mediante `withDefaultOptions`). Ten en cuenta que no puedes especificar opciones para operaciones que hayas reemplazado mediante `withOverrides`, ya que estas ya no usan la integración por defecto.
 
+Encontrarás un error de tipo si la misma operación es objetivo tanto de `withOperationOptions` como de `withOverrides`, independientemente del orden en que los llames.
+
 </Fragment>
 <Fragment slot="terraform">
 Para personalizar opciones para operaciones específicas con Terraform, necesitas editar el módulo de Terraform generado para configurar funciones Lambda individuales por operación (consulta la sección [Integraciones Explícitas](#explicit-integrations) abajo).

--- a/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### Personalizando opciones por operación
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para personalizar las opciones usadas al crear la integración por defecto para operaciones _específicas_ (sin afectar a las demás), puedes usar el método `withOperationOptions`. Por ejemplo, si deseas aumentar el timeout de la función Lambda para solo una operación:
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// Las operaciones seleccionadas siguen siendo integraciones por defecto, por lo que siguen tipadas en consecuencia:
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+Las opciones que especificas se fusionan con las opciones de integración por defecto (y cualquier opción establecida mediante `withDefaultOptions`). Ten en cuenta que no puedes especificar opciones para operaciones que hayas reemplazado mediante `withOverrides`, ya que estas ya no usan la integración por defecto.
+
+</Fragment>
+<Fragment slot="terraform">
+Para personalizar opciones para operaciones específicas con Terraform, necesitas editar el módulo de Terraform generado para configurar funciones Lambda individuales por operación (consulta la sección [Integraciones Explícitas](#explicit-integrations) abajo).
+</Fragment>
+</Infrastructure>
+
 #### Sobrescribiendo integraciones
 
 <Infrastructure>

--- a/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### Personnalisation des options par opération
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pour personnaliser les options utilisées pour créer l'intégration par défaut pour des opérations _spécifiques_ (sans affecter les autres), vous pouvez utiliser la méthode `withOperationOptions`. Par exemple, si vous souhaitez augmenter le timeout de la fonction Lambda pour une seule opération :
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// Les opérations sélectionnées restent des intégrations par défaut, elles sont donc toujours typées en conséquence :
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+Les options que vous spécifiez sont fusionnées avec les options d'intégration par défaut (et toutes les options définies via `withDefaultOptions`). Notez que vous ne pouvez pas spécifier d'options pour les opérations que vous avez remplacées via `withOverrides`, car celles-ci n'utilisent plus l'intégration par défaut.
+
+</Fragment>
+<Fragment slot="terraform">
+Pour personnaliser les options pour des opérations spécifiques avec Terraform, vous devez modifier le module Terraform généré pour configurer des fonctions Lambda individuelles par opération (voir la section [Intégrations explicites](#explicit-integrations) ci-dessous).
+</Fragment>
+</Infrastructure>
+
 #### Surcharge des intégrations
 
 <Infrastructure>

--- a/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 Les options que vous spécifiez sont fusionnées avec les options d'intégration par défaut (et toutes les options définies via `withDefaultOptions`). Notez que vous ne pouvez pas spécifier d'options pour les opérations que vous avez remplacées via `withOverrides`, car celles-ci n'utilisent plus l'intégration par défaut.
 
+Vous rencontrerez une erreur de type si la même opération est ciblée à la fois par `withOperationOptions` et `withOverrides`, quel que soit l'ordre dans lequel vous les appelez.
+
 </Fragment>
 <Fragment slot="terraform">
 Pour personnaliser les options pour des opérations spécifiques avec Terraform, vous devez modifier le module Terraform généré pour configurer des fonctions Lambda individuelles par opération (voir la section [Intégrations explicites](#explicit-integrations) ci-dessous).

--- a/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### Personalizzazione delle Opzioni per Operazione
+
+<Infrastructure>
+<Fragment slot="cdk">
+Per personalizzare le opzioni utilizzate per creare l'integrazione predefinita per operazioni _specifiche_ (senza influenzare le altre), puoi usare il metodo `withOperationOptions`. Ad esempio, se desideri aumentare il timeout della funzione Lambda per una sola operazione:
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// Le operazioni selezionate rimangono integrazioni predefinite, quindi sono ancora tipizzate di conseguenza:
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+Le opzioni che specifichi vengono unite alle opzioni di integrazione predefinite (e a qualsiasi opzione impostata tramite `withDefaultOptions`). Nota che non puoi specificare opzioni per operazioni che hai sostituito tramite `withOverrides`, poiché queste non utilizzano più l'integrazione predefinita.
+
+</Fragment>
+<Fragment slot="terraform">
+Per personalizzare le opzioni per operazioni specifiche con Terraform, devi modificare il modulo Terraform generato per configurare singole funzioni Lambda per operazione (vedi la sezione [Integrazioni Esplicite](#explicit-integrations) di seguito).
+</Fragment>
+</Infrastructure>
+
 #### Override delle Integrazioni
 
 <Infrastructure>

--- a/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 Le opzioni che specifichi vengono unite alle opzioni di integrazione predefinite (e a qualsiasi opzione impostata tramite `withDefaultOptions`). Nota che non puoi specificare opzioni per operazioni che hai sostituito tramite `withOverrides`, poiché queste non utilizzano più l'integrazione predefinita.
 
+Incontrerai un errore di tipo se la stessa operazione è targetizzata sia da `withOperationOptions` che da `withOverrides`, indipendentemente dall'ordine in cui li chiami.
+
 </Fragment>
 <Fragment slot="terraform">
 Per personalizzare le opzioni per operazioni specifiche con Terraform, devi modificare il modulo Terraform generato per configurare singole funzioni Lambda per operazione (vedi la sezione [Integrazioni Esplicite](#explicit-integrations) di seguito).

--- a/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### オペレーションごとのオプションのカスタマイズ
+
+<Infrastructure>
+<Fragment slot="cdk">
+_特定の_オペレーションのデフォルト統合を作成する際に使用するオプションをカスタマイズするには（他のオペレーションに影響を与えずに）、`withOperationOptions`メソッドを使用します。例えば、1つのオペレーションだけLambda関数のタイムアウトを増やす場合：
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// 選択されたオペレーションはデフォルト統合のままなので、それに応じて型付けされます：
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+指定したオプションはデフォルト統合オプション（および`withDefaultOptions`で設定したオプション）とマージされます。`withOverrides`で置き換えたオペレーションにはオプションを指定できないことに注意してください。これらはもはやデフォルト統合を使用しないためです。
+
+</Fragment>
+<Fragment slot="terraform">
+Terraformで特定のオペレーションのオプションをカスタマイズするには、生成されたTerraformモジュールを編集してオペレーションごとに個別のLambda関数を設定する必要があります（下記[明示的統合](#explicit-integrations)セクション参照）。
+</Fragment>
+</Infrastructure>
+
 #### 統合のオーバーライド
 
 <Infrastructure>

--- a/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 指定したオプションはデフォルト統合オプション（および`withDefaultOptions`で設定したオプション）とマージされます。`withOverrides`で置き換えたオペレーションにはオプションを指定できないことに注意してください。これらはもはやデフォルト統合を使用しないためです。
 
+同じオペレーションが`withOperationOptions`と`withOverrides`の両方でターゲットにされている場合、呼び出す順序に関係なく型エラーが発生します。
+
 </Fragment>
 <Fragment slot="terraform">
 Terraformで特定のオペレーションのオプションをカスタマイズするには、生成されたTerraformモジュールを編集してオペレーションごとに個別のLambda関数を設定する必要があります（下記[明示的統合](#explicit-integrations)セクション参照）。

--- a/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
@@ -195,6 +195,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 지정한 옵션은 기본 통합 옵션(및 `withDefaultOptions`를 통해 설정된 옵션)과 병합됩니다. `withOverrides`를 통해 교체한 작업에 대해서는 옵션을 지정할 수 없습니다. 이러한 작업은 더 이상 기본 통합을 사용하지 않기 때문입니다.
 
+`withOperationOptions`와 `withOverrides` 모두에서 동일한 작업을 대상으로 하는 경우, 호출 순서에 관계없이 타입 오류가 발생합니다.
+
 </Fragment>
 <Fragment slot="terraform">
 Terraform에서 특정 작업에 대한 옵션을 사용자 정의하려면 생성된 Terraform 모듈을 편집하여 작업별 개별 Lambda 함수를 구성해야 합니다 (아래 [명시적 통합](#explicit-integrations) 섹션 참조).

--- a/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
@@ -172,6 +172,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### 작업별 옵션 사용자 정의
+
+<Infrastructure>
+<Fragment slot="cdk">
+_특정_ 작업에 대한 기본 통합을 생성할 때 사용되는 옵션을 사용자 정의하려면(다른 작업에 영향을 주지 않고) `withOperationOptions` 메서드를 사용할 수 있습니다. 예를 들어 한 작업에 대해서만 Lambda 함수 타임아웃을 늘리려면:
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// 선택한 작업은 기본 통합으로 유지되므로 여전히 그에 따라 타입이 지정됩니다:
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+지정한 옵션은 기본 통합 옵션(및 `withDefaultOptions`를 통해 설정된 옵션)과 병합됩니다. `withOverrides`를 통해 교체한 작업에 대해서는 옵션을 지정할 수 없습니다. 이러한 작업은 더 이상 기본 통합을 사용하지 않기 때문입니다.
+
+</Fragment>
+<Fragment slot="terraform">
+Terraform에서 특정 작업에 대한 옵션을 사용자 정의하려면 생성된 Terraform 모듈을 편집하여 작업별 개별 Lambda 함수를 구성해야 합니다 (아래 [명시적 통합](#explicit-integrations) 섹션 참조).
+</Fragment>
+</Infrastructure>
+
 #### 통합 재정의
 
 <Infrastructure>

--- a/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 As opções que você especifica são mescladas com as opções de integração padrão (e quaisquer opções definidas via `withDefaultOptions`). Note que você não pode especificar opções para operações que você substituiu via `withOverrides`, pois estas não usam mais a integração padrão.
 
+Você encontrará um erro de tipo se a mesma operação for alvo tanto de `withOperationOptions` quanto de `withOverrides`, independentemente da ordem em que você os chamar.
+
 </Fragment>
 <Fragment slot="terraform">
 Para personalizar opções para operações específicas com Terraform, você precisa editar o módulo Terraform gerado para configurar funções Lambda individuais por operação (veja a seção [Integrações Explícitas](#explicit-integrations) abaixo).

--- a/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### Personalizando Opções por Operação
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para personalizar as opções usadas para criar a integração padrão para operações _específicas_ (sem afetar as outras), você pode usar o método `withOperationOptions`. Por exemplo, se você deseja aumentar o timeout da função Lambda para apenas uma operação:
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// As operações selecionadas permanecem integrações padrão, então ainda são tipadas adequadamente:
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+As opções que você especifica são mescladas com as opções de integração padrão (e quaisquer opções definidas via `withDefaultOptions`). Note que você não pode especificar opções para operações que você substituiu via `withOverrides`, pois estas não usam mais a integração padrão.
+
+</Fragment>
+<Fragment slot="terraform">
+Para personalizar opções para operações específicas com Terraform, você precisa editar o módulo Terraform gerado para configurar funções Lambda individuais por operação (veja a seção [Integrações Explícitas](#explicit-integrations) abaixo).
+</Fragment>
+</Infrastructure>
+
 #### Sobrescrevendo Integrações
 
 <Infrastructure>

--- a/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### Tùy chỉnh các tùy chọn cho từng operation
+
+<Infrastructure>
+<Fragment slot="cdk">
+Để tùy chỉnh các tùy chọn được sử dụng để tạo tích hợp mặc định cho các operation _cụ thể_ (mà không ảnh hưởng đến các operation khác), bạn có thể sử dụng phương thức `withOperationOptions`. Ví dụ, nếu bạn muốn tăng thời gian chờ của Lambda function chỉ cho một operation:
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// Các operation được chọn vẫn là tích hợp mặc định, vì vậy chúng vẫn được type tương ứng:
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+Các tùy chọn bạn chỉ định được hợp nhất với các tùy chọn tích hợp mặc định (và bất kỳ tùy chọn nào được đặt thông qua `withDefaultOptions`). Lưu ý rằng bạn không thể chỉ định tùy chọn cho các operation mà bạn đã thay thế thông qua `withOverrides`, vì chúng không còn sử dụng tích hợp mặc định nữa.
+
+</Fragment>
+<Fragment slot="terraform">
+Để tùy chỉnh các tùy chọn cho các operation cụ thể với Terraform, bạn cần chỉnh sửa module Terraform đã được tạo để cấu hình các Lambda function riêng lẻ cho từng operation (xem phần [Tích hợp rõ ràng](#explicit-integrations) bên dưới).
+</Fragment>
+</Infrastructure>
+
 #### Ghi đè các tích hợp
 
 <Infrastructure>

--- a/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 Các tùy chọn bạn chỉ định được hợp nhất với các tùy chọn tích hợp mặc định (và bất kỳ tùy chọn nào được đặt thông qua `withDefaultOptions`). Lưu ý rằng bạn không thể chỉ định tùy chọn cho các operation mà bạn đã thay thế thông qua `withOverrides`, vì chúng không còn sử dụng tích hợp mặc định nữa.
 
+Bạn sẽ gặp lỗi type nếu cùng một operation được nhắm mục tiêu bởi cả `withOperationOptions` và `withOverrides`, bất kể thứ tự bạn gọi chúng.
+
 </Fragment>
 <Fragment slot="terraform">
 Để tùy chỉnh các tùy chọn cho các operation cụ thể với Terraform, bạn cần chỉnh sửa module Terraform đã được tạo để cấu hình các Lambda function riêng lẻ cho từng operation (xem phần [Tích hợp rõ ràng](#explicit-integrations) bên dưới).

--- a/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
@@ -196,6 +196,8 @@ api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
 
 您指定的选项会与默认集成选项（以及通过 `withDefaultOptions` 设置的任何选项）合并。请注意，您不能为通过 `withOverrides` 替换的操作指定选项，因为这些操作不再使用默认集成。
 
+如果同一操作同时被 `withOperationOptions` 和 `withOverrides` 指定，无论调用顺序如何，都会遇到类型错误。
+
 </Fragment>
 <Fragment slot="terraform">
 要在 Terraform 中为特定操作自定义选项，需要编辑生成的 Terraform 模块以为每个操作配置独立的 Lambda 函数（参见下方[显式集成](#explicit-integrations)章节）。

--- a/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
@@ -173,6 +173,35 @@ module "my_api" {
 </Fragment>
 </Infrastructure>
 
+#### 自定义每个操作的选项
+
+<Infrastructure>
+<Fragment slot="cdk">
+要为_特定_操作自定义创建默认集成时使用的选项（而不影响其他操作），可以使用 `withOperationOptions` 方法。例如，如果您只想增加一个操作的 Lambda 函数超时时间：
+
+```ts {4-6}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    .withOperationOptions({
+      sayHello: {
+        timeout: Duration.seconds(60),
+      },
+    })
+    .build(),
+});
+
+// 选定的操作仍然是默认集成，因此它们仍然具有相应的类型：
+api.integrations.sayHello.handler.addToRolePolicy(new PolicyStatement({ ... }));
+```
+
+您指定的选项会与默认集成选项（以及通过 `withDefaultOptions` 设置的任何选项）合并。请注意，您不能为通过 `withOverrides` 替换的操作指定选项，因为这些操作不再使用默认集成。
+
+</Fragment>
+<Fragment slot="terraform">
+要在 Terraform 中为特定操作自定义选项，需要编辑生成的 Terraform 模块以为每个操作配置独立的 Lambda 函数（参见下方[显式集成](#explicit-integrations)章节）。
+</Fragment>
+</Infrastructure>
+
 #### 覆盖集成
 
 <Infrastructure>

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -741,6 +741,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
  * @template TOverridden - Union of operation names that have been overridden
+ * @template TOperationOptioned - Union of operation names with per-operation options
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -750,6 +751,7 @@ export class IntegrationBuilder<
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
   TOverridden extends string = never,
+  TOperationOptioned extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -921,11 +923,16 @@ export class IntegrationBuilder<
   /**
    * Overrides default integrations with custom implementations for specific operations.
    *
+   * Operations which have per-operation options set via withOperationOptions cannot be
+   * overridden, since these still use the default integration.
+   *
    * @param overrides - Map of operation names to their custom integration implementations
    * @returns The builder instance with updated type information reflecting the overrides
    */
   public withOverrides<
-    TOverrideIntegrations extends Partial<Record<TOperation, TBaseIntegration>>,
+    TOverrideIntegrations extends Partial<
+      Record<Exclude<TOperation, TOperationOptioned>, TBaseIntegration>
+    >,
   >(overrides: TOverrideIntegrations) {
     this.integrations = { ...this.integrations, ...overrides };
     // Re-type to include the overridden integration types.
@@ -942,7 +949,8 @@ export class IntegrationBuilder<
       TDefaultIntegrationProps,
       TDefaultIntegration,
       TPattern,
-      TOverridden | Extract<keyof TOverrideIntegrations, string>
+      TOverridden | Extract<keyof TOverrideIntegrations, string>,
+      TOperationOptioned
     >;
   }
 
@@ -972,21 +980,30 @@ export class IntegrationBuilder<
    * @param options - Map of operation names to partial default integration options
    * @returns The builder instance
    */
-  public withOperationOptions(
-    options: Partial<
+  public withOperationOptions<
+    TOptions extends Partial<
       Record<
         Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
         Partial<TDefaultIntegrationProps>
       >
     >,
-  ) {
+  >(options: TOptions) {
     Object.entries(options).forEach(([op, opOptions]) => {
       this.perOperationOptions[op] = {
         ...this.perOperationOptions[op],
         ...(opOptions as Partial<TDefaultIntegrationProps>),
       };
     });
-    return this;
+    return this as unknown as IntegrationBuilder<
+      TOperation,
+      TBaseIntegration,
+      TIntegrations,
+      TDefaultIntegrationProps,
+      TDefaultIntegration,
+      TPattern,
+      TOverridden,
+      TOperationOptioned | Extract<keyof TOptions, string>
+    >;
   }
 
   /**
@@ -1677,6 +1694,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
  * @template TOverridden - Union of operation names that have been overridden
+ * @template TOperationOptioned - Union of operation names with per-operation options
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -1686,6 +1704,7 @@ export class IntegrationBuilder<
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
   TOverridden extends string = never,
+  TOperationOptioned extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -1857,11 +1876,16 @@ export class IntegrationBuilder<
   /**
    * Overrides default integrations with custom implementations for specific operations.
    *
+   * Operations which have per-operation options set via withOperationOptions cannot be
+   * overridden, since these still use the default integration.
+   *
    * @param overrides - Map of operation names to their custom integration implementations
    * @returns The builder instance with updated type information reflecting the overrides
    */
   public withOverrides<
-    TOverrideIntegrations extends Partial<Record<TOperation, TBaseIntegration>>,
+    TOverrideIntegrations extends Partial<
+      Record<Exclude<TOperation, TOperationOptioned>, TBaseIntegration>
+    >,
   >(overrides: TOverrideIntegrations) {
     this.integrations = { ...this.integrations, ...overrides };
     // Re-type to include the overridden integration types.
@@ -1878,7 +1902,8 @@ export class IntegrationBuilder<
       TDefaultIntegrationProps,
       TDefaultIntegration,
       TPattern,
-      TOverridden | Extract<keyof TOverrideIntegrations, string>
+      TOverridden | Extract<keyof TOverrideIntegrations, string>,
+      TOperationOptioned
     >;
   }
 
@@ -1908,21 +1933,30 @@ export class IntegrationBuilder<
    * @param options - Map of operation names to partial default integration options
    * @returns The builder instance
    */
-  public withOperationOptions(
-    options: Partial<
+  public withOperationOptions<
+    TOptions extends Partial<
       Record<
         Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
         Partial<TDefaultIntegrationProps>
       >
     >,
-  ) {
+  >(options: TOptions) {
     Object.entries(options).forEach(([op, opOptions]) => {
       this.perOperationOptions[op] = {
         ...this.perOperationOptions[op],
         ...(opOptions as Partial<TDefaultIntegrationProps>),
       };
     });
-    return this;
+    return this as unknown as IntegrationBuilder<
+      TOperation,
+      TBaseIntegration,
+      TIntegrations,
+      TDefaultIntegrationProps,
+      TDefaultIntegration,
+      TPattern,
+      TOverridden,
+      TOperationOptioned | Extract<keyof TOptions, string>
+    >;
   }
 
   /**

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -740,6 +740,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegrationProps - Type for default integration properties
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
+ * @template TOverridden - Union of operation names that have been overridden
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -748,6 +749,7 @@ export class IntegrationBuilder<
   TDefaultIntegrationProps extends object,
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
+  TOverridden extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -759,6 +761,11 @@ export class IntegrationBuilder<
 
   /** Map of operation names to their custom integrations */
   private integrations: Partial<TIntegrations> = {};
+
+  /** Map of default integration keys to per-operation default option overrides */
+  private perOperationOptions: Partial<
+    Record<string, Partial<TDefaultIntegrationProps>>
+  > = {};
 
   /**
    * Create an Integration Builder for an HTTP API with a shared pattern
@@ -934,7 +941,8 @@ export class IntegrationBuilder<
       MergedIntegrations,
       TDefaultIntegrationProps,
       TDefaultIntegration,
-      TPattern
+      TPattern,
+      TOverridden | Extract<keyof TOverrideIntegrations, string>
     >;
   }
 
@@ -954,6 +962,34 @@ export class IntegrationBuilder<
   }
 
   /**
+   * Updates the default integration options for specific operations, without
+   * affecting the others. The given options are merged with the defaults (and
+   * any options set via withDefaultOptions) when building each default integration.
+   *
+   * Operations which have been replaced via withOverrides cannot be targeted, since
+   * they no longer use the default integration.
+   *
+   * @param options - Map of operation names to partial default integration options
+   * @returns The builder instance
+   */
+  public withOperationOptions(
+    options: Partial<
+      Record<
+        Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
+        Partial<TDefaultIntegrationProps>
+      >
+    >,
+  ) {
+    Object.entries(options).forEach(([op, opOptions]) => {
+      this.perOperationOptions[op] = {
+        ...this.perOperationOptions[op],
+        ...(opOptions as Partial<TDefaultIntegrationProps>),
+      };
+    });
+    return this;
+  }
+
+  /**
    * Builds and returns the complete set of integrations.
    *
    * This method creates the final integration map by:
@@ -967,6 +1003,10 @@ export class IntegrationBuilder<
    */
   public build(): TIntegrations {
     const options = this.options;
+    const buildOptionsFor = (op: string): TDefaultIntegrationProps => ({
+      ...options.defaultIntegrationOptions,
+      ...this.perOperationOptions[op],
+    });
     return {
       ...Object.fromEntries(
         options.pattern === 'shared'
@@ -975,7 +1015,7 @@ export class IntegrationBuilder<
                 '$router',
                 options.buildDefaultIntegration(
                   '$router',
-                  options.defaultIntegrationOptions,
+                  buildOptionsFor('$router'),
                 ),
               ],
             ]
@@ -986,10 +1026,7 @@ export class IntegrationBuilder<
               )
               .map((op) => [
                 op,
-                options.buildDefaultIntegration(
-                  op,
-                  options.defaultIntegrationOptions,
-                ),
+                options.buildDefaultIntegration(op, buildOptionsFor(op)),
               ]),
       ),
       ...this.integrations,
@@ -1639,6 +1676,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegrationProps - Type for default integration properties
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
+ * @template TOverridden - Union of operation names that have been overridden
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -1647,6 +1685,7 @@ export class IntegrationBuilder<
   TDefaultIntegrationProps extends object,
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
+  TOverridden extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -1658,6 +1697,11 @@ export class IntegrationBuilder<
 
   /** Map of operation names to their custom integrations */
   private integrations: Partial<TIntegrations> = {};
+
+  /** Map of default integration keys to per-operation default option overrides */
+  private perOperationOptions: Partial<
+    Record<string, Partial<TDefaultIntegrationProps>>
+  > = {};
 
   /**
    * Create an Integration Builder for an HTTP API with a shared pattern
@@ -1833,7 +1877,8 @@ export class IntegrationBuilder<
       MergedIntegrations,
       TDefaultIntegrationProps,
       TDefaultIntegration,
-      TPattern
+      TPattern,
+      TOverridden | Extract<keyof TOverrideIntegrations, string>
     >;
   }
 
@@ -1853,6 +1898,34 @@ export class IntegrationBuilder<
   }
 
   /**
+   * Updates the default integration options for specific operations, without
+   * affecting the others. The given options are merged with the defaults (and
+   * any options set via withDefaultOptions) when building each default integration.
+   *
+   * Operations which have been replaced via withOverrides cannot be targeted, since
+   * they no longer use the default integration.
+   *
+   * @param options - Map of operation names to partial default integration options
+   * @returns The builder instance
+   */
+  public withOperationOptions(
+    options: Partial<
+      Record<
+        Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
+        Partial<TDefaultIntegrationProps>
+      >
+    >,
+  ) {
+    Object.entries(options).forEach(([op, opOptions]) => {
+      this.perOperationOptions[op] = {
+        ...this.perOperationOptions[op],
+        ...(opOptions as Partial<TDefaultIntegrationProps>),
+      };
+    });
+    return this;
+  }
+
+  /**
    * Builds and returns the complete set of integrations.
    *
    * This method creates the final integration map by:
@@ -1866,6 +1939,10 @@ export class IntegrationBuilder<
    */
   public build(): TIntegrations {
     const options = this.options;
+    const buildOptionsFor = (op: string): TDefaultIntegrationProps => ({
+      ...options.defaultIntegrationOptions,
+      ...this.perOperationOptions[op],
+    });
     return {
       ...Object.fromEntries(
         options.pattern === 'shared'
@@ -1874,7 +1951,7 @@ export class IntegrationBuilder<
                 '$router',
                 options.buildDefaultIntegration(
                   '$router',
-                  options.defaultIntegrationOptions,
+                  buildOptionsFor('$router'),
                 ),
               ],
             ]
@@ -1885,10 +1962,7 @@ export class IntegrationBuilder<
               )
               .map((op) => [
                 op,
-                options.buildDefaultIntegration(
-                  op,
-                  options.defaultIntegrationOptions,
-                ),
+                options.buildDefaultIntegration(op, buildOptionsFor(op)),
               ]),
       ),
       ...this.integrations,

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -1752,6 +1752,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
  * @template TOverridden - Union of operation names that have been overridden
+ * @template TOperationOptioned - Union of operation names with per-operation options
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -1761,6 +1762,7 @@ export class IntegrationBuilder<
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
   TOverridden extends string = never,
+  TOperationOptioned extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -1932,11 +1934,16 @@ export class IntegrationBuilder<
   /**
    * Overrides default integrations with custom implementations for specific operations.
    *
+   * Operations which have per-operation options set via withOperationOptions cannot be
+   * overridden, since these still use the default integration.
+   *
    * @param overrides - Map of operation names to their custom integration implementations
    * @returns The builder instance with updated type information reflecting the overrides
    */
   public withOverrides<
-    TOverrideIntegrations extends Partial<Record<TOperation, TBaseIntegration>>,
+    TOverrideIntegrations extends Partial<
+      Record<Exclude<TOperation, TOperationOptioned>, TBaseIntegration>
+    >,
   >(overrides: TOverrideIntegrations) {
     this.integrations = { ...this.integrations, ...overrides };
     // Re-type to include the overridden integration types.
@@ -1953,7 +1960,8 @@ export class IntegrationBuilder<
       TDefaultIntegrationProps,
       TDefaultIntegration,
       TPattern,
-      TOverridden | Extract<keyof TOverrideIntegrations, string>
+      TOverridden | Extract<keyof TOverrideIntegrations, string>,
+      TOperationOptioned
     >;
   }
 
@@ -1983,21 +1991,30 @@ export class IntegrationBuilder<
    * @param options - Map of operation names to partial default integration options
    * @returns The builder instance
    */
-  public withOperationOptions(
-    options: Partial<
+  public withOperationOptions<
+    TOptions extends Partial<
       Record<
         Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
         Partial<TDefaultIntegrationProps>
       >
     >,
-  ) {
+  >(options: TOptions) {
     Object.entries(options).forEach(([op, opOptions]) => {
       this.perOperationOptions[op] = {
         ...this.perOperationOptions[op],
         ...(opOptions as Partial<TDefaultIntegrationProps>),
       };
     });
-    return this;
+    return this as unknown as IntegrationBuilder<
+      TOperation,
+      TBaseIntegration,
+      TIntegrations,
+      TDefaultIntegrationProps,
+      TDefaultIntegration,
+      TPattern,
+      TOverridden,
+      TOperationOptioned | Extract<keyof TOptions, string>
+    >;
   }
 
   /**
@@ -2746,6 +2763,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
  * @template TOverridden - Union of operation names that have been overridden
+ * @template TOperationOptioned - Union of operation names with per-operation options
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -2755,6 +2773,7 @@ export class IntegrationBuilder<
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
   TOverridden extends string = never,
+  TOperationOptioned extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -2926,11 +2945,16 @@ export class IntegrationBuilder<
   /**
    * Overrides default integrations with custom implementations for specific operations.
    *
+   * Operations which have per-operation options set via withOperationOptions cannot be
+   * overridden, since these still use the default integration.
+   *
    * @param overrides - Map of operation names to their custom integration implementations
    * @returns The builder instance with updated type information reflecting the overrides
    */
   public withOverrides<
-    TOverrideIntegrations extends Partial<Record<TOperation, TBaseIntegration>>,
+    TOverrideIntegrations extends Partial<
+      Record<Exclude<TOperation, TOperationOptioned>, TBaseIntegration>
+    >,
   >(overrides: TOverrideIntegrations) {
     this.integrations = { ...this.integrations, ...overrides };
     // Re-type to include the overridden integration types.
@@ -2947,7 +2971,8 @@ export class IntegrationBuilder<
       TDefaultIntegrationProps,
       TDefaultIntegration,
       TPattern,
-      TOverridden | Extract<keyof TOverrideIntegrations, string>
+      TOverridden | Extract<keyof TOverrideIntegrations, string>,
+      TOperationOptioned
     >;
   }
 
@@ -2977,21 +3002,30 @@ export class IntegrationBuilder<
    * @param options - Map of operation names to partial default integration options
    * @returns The builder instance
    */
-  public withOperationOptions(
-    options: Partial<
+  public withOperationOptions<
+    TOptions extends Partial<
       Record<
         Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
         Partial<TDefaultIntegrationProps>
       >
     >,
-  ) {
+  >(options: TOptions) {
     Object.entries(options).forEach(([op, opOptions]) => {
       this.perOperationOptions[op] = {
         ...this.perOperationOptions[op],
         ...(opOptions as Partial<TDefaultIntegrationProps>),
       };
     });
-    return this;
+    return this as unknown as IntegrationBuilder<
+      TOperation,
+      TBaseIntegration,
+      TIntegrations,
+      TDefaultIntegrationProps,
+      TDefaultIntegration,
+      TPattern,
+      TOverridden,
+      TOperationOptioned | Extract<keyof TOptions, string>
+    >;
   }
 
   /**

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -1751,6 +1751,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegrationProps - Type for default integration properties
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
+ * @template TOverridden - Union of operation names that have been overridden
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -1759,6 +1760,7 @@ export class IntegrationBuilder<
   TDefaultIntegrationProps extends object,
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
+  TOverridden extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -1770,6 +1772,11 @@ export class IntegrationBuilder<
 
   /** Map of operation names to their custom integrations */
   private integrations: Partial<TIntegrations> = {};
+
+  /** Map of default integration keys to per-operation default option overrides */
+  private perOperationOptions: Partial<
+    Record<string, Partial<TDefaultIntegrationProps>>
+  > = {};
 
   /**
    * Create an Integration Builder for an HTTP API with a shared pattern
@@ -1945,7 +1952,8 @@ export class IntegrationBuilder<
       MergedIntegrations,
       TDefaultIntegrationProps,
       TDefaultIntegration,
-      TPattern
+      TPattern,
+      TOverridden | Extract<keyof TOverrideIntegrations, string>
     >;
   }
 
@@ -1965,6 +1973,34 @@ export class IntegrationBuilder<
   }
 
   /**
+   * Updates the default integration options for specific operations, without
+   * affecting the others. The given options are merged with the defaults (and
+   * any options set via withDefaultOptions) when building each default integration.
+   *
+   * Operations which have been replaced via withOverrides cannot be targeted, since
+   * they no longer use the default integration.
+   *
+   * @param options - Map of operation names to partial default integration options
+   * @returns The builder instance
+   */
+  public withOperationOptions(
+    options: Partial<
+      Record<
+        Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
+        Partial<TDefaultIntegrationProps>
+      >
+    >,
+  ) {
+    Object.entries(options).forEach(([op, opOptions]) => {
+      this.perOperationOptions[op] = {
+        ...this.perOperationOptions[op],
+        ...(opOptions as Partial<TDefaultIntegrationProps>),
+      };
+    });
+    return this;
+  }
+
+  /**
    * Builds and returns the complete set of integrations.
    *
    * This method creates the final integration map by:
@@ -1978,6 +2014,10 @@ export class IntegrationBuilder<
    */
   public build(): TIntegrations {
     const options = this.options;
+    const buildOptionsFor = (op: string): TDefaultIntegrationProps => ({
+      ...options.defaultIntegrationOptions,
+      ...this.perOperationOptions[op],
+    });
     return {
       ...Object.fromEntries(
         options.pattern === 'shared'
@@ -1986,7 +2026,7 @@ export class IntegrationBuilder<
                 '$router',
                 options.buildDefaultIntegration(
                   '$router',
-                  options.defaultIntegrationOptions,
+                  buildOptionsFor('$router'),
                 ),
               ],
             ]
@@ -1997,10 +2037,7 @@ export class IntegrationBuilder<
               )
               .map((op) => [
                 op,
-                options.buildDefaultIntegration(
-                  op,
-                  options.defaultIntegrationOptions,
-                ),
+                options.buildDefaultIntegration(op, buildOptionsFor(op)),
               ]),
       ),
       ...this.integrations,
@@ -2708,6 +2745,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegrationProps - Type for default integration properties
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
+ * @template TOverridden - Union of operation names that have been overridden
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -2716,6 +2754,7 @@ export class IntegrationBuilder<
   TDefaultIntegrationProps extends object,
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
+  TOverridden extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -2727,6 +2766,11 @@ export class IntegrationBuilder<
 
   /** Map of operation names to their custom integrations */
   private integrations: Partial<TIntegrations> = {};
+
+  /** Map of default integration keys to per-operation default option overrides */
+  private perOperationOptions: Partial<
+    Record<string, Partial<TDefaultIntegrationProps>>
+  > = {};
 
   /**
    * Create an Integration Builder for an HTTP API with a shared pattern
@@ -2902,7 +2946,8 @@ export class IntegrationBuilder<
       MergedIntegrations,
       TDefaultIntegrationProps,
       TDefaultIntegration,
-      TPattern
+      TPattern,
+      TOverridden | Extract<keyof TOverrideIntegrations, string>
     >;
   }
 
@@ -2922,6 +2967,34 @@ export class IntegrationBuilder<
   }
 
   /**
+   * Updates the default integration options for specific operations, without
+   * affecting the others. The given options are merged with the defaults (and
+   * any options set via withDefaultOptions) when building each default integration.
+   *
+   * Operations which have been replaced via withOverrides cannot be targeted, since
+   * they no longer use the default integration.
+   *
+   * @param options - Map of operation names to partial default integration options
+   * @returns The builder instance
+   */
+  public withOperationOptions(
+    options: Partial<
+      Record<
+        Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
+        Partial<TDefaultIntegrationProps>
+      >
+    >,
+  ) {
+    Object.entries(options).forEach(([op, opOptions]) => {
+      this.perOperationOptions[op] = {
+        ...this.perOperationOptions[op],
+        ...(opOptions as Partial<TDefaultIntegrationProps>),
+      };
+    });
+    return this;
+  }
+
+  /**
    * Builds and returns the complete set of integrations.
    *
    * This method creates the final integration map by:
@@ -2935,6 +3008,10 @@ export class IntegrationBuilder<
    */
   public build(): TIntegrations {
     const options = this.options;
+    const buildOptionsFor = (op: string): TDefaultIntegrationProps => ({
+      ...options.defaultIntegrationOptions,
+      ...this.perOperationOptions[op],
+    });
     return {
       ...Object.fromEntries(
         options.pattern === 'shared'
@@ -2943,7 +3020,7 @@ export class IntegrationBuilder<
                 '$router',
                 options.buildDefaultIntegration(
                   '$router',
-                  options.defaultIntegrationOptions,
+                  buildOptionsFor('$router'),
                 ),
               ],
             ]
@@ -2954,10 +3031,7 @@ export class IntegrationBuilder<
               )
               .map((op) => [
                 op,
-                options.buildDefaultIntegration(
-                  op,
-                  options.defaultIntegrationOptions,
-                ),
+                options.buildDefaultIntegration(op, buildOptionsFor(op)),
               ]),
       ),
       ...this.integrations,

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
@@ -149,6 +149,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
  * @template TOverridden - Union of operation names that have been overridden
+ * @template TOperationOptioned - Union of operation names with per-operation options
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -158,6 +159,7 @@ export class IntegrationBuilder<
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
   TOverridden extends string = never,
+  TOperationOptioned extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -329,11 +331,16 @@ export class IntegrationBuilder<
   /**
    * Overrides default integrations with custom implementations for specific operations.
    *
+   * Operations which have per-operation options set via withOperationOptions cannot be
+   * overridden, since these still use the default integration.
+   *
    * @param overrides - Map of operation names to their custom integration implementations
    * @returns The builder instance with updated type information reflecting the overrides
    */
   public withOverrides<
-    TOverrideIntegrations extends Partial<Record<TOperation, TBaseIntegration>>,
+    TOverrideIntegrations extends Partial<
+      Record<Exclude<TOperation, TOperationOptioned>, TBaseIntegration>
+    >,
   >(overrides: TOverrideIntegrations) {
     this.integrations = { ...this.integrations, ...overrides };
     // Re-type to include the overridden integration types.
@@ -350,7 +357,8 @@ export class IntegrationBuilder<
       TDefaultIntegrationProps,
       TDefaultIntegration,
       TPattern,
-      TOverridden | Extract<keyof TOverrideIntegrations, string>
+      TOverridden | Extract<keyof TOverrideIntegrations, string>,
+      TOperationOptioned
     >;
   }
 
@@ -380,21 +388,30 @@ export class IntegrationBuilder<
    * @param options - Map of operation names to partial default integration options
    * @returns The builder instance
    */
-  public withOperationOptions(
-    options: Partial<
+  public withOperationOptions<
+    TOptions extends Partial<
       Record<
         Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
         Partial<TDefaultIntegrationProps>
       >
     >,
-  ) {
+  >(options: TOptions) {
     Object.entries(options).forEach(([op, opOptions]) => {
       this.perOperationOptions[op] = {
         ...this.perOperationOptions[op],
         ...(opOptions as Partial<TDefaultIntegrationProps>),
       };
     });
-    return this;
+    return this as unknown as IntegrationBuilder<
+      TOperation,
+      TBaseIntegration,
+      TIntegrations,
+      TDefaultIntegrationProps,
+      TDefaultIntegration,
+      TPattern,
+      TOverridden,
+      TOperationOptioned | Extract<keyof TOptions, string>
+    >;
   }
 
   /**

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/utils/utils.ts.template
@@ -148,6 +148,7 @@ export type ApiIntegrations<TOperation extends string, TBaseIntegration> =
  * @template TDefaultIntegrationProps - Type for default integration properties
  * @template TDefaultIntegration - Type for default integration implementation
  * @template TPattern - The integration pattern ('shared' or 'isolated')
+ * @template TOverridden - Union of operation names that have been overridden
  */
 export class IntegrationBuilder<
   TOperation extends string,
@@ -156,6 +157,7 @@ export class IntegrationBuilder<
   TDefaultIntegrationProps extends object,
   TDefaultIntegration extends TBaseIntegration,
   TPattern extends 'shared' | 'isolated',
+  TOverridden extends string = never,
 > {
   /** Options for the integration builder */
   private options: IntegrationBuilderProps<
@@ -167,6 +169,11 @@ export class IntegrationBuilder<
 
   /** Map of operation names to their custom integrations */
   private integrations: Partial<TIntegrations> = {};
+
+  /** Map of default integration keys to per-operation default option overrides */
+  private perOperationOptions: Partial<
+    Record<string, Partial<TDefaultIntegrationProps>>
+  > = {};
 
   /**
    * Create an Integration Builder for an HTTP API with a shared pattern
@@ -342,7 +349,8 @@ export class IntegrationBuilder<
       MergedIntegrations,
       TDefaultIntegrationProps,
       TDefaultIntegration,
-      TPattern
+      TPattern,
+      TOverridden | Extract<keyof TOverrideIntegrations, string>
     >;
   }
 
@@ -362,6 +370,34 @@ export class IntegrationBuilder<
   }
 
   /**
+   * Updates the default integration options for specific operations, without
+   * affecting the others. The given options are merged with the defaults (and
+   * any options set via withDefaultOptions) when building each default integration.
+   *
+   * Operations which have been replaced via withOverrides cannot be targeted, since
+   * they no longer use the default integration.
+   *
+   * @param options - Map of operation names to partial default integration options
+   * @returns The builder instance
+   */
+  public withOperationOptions(
+    options: Partial<
+      Record<
+        Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>,
+        Partial<TDefaultIntegrationProps>
+      >
+    >,
+  ) {
+    Object.entries(options).forEach(([op, opOptions]) => {
+      this.perOperationOptions[op] = {
+        ...this.perOperationOptions[op],
+        ...(opOptions as Partial<TDefaultIntegrationProps>),
+      };
+    });
+    return this;
+  }
+
+  /**
    * Builds and returns the complete set of integrations.
    *
    * This method creates the final integration map by:
@@ -375,6 +411,10 @@ export class IntegrationBuilder<
    */
   public build(): TIntegrations {
     const options = this.options;
+    const buildOptionsFor = (op: string): TDefaultIntegrationProps => ({
+      ...options.defaultIntegrationOptions,
+      ...this.perOperationOptions[op],
+    });
     return {
       ...Object.fromEntries(
         options.pattern === 'shared'
@@ -383,7 +423,7 @@ export class IntegrationBuilder<
                 '$router',
                 options.buildDefaultIntegration(
                   '$router',
-                  options.defaultIntegrationOptions,
+                  buildOptionsFor('$router'),
                 ),
               ],
             ]
@@ -394,10 +434,7 @@ export class IntegrationBuilder<
               )
               .map((op) => [
                 op,
-                options.buildDefaultIntegration(
-                  op,
-                  options.defaultIntegrationOptions,
-                ),
+                options.buildDefaultIntegration(op, buildOptionsFor(op)),
               ]),
       ),
       ...this.integrations,

--- a/packages/nx-plugin/src/utils/api-constructs/integration-builder.spec.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/integration-builder.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createTreeUsingTsSolutionSetup } from '../test';
+import { TypeScriptVerifier } from '../test/ts.spec';
+
+/**
+ * These tests verify the type-safety of the generated IntegrationBuilder, in particular
+ * the interaction between withOperationOptions and withOverrides. The real builder template
+ * is compiled with its aws-cdk-lib type imports redirected to a local stub, since the
+ * builder's type-safety logic does not depend on those types.
+ */
+describe('IntegrationBuilder type-safety', () => {
+  let tree: Tree;
+  const verifier = new TypeScriptVerifier();
+
+  // The real builder template, with aws-cdk-lib type imports redirected to a local stub
+  const builderTemplate = readFileSync(
+    join(__dirname, 'files/cdk/core/api/utils/utils.ts.template'),
+    'utf-8',
+  ).replace(/'aws-cdk-lib[^']*'/g, `'./cdk-stub'`);
+
+  const stub = `
+export class Integration {}
+export interface MethodOptions {}
+export class HttpRouteIntegration {}
+export interface AddRoutesOptions {
+  path: string;
+  methods: string[];
+  integration: HttpRouteIntegration;
+}
+`;
+
+  // Constructs an isolated REST builder with three operations (echo, goodbye, ping)
+  const preamble = `
+import { IntegrationBuilder, RestApiIntegration } from './utils';
+import { Integration } from './cdk-stub';
+
+interface StubProps { timeout?: number; memorySize?: number; }
+
+const integration = (): RestApiIntegration => ({ integration: new Integration() });
+
+export const isolated = () =>
+  IntegrationBuilder.rest<'echo' | 'goodbye' | 'ping', StubProps, RestApiIntegration>({
+    pattern: 'isolated',
+    operations: {
+      echo: { path: '/echo', method: 'GET' },
+      goodbye: { path: '/goodbye', method: 'GET' },
+      ping: { path: '/ping', method: 'GET' },
+    },
+    defaultIntegrationOptions: {},
+    buildDefaultIntegration: () => integration(),
+  });
+
+export const shared = () =>
+  IntegrationBuilder.rest<'echo' | 'goodbye', StubProps, RestApiIntegration>({
+    pattern: 'shared',
+    operations: {
+      echo: { path: '/echo', method: 'GET' },
+      goodbye: { path: '/goodbye', method: 'GET' },
+    },
+    defaultIntegrationOptions: {},
+    buildDefaultIntegration: () => integration(),
+  });
+`;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+    tree.write('cdk-stub.ts', stub);
+    tree.write('utils.ts', `import './cdk-stub';\n${builderTemplate}`);
+  });
+
+  const expectScenario = (chain: string, shouldCompile: boolean) => {
+    tree.write('scenario.ts', `${preamble}\nexport const result = ${chain};`);
+    const paths = ['cdk-stub.ts', 'utils.ts', 'scenario.ts'];
+    if (shouldCompile) {
+      verifier.expectTypeScriptToCompile(tree, paths);
+    } else {
+      expect(() =>
+        verifier.expectTypeScriptToCompile(tree, paths, true),
+      ).toThrow();
+    }
+  };
+
+  // Positive cases
+
+  it('should allow per-operation options for a valid operation', () => {
+    expectScenario(
+      `isolated().withOperationOptions({ echo: { timeout: 60, memorySize: 512 } }).build()`,
+      true,
+    );
+  });
+
+  it('should allow per-operation options for multiple operations at once', () => {
+    expectScenario(
+      `isolated().withOperationOptions({
+        echo: { timeout: 10 },
+        goodbye: { memorySize: 256 },
+        ping: { timeout: 20, memorySize: 1024 },
+      }).build()`,
+      true,
+    );
+  });
+
+  it('should allow tuning a different operation to the one overridden', () => {
+    expectScenario(
+      `isolated()
+        .withOverrides({ echo: { integration: new Integration() } })
+        .withOperationOptions({ goodbye: { timeout: 60 } })
+        .build()`,
+      true,
+    );
+  });
+
+  it('should allow $router options for the shared pattern', () => {
+    expectScenario(
+      `shared().withOperationOptions({ $router: { timeout: 60 } }).build()`,
+      true,
+    );
+  });
+
+  // Negative cases
+
+  it('should reject per-operation options for an unknown operation', () => {
+    expectScenario(
+      `isolated().withOperationOptions({ doesNotExist: { timeout: 60 } }).build()`,
+      false,
+    );
+  });
+
+  it('should reject a per-operation option value of the wrong type', () => {
+    expectScenario(
+      `isolated().withOperationOptions({ echo: { timeout: 'nope' } }).build()`,
+      false,
+    );
+  });
+
+  it('should reject an unknown per-operation option property', () => {
+    expectScenario(
+      `isolated().withOperationOptions({ echo: { notARealProp: 1 } }).build()`,
+      false,
+    );
+  });
+
+  it('should reject an operation key for the shared pattern', () => {
+    expectScenario(
+      `shared().withOperationOptions({ echo: { timeout: 60 } }).build()`,
+      false,
+    );
+  });
+
+  // Negative cases - clashes between withOperationOptions and withOverrides (both orders)
+
+  it('should reject per-operation options for an operation overridden earlier in the chain', () => {
+    expectScenario(
+      `isolated()
+        .withOverrides({ echo: { integration: new Integration() } })
+        .withOperationOptions({ echo: { timeout: 60 } })
+        .build()`,
+      false,
+    );
+  });
+
+  it('should reject overriding an operation given per-operation options earlier in the chain', () => {
+    expectScenario(
+      `isolated()
+        .withOperationOptions({ echo: { timeout: 60 } })
+        .withOverrides({ echo: { integration: new Integration() } })
+        .build()`,
+      false,
+    );
+  });
+});


### PR DESCRIPTION
### Reason for this change

The generated API CDK constructs offer two ways to customise the default Lambda integrations:

- `withDefaultOptions(...)` — applies options to **every** operation
- `withOverrides({ op: {...} })` — **replaces** an operation's integration entirely, requiring you to rebuild the `Function` and `LambdaIntegration` from scratch

There was no intuitive, type-safe way to make a small change to the default integration for a **single** operation (e.g. increasing the Lambda `timeout` or `memorySize` for one slow operation). Accessing `api.integrations.foo.handler` doesn't help either, since most `FunctionProps` (including `timeout`) are immutable after construction in the L2 `Function`, forcing an ugly escape-hatch to `cfnFunction`.

### Description of changes

Adds a `withOperationOptions(map)` method to the `IntegrationBuilder` (in `utils.ts.template`), the per-operation sibling of `withDefaultOptions`:

```ts
new MyApi(this, 'MyApi', {
  integrations: MyApi.defaultIntegrations(this)
    .withOperationOptions({
      sayHello: { timeout: Duration.seconds(60), memorySize: 512 },
    })
    .build(),
});

// sayHello remains a default integration, so its handler stays typed:
api.integrations.sayHello.handler.addToRolePolicy(...);
```

- The supplied `Partial<FunctionProps>` is merged over the defaults (and anything set via `withDefaultOptions`) when each default integration is built.
- Targeted operations remain **default** integrations, so `api.integrations.<op>.handler` stays fully type-safe — no escape hatch, no rebuild.
- Keys are gated by `Exclude<DefaultIntegrationKeys<TPattern, TOperation>, TOverridden>`:
  - `isolated` pattern → all operations are valid keys
  - `shared` pattern → only `$router` is valid
  - any operation already passed to `withOverrides` is **excluded at the type level**, since it no longer uses the default integration
- Adds a `TOverridden` type parameter (defaulting to `never`) that `withOverrides` accumulates into, to power that exclusion.
- The exclusion is **order-independent**: `withOverrides` likewise excludes any operation already given per-operation options (via a symmetric `TOperationOptioned` type parameter), so targeting the same operation with both methods is a precise compile error regardless of which is called first. Whichever method appears second in the chain reports the error.

Documentation: added a "Customising Options Per-Operation" section to `type-safe-api-integrations.mdx` (English source only).

### Description of how you validated changes

- Updated and verified the affected generator unit-test snapshots (`ts#trpc-api` backend and `py#fast-api`).
- End-to-end: vended a `ts#trpc-api` (rest-lambda, isolated) workspace, linked the locally compiled plugin, added a second operation, and:
  - **Runtime synth** confirmed the synthesized CloudFormation: `echoHandler` → `Timeout=60, MemorySize=512`, while `goodbyeHandler` kept the default `Timeout=30` (unaffected).
  - **Type safety (positive):** `withOperationOptions` composes with `withDefaultOptions` + `withOverrides` and type-checks; handler access stays typed.
  - **Type safety (negative):** verified that targeting an overridden operation (in either chain order), a non-existent operation, a non-`$router` key in the shared pattern, or a wrongly-typed/unknown option, is a genuine compile error.
- Added compile-level unit tests (`integration-builder.spec.ts`) that compile the real builder template via the `TypeScriptVerifier`, covering positive scenarios and negative scenarios for both clash orderings. Confirmed the clash tests are sensitive by reverting the fix and observing the order-dependent test fail.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*