### PR TITLE
fix(py#agent): bump ag-ui-strands to 0.2.1 and remove license-checker exemption

### DIFF
--- a/packages/nx-plugin/src/license/generator.spec.ts
+++ b/packages/nx-plugin/src/license/generator.spec.ts
@@ -289,51 +289,7 @@ describe('license generator', () => {
       expect(config).toContain('@modelcontextprotocol/inspector');
     });
 
-    it('should add AG-UI exceptions when py#agent with ag-ui protocol exists (license after agent)', async () => {
-      addProjectConfiguration(tree, 'my-project', {
-        root: 'packages/my-project',
-        sourceRoot: 'packages/my-project/src',
-        metadata: {
-          components: [
-            {
-              generator: 'py#agent',
-              path: 'src/agent',
-              name: 'my-agent',
-              protocol: 'ag-ui',
-            },
-          ],
-        } as any,
-      });
-
-      await licenseGenerator(tree, options);
-
-      const config = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')!;
-      expect(config).toContain('ag_ui_strands');
-    });
-
-    it('should NOT add AG-UI exceptions for ts#agent (only py#agent uses ag_ui_strands)', async () => {
-      addProjectConfiguration(tree, 'my-project', {
-        root: 'packages/my-project',
-        sourceRoot: 'packages/my-project/src',
-        metadata: {
-          components: [
-            {
-              generator: 'ts#agent',
-              path: 'src/agent',
-              name: 'my-agent',
-              protocol: 'ag-ui',
-            },
-          ],
-        } as any,
-      });
-
-      await licenseGenerator(tree, options);
-
-      const config = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')!;
-      expect(config).not.toContain('ag_ui_strands');
-    });
-
-    it('should not add exceptions when no MCP/AG-UI projects exist', async () => {
+    it('should not add exceptions when no MCP projects exist', async () => {
       addProjectConfiguration(tree, 'my-project', {
         root: 'packages/my-project',
         sourceRoot: 'packages/my-project/src',
@@ -348,7 +304,6 @@ describe('license generator', () => {
 
       const config = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')!;
       expect(config).not.toContain('@modelcontextprotocol/inspector');
-      expect(config).not.toContain('ag_ui_strands');
     });
 
     it('should add pythonCollector when py#project runs after license generator', async () => {
@@ -386,19 +341,6 @@ describe('license generator', () => {
       await ensureLicenseExceptions(tree, MCP_INSPECTOR_EXCEPTIONS);
       config = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')!;
       expect(config).toContain('@modelcontextprotocol/inspector');
-    });
-
-    it('should add AG-UI exceptions when py#agent runs after license generator', async () => {
-      const { ensureLicenseExceptions } = await import('./config');
-      const { AG_UI_STRANDS_EXCEPTIONS } = await import('./known-exceptions');
-
-      await licenseGenerator(tree, options);
-      let config = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')!;
-      expect(config).not.toContain('ag_ui_strands');
-
-      await ensureLicenseExceptions(tree, AG_UI_STRANDS_EXCEPTIONS);
-      config = tree.read(AWS_NX_PLUGIN_CONFIG_FILE_NAME, 'utf-8')!;
-      expect(config).toContain('ag_ui_strands');
     });
 
     it('should be no-op when ensure functions run before license generator', async () => {

--- a/packages/nx-plugin/src/license/generator.ts
+++ b/packages/nx-plugin/src/license/generator.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getProjects, readNxJson, type Tree, updateNxJson } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../py/agent/generator';
 import { PY_MCP_SERVER_GENERATOR_INFO } from '../py/mcp-server/generator';
 import { TS_MCP_SERVER_GENERATOR_INFO } from '../ts/mcp-server/generator';
 import { ensureAwsNxPluginConfig } from '../utils/config/utils';
@@ -19,10 +18,7 @@ import {
   updateLicenseCheckTargetInputs,
   writeLicenseConfig,
 } from './config';
-import {
-  AG_UI_STRANDS_EXCEPTIONS,
-  MCP_INSPECTOR_EXCEPTIONS,
-} from './known-exceptions';
+import { MCP_INSPECTOR_EXCEPTIONS } from './known-exceptions';
 import type { LicenseGeneratorSchema } from './schema';
 import { SYNC_GENERATOR_NAME } from './sync/generator';
 
@@ -128,13 +124,11 @@ const writeLicenseCheckTarget = async (tree: Tree): Promise<void> => {
 const addExceptionsForExistingProjects = async (tree: Tree): Promise<void> => {
   const projects = getProjects(tree);
   let needsMcp = false;
-  let needsAgUi = false;
 
   const mcpIds = [
     TS_MCP_SERVER_GENERATOR_INFO.id,
     PY_MCP_SERVER_GENERATOR_INFO.id,
   ];
-  const pyAgentId = PY_AGENT_GENERATOR_INFO.id;
 
   for (const [, config] of projects) {
     const components =
@@ -146,18 +140,10 @@ const addExceptionsForExistingProjects = async (tree: Tree): Promise<void> => {
       if (typeof gen === 'string' && mcpIds.includes(gen)) {
         needsMcp = true;
       }
-      if (typeof gen === 'string' && gen === pyAgentId) {
-        if (comp.protocol === 'AG-UI' || comp.protocol === 'ag-ui') {
-          needsAgUi = true;
-        }
-      }
     }
   }
 
-  const exceptions = [
-    ...(needsMcp ? MCP_INSPECTOR_EXCEPTIONS : []),
-    ...(needsAgUi ? AG_UI_STRANDS_EXCEPTIONS : []),
-  ];
+  const exceptions = [...(needsMcp ? MCP_INSPECTOR_EXCEPTIONS : [])];
 
   if (exceptions.length > 0) {
     await ensureLicenseExceptions(tree, exceptions);

--- a/packages/nx-plugin/src/license/known-exceptions.ts
+++ b/packages/nx-plugin/src/license/known-exceptions.ts
@@ -30,12 +30,3 @@ export const MCP_INSPECTOR_EXCEPTIONS: DependencyCheckException[] = [
     spdx: 'Apache-2.0',
   },
 ];
-
-export const AG_UI_STRANDS_EXCEPTIONS: DependencyCheckException[] = [
-  {
-    package: 'ag_ui_strands',
-    reason:
-      'Part of MIT-licensed ag-ui-protocol/ag-ui repo. Wheel ships without license metadata.',
-    spdx: 'MIT',
-  },
-];

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -12,8 +12,6 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { ensureLicenseExceptions } from '../../license/config';
-import { AG_UI_STRANDS_EXCEPTIONS } from '../../license/known-exceptions';
 import { addAgentChatScripts } from '../../utils/agent-chat/agent-chat';
 import {
   ensurePythonAgentConnectionProject,
@@ -415,10 +413,6 @@ export const pyAgentGenerator = async (
   );
 
   await addGeneratorMetricsIfApplicable(tree, [PY_AGENT_GENERATOR_INFO]);
-
-  if (protocol === 'ag-ui') {
-    await ensureLicenseExceptions(tree, AG_UI_STRANDS_EXCEPTIONS);
-  }
 
   await formatFilesInSubtree(tree);
   return async () => {

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -137,7 +137,7 @@ export const withVersions = (deps: ITsDepVersion[]) =>
  */
 export const PY_VERSIONS = {
   'ag-ui-protocol': '==0.1.19',
-  'ag-ui-strands': '==0.1.9',
+  'ag-ui-strands': '==0.2.1',
   'aws-lambda-powertools': '==3.29.0',
   'aws-lambda-powertools[tracer]': '==3.29.0',
   'aws-lambda-powertools[parser]': '==3.29.0',


### PR DESCRIPTION
### Reason for this change

The license dependency checker carried an exemption for the Python `ag_ui_strands` package because its published wheel (v0.1.9) shipped with **no license metadata** — no SPDX expression, no classifier, and no bundled `LICENSE` file (upstream issue [ag-ui-protocol/ag-ui#1927](https://github.com/ag-ui-protocol/ag-ui/issues/1927)).

The upstream fix has now been released: `ag-ui-strands` **0.2.1** publishes proper license metadata. Verified directly against the published wheel:

```
License-Expression: MIT
License-File: LICENSE
ag_ui_strands-0.2.1.dist-info/licenses/LICENSE
```

With the metadata in place, the exemption is no longer needed and the dependency can resolve its license normally.

### Description of changes

- Bump `ag-ui-strands` from `==0.1.9` to `==0.2.1` in `PY_VERSIONS` (`packages/nx-plugin/src/utils/versions.ts`).
- Remove the `AG_UI_STRANDS_EXCEPTIONS` definition from `known-exceptions.ts`.
- Remove the logic that injected the exemption for `py#agent` projects using the AG-UI protocol — both in the `license` generator (`addExceptionsForExistingProjects`, dropping the now-unused `needsAgUi`/`PY_AGENT_GENERATOR_INFO` paths) and in the `py#agent` generator (the `ensureLicenseExceptions` call).
- Remove the associated unit tests asserting the AG-UI exception was added.

Note: `ag-ui-protocol` (`==0.1.19`) already publishes `License-Expression: MIT` and was never exempted, so it is unchanged. The TypeScript `@ag-ui/*` packages bundle a `LICENSE` file in their tarballs and were never exempted either, so they are out of scope.

### Description of how you validated changes

- Confirmed the published `ag-ui-strands` 0.2.1 wheel contains license metadata by downloading and inspecting its `METADATA`.
- `pnpm nx run @aws/nx-plugin:compile` — passes.
- License generator tests (`license/generator.spec.ts`, `license/config.spec.ts`) — 83/83 pass.
- `py#agent` generator tests (`py/agent/generator.spec.ts`) — 67/67 pass.
- Lint clean on all changed files.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*