### PR TITLE
refactor(py#agent,ts#agent): make MCP and gateway clients framework-agnostic

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -996,7 +996,7 @@ The `connection` generator generates/updates these files:
 </FileTree>
 
 The generator:
-- Creates a shared `agent_connection` Python project (if it doesn't already exist) with the core `AgentCoreMCPClient`
+- Creates a shared `agent_connection` Python project (if it doesn't already exist) with the core `StrandsAgentCoreMCPClient`
 - Generates an `InventoryMcpServerClient` class that handles connecting to the MCP server both locally (direct HTTP) and when deployed (via AgentCore with IAM auth)
 - Transforms `agent.py` to import the client, create an instance, and wire the MCP server's tools into the agent
 - Adds the `agent_connection` project as a workspace dependency of the story project

--- a/docs/src/content/docs/en/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-gateway.mdx
@@ -44,7 +44,7 @@ The generator emits shared core-gateway modules into your `agent_connection` Pyt
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py SigV4 MCP client using `httpx`
+      - strands\_agentcore\_gateway\_mcp\_client.py Strands MCP client for the deployed Gateway
     - app/
       - \<gateway\_snake>\_client.py Per-Gateway client wrapper
     - \_\_init\_\_.py Re-exports the Gateway client

--- a/docs/src/content/docs/en/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ The generator creates a shared `agent_connection` Python project at `packages/co
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py Re-exports per-connection clients
     - core
-      - agentcore\_mcp\_client.py Core AgentCore MCP client
+      - strands\_agentcore\_mcp\_client.py Strands MCP client wrapping the framework-agnostic transport
     - app
       - \<mcp\_server\_name>\_client.py Per-connection client for each MCP server
 

--- a/docs/src/content/docs/en/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ The generator emits shared core client files into your `agent-connection` packag
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts SigV4 MCP client for the deployed Gateway
+      - strands-agentcore-gateway-mcp-client.ts Strands MCP client for the deployed Gateway
     - app/
       - \<gateway-kebab>-client.ts Per-Gateway client wrapper
     - index.ts Re-exports the Gateway client

--- a/docs/src/content/docs/en/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ The generator creates a shared `agent-connection` package and modifies your agen
     - app
       - \<mcp-server-name>-client.ts High-level client for the connected MCP server
     - core
-      - agentcore-mcp-client.ts Low-level AgentCore MCP client with SigV4/JWT authentication
+      - strands-agentcore-mcp-client.ts Strands MCP client wrapping the framework-agnostic transport
     - index.ts Exports all clients
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -996,7 +996,7 @@ El generador `connection` genera/actualiza estos archivos:
 </FileTree>
 
 El generador:
-- Crea un proyecto Python compartido `agent_connection` (si aún no existe) con el `AgentCoreMCPClient` central
+- Crea un proyecto Python compartido `agent_connection` (si aún no existe) con el `StrandsAgentCoreMCPClient` central
 - Genera una clase `InventoryMcpServerClient` que maneja la conexión al servidor MCP tanto localmente (HTTP directo) como cuando está desplegado (vía AgentCore con autenticación IAM)
 - Transforma `agent.py` para importar el cliente, crear una instancia y conectar las herramientas del servidor MCP al agente
 - Agrega el proyecto `agent_connection` como una dependencia de workspace del proyecto story

--- a/docs/src/content/docs/es/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-gateway.mdx
@@ -44,7 +44,7 @@ El generador emite módulos compartidos de core-gateway en tu proyecto Python `a
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py Cliente MCP SigV4 usando `httpx`
+      - strands\_agentcore\_gateway\_mcp\_client.py Cliente MCP Strands para el Gateway desplegado
     - app/
       - \<gateway\_snake>\_client.py Envoltorio de cliente por Gateway
     - \_\_init\_\_.py Re-exporta el cliente del Gateway

--- a/docs/src/content/docs/es/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ El generador crea un proyecto Python compartido `agent_connection` en `packages/
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py Re-exporta clientes por conexión
     - core
-      - agentcore\_mcp\_client.py Cliente MCP AgentCore principal
+      - strands\_agentcore\_mcp\_client.py Cliente MCP Strands que envuelve el transporte agnóstico del framework
     - app
       - \<mcp\_server\_name>\_client.py Cliente por conexión para cada servidor MCP
 

--- a/docs/src/content/docs/es/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ El generador emite archivos de cliente compartidos en tu paquete `agent-connecti
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts Cliente MCP SigV4 para el Gateway desplegado
+      - strands-agentcore-gateway-mcp-client.ts Cliente MCP Strands para el Gateway desplegado
     - app/
       - \<gateway-kebab>-client.ts Wrapper de cliente por Gateway
     - index.ts Re-exporta el cliente Gateway

--- a/docs/src/content/docs/es/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-mcp.mdx
@@ -50,7 +50,7 @@ El generador crea un paquete compartido `agent-connection` y modifica el código
     - app
       - \<mcp-server-name>-client.ts Cliente de alto nivel para el servidor MCP conectado
     - core
-      - agentcore-mcp-client.ts Cliente MCP AgentCore de bajo nivel con autenticación SigV4/JWT
+      - strands-agentcore-mcp-client.ts Cliente MCP Strands que envuelve el transporte agnóstico del framework
     - index.ts Exporta todos los clientes
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -997,7 +997,7 @@ Le générateur `connection` génère/met à jour ces fichiers :
 </FileTree>
 
 Le générateur :
-- Crée un projet Python partagé `agent_connection` (s'il n'existe pas déjà) avec le `AgentCoreMCPClient` principal
+- Crée un projet Python partagé `agent_connection` (s'il n'existe pas déjà) avec le `StrandsAgentCoreMCPClient` principal
 - Génère une classe `InventoryMcpServerClient` qui gère la connexion au serveur MCP à la fois localement (HTTP direct) et lors du déploiement (via AgentCore avec authentification IAM)
 - Transforme `agent.py` pour importer le client, créer une instance et connecter les outils du serveur MCP à l'agent
 - Ajoute le projet `agent_connection` en tant que dépendance workspace du projet story

--- a/docs/src/content/docs/fr/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-gateway.mdx
@@ -44,7 +44,7 @@ Le générateur émet des modules core-gateway partagés dans votre projet Pytho
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py Client MCP SigV4 utilisant `httpx`
+      - strands\_agentcore\_gateway\_mcp\_client.py Client MCP Strands pour la Gateway déployée
     - app/
       - \<gateway\_snake>\_client.py Wrapper client par Gateway
     - \_\_init\_\_.py Ré-exporte le client Gateway

--- a/docs/src/content/docs/fr/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ Le générateur crée un projet Python partagé `agent_connection` dans `package
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py Ré-exporte les clients par connexion
     - core
-      - agentcore\_mcp\_client.py Client MCP AgentCore principal
+      - strands\_agentcore\_mcp\_client.py Client MCP Strands encapsulant le transport indépendant du framework
     - app
       - \<mcp\_server\_name>\_client.py Client par connexion pour chaque serveur MCP
 

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ Le générateur émet des fichiers client partagés dans votre package `agent-co
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts Client MCP SigV4 pour la Gateway déployée
+      - strands-agentcore-gateway-mcp-client.ts Client MCP Strands pour la Gateway déployée
     - app/
       - \<gateway-kebab>-client.ts Wrapper client par Gateway
     - index.ts Ré-exporte le client Gateway

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ Le générateur crée un package partagé `agent-connection` et modifie le code 
     - app
       - \<mcp-server-name>-client.ts Client de haut niveau pour le serveur MCP connecté
     - core
-      - agentcore-mcp-client.ts Client MCP AgentCore de bas niveau avec authentification SigV4/JWT
+      - strands-agentcore-mcp-client.ts Client MCP Strands encapsulant le transport agnostique du framework
     - index.ts Exporte tous les clients
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -996,7 +996,7 @@ Il generatore `connection` genera/aggiorna questi file:
 </FileTree>
 
 Il generatore:
-- Crea un progetto Python condiviso `agent_connection` (se non esiste già) con il `AgentCoreMCPClient` principale
+- Crea un progetto Python condiviso `agent_connection` (se non esiste già) con il `StrandsAgentCoreMCPClient` principale
 - Genera una classe `InventoryMcpServerClient` che gestisce la connessione al server MCP sia localmente (HTTP diretto) che quando deployato (tramite AgentCore con autenticazione IAM)
 - Trasforma `agent.py` per importare il client, creare un'istanza e collegare gli strumenti del server MCP all'agente
 - Aggiunge il progetto `agent_connection` come dipendenza workspace del progetto story

--- a/docs/src/content/docs/it/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-gateway.mdx
@@ -14,7 +14,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Il generatore `connection` può connettere il tuo <Link path="guides/py-agent">Python Agent</Link> a un <Link path="guides/agentcore-gateway">AgentCore Gateway</Link>.
 
-Il generatore configura l'agent in modo che si autentichi al Gateway con IAM SigV4 (tramite la firma delle richieste `httpx`) quando distribuito, e si connetta direttamente ai server MCP collegati quando eseguito localmente.
+Il generatore configura l'agent in modo che si autentichi al Gateway con IAM SigV4 (tramite la firma delle richieste `httpx`) quando distribuito, e si connetta al gateway locale avviato dal progetto Gateway quando eseguito localmente.
 
 ## Prerequisiti
 
@@ -44,10 +44,9 @@ Il generatore emette moduli core-gateway condivisi nel tuo progetto Python `agen
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py Client MCP SigV4 che utilizza `httpx`
-      - agentcore\_gateway\_mcp\_local\_client.py Client multiplex locale per server MCP collegati
+      - strands\_agentcore\_gateway\_mcp\_client.py Client MCP Strands per il Gateway distribuito
     - app/
-      - \<gateway\_snake>\_client.py Wrapper per-Gateway con lista `ATTACHED_MCP_SERVERS`
+      - \<gateway\_snake>\_client.py Wrapper client per-Gateway
     - \_\_init\_\_.py Ri-esporta il client Gateway
 
 </FileTree>
@@ -83,7 +82,7 @@ def get_agent():
 `MyGatewayClient.create()` restituisce un singolo client gestibile tramite context manager il cui `list_tools_sync()` fornisce ogni strumento disponibile attraverso il Gateway:
 
 - **Modalità distribuita** (`SERVE_LOCAL` non impostato): un singolo `MCPClient` puntato all'endpoint MCP del Gateway, firmato con SigV4.
-- **Modalità locale** (`SERVE_LOCAL=true`): un `AgentCoreGatewayLocalMultiplexClient` che si distribuisce a ciascun server MCP collegato e presenta l'unione dei loro strumenti.
+- **Modalità locale** (`SERVE_LOCAL=true`): un `MCPClient` HTTP semplice puntato al gateway locale avviato dal target `serve-local` del progetto Gateway.
 
 L'ID di sessione viene propagato automaticamente ai server MCP downstream tramite l'header `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`.
 
@@ -140,8 +139,8 @@ L'URL del Gateway viene automaticamente registrato nel namespace `agentcore.gate
 
 Il generatore configura il target `serve-local` dell'agent per:
 
-1. Avviare ogni server MCP collegato al Gateway connesso
-2. Impostare `SERVE_LOCAL=true` in modo che il client generato si distribuisca a quei server MCP locali invece di chiamare il Gateway distribuito
+1. Avviare il gateway locale del Gateway connesso e ogni server MCP collegato
+2. Impostare `SERVE_LOCAL=true` in modo che il client generato punti al gateway locale invece del Gateway distribuito
 
 Esegui l'agent localmente con:
 

--- a/docs/src/content/docs/it/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ Il generatore crea un progetto Python condiviso `agent_connection` in `packages/
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py Ri-esporta i client per-connessione
     - core
-      - agentcore\_mcp\_client.py Client MCP AgentCore di base
+      - strands\_agentcore\_mcp\_client.py Client MCP Strands che avvolge il trasporto framework-agnostic
     - app
       - \<mcp\_server\_name>\_client.py Client per-connessione per ogni server MCP
 

--- a/docs/src/content/docs/it/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-gateway.mdx
@@ -14,7 +14,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Il generatore `connection` può connettere il tuo <Link path="guides/ts-agent">TypeScript Agent</Link> a un <Link path="guides/agentcore-gateway">AgentCore Gateway</Link>.
 
-Il generatore configura l'agent in modo che si autentichi al Gateway con IAM SigV4 quando viene distribuito, e si colleghi direttamente ai server MCP collegati quando viene eseguito localmente.
+Il generatore configura l'agent in modo che si autentichi al Gateway con IAM SigV4 quando viene distribuito, e si colleghi al gateway locale avviato dal progetto Gateway quando viene eseguito localmente.
 
 ## Prerequisiti
 
@@ -44,10 +44,9 @@ Il generatore emette file client core condivisi nel tuo package `agent-connectio
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts Client MCP SigV4 per il Gateway distribuito
-      - agentcore-gateway-mcp-local-client.ts Client multiplex locale che si distribuisce ai server MCP collegati
+      - strands-agentcore-gateway-mcp-client.ts Client MCP Strands per il Gateway distribuito
     - app/
-      - \<gateway-kebab>-client.ts Wrapper per-Gateway con lista `ATTACHED_MCP_SERVERS`
+      - \<gateway-kebab>-client.ts Wrapper client per-Gateway
     - index.ts Ri-esporta il client Gateway
 
 </FileTree>

--- a/docs/src/content/docs/it/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ Il generatore crea un pacchetto condiviso `agent-connection` e modifica il codic
     - app
       - \<mcp-server-name>-client.ts Client di alto livello per il server MCP connesso
     - core
-      - agentcore-mcp-client.ts Client MCP AgentCore di basso livello con autenticazione SigV4/JWT
+      - strands-agentcore-mcp-client.ts Client MCP Strands che avvolge il trasporto framework-agnostic
     - index.ts Esporta tutti i client
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -996,7 +996,7 @@ root &&
 </FileTree>
 
 ジェネレーターは:
-- コア`AgentCoreMCPClient`を持つ共有`agent_connection` Pythonプロジェクトを作成します（まだ存在しない場合）
+- コア`StrandsAgentCoreMCPClient`を持つ共有`agent_connection` Pythonプロジェクトを作成します（まだ存在しない場合）
 - ローカル（直接HTTP）とデプロイ時（IAM認証を使用したAgentCore経由）の両方でMCPサーバーへの接続を処理する`InventoryMcpServerClient`クラスを生成します
 - `agent.py`を変換してクライアントをインポートし、インスタンスを作成し、MCPサーバーのツールをエージェントに接続します
 - `agent_connection`プロジェクトをstoryプロジェクトのワークスペース依存関係として追加します

--- a/docs/src/content/docs/jp/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-gateway.mdx
@@ -14,7 +14,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 `connection`ジェネレーターは、<Link path="guides/py-agent">Python Agent</Link>を<Link path="guides/agentcore-gateway">AgentCore Gateway</Link>に接続できます。
 
-このジェネレーターは、デプロイ時にGatewayに対してIAM SigV4（`httpx`リクエスト署名経由）で認証し、ローカル実行時には接続されたMCPサーバーに直接多重化するようにエージェントを配線します。
+このジェネレーターは、デプロイ時にGatewayに対してIAM SigV4（`httpx`リクエスト署名経由）で認証し、ローカル実行時にはGatewayプロジェクトによって起動されたローカルゲートウェイに接続するようにエージェントを配線します。
 
 ## 前提条件
 
@@ -44,10 +44,9 @@ import Infrastructure from '@components/infrastructure.astro';
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py `httpx`を使用したSigV4 MCPクライアント
-      - agentcore\_gateway\_mcp\_local\_client.py 接続されたMCPサーバー用のローカル多重化クライアント
+      - strands\_agentcore\_gateway\_mcp\_client.py デプロイされたGateway用のStrands MCPクライアント
     - app/
-      - \<gateway\_snake>\_client.py `ATTACHED_MCP_SERVERS`リストを持つGatewayごとのラッパー
+      - \<gateway\_snake>\_client.py Gatewayごとのクライアントラッパー
     - \_\_init\_\_.py Gatewayクライアントを再エクスポート
 
 </FileTree>
@@ -83,7 +82,7 @@ def get_agent():
 `MyGatewayClient.create()`は、`list_tools_sync()`がGatewayを通じて利用可能なすべてのツールを生成する、単一のコンテキスト管理可能なクライアントを返します：
 
 - **デプロイモード**（`SERVE_LOCAL`未設定）：GatewayのMCPエンドポイントを指す単一の`MCPClient`、SigV4署名付き。
-- **ローカルモード**（`SERVE_LOCAL=true`）：接続された各MCPサーバーにファンアウトし、それらのツールの和集合を提示する`AgentCoreGatewayLocalMultiplexClient`。
+- **ローカルモード**（`SERVE_LOCAL=true`）：Gatewayプロジェクトの`serve-local`ターゲットによって起動されたローカルゲートウェイを指すプレーンHTTPの`MCPClient`。
 
 セッションIDは`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`ヘッダーを介して、下流のMCPサーバーに自動的に伝播されます。
 
@@ -140,8 +139,8 @@ Gateway URLは、生成されたTerraformモジュールによって<Link path="
 
 ジェネレーターは、エージェントの`serve-local`ターゲットを次のように設定します：
 
-1. 接続されたGatewayに接続されているすべてのMCPサーバーを起動
-2. `SERVE_LOCAL=true`を設定して、生成されたクライアントがデプロイされたGatewayを呼び出す代わりに、それらのローカルMCPサーバーにファンアウトするようにします
+1. 接続されたGatewayのローカルゲートウェイと接続されているすべてのMCPサーバーを起動
+2. `SERVE_LOCAL=true`を設定して、生成されたクライアントがデプロイされたGatewayの代わりにローカルゲートウェイを指すようにします
 
 エージェントをローカルで実行するには：
 

--- a/docs/src/content/docs/jp/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ import Infrastructure from '@components/infrastructure.astro';
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py 接続ごとのクライアントを再エクスポート
     - core
-      - agentcore\_mcp\_client.py コア AgentCore MCP クライアント
+      - strands\_agentcore\_mcp\_client.py フレームワークに依存しないトランスポートをラップする Strands MCP クライアント
     - app
       - \<mcp\_server\_name>\_client.py 各 MCP サーバーの接続ごとのクライアント
 

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ import Infrastructure from '@components/infrastructure.astro';
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts デプロイされたGateway用のSigV4 MCPクライアント
+      - strands-agentcore-gateway-mcp-client.ts デプロイされたGateway用のStrands MCPクライアント
     - app/
       - \<gateway-kebab>-client.ts Gateway毎のクライアントラッパー
     - index.ts Gatewayクライアントを再エクスポート

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ import Infrastructure from '@components/infrastructure.astro';
     - app
       - \<mcp-server-name>-client.ts 接続された MCP サーバー用の高レベルクライアント
     - core
-      - agentcore-mcp-client.ts SigV4/JWT 認証を備えた低レベル AgentCore MCP クライアント
+      - strands-agentcore-mcp-client.ts フレームワークに依存しないトランスポートをラップする Strands MCP クライアント
     - index.ts すべてのクライアントをエクスポート
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -993,7 +993,7 @@ root &&
 </FileTree>
 
 생성기는 다음을 수행합니다:
-- 핵심 `AgentCoreMCPClient`가 포함된 공유 `agent_connection` Python 프로젝트 생성(아직 없는 경우)
+- 핵심 `StrandsAgentCoreMCPClient`가 포함된 공유 `agent_connection` Python 프로젝트 생성(아직 없는 경우)
 - 로컬(직접 HTTP) 및 배포 시(IAM 인증을 통한 AgentCore) 모두에서 MCP 서버에 연결하는 `InventoryMcpServerClient` 클래스 생성
 - 클라이언트를 가져오고, 인스턴스를 생성하며, MCP 서버의 도구를 에이전트에 연결하도록 `agent.py` 변환
 - story 프로젝트의 워크스페이스 종속성으로 `agent_connection` 프로젝트 추가

--- a/docs/src/content/docs/ko/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-gateway.mdx
@@ -14,7 +14,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 `connection` 생성기는 <Link path="guides/py-agent">Python Agent</Link>를 <Link path="guides/agentcore-gateway">AgentCore Gateway</Link>에 연결할 수 있습니다.
 
-생성기는 에이전트가 배포 시 IAM SigV4(`httpx` 요청 서명 사용)로 Gateway에 인증하고, 로컬 실행 시 연결된 MCP 서버에 직접 멀티플렉싱하도록 연결합니다.
+생성기는 에이전트가 배포 시 IAM SigV4(`httpx` 요청 서명 사용)로 Gateway에 인증하고, 로컬 실행 시 Gateway 프로젝트에서 시작한 로컬 게이트웨이에 연결하도록 연결합니다.
 
 ## 사전 요구 사항
 
@@ -44,10 +44,9 @@ import Infrastructure from '@components/infrastructure.astro';
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py `httpx`를 사용하는 SigV4 MCP 클라이언트
-      - agentcore\_gateway\_mcp\_local\_client.py 연결된 MCP 서버용 로컬 멀티플렉스 클라이언트
+      - strands\_agentcore\_gateway\_mcp\_client.py 배포된 Gateway용 Strands MCP 클라이언트
     - app/
-      - \<gateway\_snake>\_client.py `ATTACHED_MCP_SERVERS` 목록이 있는 Gateway별 래퍼
+      - \<gateway\_snake>\_client.py Gateway별 클라이언트 래퍼
     - \_\_init\_\_.py Gateway 클라이언트를 재내보내기
 
 </FileTree>
@@ -83,7 +82,7 @@ def get_agent():
 `MyGatewayClient.create()`는 컨텍스트 관리 가능한 단일 클라이언트를 반환하며, 이 클라이언트의 `list_tools_sync()`는 Gateway를 통해 사용 가능한 모든 도구를 제공합니다:
 
 - **배포 모드** (`SERVE_LOCAL` 미설정): Gateway의 MCP 엔드포인트를 가리키는 단일 `MCPClient`, SigV4 서명됨.
-- **로컬 모드** (`SERVE_LOCAL=true`): 연결된 각 MCP 서버로 팬아웃하고 도구의 합집합을 제공하는 `AgentCoreGatewayLocalMultiplexClient`.
+- **로컬 모드** (`SERVE_LOCAL=true`): Gateway 프로젝트의 `serve-local` 대상에서 시작한 로컬 게이트웨이를 가리키는 일반 HTTP `MCPClient`.
 
 세션 ID는 `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` 헤더를 통해 다운스트림 MCP 서버로 자동으로 전파됩니다.
 
@@ -140,8 +139,8 @@ Gateway URL은 생성된 Terraform 모듈에 의해 <Link path="guides/runtime-c
 
 생성기는 에이전트의 `serve-local` 대상을 다음과 같이 구성합니다:
 
-1. 연결된 Gateway에 연결된 모든 MCP 서버 시작
-2. `SERVE_LOCAL=true`를 설정하여 생성된 클라이언트가 배포된 Gateway를 호출하는 대신 로컬 MCP 서버로 팬아웃하도록 함
+1. 연결된 Gateway의 로컬 게이트웨이와 연결된 모든 MCP 서버 시작
+2. `SERVE_LOCAL=true`를 설정하여 생성된 클라이언트가 배포된 Gateway 대신 로컬 게이트웨이를 가리키도록 함
 
 다음 명령으로 에이전트를 로컬에서 실행하세요:
 

--- a/docs/src/content/docs/ko/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ import Infrastructure from '@components/infrastructure.astro';
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py 연결별 클라이언트를 재내보냄
     - core
-      - agentcore\_mcp\_client.py 핵심 AgentCore MCP 클라이언트
+      - strands\_agentcore\_mcp\_client.py 프레임워크에 구애받지 않는 전송을 래핑하는 Strands MCP 클라이언트
     - app
       - \<mcp\_server\_name>\_client.py 각 MCP 서버에 대한 연결별 클라이언트
 

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ import Infrastructure from '@components/infrastructure.astro';
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts 배포된 Gateway용 SigV4 MCP 클라이언트
+      - strands-agentcore-gateway-mcp-client.ts 배포된 Gateway용 Strands MCP 클라이언트
     - app/
       - \<gateway-kebab>-client.ts Gateway별 클라이언트 래퍼
     - index.ts Gateway 클라이언트를 재내보냄

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ import Infrastructure from '@components/infrastructure.astro';
     - app
       - \<mcp-server-name>-client.ts 연결된 MCP 서버를 위한 고수준 클라이언트
     - core
-      - agentcore-mcp-client.ts SigV4/JWT 인증을 사용하는 저수준 AgentCore MCP 클라이언트
+      - strands-agentcore-mcp-client.ts 프레임워크에 구애받지 않는 전송을 래핑하는 Strands MCP 클라이언트
     - index.ts 모든 클라이언트 내보내기
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -996,7 +996,7 @@ O gerador `connection` gera/atualiza estes arquivos:
 </FileTree>
 
 O gerador:
-- Cria um projeto Python compartilhado `agent_connection` (se ainda não existir) com o `AgentCoreMCPClient` principal
+- Cria um projeto Python compartilhado `agent_connection` (se ainda não existir) com o `StrandsAgentCoreMCPClient` principal
 - Gera uma classe `InventoryMcpServerClient` que lida com a conexão ao servidor MCP tanto localmente (HTTP direto) quanto quando implantado (via AgentCore com autenticação IAM)
 - Transforma `agent.py` para importar o cliente, criar uma instância e conectar as ferramentas do servidor MCP ao agente
 - Adiciona o projeto `agent_connection` como uma dependência de workspace do projeto story

--- a/docs/src/content/docs/pt/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-gateway.mdx
@@ -44,7 +44,7 @@ O gerador emite módulos compartilhados core-gateway em seu projeto Python `agen
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py Cliente MCP SigV4 usando `httpx`
+      - strands\_agentcore\_gateway\_mcp\_client.py Cliente MCP Strands para o Gateway implantado
     - app/
       - \<gateway\_snake>\_client.py Wrapper de cliente por Gateway
     - \_\_init\_\_.py Re-exporta o cliente do Gateway

--- a/docs/src/content/docs/pt/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ O gerador cria um projeto Python compartilhado `agent_connection` em `packages/c
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py Re-exporta clientes por conexão
     - core
-      - agentcore\_mcp\_client.py Cliente MCP AgentCore principal
+      - strands\_agentcore\_mcp\_client.py Cliente MCP Strands que envolve o transporte agnóstico de framework
     - app
       - \<mcp\_server\_name>\_client.py Cliente por conexão para cada servidor MCP
 

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ O gerador emite arquivos de cliente principais compartilhados em seu pacote `age
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts Cliente MCP SigV4 para o Gateway implantado
+      - strands-agentcore-gateway-mcp-client.ts Cliente MCP Strands para o Gateway implantado
     - app/
       - \<gateway-kebab>-client.ts Wrapper de cliente por Gateway
     - index.ts Re-exporta o cliente do Gateway

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ O gerador cria um pacote compartilhado `agent-connection` e modifica o código d
     - app
       - \<mcp-server-name>-client.ts Cliente de alto nível para o servidor MCP conectado
     - core
-      - agentcore-mcp-client.ts Cliente MCP AgentCore de baixo nível com autenticação SigV4/JWT
+      - strands-agentcore-mcp-client.ts Cliente MCP Strands que envolve o transporte agnóstico de framework
     - index.ts Exporta todos os clientes
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -996,7 +996,7 @@ Trình tạo `connection` tạo/cập nhật các tệp này:
 </FileTree>
 
 Trình tạo:
-- Tạo một dự án Python `agent_connection` được chia sẻ (nếu chưa tồn tại) với `AgentCoreMCPClient` cốt lõi
+- Tạo một dự án Python `agent_connection` được chia sẻ (nếu chưa tồn tại) với `StrandsAgentCoreMCPClient` cốt lõi
 - Tạo một class `InventoryMcpServerClient` xử lý kết nối đến máy chủ MCP cả cục bộ (HTTP trực tiếp) và khi được triển khai (qua AgentCore với xác thực IAM)
 - Biến đổi `agent.py` để import client, tạo một instance và kết nối các công cụ của máy chủ MCP vào agent
 - Thêm dự án `agent_connection` làm phụ thuộc workspace của dự án story

--- a/docs/src/content/docs/vi/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-gateway.mdx
@@ -14,7 +14,7 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Trình tạo `connection` có thể kết nối <Link path="guides/py-agent">Python Agent</Link> của bạn với <Link path="guides/agentcore-gateway">AgentCore Gateway</Link>.
 
-Trình tạo sẽ cấu hình agent để xác thực với Gateway bằng IAM SigV4 (thông qua ký yêu cầu `httpx`) khi triển khai, và ghép kênh trực tiếp đến các máy chủ MCP được đính kèm khi chạy cục bộ.
+Trình tạo sẽ cấu hình agent để xác thực với Gateway bằng IAM SigV4 (thông qua ký yêu cầu `httpx`) khi triển khai, và kết nối với gateway cục bộ được khởi động bởi dự án Gateway khi chạy cục bộ.
 
 ## Điều kiện tiên quyết
 
@@ -44,10 +44,9 @@ Trình tạo tạo ra các module core-gateway được chia sẻ vào dự án 
 - packages/common/agent\_connection
   - \<scope>\_agent\_connection
     - core/
-      - agentcore\_gateway\_mcp\_client.py SigV4 MCP client sử dụng `httpx`
-      - agentcore\_gateway\_mcp\_local\_client.py Local multiplex client cho các máy chủ MCP được đính kèm
+      - strands\_agentcore\_gateway\_mcp\_client.py Strands MCP client cho Gateway đã triển khai
     - app/
-      - \<gateway\_snake>\_client.py Wrapper cho mỗi Gateway với danh sách `ATTACHED_MCP_SERVERS`
+      - \<gateway\_snake>\_client.py Wrapper client cho mỗi Gateway
     - \_\_init\_\_.py Xuất lại Gateway client
 
 </FileTree>
@@ -83,7 +82,7 @@ def get_agent():
 `MyGatewayClient.create()` trả về một client có thể quản lý ngữ cảnh duy nhất mà `list_tools_sync()` của nó cung cấp mọi công cụ có sẵn thông qua Gateway:
 
 - **Chế độ triển khai** (`SERVE_LOCAL` không được đặt): một `MCPClient` duy nhất trỏ đến điểm cuối MCP của Gateway, được ký SigV4.
-- **Chế độ cục bộ** (`SERVE_LOCAL=true`): một `AgentCoreGatewayLocalMultiplexClient` phân tán đến từng máy chủ MCP được đính kèm và trình bày tập hợp các công cụ của chúng.
+- **Chế độ cục bộ** (`SERVE_LOCAL=true`): một `MCPClient` HTTP thuần trỏ đến gateway cục bộ được khởi động bởi target `serve-local` của dự án Gateway.
 
 Session ID được truyền tự động đến các máy chủ MCP downstream thông qua header `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`.
 
@@ -140,8 +139,8 @@ URL Gateway được tự động đăng ký trong namespace `agentcore.gateways
 
 Trình tạo cấu hình target `serve-local` của agent để:
 
-1. Khởi động mọi máy chủ MCP được đính kèm với Gateway đã kết nối
-2. Đặt `SERVE_LOCAL=true` để client được tạo phân tán đến các máy chủ MCP cục bộ đó thay vì gọi Gateway đã triển khai
+1. Khởi động gateway cục bộ của Gateway đã kết nối và mọi máy chủ MCP được đính kèm
+2. Đặt `SERVE_LOCAL=true` để client được tạo trỏ đến gateway cục bộ thay vì Gateway đã triển khai
 
 Chạy agent cục bộ với:
 

--- a/docs/src/content/docs/vi/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ Trình tạo tạo một dự án Python `agent_connection` được chia sẻ t
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py Xuất lại các client theo từng kết nối
     - core
-      - agentcore\_mcp\_client.py Client MCP AgentCore cốt lõi
+      - strands\_agentcore\_mcp\_client.py Client MCP Strands bao bọc truyền tải không phụ thuộc framework
     - app
       - \<mcp\_server\_name>\_client.py Client theo từng kết nối cho mỗi MCP server
 

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ Trình tạo tạo ra các tệp client cốt lõi được chia sẻ vào gói 
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts SigV4 MCP client cho Gateway đã triển khai
+      - strands-agentcore-gateway-mcp-client.ts Strands MCP client cho Gateway đã triển khai
     - app/
       - \<gateway-kebab>-client.ts Wrapper client cho mỗi Gateway
     - index.ts Xuất lại Gateway client

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ Trình tạo tạo một gói `agent-connection` được chia sẻ và sửa đ
     - app
       - \<mcp-server-name>-client.ts Client cấp cao cho máy chủ MCP được kết nối
     - core
-      - agentcore-mcp-client.ts Client MCP AgentCore cấp thấp với xác thực SigV4/JWT
+      - strands-agentcore-mcp-client.ts Client MCP Strands bao bọc transport không phụ thuộc framework
     - index.ts Xuất tất cả các client
   - project.json
   - tsconfig.json

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -993,7 +993,7 @@ root &&
 </FileTree>
 
 生成器会:
-- 创建共享的 `agent_connection` Python 项目(如果尚不存在),包含核心 `AgentCoreMCPClient`
+- 创建共享的 `agent_connection` Python 项目(如果尚不存在),包含核心 `StrandsAgentCoreMCPClient`
 - 生成 `InventoryMcpServerClient` 类,处理本地(直接 HTTP)和部署时(通过 AgentCore 使用 IAM 身份验证)连接 MCP 服务器
 - 转换 `agent.py` 以导入客户端、创建实例并将 MCP 服务器的工具连接到代理
 - 将 `agent_connection` 项目作为工作区依赖添加到 story 项目

--- a/docs/src/content/docs/zh/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-gateway.mdx
@@ -140,8 +140,8 @@ Gateway URL 会由生成的 Terraform 模块自动注册到 <Link path="guides/r
 
 生成器会配置 agent 的 `serve-local` 目标以：
 
-1. 启动连接到 Gateway 的每个 MCP 服务器
-2. 设置 `SERVE_LOCAL=true`，以便生成的客户端扇出到这些本地 MCP 服务器，而不是调用已部署的 Gateway
+1. 启动连接的 Gateway 的本地网关和每个附加的 MCP 服务器
+2. 设置 `SERVE_LOCAL=true`，以便生成的客户端指向本地网关，而不是已部署的 Gateway
 
 使用以下命令在本地运行 agent：
 

--- a/docs/src/content/docs/zh/guides/connection/py-agent-mcp.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-mcp.mdx
@@ -48,7 +48,7 @@ import Infrastructure from '@components/infrastructure.astro';
   - \<scope>\_agent\_connection
     - \_\_init\_\_.py 重新导出每个连接的客户端
     - core
-      - agentcore\_mcp\_client.py 核心 AgentCore MCP 客户端
+      - strands\_agentcore\_mcp\_client.py 封装框架无关传输的 Strands MCP 客户端
     - app
       - \<mcp\_server\_name>\_client.py 每个 MCP 服务器的专用连接客户端
 

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-gateway.mdx
@@ -44,7 +44,7 @@ import Infrastructure from '@components/infrastructure.astro';
 - packages/common/agent-connection
   - src
     - core/
-      - agentcore-gateway-mcp-client.ts 用于已部署 Gateway 的 SigV4 MCP 客户端
+      - strands-agentcore-gateway-mcp-client.ts 用于已部署 Gateway 的 Strands MCP 客户端
     - app/
       - \<gateway-kebab>-client.ts 每个 Gateway 的客户端包装器
     - index.ts 重新导出 Gateway 客户端

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-mcp.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-mcp.mdx
@@ -49,7 +49,7 @@ import Infrastructure from '@components/infrastructure.astro';
     - app
       - \<mcp-server-name>-client.ts 连接的 MCP 服务器的高级客户端
     - core
-      - agentcore-mcp-client.ts 带有 SigV4/JWT 身份验证的低级 AgentCore MCP 客户端
+      - strands-agentcore-mcp-client.ts 包装框架无关传输的 Strands MCP 客户端
     - index.ts 导出所有客户端
   - project.json
   - tsconfig.json

--- a/packages/nx-plugin/src/py/agent/gateway-connection/files/agent-connection/app/__gatewaySnakeCase___client.py.template
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/files/agent-connection/app/__gatewaySnakeCase___client.py.template
@@ -2,8 +2,8 @@ import os
 
 from strands.tools.mcp.mcp_client import MCPClient
 
-from <%- agentConnectionModuleName %>.core.agentcore_gateway_mcp_client import (
-    AgentCoreGatewayMCPClient,
+from <%- agentConnectionModuleName %>.core.strands_agentcore_gateway_mcp_client import (
+    StrandsAgentCoreGatewayMCPClient,
 )
 from <%- agentConnectionModuleName %>.core.runtime_config import (
     get_agentcore_runtime_config,
@@ -23,7 +23,7 @@ class <%- gatewayClassName %>Client:
     @staticmethod
     def create() -> MCPClient:
         if os.environ.get("SERVE_LOCAL") == "true":
-            return AgentCoreGatewayMCPClient.without_auth(
+            return StrandsAgentCoreGatewayMCPClient.without_auth(
                 gateway_url="http://localhost:<%- gatewayPort %>/mcp"
             )
         config = get_agentcore_runtime_config()
@@ -32,4 +32,4 @@ class <%- gatewayClassName %>Client:
             raise RuntimeError(
                 "No connected gateway named '<%- gatewayClassName %>' found in runtime configuration."
             )
-        return AgentCoreGatewayMCPClient.with_iam_auth(gateway_url=gateway_url)
+        return StrandsAgentCoreGatewayMCPClient.with_iam_auth(gateway_url=gateway_url)

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
@@ -127,6 +127,22 @@ dependencies = ["strands-agents"]
         `packages/common/agent_connection/${moduleName}/core/agentcore_gateway_mcp_client.py`,
       ),
     ).toBe(true);
+    // Framework-agnostic transport layer shared with the MCP client
+    expect(
+      tree.exists(
+        `packages/common/agent_connection/${moduleName}/core/agentcore_gateway_mcp_transport.py`,
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        `packages/common/agent_connection/${moduleName}/core/agentcore_transport.py`,
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        `packages/common/agent_connection/${moduleName}/core/auth/session.py`,
+      ),
+    ).toBe(true);
     // Per-connection app client
     expect(
       tree.exists(

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
@@ -124,7 +124,7 @@ dependencies = ["strands-agents"]
     ).toBe(true);
     expect(
       tree.exists(
-        `packages/common/agent_connection/${moduleName}/core/agentcore_gateway_mcp_client.py`,
+        `packages/common/agent_connection/${moduleName}/core/strands_agentcore_gateway_mcp_client.py`,
       ),
     ).toBe(true);
     // Framework-agnostic transport layer shared with the MCP client

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -23,40 +23,6 @@ __all__ = [
 "
 `;
 
-exports[`py#agent#mcp-connection generator > should match snapshot for generated files > agentcore_mcp_client.py 1`] = `
-"from collections.abc import Callable
-
-from strands.tools.mcp.mcp_client import MCPClient
-
-from .agentcore_mcp_transport import AgentCoreMCPTransport
-
-
-class AgentCoreMCPClient:
-    """Factory for Strands MCP clients that connect to an AgentCore runtime."""
-
-    @staticmethod
-    def with_iam_auth(agent_runtime_arn: str) -> MCPClient:
-        """SigV4-authenticated client for a Bedrock AgentCore runtime."""
-        return MCPClient(AgentCoreMCPTransport.with_iam_auth(agent_runtime_arn))
-
-    @staticmethod
-    def with_jwt_auth(
-        agent_runtime_arn: str, access_token_provider: Callable[[], str]
-    ) -> MCPClient:
-        """Bearer-authenticated client for a Bedrock AgentCore runtime."""
-        return MCPClient(
-            AgentCoreMCPTransport.with_jwt_auth(
-                agent_runtime_arn, access_token_provider
-            )
-        )
-
-    @staticmethod
-    def without_auth(url: str) -> MCPClient:
-        """Plain-HTTP client — for local dev."""
-        return MCPClient(AgentCoreMCPTransport.without_auth(url))
-"
-`;
-
 exports[`py#agent#mcp-connection generator > should match snapshot for generated files > agentcore_mcp_transport.py 1`] = `
 "from collections.abc import Callable
 
@@ -155,7 +121,9 @@ exports[`py#agent#mcp-connection generator > should match snapshot for generated
 
 from strands.tools.mcp.mcp_client import MCPClient
 
-from proj_agent_connection.core.agentcore_mcp_client import AgentCoreMCPClient
+from proj_agent_connection.core.strands_agentcore_mcp_client import (
+    StrandsAgentCoreMCPClient,
+)
 from proj_agent_connection.core.runtime_config import (
     get_agentcore_runtime_config,
 )
@@ -167,14 +135,14 @@ class InventoryMcpClient:
     @staticmethod
     def create() -> MCPClient:
         if os.environ.get("SERVE_LOCAL") == "true":
-            return AgentCoreMCPClient.without_auth("http://localhost:8082/mcp")
+            return StrandsAgentCoreMCPClient.without_auth("http://localhost:8082/mcp")
         config = get_agentcore_runtime_config()
         agent_runtime_arn = config.get("agentRuntimes", {}).get("InventoryMcp")
         if not agent_runtime_arn:
             raise RuntimeError(
                 "No connected MCP server runtime named 'InventoryMcp' found in runtime configuration."
             )
-        return AgentCoreMCPClient.with_iam_auth(agent_runtime_arn)
+        return StrandsAgentCoreMCPClient.with_iam_auth(agent_runtime_arn)
 "
 `;
 
@@ -230,6 +198,40 @@ def jwt_auth(access_token_provider: Callable[[], str]) -> httpx.Auth:
 def plain_auth() -> httpx.Auth:
     """Session-forwarding plain auth — for local dev."""
     return SessionHeaderAuth()
+"
+`;
+
+exports[`py#agent#mcp-connection generator > should match snapshot for generated files > strands_agentcore_mcp_client.py 1`] = `
+"from collections.abc import Callable
+
+from strands.tools.mcp.mcp_client import MCPClient
+
+from .agentcore_mcp_transport import AgentCoreMCPTransport
+
+
+class StrandsAgentCoreMCPClient:
+    """Factory for Strands MCP clients that connect to an AgentCore runtime."""
+
+    @staticmethod
+    def with_iam_auth(agent_runtime_arn: str) -> MCPClient:
+        """SigV4-authenticated client for a Bedrock AgentCore runtime."""
+        return MCPClient(AgentCoreMCPTransport.with_iam_auth(agent_runtime_arn))
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str, access_token_provider: Callable[[], str]
+    ) -> MCPClient:
+        """Bearer-authenticated client for a Bedrock AgentCore runtime."""
+        return MCPClient(
+            AgentCoreMCPTransport.with_jwt_auth(
+                agent_runtime_arn, access_token_provider
+            )
+        )
+
+    @staticmethod
+    def without_auth(url: str) -> MCPClient:
+        """Plain-HTTP client — for local dev."""
+        return MCPClient(AgentCoreMCPTransport.without_auth(url))
 "
 `;
 

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -26,93 +26,127 @@ __all__ = [
 exports[`py#agent#mcp-connection generator > should match snapshot for generated files > agentcore_mcp_client.py 1`] = `
 "from collections.abc import Callable
 
-import boto3
-import httpx
-from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp.mcp_client import MCPClient
 
-from .auth import SigV4HTTPXAuth
-from .session_context import get_current_session_id
-
-SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
-
-
-class _SessionHeaderAuth(httpx.Auth):
-    """Stamps the AgentCore session header from the current async context."""
-
-    requires_request_body = True
-    requires_response_body = True
-
-    def __init__(self, inner: httpx.Auth | None = None):
-        self._inner = inner
-
-    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
-        sid = get_current_session_id()
-        if sid:
-            request.headers[SESSION_HEADER] = sid
-        if self._inner is None:
-            yield request
-            return
-        yield from self._inner.auth_flow(request)
+from .agentcore_mcp_transport import AgentCoreMCPTransport
 
 
 class AgentCoreMCPClient:
-    """Factory for MCP clients that forward the current async-context session."""
-
-    @staticmethod
-    def _build_url(agent_runtime_arn: str) -> tuple[str, str]:
-        """Extract region from ARN and construct the invocation URL.
-
-        ARN format: arn:partition:service:region:account-id:resource
-        """
-        region = agent_runtime_arn.split(":")[3]
-        encoded_arn = agent_runtime_arn.replace(":", "%3A").replace("/", "%2F")
-        url = (
-            f"https://bedrock-agentcore.{region}.amazonaws.com/runtimes/"
-            f"{encoded_arn}/invocations?qualifier=DEFAULT"
-        )
-        return region, url
-
-    @staticmethod
-    def _create(url: str, auth: httpx.Auth | None = None) -> MCPClient:
-        return MCPClient(
-            lambda: streamablehttp_client(
-                url,
-                auth=_SessionHeaderAuth(auth),
-                timeout=120,
-                terminate_on_close=False,
-            )
-        )
+    """Factory for Strands MCP clients that connect to an AgentCore runtime."""
 
     @staticmethod
     def with_iam_auth(agent_runtime_arn: str) -> MCPClient:
         """SigV4-authenticated client for a Bedrock AgentCore runtime."""
-        region, url = AgentCoreMCPClient._build_url(agent_runtime_arn)
-        credentials = boto3.Session(region_name=region).get_credentials()
-        return AgentCoreMCPClient._create(
-            url, SigV4HTTPXAuth(credentials, "bedrock-agentcore", region)
-        )
+        return MCPClient(AgentCoreMCPTransport.with_iam_auth(agent_runtime_arn))
 
     @staticmethod
     def with_jwt_auth(
         agent_runtime_arn: str, access_token_provider: Callable[[], str]
     ) -> MCPClient:
         """Bearer-authenticated client for a Bedrock AgentCore runtime."""
-        _, url = AgentCoreMCPClient._build_url(agent_runtime_arn)
         return MCPClient(
-            lambda: streamablehttp_client(
-                url,
-                auth=_SessionHeaderAuth(),
-                headers={"Authorization": f"Bearer {access_token_provider()}"},
-                timeout=120,
-                terminate_on_close=False,
+            AgentCoreMCPTransport.with_jwt_auth(
+                agent_runtime_arn, access_token_provider
             )
         )
 
     @staticmethod
     def without_auth(url: str) -> MCPClient:
         """Plain-HTTP client — for local dev."""
-        return AgentCoreMCPClient._create(url)
+        return MCPClient(AgentCoreMCPTransport.without_auth(url))
+"
+`;
+
+exports[`py#agent#mcp-connection generator > should match snapshot for generated files > agentcore_mcp_transport.py 1`] = `
+"from collections.abc import Callable
+
+from .agentcore_transport import (
+    TransportFactory,
+    jwt_transport,
+    no_auth_transport,
+    sigv4_transport,
+)
+
+
+def _resolve(agent_runtime_arn: str) -> tuple[str, str]:
+    """Extract region from ARN and construct the invocation URL.
+
+    ARN format: arn:partition:service:region:account-id:resource
+    """
+    region = agent_runtime_arn.split(":")[3]
+    encoded_arn = agent_runtime_arn.replace(":", "%3A").replace("/", "%2F")
+    url = (
+        f"https://bedrock-agentcore.{region}.amazonaws.com/runtimes/"
+        f"{encoded_arn}/invocations?qualifier=DEFAULT"
+    )
+    return region, url
+
+
+class AgentCoreMCPTransport:
+    """Factory for MCP transport factories that connect to an AgentCore runtime."""
+
+    @staticmethod
+    def with_iam_auth(agent_runtime_arn: str) -> TransportFactory:
+        """SigV4-authenticated transport for a Bedrock AgentCore runtime."""
+        region, url = _resolve(agent_runtime_arn)
+        return sigv4_transport(url, region)
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str, access_token_provider: Callable[[], str]
+    ) -> TransportFactory:
+        """Bearer-authenticated transport for a Bedrock AgentCore runtime."""
+        _, url = _resolve(agent_runtime_arn)
+        return jwt_transport(url, access_token_provider)
+
+    @staticmethod
+    def without_auth(url: str) -> TransportFactory:
+        """Plain-HTTP transport — for local dev."""
+        return no_auth_transport(url)
+"
+`;
+
+exports[`py#agent#mcp-connection generator > should match snapshot for generated files > agentcore_transport.py 1`] = `
+"from collections.abc import Callable
+from typing import Any
+
+import boto3
+
+from mcp.client.streamable_http import streamablehttp_client
+
+from .auth.session import jwt_auth, plain_auth, sigv4_auth
+
+# Agent frameworks wrap a transport *factory* — a no-arg callable returning a
+# streamable-HTTP transport context manager. Typed as \`\`Any\`\` so this layer
+# stays free of any framework-specific transport type.
+TransportFactory = Callable[[], Any]
+
+
+def _factory(url: str, auth) -> TransportFactory:
+    return lambda: streamablehttp_client(
+        url,
+        auth=auth,
+        timeout=120,
+        terminate_on_close=False,
+    )
+
+
+def sigv4_transport(url: str, region: str) -> TransportFactory:
+    """SigV4-signed transport factory for a resolved AgentCore endpoint."""
+    credentials = boto3.Session(region_name=region).get_credentials()
+    return _factory(url, sigv4_auth(credentials, region))
+
+
+def jwt_transport(
+    url: str, access_token_provider: Callable[[], str]
+) -> TransportFactory:
+    """Bearer-token transport factory for a resolved AgentCore endpoint."""
+    return _factory(url, jwt_auth(access_token_provider))
+
+
+def no_auth_transport(url: str) -> TransportFactory:
+    """Plain-HTTP transport factory — for local dev."""
+    return _factory(url, plain_auth())
 "
 `;
 
@@ -141,6 +175,61 @@ class InventoryMcpClient:
                 "No connected MCP server runtime named 'InventoryMcp' found in runtime configuration."
             )
         return AgentCoreMCPClient.with_iam_auth(agent_runtime_arn)
+"
+`;
+
+exports[`py#agent#mcp-connection generator > should match snapshot for generated files > session.py 1`] = `
+"from collections.abc import Callable
+
+import httpx
+
+from ..session_context import get_current_session_id
+from .sigv4 import SigV4HTTPXAuth
+
+SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+
+
+class SessionHeaderAuth(httpx.Auth):
+    """Stamps the AgentCore session header from the current async context,
+    then delegates to an optional inner auth (e.g. SigV4)."""
+
+    requires_request_body = True
+    requires_response_body = True
+
+    def __init__(self, inner: httpx.Auth | None = None):
+        self._inner = inner
+
+    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
+        sid = get_current_session_id()
+        if sid:
+            request.headers[SESSION_HEADER] = sid
+        if self._inner is None:
+            yield request
+            return
+        yield from self._inner.auth_flow(request)
+
+
+def sigv4_auth(
+    credentials, region: str, service: str = "bedrock-agentcore"
+) -> httpx.Auth:
+    """Session-forwarding SigV4 auth (per-request, body-aware)."""
+    return SessionHeaderAuth(SigV4HTTPXAuth(credentials, service, region))
+
+
+def jwt_auth(access_token_provider: Callable[[], str]) -> httpx.Auth:
+    """Session-forwarding bearer-token auth."""
+
+    class _Bearer(httpx.Auth):
+        def auth_flow(self, request: httpx.Request):
+            request.headers["Authorization"] = f"Bearer {access_token_provider()}"
+            yield request
+
+    return SessionHeaderAuth(_Bearer())
+
+
+def plain_auth() -> httpx.Auth:
+    """Session-forwarding plain auth — for local dev."""
+    return SessionHeaderAuth()
 "
 `;
 

--- a/packages/nx-plugin/src/py/agent/mcp-connection/files/agent-connection/app/__mcpServerSnakeCase___client.py.template
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/files/agent-connection/app/__mcpServerSnakeCase___client.py.template
@@ -2,7 +2,9 @@ import os
 
 from strands.tools.mcp.mcp_client import MCPClient
 
-from <%- agentConnectionModuleName %>.core.agentcore_mcp_client import AgentCoreMCPClient
+from <%- agentConnectionModuleName %>.core.strands_agentcore_mcp_client import (
+    StrandsAgentCoreMCPClient,
+)
 from <%- agentConnectionModuleName %>.core.runtime_config import (
     get_agentcore_runtime_config,
 )
@@ -14,7 +16,7 @@ class <%- mcpServerClassName %>Client:
     @staticmethod
     def create() -> MCPClient:
         if os.environ.get("SERVE_LOCAL") == "true":
-            return AgentCoreMCPClient.without_auth(
+            return StrandsAgentCoreMCPClient.without_auth(
                 "http://localhost:<%- mcpServerPort %>/mcp"
             )
         config = get_agentcore_runtime_config()
@@ -25,4 +27,4 @@ class <%- mcpServerClassName %>Client:
             raise RuntimeError(
                 "No connected MCP server runtime named '<%- mcpServerClassName %>' found in runtime configuration."
             )
-        return AgentCoreMCPClient.with_iam_auth(agent_runtime_arn)
+        return StrandsAgentCoreMCPClient.with_iam_auth(agent_runtime_arn)

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
@@ -159,6 +159,23 @@ dependencies = ["strands-agents"]
       ),
     ).toBe(true);
 
+    // Check the framework-agnostic transport layer was generated
+    expect(
+      tree.exists(
+        'packages/common/agent_connection/proj_agent_connection/core/agentcore_mcp_transport.py',
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        'packages/common/agent_connection/proj_agent_connection/core/agentcore_transport.py',
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        'packages/common/agent_connection/proj_agent_connection/core/auth/session.py',
+      ),
+    ).toBe(true);
+
     // Check per-connection client was generated in the shared project
     expect(
       tree.exists(
@@ -496,6 +513,24 @@ dependencies = ["strands-agents"]
       'utf-8',
     );
     expect(agentCoreMcpClient).toMatchSnapshot('agentcore_mcp_client.py');
+
+    const agentCoreMcpTransport = tree.read(
+      'packages/common/agent_connection/proj_agent_connection/core/agentcore_mcp_transport.py',
+      'utf-8',
+    );
+    expect(agentCoreMcpTransport).toMatchSnapshot('agentcore_mcp_transport.py');
+
+    const agentCoreTransport = tree.read(
+      'packages/common/agent_connection/proj_agent_connection/core/agentcore_transport.py',
+      'utf-8',
+    );
+    expect(agentCoreTransport).toMatchSnapshot('agentcore_transport.py');
+
+    const sessionAuth = tree.read(
+      'packages/common/agent_connection/proj_agent_connection/core/auth/session.py',
+      'utf-8',
+    );
+    expect(sessionAuth).toMatchSnapshot('session.py');
 
     const initPy = tree.read(
       'packages/common/agent_connection/proj_agent_connection/__init__.py',

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
@@ -152,10 +152,10 @@ dependencies = ["strands-agents"]
       true,
     );
 
-    // Check core agentcore_mcp_client.py was generated
+    // Check core strands_agentcore_mcp_client.py was generated
     expect(
       tree.exists(
-        'packages/common/agent_connection/proj_agent_connection/core/agentcore_mcp_client.py',
+        'packages/common/agent_connection/proj_agent_connection/core/strands_agentcore_mcp_client.py',
       ),
     ).toBe(true);
 
@@ -508,11 +508,13 @@ dependencies = ["strands-agents"]
     );
     expect(clientFile).toMatchSnapshot('inventory_mcp_client.py');
 
-    const agentCoreMcpClient = tree.read(
-      'packages/common/agent_connection/proj_agent_connection/core/agentcore_mcp_client.py',
+    const strandsAgentCoreMcpClient = tree.read(
+      'packages/common/agent_connection/proj_agent_connection/core/strands_agentcore_mcp_client.py',
       'utf-8',
     );
-    expect(agentCoreMcpClient).toMatchSnapshot('agentcore_mcp_client.py');
+    expect(strandsAgentCoreMcpClient).toMatchSnapshot(
+      'strands_agentcore_mcp_client.py',
+    );
 
     const agentCoreMcpTransport = tree.read(
       'packages/common/agent_connection/proj_agent_connection/core/agentcore_mcp_transport.py',

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/files/agent-connection/app/__gatewayKebabCase__-client.ts.template
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/files/agent-connection/app/__gatewayKebabCase__-client.ts.template
@@ -1,5 +1,5 @@
 import { McpClient } from '@strands-agents/sdk';
-import { AgentCoreGatewayMcpClient } from '../core/agentcore-gateway-mcp-client.js';
+import { StrandsAgentCoreGatewayMcpClient } from '../core/strands-agentcore-gateway-mcp-client.js';
 import { getAgentCoreRuntimeConfig } from '../core/runtime-config.js';
 
 /**
@@ -14,7 +14,7 @@ import { getAgentCoreRuntimeConfig } from '../core/runtime-config.js';
 export class <%- gatewayClassName %>Client {
   static async create(): Promise<McpClient> {
     if (process.env.SERVE_LOCAL === 'true') {
-      return AgentCoreGatewayMcpClient.withoutAuth({
+      return StrandsAgentCoreGatewayMcpClient.withoutAuth({
         gatewayUrl: 'http://localhost:<%- gatewayPort %>/mcp',
       });
     }
@@ -25,6 +25,6 @@ export class <%- gatewayClassName %>Client {
         `No connected gateway named '<%- gatewayClassName %>' found in runtime configuration.`,
       );
     }
-    return AgentCoreGatewayMcpClient.withIamAuth({ gatewayUrl });
+    return StrandsAgentCoreGatewayMcpClient.withIamAuth({ gatewayUrl });
   }
 }

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
@@ -105,7 +105,7 @@ export const getAgent = async (sessionId: string) =>
     );
     expect(
       tree.exists(
-        'packages/common/agent-connection/src/core/agentcore-gateway-mcp-client.ts',
+        'packages/common/agent-connection/src/core/strands-agentcore-gateway-mcp-client.ts',
       ),
     ).toBe(true);
     // Framework-agnostic transport layer shared with the MCP client

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
@@ -108,6 +108,22 @@ export const getAgent = async (sessionId: string) =>
         'packages/common/agent-connection/src/core/agentcore-gateway-mcp-client.ts',
       ),
     ).toBe(true);
+    // Framework-agnostic transport layer shared with the MCP client
+    expect(
+      tree.exists(
+        'packages/common/agent-connection/src/core/agentcore-gateway-mcp-transport.ts',
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        'packages/common/agent-connection/src/core/agentcore-transport.ts',
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        'packages/common/agent-connection/src/core/agentcore-fetch.ts',
+      ),
+    ).toBe(true);
     expect(
       tree.exists(
         'packages/common/agent-connection/src/app/my-gateway-client.ts',

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -67,41 +67,6 @@ export const createPlainFetch = (): typeof fetch => withSessionHeader(fetch);
 "
 `;
 
-exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-mcp-client.ts 1`] = `
-"import { McpClient } from '@strands-agents/sdk';
-import {
-  AgentCoreMcpTransport,
-  type AgentCoreMcpTransportIamOptions,
-  type AgentCoreMcpTransportJwtOptions,
-  type AgentCoreMcpTransportNoAuthOptions,
-} from './agentcore-mcp-transport.js';
-
-/** Strands MCP clients for a Bedrock AgentCore runtime. */
-export class AgentCoreMcpClient {
-  /** SigV4-authenticated client for a Bedrock AgentCore runtime. */
-  static withIamAuth(options: AgentCoreMcpTransportIamOptions): McpClient {
-    return new McpClient({
-      transport: AgentCoreMcpTransport.withIamAuth(options),
-    });
-  }
-
-  /** Bearer-authenticated client for a Bedrock AgentCore runtime. */
-  static withJwtAuth(options: AgentCoreMcpTransportJwtOptions): McpClient {
-    return new McpClient({
-      transport: AgentCoreMcpTransport.withJwtAuth(options),
-    });
-  }
-
-  /** For local dev — plain HTTP, no auth. */
-  static withoutAuth(options: AgentCoreMcpTransportNoAuthOptions): McpClient {
-    return new McpClient({
-      transport: AgentCoreMcpTransport.withoutAuth(options),
-    });
-  }
-}
-"
-`;
-
 exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-mcp-transport.ts 1`] = `
 "import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -226,14 +191,14 @@ export const noAuthTransport = (options: {
 
 exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > inventory-mcp-client.ts 1`] = `
 "import { McpClient } from '@strands-agents/sdk';
-import { AgentCoreMcpClient } from '../core/agentcore-mcp-client.js';
+import { StrandsAgentCoreMcpClient } from '../core/strands-agentcore-mcp-client.js';
 import { getAgentCoreRuntimeConfig } from '../core/runtime-config.js';
 
 /** Client for the InventoryMcp MCP server. */
 export class InventoryMcpClient {
   static async create(): Promise<McpClient> {
     if (process.env.SERVE_LOCAL === 'true') {
-      return AgentCoreMcpClient.withoutAuth({
+      return StrandsAgentCoreMcpClient.withoutAuth({
         url: 'http://localhost:8082/mcp',
       });
     }
@@ -244,7 +209,42 @@ export class InventoryMcpClient {
         \`No connected MCP server runtime named 'InventoryMcp' found in runtime configuration.\`,
       );
     }
-    return AgentCoreMcpClient.withIamAuth({ agentRuntimeArn });
+    return StrandsAgentCoreMcpClient.withIamAuth({ agentRuntimeArn });
+  }
+}
+"
+`;
+
+exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > strands-agentcore-mcp-client.ts 1`] = `
+"import { McpClient } from '@strands-agents/sdk';
+import {
+  AgentCoreMcpTransport,
+  type AgentCoreMcpTransportIamOptions,
+  type AgentCoreMcpTransportJwtOptions,
+  type AgentCoreMcpTransportNoAuthOptions,
+} from './agentcore-mcp-transport.js';
+
+/** Strands MCP clients for a Bedrock AgentCore runtime. */
+export class StrandsAgentCoreMcpClient {
+  /** SigV4-authenticated client for a Bedrock AgentCore runtime. */
+  static withIamAuth(options: AgentCoreMcpTransportIamOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withIamAuth(options),
+    });
+  }
+
+  /** Bearer-authenticated client for a Bedrock AgentCore runtime. */
+  static withJwtAuth(options: AgentCoreMcpTransportJwtOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withJwtAuth(options),
+    });
+  }
+
+  /** For local dev — plain HTTP, no auth. */
+  static withoutAuth(options: AgentCoreMcpTransportNoAuthOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withoutAuth(options),
+    });
   }
 }
 "

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -9,137 +9,218 @@ export * from './core/session-context.js';
 "
 `;
 
-exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-mcp-client.ts 1`] = `
-"import { McpClient } from '@strands-agents/sdk';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { AwsClient } from 'aws4fetch';
+exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-fetch.ts 1`] = `
+"import { AwsClient } from 'aws4fetch';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getCurrentSessionId } from './session-context.js';
 
 const SESSION_HEADER = 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id';
 
-/**
- * Common options for creating an AgentCore MCP client.
- */
-export interface AgentCoreMcpClientOptions {
-  /**
-   * The ARN of the Bedrock AgentCore Runtime to connect to.
-   */
-  agentRuntimeArn: string;
-}
+/** Wrap a fetch so each request carries the current async-context session id. */
+const withSessionHeader =
+  (inner: typeof fetch): typeof fetch =>
+  async (input, init) => {
+    const headers = new Headers(init?.headers);
+    const sessionId = getCurrentSessionId();
+    if (sessionId) headers.set(SESSION_HEADER, sessionId);
+    return inner(input, { ...init, headers });
+  };
 
-/**
- * Options for creating an AgentCore MCP client with IAM authentication.
- */
-export interface AgentCoreMcpClientIamOptions
-  extends AgentCoreMcpClientOptions {
-  /**
-   * Optional AWS credential provider. If not provided, uses the default
-   * credential provider chain from the AWS SDK.
-   */
+/** Options for a SigV4-signing fetch. */
+export interface SigV4FetchOptions {
+  /** AWS region to sign for. */
+  region: string;
+  /** AWS service to sign for. Defaults to \`bedrock-agentcore\`. */
+  service?: string;
+  /** AWS credential provider; defaults to the standard provider chain. */
   credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
 }
 
-/**
- * Options for creating an AgentCore MCP client with JWT authentication.
- */
-export interface AgentCoreMcpClientJwtOptions
-  extends AgentCoreMcpClientOptions {
-  /**
-   * A function which returns the JWT access token used to authenticate.
-   */
-  accessTokenProvider: () => Promise<string>;
-}
-
-/**
- * Options for creating an MCP client with no auth (local dev).
- */
-export interface AgentCoreMcpClientNoAuthOptions {
-  /** Full URL of the local MCP endpoint. */
-  url: string;
-}
-
-interface CreateOptions {
-  url: string;
-  buildHeaders?: () => Promise<Record<string, string>>;
-  fetch?: typeof fetch;
-}
-
-/** Factory for MCP clients that forward the current async-context session. */
-export class AgentCoreMcpClient {
-  /**
-   * Construct the invocation URL for an AgentCore runtime ARN and extract
-   * the region. ARN format: arn:partition:service:region:account-id:resource
-   */
-  private static buildUrl(agentRuntimeArn: string): {
-    region: string;
-    url: string;
-  } {
-    const region = agentRuntimeArn.split(':')[3];
-    const url = \`https://bedrock-agentcore.\${region}.amazonaws.com/runtimes/\${encodeURIComponent(agentRuntimeArn)}/invocations?qualifier=DEFAULT\`;
-    return { region, url };
-  }
-
-  private static create(options: CreateOptions): McpClient {
-    const {
-      url,
-      buildHeaders = async (): Promise<Record<string, string>> => ({}),
-      fetch: customFetch,
-    } = options;
-    const fetchWithHeaders: typeof fetch = async (input, init) => {
-      const headers = new Headers(init?.headers);
-      const sessionId = getCurrentSessionId();
-      if (sessionId) headers.set(SESSION_HEADER, sessionId);
-      const extra = await buildHeaders();
-      for (const k of Object.keys(extra)) {
-        headers.set(k, extra[k]);
-      }
-      return (customFetch ?? fetch)(input, { ...init, headers });
-    };
-    const transport = new StreamableHTTPClientTransport(new URL(url), {
-      fetch: fetchWithHeaders,
+/** A fetch that signs every request with AWS SigV4 (per-request, body-aware). */
+export const createSigV4Fetch = (options: SigV4FetchOptions): typeof fetch => {
+  const { region, service = 'bedrock-agentcore' } = options;
+  const credentialProvider =
+    options.credentialProvider ?? fromNodeProviderChain();
+  const signedFetch: typeof fetch = async (...args) => {
+    const client = new AwsClient({
+      ...(await credentialProvider()),
+      service,
+      region,
     });
-    return new McpClient({ transport });
+    return client.fetch(...args);
+  };
+  return withSessionHeader(signedFetch);
+};
+
+/** A fetch that adds a bearer token from the given async provider. */
+export const createJwtFetch = (
+  accessTokenProvider: () => Promise<string>,
+): typeof fetch =>
+  withSessionHeader(async (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', \`Bearer \${await accessTokenProvider()}\`);
+    return fetch(input, { ...init, headers });
+  });
+
+/** A plain fetch (local dev) that still forwards the session id. */
+export const createPlainFetch = (): typeof fetch => withSessionHeader(fetch);
+"
+`;
+
+exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-mcp-client.ts 1`] = `
+"import { McpClient } from '@strands-agents/sdk';
+import {
+  AgentCoreMcpTransport,
+  type AgentCoreMcpTransportIamOptions,
+  type AgentCoreMcpTransportJwtOptions,
+  type AgentCoreMcpTransportNoAuthOptions,
+} from './agentcore-mcp-transport.js';
+
+/** Strands MCP clients for a Bedrock AgentCore runtime. */
+export class AgentCoreMcpClient {
+  /** SigV4-authenticated client for a Bedrock AgentCore runtime. */
+  static withIamAuth(options: AgentCoreMcpTransportIamOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withIamAuth(options),
+    });
   }
 
-  /**
-   * SigV4-authenticated client for a Bedrock AgentCore runtime.
-   */
-  static withIamAuth(options: AgentCoreMcpClientIamOptions): McpClient {
-    const { region, url } = AgentCoreMcpClient.buildUrl(
-      options.agentRuntimeArn,
-    );
-    const credentialProvider =
-      options.credentialProvider ?? fromNodeProviderChain();
-    const sigv4Fetch: typeof fetch = async (...args) => {
-      const client = new AwsClient({
-        ...(await credentialProvider()),
-        service: 'bedrock-agentcore',
-        region,
-      });
-      return client.fetch(...args);
-    };
-    return AgentCoreMcpClient.create({ url, fetch: sigv4Fetch });
-  }
-
-  /**
-   * Bearer-authenticated client for a Bedrock AgentCore runtime.
-   */
-  static withJwtAuth(options: AgentCoreMcpClientJwtOptions): McpClient {
-    const { url } = AgentCoreMcpClient.buildUrl(options.agentRuntimeArn);
-    return AgentCoreMcpClient.create({
-      url,
-      buildHeaders: async () => ({
-        Authorization: \`Bearer \${await options.accessTokenProvider()}\`,
-      }),
+  /** Bearer-authenticated client for a Bedrock AgentCore runtime. */
+  static withJwtAuth(options: AgentCoreMcpTransportJwtOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withJwtAuth(options),
     });
   }
 
   /** For local dev — plain HTTP, no auth. */
-  static withoutAuth(options: AgentCoreMcpClientNoAuthOptions): McpClient {
-    return AgentCoreMcpClient.create({ url: options.url });
+  static withoutAuth(options: AgentCoreMcpTransportNoAuthOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withoutAuth(options),
+    });
   }
 }
+"
+`;
+
+exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-mcp-transport.ts 1`] = `
+"import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import {
+  sigV4Transport,
+  jwtTransport,
+  noAuthTransport,
+} from './agentcore-transport.js';
+
+/**
+ * Options for an MCP transport with IAM authentication.
+ */
+export interface AgentCoreMcpTransportIamOptions {
+  /** The ARN of the Bedrock AgentCore Runtime to connect to. */
+  agentRuntimeArn: string;
+  /** AWS credential provider; defaults to the standard provider chain. */
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}
+
+/**
+ * Options for an MCP transport with JWT authentication.
+ */
+export interface AgentCoreMcpTransportJwtOptions {
+  /** The ARN of the Bedrock AgentCore Runtime to connect to. */
+  agentRuntimeArn: string;
+  /** A function which returns the JWT access token used to authenticate. */
+  accessTokenProvider: () => Promise<string>;
+}
+
+/**
+ * Options for an MCP transport with no auth (local dev).
+ */
+export interface AgentCoreMcpTransportNoAuthOptions {
+  /** Full URL of the local MCP endpoint. */
+  url: string;
+}
+
+/**
+ * Construct the invocation URL for an AgentCore runtime ARN and extract the
+ * region. ARN format: arn:partition:service:region:account-id:resource
+ */
+const resolve = (agentRuntimeArn: string): { region: string; url: string } => {
+  const region = agentRuntimeArn.split(':')[3];
+  const url = \`https://bedrock-agentcore.\${region}.amazonaws.com/runtimes/\${encodeURIComponent(agentRuntimeArn)}/invocations?qualifier=DEFAULT\`;
+  return { region, url };
+};
+
+/** Factory for MCP transports that connect to a Bedrock AgentCore runtime. */
+export class AgentCoreMcpTransport {
+  /** SigV4-authenticated transport for a Bedrock AgentCore runtime. */
+  static withIamAuth(
+    options: AgentCoreMcpTransportIamOptions,
+  ): StreamableHTTPClientTransport {
+    return sigV4Transport({
+      ...resolve(options.agentRuntimeArn),
+      credentialProvider: options.credentialProvider,
+    });
+  }
+
+  /** Bearer-authenticated transport for a Bedrock AgentCore runtime. */
+  static withJwtAuth(
+    options: AgentCoreMcpTransportJwtOptions,
+  ): StreamableHTTPClientTransport {
+    return jwtTransport({
+      url: resolve(options.agentRuntimeArn).url,
+      accessTokenProvider: options.accessTokenProvider,
+    });
+  }
+
+  /** For local dev — plain HTTP, no auth. */
+  static withoutAuth(
+    options: AgentCoreMcpTransportNoAuthOptions,
+  ): StreamableHTTPClientTransport {
+    return noAuthTransport({ url: options.url });
+  }
+}
+"
+`;
+
+exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agentcore-transport.ts 1`] = `
+"import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import {
+  createSigV4Fetch,
+  createJwtFetch,
+  createPlainFetch,
+} from './agentcore-fetch.js';
+
+const build = (
+  url: string,
+  fetchFn: typeof fetch,
+): StreamableHTTPClientTransport =>
+  new StreamableHTTPClientTransport(new URL(url), { fetch: fetchFn });
+
+/** SigV4-signed transport for a resolved AgentCore endpoint. */
+export const sigV4Transport = (options: {
+  region: string;
+  url: string;
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}): StreamableHTTPClientTransport =>
+  build(
+    options.url,
+    createSigV4Fetch({
+      region: options.region,
+      credentialProvider: options.credentialProvider,
+    }),
+  );
+
+/** Bearer-token transport for a resolved AgentCore endpoint. */
+export const jwtTransport = (options: {
+  url: string;
+  accessTokenProvider: () => Promise<string>;
+}): StreamableHTTPClientTransport =>
+  build(options.url, createJwtFetch(options.accessTokenProvider));
+
+/** Plain-HTTP transport — for local dev. */
+export const noAuthTransport = (options: {
+  url: string;
+}): StreamableHTTPClientTransport => build(options.url, createPlainFetch());
 "
 `;
 

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/files/agent-connection/app/__mcpServerKebabCase__-client.ts.template
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/files/agent-connection/app/__mcpServerKebabCase__-client.ts.template
@@ -1,12 +1,12 @@
 import { McpClient } from '@strands-agents/sdk';
-import { AgentCoreMcpClient } from '../core/agentcore-mcp-client.js';
+import { StrandsAgentCoreMcpClient } from '../core/strands-agentcore-mcp-client.js';
 import { getAgentCoreRuntimeConfig } from '../core/runtime-config.js';
 
 /** Client for the <%- mcpServerClassName %> MCP server. */
 export class <%- mcpServerClassName %>Client {
   static async create(): Promise<McpClient> {
     if (process.env.SERVE_LOCAL === 'true') {
-      return AgentCoreMcpClient.withoutAuth({
+      return StrandsAgentCoreMcpClient.withoutAuth({
         url: 'http://localhost:<%- mcpServerPort %>/mcp',
       });
     }
@@ -17,6 +17,6 @@ export class <%- mcpServerClassName %>Client {
         `No connected MCP server runtime named '<%- mcpServerClassName %>' found in runtime configuration.`,
       );
     }
-    return AgentCoreMcpClient.withIamAuth({ agentRuntimeArn });
+    return StrandsAgentCoreMcpClient.withIamAuth({ agentRuntimeArn });
   }
 }

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.spec.ts
@@ -138,6 +138,23 @@ export const getAgent = async (sessionId: string) =>
       ),
     ).toBe(true);
 
+    // Check the framework-agnostic transport layer was generated in core/
+    expect(
+      tree.exists(
+        'packages/common/agent-connection/src/core/agentcore-mcp-transport.ts',
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        'packages/common/agent-connection/src/core/agentcore-transport.ts',
+      ),
+    ).toBe(true);
+    expect(
+      tree.exists(
+        'packages/common/agent-connection/src/core/agentcore-fetch.ts',
+      ),
+    ).toBe(true);
+
     // Check per-connection client was generated in app/
     expect(
       tree.exists(
@@ -447,6 +464,24 @@ export const getAgent = async (sessionId: string) => {
       'utf-8',
     );
     expect(agentCoreMcpClient).toMatchSnapshot('agentcore-mcp-client.ts');
+
+    const agentCoreMcpTransport = tree.read(
+      'packages/common/agent-connection/src/core/agentcore-mcp-transport.ts',
+      'utf-8',
+    );
+    expect(agentCoreMcpTransport).toMatchSnapshot('agentcore-mcp-transport.ts');
+
+    const agentCoreTransport = tree.read(
+      'packages/common/agent-connection/src/core/agentcore-transport.ts',
+      'utf-8',
+    );
+    expect(agentCoreTransport).toMatchSnapshot('agentcore-transport.ts');
+
+    const agentCoreFetch = tree.read(
+      'packages/common/agent-connection/src/core/agentcore-fetch.ts',
+      'utf-8',
+    );
+    expect(agentCoreFetch).toMatchSnapshot('agentcore-fetch.ts');
 
     const inventoryMcpClient = tree.read(
       'packages/common/agent-connection/src/app/inventory-mcp-client.ts',

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.spec.ts
@@ -131,10 +131,10 @@ export const getAgent = async (sessionId: string) =>
       true,
     );
 
-    // Check agentcore-mcp-client.ts was generated in core/
+    // Check strands-agentcore-mcp-client.ts was generated in core/
     expect(
       tree.exists(
-        'packages/common/agent-connection/src/core/agentcore-mcp-client.ts',
+        'packages/common/agent-connection/src/core/strands-agentcore-mcp-client.ts',
       ),
     ).toBe(true);
 
@@ -459,11 +459,13 @@ export const getAgent = async (sessionId: string) => {
       },
     });
 
-    const agentCoreMcpClient = tree.read(
-      'packages/common/agent-connection/src/core/agentcore-mcp-client.ts',
+    const strandsAgentCoreMcpClient = tree.read(
+      'packages/common/agent-connection/src/core/strands-agentcore-mcp-client.ts',
       'utf-8',
     );
-    expect(agentCoreMcpClient).toMatchSnapshot('agentcore-mcp-client.ts');
+    expect(strandsAgentCoreMcpClient).toMatchSnapshot(
+      'strands-agentcore-mcp-client.ts',
+    );
 
     const agentCoreMcpTransport = tree.read(
       'packages/common/agent-connection/src/core/agentcore-mcp-transport.ts',

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -132,18 +132,35 @@ export async function ensureTypeScriptAgentConnectionProject(
 }
 
 /**
- * Emit one of the TypeScript core client templates (mcp or a2a) into the
- * agent-connection project's `src/core/` directory. Safe to call multiple
+ * Emit one of the TypeScript core client templates (mcp / a2a / gateway) into
+ * the agent-connection project's `src/core/` directory. Safe to call multiple
  * times — `KeepExisting` preserves customised files.
+ *
+ * The MCP and gateway clients share the auth + transport helpers in
+ * `core-shared`, so those are emitted alongside them.
  */
 export function addTypeScriptCoreClient(
   tree: Tree,
   kind: keyof typeof TS_CORE_TEMPLATES,
 ): void {
+  const coreDir = joinPathFragments(
+    AGENT_CONNECTION_PROJECT_DIR,
+    'src',
+    'core',
+  );
+  if (kind === 'mcp' || kind === 'gateway') {
+    generateFiles(
+      tree,
+      joinPathFragments(__dirname, 'files', 'core-shared'),
+      coreDir,
+      {},
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
+    );
+  }
   generateFiles(
     tree,
     joinPathFragments(__dirname, 'files', TS_CORE_TEMPLATES[kind]),
-    joinPathFragments(AGENT_CONNECTION_PROJECT_DIR, 'src', 'core'),
+    coreDir,
     {},
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
@@ -232,8 +249,11 @@ export async function ensurePythonAgentConnectionProject(
 }
 
 /**
- * Emit a Python core client template (mcp / a2a / shared auth) into the
- * agent-connection project's core directory.
+ * Emit a Python core client template (mcp / a2a / gateway / shared auth) into
+ * the agent-connection project's core directory.
+ *
+ * The MCP and gateway clients share the transport helpers in `py-core-shared`,
+ * so those are emitted alongside them.
  */
 export function addPythonCoreClient(
   tree: Tree,
@@ -242,6 +262,15 @@ export function addPythonCoreClient(
   const projectDir = getPythonAgentConnectionProjectDir(tree);
   const moduleName = getPythonAgentConnectionModuleName(tree);
   const coreDir = joinPathFragments(projectDir, moduleName, 'core');
+  if (kind === 'mcp' || kind === 'gateway') {
+    generateFiles(
+      tree,
+      joinPathFragments(__dirname, 'files', 'py-core-shared'),
+      coreDir,
+      {},
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
+    );
+  }
   generateFiles(
     tree,
     joinPathFragments(__dirname, 'files', PY_CORE_TEMPLATES[kind]),

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-gateway/agentcore-gateway-mcp-client.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-gateway/agentcore-gateway-mcp-client.ts.template
@@ -1,78 +1,26 @@
 import { McpClient } from '@strands-agents/sdk';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { AwsClient } from 'aws4fetch';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { getCurrentSessionId } from './session-context.js';
-
-const SESSION_HEADER = 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id';
-
-export interface AgentCoreGatewayMcpClientIamOptions {
-  /**
-   * The MCP URL of the AgentCore Gateway, of the form
-   * https://<gatewayId>.gateway.bedrock-agentcore.<region>.amazonaws.com/mcp
-   */
-  gatewayUrl: string;
-  /** AWS region override; by default parsed from `gatewayUrl`. */
-  region?: string;
-  /** AWS credential provider; defaults to the standard provider chain. */
-  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
-}
+import {
+  AgentCoreGatewayMcpTransport,
+  type AgentCoreGatewayMcpTransportIamOptions,
+} from './agentcore-gateway-mcp-transport.js';
 
 /**
- * Factory for MCP clients that connect to an AgentCore Gateway. Forwards the
- * current async-context session via the AgentCore session header, which the
- * gateway propagates to downstream MCP server targets.
+ * Strands MCP clients that connect to an AgentCore Gateway.
  */
 export class AgentCoreGatewayMcpClient {
   /** Create a gateway MCP client authenticated with IAM SigV4. */
-  static withIamAuth(options: AgentCoreGatewayMcpClientIamOptions): McpClient {
-    const credentialProvider =
-      options.credentialProvider ?? fromNodeProviderChain();
-    const region =
-      options.region ?? parseRegionFromGatewayUrl(options.gatewayUrl);
-
-    const sigv4Fetch: typeof fetch = async (input, init) => {
-      const client = new AwsClient({
-        ...(await credentialProvider()),
-        service: 'bedrock-agentcore',
-        region,
-      });
-      return client.fetch(input, {
-        ...init,
-        headers: withSessionHeader(init?.headers),
-      });
-    };
-    return AgentCoreGatewayMcpClient.create(options.gatewayUrl, sigv4Fetch);
+  static withIamAuth(
+    options: AgentCoreGatewayMcpTransportIamOptions,
+  ): McpClient {
+    return new McpClient({
+      transport: AgentCoreGatewayMcpTransport.withIamAuth(options),
+    });
   }
 
   /** Plain-HTTP gateway client, for the local gateway started by serve-local. */
   static withoutAuth(options: { gatewayUrl: string }): McpClient {
-    const plainFetch: typeof fetch = async (input, init) =>
-      fetch(input, { ...init, headers: withSessionHeader(init?.headers) });
-    return AgentCoreGatewayMcpClient.create(options.gatewayUrl, plainFetch);
-  }
-
-  private static create(gatewayUrl: string, fetchFn: typeof fetch): McpClient {
-    const transport = new StreamableHTTPClientTransport(new URL(gatewayUrl), {
-      fetch: fetchFn,
+    return new McpClient({
+      transport: AgentCoreGatewayMcpTransport.withoutAuth(options),
     });
-    return new McpClient({ transport });
   }
 }
-
-const withSessionHeader = (init?: RequestInit['headers']): Headers => {
-  const headers = new Headers(init);
-  const sessionId = getCurrentSessionId();
-  if (sessionId) headers.set(SESSION_HEADER, sessionId);
-  return headers;
-};
-
-const parseRegionFromGatewayUrl = (gatewayUrl: string): string => {
-  const match = /\.bedrock-agentcore\.([^.]+)\.amazonaws\.com/.exec(gatewayUrl);
-  if (!match) {
-    throw new Error(
-      `Cannot determine region from gateway URL '${gatewayUrl}'. Pass region explicitly.`,
-    );
-  }
-  return match[1];
-};

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-gateway/agentcore-gateway-mcp-transport.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-gateway/agentcore-gateway-mcp-transport.ts.template
@@ -1,0 +1,50 @@
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { sigV4Transport, noAuthTransport } from './agentcore-transport.js';
+
+export interface AgentCoreGatewayMcpTransportIamOptions {
+  /**
+   * The MCP URL of the AgentCore Gateway, of the form
+   * https://<gatewayId>.gateway.bedrock-agentcore.<region>.amazonaws.com/mcp
+   */
+  gatewayUrl: string;
+  /** AWS region override; by default parsed from `gatewayUrl`. */
+  region?: string;
+  /** AWS credential provider; defaults to the standard provider chain. */
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}
+
+const parseRegionFromGatewayUrl = (gatewayUrl: string): string => {
+  const match = /\.bedrock-agentcore\.([^.]+)\.amazonaws\.com/.exec(gatewayUrl);
+  if (!match) {
+    throw new Error(
+      `Cannot determine region from gateway URL '${gatewayUrl}'. Pass region explicitly.`,
+    );
+  }
+  return match[1];
+};
+
+/**
+ * Factory for MCP transports that connect to an AgentCore Gateway. Forwards the
+ * current async-context session via the AgentCore session header, which the
+ * gateway propagates to downstream MCP server targets.
+ */
+export class AgentCoreGatewayMcpTransport {
+  /** Create a gateway MCP transport authenticated with IAM SigV4. */
+  static withIamAuth(
+    options: AgentCoreGatewayMcpTransportIamOptions,
+  ): StreamableHTTPClientTransport {
+    return sigV4Transport({
+      region: options.region ?? parseRegionFromGatewayUrl(options.gatewayUrl),
+      url: options.gatewayUrl,
+      credentialProvider: options.credentialProvider,
+    });
+  }
+
+  /** Plain-HTTP gateway transport, for the local gateway started by serve-local. */
+  static withoutAuth(options: {
+    gatewayUrl: string;
+  }): StreamableHTTPClientTransport {
+    return noAuthTransport({ url: options.gatewayUrl });
+  }
+}

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-gateway/strands-agentcore-gateway-mcp-client.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-gateway/strands-agentcore-gateway-mcp-client.ts.template
@@ -7,7 +7,7 @@ import {
 /**
  * Strands MCP clients that connect to an AgentCore Gateway.
  */
-export class AgentCoreGatewayMcpClient {
+export class StrandsAgentCoreGatewayMcpClient {
   /** Create a gateway MCP client authenticated with IAM SigV4. */
   static withIamAuth(
     options: AgentCoreGatewayMcpTransportIamOptions,

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-client.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-client.ts.template
@@ -1,128 +1,27 @@
 import { McpClient } from '@strands-agents/sdk';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { AwsClient } from 'aws4fetch';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { getCurrentSessionId } from './session-context.js';
+import {
+  AgentCoreMcpTransport,
+  type AgentCoreMcpTransportIamOptions,
+  type AgentCoreMcpTransportJwtOptions,
+  type AgentCoreMcpTransportNoAuthOptions,
+} from './agentcore-mcp-transport.js';
 
-const SESSION_HEADER = 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id';
-
-/**
- * Common options for creating an AgentCore MCP client.
- */
-export interface AgentCoreMcpClientOptions {
-  /**
-   * The ARN of the Bedrock AgentCore Runtime to connect to.
-   */
-  agentRuntimeArn: string;
-}
-
-/**
- * Options for creating an AgentCore MCP client with IAM authentication.
- */
-export interface AgentCoreMcpClientIamOptions
-  extends AgentCoreMcpClientOptions {
-  /**
-   * Optional AWS credential provider. If not provided, uses the default
-   * credential provider chain from the AWS SDK.
-   */
-  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
-}
-
-/**
- * Options for creating an AgentCore MCP client with JWT authentication.
- */
-export interface AgentCoreMcpClientJwtOptions
-  extends AgentCoreMcpClientOptions {
-  /**
-   * A function which returns the JWT access token used to authenticate.
-   */
-  accessTokenProvider: () => Promise<string>;
-}
-
-/**
- * Options for creating an MCP client with no auth (local dev).
- */
-export interface AgentCoreMcpClientNoAuthOptions {
-  /** Full URL of the local MCP endpoint. */
-  url: string;
-}
-
-interface CreateOptions {
-  url: string;
-  buildHeaders?: () => Promise<Record<string, string>>;
-  fetch?: typeof fetch;
-}
-
-/** Factory for MCP clients that forward the current async-context session. */
+/** Strands MCP clients for a Bedrock AgentCore runtime. */
 export class AgentCoreMcpClient {
-  /**
-   * Construct the invocation URL for an AgentCore runtime ARN and extract
-   * the region. ARN format: arn:partition:service:region:account-id:resource
-   */
-  private static buildUrl(agentRuntimeArn: string): {
-    region: string;
-    url: string;
-  } {
-    const region = agentRuntimeArn.split(':')[3];
-    const url = `https://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodeURIComponent(agentRuntimeArn)}/invocations?qualifier=DEFAULT`;
-    return { region, url };
+  /** SigV4-authenticated client for a Bedrock AgentCore runtime. */
+  static withIamAuth(options: AgentCoreMcpTransportIamOptions): McpClient {
+    return new McpClient({ transport: AgentCoreMcpTransport.withIamAuth(options) });
   }
 
-  private static create(options: CreateOptions): McpClient {
-    const {
-      url,
-      buildHeaders = async (): Promise<Record<string, string>> => ({}),
-      fetch: customFetch,
-    } = options;
-    const fetchWithHeaders: typeof fetch = async (input, init) => {
-      const headers = new Headers(init?.headers);
-      const sessionId = getCurrentSessionId();
-      if (sessionId) headers.set(SESSION_HEADER, sessionId);
-      const extra = await buildHeaders();
-      for (const k of Object.keys(extra)) {
-        headers.set(k, extra[k]);
-      }
-      return (customFetch ?? fetch)(input, { ...init, headers });
-    };
-    const transport = new StreamableHTTPClientTransport(new URL(url), {
-      fetch: fetchWithHeaders,
-    });
-    return new McpClient({ transport });
-  }
-
-  /**
-   * SigV4-authenticated client for a Bedrock AgentCore runtime.
-   */
-  static withIamAuth(options: AgentCoreMcpClientIamOptions): McpClient {
-    const { region, url } = AgentCoreMcpClient.buildUrl(options.agentRuntimeArn);
-    const credentialProvider =
-      options.credentialProvider ?? fromNodeProviderChain();
-    const sigv4Fetch: typeof fetch = async (...args) => {
-      const client = new AwsClient({
-        ...(await credentialProvider()),
-        service: 'bedrock-agentcore',
-        region,
-      });
-      return client.fetch(...args);
-    };
-    return AgentCoreMcpClient.create({ url, fetch: sigv4Fetch });
-  }
-
-  /**
-   * Bearer-authenticated client for a Bedrock AgentCore runtime.
-   */
-  static withJwtAuth(options: AgentCoreMcpClientJwtOptions): McpClient {
-    const { url } = AgentCoreMcpClient.buildUrl(options.agentRuntimeArn);
-    return AgentCoreMcpClient.create({
-      url,
-      buildHeaders: async () => ({
-        Authorization: `Bearer ${await options.accessTokenProvider()}`,
-      }),
-    });
+  /** Bearer-authenticated client for a Bedrock AgentCore runtime. */
+  static withJwtAuth(options: AgentCoreMcpTransportJwtOptions): McpClient {
+    return new McpClient({ transport: AgentCoreMcpTransport.withJwtAuth(options) });
   }
 
   /** For local dev — plain HTTP, no auth. */
-  static withoutAuth(options: AgentCoreMcpClientNoAuthOptions): McpClient {
-    return AgentCoreMcpClient.create({ url: options.url });
+  static withoutAuth(options: AgentCoreMcpTransportNoAuthOptions): McpClient {
+    return new McpClient({
+      transport: AgentCoreMcpTransport.withoutAuth(options),
+    });
   }
 }

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-transport.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/agentcore-mcp-transport.ts.template
@@ -1,0 +1,75 @@
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import {
+  sigV4Transport,
+  jwtTransport,
+  noAuthTransport,
+} from './agentcore-transport.js';
+
+/**
+ * Options for an MCP transport with IAM authentication.
+ */
+export interface AgentCoreMcpTransportIamOptions {
+  /** The ARN of the Bedrock AgentCore Runtime to connect to. */
+  agentRuntimeArn: string;
+  /** AWS credential provider; defaults to the standard provider chain. */
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}
+
+/**
+ * Options for an MCP transport with JWT authentication.
+ */
+export interface AgentCoreMcpTransportJwtOptions {
+  /** The ARN of the Bedrock AgentCore Runtime to connect to. */
+  agentRuntimeArn: string;
+  /** A function which returns the JWT access token used to authenticate. */
+  accessTokenProvider: () => Promise<string>;
+}
+
+/**
+ * Options for an MCP transport with no auth (local dev).
+ */
+export interface AgentCoreMcpTransportNoAuthOptions {
+  /** Full URL of the local MCP endpoint. */
+  url: string;
+}
+
+/**
+ * Construct the invocation URL for an AgentCore runtime ARN and extract the
+ * region. ARN format: arn:partition:service:region:account-id:resource
+ */
+const resolve = (agentRuntimeArn: string): { region: string; url: string } => {
+  const region = agentRuntimeArn.split(':')[3];
+  const url = `https://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodeURIComponent(agentRuntimeArn)}/invocations?qualifier=DEFAULT`;
+  return { region, url };
+};
+
+/** Factory for MCP transports that connect to a Bedrock AgentCore runtime. */
+export class AgentCoreMcpTransport {
+  /** SigV4-authenticated transport for a Bedrock AgentCore runtime. */
+  static withIamAuth(
+    options: AgentCoreMcpTransportIamOptions,
+  ): StreamableHTTPClientTransport {
+    return sigV4Transport({
+      ...resolve(options.agentRuntimeArn),
+      credentialProvider: options.credentialProvider,
+    });
+  }
+
+  /** Bearer-authenticated transport for a Bedrock AgentCore runtime. */
+  static withJwtAuth(
+    options: AgentCoreMcpTransportJwtOptions,
+  ): StreamableHTTPClientTransport {
+    return jwtTransport({
+      url: resolve(options.agentRuntimeArn).url,
+      accessTokenProvider: options.accessTokenProvider,
+    });
+  }
+
+  /** For local dev — plain HTTP, no auth. */
+  static withoutAuth(
+    options: AgentCoreMcpTransportNoAuthOptions,
+  ): StreamableHTTPClientTransport {
+    return noAuthTransport({ url: options.url });
+  }
+}

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/strands-agentcore-mcp-client.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-mcp/strands-agentcore-mcp-client.ts.template
@@ -7,7 +7,7 @@ import {
 } from './agentcore-mcp-transport.js';
 
 /** Strands MCP clients for a Bedrock AgentCore runtime. */
-export class AgentCoreMcpClient {
+export class StrandsAgentCoreMcpClient {
   /** SigV4-authenticated client for a Bedrock AgentCore runtime. */
   static withIamAuth(options: AgentCoreMcpTransportIamOptions): McpClient {
     return new McpClient({ transport: AgentCoreMcpTransport.withIamAuth(options) });

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-shared/agentcore-fetch.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-shared/agentcore-fetch.ts.template
@@ -1,0 +1,54 @@
+import { AwsClient } from 'aws4fetch';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { getCurrentSessionId } from './session-context.js';
+
+const SESSION_HEADER = 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id';
+
+/** Wrap a fetch so each request carries the current async-context session id. */
+const withSessionHeader =
+  (inner: typeof fetch): typeof fetch =>
+  async (input, init) => {
+    const headers = new Headers(init?.headers);
+    const sessionId = getCurrentSessionId();
+    if (sessionId) headers.set(SESSION_HEADER, sessionId);
+    return inner(input, { ...init, headers });
+  };
+
+/** Options for a SigV4-signing fetch. */
+export interface SigV4FetchOptions {
+  /** AWS region to sign for. */
+  region: string;
+  /** AWS service to sign for. Defaults to `bedrock-agentcore`. */
+  service?: string;
+  /** AWS credential provider; defaults to the standard provider chain. */
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}
+
+/** A fetch that signs every request with AWS SigV4 (per-request, body-aware). */
+export const createSigV4Fetch = (options: SigV4FetchOptions): typeof fetch => {
+  const { region, service = 'bedrock-agentcore' } = options;
+  const credentialProvider =
+    options.credentialProvider ?? fromNodeProviderChain();
+  const signedFetch: typeof fetch = async (...args) => {
+    const client = new AwsClient({
+      ...(await credentialProvider()),
+      service,
+      region,
+    });
+    return client.fetch(...args);
+  };
+  return withSessionHeader(signedFetch);
+};
+
+/** A fetch that adds a bearer token from the given async provider. */
+export const createJwtFetch = (
+  accessTokenProvider: () => Promise<string>,
+): typeof fetch =>
+  withSessionHeader(async (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Bearer ${await accessTokenProvider()}`);
+    return fetch(input, { ...init, headers });
+  });
+
+/** A plain fetch (local dev) that still forwards the session id. */
+export const createPlainFetch = (): typeof fetch => withSessionHeader(fetch);

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-shared/agentcore-transport.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-shared/agentcore-transport.ts.template
@@ -1,0 +1,39 @@
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import {
+  createSigV4Fetch,
+  createJwtFetch,
+  createPlainFetch,
+} from './agentcore-fetch.js';
+
+const build = (
+  url: string,
+  fetchFn: typeof fetch,
+): StreamableHTTPClientTransport =>
+  new StreamableHTTPClientTransport(new URL(url), { fetch: fetchFn });
+
+/** SigV4-signed transport for a resolved AgentCore endpoint. */
+export const sigV4Transport = (options: {
+  region: string;
+  url: string;
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}): StreamableHTTPClientTransport =>
+  build(
+    options.url,
+    createSigV4Fetch({
+      region: options.region,
+      credentialProvider: options.credentialProvider,
+    }),
+  );
+
+/** Bearer-token transport for a resolved AgentCore endpoint. */
+export const jwtTransport = (options: {
+  url: string;
+  accessTokenProvider: () => Promise<string>;
+}): StreamableHTTPClientTransport =>
+  build(options.url, createJwtFetch(options.accessTokenProvider));
+
+/** Plain-HTTP transport — for local dev. */
+export const noAuthTransport = (options: {
+  url: string;
+}): StreamableHTTPClientTransport => build(options.url, createPlainFetch());

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-auth/auth/session.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-auth/auth/session.py.template
@@ -1,0 +1,51 @@
+from collections.abc import Callable
+
+import httpx
+
+from ..session_context import get_current_session_id
+from .sigv4 import SigV4HTTPXAuth
+
+SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+
+
+class SessionHeaderAuth(httpx.Auth):
+    """Stamps the AgentCore session header from the current async context,
+    then delegates to an optional inner auth (e.g. SigV4)."""
+
+    requires_request_body = True
+    requires_response_body = True
+
+    def __init__(self, inner: httpx.Auth | None = None):
+        self._inner = inner
+
+    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
+        sid = get_current_session_id()
+        if sid:
+            request.headers[SESSION_HEADER] = sid
+        if self._inner is None:
+            yield request
+            return
+        yield from self._inner.auth_flow(request)
+
+
+def sigv4_auth(
+    credentials, region: str, service: str = "bedrock-agentcore"
+) -> httpx.Auth:
+    """Session-forwarding SigV4 auth (per-request, body-aware)."""
+    return SessionHeaderAuth(SigV4HTTPXAuth(credentials, service, region))
+
+
+def jwt_auth(access_token_provider: Callable[[], str]) -> httpx.Auth:
+    """Session-forwarding bearer-token auth."""
+
+    class _Bearer(httpx.Auth):
+        def auth_flow(self, request: httpx.Request):
+            request.headers["Authorization"] = f"Bearer {access_token_provider()}"
+            yield request
+
+    return SessionHeaderAuth(_Bearer())
+
+
+def plain_auth() -> httpx.Auth:
+    """Session-forwarding plain auth — for local dev."""
+    return SessionHeaderAuth()

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-gateway/agentcore_gateway_mcp_client.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-gateway/agentcore_gateway_mcp_client.py.template
@@ -1,50 +1,10 @@
-import re
-
-import boto3
-import httpx
-from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp.mcp_client import MCPClient
 
-from .auth import SigV4HTTPXAuth
-from .session_context import get_current_session_id
-
-SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
-
-
-class _SessionHeaderAuth(httpx.Auth):
-    """Stamps the AgentCore session header from the current async context."""
-
-    requires_request_body = True
-    requires_response_body = True
-
-    def __init__(self, inner: httpx.Auth | None = None):
-        self._inner = inner
-
-    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
-        sid = get_current_session_id()
-        if sid:
-            request.headers[SESSION_HEADER] = sid
-        if self._inner is None:
-            yield request
-            return
-        yield from self._inner.auth_flow(request)
-
-
-def _parse_region_from_gateway_url(gateway_url: str) -> str:
-    match = re.search(r"\.bedrock-agentcore\.([^.]+)\.amazonaws\.com", gateway_url)
-    if not match:
-        raise ValueError(
-            f"Cannot determine region from gateway URL '{gateway_url}'. "
-            "Pass region explicitly."
-        )
-    return match.group(1)
+from .agentcore_gateway_mcp_transport import AgentCoreGatewayMCPTransport
 
 
 class AgentCoreGatewayMCPClient:
-    """Factory for MCP clients that connect to an AgentCore Gateway. Forwards
-    the current async-context session via the AgentCore session header, which
-    the gateway propagates to downstream MCP server targets.
-    """
+    """Factory for Strands MCP clients that connect to an AgentCore Gateway."""
 
     @staticmethod
     def with_iam_auth(
@@ -52,27 +12,11 @@ class AgentCoreGatewayMCPClient:
         region: str | None = None,
     ) -> MCPClient:
         """Create a gateway MCP client authenticated with IAM SigV4."""
-        resolved_region = region or _parse_region_from_gateway_url(gateway_url)
-        credentials = boto3.Session(region_name=resolved_region).get_credentials()
-        return _create_client(
-            gateway_url,
-            _SessionHeaderAuth(
-                SigV4HTTPXAuth(credentials, "bedrock-agentcore", resolved_region),
-            ),
+        return MCPClient(
+            AgentCoreGatewayMCPTransport.with_iam_auth(gateway_url, region)
         )
 
     @staticmethod
     def without_auth(gateway_url: str) -> MCPClient:
         """Plain-HTTP gateway client, for the local gateway started by serve-local."""
-        return _create_client(gateway_url, _SessionHeaderAuth())
-
-
-def _create_client(gateway_url: str, auth: httpx.Auth) -> MCPClient:
-    return MCPClient(
-        lambda: streamablehttp_client(
-            gateway_url,
-            auth=auth,
-            timeout=120,
-            terminate_on_close=False,
-        )
-    )
+        return MCPClient(AgentCoreGatewayMCPTransport.without_auth(gateway_url))

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-gateway/agentcore_gateway_mcp_transport.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-gateway/agentcore_gateway_mcp_transport.py.template
@@ -1,0 +1,39 @@
+import re
+
+from .agentcore_transport import (
+    TransportFactory,
+    no_auth_transport,
+    sigv4_transport,
+)
+
+
+def _parse_region_from_gateway_url(gateway_url: str) -> str:
+    match = re.search(r"\.bedrock-agentcore\.([^.]+)\.amazonaws\.com", gateway_url)
+    if not match:
+        raise ValueError(
+            f"Cannot determine region from gateway URL '{gateway_url}'. "
+            "Pass region explicitly."
+        )
+    return match.group(1)
+
+
+class AgentCoreGatewayMCPTransport:
+    """Factory for MCP transport factories that connect to an AgentCore Gateway.
+    Forwards the current async-context session via the AgentCore session header,
+    which the gateway propagates to downstream MCP server targets.
+    """
+
+    @staticmethod
+    def with_iam_auth(
+        gateway_url: str,
+        region: str | None = None,
+    ) -> TransportFactory:
+        """Create a gateway MCP transport authenticated with IAM SigV4."""
+        return sigv4_transport(
+            gateway_url, region or _parse_region_from_gateway_url(gateway_url)
+        )
+
+    @staticmethod
+    def without_auth(gateway_url: str) -> TransportFactory:
+        """Plain-HTTP gateway transport, for the local gateway started by serve-local."""
+        return no_auth_transport(gateway_url)

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-gateway/strands_agentcore_gateway_mcp_client.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-gateway/strands_agentcore_gateway_mcp_client.py.template
@@ -3,7 +3,7 @@ from strands.tools.mcp.mcp_client import MCPClient
 from .agentcore_gateway_mcp_transport import AgentCoreGatewayMCPTransport
 
 
-class AgentCoreGatewayMCPClient:
+class StrandsAgentCoreGatewayMCPClient:
     """Factory for Strands MCP clients that connect to an AgentCore Gateway."""
 
     @staticmethod

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-mcp/agentcore_mcp_client.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-mcp/agentcore_mcp_client.py.template
@@ -1,89 +1,30 @@
 from collections.abc import Callable
 
-import boto3
-import httpx
-from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp.mcp_client import MCPClient
 
-from .auth import SigV4HTTPXAuth
-from .session_context import get_current_session_id
-
-SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
-
-
-class _SessionHeaderAuth(httpx.Auth):
-    """Stamps the AgentCore session header from the current async context."""
-
-    requires_request_body = True
-    requires_response_body = True
-
-    def __init__(self, inner: httpx.Auth | None = None):
-        self._inner = inner
-
-    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
-        sid = get_current_session_id()
-        if sid:
-            request.headers[SESSION_HEADER] = sid
-        if self._inner is None:
-            yield request
-            return
-        yield from self._inner.auth_flow(request)
+from .agentcore_mcp_transport import AgentCoreMCPTransport
 
 
 class AgentCoreMCPClient:
-    """Factory for MCP clients that forward the current async-context session."""
-
-    @staticmethod
-    def _build_url(agent_runtime_arn: str) -> tuple[str, str]:
-        """Extract region from ARN and construct the invocation URL.
-
-        ARN format: arn:partition:service:region:account-id:resource
-        """
-        region = agent_runtime_arn.split(":")[3]
-        encoded_arn = agent_runtime_arn.replace(":", "%3A").replace("/", "%2F")
-        url = (
-            f"https://bedrock-agentcore.{region}.amazonaws.com/runtimes/"
-            f"{encoded_arn}/invocations?qualifier=DEFAULT"
-        )
-        return region, url
-
-    @staticmethod
-    def _create(url: str, auth: httpx.Auth | None = None) -> MCPClient:
-        return MCPClient(
-            lambda: streamablehttp_client(
-                url,
-                auth=_SessionHeaderAuth(auth),
-                timeout=120,
-                terminate_on_close=False,
-            )
-        )
+    """Factory for Strands MCP clients that connect to an AgentCore runtime."""
 
     @staticmethod
     def with_iam_auth(agent_runtime_arn: str) -> MCPClient:
         """SigV4-authenticated client for a Bedrock AgentCore runtime."""
-        region, url = AgentCoreMCPClient._build_url(agent_runtime_arn)
-        credentials = boto3.Session(region_name=region).get_credentials()
-        return AgentCoreMCPClient._create(
-            url, SigV4HTTPXAuth(credentials, "bedrock-agentcore", region)
-        )
+        return MCPClient(AgentCoreMCPTransport.with_iam_auth(agent_runtime_arn))
 
     @staticmethod
     def with_jwt_auth(
         agent_runtime_arn: str, access_token_provider: Callable[[], str]
     ) -> MCPClient:
         """Bearer-authenticated client for a Bedrock AgentCore runtime."""
-        _, url = AgentCoreMCPClient._build_url(agent_runtime_arn)
         return MCPClient(
-            lambda: streamablehttp_client(
-                url,
-                auth=_SessionHeaderAuth(),
-                headers={"Authorization": f"Bearer {access_token_provider()}"},
-                timeout=120,
-                terminate_on_close=False,
+            AgentCoreMCPTransport.with_jwt_auth(
+                agent_runtime_arn, access_token_provider
             )
         )
 
     @staticmethod
     def without_auth(url: str) -> MCPClient:
         """Plain-HTTP client — for local dev."""
-        return AgentCoreMCPClient._create(url)
+        return MCPClient(AgentCoreMCPTransport.without_auth(url))

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-mcp/agentcore_mcp_transport.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-mcp/agentcore_mcp_transport.py.template
@@ -1,0 +1,45 @@
+from collections.abc import Callable
+
+from .agentcore_transport import (
+    TransportFactory,
+    jwt_transport,
+    no_auth_transport,
+    sigv4_transport,
+)
+
+
+def _resolve(agent_runtime_arn: str) -> tuple[str, str]:
+    """Extract region from ARN and construct the invocation URL.
+
+    ARN format: arn:partition:service:region:account-id:resource
+    """
+    region = agent_runtime_arn.split(":")[3]
+    encoded_arn = agent_runtime_arn.replace(":", "%3A").replace("/", "%2F")
+    url = (
+        f"https://bedrock-agentcore.{region}.amazonaws.com/runtimes/"
+        f"{encoded_arn}/invocations?qualifier=DEFAULT"
+    )
+    return region, url
+
+
+class AgentCoreMCPTransport:
+    """Factory for MCP transport factories that connect to an AgentCore runtime."""
+
+    @staticmethod
+    def with_iam_auth(agent_runtime_arn: str) -> TransportFactory:
+        """SigV4-authenticated transport for a Bedrock AgentCore runtime."""
+        region, url = _resolve(agent_runtime_arn)
+        return sigv4_transport(url, region)
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str, access_token_provider: Callable[[], str]
+    ) -> TransportFactory:
+        """Bearer-authenticated transport for a Bedrock AgentCore runtime."""
+        _, url = _resolve(agent_runtime_arn)
+        return jwt_transport(url, access_token_provider)
+
+    @staticmethod
+    def without_auth(url: str) -> TransportFactory:
+        """Plain-HTTP transport — for local dev."""
+        return no_auth_transport(url)

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-mcp/strands_agentcore_mcp_client.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-mcp/strands_agentcore_mcp_client.py.template
@@ -5,7 +5,7 @@ from strands.tools.mcp.mcp_client import MCPClient
 from .agentcore_mcp_transport import AgentCoreMCPTransport
 
 
-class AgentCoreMCPClient:
+class StrandsAgentCoreMCPClient:
     """Factory for Strands MCP clients that connect to an AgentCore runtime."""
 
     @staticmethod

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-shared/agentcore_transport.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-shared/agentcore_transport.py.template
@@ -1,0 +1,40 @@
+from collections.abc import Callable
+from typing import Any
+
+import boto3
+
+from mcp.client.streamable_http import streamablehttp_client
+
+from .auth.session import jwt_auth, plain_auth, sigv4_auth
+
+# Agent frameworks wrap a transport *factory* — a no-arg callable returning a
+# streamable-HTTP transport context manager. Typed as ``Any`` so this layer
+# stays free of any framework-specific transport type.
+TransportFactory = Callable[[], Any]
+
+
+def _factory(url: str, auth) -> TransportFactory:
+    return lambda: streamablehttp_client(
+        url,
+        auth=auth,
+        timeout=120,
+        terminate_on_close=False,
+    )
+
+
+def sigv4_transport(url: str, region: str) -> TransportFactory:
+    """SigV4-signed transport factory for a resolved AgentCore endpoint."""
+    credentials = boto3.Session(region_name=region).get_credentials()
+    return _factory(url, sigv4_auth(credentials, region))
+
+
+def jwt_transport(
+    url: str, access_token_provider: Callable[[], str]
+) -> TransportFactory:
+    """Bearer-token transport factory for a resolved AgentCore endpoint."""
+    return _factory(url, jwt_auth(access_token_provider))
+
+
+def no_auth_transport(url: str) -> TransportFactory:
+    """Plain-HTTP transport factory — for local dev."""
+    return _factory(url, plain_auth())

--- a/rfcs/0001-framework-agnostic-mcp-clients.md
+++ b/rfcs/0001-framework-agnostic-mcp-clients.md
@@ -1,0 +1,625 @@
+# RFC: Framework-agnostic MCP and Gateway clients
+
+- Status: Draft
+- Date: 2026-06-19
+- Affects generators: `ts#agent#mcp-connection`, `ts#agent#gateway-connection`, `py#agent#mcp-connection`, `py#agent#gateway-connection`, and the shared `utils/agent-connection`
+
+## Summary
+
+The MCP clients generated for connecting agents to **MCP servers** and to **AgentCore
+Gateways** are currently tied to the [Strands Agents](https://strandsagents.com) SDK. For
+each connection we generate a core client that ends in a single Strands-specific line:
+
+```ts
+// TypeScript — core-mcp/agentcore-mcp-client.ts
+return new McpClient({ transport });
+```
+
+```python
+# Python — py-core-mcp/agentcore_mcp_client.py
+return MCPClient(lambda: streamablehttp_client(url, auth=..., ...))
+```
+
+Everything else in these files — ARN/URL resolution from runtime config, SigV4 request
+signing, JWT bearer auth, plain-HTTP local dev, and AgentCore session-header forwarding —
+is framework-agnostic AWS/MCP plumbing.
+
+This RFC proposes splitting these clients into layers so that the framework-specific code is
+isolated to a thin top layer, the shared AWS/MCP code can be reused by other agent
+frameworks (LangChain, CrewAI, the Claude Agent SDK, …), and adding a new framework is an
+additive change rather than a fork.
+
+## Motivation
+
+We currently support only Strands. As we add support for other agent frameworks we must not
+duplicate the genuinely hard and security-sensitive parts of these clients — SigV4 signing,
+ARN→URL construction, runtime-config resolution, and AgentCore session propagation — once
+per framework. Today a second framework would mean copying ~120 lines of auth/runtime code
+and changing one line at the end.
+
+## Background: how the clients work today
+
+Three layers already exist implicitly, but the bottom two are fused into one file per
+connection type.
+
+### Runtime-config resolution (already generic)
+
+`runtime-config.ts` / `runtime_config.py` reads the `agentcore` namespace from AppConfig
+using the `RUNTIME_CONFIG_APP_ID` environment variable (set on the AgentCore runtime by the
+generated CDK/Terraform construct) and returns:
+
+```jsonc
+{
+  "agentRuntimes": { "MyMcpServer": "arn:aws:bedrock-agentcore:..." },
+  "gateways":      { "MyGateway":   "https://<id>.gateway.bedrock-agentcore.<region>.amazonaws.com/mcp" }
+}
+```
+
+This module has **zero framework dependency** and is unchanged by this RFC.
+
+### Per-connection client (resolves which endpoint)
+
+Generated per connection, e.g. `MyMcpServerClient.create()`:
+
+1. branch on `SERVE_LOCAL=true` → local plain-HTTP URL,
+2. otherwise call `getAgentCoreRuntimeConfig()` and select the ARN/URL by construct class name,
+3. hand the ARN/URL to the core client.
+
+The only Strands reference here is the **return type** (`McpClient` / `MCPClient`).
+
+### Core client (builds auth + transport, wraps in Strands)
+
+Builds the invocation URL from the ARN, constructs the SigV4 signer (`aws4fetch` in TS /
+`botocore` `SigV4Auth` via `httpx.Auth` in Python), forwards the
+`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header from async context, creates the MCP
+`StreamableHTTPClientTransport` / `streamablehttp_client`, and finally wraps it in the
+Strands client. Only the final wrap is framework-specific.
+
+### How agents consume the client
+
+- **Strands TypeScript**: the `McpClient` is added directly to the Agent's `tools: [...]`
+  array. The Agent framework drives `listTools()`/`callTool()` internally.
+- **Strands Python**: the `MCPClient` is used as a context manager and its
+  `list_tools_sync()` is spread into `Agent(tools=[...])`.
+
+## Key finding: the transport is the right seam for Strands, but the *signer* is the
+portable primitive
+
+We verified the "share a configured transport, wrap per framework" idea against the agent
+SDKs we expect to support next. The result is an asymmetry that shapes the design: different
+frameworks accept an MCP connection at **different layers**, and the only piece every
+framework can reuse is the **SigV4 request signer** plus the ARN/URL resolution — not the
+transport object itself.
+
+| Framework | Python | TypeScript | Layer it consumes |
+|---|---|---|---|
+| **Strands** (today) | wraps a transport **factory**: `MCPClient(lambda: transport())` | wraps a **transport**: `new McpClient({ transport })` | transport |
+| **LangChain** | accepts `auth=httpx.Auth` / `httpx_client_factory` in connection config, or a pre-built `ClientSession` via `load_mcp_tools` | **no per-request hook** — only `{ url, static headers, OAuth authProvider }`; must bypass `@langchain/mcp-adapters` and drive the MCP `Client` directly | **signer** (Py) / none usable (TS) |
+| **CrewAI** | forwards kwargs to `streamablehttp_client`, so `auth=` / `httpx_client_factory=` works (requires `mcp` SDK ≥ ~1.10) | n/a (Python-first) | **signer** |
+| **Claude Agent SDK** | HTTP config is `url` + static headers only | HTTP config is `url` + static headers only | only via an **in-process SDK MCP server** adapter (you make the signed calls inside a tool handler) |
+
+Why SigV4 forces this: SigV4 is **not** a static header. It signs each request from its
+method, URL, headers, and body using AWS credentials, so it requires a per-request hook — a
+custom `fetch` (TS) or an `httpx.Auth` (Python). A framework that only accepts
+`{ url, headers }` can carry a static JWT bearer token but **cannot** carry SigV4.
+
+Consequences:
+
+- **LangChain-Python and CrewAI** never want our transport; they build their own and just
+  need our SigV4 signer. So the signer must be reusable on its own.
+- **LangChain-TS and the Claude Agent SDK (both languages)** expose no per-request signing
+  hook on their HTTP transport. Supporting them is **not** a thin wrapper — it means either
+  bypassing the adapter to drive the MCP `Client` ourselves, or building an in-process MCP
+  server adapter whose tool handlers make the signed calls. The architecture should make this
+  *possible* (by exposing the signer and a ready-built transport) without pretending it is a
+  one-liner everywhere.
+
+## Proposed design
+
+Bottom out the shared code at the **signer + runtime-config/endpoint resolution**, with the
+transport as the next layer, and the framework client as a thin top layer. Each framework
+taps in at whichever layer it supports.
+
+```
+Layer 0  runtime-config + endpoint resolver   (generic)        getAgentCoreRuntimeConfig; SERVE_LOCAL branch; pick ARN/URL by name
+Layer 0  SigV4 signer + session-header forward (generic)        the most portable primitive: fetch wrapper (TS) / httpx.Auth (Python)
+Layer 1  transport builder                     (generic, MCP SDK only)  StreamableHTTPClientTransport / streamablehttp_client factory
+Layer 2  framework adapter                      (per framework, thin)    new McpClient({transport}) / MCPClient(lambda: transport())
+```
+
+Within Layer 1 there is a further split: the MCP and gateway transports differ only in how
+they derive `{ region, url }` from their identifier (ARN parsing vs. gateway-URL parsing).
+The auth-mode → transport mapping (SigV4 / JWT / plain) is identical and is shared, so each
+transport class reduces to a single `resolve()` function plus thin delegations to the shared
+core. See the appendices for the full reference implementation.
+
+### File layout (TypeScript, `core-*` directories)
+
+```
+core-runtime-config/runtime-config.ts            (unchanged)  Layer 0 — getAgentCoreRuntimeConfig
+core-runtime-config/session-context.ts           (unchanged)  Layer 0 — async-context session id
+core-auth/agentcore-fetch.ts                     NEW  Layer 0 — createSigV4Fetch / createJwtFetch / createPlainFetch (each forwards the session header)
+core-transport/agentcore-transport.ts            NEW  Layer 1 shared — sigV4Transport / jwtTransport / noAuthTransport (endpoint-agnostic)
+core-mcp/agentcore-mcp-transport.ts              NEW  Layer 1 — resolve ARN → { region, url }, delegate to shared core
+core-mcp/agentcore-mcp-client.ts                 KEEP Layer 2 — thin: new McpClient({ transport })
+core-gateway/agentcore-gateway-mcp-transport.ts  NEW  Layer 1 — resolve gateway URL → region, delegate to shared core
+core-gateway/agentcore-gateway-mcp-client.ts     KEEP Layer 2 — thin Strands wrapper
+```
+
+### File layout (Python, `py-core-*` directories) — structurally equivalent
+
+```
+core-runtime-config/runtime_config.py            (unchanged)  Layer 0 — get_agentcore_runtime_config
+core-runtime-config/session_context.py           (unchanged)  Layer 0 — async-context session id
+core-auth/auth/sigv4.py                           (unchanged)  Layer 0 — SigV4HTTPXAuth
+core-auth/auth/session.py                        NEW  Layer 0 — SessionHeaderAuth + sigv4_auth / jwt_auth / plain_auth builders (each forwards the session header)
+core-transport/agentcore_transport.py            NEW  Layer 1 shared — sigv4_transport / jwt_transport / no_auth_transport (return a transport factory)
+core-mcp/agentcore_mcp_transport.py              NEW  Layer 1 — resolve ARN → (region, url), delegate to shared core
+core-mcp/agentcore_mcp_client.py                 KEEP Layer 2 — thin: MCPClient(<factory>)
+core-gateway/agentcore_gateway_mcp_transport.py  NEW  Layer 1 — resolve gateway URL → region, delegate to shared core
+core-gateway/agentcore_gateway_mcp_client.py     KEEP Layer 2 — thin Strands wrapper
+```
+
+The languages are equivalent layer-for-layer. The only intrinsic difference is the auth
+mechanism the seam carries: TypeScript wraps a `fetch` (and the session header is set inside
+that wrapper before signing), while Python wraps an `httpx.Auth` (the session header is
+stamped by a `SessionHeaderAuth` wrapper that delegates to the inner SigV4/JWT auth). The
+`SessionHeaderAuth` wrapper — today **duplicated** in both Python client files — moves into
+the shared Layer-0 `auth/session.py`. Because Strands Python wraps a transport *factory*
+(`MCPClient(lambda: streamablehttp_client(...))`), the Python Layer-1 functions return that
+factory callable, mirroring the TS functions that return a `StreamableHTTPClientTransport`.
+
+### Per-connection client and agent wiring
+
+- The per-connection `create()` keeps the `SERVE_LOCAL` branch and ARN/URL selection, but
+  these are framework-agnostic and should call a generic resolver (Layer 0) so the resolution
+  is shared. Only the final framework wrap differs by framework.
+- The agent AST wiring (`addTypeScriptClientToAgent` / `addPythonClientToAgent`) stays
+  Strands-shaped for now, because the agent file *is* Strands. When a second framework lands,
+  the wiring becomes framework-conditional, selecting the matching Layer-2 client and
+  injection style.
+
+### Dependency isolation
+
+Only the Layer-2 files import `@strands-agents/sdk` / `strands-agents`. Layers 0 and 1 depend
+solely on `@modelcontextprotocol/sdk` / `mcp`, `aws4fetch` / `botocore`, the AWS SDK, and
+`@aws-lambda-powertools/parameters`. `with-session-id.ts` (the Strands `Agent` session-cache
+wrapper) stays in the framework layer.
+
+## Adding a new framework after this RFC
+
+- **LangChain-Python / CrewAI**: new Layer-2 file consuming the **Layer-0 signer** directly
+  (passes our `httpx.Auth` via `auth=` / `httpx_client_factory`), skipping Layer 1.
+- **LangChain-TS / Claude Agent SDK**: new Layer-2 file that drives the MCP `Client` itself
+  using Layers 0–1 (or an in-process SDK MCP server adapter). No thin wrapper is possible;
+  this is documented as a known constraint of those SDKs.
+
+## What this RFC does not change
+
+- The runtime-config / ARN resolution module and the AppConfig contract.
+- The AgentCore session-header name and propagation semantics.
+- The A2A connection client. A2A is more tightly coupled (`strands.agent.a2a_agent.A2AAgent`
+  returns an Agent, not a transport) and is out of scope; it should be treated separately.
+- Generated CDK/Terraform constructs and the `SERVE_LOCAL` local-dev workflow.
+
+## Open questions
+
+1. Do we want the Layer-0 signer published as part of the generated `agent-connection`
+   project's public surface, or kept internal until a second framework actually lands?
+2. For TypeScript LangChain / Claude SDK support, do we prefer the "drive the MCP `Client`
+   ourselves" path or the "in-process SDK MCP server adapter" path? They have different
+   ergonomics for tool listing and lifecycle.
+3. Should framework selection be a generator option (e.g. `--framework=strands|langchain`) on
+   the agent generator, propagated to the connection generators, or inferred from the agent
+   project?
+
+## Rollout
+
+1. Land the Layer 0/1/2 split for Strands MCP + gateway in both languages (no behavior
+   change; snapshots update for the new file layout).
+2. Document the layering and the per-framework constraints.
+3. Add a second framework as a follow-up, validating that only a Layer-2 file (plus
+   conditional agent wiring) is required.
+
+## Appendix A: TypeScript reference implementation
+
+### Layer 0 — `core-auth/agentcore-fetch.ts`
+
+```ts
+import { AwsClient } from 'aws4fetch';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { getCurrentSessionId } from '../core-runtime-config/session-context.js';
+
+const SESSION_HEADER = 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id';
+
+/** Wrap a fetch so each request carries the current async-context session id. */
+const withSessionHeader =
+  (inner: typeof fetch): typeof fetch =>
+  async (input, init) => {
+    const headers = new Headers(init?.headers);
+    const sessionId = getCurrentSessionId();
+    if (sessionId) headers.set(SESSION_HEADER, sessionId);
+    return inner(input, { ...init, headers });
+  };
+
+export interface SigV4FetchOptions {
+  region: string;
+  service?: string;
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}
+
+/** A fetch that signs every request with AWS SigV4 (per-request, body-aware). */
+export const createSigV4Fetch = (options: SigV4FetchOptions): typeof fetch => {
+  const { region, service = 'bedrock-agentcore' } = options;
+  const credentialProvider =
+    options.credentialProvider ?? fromNodeProviderChain();
+  const signedFetch: typeof fetch = async (input, init) => {
+    const client = new AwsClient({ ...(await credentialProvider()), service, region });
+    return client.fetch(input as RequestInfo, init);
+  };
+  return withSessionHeader(signedFetch);
+};
+
+/** A fetch that adds a bearer token from the given async provider. */
+export const createJwtFetch = (
+  accessTokenProvider: () => Promise<string>,
+): typeof fetch =>
+  withSessionHeader(async (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Bearer ${await accessTokenProvider()}`);
+    return fetch(input, { ...init, headers });
+  });
+
+/** A plain fetch (local dev) that still forwards the session id. */
+export const createPlainFetch = (): typeof fetch => withSessionHeader(fetch);
+```
+
+### Layer 1 shared — `core-transport/agentcore-transport.ts`
+
+```ts
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import {
+  createSigV4Fetch,
+  createJwtFetch,
+  createPlainFetch,
+} from '../core-auth/agentcore-fetch.js';
+
+const build = (url: string, fetchFn: typeof fetch): StreamableHTTPClientTransport =>
+  new StreamableHTTPClientTransport(new URL(url), { fetch: fetchFn });
+
+/** SigV4-signed transport for a resolved AgentCore endpoint. */
+export const sigV4Transport = (o: {
+  region: string;
+  url: string;
+  credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+}): StreamableHTTPClientTransport =>
+  build(o.url, createSigV4Fetch({ region: o.region, credentialProvider: o.credentialProvider }));
+
+/** Bearer-token transport for a resolved AgentCore endpoint. */
+export const jwtTransport = (o: {
+  url: string;
+  accessTokenProvider: () => Promise<string>;
+}): StreamableHTTPClientTransport => build(o.url, createJwtFetch(o.accessTokenProvider));
+
+/** Plain-HTTP transport (local dev). */
+export const noAuthTransport = (o: { url: string }): StreamableHTTPClientTransport =>
+  build(o.url, createPlainFetch());
+```
+
+### Layer 1 — `core-mcp/agentcore-mcp-transport.ts`
+
+```ts
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import {
+  sigV4Transport,
+  jwtTransport,
+  noAuthTransport,
+} from '../core-transport/agentcore-transport.js';
+
+/** Build the invocation URL + region from an AgentCore runtime ARN. */
+const resolve = (agentRuntimeArn: string): { region: string; url: string } => {
+  const region = agentRuntimeArn.split(':')[3];
+  const url = `https://bedrock-agentcore.${region}.amazonaws.com/runtimes/${encodeURIComponent(agentRuntimeArn)}/invocations?qualifier=DEFAULT`;
+  return { region, url };
+};
+
+export class AgentCoreMcpTransport {
+  static withIamAuth(o: {
+    agentRuntimeArn: string;
+    credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+  }): StreamableHTTPClientTransport {
+    return sigV4Transport({ ...resolve(o.agentRuntimeArn), credentialProvider: o.credentialProvider });
+  }
+  static withJwtAuth(o: {
+    agentRuntimeArn: string;
+    accessTokenProvider: () => Promise<string>;
+  }): StreamableHTTPClientTransport {
+    return jwtTransport({ url: resolve(o.agentRuntimeArn).url, accessTokenProvider: o.accessTokenProvider });
+  }
+  static withoutAuth(o: { url: string }): StreamableHTTPClientTransport {
+    return noAuthTransport(o);
+  }
+}
+```
+
+### Layer 1 — `core-gateway/agentcore-gateway-mcp-transport.ts`
+
+```ts
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { sigV4Transport, noAuthTransport } from '../core-transport/agentcore-transport.js';
+
+const resolveRegion = (gatewayUrl: string): string => {
+  const match = /\.bedrock-agentcore\.([^.]+)\.amazonaws\.com/.exec(gatewayUrl);
+  if (!match) {
+    throw new Error(`Cannot determine region from gateway URL '${gatewayUrl}'. Pass region explicitly.`);
+  }
+  return match[1];
+};
+
+export class AgentCoreGatewayMcpTransport {
+  static withIamAuth(o: {
+    gatewayUrl: string;
+    region?: string;
+    credentialProvider?: ReturnType<typeof fromNodeProviderChain>;
+  }): StreamableHTTPClientTransport {
+    return sigV4Transport({
+      region: o.region ?? resolveRegion(o.gatewayUrl),
+      url: o.gatewayUrl,
+      credentialProvider: o.credentialProvider,
+    });
+  }
+  static withoutAuth(o: { gatewayUrl: string }): StreamableHTTPClientTransport {
+    return noAuthTransport({ url: o.gatewayUrl });
+  }
+}
+```
+
+### Layer 2 — `core-mcp/agentcore-mcp-client.ts` (only file importing Strands)
+
+```ts
+import { McpClient } from '@strands-agents/sdk';
+import {
+  AgentCoreMcpTransport,
+  AgentCoreMcpTransportIamOptions,
+  AgentCoreMcpTransportJwtOptions,
+  AgentCoreMcpTransportNoAuthOptions,
+} from './agentcore-mcp-transport.js';
+
+export class AgentCoreMcpClient {
+  static withIamAuth(o: AgentCoreMcpTransportIamOptions): McpClient {
+    return new McpClient({ transport: AgentCoreMcpTransport.withIamAuth(o) });
+  }
+  static withJwtAuth(o: AgentCoreMcpTransportJwtOptions): McpClient {
+    return new McpClient({ transport: AgentCoreMcpTransport.withJwtAuth(o) });
+  }
+  static withoutAuth(o: AgentCoreMcpTransportNoAuthOptions): McpClient {
+    return new McpClient({ transport: AgentCoreMcpTransport.withoutAuth(o) });
+  }
+}
+```
+
+`core-gateway/agentcore-gateway-mcp-client.ts` is the same shape, delegating to
+`AgentCoreGatewayMcpTransport`.
+
+## Appendix B: Python reference implementation (equivalent)
+
+### Layer 0 — `core-auth/auth/session.py`
+
+```python
+from collections.abc import Callable
+
+import httpx
+
+from .sigv4 import SigV4HTTPXAuth
+from ..core_runtime_config.session_context import get_current_session_id
+
+SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+
+
+class SessionHeaderAuth(httpx.Auth):
+    """Stamps the AgentCore session header from the current async context,
+    then delegates to an optional inner auth (e.g. SigV4)."""
+
+    requires_request_body = True
+    requires_response_body = True
+
+    def __init__(self, inner: httpx.Auth | None = None):
+        self._inner = inner
+
+    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
+        sid = get_current_session_id()
+        if sid:
+            request.headers[SESSION_HEADER] = sid
+        if self._inner is None:
+            yield request
+            return
+        yield from self._inner.auth_flow(request)
+
+
+def sigv4_auth(credentials, region: str, service: str = "bedrock-agentcore") -> httpx.Auth:
+    """Session-forwarding SigV4 auth (per-request, body-aware)."""
+    return SessionHeaderAuth(SigV4HTTPXAuth(credentials, service, region))
+
+
+def jwt_auth(access_token_provider: Callable[[], str]) -> httpx.Auth:
+    """Session-forwarding bearer-token auth."""
+
+    class _Bearer(httpx.Auth):
+        def auth_flow(self, request: httpx.Request):
+            request.headers["Authorization"] = f"Bearer {access_token_provider()}"
+            yield request
+
+    return SessionHeaderAuth(_Bearer())
+
+
+def plain_auth() -> httpx.Auth:
+    """Session-forwarding plain auth (local dev)."""
+    return SessionHeaderAuth()
+```
+
+### Layer 1 shared — `core-transport/agentcore_transport.py`
+
+```python
+from collections.abc import Callable
+
+import boto3
+import httpx
+from mcp.client.streamable_http import streamablehttp_client
+
+from ..core_auth.auth.session import sigv4_auth, jwt_auth, plain_auth
+
+# Strands wraps a transport *factory*, so each builder returns a no-arg callable.
+TransportFactory = Callable[[], object]
+
+
+def _factory(url: str, auth: httpx.Auth) -> TransportFactory:
+    return lambda: streamablehttp_client(
+        url, auth=auth, timeout=120, terminate_on_close=False
+    )
+
+
+def sigv4_transport(url: str, region: str) -> TransportFactory:
+    """SigV4-signed transport factory for a resolved AgentCore endpoint."""
+    credentials = boto3.Session(region_name=region).get_credentials()
+    return _factory(url, sigv4_auth(credentials, region))
+
+
+def jwt_transport(url: str, access_token_provider: Callable[[], str]) -> TransportFactory:
+    """Bearer-token transport factory for a resolved AgentCore endpoint."""
+    return _factory(url, jwt_auth(access_token_provider))
+
+
+def no_auth_transport(url: str) -> TransportFactory:
+    """Plain-HTTP transport factory (local dev)."""
+    return _factory(url, plain_auth())
+```
+
+### Layer 1 — `core-mcp/agentcore_mcp_transport.py`
+
+```python
+from collections.abc import Callable
+
+from ..core_transport.agentcore_transport import (
+    sigv4_transport,
+    jwt_transport,
+    no_auth_transport,
+    TransportFactory,
+)
+
+
+def _resolve(agent_runtime_arn: str) -> tuple[str, str]:
+    """Extract region from ARN and construct the invocation URL.
+
+    ARN format: arn:partition:service:region:account-id:resource
+    """
+    region = agent_runtime_arn.split(":")[3]
+    encoded_arn = agent_runtime_arn.replace(":", "%3A").replace("/", "%2F")
+    url = (
+        f"https://bedrock-agentcore.{region}.amazonaws.com/runtimes/"
+        f"{encoded_arn}/invocations?qualifier=DEFAULT"
+    )
+    return region, url
+
+
+class AgentCoreMcpTransport:
+    @staticmethod
+    def with_iam_auth(agent_runtime_arn: str) -> TransportFactory:
+        region, url = _resolve(agent_runtime_arn)
+        return sigv4_transport(url, region)
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str, access_token_provider: Callable[[], str]
+    ) -> TransportFactory:
+        _, url = _resolve(agent_runtime_arn)
+        return jwt_transport(url, access_token_provider)
+
+    @staticmethod
+    def without_auth(url: str) -> TransportFactory:
+        return no_auth_transport(url)
+```
+
+### Layer 1 — `core-gateway/agentcore_gateway_mcp_transport.py`
+
+```python
+import re
+
+from ..core_transport.agentcore_transport import (
+    sigv4_transport,
+    no_auth_transport,
+    TransportFactory,
+)
+
+
+def _resolve_region(gateway_url: str) -> str:
+    match = re.search(r"\.bedrock-agentcore\.([^.]+)\.amazonaws\.com", gateway_url)
+    if not match:
+        raise ValueError(
+            f"Cannot determine region from gateway URL '{gateway_url}'. "
+            "Pass region explicitly."
+        )
+    return match.group(1)
+
+
+class AgentCoreGatewayMcpTransport:
+    @staticmethod
+    def with_iam_auth(gateway_url: str, region: str | None = None) -> TransportFactory:
+        return sigv4_transport(gateway_url, region or _resolve_region(gateway_url))
+
+    @staticmethod
+    def without_auth(gateway_url: str) -> TransportFactory:
+        return no_auth_transport(gateway_url)
+```
+
+### Layer 2 — `core-mcp/agentcore_mcp_client.py` (only file importing Strands)
+
+```python
+from collections.abc import Callable
+
+from strands.tools.mcp.mcp_client import MCPClient
+
+from .agentcore_mcp_transport import AgentCoreMcpTransport
+
+
+class AgentCoreMCPClient:
+    @staticmethod
+    def with_iam_auth(agent_runtime_arn: str) -> MCPClient:
+        return MCPClient(AgentCoreMcpTransport.with_iam_auth(agent_runtime_arn))
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str, access_token_provider: Callable[[], str]
+    ) -> MCPClient:
+        return MCPClient(
+            AgentCoreMcpTransport.with_jwt_auth(agent_runtime_arn, access_token_provider)
+        )
+
+    @staticmethod
+    def without_auth(url: str) -> MCPClient:
+        return MCPClient(AgentCoreMcpTransport.without_auth(url))
+```
+
+`core-gateway/agentcore_gateway_mcp_client.py` is the same shape, delegating to
+`AgentCoreGatewayMcpTransport`.
+
+## Appendix C: Adding a non-Strands framework (TypeScript)
+
+LangChain-TS and the Claude Agent SDK expose no per-request signing hook on their HTTP MCP
+transport, so they skip Layer 2 and drive the MCP `Client` themselves using the shared
+Layers 0–1:
+
+```ts
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { AgentCoreMcpTransport } from '../core/agentcore-mcp-transport.js';
+
+const client = new Client({ name: 'agent', version: '1.0.0' });
+await client.connect(AgentCoreMcpTransport.withIamAuth({ agentRuntimeArn }));
+const { tools } = await client.listTools();
+// → adapt `tools` to the target framework's tool type here
+```
+
+This demonstrates the payoff: a new framework reuses all signing / URL / session code and
+adds only a new Layer-2 file (or direct Layer-1 use), with no duplication.

--- a/rfcs/0001-framework-agnostic-mcp-clients.md
+++ b/rfcs/0001-framework-agnostic-mcp-clients.md
@@ -141,9 +141,9 @@ core-runtime-config/session-context.ts           (unchanged)  Layer 0 — async-
 core-auth/agentcore-fetch.ts                     NEW  Layer 0 — createSigV4Fetch / createJwtFetch / createPlainFetch (each forwards the session header)
 core-transport/agentcore-transport.ts            NEW  Layer 1 shared — sigV4Transport / jwtTransport / noAuthTransport (endpoint-agnostic)
 core-mcp/agentcore-mcp-transport.ts              NEW  Layer 1 — resolve ARN → { region, url }, delegate to shared core
-core-mcp/agentcore-mcp-client.ts                 KEEP Layer 2 — thin: new McpClient({ transport })
+core-mcp/strands-agentcore-mcp-client.ts         NEW  Layer 2 — thin Strands wrapper: new McpClient({ transport })
 core-gateway/agentcore-gateway-mcp-transport.ts  NEW  Layer 1 — resolve gateway URL → region, delegate to shared core
-core-gateway/agentcore-gateway-mcp-client.ts     KEEP Layer 2 — thin Strands wrapper
+core-gateway/strands-agentcore-gateway-mcp-client.ts  NEW  Layer 2 — thin Strands wrapper
 ```
 
 ### File layout (Python, `py-core-*` directories) — structurally equivalent
@@ -155,9 +155,9 @@ core-auth/auth/sigv4.py                           (unchanged)  Layer 0 — SigV4
 core-auth/auth/session.py                        NEW  Layer 0 — SessionHeaderAuth + sigv4_auth / jwt_auth / plain_auth builders (each forwards the session header)
 core-transport/agentcore_transport.py            NEW  Layer 1 shared — sigv4_transport / jwt_transport / no_auth_transport (return a transport factory)
 core-mcp/agentcore_mcp_transport.py              NEW  Layer 1 — resolve ARN → (region, url), delegate to shared core
-core-mcp/agentcore_mcp_client.py                 KEEP Layer 2 — thin: MCPClient(<factory>)
+core-mcp/strands_agentcore_mcp_client.py         NEW  Layer 2 — thin Strands wrapper: MCPClient(<factory>)
 core-gateway/agentcore_gateway_mcp_transport.py  NEW  Layer 1 — resolve gateway URL → region, delegate to shared core
-core-gateway/agentcore_gateway_mcp_client.py     KEEP Layer 2 — thin Strands wrapper
+core-gateway/strands_agentcore_gateway_mcp_client.py  NEW  Layer 2 — thin Strands wrapper
 ```
 
 The languages are equivalent layer-for-layer. The only intrinsic difference is the auth
@@ -377,7 +377,7 @@ export class AgentCoreGatewayMcpTransport {
 }
 ```
 
-### Layer 2 — `core-mcp/agentcore-mcp-client.ts` (only file importing Strands)
+### Layer 2 — `core-mcp/strands-agentcore-mcp-client.ts` (only file importing Strands)
 
 ```ts
 import { McpClient } from '@strands-agents/sdk';
@@ -388,7 +388,7 @@ import {
   AgentCoreMcpTransportNoAuthOptions,
 } from './agentcore-mcp-transport.js';
 
-export class AgentCoreMcpClient {
+export class StrandsAgentCoreMcpClient {
   static withIamAuth(o: AgentCoreMcpTransportIamOptions): McpClient {
     return new McpClient({ transport: AgentCoreMcpTransport.withIamAuth(o) });
   }
@@ -401,8 +401,12 @@ export class AgentCoreMcpClient {
 }
 ```
 
-`core-gateway/agentcore-gateway-mcp-client.ts` is the same shape, delegating to
+`core-gateway/strands-agentcore-gateway-mcp-client.ts` is the same shape, delegating to
 `AgentCoreGatewayMcpTransport`.
+
+The framework name is part of the class name (`StrandsAgentCoreMcpClient`) and file name
+because these files *are* Strands-specific — only the framework-agnostic Layers 0–1 (the
+transport, signer, and runtime-config resolution) keep generic `AgentCore*` names.
 
 ## Appendix B: Python reference implementation (equivalent)
 
@@ -574,7 +578,7 @@ class AgentCoreGatewayMcpTransport:
         return no_auth_transport(gateway_url)
 ```
 
-### Layer 2 — `core-mcp/agentcore_mcp_client.py` (only file importing Strands)
+### Layer 2 — `core-mcp/strands_agentcore_mcp_client.py` (only file importing Strands)
 
 ```python
 from collections.abc import Callable
@@ -584,7 +588,7 @@ from strands.tools.mcp.mcp_client import MCPClient
 from .agentcore_mcp_transport import AgentCoreMcpTransport
 
 
-class AgentCoreMCPClient:
+class StrandsAgentCoreMCPClient:
     @staticmethod
     def with_iam_auth(agent_runtime_arn: str) -> MCPClient:
         return MCPClient(AgentCoreMcpTransport.with_iam_auth(agent_runtime_arn))
@@ -602,7 +606,7 @@ class AgentCoreMCPClient:
         return MCPClient(AgentCoreMcpTransport.without_auth(url))
 ```
 
-`core-gateway/agentcore_gateway_mcp_client.py` is the same shape, delegating to
+`core-gateway/strands_agentcore_gateway_mcp_client.py` is the same shape, delegating to
 `AgentCoreGatewayMcpTransport`.
 
 ## Appendix C: Adding a non-Strands framework (TypeScript)


### PR DESCRIPTION
### Reason for this change

The MCP-server and AgentCore-Gateway connection clients generated for agents are currently coupled to the [Strands Agents](https://strandsagents.com) SDK. Each core client ends in a single Strands-specific line (`new McpClient({ transport })` / `MCPClient(lambda: streamablehttp_client(...))`), while everything else — SigV4 request signing, ARN/URL resolution from runtime config, JWT/plain auth, and AgentCore session-header forwarding — is framework-agnostic AWS/MCP plumbing.

As we add support for other agent frameworks (LangChain, CrewAI, the Claude Agent SDK, …) we should not duplicate the hard, security-sensitive parts of these clients once per framework.

### Description of changes

Splits the MCP and gateway connection clients into layers, in both TypeScript and Python, so the Strands dependency is isolated to a thin top layer and the shared code can be reused:

- **Layer 0** — runtime-config resolver (unchanged) + SigV4 / JWT / plain auth, each forwarding the AgentCore session header. This is the portable primitive other frameworks can reuse directly.
- **Layer 1** — a shared transport core (`agentcore-transport` / `agentcore_transport`) plus per-endpoint resolvers (`agentcore-mcp-transport`, `agentcore-gateway-mcp-transport`) that differ only in how they derive `{ region, url }` (runtime ARN vs gateway URL).
- **Layer 2** — the thin per-framework client (`AgentCoreMcpClient`, `AgentCoreGatewayMcpClient`) — the only files importing `@strands-agents/sdk` / `strands-agents`.

Runtime behaviour is unchanged: the Strands client wraps the exact same transport with the same arguments as before. The per-connection `*Client.create()` files and the agent AST wiring are untouched.

A design doc is added at `rfcs/0001-framework-agnostic-mcp-clients.md` describing the layering and the per-framework constraints (verified against LangChain, CrewAI, and the Claude Agent SDK for both Python and TypeScript) that motivated bottoming out the shared code at the signer rather than the transport.

### Description of how you validated changes

**Unit tests** — updated tests + snapshots for the `ts#agent` and `py#agent` mcp-connection and gateway-connection generators (added existence/snapshot assertions for the new transport + shared files). All 126 connection-generator tests pass; full `@aws/nx-plugin` Build (incl. snapshots) is green in CI.

**Deployed (real AWS) — all affected permutations passed.** Deployed the full generator-matrix workspace to AWS and invoked every affected path (SigV4 + Cedar where applicable); each returned the expected result through the refactored transport layers:

| Permutation | Result |
| --- | --- |
| TS MCP server / PY MCP server (direct runtime, SigV4) | invoked OK |
| TS Agent -> PY MCP (direct connection) | add(4,5)=9 |
| PY Agent -> TS MCP (direct connection) | divide(10,2)=5 |
| TS Agent -> Gateway -> TS MCP | divide(6,2)=3 |
| TS Agent -> Gateway -> PY MCP | add(6,2)=8 |
| PY Agent -> Gateway -> TS MCP | divide(6,2)=3 |
| PY Agent -> Gateway -> PY MCP | add(6,2)=8 |
| Chained gateways: Parent -> my-gateway -> TS MCP | tools listed + divide(6,2)=3 |

This exercises SigV4 signing, ARN/URL resolution from runtime config, and session-header forwarding through the new layers — both languages, direct + via gateway + chained gateways. Stack torn down after validation.

**Local (`SERVE_LOCAL=true`)** — started the generated TS MCP server locally and drove `AgentCoreMcpClient.withoutAuth(...)` (the exact path the generated per-connection client runs under `SERVE_LOCAL`): connected, listed tools (`divide`), and `divide(6,2)` returned `3` through Layer 0->1->2. The `serve-local` smoke test (LLM-mock-driven agent -> local gateway -> MCP, both languages + chained gateways) also runs in CI.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
