### PR TITLE
chore(docs): trigger translate-docs on push instead of pull_request

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -1,7 +1,8 @@
 name: Translate Documentation
 
 on:
-  pull_request:
+  push:
+    branches: [main, 'release/0.x']
     paths:
       - 'docs/src/content/docs/en/**/*.md'
       - 'docs/src/content/docs/en/**/*.mdx'
@@ -22,7 +23,6 @@ on:
 permissions:
   id-token: write # Required for OIDC
   contents: write # Required for committing changes
-  pull-requests: write # Required for updating PR
 
 jobs:
   translate:
@@ -32,9 +32,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }} # Explicitly checkout the PR branch
           fetch-depth: 0 # Required to detect changed files
-          token: ${{ secrets.TRANSLATE_PUSH_GITHUB_TOKEN }} # needed to trigger PR workflow after push
+          token: ${{ secrets.TRANSLATE_PUSH_GITHUB_TOKEN }} # needed to trigger workflow after push
       - uses: ./.github/actions/init-monorepo
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
@@ -82,19 +81,5 @@ jobs:
           git add docs/src/content/docs/ docs/src/i18n/schema-translations.json
           git commit -m "docs: update translations" --no-verify
 
-          # Push directly to the PR branch
-          git push origin HEAD:${{ github.head_ref }}
-      - name: Update PR
-        if: github.event_name == 'pull_request' && steps.translate.outputs.has_changes == 'true'
-        env:
-          URL: ${{ github.event.pull_request.comments_url}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          FILES_CHANGED=$(git diff --name-only HEAD^ | xargs -I{} bash -c 'echo -n "\n{}";')
-          LATEST_COMMIT=$(git log --pretty=format:"%h" -n 1)
-
-          # Use GitHub API to create a comment
-          curl -X POST "$URL" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -d "{\"body\":\"📚 Documentation translations have been updated and committed ($LATEST_COMMIT) to this PR.\n\n\`\`\`$FILES_CHANGED\n\`\`\`\"}"
+          # Push directly to the branch that was pushed to
+          git push origin HEAD:${{ github.ref_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,12 +238,11 @@ pnpm tsx ./scripts/translate.ts --dry-run
 
 #### GitHub Workflow
 
-A GitHub workflow automatically translates documentation when changes are made to English documentation files in pull requests. The workflow:
+A GitHub workflow automatically translates documentation after changes to English documentation files are merged to `main` or `release/0.x`. The workflow:
 
 1. Detects changes to English documentation files
 2. Translates the changed files using DeepSeek and Haiku 3.5 on AWS Bedrock
-3. Commits the translations back to the source branch
-4. Updates the PR with files translated
+3. Commits the translations back to the branch that was pushed to
 
 ## Finding contributions to work on
 


### PR DESCRIPTION
### Reason for this change

This is a defence-in-depth / least-privilege tidying change. The `translate-docs.yml` workflow's `pull_request` trigger issued AWS OIDC credentials (Bedrock `InvokeModel`, ECR public) during PR builds. There is no reason to issue credentials before the translation source change has been reviewed and merged. (GitHub already withholds OIDC tokens from fork PRs, so credentials were only ever issued to in-repo branches authored by trusted team members — hence this is hygiene, not urgent remediation.)

### Description of changes

- Replaced the `pull_request` trigger (targeting `main`/`release/0.x`) with a `push` trigger on branches `[main, 'release/0.x']`, keeping the same `paths` filter.
- `workflow_dispatch` and its inputs are unchanged.
- Removed `ref: ${{ github.head_ref }}` from the checkout step — in a push context the default checkout already points at the correct SHA. The `TRANSLATE_PUSH_GITHUB_TOKEN` token stays (needed to push back).
- The "Commit translations" step now pushes to `HEAD:${{ github.ref_name }}` (the branch that was just pushed to) instead of `HEAD:${{ github.head_ref }}`.
- Removed the "Update PR" comment step entirely — there is no PR to comment on in a push context.
- Removed the now-unused `pull-requests: write` permission (its only consumer was the removed comment step). The `id-token: write` / `contents: write` permissions are unchanged.

Behavioral note: translations now commit to `main`/`release/0.x` directly as a follow-up commit after merge, rather than being added to the PR before merge.

> ⚠️ **For repo owners:** branch protection on `main`/`release/0.x` restricts pushes to members of `awslabs/aws-apj-cope-developers`/`aws-apj-cope-admin`. For the post-merge translation commit to push back successfully, the PAT owner behind `TRANSLATE_PUSH_GITHUB_TOKEN` must be in one of those teams or have bypass rights, otherwise the push will fail. The secret exists (confirmed via `gh secret list`); ownership/permissions need human confirmation.

### Description of how you validated changes

- `actionlint` passes on the changed workflow file.
- YAML validated; the `on:` block contains only `push` and `workflow_dispatch`.
- Confirmed `github.head_ref` no longer appears anywhere in the file and the push target is `HEAD:${{ github.ref_name }}`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*