### PR TITLE
feat(api): add default API Gateway throttling to CDK constructs

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -253,6 +253,7 @@ import {
   HttpMethod,
   HttpStage,
   LogGroupLogDestination,
+  ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { suppressRules } from '../checkov.js';
@@ -279,6 +280,12 @@ export interface HttpApiProps<
    * Map of operation names to their API Gateway integrations
    */
   readonly integrations: TIntegrations;
+  /**
+   * Default throttling limits applied to the API's default stage.
+   *
+   * @default { rateLimit: 10000, burstLimit: 5000 }
+   */
+  readonly throttle?: ThrottleSettings;
 }
 
 /**
@@ -312,6 +319,7 @@ export class HttpApi<
       apiName,
       operations,
       integrations,
+      throttle = { rateLimit: 10000, burstLimit: 5000 },
       ...props
     }: HttpApiProps<TIntegrations, TOperation>,
   ) {
@@ -339,6 +347,7 @@ export class HttpApi<
     this.defaultStage = new HttpStage(this, 'DefaultStage', {
       httpApi: this.api,
       autoDeploy: true,
+      throttle,
       accessLogSettings: {
         destination: new LogGroupLogDestination(accessLogGroup),
       },
@@ -1062,6 +1071,7 @@ import {
   RestApiProps as _RestApiProps,
   IResource,
   Stage,
+  ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
 import { IAspect, RemovalPolicy } from 'aws-cdk-lib';
 import {
@@ -1108,6 +1118,12 @@ export interface RestApiProps<
    * @default true
    */
   readonly enableWaf?: boolean;
+  /**
+   * Default throttling limits applied to all methods on the API's default stage.
+   *
+   * @default { rateLimit: 10000, burstLimit: 5000 }
+   */
+  readonly throttle?: ThrottleSettings;
 }
 
 /**
@@ -1142,6 +1158,7 @@ export class RestApi<
       operations,
       integrations,
       enableWaf = true,
+      throttle = { rateLimit: 10000, burstLimit: 5000 },
       ...props
     }: RestApiProps<TIntegrations, TOperation>,
   ) {
@@ -1149,7 +1166,21 @@ export class RestApi<
     this.integrations = integrations;
 
     // Create the API Gateway REST API
-    this.api = new _RestApi(this, 'Api', props);
+    this.api = new _RestApi(this, 'Api', {
+      ...props,
+      deployOptions: {
+        ...props.deployOptions,
+        methodOptions: {
+          ...props.deployOptions?.methodOptions,
+          // Default throttling applied to all resource paths and methods
+          '/*/*': {
+            throttlingRateLimit: throttle.rateLimit,
+            throttlingBurstLimit: throttle.burstLimit,
+            ...props.deployOptions?.methodOptions?.['/*/*'],
+          },
+        },
+      },
+    });
 
     if (enableWaf) {
       this.webAcl = new CfnWebACL(this, 'WebAcl', {

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -1206,6 +1206,7 @@ import {
   HttpMethod,
   HttpStage,
   LogGroupLogDestination,
+  ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { suppressRules } from '../checkov.js';
@@ -1232,6 +1233,12 @@ export interface HttpApiProps<
    * Map of operation names to their API Gateway integrations
    */
   readonly integrations: TIntegrations;
+  /**
+   * Default throttling limits applied to the API's default stage.
+   *
+   * @default { rateLimit: 10000, burstLimit: 5000 }
+   */
+  readonly throttle?: ThrottleSettings;
 }
 
 /**
@@ -1265,6 +1272,7 @@ export class HttpApi<
       apiName,
       operations,
       integrations,
+      throttle = { rateLimit: 10000, burstLimit: 5000 },
       ...props
     }: HttpApiProps<TIntegrations, TOperation>,
   ) {
@@ -1292,6 +1300,7 @@ export class HttpApi<
     this.defaultStage = new HttpStage(this, 'DefaultStage', {
       httpApi: this.api,
       autoDeploy: true,
+      throttle,
       accessLogSettings: {
         destination: new LogGroupLogDestination(accessLogGroup),
       },
@@ -2073,6 +2082,7 @@ import {
   RestApiProps as _RestApiProps,
   IResource,
   Stage,
+  ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
 import { IAspect, RemovalPolicy } from 'aws-cdk-lib';
 import {
@@ -2119,6 +2129,12 @@ export interface RestApiProps<
    * @default true
    */
   readonly enableWaf?: boolean;
+  /**
+   * Default throttling limits applied to all methods on the API's default stage.
+   *
+   * @default { rateLimit: 10000, burstLimit: 5000 }
+   */
+  readonly throttle?: ThrottleSettings;
 }
 
 /**
@@ -2153,6 +2169,7 @@ export class RestApi<
       operations,
       integrations,
       enableWaf = true,
+      throttle = { rateLimit: 10000, burstLimit: 5000 },
       ...props
     }: RestApiProps<TIntegrations, TOperation>,
   ) {
@@ -2160,7 +2177,21 @@ export class RestApi<
     this.integrations = integrations;
 
     // Create the API Gateway REST API
-    this.api = new _RestApi(this, 'Api', props);
+    this.api = new _RestApi(this, 'Api', {
+      ...props,
+      deployOptions: {
+        ...props.deployOptions,
+        methodOptions: {
+          ...props.deployOptions?.methodOptions,
+          // Default throttling applied to all resource paths and methods
+          '/*/*': {
+            throttlingRateLimit: throttle.rateLimit,
+            throttlingBurstLimit: throttle.burstLimit,
+            ...props.deployOptions?.methodOptions?.['/*/*'],
+          },
+        },
+      },
+    });
 
     if (enableWaf) {
       this.webAcl = new CfnWebACL(this, 'WebAcl', {

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/http/http-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/http/http-api.ts.template
@@ -12,6 +12,7 @@ import {
   HttpMethod,
   HttpStage,
   LogGroupLogDestination,
+  ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { suppressRules } from '../checkov.js';
@@ -38,6 +39,12 @@ export interface HttpApiProps<
    * Map of operation names to their API Gateway integrations
    */
   readonly integrations: TIntegrations;
+  /**
+   * Default throttling limits applied to the API's default stage.
+   *
+   * @default { rateLimit: 10000, burstLimit: 5000 }
+   */
+  readonly throttle?: ThrottleSettings;
 }
 
 /**
@@ -71,6 +78,7 @@ export class HttpApi<
       apiName,
       operations,
       integrations,
+      throttle = { rateLimit: 10000, burstLimit: 5000 },
       ...props
     }: HttpApiProps<TIntegrations, TOperation>,
   ) {
@@ -98,6 +106,7 @@ export class HttpApi<
     this.defaultStage = new HttpStage(this, 'DefaultStage', {
       httpApi: this.api,
       autoDeploy: true,
+      throttle,
       accessLogSettings: {
         destination: new LogGroupLogDestination(accessLogGroup),
       },

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
@@ -6,6 +6,7 @@ import {
   RestApiProps as _RestApiProps,
   IResource,
   Stage,
+  ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
 import { IAspect, RemovalPolicy } from 'aws-cdk-lib';
 import {
@@ -52,6 +53,12 @@ export interface RestApiProps<
    * @default true
    */
   readonly enableWaf?: boolean;
+  /**
+   * Default throttling limits applied to all methods on the API's default stage.
+   *
+   * @default { rateLimit: 10000, burstLimit: 5000 }
+   */
+  readonly throttle?: ThrottleSettings;
 }
 
 /**
@@ -86,6 +93,7 @@ export class RestApi<
       operations,
       integrations,
       enableWaf = true,
+      throttle = { rateLimit: 10000, burstLimit: 5000 },
       ...props
     }: RestApiProps<TIntegrations, TOperation>,
   ) {
@@ -93,7 +101,21 @@ export class RestApi<
     this.integrations = integrations;
 
     // Create the API Gateway REST API
-    this.api = new _RestApi(this, 'Api', props);
+    this.api = new _RestApi(this, 'Api', {
+      ...props,
+      deployOptions: {
+        ...props.deployOptions,
+        methodOptions: {
+          ...props.deployOptions?.methodOptions,
+          // Default throttling applied to all resource paths and methods
+          '/*/*': {
+            throttlingRateLimit: throttle.rateLimit,
+            throttlingBurstLimit: throttle.burstLimit,
+            ...props.deployOptions?.methodOptions?.['/*/*'],
+          },
+        },
+      },
+    });
 
     if (enableWaf) {
       this.webAcl = new CfnWebACL(this, 'WebAcl', {


### PR DESCRIPTION
### Reason for this change

The shared CDK HTTP/REST API constructs used by the `ts#trpc-api` and `py#fast-api` generators did not apply any default API Gateway stage throttling. The FastAPI Terraform implementation already ships with default stage throttling (rateLimit: 10000, burstLimit: 5000), so CDK-deployed APIs were inconsistent with their Terraform equivalents and had no default rate/burst ceiling.

### Description of changes

Added default API Gateway stage throttling to the shared CDK API constructs:

- **HTTP API** (`cdk/core/api/http/http-api.ts`): set `throttle` on the `HttpStage` default stage.
- **REST API** (`cdk/core/api/rest/rest-api.ts`): set `deployOptions.methodOptions['/*/*']` throttling on the auto-created default stage.

Both default to `{ rateLimit: 10000, burstLimit: 5000 }`, matching the existing FastAPI Terraform defaults, and expose an overridable `throttle?: ThrottleSettings` prop. User-supplied `deployOptions`/`methodOptions` are merged so consumers can override the per-path or default throttle without losing the construct's other settings.

These generous limits (10k req/s) cause no friction in normal usage while bringing the CDK constructs to parity with the FastAPI Terraform defaults.

### Description of how you validated changes

Ran the affected generator snapshot suites with `-u`:
- `@aws/nx-plugin` `src/trpc/backend/generator.spec.ts`
- `@aws/nx-plugin` `src/py/fast-api/generator.spec.ts`

Performed an end-to-end deployment test: scaffolded a `ts#trpc-api` project with CDK infrastructure using the locally compiled and linked plugin, ran `cdk deploy`, and verified via `aws apigatewayv2 get-stage` that the default stage applied `ThrottlingRateLimit: 10000` and `ThrottlingBurstLimit: 5000`. A live invocation of the deployed endpoint returned successfully. (Full output posted in a PR comment.)

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*