### PR TITLE
feat(api,agent): validate string input length

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 This file is the implementation of the `echo` method and as you can see is strongly typed by declaring its input and output data structures.
@@ -156,13 +156,13 @@ This file is the implementation of the `echo` method and as you can see is stron
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -138,7 +138,7 @@ The example `echo` procedure is generated for you in `src/procedures/echo.ts`:
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 To break down the above:

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -156,13 +156,13 @@ Este archivo es la implementación del método `echo` y como puedes ver está fu
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -138,7 +138,7 @@ El procedimiento `echo` de ejemplo se genera en `src/procedures/echo.ts`:
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Desglosando lo anterior:

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -156,13 +156,13 @@ Ce fichier est l'implémentation de la méthode `echo` et comme vous pouvez le v
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -138,7 +138,7 @@ L'exemple de procédure `echo` est généré pour vous dans `src/procedures/echo
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Décomposons ceci :

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -156,13 +156,13 @@ Questo file implementa il metodo `echo` ed è fortemente tipizzato dichiarando l
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -138,7 +138,7 @@ La procedura `echo` di esempio è generata per te in `src/procedures/echo.ts`:
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Analizzando il codice sopra:

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -156,13 +156,13 @@ export const echo = publicProcedure
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -138,7 +138,7 @@ export const appRouter = router({
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 上記の分解:

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 이 파일은 `echo` 메서드의 구현이며, 입력 및 출력 데이터 구조를 선언하여 강력하게 타입화되어 있습니다.
@@ -156,13 +156,13 @@ export const echo = publicProcedure
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -138,7 +138,7 @@ export const appRouter = router({
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 위 코드를 분석하면:

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -156,13 +156,13 @@ Este arquivo é a implementação do método `echo` e como você pode ver é for
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -138,7 +138,7 @@ O procedimento `echo` de exemplo é gerado em `src/procedures/echo.ts`:
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Analisando o código acima:

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Tệp này là triển khai của phương thức `echo` và như bạn có thể thấy được định kiểu mạnh bằng cách khai báo các cấu trúc dữ liệu đầu vào và đầu ra của nó.
@@ -156,13 +156,13 @@ Tệp này là triển khai của phương thức `echo` và như bạn có th�
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -138,7 +138,7 @@ Procedure `echo` ví dụ được tạo cho bạn trong `src/procedures/echo.ts
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Để phân tích đoạn mã trên:

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -156,13 +156,13 @@ export const echo = publicProcedure
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -138,7 +138,7 @@ export const appRouter = router({
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 分解上述代码:

--- a/e2e/src/smoke-tests/deploy-invocations.ts
+++ b/e2e/src/smoke-tests/deploy-invocations.ts
@@ -64,7 +64,7 @@ export async function invokeTrpcApi(
   );
   const data = await response.json();
   console.log(`${apiName} response:`, data);
-  expect(data.result.data.result).toBe('test');
+  expect(data.result.data.message).toBe('test');
 }
 
 export async function invokeRestApi(

--- a/e2e/src/smoke-tests/serve-local.spec.ts
+++ b/e2e/src/smoke-tests/serve-local.spec.ts
@@ -610,7 +610,7 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     );
     const body = await res.json();
     console.log('tRPC echo response:', JSON.stringify(body));
-    expect(body.result.data.result).toBe('hello');
+    expect(body.result.data.message).toBe('hello');
     await stopLast();
   });
 
@@ -633,9 +633,8 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
 
     // Wait out the gap between DynamoDB Local's port opening and the local
     // table being created, then assert the (empty) category query succeeds.
-    const empty = await waitForJson(
-      `${base}/examples?category=tools`,
-      (b) => Array.isArray(b),
+    const empty = await waitForJson(`${base}/examples?category=tools`, (b) =>
+      Array.isArray(b),
     );
     console.log('examples (empty):', JSON.stringify(empty));
     expect(empty).toEqual([]);
@@ -661,8 +660,8 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     expect(fetched).toEqual({ id: '1', name: 'Widget', category: 'tools' });
 
     // List exercises a GSI query (gsi1 by category)
-    const byCategory = await fetch(`${base}/examples?category=tools`).then((r) =>
-      r.json(),
+    const byCategory = await fetch(`${base}/examples?category=tools`).then(
+      (r) => r.json(),
     );
     console.log('examples by category:', JSON.stringify(byCategory));
     expect(byCategory).toHaveLength(2);

--- a/e2e/src/smoke-tests/serve-local.spec.ts
+++ b/e2e/src/smoke-tests/serve-local.spec.ts
@@ -1268,7 +1268,7 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     );
     const trpcBody = await trpcRes.json();
     console.log('tRPC cascade echo:', JSON.stringify(trpcBody));
-    expect(trpcBody.result.data.result).toBe('cascade');
+    expect(trpcBody.result.data.message).toBe('cascade');
 
     const fastApiRes = await fetch(
       `http://127.0.0.1:${ports.fastApi}/echo?message=cascade`,

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -1285,7 +1285,7 @@ exports[`py#agent generator > should match snapshot for generated files > agent-
 import uvicorn
 from bedrock_agentcore.runtime.models import PingStatus
 from fastapi import Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 from proj_agent_connection import session_id_context, with_session_id
 
@@ -1303,7 +1303,7 @@ _agent = _agent_ctx.__enter__()
 
 
 class InvokeInput(BaseModel):
-    message: str
+    message: str = Field(max_length=100000)
 
 
 class StreamChunk(BaseModel):

--- a/packages/nx-plugin/src/py/agent/files/http/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/http/main.py.template
@@ -3,7 +3,7 @@ import uuid
 import uvicorn
 from bedrock_agentcore.runtime.models import PingStatus
 from fastapi import Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 from <%- agentConnectionModuleName %> import session_id_context, with_session_id
 
@@ -21,7 +21,7 @@ _agent = _agent_ctx.__enter__()
 
 
 class InvokeInput(BaseModel):
-    message: str
+    message: str = Field(max_length=100000)
 
 
 class StreamChunk(BaseModel):

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -191,7 +191,10 @@ class LoggerRouteHandler(APIRoute):
 
 app.router.route_class = LoggerRouteHandler
 ",
-  "apps/test_api/proj_test_api/main.py": "import uvicorn
+  "apps/test_api/proj_test_api/main.py": "from typing import Annotated
+
+import uvicorn
+from fastapi import Query
 from pydantic import BaseModel
 
 from .init import app, tracer
@@ -203,7 +206,7 @@ class EchoOutput(BaseModel):
 
 @app.get("/echo")
 @tracer.capture_method
-def echo(message: str) -> EchoOutput:
+def echo(message: Annotated[str, Query(max_length=1024)]) -> EchoOutput:
     return EchoOutput(message=f"{message}")
 
 

--- a/packages/nx-plugin/src/py/fast-api/files/app/__name__/main.py.template
+++ b/packages/nx-plugin/src/py/fast-api/files/app/__name__/main.py.template
@@ -1,4 +1,7 @@
+from typing import Annotated
+
 import uvicorn
+from fastapi import Query
 from pydantic import BaseModel
 
 from .init import app, tracer
@@ -10,7 +13,7 @@ class EchoOutput(BaseModel):
 
 @app.get("/echo")
 @tracer.capture_method
-def echo(message: str) -> EchoOutput:
+def echo(message: Annotated[str, Query(max_length=1024)]) -> EchoOutput:
     return EchoOutput(message=f"{message}")
 
 

--- a/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
@@ -249,6 +249,7 @@ operation Echo {
     input := {
         @httpQuery("message")
         @required
+        @length(max: 1024)
         message: String
     }
     output := {

--- a/packages/nx-plugin/src/smithy/project/files/src/operations/echo.smithy.template
+++ b/packages/nx-plugin/src/smithy/project/files/src/operations/echo.smithy.template
@@ -9,6 +9,7 @@ operation Echo {
     input := {
         @httpQuery("message")
         @required
+        @length(max: 1024)
         message: String
     }
     output := {

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -281,7 +281,7 @@ import { EchoInputSchema, EchoOutputSchema } from '../schema/index.js';
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 "
 `;
 
@@ -303,13 +303,13 @@ exports[`trpc backend generator > should generate the project > apps/test-api/sr
 "import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/packages/nx-plugin/src/trpc/backend/files/src/procedures/echo.ts.template
+++ b/packages/nx-plugin/src/trpc/backend/files/src/procedures/echo.ts.template
@@ -5,4 +5,4 @@ import { EchoInputSchema, EchoOutputSchema } from '../schema/index.js';
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));

--- a/packages/nx-plugin/src/trpc/backend/files/src/schema/echo.ts.template
+++ b/packages/nx-plugin/src/trpc/backend/files/src/schema/echo.ts.template
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 
 export const EchoInputSchema = z.object({
-  message: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoInput = z.TypeOf<typeof EchoInputSchema>;
 
 export const EchoOutputSchema = z.object({
-  result: z.string(),
+  message: z.string().max(1024),
 });
 
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -1560,7 +1560,7 @@ const agent = withSessionId(getAgent);
 
 export const appRouter = router({
   invoke: publicProcedure
-    .input(z.object({ message: z.string() }))
+    .input(z.object({ message: z.string().max(100000) }))
     .output(
       zAsyncIterable({
         yield: z.string(),

--- a/packages/nx-plugin/src/ts/agent/files/http/router.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/http/router.ts.template
@@ -10,7 +10,7 @@ const agent = withSessionId(getAgent);
 
 export const appRouter = router({
   invoke: publicProcedure
-    .input(z.object({ message: z.string() }))
+    .input(z.object({ message: z.string().max(100000) }))
     .output(
       zAsyncIterable({
         yield: z.string(),


### PR DESCRIPTION
### Reason for this change

The example procedures, routes and handlers vended by the API and agent generators accept public-facing string inputs (e.g. `message`) with no length constraint. Unbounded string inputs are a footgun for generated projects — they allow arbitrarily large payloads to reach the backend before any validation occurs.

Additionally, the tRPC `echo` procedure returned its result under a `result` field while the input was `message`. This is inconsistent — the output field is now `message` too.

### Description of changes

Added maximum length validation to public-facing string inputs across the API and agent generators, with sizes chosen to suit each use case:

- **tRPC API** (`ts#trpc-api`): `EchoInputSchema`/`EchoOutputSchema` cap `message` at `z.string().max(1024)`. The output field is renamed from `result` to `message` for consistency, and the procedure returns `{ message: opts.input.message }`.
- **FastAPI** (`py#fast-api`): the `/echo` query parameter is now `Annotated[str, Query(max_length=1024)]`.
- **Smithy API** (`ts#smithy-api`): the echo operation's `message` input gains `@length(max: 1024)`.
- **TS agent** (`ts#agent`): the HTTP `invoke` input caps `message` at `z.string().max(100000)`.
- **Python agent** (`py#agent`): the HTTP `InvokeInput.message` caps at `Field(max_length=100000)`.

APIs use a conservative 1024-character limit, while agents use a much larger 100,000-character limit since users may legitimately submit large prompts.

Documentation (tRPC guide, dungeon-adventure tutorial) and e2e smoke-test assertions were updated to match (including the tRPC `result` → `message` rename).

### Description of how you validated changes

Updated and verified the generator unit-test snapshots for all five affected generators (`trpc/backend`, `py/fast-api`, `smithy/project`, `ts/agent`, `py/agent`) — each spec passes. e2e assertions for the tRPC echo output field were updated accordingly.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*