### PR TITLE
fix(ts#lambda-function): pin Lambda runtime to NODEJS_22_X

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -242,7 +242,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -242,7 +242,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -242,7 +242,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -242,7 +242,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -242,7 +242,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -242,7 +242,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -87,7 +87,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: OPERATION_DETAILS,
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -267,7 +267,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: OPERATION_DETAILS,
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -436,7 +436,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -638,7 +638,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -851,7 +851,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -890,7 +890,7 @@ export class TestApi<
       scope,
       'TestApiAuthorizerFunction',
       {
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -1063,7 +1063,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -1103,7 +1103,7 @@ export class TestApi<
       scope,
       'TestApiAuthorizerFunction',
       {
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -1413,7 +1413,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -2415,7 +2415,7 @@ export class TestApi<
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
       defaultIntegrationOptions: <FunctionProps>{
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(

--- a/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -10,7 +10,7 @@ export class TestProjectTestFunction extends Function {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
       timeout: Duration.seconds(30),
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'index.handler',
       code: Code.fromAsset(
         url.fileURLToPath(

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -646,7 +646,7 @@ export abstract class AuroraDatabase extends Construct {
     const createDbUserHandler = new Function(this, 'CreateDbUserHandler', {
       code: Code.fromAsset(createDbUserBundleDir),
       handler: 'index.handler',
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: Runtime.NODEJS_22_X,
       timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
@@ -4401,7 +4401,7 @@ export abstract class AuroraDatabase extends Construct {
     const createDbUserHandler = new Function(this, 'CreateDbUserHandler', {
       code: Code.fromAsset(createDbUserBundleDir),
       handler: 'index.handler',
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: Runtime.NODEJS_22_X,
       timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -110,7 +110,7 @@ export class <%= apiNameClassName %><
       <%_ } _%>
       defaultIntegrationOptions: <FunctionProps>{
         <%_ if (['trpc', 'smithy'].includes(backend.type)) { _%>
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -178,7 +178,7 @@ export class <%= apiNameClassName %><
     <%_ if (auth === 'custom') { _%>
     const authorizerFunction = new Function(scope, '<%= apiNameClassName %>AuthorizerFunction', {
       <%_ if (['trpc', 'smithy'].includes(backend.type)) { _%>
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'index.handler',
       code: Code.fromAsset(
         url.fileURLToPath(

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -120,7 +120,7 @@ export class <%= apiNameClassName %><
       <%_ } _%>
       defaultIntegrationOptions: <FunctionProps>{
         <%_ if (['trpc', 'smithy'].includes(backend.type)) { _%>
-        runtime: Runtime.NODEJS_LATEST,
+        runtime: Runtime.NODEJS_22_X,
         handler: 'index.handler',
         code: Code.fromAsset(
           url.fileURLToPath(
@@ -198,7 +198,7 @@ export class <%= apiNameClassName %><
     <%_ if (auth === 'custom') { _%>
     const authorizerFunction = new Function(scope, '<%= apiNameClassName %>AuthorizerFunction', {
       <%_ if (['trpc', 'smithy'].includes(backend.type)) { _%>
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'index.handler',
       code: Code.fromAsset(
         url.fileURLToPath(

--- a/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
+++ b/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
@@ -80,7 +80,7 @@ const addLambdaFunctionCdkConstructs = async (
     ),
     {
       ...options,
-      runtime: `Runtime.${options.runtime === 'python' ? 'PYTHON_3_14' : 'NODEJS_LATEST'}`,
+      runtime: `Runtime.${options.runtime === 'python' ? 'PYTHON_3_14' : 'NODEJS_22_X'}`,
     },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
@@ -292,7 +292,7 @@ export abstract class AuroraDatabase extends Construct {
     const createDbUserHandler = new Function(this, 'CreateDbUserHandler', {
       code: Code.fromAsset(createDbUserBundleDir),
       handler: 'index.handler',
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: Runtime.NODEJS_22_X,
       timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,


### PR DESCRIPTION
### Reason for this change

Generated Lambda function definitions used `lambda.Runtime.NODEJS_LATEST`, a floating/unpinned runtime. The threat model flags this as a supply-chain and reproducibility risk (T36, T49): the runtime can change underneath users without an explicit code change, breaking deterministic builds.

### Description of changes

Replaced `Runtime.NODEJS_LATEST` with the pinned LTS runtime `Runtime.NODEJS_22_X` across all generated Lambda function definitions:

- `src/utils/function-constructs/function-constructs.ts` (Node lambda-function CDK construct; Python branch already pins `PYTHON_3_14`)
- `src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template` (CreateDbUser handler)
- `src/utils/api-constructs/files/cdk/app/apis/{http,rest}/__apiNameKebabCase__.ts.template` (default integration + custom authorizer handlers)
- Updated affected snapshots (trpc/backend, smithy/ts/api, ts/lambda-function, ts/rdb)
- Updated the dungeon-game tutorial (English) generated-output snippet to match

No `PYTHON_LATEST` usages exist — Python generators already pin to `PYTHON_3_14`, so they were left as-is. The pinned Node version can be bumped explicitly in a future PR.

### Description of how you validated changes

Ran the affected generator unit tests with snapshot updates and verified the only snapshot diffs are the runtime change:

- `ts/lambda-function/generator.spec.ts` — 93 passed
- `ts/rdb/generator.spec.ts`, `smithy/ts/api/generator.spec.ts`, `trpc/backend/generator.spec.ts` — 115 passed

### Issue # (if applicable)

N/A (threat-model items T36, T49).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*