### PR TITLE
fix(ts#trpc-api,api-connection): send Cognito access_token as Bearer and accept it on REST + HTTP APIs

### DIFF
--- a/docs/src/content/docs/en/guides/fastapi.mdx
+++ b/docs/src/content/docs/en/guides/fastapi.mdx
@@ -185,6 +185,118 @@ Unhandled exceptions are caught by the middleware and:
 It's recommended to specify response models for your API operations for better code generation if using the `connection` generator. <Link path="guides/connection/react-fastapi#errors">See here for more details</Link>.
 :::
 
+### Accessing the Calling User
+
+When your API is protected by authentication, your route handlers often need to know who is calling. The generated FastAPI runs inside AWS Lambda via the [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), which forwards the API Gateway request context as JSON on the `x-amzn-request-context` header. You can read it from the FastAPI `Request` to extract the caller's identity.
+
+As an example, let's add a `/me` endpoint that returns details about the calling user. We'll implement the extraction as a [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) so it can be reused across routes. The way you extract the caller's identity depends on your selected `auth` method:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway request context. Create `identity.py` alongside `main.py`:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # The Lambda Web Adapter forwards the API Gateway request context as JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Assumes user pool id is configured in lambda environment
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the request context at `authorizer.claims`. The dependency just reads those claims — no extra AWS SDK calls, no manual JWT verification.
+
+The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens. Create `identity.py` alongside `main.py`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # The Lambda Web Adapter forwards the API Gateway request context as JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[Verifying the token]
+You don't need any JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
+:::
+</OptionFilter>
+
+You can then inject the `CurrentUser` dependency into any route that needs the caller's identity:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### Streaming
 

--- a/docs/src/content/docs/en/guides/fastapi.mdx
+++ b/docs/src/content/docs/en/guides/fastapi.mdx
@@ -189,11 +189,13 @@ It's recommended to specify response models for your API operations for better c
 
 When your API is protected by authentication, your route handlers often need to know who is calling. The generated FastAPI runs inside AWS Lambda via the [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), which forwards the API Gateway request context as JSON on the `x-amzn-request-context` header. You can read it from the FastAPI `Request` to extract the caller's identity.
 
-As an example, let's add a `/me` endpoint that returns details about the calling user. We'll implement the extraction as a [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) so it can be reused across routes. The way you extract the caller's identity depends on your selected `auth` method:
+As an example, let's add a `/me` endpoint that returns details about the calling user. We'll implement the extraction as a [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) so it can be reused across routes. The shape of the request context — and therefore how you extract the identity — depends on both your selected `auth` method and whether you deployed a REST or HTTP API.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway request context. Create `identity.py` alongside `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # The Lambda Web Adapter forwards the API Gateway request context as JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Assumes user pool id is configured in lambda environment
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the request context at `authorizer.claims`. The dependency just reads those claims — no extra AWS SDK calls, no manual JWT verification.
+With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the request context. The dependency just reads those claims — no extra AWS SDK calls, no manual JWT verification.
 
 The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens. Create `identity.py` alongside `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP APIs use a JWT authorizer which places the verified claims under `authorizer.jwt.claims`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # The Lambda Web Adapter forwards the API Gateway request context as JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[Verifying the token]
 You don't need any JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.

--- a/docs/src/content/docs/en/guides/fastapi.mdx
+++ b/docs/src/content/docs/en/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the request context. The dependency just reads those claims — no extra AWS SDK calls, no manual JWT verification.
+With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the request context.
 
-The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens. Create `identity.py` alongside `main.py`:
+Create `identity.py` alongside `main.py`:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[Verifying the token]
+:::tip[No token verification required]
 You don't need any JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Note that we define an additional _optional_ property on the context. tRPC manages ensuring that this is defined in procedures which have correctly configured this middleware.
 
-Next, the middleware itself. The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens:
+Next, the middleware itself:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[Verifying the token]
+:::tip[No token verification required]
 You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Note that we define an additional _optional_ property on the context. tRPC manages ensuring that this is defined in procedures which have correctly configured this middleware.
 
-Next, the middleware itself. The generator wires the authorizer to accept ID tokens, so `cognito:username` is the canonical username claim; we fall back to `username` for access tokens in case you reconfigure the authorizer:
+Next, the middleware itself. The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[Verifying the token]
-You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, audience, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
+You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Accessing the Calling User
 
-When your API is protected by authentication, your operations often need to know who is calling. The cleanest approach is to resolve the caller's identity once in the handler and pass it through the [service context](#service-context), so your operations stay free of any API Gateway event parsing.
+When your API is protected by authentication, your operations often need to know who is calling. The recommended approach is to resolve the caller's identity once in the handler and pass it through the [service context](#service-context) for consumption by specific operations.
 
-As an example, let's add a `Me` operation that returns details about the calling user.
+We'll model the unauthorized case as a Smithy error so it serializes to a proper `403` response. Add it to your model, for example in `model/src/operations/errors.smithy`, and reference it on any operation that requires identity:
 
-First, add the resolved identity to the service context in `src/context.ts`:
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+First, expose the resolved identity on the service context in `src/context.ts`. We provide it as a function so that the `UnauthorizedError` is thrown from within an operation (where the Server SDK serializes it to a `403`), rather than from the handler:
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-Next, write a function which resolves the identity from the API Gateway event in `src/identity.ts`. The implementation depends on your selected `auth` method:
+Next, write the resolver in `src/identity.ts`. It throws `UnauthorizedError` when the caller cannot be determined. The implementation depends on your selected `auth` method:
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
 For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway event:
@@ -439,12 +453,13 @@ For `IAM` authentication, we look up the caller in Cognito using the sub extract
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
-With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the event at `event.requestContext.authorizer.claims`. We just read those claims — no extra AWS SDK calls, no manual JWT verification.
-
-The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens:
+With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the event at `event.requestContext.authorizer.claims`:
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[Verifying the token]
+:::tip[No token verification required]
 You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
 :::
 </OptionFilter>
 
-Then call `getIdentity` in `src/handler.ts` and add the result to the context:
+Then wire the resolver into the context in `src/handler.ts`:
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[IAM lookup is asynchronous]
-For `IAM` auth, `getIdentity` is `async` (it calls Cognito), which is why we `await` it above. For `cognito` auth it just reads claims and is synchronous, but awaiting it is harmless — so the handler code is identical for both.
-:::
-
-Now define the `Me` operation in your Smithy model, for example in `model/src/operations/me.smithy`:
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-Remember to register the operation on your service in `model/src/main.smithy`:
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-Implement the operation in `src/operations/me.ts`, reading the resolved identity straight from the context:
+We can now use the resolved identity in an operation, for example in `src/operations/echo.ts`:
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-Finally, register the operation on your service in `src/service.ts`:
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Accessing the Calling User
 
-When your API is protected by authentication, your operations often need to know who is calling. The generator does not add this for you, but since the raw API Gateway event is available, you can extract the caller's identity in an operation.
+When your API is protected by authentication, your operations often need to know who is calling. The cleanest approach is to resolve the caller's identity once in the handler and pass it through the [service context](#service-context), so your operations stay free of any API Gateway event parsing.
 
-As an example, let's add a `Me` operation that returns details about the calling user. First, make the API Gateway event available on the [service context](#service-context) by adding it in `src/context.ts`:
+As an example, let's add a `Me` operation that returns details about the calling user.
 
-```ts {4,12} ins={4,12}
+First, add the resolved identity to the service context in `src/context.ts`:
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-Then pass the event through when you construct the context in `src/handler.ts`:
+Next, write a function which resolves the identity from the API Gateway event in `src/identity.ts`. The implementation depends on your selected `auth` method:
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
+For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway event:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
+With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the event at `event.requestContext.authorizer.claims`. We just read those claims — no extra AWS SDK calls, no manual JWT verification.
+
+The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens:
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verifying the token]
+You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
+:::
+</OptionFilter>
+
+Then call `getIdentity` in `src/handler.ts` and add the result to the context:
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[Local Server]
-The `serve` target's `src/local-server.ts` also constructs the context. There is no API Gateway event when running locally, so you can pass a stub (e.g. `event: { requestContext: {} } as never`) to satisfy the type.
+:::note[IAM lookup is asynchronous]
+For `IAM` auth, `getIdentity` is `async` (it calls Cognito), which is why we `await` it above. For `cognito` auth it just reads claims and is synchronous, but awaiting it is harmless — so the handler code is identical for both.
 :::
 
-Next, define the `Me` operation in your Smithy model, for example in `model/src/operations/me.smithy`:
+Now define the `Me` operation in your Smithy model, for example in `model/src/operations/me.smithy`:
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-Now implement the operation. The way you extract the caller's identity depends on your selected `auth` method:
-
-<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
-For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway event. Create `src/operations/me.ts`:
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the event at `event.requestContext.authorizer.claims`. The operation just reads those claims — no extra AWS SDK calls, no manual JWT verification.
-
-The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens. Create `src/operations/me.ts`:
+Implement the operation in `src/operations/me.ts`, reading the resolved identity straight from the context:
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[Verifying the token]
-You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
-:::
-</OptionFilter>
 
 Finally, register the operation on your service in `src/service.ts`:
 

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### Accessing the Calling User
+
+When your API is protected by authentication, your operations often need to know who is calling. The generator does not add this for you, but since the raw API Gateway event is available, you can extract the caller's identity in an operation.
+
+As an example, let's add a `Me` operation that returns details about the calling user. First, make the API Gateway event available on the [service context](#service-context) by adding it in `src/context.ts`:
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+Then pass the event through when you construct the context in `src/handler.ts`:
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[Local Server]
+The `serve` target's `src/local-server.ts` also constructs the context. There is no API Gateway event when running locally, so you can pass a stub (e.g. `event: { requestContext: {} } as never`) to satisfy the type.
+:::
+
+Next, define the `Me` operation in your Smithy model, for example in `model/src/operations/me.smithy`:
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Remember to register the operation on your service in `model/src/main.smithy`:
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+Now implement the operation. The way you extract the caller's identity depends on your selected `auth` method:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway event. Create `src/operations/me.ts`:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+With `auth: 'cognito'`, the API Gateway Cognito User Pools authorizer verifies the JWT that the caller supplies in the `Authorization` header and places the verified claims on the event at `event.requestContext.authorizer.claims`. The operation just reads those claims — no extra AWS SDK calls, no manual JWT verification.
+
+The generator wires the authorizer to accept Cognito access tokens, so `username` is the canonical username claim; we fall back to `cognito:username` in case you reconfigure the authorizer to accept ID tokens. Create `src/operations/me.ts`:
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verifying the token]
+You don't need `aws-jwt-verify` or any other JWT-verification library here — the API Gateway Cognito User Pools authorizer has already verified the signature, issuer, scopes, and expiry by the time your Lambda runs. If any of those checks fail, API Gateway returns `401 Unauthorized` and your handler is never invoked.
+:::
+</OptionFilter>
+
+Finally, register the operation on your service in `src/service.ts`:
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## Building and Code Generation
 
 The Smithy model project uses [Docker](https://www.docker.com/) to build the Smithy artifacts and generate the TypeScript Server SDK:

--- a/docs/src/content/docs/es/guides/fastapi.mdx
+++ b/docs/src/content/docs/es/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamador proporciona en el encabezado `Authorization` y coloca los claims verificados en el contexto de solicitud. La dependencia simplemente lee esos claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
+Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamador proporciona en el encabezado `Authorization` y coloca los claims verificados en el contexto de solicitud.
 
-El generador conecta el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es el claim de nombre de usuario canónico; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID. Crea `identity.py` junto a `main.py`:
+Crea `identity.py` junto a `main.py`:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[Verificando el token]
+:::tip[No se requiere verificación de token]
 No necesitas ninguna biblioteca de verificación JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu manejador nunca se invoca.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/es/guides/fastapi.mdx
+++ b/docs/src/content/docs/es/guides/fastapi.mdx
@@ -189,11 +189,13 @@ Se recomienda especificar modelos de respuesta para tus operaciones API para una
 
 Cuando tu API está protegida por autenticación, tus manejadores de rutas a menudo necesitan saber quién está llamando. La FastAPI generada se ejecuta dentro de AWS Lambda mediante el [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), que reenvía el contexto de solicitud de API Gateway como JSON en el encabezado `x-amzn-request-context`. Puedes leerlo desde el `Request` de FastAPI para extraer la identidad del llamador.
 
-Como ejemplo, agreguemos un endpoint `/me` que devuelve detalles sobre el usuario que llama. Implementaremos la extracción como una [dependencia de FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) para que pueda reutilizarse en todas las rutas. La forma en que extraes la identidad del llamador depende del método `auth` seleccionado:
+Como ejemplo, agreguemos un endpoint `/me` que devuelve detalles sobre el usuario que llama. Implementaremos la extracción como una [dependencia de FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) para que pueda reutilizarse en todas las rutas. La forma del contexto de solicitud — y por lo tanto cómo extraes la identidad — depende tanto de tu método `auth` seleccionado como de si desplegaste una REST API o HTTP API.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 Para autenticación `IAM`, buscamos al llamador en Cognito usando el sub extraído del contexto de solicitud de API Gateway. Crea `identity.py` junto a `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # El Lambda Web Adapter reenvía el contexto de solicitud de API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Asume que el id del user pool está configurado en el entorno lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamador proporciona en el encabezado `Authorization` y coloca los claims verificados en el contexto de solicitud en `authorizer.claims`. La dependencia simplemente lee esos claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
+Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamador proporciona en el encabezado `Authorization` y coloca los claims verificados en el contexto de solicitud. La dependencia simplemente lee esos claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
 
 El generador conecta el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es el claim de nombre de usuario canónico; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID. Crea `identity.py` junto a `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+Las HTTP APIs usan un autorizador JWT que coloca los claims verificados bajo `authorizer.jwt.claims`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # El Lambda Web Adapter reenvía el contexto de solicitud de API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[Verificando el token]
 No necesitas ninguna biblioteca de verificación JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu manejador nunca se invoca.

--- a/docs/src/content/docs/es/guides/fastapi.mdx
+++ b/docs/src/content/docs/es/guides/fastapi.mdx
@@ -185,6 +185,118 @@ Las excepciones no manejadas son capturadas por el middleware y:
 Se recomienda especificar modelos de respuesta para tus operaciones API para una mejor generación de código si usas el generador `connection`. <Link path="guides/connection/react-fastapi#errors">Consulta aquí para más detalles</Link>.
 :::
 
+### Accediendo al usuario que llama
+
+Cuando tu API está protegida por autenticación, tus manejadores de rutas a menudo necesitan saber quién está llamando. La FastAPI generada se ejecuta dentro de AWS Lambda mediante el [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), que reenvía el contexto de solicitud de API Gateway como JSON en el encabezado `x-amzn-request-context`. Puedes leerlo desde el `Request` de FastAPI para extraer la identidad del llamador.
+
+Como ejemplo, agreguemos un endpoint `/me` que devuelve detalles sobre el usuario que llama. Implementaremos la extracción como una [dependencia de FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) para que pueda reutilizarse en todas las rutas. La forma en que extraes la identidad del llamador depende del método `auth` seleccionado:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Para autenticación `IAM`, buscamos al llamador en Cognito usando el sub extraído del contexto de solicitud de API Gateway. Crea `identity.py` junto a `main.py`:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # El Lambda Web Adapter reenvía el contexto de solicitud de API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Asume que el id del user pool está configurado en el entorno lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamador proporciona en el encabezado `Authorization` y coloca los claims verificados en el contexto de solicitud en `authorizer.claims`. La dependencia simplemente lee esos claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
+
+El generador conecta el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es el claim de nombre de usuario canónico; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID. Crea `identity.py` junto a `main.py`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # El Lambda Web Adapter reenvía el contexto de solicitud de API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[Verificando el token]
+No necesitas ninguna biblioteca de verificación JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu manejador nunca se invoca.
+:::
+</OptionFilter>
+
+Luego puedes inyectar la dependencia `CurrentUser` en cualquier ruta que necesite la identidad del llamador:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### Streaming
 

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Nota que definimos una propiedad adicional _opcional_ en el contexto. tRPC se encarga de asegurar que esto esté definido en procedimientos que hayan configurado correctamente este middleware.
 
-A continuación, el middleware mismo. El generador configura el autorizador para aceptar tokens de ID, por lo que `cognito:username` es la claim de nombre de usuario canónica; recurrimos a `username` para tokens de acceso en caso de que reconfigures el autorizador:
+A continuación, el middleware mismo. El generador configura el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es la claim de nombre de usuario canónica; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[Verificando el token]
-No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, la audiencia y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu manejador nunca se invoca.
+No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu manejador nunca se invoca.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Nota que definimos una propiedad adicional _opcional_ en el contexto. tRPC se encarga de asegurar que esto esté definido en procedimientos que hayan configurado correctamente este middleware.
 
-A continuación, el middleware mismo. El generador configura el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es la claim de nombre de usuario canónica; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID:
+A continuación, el middleware mismo:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[Verificando el token]
+:::tip[No se requiere verificación de token]
 No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu manejador nunca se invoca.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Acceso al Usuario que Realiza la Llamada
 
-Cuando tu API está protegida por autenticación, tus operaciones a menudo necesitan saber quién está realizando la llamada. El generador no añade esto por ti, pero dado que el evento sin procesar de API Gateway está disponible, puedes extraer la identidad del llamante en una operación.
+Cuando tu API está protegida por autenticación, tus operaciones a menudo necesitan saber quién está realizando la llamada. El enfoque más limpio es resolver la identidad del llamante una vez en el handler y pasarla a través del [contexto del servicio](#service-context), para que tus operaciones permanezcan libres de cualquier análisis de eventos de API Gateway.
 
-Como ejemplo, agreguemos una operación `Me` que devuelve detalles sobre el usuario que realiza la llamada. Primero, haz que el evento de API Gateway esté disponible en el [contexto del servicio](#service-context) agregándolo en `src/context.ts`:
+Como ejemplo, agreguemos una operación `Me` que devuelve detalles sobre el usuario que realiza la llamada.
 
-```ts {4,12} ins={4,12}
+Primero, agrega la identidad resuelta al contexto del servicio en `src/context.ts`:
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-Luego pasa el evento cuando construyas el contexto en `src/handler.ts`:
+A continuación, escribe una función que resuelva la identidad del evento de API Gateway en `src/identity.ts`. La implementación depende del método `auth` seleccionado:
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
+Para la autenticación `IAM`, buscamos el llamante en Cognito usando el sub extraído del evento de API Gateway:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
+Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamante proporciona en el encabezado `Authorization` y coloca las claims verificadas en el evento en `event.requestContext.authorizer.claims`. Simplemente leemos esas claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
+
+El generador configura el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es la claim de nombre de usuario canónica; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID:
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verificando el token]
+No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu handler nunca se invoca.
+:::
+</OptionFilter>
+
+Luego llama a `getIdentity` en `src/handler.ts` y agrega el resultado al contexto:
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[Servidor Local]
-El `src/local-server.ts` del target `serve` también construye el contexto. No hay evento de API Gateway cuando se ejecuta localmente, por lo que puedes pasar un stub (por ejemplo, `event: { requestContext: {} } as never`) para satisfacer el tipo.
+:::note[La búsqueda IAM es asíncrona]
+Para la autenticación `IAM`, `getIdentity` es `async` (llama a Cognito), por lo que hacemos `await` arriba. Para la autenticación `cognito` simplemente lee las claims y es síncrona, pero hacer `await` es inofensivo — por lo que el código del handler es idéntico para ambos.
 :::
 
-A continuación, define la operación `Me` en tu modelo Smithy, por ejemplo en `model/src/operations/me.smithy`:
+Ahora define la operación `Me` en tu modelo Smithy, por ejemplo en `model/src/operations/me.smithy`:
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-Ahora implementa la operación. La forma en que extraes la identidad del llamante depende del método `auth` seleccionado:
-
-<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
-Para la autenticación `IAM`, buscamos el llamante en Cognito usando el sub extraído del evento de API Gateway. Crea `src/operations/me.ts`:
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamante proporciona en el encabezado `Authorization` y coloca las claims verificadas en el evento en `event.requestContext.authorizer.claims`. La operación simplemente lee esas claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
-
-El generador configura el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es la claim de nombre de usuario canónica; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID. Crea `src/operations/me.ts`:
+Implementa la operación en `src/operations/me.ts`, leyendo la identidad resuelta directamente del contexto:
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[Verificando el token]
-No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu handler nunca se invoca.
-:::
-</OptionFilter>
 
 Finalmente, registra la operación en tu servicio en `src/service.ts`:
 

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Acceso al Usuario que Realiza la Llamada
 
-Cuando tu API está protegida por autenticación, tus operaciones a menudo necesitan saber quién está realizando la llamada. El enfoque más limpio es resolver la identidad del llamante una vez en el handler y pasarla a través del [contexto del servicio](#service-context), para que tus operaciones permanezcan libres de cualquier análisis de eventos de API Gateway.
+Cuando tu API está protegida por autenticación, tus operaciones a menudo necesitan saber quién está realizando la llamada. El enfoque recomendado es resolver la identidad del llamante una vez en el handler y pasarla a través del [contexto del servicio](#service-context) para su consumo por operaciones específicas.
 
-Como ejemplo, agreguemos una operación `Me` que devuelve detalles sobre el usuario que realiza la llamada.
+Modelaremos el caso no autorizado como un error de Smithy para que se serialice a una respuesta `403` adecuada. Agrégalo a tu modelo, por ejemplo en `model/src/operations/errors.smithy`, y referéncialo en cualquier operación que requiera identidad:
 
-Primero, agrega la identidad resuelta al contexto del servicio en `src/context.ts`:
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Primero, expón la identidad resuelta en el contexto del servicio en `src/context.ts`. La proporcionamos como una función para que el `UnauthorizedError` se lance desde dentro de una operación (donde el Server SDK lo serializa a un `403`), en lugar de desde el handler:
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-A continuación, escribe una función que resuelva la identidad del evento de API Gateway en `src/identity.ts`. La implementación depende del método `auth` seleccionado:
+A continuación, escribe el resolver en `src/identity.ts`. Lanza `UnauthorizedError` cuando no se puede determinar el llamante. La implementación depende del método `auth` seleccionado:
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
 Para la autenticación `IAM`, buscamos el llamante en Cognito usando el sub extraído del evento de API Gateway:
@@ -439,12 +453,13 @@ Para la autenticación `IAM`, buscamos el llamante en Cognito usando el sub extr
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamante proporciona en el encabezado `Authorization` y coloca las claims verificadas en el evento en `event.requestContext.authorizer.claims`. Simplemente leemos esas claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
-
-El generador configura el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es la claim de nombre de usuario canónica; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID:
+Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamante proporciona en el encabezado `Authorization` y coloca las claims verificadas en el evento en `event.requestContext.authorizer.claims`:
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[Verificando el token]
+:::tip[No se requiere verificación de token]
 No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu handler nunca se invoca.
 :::
 </OptionFilter>
 
-Luego llama a `getIdentity` en `src/handler.ts` y agrega el resultado al contexto:
+Luego conecta el resolver al contexto en `src/handler.ts`:
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[La búsqueda IAM es asíncrona]
-Para la autenticación `IAM`, `getIdentity` es `async` (llama a Cognito), por lo que hacemos `await` arriba. Para la autenticación `cognito` simplemente lee las claims y es síncrona, pero hacer `await` es inofensivo — por lo que el código del handler es idéntico para ambos.
-:::
-
-Ahora define la operación `Me` en tu modelo Smithy, por ejemplo en `model/src/operations/me.smithy`:
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-Recuerda registrar la operación en tu servicio en `model/src/main.smithy`:
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-Implementa la operación en `src/operations/me.ts`, leyendo la identidad resuelta directamente del contexto:
+Ahora podemos usar la identidad resuelta en una operación, por ejemplo en `src/operations/echo.ts`:
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-Finalmente, registra la operación en tu servicio en `src/service.ts`:
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### Acceso al Usuario que Realiza la Llamada
+
+Cuando tu API está protegida por autenticación, tus operaciones a menudo necesitan saber quién está realizando la llamada. El generador no añade esto por ti, pero dado que el evento sin procesar de API Gateway está disponible, puedes extraer la identidad del llamante en una operación.
+
+Como ejemplo, agreguemos una operación `Me` que devuelve detalles sobre el usuario que realiza la llamada. Primero, haz que el evento de API Gateway esté disponible en el [contexto del servicio](#service-context) agregándolo en `src/context.ts`:
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+Luego pasa el evento cuando construyas el contexto en `src/handler.ts`:
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[Servidor Local]
+El `src/local-server.ts` del target `serve` también construye el contexto. No hay evento de API Gateway cuando se ejecuta localmente, por lo que puedes pasar un stub (por ejemplo, `event: { requestContext: {} } as never`) para satisfacer el tipo.
+:::
+
+A continuación, define la operación `Me` en tu modelo Smithy, por ejemplo en `model/src/operations/me.smithy`:
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Recuerda registrar la operación en tu servicio en `model/src/main.smithy`:
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+Ahora implementa la operación. La forma en que extraes la identidad del llamante depende del método `auth` seleccionado:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Para la autenticación `IAM`, buscamos el llamante en Cognito usando el sub extraído del evento de API Gateway. Crea `src/operations/me.ts`:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Con `auth: 'cognito'`, el autorizador de Cognito User Pools de API Gateway verifica el JWT que el llamante proporciona en el encabezado `Authorization` y coloca las claims verificadas en el evento en `event.requestContext.authorizer.claims`. La operación simplemente lee esas claims — sin llamadas adicionales al SDK de AWS, sin verificación manual de JWT.
+
+El generador configura el autorizador para aceptar tokens de acceso de Cognito, por lo que `username` es la claim de nombre de usuario canónica; recurrimos a `cognito:username` en caso de que reconfigures el autorizador para aceptar tokens de ID. Crea `src/operations/me.ts`:
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verificando el token]
+No necesitas `aws-jwt-verify` ni ninguna otra biblioteca de verificación de JWT aquí — el autorizador de Cognito User Pools de API Gateway ya ha verificado la firma, el emisor, los scopes y la expiración para cuando se ejecuta tu Lambda. Si alguna de esas verificaciones falla, API Gateway devuelve `401 Unauthorized` y tu handler nunca se invoca.
+:::
+</OptionFilter>
+
+Finalmente, registra la operación en tu servicio en `src/service.ts`:
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## Construcción y Generación de Código
 
 El proyecto del modelo Smithy usa [Docker](https://www.docker.com/) para construir los artefactos Smithy y generar el SDK de servidor TypeScript:

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les claims vérifiés sur le contexte de requête. La dépendance lit simplement ces claims — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
+Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les claims vérifiés sur le contexte de requête.
 
-Le générateur configure l'autorisateur pour accepter les tokens d'accès Cognito, donc `username` est le claim de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les tokens ID. Créez `identity.py` à côté de `main.py` :
+Créez `identity.py` à côté de `main.py` :
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[Vérification du token]
+:::tip[Aucune vérification de token requise]
 Vous n'avez pas besoin de bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les scopes et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -185,6 +185,118 @@ Les exceptions non gérées sont capturées par le middleware et :
 Il est recommandé de spécifier des modèles de réponse pour vos opérations API afin de faciliter la génération de code si vous utilisez le générateur `connection`. <Link path="guides/connection/react-fastapi#errors">Voir ici pour plus de détails</Link>.
 :::
 
+### Accès à l'utilisateur appelant
+
+Lorsque votre API est protégée par authentification, vos gestionnaires de route ont souvent besoin de savoir qui appelle. La FastAPI générée s'exécute dans AWS Lambda via le [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), qui transmet le contexte de requête API Gateway sous forme de JSON dans l'en-tête `x-amzn-request-context`. Vous pouvez le lire depuis la `Request` FastAPI pour extraire l'identité de l'appelant.
+
+À titre d'exemple, ajoutons un endpoint `/me` qui retourne les détails de l'utilisateur appelant. Nous implémenterons l'extraction comme une [dépendance FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) afin qu'elle puisse être réutilisée entre les routes. La façon dont vous extrayez l'identité de l'appelant dépend de votre méthode `auth` sélectionnée :
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait du contexte de requête API Gateway. Créez `identity.py` à côté de `main.py` :
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Le Lambda Web Adapter transmet le contexte de requête API Gateway sous forme de JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Suppose que l'ID du user pool est configuré dans l'environnement lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les claims vérifiés sur le contexte de requête à `authorizer.claims`. La dépendance lit simplement ces claims — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
+
+Le générateur configure l'autorisateur pour accepter les tokens d'accès Cognito, donc `username` est le claim de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les tokens ID. Créez `identity.py` à côté de `main.py` :
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Le Lambda Web Adapter transmet le contexte de requête API Gateway sous forme de JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[Vérification du token]
+Vous n'avez pas besoin de bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les scopes et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
+:::
+</OptionFilter>
+
+Vous pouvez ensuite injecter la dépendance `CurrentUser` dans n'importe quelle route qui a besoin de l'identité de l'appelant :
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### Streaming
 

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -189,11 +189,13 @@ Il est recommandé de spécifier des modèles de réponse pour vos opérations A
 
 Lorsque votre API est protégée par authentification, vos gestionnaires de route ont souvent besoin de savoir qui appelle. La FastAPI générée s'exécute dans AWS Lambda via le [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), qui transmet le contexte de requête API Gateway sous forme de JSON dans l'en-tête `x-amzn-request-context`. Vous pouvez le lire depuis la `Request` FastAPI pour extraire l'identité de l'appelant.
 
-À titre d'exemple, ajoutons un endpoint `/me` qui retourne les détails de l'utilisateur appelant. Nous implémenterons l'extraction comme une [dépendance FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) afin qu'elle puisse être réutilisée entre les routes. La façon dont vous extrayez l'identité de l'appelant dépend de votre méthode `auth` sélectionnée :
+À titre d'exemple, ajoutons un endpoint `/me` qui retourne les détails de l'utilisateur appelant. Nous implémenterons l'extraction comme une [dépendance FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) afin qu'elle puisse être réutilisée entre les routes. La forme du contexte de requête — et donc la façon dont vous extrayez l'identité — dépend à la fois de votre méthode `auth` sélectionnée et du fait que vous ayez déployé une API REST ou HTTP.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait du contexte de requête API Gateway. Créez `identity.py` à côté de `main.py` :
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Le Lambda Web Adapter transmet le contexte de requête API Gateway sous forme de JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Suppose que l'ID du user pool est configuré dans l'environnement lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les claims vérifiés sur le contexte de requête à `authorizer.claims`. La dépendance lit simplement ces claims — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
+Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les claims vérifiés sur le contexte de requête. La dépendance lit simplement ces claims — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
 
 Le générateur configure l'autorisateur pour accepter les tokens d'accès Cognito, donc `username` est le claim de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les tokens ID. Créez `identity.py` à côté de `main.py` :
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+Les API HTTP utilisent un autorisateur JWT qui place les claims vérifiés sous `authorizer.jwt.claims` :
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Le Lambda Web Adapter transmet le contexte de requête API Gateway sous forme de JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[Vérification du token]
 Vous n'avez pas besoin de bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les scopes et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Notez que nous définissons une propriété supplémentaire _optionnelle_ au contexte. tRPC s'assure que celle-ci est définie dans les procédures ayant correctement configuré ce middleware.
 
-Ensuite, le middleware lui-même. Le générateur configure l'autorisateur pour accepter les tokens ID, donc `cognito:username` est le claim de nom d'utilisateur canonique ; nous revenons à `username` pour les tokens d'accès au cas où vous reconfigureriez l'autorisateur :
+Ensuite, le middleware lui-même. Le générateur configure l'autorisateur pour accepter les tokens d'accès Cognito, donc `username` est le claim de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les tokens ID :
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[Vérification du token]
-Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, l'audience et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
+Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les scopes et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Notez que nous définissons une propriété supplémentaire _optionnelle_ au contexte. tRPC s'assure que celle-ci est définie dans les procédures ayant correctement configuré ce middleware.
 
-Ensuite, le middleware lui-même. Le générateur configure l'autorisateur pour accepter les tokens d'accès Cognito, donc `username` est le claim de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les tokens ID :
+Ensuite, le middleware lui-même :
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[Vérification du token]
+:::tip[Aucune vérification de token requise]
 Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les scopes et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Accès à l'utilisateur appelant
 
-Lorsque votre API est protégée par authentification, vos opérations ont souvent besoin de savoir qui appelle. L'approche la plus propre consiste à résoudre l'identité de l'appelant une fois dans le gestionnaire et à la transmettre via le [contexte de service](#service-context), afin que vos opérations restent libres de toute analyse d'événement API Gateway.
+Lorsque votre API est protégée par authentification, vos opérations ont souvent besoin de savoir qui appelle. L'approche recommandée consiste à résoudre l'identité de l'appelant une fois dans le gestionnaire et à la transmettre via le [contexte de service](#service-context) pour consommation par des opérations spécifiques.
 
-À titre d'exemple, ajoutons une opération `Me` qui retourne les détails de l'utilisateur appelant.
+Nous allons modéliser le cas non autorisé comme une erreur Smithy afin qu'elle se sérialise en une réponse `403` appropriée. Ajoutez-la à votre modèle, par exemple dans `model/src/operations/errors.smithy`, et référencez-la sur toute opération qui nécessite une identité :
 
-Tout d'abord, ajoutez l'identité résolue au contexte de service dans `src/context.ts` :
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Tout d'abord, exposez l'identité résolue sur le contexte de service dans `src/context.ts`. Nous la fournissons sous forme de fonction afin que l'`UnauthorizedError` soit levée depuis une opération (où le SDK serveur la sérialise en `403`), plutôt que depuis le gestionnaire :
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-Ensuite, écrivez une fonction qui résout l'identité à partir de l'événement API Gateway dans `src/identity.ts`. L'implémentation dépend de votre méthode `auth` sélectionnée :
+Ensuite, écrivez le résolveur dans `src/identity.ts`. Il lève `UnauthorizedError` lorsque l'appelant ne peut pas être déterminé. L'implémentation dépend de votre méthode `auth` sélectionnée :
 
 <OptionFilter when={{ auth: 'iam' }} description="Résolution d'identité pour les API authentifiées par IAM">
 Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway :
@@ -439,12 +453,13 @@ Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utili
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Résolution d'identité pour les API authentifiées par Cognito">
-Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les revendications vérifiées sur l'événement à `event.requestContext.authorizer.claims`. Nous lisons simplement ces revendications — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
-
-Le générateur configure l'autorisateur pour accepter les jetons d'accès Cognito, donc `username` est la revendication de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les jetons ID :
+Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les revendications vérifiées sur l'événement à `event.requestContext.authorizer.claims` :
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[Vérification du jeton]
+:::tip[Aucune vérification de jeton requise]
 Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les portées et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
 :::
 </OptionFilter>
 
-Ensuite, appelez `getIdentity` dans `src/handler.ts` et ajoutez le résultat au contexte :
+Ensuite, intégrez le résolveur dans le contexte dans `src/handler.ts` :
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[La recherche IAM est asynchrone]
-Pour l'authentification `IAM`, `getIdentity` est `async` (elle appelle Cognito), c'est pourquoi nous l'attendons (`await`) ci-dessus. Pour l'authentification `cognito`, elle lit simplement les revendications et est synchrone, mais l'attendre est inoffensif — donc le code du gestionnaire est identique pour les deux.
-:::
-
-Maintenant, définissez l'opération `Me` dans votre modèle Smithy, par exemple dans `model/src/operations/me.smithy` :
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-N'oubliez pas d'enregistrer l'opération sur votre service dans `model/src/main.smithy` :
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-Implémentez l'opération dans `src/operations/me.ts`, en lisant l'identité résolue directement depuis le contexte :
+Nous pouvons maintenant utiliser l'identité résolue dans une opération, par exemple dans `src/operations/echo.ts` :
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-Enfin, enregistrez l'opération sur votre service dans `src/service.ts` :
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### Accès à l'utilisateur appelant
+
+Lorsque votre API est protégée par authentification, vos opérations ont souvent besoin de savoir qui appelle. Le générateur n'ajoute pas cela pour vous, mais comme l'événement brut API Gateway est disponible, vous pouvez extraire l'identité de l'appelant dans une opération.
+
+À titre d'exemple, ajoutons une opération `Me` qui retourne les détails de l'utilisateur appelant. Tout d'abord, rendez l'événement API Gateway disponible sur le [contexte de service](#service-context) en l'ajoutant dans `src/context.ts` :
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+Ensuite, passez l'événement lors de la construction du contexte dans `src/handler.ts` :
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[Serveur local]
+Le `src/local-server.ts` de la cible `serve` construit également le contexte. Il n'y a pas d'événement API Gateway lors de l'exécution locale, vous pouvez donc passer un stub (par exemple `event: { requestContext: {} } as never`) pour satisfaire le type.
+:::
+
+Ensuite, définissez l'opération `Me` dans votre modèle Smithy, par exemple dans `model/src/operations/me.smithy` :
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+N'oubliez pas d'enregistrer l'opération sur votre service dans `model/src/main.smithy` :
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+Maintenant, implémentez l'opération. La façon dont vous extrayez l'identité de l'appelant dépend de votre méthode `auth` sélectionnée :
+
+<OptionFilter when={{ auth: 'iam' }} description="Extraction d'identité pour les API authentifiées par IAM">
+Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway. Créez `src/operations/me.ts` :
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Extraction d'identité pour les API authentifiées par Cognito">
+Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les revendications vérifiées sur l'événement à `event.requestContext.authorizer.claims`. L'opération lit simplement ces revendications — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
+
+Le générateur configure l'autorisateur pour accepter les jetons d'accès Cognito, donc `username` est la revendication de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les jetons ID. Créez `src/operations/me.ts` :
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Vérification du jeton]
+Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les portées et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
+:::
+</OptionFilter>
+
+Enfin, enregistrez l'opération sur votre service dans `src/service.ts` :
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## Build et génération de code
 
 Le projet de modèle Smithy utilise [Docker](https://www.docker.com/) pour construire les artefacts Smithy et générer le SDK serveur TypeScript :

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Accès à l'utilisateur appelant
 
-Lorsque votre API est protégée par authentification, vos opérations ont souvent besoin de savoir qui appelle. Le générateur n'ajoute pas cela pour vous, mais comme l'événement brut API Gateway est disponible, vous pouvez extraire l'identité de l'appelant dans une opération.
+Lorsque votre API est protégée par authentification, vos opérations ont souvent besoin de savoir qui appelle. L'approche la plus propre consiste à résoudre l'identité de l'appelant une fois dans le gestionnaire et à la transmettre via le [contexte de service](#service-context), afin que vos opérations restent libres de toute analyse d'événement API Gateway.
 
-À titre d'exemple, ajoutons une opération `Me` qui retourne les détails de l'utilisateur appelant. Tout d'abord, rendez l'événement API Gateway disponible sur le [contexte de service](#service-context) en l'ajoutant dans `src/context.ts` :
+À titre d'exemple, ajoutons une opération `Me` qui retourne les détails de l'utilisateur appelant.
 
-```ts {4,12} ins={4,12}
+Tout d'abord, ajoutez l'identité résolue au contexte de service dans `src/context.ts` :
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-Ensuite, passez l'événement lors de la construction du contexte dans `src/handler.ts` :
+Ensuite, écrivez une fonction qui résout l'identité à partir de l'événement API Gateway dans `src/identity.ts`. L'implémentation dépend de votre méthode `auth` sélectionnée :
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Résolution d'identité pour les API authentifiées par IAM">
+Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway :
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Résolution d'identité pour les API authentifiées par Cognito">
+Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les revendications vérifiées sur l'événement à `event.requestContext.authorizer.claims`. Nous lisons simplement ces revendications — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
+
+Le générateur configure l'autorisateur pour accepter les jetons d'accès Cognito, donc `username` est la revendication de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les jetons ID :
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Vérification du jeton]
+Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les portées et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
+:::
+</OptionFilter>
+
+Ensuite, appelez `getIdentity` dans `src/handler.ts` et ajoutez le résultat au contexte :
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[Serveur local]
-Le `src/local-server.ts` de la cible `serve` construit également le contexte. Il n'y a pas d'événement API Gateway lors de l'exécution locale, vous pouvez donc passer un stub (par exemple `event: { requestContext: {} } as never`) pour satisfaire le type.
+:::note[La recherche IAM est asynchrone]
+Pour l'authentification `IAM`, `getIdentity` est `async` (elle appelle Cognito), c'est pourquoi nous l'attendons (`await`) ci-dessus. Pour l'authentification `cognito`, elle lit simplement les revendications et est synchrone, mais l'attendre est inoffensif — donc le code du gestionnaire est identique pour les deux.
 :::
 
-Ensuite, définissez l'opération `Me` dans votre modèle Smithy, par exemple dans `model/src/operations/me.smithy` :
+Maintenant, définissez l'opération `Me` dans votre modèle Smithy, par exemple dans `model/src/operations/me.smithy` :
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-Maintenant, implémentez l'opération. La façon dont vous extrayez l'identité de l'appelant dépend de votre méthode `auth` sélectionnée :
-
-<OptionFilter when={{ auth: 'iam' }} description="Extraction d'identité pour les API authentifiées par IAM">
-Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway. Créez `src/operations/me.ts` :
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Extraction d'identité pour les API authentifiées par Cognito">
-Avec `auth: 'cognito'`, l'autorisateur Cognito User Pools d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les revendications vérifiées sur l'événement à `event.requestContext.authorizer.claims`. L'opération lit simplement ces revendications — pas d'appels AWS SDK supplémentaires, pas de vérification JWT manuelle.
-
-Le générateur configure l'autorisateur pour accepter les jetons d'accès Cognito, donc `username` est la revendication de nom d'utilisateur canonique ; nous revenons à `cognito:username` au cas où vous reconfigureriez l'autorisateur pour accepter les jetons ID. Créez `src/operations/me.ts` :
+Implémentez l'opération dans `src/operations/me.ts`, en lisant l'identité résolue directement depuis le contexte :
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[Vérification du jeton]
-Vous n'avez pas besoin de `aws-jwt-verify` ou d'une autre bibliothèque de vérification JWT ici — l'autorisateur Cognito User Pools d'API Gateway a déjà vérifié la signature, l'émetteur, les portées et l'expiration au moment où votre Lambda s'exécute. Si l'une de ces vérifications échoue, API Gateway retourne `401 Unauthorized` et votre gestionnaire n'est jamais invoqué.
-:::
-</OptionFilter>
 
 Enfin, enregistrez l'opération sur votre service dans `src/service.ts` :
 

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -185,6 +185,118 @@ Le eccezioni non gestite vengono intercettate dal middleware e:
 Si consiglia di specificare i modelli di risposta per le operazioni API per una migliore generazione del codice se si utilizza il generatore `connection`. <Link path="guides/connection/react-fastapi#errors">Vedi qui per maggiori dettagli</Link>.
 :::
 
+### Accesso all'Utente Chiamante
+
+Quando la tua API è protetta da autenticazione, i tuoi route handler spesso devono sapere chi sta chiamando. La FastAPI generata viene eseguita all'interno di AWS Lambda tramite il [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), che inoltra il contesto della richiesta API Gateway come JSON nell'header `x-amzn-request-context`. Puoi leggerlo dalla `Request` di FastAPI per estrarre l'identità del chiamante.
+
+Come esempio, aggiungiamo un endpoint `/me` che restituisce dettagli sull'utente chiamante. Implementeremo l'estrazione come una [dipendenza FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) in modo che possa essere riutilizzata tra le route. Il modo in cui estrai l'identità del chiamante dipende dal metodo `auth` selezionato:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito utilizzando il sub estratto dal contesto della richiesta API Gateway. Crea `identity.py` accanto a `main.py`:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Il Lambda Web Adapter inoltra il contesto della richiesta API Gateway come JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Assume che l'id del user pool sia configurato nell'ambiente lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Con `auth: 'cognito'`, l'authorizer Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sul contesto della richiesta in `authorizer.claims`. La dipendenza legge semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
+
+Il generatore collega l'authorizer per accettare access token Cognito, quindi `username` è il claim username canonico; ricadiamo su `cognito:username` nel caso tu riconfiguri l'authorizer per accettare ID token. Crea `identity.py` accanto a `main.py`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Il Lambda Web Adapter inoltra il contesto della richiesta API Gateway come JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[Verifica del token]
+Non hai bisogno di alcuna libreria di verifica JWT qui — l'authorizer Cognito User Pools di API Gateway ha già verificato la firma, l'emittente, gli scope e la scadenza prima che la tua Lambda venga eseguita. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
+:::
+</OptionFilter>
+
+Puoi quindi iniettare la dipendenza `CurrentUser` in qualsiasi route che necessita dell'identità del chiamante:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### Streaming
 

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, l'authorizer Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sul contesto della richiesta. La dipendenza legge semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
+Con `auth: 'cognito'`, l'authorizer Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sul contesto della richiesta.
 
-Il generatore collega l'authorizer per accettare access token Cognito, quindi `username` è il claim username canonico; ricadiamo su `cognito:username` nel caso tu riconfiguri l'authorizer per accettare ID token. Crea `identity.py` accanto a `main.py`:
+Crea `identity.py` accanto a `main.py`:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[Verifica del token]
+:::tip[Nessuna verifica del token richiesta]
 Non hai bisogno di alcuna libreria di verifica JWT qui — l'authorizer Cognito User Pools di API Gateway ha già verificato la firma, l'emittente, gli scope e la scadenza prima che la tua Lambda venga eseguita. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -189,11 +189,13 @@ Si consiglia di specificare i modelli di risposta per le operazioni API per una 
 
 Quando la tua API è protetta da autenticazione, i tuoi route handler spesso devono sapere chi sta chiamando. La FastAPI generata viene eseguita all'interno di AWS Lambda tramite il [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), che inoltra il contesto della richiesta API Gateway come JSON nell'header `x-amzn-request-context`. Puoi leggerlo dalla `Request` di FastAPI per estrarre l'identità del chiamante.
 
-Come esempio, aggiungiamo un endpoint `/me` che restituisce dettagli sull'utente chiamante. Implementeremo l'estrazione come una [dipendenza FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) in modo che possa essere riutilizzata tra le route. Il modo in cui estrai l'identità del chiamante dipende dal metodo `auth` selezionato:
+Come esempio, aggiungiamo un endpoint `/me` che restituisce dettagli sull'utente chiamante. Implementeremo l'estrazione come una [dipendenza FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) in modo che possa essere riutilizzata tra le route. La forma del contesto della richiesta — e quindi come estrai l'identità — dipende sia dal metodo `auth` selezionato che dal fatto che tu abbia distribuito una REST API o HTTP API.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito utilizzando il sub estratto dal contesto della richiesta API Gateway. Crea `identity.py` accanto a `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Il Lambda Web Adapter inoltra il contesto della richiesta API Gateway come JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Assume che l'id del user pool sia configurato nell'ambiente lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, l'authorizer Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sul contesto della richiesta in `authorizer.claims`. La dipendenza legge semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
+Con `auth: 'cognito'`, l'authorizer Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sul contesto della richiesta. La dipendenza legge semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
 
 Il generatore collega l'authorizer per accettare access token Cognito, quindi `username` è il claim username canonico; ricadiamo su `cognito:username` nel caso tu riconfiguri l'authorizer per accettare ID token. Crea `identity.py` accanto a `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+Le HTTP API utilizzano un authorizer JWT che posiziona i claim verificati sotto `authorizer.jwt.claims`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Il Lambda Web Adapter inoltra il contesto della richiesta API Gateway come JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[Verifica del token]
 Non hai bisogno di alcuna libreria di verifica JWT qui — l'authorizer Cognito User Pools di API Gateway ha già verificato la firma, l'emittente, gli scope e la scadenza prima che la tua Lambda venga eseguita. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Nota che definiamo una proprietà _opzionale_ aggiuntiva al contesto. tRPC gestisce l'assicurazione che questa sia definita nelle procedure che hanno configurato correttamente questo middleware.
 
-Successivamente, il middleware stesso. Il generatore configura l'authorizer per accettare ID token, quindi `cognito:username` è il claim username canonico; facciamo fallback a `username` per gli access token nel caso tu riconfiguri l'authorizer:
+Successivamente, il middleware stesso. Il generatore configura l'authorizer per accettare access token Cognito, quindi `username` è il claim username canonico; facciamo fallback a `cognito:username` nel caso tu riconfiguri l'authorizer per accettare ID token:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[Verifica del token]
-Non hai bisogno di `aws-jwt-verify` o di altre librerie di verifica JWT qui — l'authorizer Cognito User Pools di API Gateway ha già verificato la firma, l'issuer, l'audience e la scadenza prima che il tuo Lambda venga eseguito. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
+Non hai bisogno di `aws-jwt-verify` o di altre librerie di verifica JWT qui — l'authorizer Cognito User Pools di API Gateway ha già verificato la firma, l'issuer, gli scope e la scadenza prima che il tuo Lambda venga eseguito. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Nota che definiamo una proprietà _opzionale_ aggiuntiva al contesto. tRPC gestisce l'assicurazione che questa sia definita nelle procedure che hanno configurato correttamente questo middleware.
 
-Successivamente, il middleware stesso. Il generatore configura l'authorizer per accettare access token Cognito, quindi `username` è il claim username canonico; facciamo fallback a `cognito:username` nel caso tu riconfiguri l'authorizer per accettare ID token:
+Successivamente, il middleware stesso:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[Verifica del token]
+:::tip[Nessuna verifica del token richiesta]
 Non hai bisogno di `aws-jwt-verify` o di altre librerie di verifica JWT qui — l'authorizer Cognito User Pools di API Gateway ha già verificato la firma, l'issuer, gli scope e la scadenza prima che il tuo Lambda venga eseguito. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -439,12 +439,13 @@ Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito usando il sub estr
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +456,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +467,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -851,6 +852,16 @@ resource "aws_iam_policy" "api_invoke_policy" {
 # Allega la politica a un ruolo IAM
 resource "aws_iam_role_policy_attachment" "api_invoke_access" {
   role       = aws_iam_role.authenticated_user_role.name
+  policy_arn = aws_iam_policy.api_invoke_policy.arn
+}
+```
+</Fragment>
+</Infrastructure>
+</OptionFilter>
+
+## Invocare la tua API Smithy
+
+Per invocare la tua API da un sito React, puoi usare il generatore <Link path="guides/connection/react-smithy">`connection`</Link>, che fornisce generazione type-safe del client dal tuo modello Smithy..name
   policy_arn = aws_iam_policy.api_invoke_policy.arn
 }
 ```

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### Accesso all'Utente Chiamante
+
+Quando la tua API è protetta da autenticazione, le tue operazioni spesso devono sapere chi sta chiamando. Il generatore non aggiunge questo per te, ma poiché l'evento grezzo di API Gateway è disponibile, puoi estrarre l'identità del chiamante in un'operazione.
+
+Come esempio, aggiungiamo un'operazione `Me` che restituisce i dettagli sull'utente chiamante. Prima, rendi disponibile l'evento di API Gateway sul [contesto del servizio](#service-context) aggiungendolo in `src/context.ts`:
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+Quindi passa l'evento quando costruisci il contesto in `src/handler.ts`:
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[Server Locale]
+Il target `serve` in `src/local-server.ts` costruisce anche il contesto. Non c'è un evento di API Gateway quando si esegue localmente, quindi puoi passare uno stub (ad es. `event: { requestContext: {} } as never`) per soddisfare il tipo.
+:::
+
+Successivamente, definisci l'operazione `Me` nel tuo modello Smithy, ad esempio in `model/src/operations/me.smithy`:
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Ricorda di registrare l'operazione sul tuo servizio in `model/src/main.smithy`:
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+Ora implementa l'operazione. Il modo in cui estrai l'identità del chiamante dipende dal metodo `auth` selezionato:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito usando il sub estratto dall'evento di API Gateway. Crea `src/operations/me.ts`:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Con `auth: 'cognito'`, l'autorizzatore Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sull'evento in `event.requestContext.authorizer.claims`. L'operazione legge semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
+
+Il generatore collega l'autorizzatore per accettare token di accesso Cognito, quindi `username` è il claim del nome utente canonico; ricadiamo su `cognito:username` nel caso tu riconfiguri l'autorizzatore per accettare token ID. Crea `src/operations/me.ts`:
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verifica del token]
+Non hai bisogno di `aws-jwt-verify` o di qualsiasi altra libreria di verifica JWT qui — l'autorizzatore Cognito User Pools di API Gateway ha già verificato la firma, l'emittente, gli scope e la scadenza prima che la tua Lambda venga eseguita. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
+:::
+</OptionFilter>
+
+Infine, registra l'operazione sul tuo servizio in `src/service.ts`:
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## Build e Generazione del Codice
 
 Il progetto del modello Smithy utilizza [Docker](https://www.docker.com/) per costruire gli artefatti Smithy e generare l'SDK Server TypeScript:

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Accesso all'Utente Chiamante
 
-Quando la tua API è protetta da autenticazione, le tue operazioni spesso devono sapere chi sta chiamando. Il generatore non aggiunge questo per te, ma poiché l'evento grezzo di API Gateway è disponibile, puoi estrarre l'identità del chiamante in un'operazione.
+Quando la tua API è protetta da autenticazione, le tue operazioni spesso devono sapere chi sta chiamando. L'approccio più pulito è risolvere l'identità del chiamante una volta nell'handler e passarla attraverso il [contesto del servizio](#service-context), in modo che le tue operazioni rimangano libere da qualsiasi parsing dell'evento di API Gateway.
 
-Come esempio, aggiungiamo un'operazione `Me` che restituisce i dettagli sull'utente chiamante. Prima, rendi disponibile l'evento di API Gateway sul [contesto del servizio](#service-context) aggiungendolo in `src/context.ts`:
+Come esempio, aggiungiamo un'operazione `Me` che restituisce i dettagli sull'utente chiamante.
 
-```ts {4,12} ins={4,12}
+Prima, aggiungi l'identità risolta al contesto del servizio in `src/context.ts`:
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-Quindi passa l'evento quando costruisci il contesto in `src/handler.ts`:
+Successivamente, scrivi una funzione che risolve l'identità dall'evento di API Gateway in `src/identity.ts`. L'implementazione dipende dal metodo `auth` selezionato:
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
+Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito usando il sub estratto dall'evento di API Gateway:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
+Con `auth: 'cognito'`, l'autorizzatore Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sull'evento in `event.requestContext.authorizer.claims`. Leggiamo semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
+
+Il generatore collega l'autorizzatore per accettare token di accesso Cognito, quindi `username` è il claim del nome utente canonico; ricadiamo su `cognito:username` nel caso tu riconfiguri l'autorizzatore per accettare token ID:
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verifica del token]
+Non hai bisogno di `aws-jwt-verify` o di qualsiasi altra libreria di verifica JWT qui — l'autorizzatore Cognito User Pools di API Gateway ha già verificato la firma, l'emittente, gli scope e la scadenza prima che la tua Lambda venga eseguita. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
+:::
+</OptionFilter>
+
+Quindi chiama `getIdentity` in `src/handler.ts` e aggiungi il risultato al contesto:
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[Server Locale]
-Il target `serve` in `src/local-server.ts` costruisce anche il contesto. Non c'è un evento di API Gateway quando si esegue localmente, quindi puoi passare uno stub (ad es. `event: { requestContext: {} } as never`) per soddisfare il tipo.
+:::note[La ricerca IAM è asincrona]
+Per l'autenticazione `IAM`, `getIdentity` è `async` (chiama Cognito), motivo per cui la attendiamo sopra. Per l'autenticazione `cognito` legge semplicemente i claim ed è sincrona, ma attenderla è innocuo — quindi il codice dell'handler è identico per entrambi.
 :::
 
-Successivamente, definisci l'operazione `Me` nel tuo modello Smithy, ad esempio in `model/src/operations/me.smithy`:
+Ora definisci l'operazione `Me` nel tuo modello Smithy, ad esempio in `model/src/operations/me.smithy`:
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-Ora implementa l'operazione. Il modo in cui estrai l'identità del chiamante dipende dal metodo `auth` selezionato:
-
-<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
-Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito usando il sub estratto dall'evento di API Gateway. Crea `src/operations/me.ts`:
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Con `auth: 'cognito'`, l'autorizzatore Cognito User Pools di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sull'evento in `event.requestContext.authorizer.claims`. L'operazione legge semplicemente quei claim — nessuna chiamata extra all'SDK AWS, nessuna verifica manuale del JWT.
-
-Il generatore collega l'autorizzatore per accettare token di accesso Cognito, quindi `username` è il claim del nome utente canonico; ricadiamo su `cognito:username` nel caso tu riconfiguri l'autorizzatore per accettare token ID. Crea `src/operations/me.ts`:
+Implementa l'operazione in `src/operations/me.ts`, leggendo l'identità risolta direttamente dal contesto:
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[Verifica del token]
-Non hai bisogno di `aws-jwt-verify` o di qualsiasi altra libreria di verifica JWT qui — l'autorizzatore Cognito User Pools di API Gateway ha già verificato la firma, l'emittente, gli scope e la scadenza prima che la tua Lambda venga eseguita. Se uno di questi controlli fallisce, API Gateway restituisce `401 Unauthorized` e il tuo handler non viene mai invocato.
-:::
-</OptionFilter>
 
 Infine, registra l'operazione sul tuo servizio in `src/service.ts`:
 

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-`auth: 'cognito'` の場合、API Gateway Cognito User Pools オーソライザーは呼び出し元が `Authorization` ヘッダーで提供する JWT を検証し、検証済みのクレームをリクエストコンテキストに配置します。依存関係はこれらのクレームを読み取るだけで、追加の AWS SDK 呼び出しや手動の JWT 検証は不要です。
+`auth: 'cognito'` の場合、API Gateway Cognito User Pools オーソライザーは呼び出し元が `Authorization` ヘッダーで提供する JWT を検証し、検証済みのクレームをリクエストコンテキストに配置します。
 
-ジェネレータはオーソライザーを Cognito アクセストークンを受け入れるように配線するため、`username` は正規のユーザー名クレームです。ID トークンを受け入れるようにオーソライザーを再設定する場合に備えて、`cognito:username` にフォールバックします。`main.py` と同じ場所に `identity.py` を作成します:
+`main.py` と同じ場所に `identity.py` を作成します:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[トークンの検証]
+:::tip[トークン検証は不要]
 ここでは JWT 検証ライブラリは不要です — API Gateway Cognito User Pools オーソライザーは、Lambda が実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gateway は `401 Unauthorized` を返し、ハンドラは呼び出されません。
 :::
 </OptionFilter>

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -189,11 +189,13 @@ def read_item(item_id: int):
 
 API が認証で保護されている場合、ルートハンドラは誰が呼び出しているかを知る必要があることがよくあります。生成された FastAPI は [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter) を介して AWS Lambda 内で実行され、API Gateway リクエストコンテキストを JSON として `x-amzn-request-context` ヘッダーに転送します。FastAPI の `Request` からこれを読み取り、呼び出し元の ID を抽出できます。
 
-例として、呼び出しユーザーの詳細を返す `/me` エンドポイントを追加しましょう。抽出処理を [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) として実装し、ルート間で再利用できるようにします。呼び出し元の ID を抽出する方法は、選択した `auth` メソッドによって異なります:
+例として、呼び出しユーザーの詳細を返す `/me` エンドポイントを追加しましょう。抽出処理を [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) として実装し、ルート間で再利用できるようにします。リクエストコンテキストの形状 — したがって ID の抽出方法 — は、選択した `auth` メソッドと REST API または HTTP API のどちらをデプロイしたかの両方に依存します。
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 `IAM` 認証の場合、API Gateway リクエストコンテキストから抽出した sub を使用して Cognito で呼び出し元を検索します。`main.py` と同じ場所に `identity.py` を作成します:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter は API Gateway リクエストコンテキストを JSON として転送します
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # ユーザープール ID が Lambda 環境に設定されていることを前提とします
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-`auth: 'cognito'` の場合、API Gateway Cognito User Pools オーソライザーは呼び出し元が `Authorization` ヘッダーで提供する JWT を検証し、検証済みのクレームをリクエストコンテキストの `authorizer.claims` に配置します。依存関係はこれらのクレームを読み取るだけで、追加の AWS SDK 呼び出しや手動の JWT 検証は不要です。
+`auth: 'cognito'` の場合、API Gateway Cognito User Pools オーソライザーは呼び出し元が `Authorization` ヘッダーで提供する JWT を検証し、検証済みのクレームをリクエストコンテキストに配置します。依存関係はこれらのクレームを読み取るだけで、追加の AWS SDK 呼び出しや手動の JWT 検証は不要です。
 
 ジェネレータはオーソライザーを Cognito アクセストークンを受け入れるように配線するため、`username` は正規のユーザー名クレームです。ID トークンを受け入れるようにオーソライザーを再設定する場合に備えて、`cognito:username` にフォールバックします。`main.py` と同じ場所に `identity.py` を作成します:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP API は JWT オーソライザーを使用し、検証済みのクレームを `authorizer.jwt.claims` に配置します:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter は API Gateway リクエストコンテキストを JSON として転送します
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[トークンの検証]
 ここでは JWT 検証ライブラリは不要です — API Gateway Cognito User Pools オーソライザーは、Lambda が実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gateway は `401 Unauthorized` を返し、ハンドラは呼び出されません。

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -185,6 +185,118 @@ def read_item(item_id: int):
 `connection` ジェネレータを使用する場合、より良いコード生成のため API 操作のレスポンスモデルを指定することを推奨します。<Link path="guides/connection/react-fastapi#errors">詳細はこちら</Link>
 :::
 
+### 呼び出しユーザーへのアクセス
+
+API が認証で保護されている場合、ルートハンドラは誰が呼び出しているかを知る必要があることがよくあります。生成された FastAPI は [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter) を介して AWS Lambda 内で実行され、API Gateway リクエストコンテキストを JSON として `x-amzn-request-context` ヘッダーに転送します。FastAPI の `Request` からこれを読み取り、呼び出し元の ID を抽出できます。
+
+例として、呼び出しユーザーの詳細を返す `/me` エンドポイントを追加しましょう。抽出処理を [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) として実装し、ルート間で再利用できるようにします。呼び出し元の ID を抽出する方法は、選択した `auth` メソッドによって異なります:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+`IAM` 認証の場合、API Gateway リクエストコンテキストから抽出した sub を使用して Cognito で呼び出し元を検索します。`main.py` と同じ場所に `identity.py` を作成します:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter は API Gateway リクエストコンテキストを JSON として転送します
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # ユーザープール ID が Lambda 環境に設定されていることを前提とします
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+`auth: 'cognito'` の場合、API Gateway Cognito User Pools オーソライザーは呼び出し元が `Authorization` ヘッダーで提供する JWT を検証し、検証済みのクレームをリクエストコンテキストの `authorizer.claims` に配置します。依存関係はこれらのクレームを読み取るだけで、追加の AWS SDK 呼び出しや手動の JWT 検証は不要です。
+
+ジェネレータはオーソライザーを Cognito アクセストークンを受け入れるように配線するため、`username` は正規のユーザー名クレームです。ID トークンを受け入れるようにオーソライザーを再設定する場合に備えて、`cognito:username` にフォールバックします。`main.py` と同じ場所に `identity.py` を作成します:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter は API Gateway リクエストコンテキストを JSON として転送します
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[トークンの検証]
+ここでは JWT 検証ライブラリは不要です — API Gateway Cognito User Pools オーソライザーは、Lambda が実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gateway は `401 Unauthorized` を返し、ハンドラは呼び出されません。
+:::
+</OptionFilter>
+
+その後、呼び出し元の ID が必要な任意のルートに `CurrentUser` 依存関係を注入できます:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### ストリーミング
 

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 コンテキストに追加の _オプション_ プロパティを定義していることに注意してください。tRPC は、このミドルウェアを正しく設定したプロシージャでこれが定義されていることを保証します。
 
-次に、ミドルウェア自体です。ジェネレータはオーソライザーを ID トークンを受け入れるように設定するため、`cognito:username` が正規のユーザー名クレームです。オーソライザーを再設定した場合に備えて、アクセストークン用に `username` にフォールバックします:
+次に、ミドルウェア自体です。ジェネレータはオーソライザーを Cognito アクセストークンを受け入れるように設定するため、`username` が正規のユーザー名クレームです。オーソライザーを ID トークンを受け入れるように再設定した場合に備えて、`cognito:username` にフォールバックします:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[トークンの検証]
-ここでは `aws-jwt-verify` やその他の JWT 検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambda が実行される時点で既に署名、発行者、オーディエンス、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gateway は `401 Unauthorized` を返し、ハンドラーは呼び出されません。
+ここでは `aws-jwt-verify` やその他の JWT 検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambda が実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gateway は `401 Unauthorized` を返し、ハンドラーは呼び出されません。
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 コンテキストに追加の _オプション_ プロパティを定義していることに注意してください。tRPC は、このミドルウェアを正しく設定したプロシージャでこれが定義されていることを保証します。
 
-次に、ミドルウェア自体です。ジェネレータはオーソライザーを Cognito アクセストークンを受け入れるように設定するため、`username` が正規のユーザー名クレームです。オーソライザーを ID トークンを受け入れるように再設定した場合に備えて、`cognito:username` にフォールバックします:
+次に、ミドルウェア自体です:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[トークンの検証]
+:::tip[トークン検証は不要]
 ここでは `aws-jwt-verify` やその他の JWT 検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambda が実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gateway は `401 Unauthorized` を返し、ハンドラーは呼び出されません。
 :::
 </OptionFilter>

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### 呼び出しユーザーへのアクセス
 
-APIが認証で保護されている場合、オペレーションは誰が呼び出しているかを知る必要があることがよくあります。ジェネレーターはこれを自動的に追加しませんが、生のAPI Gatewayイベントが利用可能なため、オペレーション内で呼び出し元のIDを抽出できます。
+APIが認証で保護されている場合、オペレーションは誰が呼び出しているかを知る必要があることがよくあります。最もクリーンなアプローチは、ハンドラーで一度呼び出し元のIDを解決し、[サービスコンテキスト](#service-context)を通じて渡すことです。これにより、オペレーションはAPI Gatewayイベントの解析から解放されます。
 
-例として、呼び出しユーザーの詳細を返す`Me`オペレーションを追加してみましょう。まず、`src/context.ts`に追加して、API Gatewayイベントを[サービスコンテキスト](#service-context)で利用できるようにします：
+例として、呼び出しユーザーの詳細を返す`Me`オペレーションを追加してみましょう。
 
-```ts {4,12} ins={4,12}
+まず、`src/context.ts`でサービスコンテキストに解決されたIDを追加します：
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,23 +426,102 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-次に、`src/handler.ts`でコンテキストを構築する際にイベントを渡します：
+次に、`src/identity.ts`でAPI GatewayイベントからIDを解決する関数を記述します。実装は選択した`auth`メソッドによって異なります：
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="IAM認証APIのID解決">
+`IAM`認証の場合、API Gatewayイベントから抽出したsubを使用してCognitoで呼び出し元を検索します：
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Cognito認証APIのID解決">
+`auth: 'cognito'`の場合、API Gateway Cognito User Pools オーソライザーは、呼び出し元が`Authorization`ヘッダーで提供するJWTを検証し、検証済みのクレームを`event.requestContext.authorizer.claims`のイベントに配置します。これらのクレームを読み取るだけで、追加のAWS SDK呼び出しや手動のJWT検証は不要です。
+
+ジェネレーターはCognitoアクセストークンを受け入れるようにオーソライザーを配線するため、`username`は正規のユーザー名クレームです。IDトークンを受け入れるようにオーソライザーを再構成する場合に備えて、`cognito:username`にフォールバックします：
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[トークンの検証]
+ここでは`aws-jwt-verify`や他のJWT検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambdaが実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gatewayは`401 Unauthorized`を返し、ハンドラーは呼び出されません。
+:::
+</OptionFilter>
+
+次に、`src/handler.ts`で`getIdentity`を呼び出し、結果をコンテキストに追加します：
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[ローカルサーバー]
-`serve`ターゲットの`src/local-server.ts`もコンテキストを構築します。ローカルで実行する場合はAPI Gatewayイベントがないため、型を満たすためにスタブ（例：`event: { requestContext: {} } as never`）を渡すことができます。
+:::note[IAMルックアップは非同期]
+`IAM`認証の場合、`getIdentity`は`async`です（Cognitoを呼び出すため）。そのため上記で`await`しています。`cognito`認証の場合はクレームを読み取るだけで同期的ですが、awaitしても害はありません — そのため、ハンドラーコードは両方で同一です。
 :::
 
 次に、Smithyモデルで`Me`オペレーションを定義します。例えば`model/src/operations/me.smithy`に：
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-次に、オペレーションを実装します。呼び出し元のIDを抽出する方法は、選択した`auth`メソッドによって異なります：
-
-<OptionFilter when={{ auth: 'iam' }} description="IAM認証APIのID抽出">
-`IAM`認証の場合、API Gatewayイベントから抽出したsubを使用してCognitoで呼び出し元を検索します。`src/operations/me.ts`を作成します：
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Cognito認証APIのID抽出">
-`auth: 'cognito'`の場合、API Gateway Cognito User Pools オーソライザーは、呼び出し元が`Authorization`ヘッダーで提供するJWTを検証し、検証済みのクレームを`event.requestContext.authorizer.claims`のイベントに配置します。オペレーションはそれらのクレームを読み取るだけで、追加のAWS SDK呼び出しや手動のJWT検証は不要です。
-
-ジェネレーターはCognitoアクセストークンを受け入れるようにオーソライザーを配線するため、`username`は正規のユーザー名クレームです。IDトークンを受け入れるようにオーソライザーを再構成する場合に備えて、`cognito:username`にフォールバックします。`src/operations/me.ts`を作成します：
+`src/operations/me.ts`でオペレーションを実装し、コンテキストから解決されたIDを直接読み取ります：
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[トークンの検証]
-ここでは`aws-jwt-verify`や他のJWT検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambdaが実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gatewayは`401 Unauthorized`を返し、ハンドラーは呼び出されません。
-:::
-</OptionFilter>
 
 最後に、`src/service.ts`でサービスにオペレーションを登録します：
 

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### 呼び出しユーザーへのアクセス
 
-APIが認証で保護されている場合、オペレーションは誰が呼び出しているかを知る必要があることがよくあります。最もクリーンなアプローチは、ハンドラーで一度呼び出し元のIDを解決し、[サービスコンテキスト](#service-context)を通じて渡すことです。これにより、オペレーションはAPI Gatewayイベントの解析から解放されます。
+APIが認証で保護されている場合、オペレーションは誰が呼び出しているかを知る必要があることがよくあります。推奨されるアプローチは、ハンドラーで一度呼び出し元のIDを解決し、[サービスコンテキスト](#service-context)を通じて渡して、特定のオペレーションで使用できるようにすることです。
 
-例として、呼び出しユーザーの詳細を返す`Me`オペレーションを追加してみましょう。
+未認証のケースをSmithyエラーとしてモデル化し、適切な`403`レスポンスにシリアライズされるようにします。モデルに追加します。例えば`model/src/operations/errors.smithy`に追加し、IDを必要とする任意のオペレーションで参照します：
 
-まず、`src/context.ts`でサービスコンテキストに解決されたIDを追加します：
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+まず、`src/context.ts`でサービスコンテキストに解決されたIDを公開します。`UnauthorizedError`がハンドラーからではなく、オペレーション内から（Server SDKが`403`にシリアライズする場所で）スローされるように、関数として提供します：
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-次に、`src/identity.ts`でAPI GatewayイベントからIDを解決する関数を記述します。実装は選択した`auth`メソッドによって異なります：
+次に、`src/identity.ts`でリゾルバーを記述します。呼び出し元を特定できない場合は`UnauthorizedError`をスローします。実装は選択した`auth`メソッドによって異なります：
 
 <OptionFilter when={{ auth: 'iam' }} description="IAM認証APIのID解決">
 `IAM`認証の場合、API Gatewayイベントから抽出したsubを使用してCognitoで呼び出し元を検索します：
@@ -439,12 +453,13 @@ export interface ServiceContext {
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Cognito認証APIのID解決">
-`auth: 'cognito'`の場合、API Gateway Cognito User Pools オーソライザーは、呼び出し元が`Authorization`ヘッダーで提供するJWTを検証し、検証済みのクレームを`event.requestContext.authorizer.claims`のイベントに配置します。これらのクレームを読み取るだけで、追加のAWS SDK呼び出しや手動のJWT検証は不要です。
-
-ジェネレーターはCognitoアクセストークンを受け入れるようにオーソライザーを配線するため、`username`は正規のユーザー名クレームです。IDトークンを受け入れるようにオーソライザーを再構成する場合に備えて、`cognito:username`にフォールバックします：
+`auth: 'cognito'`の場合、API Gateway Cognito User Pools オーソライザーは、呼び出し元が`Authorization`ヘッダーで提供するJWTを検証し、検証済みのクレームを`event.requestContext.authorizer.claims`のイベントに配置します：
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[トークンの検証]
+:::tip[トークン検証は不要]
 ここでは`aws-jwt-verify`や他のJWT検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambdaが実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gatewayは`401 Unauthorized`を返し、ハンドラーは呼び出されません。
 :::
 </OptionFilter>
 
-次に、`src/handler.ts`で`getIdentity`を呼び出し、結果をコンテキストに追加します：
+次に、`src/handler.ts`でリゾルバーをコンテキストに配線します：
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[IAMルックアップは非同期]
-`IAM`認証の場合、`getIdentity`は`async`です（Cognitoを呼び出すため）。そのため上記で`await`しています。`cognito`認証の場合はクレームを読み取るだけで同期的ですが、awaitしても害はありません — そのため、ハンドラーコードは両方で同一です。
-:::
-
-次に、Smithyモデルで`Me`オペレーションを定義します。例えば`model/src/operations/me.smithy`に：
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-`model/src/main.smithy`でサービスにオペレーションを登録することを忘れないでください：
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-`src/operations/me.ts`でオペレーションを実装し、コンテキストから解決されたIDを直接読み取ります：
+これで、オペレーション内で解決されたIDを使用できます。例えば`src/operations/echo.ts`で：
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-最後に、`src/service.ts`でサービスにオペレーションを登録します：
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### 呼び出しユーザーへのアクセス
+
+APIが認証で保護されている場合、オペレーションは誰が呼び出しているかを知る必要があることがよくあります。ジェネレーターはこれを自動的に追加しませんが、生のAPI Gatewayイベントが利用可能なため、オペレーション内で呼び出し元のIDを抽出できます。
+
+例として、呼び出しユーザーの詳細を返す`Me`オペレーションを追加してみましょう。まず、`src/context.ts`に追加して、API Gatewayイベントを[サービスコンテキスト](#service-context)で利用できるようにします：
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+次に、`src/handler.ts`でコンテキストを構築する際にイベントを渡します：
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[ローカルサーバー]
+`serve`ターゲットの`src/local-server.ts`もコンテキストを構築します。ローカルで実行する場合はAPI Gatewayイベントがないため、型を満たすためにスタブ（例：`event: { requestContext: {} } as never`）を渡すことができます。
+:::
+
+次に、Smithyモデルで`Me`オペレーションを定義します。例えば`model/src/operations/me.smithy`に：
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+`model/src/main.smithy`でサービスにオペレーションを登録することを忘れないでください：
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+次に、オペレーションを実装します。呼び出し元のIDを抽出する方法は、選択した`auth`メソッドによって異なります：
+
+<OptionFilter when={{ auth: 'iam' }} description="IAM認証APIのID抽出">
+`IAM`認証の場合、API Gatewayイベントから抽出したsubを使用してCognitoで呼び出し元を検索します。`src/operations/me.ts`を作成します：
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Cognito認証APIのID抽出">
+`auth: 'cognito'`の場合、API Gateway Cognito User Pools オーソライザーは、呼び出し元が`Authorization`ヘッダーで提供するJWTを検証し、検証済みのクレームを`event.requestContext.authorizer.claims`のイベントに配置します。オペレーションはそれらのクレームを読み取るだけで、追加のAWS SDK呼び出しや手動のJWT検証は不要です。
+
+ジェネレーターはCognitoアクセストークンを受け入れるようにオーソライザーを配線するため、`username`は正規のユーザー名クレームです。IDトークンを受け入れるようにオーソライザーを再構成する場合に備えて、`cognito:username`にフォールバックします。`src/operations/me.ts`を作成します：
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[トークンの検証]
+ここでは`aws-jwt-verify`や他のJWT検証ライブラリは必要ありません — API Gateway Cognito User Pools オーソライザーは、Lambdaが実行される時点で既に署名、発行者、スコープ、有効期限を検証しています。これらのチェックのいずれかが失敗した場合、API Gatewayは`401 Unauthorized`を返し、ハンドラーは呼び出されません。
+:::
+</OptionFilter>
+
+最後に、`src/service.ts`でサービスにオペレーションを登録します：
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## ビルドとコード生成
 
 Smithyモデルプロジェクトは[Docker](https://www.docker.com/)を使用してSmithyアーティファクトをビルドし、TypeScript Server SDKを生成します：

--- a/docs/src/content/docs/ko/guides/fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/fastapi.mdx
@@ -185,6 +185,118 @@ def read_item(item_id: int):
 `connection` 생성기를 사용하는 경우 더 나은 코드 생성을 위해 API 작업에 응답 모델을 지정하는 것이 좋습니다. <Link path="guides/connection/react-fastapi#errors">자세한 내용 참조</Link>.
 :::
 
+### 호출 사용자 접근
+
+API가 인증으로 보호되는 경우, 라우트 핸들러는 종종 누가 호출하는지 알아야 합니다. 생성된 FastAPI는 [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)를 통해 AWS Lambda 내에서 실행되며, API Gateway 요청 컨텍스트를 `x-amzn-request-context` 헤더에 JSON으로 전달합니다. FastAPI `Request`에서 이를 읽어 호출자의 신원을 추출할 수 있습니다.
+
+예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `/me` 엔드포인트를 추가해 보겠습니다. 추출을 [FastAPI 의존성](https://fastapi.tiangolo.com/tutorial/dependencies/)으로 구현하여 여러 경로에서 재사용할 수 있도록 하겠습니다. 호출자의 신원을 추출하는 방법은 선택한 `auth` 방법에 따라 다릅니다:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+`IAM` 인증의 경우, API Gateway 요청 컨텍스트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다. `main.py` 옆에 `identity.py`를 생성하세요:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter가 API Gateway 요청 컨텍스트를 JSON으로 전달
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Lambda 환경에 user pool id가 구성되어 있다고 가정
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools authorizer가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `authorizer.claims`의 요청 컨텍스트에 배치합니다. 의존성은 단순히 해당 클레임을 읽기만 하면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
+
+생성기는 authorizer를 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 authorizer를 재구성하는 경우를 대비하여 `cognito:username`으로 폴백합니다. `main.py` 옆에 `identity.py`를 생성하세요:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter가 API Gateway 요청 컨텍스트를 JSON으로 전달
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[토큰 검증]
+여기서는 JWT 검증 라이브러리가 필요하지 않습니다 — API Gateway Cognito User Pools authorizer가 Lambda가 실행되기 전에 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
+:::
+</OptionFilter>
+
+그런 다음 호출자의 신원이 필요한 모든 경로에 `CurrentUser` 의존성을 주입할 수 있습니다:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### 스트리밍
 

--- a/docs/src/content/docs/ko/guides/fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools authorizer가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 요청 컨텍스트에 배치합니다. 의존성은 단순히 해당 클레임을 읽기만 하면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
+`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools authorizer가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 요청 컨텍스트에 배치합니다.
 
-생성기는 authorizer를 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 authorizer를 재구성하는 경우를 대비하여 `cognito:username`으로 폴백합니다. `main.py` 옆에 `identity.py`를 생성하세요:
+`main.py` 옆에 `identity.py`를 생성하세요:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[토큰 검증]
+:::tip[토큰 검증 불필요]
 여기서는 JWT 검증 라이브러리가 필요하지 않습니다 — API Gateway Cognito User Pools authorizer가 Lambda가 실행되기 전에 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/ko/guides/fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/fastapi.mdx
@@ -189,11 +189,13 @@ def read_item(item_id: int):
 
 API가 인증으로 보호되는 경우, 라우트 핸들러는 종종 누가 호출하는지 알아야 합니다. 생성된 FastAPI는 [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)를 통해 AWS Lambda 내에서 실행되며, API Gateway 요청 컨텍스트를 `x-amzn-request-context` 헤더에 JSON으로 전달합니다. FastAPI `Request`에서 이를 읽어 호출자의 신원을 추출할 수 있습니다.
 
-예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `/me` 엔드포인트를 추가해 보겠습니다. 추출을 [FastAPI 의존성](https://fastapi.tiangolo.com/tutorial/dependencies/)으로 구현하여 여러 경로에서 재사용할 수 있도록 하겠습니다. 호출자의 신원을 추출하는 방법은 선택한 `auth` 방법에 따라 다릅니다:
+예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `/me` 엔드포인트를 추가해 보겠습니다. 추출을 [FastAPI 의존성](https://fastapi.tiangolo.com/tutorial/dependencies/)으로 구현하여 여러 경로에서 재사용할 수 있도록 하겠습니다. 요청 컨텍스트의 형태 — 따라서 신원을 추출하는 방법 — 는 선택한 `auth` 방법과 REST 또는 HTTP API를 배포했는지 여부에 따라 달라집니다.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 `IAM` 인증의 경우, API Gateway 요청 컨텍스트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다. `main.py` 옆에 `identity.py`를 생성하세요:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter가 API Gateway 요청 컨텍스트를 JSON으로 전달
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Lambda 환경에 user pool id가 구성되어 있다고 가정
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools authorizer가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `authorizer.claims`의 요청 컨텍스트에 배치합니다. 의존성은 단순히 해당 클레임을 읽기만 하면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
+`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools authorizer가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 요청 컨텍스트에 배치합니다. 의존성은 단순히 해당 클레임을 읽기만 하면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
 
 생성기는 authorizer를 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 authorizer를 재구성하는 경우를 대비하여 `cognito:username`으로 폴백합니다. `main.py` 옆에 `identity.py`를 생성하세요:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP API는 검증된 클레임을 `authorizer.jwt.claims` 아래에 배치하는 JWT authorizer를 사용합니다:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter가 API Gateway 요청 컨텍스트를 JSON으로 전달
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[토큰 검증]
 여기서는 JWT 검증 라이브러리가 필요하지 않습니다 — API Gateway Cognito User Pools authorizer가 Lambda가 실행되기 전에 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 컨텍스트에 추가 _선택적_ 속성을 정의한다는 점에 주목하세요. tRPC는 이 미들웨어를 올바르게 구성한 프로시저에서 이것이 정의되도록 관리합니다.
 
-다음으로 미들웨어 자체를 구현합니다. 생성기는 인증자가 ID 토큰을 수락하도록 구성하므로 `cognito:username`이 정식 사용자 이름 클레임입니다. 인증자를 재구성하는 경우를 대비하여 액세스 토큰에 대해서는 `username`으로 폴백합니다:
+다음으로 미들웨어 자체를 구현합니다. 생성기는 인증자가 Cognito 액세스 토큰을 수락하도록 구성하므로 `username`이 정식 사용자 이름 클레임입니다. ID 토큰을 수락하도록 인증자를 재구성하는 경우를 대비하여 `cognito:username`으로 폴백합니다:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[토큰 검증]
-여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — API Gateway Cognito User Pools 인증자가 Lambda가 실행되기 전에 이미 서명, 발급자, 대상 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
+여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — API Gateway Cognito User Pools 인증자가 Lambda가 실행되기 전에 이미 서명, 발급자, 스코프 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 컨텍스트에 추가 _선택적_ 속성을 정의한다는 점에 주목하세요. tRPC는 이 미들웨어를 올바르게 구성한 프로시저에서 이것이 정의되도록 관리합니다.
 
-다음으로 미들웨어 자체를 구현합니다. 생성기는 인증자가 Cognito 액세스 토큰을 수락하도록 구성하므로 `username`이 정식 사용자 이름 클레임입니다. ID 토큰을 수락하도록 인증자를 재구성하는 경우를 대비하여 `cognito:username`으로 폴백합니다:
+다음으로 미들웨어 자체를 구현합니다:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[토큰 검증]
+:::tip[토큰 검증 불필요]
 여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — API Gateway Cognito User Pools 인증자가 Lambda가 실행되기 전에 이미 서명, 발급자, 스코프 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### 호출 사용자 액세스
 
-API가 인증으로 보호되는 경우, 오퍼레이션은 누가 호출하는지 알아야 하는 경우가 많습니다. 가장 깔끔한 접근 방식은 핸들러에서 호출자의 신원을 한 번 확인하고 [서비스 컨텍스트](#service-context)를 통해 전달하는 것입니다. 이렇게 하면 오퍼레이션이 API Gateway 이벤트 파싱에서 자유로워집니다.
+API가 인증으로 보호되는 경우, 오퍼레이션은 누가 호출하는지 알아야 하는 경우가 많습니다. 권장되는 접근 방식은 핸들러에서 호출자의 신원을 한 번 확인하고 [서비스 컨텍스트](#service-context)를 통해 전달하여 특정 오퍼레이션에서 사용하도록 하는 것입니다.
 
-예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `Me` 오퍼레이션을 추가해 보겠습니다.
+무단 액세스 케이스를 Smithy 오류로 모델링하여 적절한 `403` 응답으로 직렬화되도록 합니다. 예를 들어 `model/src/operations/errors.smithy`에서 모델에 추가하고, 신원이 필요한 모든 오퍼레이션에서 참조합니다:
 
-먼저 `src/context.ts`에서 서비스 컨텍스트에 확인된 신원을 추가합니다:
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+먼저 `src/context.ts`에서 서비스 컨텍스트에 확인된 신원을 노출합니다. `UnauthorizedError`가 핸들러가 아닌 오퍼레이션 내에서 발생하도록(Server SDK가 이를 `403`으로 직렬화하는 곳) 함수로 제공합니다:
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-다음으로, `src/identity.ts`에서 API Gateway 이벤트로부터 신원을 확인하는 함수를 작성합니다. 구현은 선택한 `auth` 방법에 따라 다릅니다:
+다음으로, `src/identity.ts`에서 리졸버를 작성합니다. 호출자를 확인할 수 없을 때 `UnauthorizedError`를 발생시킵니다. 구현은 선택한 `auth` 방법에 따라 다릅니다:
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
 `IAM` 인증의 경우, API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다:
@@ -439,12 +453,13 @@ export interface ServiceContext {
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
-`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools 권한 부여자가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `event.requestContext.authorizer.claims`의 이벤트에 배치합니다. 우리는 해당 클레임만 읽으면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
-
-생성기는 권한 부여자가 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 권한 부여자를 재구성하는 경우를 대비하여 `cognito:username`으로 대체합니다:
+`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools 권한 부여자가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `event.requestContext.authorizer.claims`의 이벤트에 배치합니다:
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[토큰 검증]
+:::tip[토큰 검증 불필요]
 여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — Lambda가 실행될 때까지 API Gateway Cognito User Pools 권한 부여자가 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
 :::
 </OptionFilter>
 
-그런 다음 `src/handler.ts`에서 `getIdentity`를 호출하고 결과를 컨텍스트에 추가합니다:
+그런 다음 `src/handler.ts`에서 리졸버를 컨텍스트에 연결합니다:
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[IAM 조회는 비동기입니다]
-`IAM` 인증의 경우, `getIdentity`는 `async`입니다(Cognito를 호출하기 때문에). 이것이 위에서 `await`하는 이유입니다. `cognito` 인증의 경우 클레임만 읽고 동기적이지만, await하는 것은 무해합니다 — 따라서 핸들러 코드는 두 경우 모두 동일합니다.
-:::
-
-이제 Smithy 모델에서 `Me` 오퍼레이션을 정의합니다. 예를 들어 `model/src/operations/me.smithy`에서:
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-`model/src/main.smithy`에서 서비스에 오퍼레이션을 등록하는 것을 잊지 마세요:
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-`src/operations/me.ts`에서 오퍼레이션을 구현하고, 컨텍스트에서 확인된 신원을 직접 읽습니다:
+이제 오퍼레이션에서 확인된 신원을 사용할 수 있습니다. 예를 들어 `src/operations/echo.ts`에서:
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-마지막으로 `src/service.ts`에서 서비스에 오퍼레이션을 등록합니다:
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### 호출 사용자 액세스
 
-API가 인증으로 보호되는 경우, 오퍼레이션은 누가 호출하는지 알아야 하는 경우가 많습니다. 생성기는 이를 자동으로 추가하지 않지만, 원시 API Gateway 이벤트를 사용할 수 있으므로 오퍼레이션에서 호출자의 신원을 추출할 수 있습니다.
+API가 인증으로 보호되는 경우, 오퍼레이션은 누가 호출하는지 알아야 하는 경우가 많습니다. 가장 깔끔한 접근 방식은 핸들러에서 호출자의 신원을 한 번 확인하고 [서비스 컨텍스트](#service-context)를 통해 전달하는 것입니다. 이렇게 하면 오퍼레이션이 API Gateway 이벤트 파싱에서 자유로워집니다.
 
-예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `Me` 오퍼레이션을 추가해 보겠습니다. 먼저 `src/context.ts`에 추가하여 [서비스 컨텍스트](#service-context)에서 API Gateway 이벤트를 사용할 수 있도록 합니다:
+예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `Me` 오퍼레이션을 추가해 보겠습니다.
 
-```ts {4,12} ins={4,12}
+먼저 `src/context.ts`에서 서비스 컨텍스트에 확인된 신원을 추가합니다:
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-그런 다음 `src/handler.ts`에서 컨텍스트를 구성할 때 이벤트를 전달합니다:
+다음으로, `src/identity.ts`에서 API Gateway 이벤트로부터 신원을 확인하는 함수를 작성합니다. 구현은 선택한 `auth` 방법에 따라 다릅니다:
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
+`IAM` 인증의 경우, API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
+`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools 권한 부여자가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `event.requestContext.authorizer.claims`의 이벤트에 배치합니다. 우리는 해당 클레임만 읽으면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
+
+생성기는 권한 부여자가 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 권한 부여자를 재구성하는 경우를 대비하여 `cognito:username`으로 대체합니다:
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[토큰 검증]
+여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — Lambda가 실행될 때까지 API Gateway Cognito User Pools 권한 부여자가 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
+:::
+</OptionFilter>
+
+그런 다음 `src/handler.ts`에서 `getIdentity`를 호출하고 결과를 컨텍스트에 추가합니다:
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[로컬 서버]
-`serve` 타겟의 `src/local-server.ts`도 컨텍스트를 구성합니다. 로컬에서 실행할 때는 API Gateway 이벤트가 없으므로, 타입을 만족시키기 위해 스텁(예: `event: { requestContext: {} } as never`)을 전달할 수 있습니다.
+:::note[IAM 조회는 비동기입니다]
+`IAM` 인증의 경우, `getIdentity`는 `async`입니다(Cognito를 호출하기 때문에). 이것이 위에서 `await`하는 이유입니다. `cognito` 인증의 경우 클레임만 읽고 동기적이지만, await하는 것은 무해합니다 — 따라서 핸들러 코드는 두 경우 모두 동일합니다.
 :::
 
-다음으로, Smithy 모델에서 `Me` 오퍼레이션을 정의합니다. 예를 들어 `model/src/operations/me.smithy`에서:
+이제 Smithy 모델에서 `Me` 오퍼레이션을 정의합니다. 예를 들어 `model/src/operations/me.smithy`에서:
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-이제 오퍼레이션을 구현합니다. 호출자의 신원을 추출하는 방법은 선택한 `auth` 방법에 따라 다릅니다:
-
-<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
-`IAM` 인증의 경우, API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다. `src/operations/me.ts`를 생성합니다:
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools 권한 부여자가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `event.requestContext.authorizer.claims`의 이벤트에 배치합니다. 오퍼레이션은 해당 클레임만 읽으면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
-
-생성기는 권한 부여자가 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 권한 부여자를 재구성하는 경우를 대비하여 `cognito:username`으로 대체합니다. `src/operations/me.ts`를 생성합니다:
+`src/operations/me.ts`에서 오퍼레이션을 구현하고, 컨텍스트에서 확인된 신원을 직접 읽습니다:
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[토큰 검증]
-여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — Lambda가 실행될 때까지 API Gateway Cognito User Pools 권한 부여자가 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
-:::
-</OptionFilter>
 
 마지막으로 `src/service.ts`에서 서비스에 오퍼레이션을 등록합니다:
 

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### 호출 사용자 액세스
+
+API가 인증으로 보호되는 경우, 오퍼레이션은 누가 호출하는지 알아야 하는 경우가 많습니다. 생성기는 이를 자동으로 추가하지 않지만, 원시 API Gateway 이벤트를 사용할 수 있으므로 오퍼레이션에서 호출자의 신원을 추출할 수 있습니다.
+
+예를 들어, 호출 사용자에 대한 세부 정보를 반환하는 `Me` 오퍼레이션을 추가해 보겠습니다. 먼저 `src/context.ts`에 추가하여 [서비스 컨텍스트](#service-context)에서 API Gateway 이벤트를 사용할 수 있도록 합니다:
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+그런 다음 `src/handler.ts`에서 컨텍스트를 구성할 때 이벤트를 전달합니다:
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[로컬 서버]
+`serve` 타겟의 `src/local-server.ts`도 컨텍스트를 구성합니다. 로컬에서 실행할 때는 API Gateway 이벤트가 없으므로, 타입을 만족시키기 위해 스텁(예: `event: { requestContext: {} } as never`)을 전달할 수 있습니다.
+:::
+
+다음으로, Smithy 모델에서 `Me` 오퍼레이션을 정의합니다. 예를 들어 `model/src/operations/me.smithy`에서:
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+`model/src/main.smithy`에서 서비스에 오퍼레이션을 등록하는 것을 잊지 마세요:
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+이제 오퍼레이션을 구현합니다. 호출자의 신원을 추출하는 방법은 선택한 `auth` 방법에 따라 다릅니다:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+`IAM` 인증의 경우, API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다. `src/operations/me.ts`를 생성합니다:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+`auth: 'cognito'`를 사용하면, API Gateway Cognito User Pools 권한 부여자가 호출자가 `Authorization` 헤더에 제공하는 JWT를 검증하고 검증된 클레임을 `event.requestContext.authorizer.claims`의 이벤트에 배치합니다. 오퍼레이션은 해당 클레임만 읽으면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 검증이 필요하지 않습니다.
+
+생성기는 권한 부여자가 Cognito 액세스 토큰을 수락하도록 연결하므로 `username`이 표준 사용자 이름 클레임입니다. ID 토큰을 수락하도록 권한 부여자를 재구성하는 경우를 대비하여 `cognito:username`으로 대체합니다. `src/operations/me.ts`를 생성합니다:
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[토큰 검증]
+여기서는 `aws-jwt-verify`나 다른 JWT 검증 라이브러리가 필요하지 않습니다 — Lambda가 실행될 때까지 API Gateway Cognito User Pools 권한 부여자가 이미 서명, 발급자, 범위 및 만료를 검증했습니다. 이러한 검사 중 하나라도 실패하면 API Gateway는 `401 Unauthorized`를 반환하고 핸들러는 호출되지 않습니다.
+:::
+</OptionFilter>
+
+마지막으로 `src/service.ts`에서 서비스에 오퍼레이션을 등록합니다:
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## 빌드 및 코드 생성
 
 Smithy 모델 프로젝트는 [Docker](https://www.docker.com/)를 사용하여 Smithy 아티팩트를 빌드하고 TypeScript Server SDK를 생성합니다:

--- a/docs/src/content/docs/pt/guides/fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/fastapi.mdx
@@ -185,6 +185,118 @@ Exceções não tratadas são capturadas pelo middleware e:
 Recomenda-se especificar modelos de resposta para operações da API para melhor geração de código ao usar o gerador `connection`. <Link path="guides/connection/react-fastapi#errors">Veja mais detalhes aqui</Link>.
 :::
 
+### Acessando o Usuário Chamador
+
+Quando sua API é protegida por autenticação, seus manipuladores de rota frequentemente precisam saber quem está chamando. A FastAPI gerada é executada dentro do AWS Lambda via o [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), que encaminha o contexto da requisição do API Gateway como JSON no cabeçalho `x-amzn-request-context`. Você pode lê-lo do `Request` do FastAPI para extrair a identidade do chamador.
+
+Como exemplo, vamos adicionar um endpoint `/me` que retorna detalhes sobre o usuário chamador. Implementaremos a extração como uma [dependência do FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) para que possa ser reutilizada entre rotas. A forma como você extrai a identidade do chamador depende do método `auth` selecionado:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do contexto da requisição do API Gateway. Crie `identity.py` ao lado de `main.py`:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # O Lambda Web Adapter encaminha o contexto da requisição do API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Assume que o id do user pool está configurado no ambiente do lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no contexto da requisição em `authorizer.claims`. A dependência apenas lê essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
+
+O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID. Crie `identity.py` ao lado de `main.py`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # O Lambda Web Adapter encaminha o contexto da requisição do API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[Verificando o token]
+Você não precisa de nenhuma biblioteca de verificação JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu manipulador nunca é invocado.
+:::
+</OptionFilter>
+
+Você pode então injetar a dependência `CurrentUser` em qualquer rota que precise da identidade do chamador:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### Streaming
 

--- a/docs/src/content/docs/pt/guides/fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/fastapi.mdx
@@ -189,11 +189,13 @@ Recomenda-se especificar modelos de resposta para operações da API para melhor
 
 Quando sua API é protegida por autenticação, seus manipuladores de rota frequentemente precisam saber quem está chamando. A FastAPI gerada é executada dentro do AWS Lambda via o [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), que encaminha o contexto da requisição do API Gateway como JSON no cabeçalho `x-amzn-request-context`. Você pode lê-lo do `Request` do FastAPI para extrair a identidade do chamador.
 
-Como exemplo, vamos adicionar um endpoint `/me` que retorna detalhes sobre o usuário chamador. Implementaremos a extração como uma [dependência do FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) para que possa ser reutilizada entre rotas. A forma como você extrai a identidade do chamador depende do método `auth` selecionado:
+Como exemplo, vamos adicionar um endpoint `/me` que retorna detalhes sobre o usuário chamador. Implementaremos a extração como uma [dependência do FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/) para que possa ser reutilizada entre rotas. A forma do contexto da requisição — e portanto como você extrai a identidade — depende tanto do método `auth` selecionado quanto se você implantou uma REST API ou HTTP API.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do contexto da requisição do API Gateway. Crie `identity.py` ao lado de `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # O Lambda Web Adapter encaminha o contexto da requisição do API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Assume que o id do user pool está configurado no ambiente do lambda
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no contexto da requisição em `authorizer.claims`. A dependência apenas lê essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
+Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no contexto da requisição. A dependência apenas lê essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
 
 O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID. Crie `identity.py` ao lado de `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP APIs usam um autorizador JWT que coloca as claims verificadas em `authorizer.jwt.claims`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # O Lambda Web Adapter encaminha o contexto da requisição do API Gateway como JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[Verificando o token]
 Você não precisa de nenhuma biblioteca de verificação JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu manipulador nunca é invocado.

--- a/docs/src/content/docs/pt/guides/fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no contexto da requisição. A dependência apenas lê essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
+Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no contexto da requisição.
 
-O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID. Crie `identity.py` ao lado de `main.py`:
+Crie `identity.py` ao lado de `main.py`:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[Verificando o token]
+:::tip[Nenhuma verificação de token necessária]
 Você não precisa de nenhuma biblioteca de verificação JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu manipulador nunca é invocado.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Note que definimos uma propriedade adicional _opcional_ no contexto. tRPC gerencia a garantia de que isso esteja definido em procedimentos que configuraram corretamente este middleware.
 
-Em seguida, o middleware em si. O gerador configura o autorizador para aceitar tokens de ID, então `cognito:username` é a claim de nome de usuário canônica; fazemos fallback para `username` para tokens de acesso caso você reconfigure o autorizador:
+Em seguida, o middleware em si. O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; fazemos fallback para `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[Verificando o token]
-Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, audiência e expiração no momento em que seu Lambda é executado. Se qualquer uma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
+Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se qualquer uma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Note que definimos uma propriedade adicional _opcional_ no contexto. tRPC gerencia a garantia de que isso esteja definido em procedimentos que configuraram corretamente este middleware.
 
-Em seguida, o middleware em si. O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; fazemos fallback para `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID:
+Em seguida, o middleware em si:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[Verificando o token]
+:::tip[Nenhuma verificação de token necessária]
 Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se qualquer uma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### Acessando o Usuário Chamador
+
+Quando sua API é protegida por autenticação, suas operações frequentemente precisam saber quem está chamando. O gerador não adiciona isso para você, mas como o evento bruto do API Gateway está disponível, você pode extrair a identidade do chamador em uma operação.
+
+Como exemplo, vamos adicionar uma operação `Me` que retorna detalhes sobre o usuário chamador. Primeiro, torne o evento do API Gateway disponível no [contexto do serviço](#service-context) adicionando-o em `src/context.ts`:
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+Em seguida, passe o evento ao construir o contexto em `src/handler.ts`:
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[Servidor Local]
+O `src/local-server.ts` do target `serve` também constrói o contexto. Não há evento do API Gateway ao executar localmente, então você pode passar um stub (por exemplo, `event: { requestContext: {} } as never`) para satisfazer o tipo.
+:::
+
+Em seguida, defina a operação `Me` no seu modelo Smithy, por exemplo em `model/src/operations/me.smithy`:
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Lembre-se de registrar a operação no seu serviço em `model/src/main.smithy`:
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+Agora implemente a operação. A maneira como você extrai a identidade do chamador depende do método `auth` selecionado:
+
+<OptionFilter when={{ auth: 'iam' }} description="Extração de identidade para APIs autenticadas com IAM">
+Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do evento do API Gateway. Crie `src/operations/me.ts`:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Extração de identidade para APIs autenticadas com Cognito">
+Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no evento em `event.requestContext.authorizer.claims`. A operação apenas lê essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
+
+O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID. Crie `src/operations/me.ts`:
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verificando o token]
+Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
+:::
+</OptionFilter>
+
+Finalmente, registre a operação no seu serviço em `src/service.ts`:
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## Build e Geração de Código
 
 O projeto de modelo Smithy usa [Docker](https://www.docker.com/) para construir os artefatos Smithy e gerar o TypeScript Server SDK:

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Acessando o Usuário Chamador
 
-Quando sua API é protegida por autenticação, suas operações frequentemente precisam saber quem está chamando. O gerador não adiciona isso para você, mas como o evento bruto do API Gateway está disponível, você pode extrair a identidade do chamador em uma operação.
+Quando sua API é protegida por autenticação, suas operações frequentemente precisam saber quem está chamando. A abordagem mais limpa é resolver a identidade do chamador uma vez no handler e passá-la através do [contexto do serviço](#service-context), para que suas operações permaneçam livres de qualquer análise de evento do API Gateway.
 
-Como exemplo, vamos adicionar uma operação `Me` que retorna detalhes sobre o usuário chamador. Primeiro, torne o evento do API Gateway disponível no [contexto do serviço](#service-context) adicionando-o em `src/context.ts`:
+Como exemplo, vamos adicionar uma operação `Me` que retorna detalhes sobre o usuário chamador.
 
-```ts {4,12} ins={4,12}
+Primeiro, adicione a identidade resolvida ao contexto do serviço em `src/context.ts`:
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-Em seguida, passe o evento ao construir o contexto em `src/handler.ts`:
+Em seguida, escreva uma função que resolve a identidade a partir do evento do API Gateway em `src/identity.ts`. A implementação depende do método `auth` selecionado:
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Resolução de identidade para APIs autenticadas com IAM">
+Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do evento do API Gateway:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Resolução de identidade para APIs autenticadas com Cognito">
+Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no evento em `event.requestContext.authorizer.claims`. Nós apenas lemos essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
+
+O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID:
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verificando o token]
+Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
+:::
+</OptionFilter>
+
+Em seguida, chame `getIdentity` em `src/handler.ts` e adicione o resultado ao contexto:
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[Servidor Local]
-O `src/local-server.ts` do target `serve` também constrói o contexto. Não há evento do API Gateway ao executar localmente, então você pode passar um stub (por exemplo, `event: { requestContext: {} } as never`) para satisfazer o tipo.
+:::note[Consulta IAM é assíncrona]
+Para autenticação `IAM`, `getIdentity` é `async` (ela chama o Cognito), e é por isso que fazemos `await` acima. Para autenticação `cognito` ela apenas lê as claims e é síncrona, mas fazer `await` é inofensivo — então o código do handler é idêntico para ambos.
 :::
 
-Em seguida, defina a operação `Me` no seu modelo Smithy, por exemplo em `model/src/operations/me.smithy`:
+Agora defina a operação `Me` no seu modelo Smithy, por exemplo em `model/src/operations/me.smithy`:
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-Agora implemente a operação. A maneira como você extrai a identidade do chamador depende do método `auth` selecionado:
-
-<OptionFilter when={{ auth: 'iam' }} description="Extração de identidade para APIs autenticadas com IAM">
-Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do evento do API Gateway. Crie `src/operations/me.ts`:
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Extração de identidade para APIs autenticadas com Cognito">
-Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no evento em `event.requestContext.authorizer.claims`. A operação apenas lê essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
-
-O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID. Crie `src/operations/me.ts`:
+Implemente a operação em `src/operations/me.ts`, lendo a identidade resolvida diretamente do contexto:
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[Verificando o token]
-Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
-:::
-</OptionFilter>
 
 Finalmente, registre a operação no seu serviço em `src/service.ts`:
 

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Acessando o Usuário Chamador
 
-Quando sua API é protegida por autenticação, suas operações frequentemente precisam saber quem está chamando. A abordagem mais limpa é resolver a identidade do chamador uma vez no handler e passá-la através do [contexto do serviço](#service-context), para que suas operações permaneçam livres de qualquer análise de evento do API Gateway.
+Quando sua API é protegida por autenticação, suas operações frequentemente precisam saber quem está chamando. A abordagem recomendada é resolver a identidade do chamador uma vez no handler e passá-la através do [contexto do serviço](#service-context) para consumo por operações específicas.
 
-Como exemplo, vamos adicionar uma operação `Me` que retorna detalhes sobre o usuário chamador.
+Vamos modelar o caso não autorizado como um erro Smithy para que ele serialize para uma resposta `403` adequada. Adicione-o ao seu modelo, por exemplo em `model/src/operations/errors.smithy`, e referencie-o em qualquer operação que requer identidade:
 
-Primeiro, adicione a identidade resolvida ao contexto do serviço em `src/context.ts`:
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Primeiro, exponha a identidade resolvida no contexto do serviço em `src/context.ts`. Fornecemos isso como uma função para que o `UnauthorizedError` seja lançado de dentro de uma operação (onde o Server SDK o serializa para um `403`), em vez de a partir do handler:
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-Em seguida, escreva uma função que resolve a identidade a partir do evento do API Gateway em `src/identity.ts`. A implementação depende do método `auth` selecionado:
+Em seguida, escreva o resolver em `src/identity.ts`. Ele lança `UnauthorizedError` quando o chamador não pode ser determinado. A implementação depende do método `auth` selecionado:
 
 <OptionFilter when={{ auth: 'iam' }} description="Resolução de identidade para APIs autenticadas com IAM">
 Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do evento do API Gateway:
@@ -439,12 +453,13 @@ Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraí
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Resolução de identidade para APIs autenticadas com Cognito">
-Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no evento em `event.requestContext.authorizer.claims`. Nós apenas lemos essas claims — sem chamadas extras ao AWS SDK, sem verificação manual de JWT.
-
-O gerador configura o autorizador para aceitar tokens de acesso do Cognito, então `username` é a claim de nome de usuário canônica; recorremos a `cognito:username` caso você reconfigure o autorizador para aceitar tokens de ID:
+Com `auth: 'cognito'`, o autorizador Cognito User Pools do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as claims verificadas no evento em `event.requestContext.authorizer.claims`:
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[Verificando o token]
+:::tip[Nenhuma verificação de token necessária]
 Você não precisa de `aws-jwt-verify` ou qualquer outra biblioteca de verificação de JWT aqui — o autorizador Cognito User Pools do API Gateway já verificou a assinatura, emissor, escopos e expiração no momento em que seu Lambda é executado. Se alguma dessas verificações falhar, o API Gateway retorna `401 Unauthorized` e seu handler nunca é invocado.
 :::
 </OptionFilter>
 
-Em seguida, chame `getIdentity` em `src/handler.ts` e adicione o resultado ao contexto:
+Em seguida, conecte o resolver ao contexto em `src/handler.ts`:
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[Consulta IAM é assíncrona]
-Para autenticação `IAM`, `getIdentity` é `async` (ela chama o Cognito), e é por isso que fazemos `await` acima. Para autenticação `cognito` ela apenas lê as claims e é síncrona, mas fazer `await` é inofensivo — então o código do handler é idêntico para ambos.
-:::
-
-Agora defina a operação `Me` no seu modelo Smithy, por exemplo em `model/src/operations/me.smithy`:
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-Lembre-se de registrar a operação no seu serviço em `model/src/main.smithy`:
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-Implemente a operação em `src/operations/me.ts`, lendo a identidade resolvida diretamente do contexto:
+Agora podemos usar a identidade resolvida em uma operação, por exemplo em `src/operations/echo.ts`:
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-Finalmente, registre a operação no seu serviço em `src/service.ts`:
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/vi/guides/fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/fastapi.mdx
@@ -189,11 +189,13 @@ Nên chỉ định response models cho các API operation để tạo code tốt
 
 Khi API của bạn được bảo vệ bởi xác thực, các route handler thường cần biết ai đang gọi. FastAPI được tạo chạy bên trong AWS Lambda thông qua [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), chuyển tiếp API Gateway request context dưới dạng JSON trên header `x-amzn-request-context`. Bạn có thể đọc nó từ FastAPI `Request` để trích xuất danh tính của người gọi.
 
-Ví dụ, hãy thêm một endpoint `/me` trả về thông tin chi tiết về người dùng đang gọi. Chúng ta sẽ triển khai việc trích xuất dưới dạng [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) để có thể tái sử dụng trên các route. Cách bạn trích xuất danh tính của người gọi phụ thuộc vào phương thức `auth` bạn đã chọn:
+Ví dụ, hãy thêm một endpoint `/me` trả về thông tin chi tiết về người dùng đang gọi. Chúng ta sẽ triển khai việc trích xuất dưới dạng [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) để có thể tái sử dụng trên các route. Hình dạng của request context — và do đó cách bạn trích xuất danh tính — phụ thuộc vào cả phương thức `auth` bạn đã chọn và việc bạn triển khai REST hay HTTP API.
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 Với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ API Gateway request context. Tạo `identity.py` cùng với `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter chuyển tiếp API Gateway request context dưới dạng JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Giả định user pool id được cấu hình trong lambda environment
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Với `auth: 'cognito'`, API Gateway Cognito User Pools authorizer xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claims đã xác minh trên request context tại `authorizer.claims`. Dependency chỉ đọc các claims đó — không có thêm AWS SDK calls, không cần xác minh JWT thủ công.
+Với `auth: 'cognito'`, API Gateway Cognito User Pools authorizer xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claims đã xác minh trên request context. Dependency chỉ đọc các claims đó — không có thêm AWS SDK calls, không cần xác minh JWT thủ công.
 
 Generator kết nối authorizer để chấp nhận Cognito access tokens, vì vậy `username` là canonical username claim; chúng ta fallback về `cognito:username` trong trường hợp bạn cấu hình lại authorizer để chấp nhận ID tokens. Tạo `identity.py` cùng với `main.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP APIs sử dụng JWT authorizer đặt các claims đã xác minh dưới `authorizer.jwt.claims`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter chuyển tiếp API Gateway request context dưới dạng JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[Xác minh token]
 Bạn không cần bất kỳ thư viện xác minh JWT nào ở đây — API Gateway Cognito User Pools authorizer đã xác minh chữ ký, issuer, scopes và expiry vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.

--- a/docs/src/content/docs/vi/guides/fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/fastapi.mdx
@@ -185,6 +185,118 @@ Các exception không được xử lý sẽ được middleware bắt và:
 Nên chỉ định response models cho các API operation để tạo code tốt hơn nếu sử dụng generator `connection`. <Link path="guides/connection/react-fastapi#errors">Xem thêm chi tiết tại đây</Link>.
 :::
 
+### Truy cập người dùng đang gọi
+
+Khi API của bạn được bảo vệ bởi xác thực, các route handler thường cần biết ai đang gọi. FastAPI được tạo chạy bên trong AWS Lambda thông qua [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), chuyển tiếp API Gateway request context dưới dạng JSON trên header `x-amzn-request-context`. Bạn có thể đọc nó từ FastAPI `Request` để trích xuất danh tính của người gọi.
+
+Ví dụ, hãy thêm một endpoint `/me` trả về thông tin chi tiết về người dùng đang gọi. Chúng ta sẽ triển khai việc trích xuất dưới dạng [FastAPI dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) để có thể tái sử dụng trên các route. Cách bạn trích xuất danh tính của người gọi phụ thuộc vào phương thức `auth` bạn đã chọn:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ API Gateway request context. Tạo `identity.py` cùng với `main.py`:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter chuyển tiếp API Gateway request context dưới dạng JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # Giả định user pool id được cấu hình trong lambda environment
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Với `auth: 'cognito'`, API Gateway Cognito User Pools authorizer xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claims đã xác minh trên request context tại `authorizer.claims`. Dependency chỉ đọc các claims đó — không có thêm AWS SDK calls, không cần xác minh JWT thủ công.
+
+Generator kết nối authorizer để chấp nhận Cognito access tokens, vì vậy `username` là canonical username claim; chúng ta fallback về `cognito:username` trong trường hợp bạn cấu hình lại authorizer để chấp nhận ID tokens. Tạo `identity.py` cùng với `main.py`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter chuyển tiếp API Gateway request context dưới dạng JSON
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[Xác minh token]
+Bạn không cần bất kỳ thư viện xác minh JWT nào ở đây — API Gateway Cognito User Pools authorizer đã xác minh chữ ký, issuer, scopes và expiry vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
+:::
+</OptionFilter>
+
+Sau đó, bạn có thể inject dependency `CurrentUser` vào bất kỳ route nào cần danh tính của người gọi:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### Streaming
 

--- a/docs/src/content/docs/vi/guides/fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Với `auth: 'cognito'`, API Gateway Cognito User Pools authorizer xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claims đã xác minh trên request context. Dependency chỉ đọc các claims đó — không có thêm AWS SDK calls, không cần xác minh JWT thủ công.
+Với `auth: 'cognito'`, API Gateway Cognito User Pools authorizer xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claims đã xác minh trên request context.
 
-Generator kết nối authorizer để chấp nhận Cognito access tokens, vì vậy `username` là canonical username claim; chúng ta fallback về `cognito:username` trong trường hợp bạn cấu hình lại authorizer để chấp nhận ID tokens. Tạo `identity.py` cùng với `main.py`:
+Tạo `identity.py` cùng với `main.py`:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[Xác minh token]
+:::tip[Không cần xác minh token]
 Bạn không cần bất kỳ thư viện xác minh JWT nào ở đây — API Gateway Cognito User Pools authorizer đã xác minh chữ ký, issuer, scopes và expiry vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Lưu ý rằng chúng ta định nghĩa một thuộc tính _tùy chọn_ bổ sung cho context. tRPC quản lý đảm bảo rằng điều này được định nghĩa trong các procedure đã cấu hình middleware này một cách chính xác.
 
-Tiếp theo, chính middleware đó. Trình tạo kết nối authorizer để chấp nhận ID token, vì vậy `cognito:username` là claim username chính thức; chúng ta fallback về `username` cho access token trong trường hợp bạn cấu hình lại authorizer:
+Tiếp theo, chính middleware đó. Trình tạo kết nối authorizer để chấp nhận Cognito access token, vì vậy `username` là claim username chính thức; chúng ta fallback về `cognito:username` trong trường hợp bạn cấu hình lại authorizer để chấp nhận ID token:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[Xác minh token]
-Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — API Gateway Cognito User Pools authorizer đã xác minh chữ ký, issuer, audience và expiry vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
+Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — API Gateway Cognito User Pools authorizer đã xác minh chữ ký, issuer, scope và expiry vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 Lưu ý rằng chúng ta định nghĩa một thuộc tính _tùy chọn_ bổ sung cho context. tRPC quản lý đảm bảo rằng điều này được định nghĩa trong các procedure đã cấu hình middleware này một cách chính xác.
 
-Tiếp theo, chính middleware đó. Trình tạo kết nối authorizer để chấp nhận Cognito access token, vì vậy `username` là claim username chính thức; chúng ta fallback về `cognito:username` trong trường hợp bạn cấu hình lại authorizer để chấp nhận ID token:
+Tiếp theo, chính middleware đó:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[Xác minh token]
+:::tip[Không cần xác minh token]
 Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — API Gateway Cognito User Pools authorizer đã xác minh chữ ký, issuer, scope và expiry vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
 :::
 </OptionFilter>

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### Truy Cập Người Dùng Đang Gọi
+
+Khi API của bạn được bảo vệ bằng xác thực, các operation thường cần biết ai đang gọi. Trình tạo không thêm điều này cho bạn, nhưng vì sự kiện API Gateway thô có sẵn, bạn có thể trích xuất danh tính của người gọi trong một operation.
+
+Ví dụ, hãy thêm một operation `Me` trả về thông tin chi tiết về người dùng đang gọi. Đầu tiên, làm cho sự kiện API Gateway có sẵn trên [service context](#service-context) bằng cách thêm nó vào `src/context.ts`:
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+Sau đó truyền sự kiện khi bạn xây dựng context trong `src/handler.ts`:
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[Local Server]
+Target `serve` của `src/local-server.ts` cũng xây dựng context. Không có sự kiện API Gateway khi chạy cục bộ, vì vậy bạn có thể truyền một stub (ví dụ: `event: { requestContext: {} } as never`) để thỏa mãn kiểu.
+:::
+
+Tiếp theo, định nghĩa operation `Me` trong mô hình Smithy của bạn, ví dụ trong `model/src/operations/me.smithy`:
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Nhớ đăng ký operation trên service của bạn trong `model/src/main.smithy`:
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+Bây giờ triển khai operation. Cách bạn trích xuất danh tính của người gọi phụ thuộc vào phương thức `auth` đã chọn:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+Đối với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ sự kiện API Gateway. Tạo `src/operations/me.ts`:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+Với `auth: 'cognito'`, trình ủy quyền Cognito User Pools của API Gateway xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claim đã xác minh trên sự kiện tại `event.requestContext.authorizer.claims`. Operation chỉ đọc các claim đó — không có cuộc gọi AWS SDK bổ sung, không có xác minh JWT thủ công.
+
+Trình tạo kết nối trình ủy quyền để chấp nhận access token của Cognito, vì vậy `username` là claim username chính tắc; chúng ta quay lại `cognito:username` trong trường hợp bạn cấu hình lại trình ủy quyền để chấp nhận ID token. Tạo `src/operations/me.ts`:
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verifying the token]
+Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — trình ủy quyền Cognito User Pools của API Gateway đã xác minh chữ ký, issuer, scope và thời hạn vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
+:::
+</OptionFilter>
+
+Cuối cùng, đăng ký operation trên service của bạn trong `src/service.ts`:
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## Building và Tạo Mã
 
 Dự án mô hình Smithy sử dụng [Docker](https://www.docker.com/) để build các artifact Smithy và tạo TypeScript Server SDK:

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Truy Cập Người Dùng Đang Gọi
 
-Khi API của bạn được bảo vệ bằng xác thực, các operation thường cần biết ai đang gọi. Trình tạo không thêm điều này cho bạn, nhưng vì sự kiện API Gateway thô có sẵn, bạn có thể trích xuất danh tính của người gọi trong một operation.
+Khi API của bạn được bảo vệ bằng xác thực, các operation thường cần biết ai đang gọi. Cách tiếp cận sạch nhất là giải quyết danh tính của người gọi một lần trong handler và truyền nó qua [service context](#service-context), để các operation của bạn không phải phân tích sự kiện API Gateway.
 
-Ví dụ, hãy thêm một operation `Me` trả về thông tin chi tiết về người dùng đang gọi. Đầu tiên, làm cho sự kiện API Gateway có sẵn trên [service context](#service-context) bằng cách thêm nó vào `src/context.ts`:
+Ví dụ, hãy thêm một operation `Me` trả về thông tin chi tiết về người dùng đang gọi.
 
-```ts {4,12} ins={4,12}
+Đầu tiên, thêm danh tính đã giải quyết vào service context trong `src/context.ts`:
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-Sau đó truyền sự kiện khi bạn xây dựng context trong `src/handler.ts`:
+Tiếp theo, viết một hàm giải quyết danh tính từ sự kiện API Gateway trong `src/identity.ts`. Cách triển khai phụ thuộc vào phương thức `auth` đã chọn:
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
+Đối với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ sự kiện API Gateway:
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
+Với `auth: 'cognito'`, trình ủy quyền Cognito User Pools của API Gateway xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claim đã xác minh trên sự kiện tại `event.requestContext.authorizer.claims`. Chúng ta chỉ đọc các claim đó — không có cuộc gọi AWS SDK bổ sung, không có xác minh JWT thủ công.
+
+Trình tạo kết nối trình ủy quyền để chấp nhận access token của Cognito, vì vậy `username` là claim username chính tắc; chúng ta quay lại `cognito:username` trong trường hợp bạn cấu hình lại trình ủy quyền để chấp nhận ID token:
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[Verifying the token]
+Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — trình ủy quyền Cognito User Pools của API Gateway đã xác minh chữ ký, issuer, scope và thời hạn vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
+:::
+</OptionFilter>
+
+Sau đó gọi `getIdentity` trong `src/handler.ts` và thêm kết quả vào context:
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[Local Server]
-Target `serve` của `src/local-server.ts` cũng xây dựng context. Không có sự kiện API Gateway khi chạy cục bộ, vì vậy bạn có thể truyền một stub (ví dụ: `event: { requestContext: {} } as never`) để thỏa mãn kiểu.
+:::note[IAM lookup is asynchronous]
+Đối với xác thực `IAM`, `getIdentity` là `async` (nó gọi Cognito), đó là lý do tại sao chúng ta `await` nó ở trên. Đối với xác thực `cognito`, nó chỉ đọc các claim và là đồng bộ, nhưng await nó là vô hại — vì vậy mã handler giống hệt nhau cho cả hai.
 :::
 
-Tiếp theo, định nghĩa operation `Me` trong mô hình Smithy của bạn, ví dụ trong `model/src/operations/me.smithy`:
+Bây giờ định nghĩa operation `Me` trong mô hình Smithy của bạn, ví dụ trong `model/src/operations/me.smithy`:
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-Bây giờ triển khai operation. Cách bạn trích xuất danh tính của người gọi phụ thuộc vào phương thức `auth` đã chọn:
-
-<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
-Đối với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ sự kiện API Gateway. Tạo `src/operations/me.ts`:
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-Với `auth: 'cognito'`, trình ủy quyền Cognito User Pools của API Gateway xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claim đã xác minh trên sự kiện tại `event.requestContext.authorizer.claims`. Operation chỉ đọc các claim đó — không có cuộc gọi AWS SDK bổ sung, không có xác minh JWT thủ công.
-
-Trình tạo kết nối trình ủy quyền để chấp nhận access token của Cognito, vì vậy `username` là claim username chính tắc; chúng ta quay lại `cognito:username` trong trường hợp bạn cấu hình lại trình ủy quyền để chấp nhận ID token. Tạo `src/operations/me.ts`:
+Triển khai operation trong `src/operations/me.ts`, đọc danh tính đã giải quyết trực tiếp từ context:
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[Verifying the token]
-Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — trình ủy quyền Cognito User Pools của API Gateway đã xác minh chữ ký, issuer, scope và thời hạn vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
-:::
-</OptionFilter>
 
 Cuối cùng, đăng ký operation trên service của bạn trong `src/service.ts`:
 

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### Truy Cập Người Dùng Đang Gọi
 
-Khi API của bạn được bảo vệ bằng xác thực, các operation thường cần biết ai đang gọi. Cách tiếp cận sạch nhất là giải quyết danh tính của người gọi một lần trong handler và truyền nó qua [service context](#service-context), để các operation của bạn không phải phân tích sự kiện API Gateway.
+Khi API của bạn được bảo vệ bằng xác thực, các operation thường cần biết ai đang gọi. Cách tiếp cận được khuyến nghị là giải quyết danh tính của người gọi một lần trong handler và truyền nó qua [service context](#service-context) để các operation cụ thể sử dụng.
 
-Ví dụ, hãy thêm một operation `Me` trả về thông tin chi tiết về người dùng đang gọi.
+Chúng ta sẽ mô hình hóa trường hợp không được ủy quyền như một lỗi Smithy để nó được tuần tự hóa thành phản hồi `403` phù hợp. Thêm nó vào mô hình của bạn, ví dụ trong `model/src/operations/errors.smithy`, và tham chiếu nó trên bất kỳ operation nào yêu cầu danh tính:
 
-Đầu tiên, thêm danh tính đã giải quyết vào service context trong `src/context.ts`:
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+Đầu tiên, hiển thị danh tính đã giải quyết trên service context trong `src/context.ts`. Chúng ta cung cấp nó dưới dạng một hàm để `UnauthorizedError` được ném ra từ bên trong một operation (nơi Server SDK tuần tự hóa nó thành `403`), thay vì từ handler:
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-Tiếp theo, viết một hàm giải quyết danh tính từ sự kiện API Gateway trong `src/identity.ts`. Cách triển khai phụ thuộc vào phương thức `auth` đã chọn:
+Tiếp theo, viết resolver trong `src/identity.ts`. Nó ném `UnauthorizedError` khi không thể xác định người gọi. Cách triển khai phụ thuộc vào phương thức `auth` đã chọn:
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
 Đối với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ sự kiện API Gateway:
@@ -439,12 +453,13 @@ Tiếp theo, viết một hàm giải quyết danh tính từ sự kiện API Ga
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity resolution for Cognito-authenticated APIs">
-Với `auth: 'cognito'`, trình ủy quyền Cognito User Pools của API Gateway xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claim đã xác minh trên sự kiện tại `event.requestContext.authorizer.claims`. Chúng ta chỉ đọc các claim đó — không có cuộc gọi AWS SDK bổ sung, không có xác minh JWT thủ công.
-
-Trình tạo kết nối trình ủy quyền để chấp nhận access token của Cognito, vì vậy `username` là claim username chính tắc; chúng ta quay lại `cognito:username` trong trường hợp bạn cấu hình lại trình ủy quyền để chấp nhận ID token:
+Với `auth: 'cognito'`, trình ủy quyền Cognito User Pools của API Gateway xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claim đã xác minh trên sự kiện tại `event.requestContext.authorizer.claims`:
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[Verifying the token]
+:::tip[No token verification required]
 Bạn không cần `aws-jwt-verify` hoặc bất kỳ thư viện xác minh JWT nào khác ở đây — trình ủy quyền Cognito User Pools của API Gateway đã xác minh chữ ký, issuer, scope và thời hạn vào thời điểm Lambda của bạn chạy. Nếu bất kỳ kiểm tra nào trong số đó thất bại, API Gateway trả về `401 Unauthorized` và handler của bạn không bao giờ được gọi.
 :::
 </OptionFilter>
 
-Sau đó gọi `getIdentity` trong `src/handler.ts` và thêm kết quả vào context:
+Sau đó kết nối resolver vào context trong `src/handler.ts`:
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[IAM lookup is asynchronous]
-Đối với xác thực `IAM`, `getIdentity` là `async` (nó gọi Cognito), đó là lý do tại sao chúng ta `await` nó ở trên. Đối với xác thực `cognito`, nó chỉ đọc các claim và là đồng bộ, nhưng await nó là vô hại — vì vậy mã handler giống hệt nhau cho cả hai.
-:::
-
-Bây giờ định nghĩa operation `Me` trong mô hình Smithy của bạn, ví dụ trong `model/src/operations/me.smithy`:
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-Nhớ đăng ký operation trên service của bạn trong `model/src/main.smithy`:
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-Triển khai operation trong `src/operations/me.ts`, đọc danh tính đã giải quyết trực tiếp từ context:
+Bây giờ chúng ta có thể sử dụng danh tính đã giải quyết trong một operation, ví dụ trong `src/operations/echo.ts`:
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-Cuối cùng, đăng ký operation trên service của bạn trong `src/service.ts`:
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/zh/guides/fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/fastapi.mdx
@@ -189,11 +189,13 @@ def read_item(item_id: int):
 
 当您的 API 受身份验证保护时,路由处理程序通常需要知道是谁在调用。生成的 FastAPI 通过 [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter) 在 AWS Lambda 内运行,它将 API Gateway 请求上下文作为 JSON 转发到 `x-amzn-request-context` 标头。您可以从 FastAPI `Request` 中读取它以提取调用者的身份。
 
-例如,让我们添加一个 `/me` 端点来返回调用用户的详细信息。我们将提取操作实现为 [FastAPI 依赖项](https://fastapi.tiangolo.com/tutorial/dependencies/),以便可以在路由之间重用。提取调用者身份的方式取决于您选择的 `auth` 方法:
+例如,让我们添加一个 `/me` 端点来返回调用用户的详细信息。我们将提取操作实现为 [FastAPI 依赖项](https://fastapi.tiangolo.com/tutorial/dependencies/),以便可以在路由之间重用。请求上下文的结构 — 以及因此如何提取身份 — 取决于您选择的 `auth` 方法以及您部署的是 REST API 还是 HTTP API。
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
 对于 `IAM` 身份验证,我们使用从 API Gateway 请求上下文中提取的 sub 在 Cognito 中查找调用者。在 `main.py` 旁边创建 `identity.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 import os
@@ -239,13 +241,70 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter 将 API Gateway 请求上下文作为 JSON 转发
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    amr = (
+        request_context.get("authorizer", {})
+        .get("iam", {})
+        .get("cognitoIdentity", {})
+        .get("amr", [])
+    )
+    sign_in = next((s for s in amr if ":CognitoSignIn:" in s), None)
+    sub = sign_in.split(":")[-1] if sign_in else None
+
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # 假设用户池 ID 在 lambda 环境中配置
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-使用 `auth: 'cognito'` 时,API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT,并将验证后的声明放置在请求上下文的 `authorizer.claims` 中。依赖项只需读取这些声明 — 无需额外的 AWS SDK 调用,无需手动 JWT 验证。
+使用 `auth: 'cognito'` 时,API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT,并将验证后的声明放置在请求上下文中。依赖项只需读取这些声明 — 无需额外的 AWS SDK 调用,无需手动 JWT 验证。
 
 生成器将授权器配置为接受 Cognito 访问令牌,因此 `username` 是规范的用户名声明;如果您重新配置授权器以接受 ID 令牌,我们会回退到 `cognito:username`。在 `main.py` 旁边创建 `identity.py`:
 
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
 ```python
 import json
 from typing import Annotated
@@ -279,6 +338,45 @@ def get_identity(request: Request) -> Identity:
 
 CurrentUser = Annotated[Identity, Depends(get_identity)]
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP API 使用 JWT 授权器,它将验证后的声明放置在 `authorizer.jwt.claims` 下:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter 将 API Gateway 请求上下文作为 JSON 转发
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</TabItem>
+</Tabs>
 
 :::tip[验证令牌]
 您不需要任何 JWT 验证库 — API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败,API Gateway 会返回 `401 Unauthorized`,您的处理程序永远不会被调用。

--- a/docs/src/content/docs/zh/guides/fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/fastapi.mdx
@@ -185,6 +185,118 @@ def read_item(item_id: int):
 如果使用 `connection` 生成器,建议为 API 操作指定响应模型以获得更好的代码生成效果。<Link path="guides/connection/react-fastapi#errors">详见此处</Link>。
 :::
 
+### 访问调用用户
+
+当您的 API 受身份验证保护时,路由处理程序通常需要知道是谁在调用。生成的 FastAPI 通过 [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter) 在 AWS Lambda 内运行,它将 API Gateway 请求上下文作为 JSON 转发到 `x-amzn-request-context` 标头。您可以从 FastAPI `Request` 中读取它以提取调用者的身份。
+
+例如,让我们添加一个 `/me` 端点来返回调用用户的详细信息。我们将提取操作实现为 [FastAPI 依赖项](https://fastapi.tiangolo.com/tutorial/dependencies/),以便可以在路由之间重用。提取调用者身份的方式取决于您选择的 `auth` 方法:
+
+<OptionFilter when={{ auth: 'iam' }} description="Identity extraction for IAM-authenticated APIs">
+对于 `IAM` 身份验证,我们使用从 API Gateway 请求上下文中提取的 sub 在 Cognito 中查找调用者。在 `main.py` 旁边创建 `identity.py`:
+
+```python
+import json
+import os
+from typing import Annotated
+
+from boto3 import client
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+cognito = client("cognito-idp")
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter 将 API Gateway 请求上下文作为 JSON 转发
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    provider = request_context.get("identity", {}).get("cognitoAuthenticationProvider")
+
+    sub = provider.split(":")[-1] if provider else None
+    if not sub:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    users = cognito.list_users(
+        # 假设用户池 ID 在 lambda 环境中配置
+        UserPoolId=os.environ["USER_POOL_ID"],
+        Limit=1,
+        Filter=f'sub="{sub}"',
+    ).get("Users", [])
+
+    if len(users) != 1:
+        raise HTTPException(status_code=403, detail=f"No user found with subjectId {sub}")
+
+    return Identity(sub=sub, username=users[0]["Username"])
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
+使用 `auth: 'cognito'` 时,API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT,并将验证后的声明放置在请求上下文的 `authorizer.claims` 中。依赖项只需读取这些声明 — 无需额外的 AWS SDK 调用,无需手动 JWT 验证。
+
+生成器将授权器配置为接受 Cognito 访问令牌,因此 `username` 是规范的用户名声明;如果您重新配置授权器以接受 ID 令牌,我们会回退到 `cognito:username`。在 `main.py` 旁边创建 `identity.py`:
+
+```python
+import json
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+
+class Identity(BaseModel):
+    sub: str
+    username: str
+
+
+def get_identity(request: Request) -> Identity:
+    # Lambda Web Adapter 将 API Gateway 请求上下文作为 JSON 转发
+    request_context_header = request.headers.get("x-amzn-request-context")
+    if not request_context_header:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    request_context = json.loads(request_context_header)
+    claims = request_context.get("authorizer", {}).get("claims", {})
+
+    sub = claims.get("sub")
+    username = claims.get("username") or claims.get("cognito:username")
+
+    if not sub or not username:
+        raise HTTPException(status_code=403, detail="Unable to determine calling user")
+
+    return Identity(sub=sub, username=username)
+
+
+CurrentUser = Annotated[Identity, Depends(get_identity)]
+```
+
+:::tip[验证令牌]
+您不需要任何 JWT 验证库 — API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败,API Gateway 会返回 `401 Unauthorized`,您的处理程序永远不会被调用。
+:::
+</OptionFilter>
+
+然后,您可以将 `CurrentUser` 依赖项注入到任何需要调用者身份的路由中:
+
+```python
+from .identity import CurrentUser, Identity
+from .init import app, tracer
+
+@app.get("/me")
+@tracer.capture_method
+def me(identity: CurrentUser) -> Identity:
+    return identity
+```
+
 <OptionFilter when={{ infra: 'rest-lambda' }} description="Streaming — REST API only">
 ### 流式传输
 

--- a/docs/src/content/docs/zh/guides/fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/fastapi.mdx
@@ -299,9 +299,9 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Identity extraction for Cognito-authenticated APIs">
-使用 `auth: 'cognito'` 时,API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT,并将验证后的声明放置在请求上下文中。依赖项只需读取这些声明 — 无需额外的 AWS SDK 调用,无需手动 JWT 验证。
+使用 `auth: 'cognito'` 时,API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT,并将验证后的声明放置在请求上下文中。
 
-生成器将授权器配置为接受 Cognito 访问令牌,因此 `username` 是规范的用户名声明;如果您重新配置授权器以接受 ID 令牌,我们会回退到 `cognito:username`。在 `main.py` 旁边创建 `identity.py`:
+在 `main.py` 旁边创建 `identity.py`:
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
@@ -328,7 +328,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -365,7 +365,7 @@ def get_identity(request: Request) -> Identity:
     claims = request_context.get("authorizer", {}).get("jwt", {}).get("claims", {})
 
     sub = claims.get("sub")
-    username = claims.get("username") or claims.get("cognito:username")
+    username = claims.get("username")
 
     if not sub or not username:
         raise HTTPException(status_code=403, detail="Unable to determine calling user")
@@ -378,7 +378,7 @@ CurrentUser = Annotated[Identity, Depends(get_identity)]
 </TabItem>
 </Tabs>
 
-:::tip[验证令牌]
+:::tip[无需令牌验证]
 您不需要任何 JWT 验证库 — API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败,API Gateway 会返回 `401 Unauthorized`,您的处理程序永远不会被调用。
 :::
 </OptionFilter>

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 注意,我们向上下文定义了一个额外的 _可选_ 属性。tRPC 会管理确保在正确配置此中间件的过程中有此定义。
 
-接下来是中间件本身。生成器将授权器配置为接受 Cognito 访问令牌,因此 `username` 是规范的用户名声明;我们回退到 `cognito:username` 以防您重新配置授权器以接受 ID 令牌:
+接下来是中间件本身:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username ?? claims?.['cognito:username'];
+    const username = claims?.username;
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -541,7 +541,7 @@ export const me = publicProcedure
   }));
 ```
 
-:::tip[验证令牌]
+:::tip[无需令牌验证]
 您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果这些检查中的任何一项失败,API Gateway 会返回 `401 Unauthorized`,并且永远不会调用您的处理程序。
 :::
 </OptionFilter>

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -478,7 +478,7 @@ export interface IIdentityContext {
 
 注意,我们向上下文定义了一个额外的 _可选_ 属性。tRPC 会管理确保在正确配置此中间件的过程中有此定义。
 
-接下来是中间件本身。生成器将授权器配置为接受 ID 令牌,因此 `cognito:username` 是规范的用户名声明;我们回退到 `username` 以支持访问令牌,以防您重新配置授权器:
+接下来是中间件本身。生成器将授权器配置为接受 Cognito 访问令牌,因此 `username` 是规范的用户名声明;我们回退到 `cognito:username` 以防您重新配置授权器以接受 ID 令牌:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -503,7 +503,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.['cognito:username'] ?? claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -542,7 +542,7 @@ export const me = publicProcedure
 ```
 
 :::tip[验证令牌]
-您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、受众和过期时间。如果这些检查中的任何一项失败,API Gateway 会返回 `401 Unauthorized`,并且永远不会调用您的处理程序。
+您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果这些检查中的任何一项失败,API Gateway 会返回 `401 Unauthorized`,并且永远不会调用您的处理程序。
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -401,6 +401,180 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 };
 ```
 
+### 访问调用用户
+
+当您的 API 受身份验证保护时，您的操作通常需要知道是谁在调用。生成器不会为您添加此功能，但由于原始 API Gateway 事件可用，您可以在操作中提取调用者的身份。
+
+例如，让我们添加一个 `Me` 操作，返回有关调用用户的详细信息。首先，通过在 `src/context.ts` 中添加 API Gateway 事件，使其在[服务上下文](#service-context)上可用：
+
+```ts {4,12} ins={4,12}
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Metrics } from '@aws-lambda-powertools/metrics';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+/**
+ * Context provided to all operations.
+ */
+export interface ServiceContext {
+  tracer: Tracer;
+  logger: Logger;
+  metrics: Metrics;
+  event: APIGatewayProxyEvent;
+}
+```
+
+然后在 `src/handler.ts` 中构造上下文时传递事件：
+
+```ts {6} ins={6}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  event,
+});
+```
+
+:::note[本地服务器]
+`serve` 目标的 `src/local-server.ts` 也会构造上下文。在本地运行时没有 API Gateway 事件，因此您可以传递一个存根（例如 `event: { requestContext: {} } as never`）来满足类型要求。
+:::
+
+接下来，在您的 Smithy 模型中定义 `Me` 操作，例如在 `model/src/operations/me.smithy` 中：
+
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Return details about the calling user
+@http(method: "GET", uri: "/me")
+@readonly
+operation Me {
+    output := {
+        @required
+        sub: String
+
+        @required
+        username: String
+    }
+    errors: [
+        UnauthorizedError
+    ]
+}
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+记得在 `model/src/main.smithy` 中将操作注册到您的服务：
+
+```smithy {4} ins={4}
+service YourService {
+    operations: [
+        Echo
+        Me
+    ]
+}
+```
+
+现在实现该操作。提取调用者身份的方式取决于您选择的 `auth` 方法：
+
+<OptionFilter when={{ auth: 'iam' }} description="IAM 身份验证 API 的身份提取">
+对于 `IAM` 身份验证，我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者。创建 `src/operations/me.ts`：
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const cognitoAuthenticationProvider =
+    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Cognito 身份验证 API 的身份提取">
+使用 `auth: 'cognito'` 时，API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT，并将验证后的声明放置在事件的 `event.requestContext.authorizer.claims` 上。该操作只需读取这些声明——无需额外的 AWS SDK 调用，无需手动 JWT 验证。
+
+生成器将授权器配置为接受 Cognito 访问令牌，因此 `username` 是规范的用户名声明；如果您重新配置授权器以接受 ID 令牌，我们会回退到 `cognito:username`。创建 `src/operations/me.ts`：
+
+```ts
+import { ServiceContext } from '../context.js';
+import {
+  Me as MeOperation,
+  UnauthorizedError,
+} from '../generated/ssdk/index.js';
+
+export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
+  const claims = ctx.event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[验证令牌]
+您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败，API Gateway 会返回 `401 Unauthorized`，并且永远不会调用您的处理程序。
+:::
+</OptionFilter>
+
+最后，在 `src/service.ts` 中将操作注册到您的服务：
+
+```ts {4,9} ins={4,9}
+import { ServiceContext } from './context.js';
+import { YourServiceService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { Me } from './operations/me.js';
+
+// Register operations to the service here
+export const Service: YourServiceService<ServiceContext> = {
+  Echo,
+  Me,
+};
+```
+
 ## 构建与代码生成
 
 Smithy 模型项目使用 [Docker](https://www.docker.com/) 构建 Smithy 产物并生成 TypeScript Server SDK：

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -403,11 +403,25 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### 访问调用用户
 
-当您的 API 受身份验证保护时，您的操作通常需要知道是谁在调用。最简洁的方法是在处理程序中一次性解析调用者的身份，并通过[服务上下文](#service-context)传递它，这样您的操作就不需要进行任何 API Gateway 事件解析。
+当您的 API 受身份验证保护时，您的操作通常需要知道是谁在调用。推荐的方法是在处理程序中一次性解析调用者的身份，并通过[服务上下文](#service-context)传递它，以供特定操作使用。
 
-例如，让我们添加一个 `Me` 操作，返回有关调用用户的详细信息。
+我们将未授权的情况建模为 Smithy 错误，以便将其序列化为正确的 `403` 响应。将其添加到您的模型中，例如在 `model/src/operations/errors.smithy` 中，并在任何需要身份的操作上引用它：
 
-首先，在 `src/context.ts` 中将解析后的身份添加到服务上下文：
+```smithy
+$version: "2.0"
+
+namespace your.namespace
+
+/// Thrown when the calling user cannot be determined
+@error("client")
+@httpError(403)
+structure UnauthorizedError {
+    @required
+    message: String
+}
+```
+
+首先，在 `src/context.ts` 中的服务上下文上公开解析后的身份。我们将其提供为一个函数，以便 `UnauthorizedError` 从操作内部抛出（Server SDK 将其序列化为 `403`），而不是从处理程序抛出：
 
 ```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -426,11 +440,11 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  identity?: Identity;
+  getIdentity: () => Promise<Identity>;
 }
 ```
 
-接下来，在 `src/identity.ts` 中编写一个函数，从 API Gateway 事件中解析身份。实现取决于您选择的 `auth` 方法：
+接下来，在 `src/identity.ts` 中编写解析器。当无法确定调用者时，它会抛出 `UnauthorizedError`。实现取决于您选择的 `auth` 方法：
 
 <OptionFilter when={{ auth: 'iam' }} description="IAM 身份验证 API 的身份解析">
 对于 `IAM` 身份验证，我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者：
@@ -439,12 +453,13 @@ export interface ServiceContext {
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
 const cognito = new CognitoIdentityProvider();
 
 export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Promise<Identity | undefined> => {
+): Promise<Identity> => {
   const cognitoAuthenticationProvider =
     event.requestContext?.identity?.cognitoAuthenticationProvider;
 
@@ -455,7 +470,7 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   const { Users } = await cognito.listUsers({
@@ -466,7 +481,7 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    return undefined;
+    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
   }
 
   return { sub, username: Users[0].Username! };
@@ -475,38 +490,37 @@ export const getIdentity = async (
 </OptionFilter>
 
 <OptionFilter when={{ auth: 'cognito' }} description="Cognito 身份验证 API 的身份解析">
-使用 `auth: 'cognito'` 时，API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT，并将验证后的声明放置在事件的 `event.requestContext.authorizer.claims` 上。我们只需读取这些声明——无需额外的 AWS SDK 调用，无需手动 JWT 验证。
-
-生成器将授权器配置为接受 Cognito 访问令牌，因此 `username` 是规范的用户名声明；如果您重新配置授权器以接受 ID 令牌，我们会回退到 `cognito:username`：
+使用 `auth: 'cognito'` 时，API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT，并将验证后的声明放置在事件的 `event.requestContext.authorizer.claims` 上：
 
 ```ts
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { Identity } from './context.js';
+import { UnauthorizedError } from './generated/ssdk/index.js';
 
-export const getIdentity = (
+export const getIdentity = async (
   event: APIGatewayProxyEvent,
-): Identity | undefined => {
+): Promise<Identity> => {
   const claims = event.requestContext?.authorizer?.claims as
     | Record<string, string>
     | undefined;
 
   const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
+  const username = claims?.username;
 
   if (!sub || !username) {
-    return undefined;
+    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
   return { sub, username };
 };
 ```
 
-:::tip[验证令牌]
+:::tip[无需令牌验证]
 您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败，API Gateway 会返回 `401 Unauthorized`，并且永远不会调用您的处理程序。
 :::
 </OptionFilter>
 
-然后在 `src/handler.ts` 中调用 `getIdentity` 并将结果添加到上下文：
+然后在 `src/handler.ts` 中将解析器连接到上下文：
 
 ```ts {2,8} ins={2,8}
 import { Service } from './service.js';
@@ -516,87 +530,19 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  identity: await getIdentity(event),
+  getIdentity: () => getIdentity(event),
 });
 ```
 
-:::note[IAM 查找是异步的]
-对于 `IAM` 身份验证，`getIdentity` 是 `async` 的（它调用 Cognito），这就是为什么我们在上面 `await` 它。对于 `cognito` 身份验证，它只是读取声明并且是同步的，但 await 它是无害的——因此两者的处理程序代码是相同的。
-:::
-
-现在在您的 Smithy 模型中定义 `Me` 操作，例如在 `model/src/operations/me.smithy` 中：
-
-```smithy
-$version: "2.0"
-
-namespace your.namespace
-
-/// Return details about the calling user
-@http(method: "GET", uri: "/me")
-@readonly
-operation Me {
-    output := {
-        @required
-        sub: String
-
-        @required
-        username: String
-    }
-    errors: [
-        UnauthorizedError
-    ]
-}
-
-/// Thrown when the calling user cannot be determined
-@error("client")
-@httpError(403)
-structure UnauthorizedError {
-    @required
-    message: String
-}
-```
-
-记得在 `model/src/main.smithy` 中将操作注册到您的服务：
-
-```smithy {4} ins={4}
-service YourService {
-    operations: [
-        Echo
-        Me
-    ]
-}
-```
-
-在 `src/operations/me.ts` 中实现该操作，直接从上下文中读取解析后的身份：
+现在我们可以在操作中使用解析后的身份，例如在 `src/operations/echo.ts` 中：
 
 ```ts
 import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
+import { Echo as EchoOperation } from '../generated/ssdk/index.js';
 
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  if (!ctx.identity) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  return { sub: ctx.identity.sub, username: ctx.identity.username };
-};
-```
-
-最后，在 `src/service.ts` 中将操作注册到您的服务：
-
-```ts {4,9} ins={4,9}
-import { ServiceContext } from './context.js';
-import { YourServiceService } from './generated/ssdk/index.js';
-import { Echo } from './operations/echo.js';
-import { Me } from './operations/me.js';
-
-// Register operations to the service here
-export const Service: YourServiceService<ServiceContext> = {
-  Echo,
-  Me,
+export const Echo: EchoOperation<ServiceContext> = async (input, ctx) => {
+  const identity = await ctx.getIdentity();
+  return { message: `${identity.username} says ${input.message}` };
 };
 ```
 

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -403,15 +403,21 @@ export const MyOperation: MyOperationHandler<ServiceContext> = async (input) => 
 
 ### 访问调用用户
 
-当您的 API 受身份验证保护时，您的操作通常需要知道是谁在调用。生成器不会为您添加此功能，但由于原始 API Gateway 事件可用，您可以在操作中提取调用者的身份。
+当您的 API 受身份验证保护时，您的操作通常需要知道是谁在调用。最简洁的方法是在处理程序中一次性解析调用者的身份，并通过[服务上下文](#service-context)传递它，这样您的操作就不需要进行任何 API Gateway 事件解析。
 
-例如，让我们添加一个 `Me` 操作，返回有关调用用户的详细信息。首先，通过在 `src/context.ts` 中添加 API Gateway 事件，使其在[服务上下文](#service-context)上可用：
+例如，让我们添加一个 `Me` 操作，返回有关调用用户的详细信息。
 
-```ts {4,12} ins={4,12}
+首先，在 `src/context.ts` 中将解析后的身份添加到服务上下文：
+
+```ts {4-7,15} ins={4-7,15}
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import type { APIGatewayProxyEvent } from 'aws-lambda';
+
+export interface Identity {
+  sub: string;
+  username: string;
+}
 
 /**
  * Context provided to all operations.
@@ -420,26 +426,105 @@ export interface ServiceContext {
   tracer: Tracer;
   logger: Logger;
   metrics: Metrics;
-  event: APIGatewayProxyEvent;
+  identity?: Identity;
 }
 ```
 
-然后在 `src/handler.ts` 中构造上下文时传递事件：
+接下来，在 `src/identity.ts` 中编写一个函数，从 API Gateway 事件中解析身份。实现取决于您选择的 `auth` 方法：
 
-```ts {6} ins={6}
+<OptionFilter when={{ auth: 'iam' }} description="IAM 身份验证 API 的身份解析">
+对于 `IAM` 身份验证，我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者：
+
+```ts
+import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+const cognito = new CognitoIdentityProvider();
+
+export const getIdentity = async (
+  event: APIGatewayProxyEvent,
+): Promise<Identity | undefined> => {
+  const cognitoAuthenticationProvider =
+    event.requestContext?.identity?.cognitoAuthenticationProvider;
+
+  let sub: string | undefined = undefined;
+  if (cognitoAuthenticationProvider) {
+    const providerParts = cognitoAuthenticationProvider.split(':');
+    sub = providerParts[providerParts.length - 1];
+  }
+
+  if (!sub) {
+    return undefined;
+  }
+
+  const { Users } = await cognito.listUsers({
+    // Assumes user pool id is configured in lambda environment
+    UserPoolId: process.env.USER_POOL_ID!,
+    Limit: 1,
+    Filter: `sub="${sub}"`,
+  });
+
+  if (!Users || Users.length !== 1) {
+    return undefined;
+  }
+
+  return { sub, username: Users[0].Username! };
+};
+```
+</OptionFilter>
+
+<OptionFilter when={{ auth: 'cognito' }} description="Cognito 身份验证 API 的身份解析">
+使用 `auth: 'cognito'` 时，API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT，并将验证后的声明放置在事件的 `event.requestContext.authorizer.claims` 上。我们只需读取这些声明——无需额外的 AWS SDK 调用，无需手动 JWT 验证。
+
+生成器将授权器配置为接受 Cognito 访问令牌，因此 `username` 是规范的用户名声明；如果您重新配置授权器以接受 ID 令牌，我们会回退到 `cognito:username`：
+
+```ts
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Identity } from './context.js';
+
+export const getIdentity = (
+  event: APIGatewayProxyEvent,
+): Identity | undefined => {
+  const claims = event.requestContext?.authorizer?.claims as
+    | Record<string, string>
+    | undefined;
+
+  const sub = claims?.sub;
+  const username = claims?.username ?? claims?.['cognito:username'];
+
+  if (!sub || !username) {
+    return undefined;
+  }
+
+  return { sub, username };
+};
+```
+
+:::tip[验证令牌]
+您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败，API Gateway 会返回 `401 Unauthorized`，并且永远不会调用您的处理程序。
+:::
+</OptionFilter>
+
+然后在 `src/handler.ts` 中调用 `getIdentity` 并将结果添加到上下文：
+
+```ts {2,8} ins={2,8}
+import { Service } from './service.js';
+import { getIdentity } from './identity.js';
+// ...
 const httpResponse = await serviceHandler.handle(httpRequest, {
   tracer,
   logger,
   metrics,
-  event,
+  identity: await getIdentity(event),
 });
 ```
 
-:::note[本地服务器]
-`serve` 目标的 `src/local-server.ts` 也会构造上下文。在本地运行时没有 API Gateway 事件，因此您可以传递一个存根（例如 `event: { requestContext: {} } as never`）来满足类型要求。
+:::note[IAM 查找是异步的]
+对于 `IAM` 身份验证，`getIdentity` 是 `async` 的（它调用 Cognito），这就是为什么我们在上面 `await` 它。对于 `cognito` 身份验证，它只是读取声明并且是同步的，但 await 它是无害的——因此两者的处理程序代码是相同的。
 :::
 
-接下来，在您的 Smithy 模型中定义 `Me` 操作，例如在 `model/src/operations/me.smithy` 中：
+现在在您的 Smithy 模型中定义 `Me` 操作，例如在 `model/src/operations/me.smithy` 中：
 
 ```smithy
 $version: "2.0"
@@ -482,55 +567,7 @@ service YourService {
 }
 ```
 
-现在实现该操作。提取调用者身份的方式取决于您选择的 `auth` 方法：
-
-<OptionFilter when={{ auth: 'iam' }} description="IAM 身份验证 API 的身份提取">
-对于 `IAM` 身份验证，我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者。创建 `src/operations/me.ts`：
-
-```ts
-import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
-import { ServiceContext } from '../context.js';
-import {
-  Me as MeOperation,
-  UnauthorizedError,
-} from '../generated/ssdk/index.js';
-
-const cognito = new CognitoIdentityProvider();
-
-export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const cognitoAuthenticationProvider =
-    ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
-
-  let sub: string | undefined = undefined;
-  if (cognitoAuthenticationProvider) {
-    const providerParts = cognitoAuthenticationProvider.split(':');
-    sub = providerParts[providerParts.length - 1];
-  }
-
-  if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
-  }
-
-  const { Users } = await cognito.listUsers({
-    // Assumes user pool id is configured in lambda environment
-    UserPoolId: process.env.USER_POOL_ID!,
-    Limit: 1,
-    Filter: `sub="${sub}"`,
-  });
-
-  if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
-  }
-
-  return { sub, username: Users[0].Username! };
-};
-```
-</OptionFilter>
-
-<OptionFilter when={{ auth: 'cognito' }} description="Cognito 身份验证 API 的身份提取">
-使用 `auth: 'cognito'` 时，API Gateway Cognito 用户池授权器会验证调用者在 `Authorization` 标头中提供的 JWT，并将验证后的声明放置在事件的 `event.requestContext.authorizer.claims` 上。该操作只需读取这些声明——无需额外的 AWS SDK 调用，无需手动 JWT 验证。
-
-生成器将授权器配置为接受 Cognito 访问令牌，因此 `username` 是规范的用户名声明；如果您重新配置授权器以接受 ID 令牌，我们会回退到 `cognito:username`。创建 `src/operations/me.ts`：
+在 `src/operations/me.ts` 中实现该操作，直接从上下文中读取解析后的身份：
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -540,25 +577,13 @@ import {
 } from '../generated/ssdk/index.js';
 
 export const Me: MeOperation<ServiceContext> = async (_input, ctx) => {
-  const claims = ctx.event.requestContext?.authorizer?.claims as
-    | Record<string, string>
-    | undefined;
-
-  const sub = claims?.sub;
-  const username = claims?.username ?? claims?.['cognito:username'];
-
-  if (!sub || !username) {
+  if (!ctx.identity) {
     throw new UnauthorizedError({ message: 'Unable to determine calling user' });
   }
 
-  return { sub, username };
+  return { sub: ctx.identity.sub, username: ctx.identity.username };
 };
 ```
-
-:::tip[验证令牌]
-您不需要 `aws-jwt-verify` 或任何其他 JWT 验证库——API Gateway Cognito 用户池授权器在您的 Lambda 运行之前已经验证了签名、颁发者、作用域和过期时间。如果任何这些检查失败，API Gateway 会返回 `401 Unauthorized`，并且永远不会调用您的处理程序。
-:::
-</OptionFilter>
 
 最后，在 `src/service.ts` 中将操作注册到您的服务：
 

--- a/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -105,7 +105,7 @@ const useCreateTestAgentClient = (): TestAgent => {
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('Authorization', \`Bearer \${user?.id_token}\`);
+    headers.set('Authorization', \`Bearer \${user?.access_token}\`);
     return fetch(url, { ...init, headers });
   };
   return useMemo(

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -4647,8 +4647,8 @@ resource "aws_api_gateway_method" "proxy_method" {
 
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
-  # Validate the access token's scope claim. Access tokens have no aud claim,
-  # so the authorizer would otherwise reject them.
+  # Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+  # and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
   authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
 
   request_parameters = {

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -4647,6 +4647,9 @@ resource "aws_api_gateway_method" "proxy_method" {
 
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
+  # Validate the access token's scope claim. Access tokens have no aud claim,
+  # so the authorizer would otherwise reject them.
+  authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
 
   request_parameters = {
     "method.request.path.proxy" = true

--- a/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/react/__snapshots__/generator.spec.ts.snap
@@ -114,7 +114,7 @@ const useCreateTestApiClient = (): TestApi => {
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('Authorization', \`Bearer \${user?.id_token}\`);
+    headers.set('Authorization', \`Bearer \${user?.access_token}\`);
     return fetch(url, { ...init, headers });
   };
   return useMemo(

--- a/packages/nx-plugin/src/smithy/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/react-connection/__snapshots__/generator.spec.ts.snap
@@ -105,7 +105,7 @@ const useCreateTestApiClient = (): TestApi => {
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('Authorization', \`Bearer \${user?.id_token}\`);
+    headers.set('Authorization', \`Bearer \${user?.access_token}\`);
     return fetch(url, { ...init, headers });
   };
   return useMemo(

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -127,8 +127,8 @@ export class TestApi<
         authorizer: new CognitoUserPoolsAuthorizer(scope, 'TestApiAuthorizer', {
           cognitoUserPools: [props.identity.userPool],
         }),
-        // Validate the access token's scope claim. Access tokens have no aud claim,
-        // so the authorizer would otherwise reject them.
+        // Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+        // and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
         authorizationScopes: ['openid', 'aws.cognito.signin.user.admin'],
       },
       deployOptions: {
@@ -2200,8 +2200,8 @@ resource "aws_api_gateway_method" "proxy_method" {
 
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
-  # Validate the access token's scope claim. Access tokens have no aud claim,
-  # so the authorizer would otherwise reject them.
+  # Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+  # and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
   authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
 
   request_parameters = {

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -127,6 +127,9 @@ export class TestApi<
         authorizer: new CognitoUserPoolsAuthorizer(scope, 'TestApiAuthorizer', {
           cognitoUserPools: [props.identity.userPool],
         }),
+        // Validate the access token's scope claim. Access tokens have no aud claim,
+        // so the authorizer would otherwise reject them.
+        authorizationScopes: ['openid', 'aws.cognito.signin.user.admin'],
       },
       deployOptions: {
         tracingEnabled: true,
@@ -2197,6 +2200,9 @@ resource "aws_api_gateway_method" "proxy_method" {
 
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
+  # Validate the access token's scope claim. Access tokens have no aud claim,
+  # so the authorizer would otherwise reject them.
+  authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
 
   request_parameters = {
     "method.request.path.proxy" = true

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -478,8 +478,8 @@ export class TestApi<
         authorizer: new CognitoUserPoolsAuthorizer(scope, 'TestApiAuthorizer', {
           cognitoUserPools: [props.identity.userPool],
         }),
-        // Validate the access token's scope claim. Access tokens have no aud claim,
-        // so the authorizer would otherwise reject them.
+        // Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+        // and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
         authorizationScopes: ['openid', 'aws.cognito.signin.user.admin'],
       },
       deployOptions: {
@@ -5644,8 +5644,8 @@ resource "aws_api_gateway_method" "proxy_method" {
 
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
-  # Validate the access token's scope claim. Access tokens have no aud claim,
-  # so the authorizer would otherwise reject them.
+  # Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+  # and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
   authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
 
   request_parameters = {

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -478,6 +478,9 @@ export class TestApi<
         authorizer: new CognitoUserPoolsAuthorizer(scope, 'TestApiAuthorizer', {
           cognitoUserPools: [props.identity.userPool],
         }),
+        // Validate the access token's scope claim. Access tokens have no aud claim,
+        // so the authorizer would otherwise reject them.
+        authorizationScopes: ['openid', 'aws.cognito.signin.user.admin'],
       },
       deployOptions: {
         tracingEnabled: true,
@@ -5641,6 +5644,9 @@ resource "aws_api_gateway_method" "proxy_method" {
 
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
+  # Validate the access token's scope claim. Access tokens have no aud claim,
+  # so the authorizer would otherwise reject them.
+  authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
 
   request_parameters = {
     "method.request.path.proxy" = true

--- a/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/react/__snapshots__/generator.spec.ts.snap
@@ -43,7 +43,7 @@ export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
             eventSourceOptions: async ({ op }) => {
               return {
                 headers: {
-                  Authorization: \`Bearer \${user?.id_token}\`,
+                  Authorization: \`Bearer \${user?.access_token}\`,
                 },
               };
             },
@@ -51,7 +51,7 @@ export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
           false: httpLink({
             url: apiUrl,
             headers: {
-              Authorization: \`Bearer \${user?.id_token}\`,
+              Authorization: \`Bearer \${user?.access_token}\`,
             },
           }),
         }),
@@ -345,7 +345,7 @@ export const TestApiClientProvider: FC<PropsWithChildren> = ({ children }) => {
     const linkOptions: HTTPLinkOptions<any> = {
       url: apiUrl,
       headers: {
-        Authorization: \`Bearer \${user?.id_token}\`,
+        Authorization: \`Bearer \${user?.access_token}\`,
       },
     };
 

--- a/packages/nx-plugin/src/trpc/react/files/src/components/__apiNameClassName__ClientProvider.tsx.template
+++ b/packages/nx-plugin/src/trpc/react/files/src/components/__apiNameClassName__ClientProvider.tsx.template
@@ -60,7 +60,7 @@ export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
               <%_ } else if (auth === 'cognito') { _%>
               return {
                 headers: {
-                  Authorization: `Bearer ${user?.id_token}`,
+                  Authorization: `Bearer ${user?.access_token}`,
                 },
               };
               <%_ } else if (auth === 'custom') { _%>
@@ -75,7 +75,7 @@ export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
             fetch: sigv4Client.fetch,
             <%_ } else if (auth === 'cognito') { _%>
             headers: {
-              Authorization: `Bearer ${user?.id_token}`,
+              Authorization: `Bearer ${user?.access_token}`,
             },
             <%_ } else if (auth === 'custom') { _%>
             // TODO: Add headers required by your custom authorizer
@@ -92,7 +92,7 @@ export const <%= apiNameClassName %>ClientProvider: FC<PropsWithChildren> = ({
       fetch: sigv4Client.fetch,
       <%_ } else if (auth === 'cognito') { _%>
       headers: {
-        Authorization: `Bearer ${user?.id_token}`,
+        Authorization: `Bearer ${user?.access_token}`,
       },
       <%_ } else if (auth === 'custom') { _%>
       // TODO: Add headers required by your custom authorizer

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -235,8 +235,8 @@ export class <%= apiNameClassName %><
         authorizer: new CognitoUserPoolsAuthorizer(scope, '<%= apiNameClassName %>Authorizer', {
           cognitoUserPools: [props.identity.userPool],
         }),
-        // Validate the access token's scope claim. Access tokens have no aud claim,
-        // so the authorizer would otherwise reject them.
+        // Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+        // and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
         authorizationScopes: ['openid', 'aws.cognito.signin.user.admin'],
         <%_ } else if (auth === 'custom') { _%>
         authorizationType: AuthorizationType.CUSTOM,

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -235,6 +235,9 @@ export class <%= apiNameClassName %><
         authorizer: new CognitoUserPoolsAuthorizer(scope, '<%= apiNameClassName %>Authorizer', {
           cognitoUserPools: [props.identity.userPool],
         }),
+        // Validate the access token's scope claim. Access tokens have no aud claim,
+        // so the authorizer would otherwise reject them.
+        authorizationScopes: ['openid', 'aws.cognito.signin.user.admin'],
         <%_ } else if (auth === 'custom') { _%>
         authorizationType: AuthorizationType.CUSTOM,
         authorizer: new TokenAuthorizer(scope, '<%= apiNameClassName %>TokenAuthorizer', {

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -413,8 +413,8 @@ resource "aws_api_gateway_method" "proxy_method" {
   <%_ } else if (auth === 'cognito') { _%>
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
-  # Validate the access token's scope claim. Access tokens have no aud claim,
-  # so the authorizer would otherwise reject them.
+  # Accept access tokens from both sign-in flows: 'openid' (Cognito hosted UI)
+  # and 'aws.cognito.signin.user.admin' (Cognito admin/SRP auth APIs).
   authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
   <%_ } else if (auth === 'custom') { _%>
   authorization = "CUSTOM"

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -413,6 +413,9 @@ resource "aws_api_gateway_method" "proxy_method" {
   <%_ } else if (auth === 'cognito') { _%>
   authorization = "COGNITO_USER_POOLS"
   authorizer_id = aws_api_gateway_authorizer.cognito_authorizer.id
+  # Validate the access token's scope claim. Access tokens have no aud claim,
+  # so the authorizer would otherwise reject them.
+  authorization_scopes = ["openid", "aws.cognito.signin.user.admin"]
   <%_ } else if (auth === 'custom') { _%>
   authorization = "CUSTOM"
   authorizer_id = aws_api_gateway_authorizer.custom_authorizer.id

--- a/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
+++ b/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
@@ -39,7 +39,7 @@ const useCreate<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('Authorization', `Bearer ${user?.id_token}`);
+    headers.set('Authorization', `Bearer ${user?.access_token}`);
     return fetch(url, { ...init, headers });
   };
   <%_ } _%>


### PR DESCRIPTION
### Reason for this change

The generated React API clients (the tRPC client provider and the shared OpenAPI client used by Smithy, FastAPI and agent connections) send the Cognito **`id_token`** as the `Authorization: Bearer` token to API Gateway.

The `access_token` is the token designed to authorize API calls: it carries OAuth scopes (`scope`) and the `client_id`. The `id_token` carries user identity claims (`email`, `name`, etc.) and is intended for the client application, not as an API credential. Sending the `id_token` means user identity claims (PII) are transmitted to the API on every request, and scope-based authorization is impossible.

A previous version of this change switched only the client and left the authorizers untouched. Live testing showed that broke the REST API: API Gateway's REST `CognitoUserPoolsAuthorizer` validates the token's `aud` claim by default, and Cognito **access tokens have no `aud` claim** (they carry `client_id` + `scope`), so they were rejected with **401**. This PR fixes that properly and is validated end-to-end against a live deployment on both REST and HTTP APIs.

### Description of changes

**Client (send `access_token` instead of `id_token`):**
- `ts#trpc-api` React client provider (`__apiNameClassName__ClientProvider.tsx.template`) - REST subscription link, REST query link, and HTTP API link branches.
- Shared OpenAPI React client provider (`__apiNameClassName__Provider.tsx.template`) used by Smithy, FastAPI and agent React connections.

The `useSigV4` IAM hook's `id_token` usage is left intact (Cognito Identity Pools authenticate via the `id_token` in their `logins` map, which is correct).

**REST API authorizer (CDK + Terraform):**
- Set `authorizationScopes` on the REST API methods to `['openid', 'aws.cognito.signin.user.admin']`. When scopes are configured, API Gateway validates the access token's `scope` claim instead of the `aud` claim, so access tokens are accepted. API Gateway authorizes the request if the token carries **any one** of the listed scopes.
- The two scopes cover both flows that the plugin's generated apps use:
  - `openid` — present on access tokens from the hosted-UI **authorization code grant**, which is what the generated `ts#react-website#auth` website uses (`react-oidc-context` with `response_type: 'code'`, `scope: 'email openid profile'`).
  - `aws.cognito.signin.user.admin` — present on access tokens from direct `USER_PASSWORD_AUTH` / SRP / admin auth.
- No resource server or custom scopes required - both scopes are available on the existing generated user pool client with no extra infrastructure.

**HTTP API authorizer:** unchanged. The `HttpUserPoolAuthorizer` (and the Terraform JWT authorizer with `audience = client_ids`) already accepts Cognito access tokens by validating `client_id`.

**Docs:**
- Updated the `ts#trpc-api` identity-middleware guidance, since the authorizer now accepts access tokens. With an access token the canonical username claim is `username` (not `cognito:username`, which only appears on ID tokens), and the authorizer validates `scope` rather than `aud`.
- Added equivalent "Accessing the Calling User" sections to the `ts#smithy-api` and `py#fast-api` guides (matching the tRPC structure, with `OptionFilter`s for both IAM and Cognito auth). The Smithy section threads the API Gateway `event` through the `ServiceContext` and adds a `Me` operation to the model; the FastAPI section reads the request context from the Lambda Web Adapter's `x-amzn-request-context` header via a FastAPI dependency.

**Scope list is minimal — confirmed by live testing.** A controlled experiment on the deployed REST authorizer (patching `authorizationScopes` and re-deploying) showed scope matching is strictly per-scope: `['openid']` alone returns 401 for direct-auth (`USER_PASSWORD_AUTH`/SRP) access tokens, which carry `aws.cognito.signin.user.admin` but not `openid`. `openid` covers the website's authorization-code-grant tokens; `aws.cognito.signin.user.admin` covers direct-auth tokens. Both are needed; neither can be dropped.

### Description of how you validated changes

**Unit tests** - updated and re-ran the affected generator snapshot tests (all pass):
- `src/trpc/backend/generator.spec.ts`, `src/smithy/ts/api/generator.spec.ts`, `src/py/fast-api/generator.spec.ts` (REST authorizer scopes, CDK + Terraform)
- `src/trpc/react/generator.spec.ts`, `src/smithy/react-connection/generator.spec.ts`, `src/py/fast-api/react/generator.spec.ts`, `src/py/agent/react-connection/generator.spec.ts` (client `access_token`)

**Live end-to-end** - deployed a real stack to AWS (`ts#react-website` + `ts#react-website#auth` + a Cognito-protected REST tRPC API + a Cognito-protected HTTP tRPC API + `ts#infra`), created a real Cognito user (with TOTP MFA), obtained a real access token, decoded its claims, and called both deployed endpoints. Full transcript posted as a comment below. Summary:

| | `access_token` | `id_token` | garbage | no auth |
|---|---|---|---|---|
| REST API (baseline, before fix) | **401** | 200 | 401 | 401 |
| REST API (with fix) | **200** | 401 | 401 | 401 |
| HTTP API (unchanged) | **200** | 200 | 401 | 401 |

The baseline confirms the regression that closed the previous version of this PR; the fix makes the access token work on the REST API while the authorizer still rejects ID tokens, garbage tokens, and unauthenticated requests. The HTTP API already accepted access tokens.

**Live end-to-end (Smithy + FastAPI + IAM, follow-up)** - deployed Cognito-protected `ts#smithy-api` and `py#fast-api` REST APIs plus IAM-auth variants of all three frameworks, and exercised the identity examples now documented. Full transcript in a comment below. Summary:

| | `access_token` | `id_token` | garbage | no-auth |
|---|---|---|---|---|
| tRPC / Smithy / FastAPI REST `/me` (Cognito) | **200** (`username` claim) | 401 | 401 | 401 |

| | SigV4-signed | unsigned |
|---|---|---|
| tRPC / Smithy / FastAPI REST `/me` (IAM) | **200** (Cognito lookup) | 403 |

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
