### PR TITLE
feat(ts#react-website): enforce a default Content-Security-Policy header

### DIFF
--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -130,9 +130,7 @@ cloudfront -> s3
 
 The CloudFront distribution applies a response headers policy that sets `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` and a `Content-Security-Policy` on all responses.
 
-A conservative starter `Content-Security-Policy` (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) is delivered in **report-only mode** by default. Report-only mode reports policy violations to the browser console (and any configured reporting endpoint) without blocking anything, so it gives you signal about what your app loads without risking breakage. Once you have verified your application's sources and tightened the policy as needed, switch to enforcement.
-
-To customize the policy or enforce it, set the `contentSecurityPolicy` and `contentSecurityPolicyReportOnly` properties on the `StaticWebsite` construct (CDK) or the `content_security_policy` and `content_security_policy_report_only` variables (Terraform). Set `contentSecurityPolicyReportOnly` to `false` to switch from the `Content-Security-Policy-Report-Only` header to the enforcing `Content-Security-Policy` header.
+A default `Content-Security-Policy` is enforced. It restricts scripts and framing to mitigate XSS and clickjacking, while permitting HTTPS and WSS connections so the website can call AWS service endpoints (such as API Gateway, Cognito and Bedrock AgentCore) whose URLs are only known at deploy time. To adjust the policy (for example to tighten `connect-src` to your specific origins), edit the `content_security_policy` value in your generated `static-website.ts` (CDK) or `static-website.tf` (Terraform).
 
 `runtime-config.json` is served with `Cache-Control: no-cache` so that browsers always fetch the latest configuration after a redeploy, rather than using a stale cached copy.
 

--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -128,7 +128,11 @@ cloudfront -> s3
 
 #### Security Headers
 
-The CloudFront distribution applies a response headers policy that sets `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` and `Referrer-Policy` on all responses. A `Content-Security-Policy` is intentionally not set by default, since a useful CSP is specific to your application - add one to the response headers policy (CDK) or `aws_cloudfront_response_headers_policy` resource (Terraform) once you know which origins, scripts and styles your site loads.
+The CloudFront distribution applies a response headers policy that sets `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` and a `Content-Security-Policy` on all responses.
+
+A conservative starter `Content-Security-Policy` (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) is delivered in **report-only mode** by default. Report-only mode reports policy violations to the browser console (and any configured reporting endpoint) without blocking anything, so it gives you signal about what your app loads without risking breakage. Once you have verified your application's sources and tightened the policy as needed, switch to enforcement.
+
+To customize the policy or enforce it, set the `contentSecurityPolicy` and `contentSecurityPolicyReportOnly` properties on the `StaticWebsite` construct (CDK) or the `content_security_policy` and `content_security_policy_report_only` variables (Terraform). Set `contentSecurityPolicyReportOnly` to `false` to switch from the `Content-Security-Policy-Report-Only` header to the enforcing `Content-Security-Policy` header.
 
 `runtime-config.json` is served with `Cache-Control: no-cache` so that browsers always fetch the latest configuration after a redeploy, rather than using a stale cached copy.
 

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### Encabezados de seguridad
 
-La distribución de CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` y una `Content-Security-Policy` en todas las respuestas.
-
-Una `Content-Security-Policy` inicial conservadora (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) se entrega en **modo solo-reporte** por defecto. El modo solo-reporte reporta violaciones de la política a la consola del navegador (y cualquier endpoint de reporte configurado) sin bloquear nada, por lo que te da señales sobre lo que carga tu aplicación sin riesgo de romperla. Una vez que hayas verificado las fuentes de tu aplicación y ajustado la política según sea necesario, cambia a modo de aplicación.
-
-Para personalizar la política o aplicarla, establece las propiedades `contentSecurityPolicy` y `contentSecurityPolicyReportOnly` en el construct `StaticWebsite` (CDK) o las variables `content_security_policy` y `content_security_policy_report_only` (Terraform). Establece `contentSecurityPolicyReportOnly` en `false` para cambiar del encabezado `Content-Security-Policy-Report-Only` al encabezado de aplicación `Content-Security-Policy`.
+La distribución de CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` y `Referrer-Policy` en todas las respuestas. Intencionalmente no se establece una `Content-Security-Policy` por defecto, ya que una CSP útil es específica de tu aplicación - añade una a la política de encabezados de respuesta (CDK) o al recurso `aws_cloudfront_response_headers_policy` (Terraform) una vez que sepas qué orígenes, scripts y estilos carga tu sitio.
 
 `runtime-config.json` se sirve con `Cache-Control: no-cache` para que los navegadores siempre obtengan la configuración más reciente después de un redespliegue, en lugar de usar una copia en caché obsoleta.
 

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### Encabezados de seguridad
 
-La distribución de CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` y `Referrer-Policy` en todas las respuestas. Intencionalmente no se establece una `Content-Security-Policy` por defecto, ya que una CSP útil es específica de tu aplicación - añade una a la política de encabezados de respuesta (CDK) o al recurso `aws_cloudfront_response_headers_policy` (Terraform) una vez que sepas qué orígenes, scripts y estilos carga tu sitio.
+La distribución de CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` y una `Content-Security-Policy` en todas las respuestas.
+
+Se aplica una `Content-Security-Policy` predeterminada. Restringe scripts y framing para mitigar XSS y clickjacking, mientras permite conexiones HTTPS y WSS para que el sitio web pueda llamar a endpoints de servicios AWS (como API Gateway, Cognito y Bedrock AgentCore) cuyas URLs solo se conocen en tiempo de despliegue. Para ajustar la política (por ejemplo, restringir `connect-src` a tus orígenes específicos), edita el valor `content_security_policy` en tu `static-website.ts` generado (CDK) o `static-website.tf` (Terraform).
 
 `runtime-config.json` se sirve con `Cache-Control: no-cache` para que los navegadores siempre obtengan la configuración más reciente después de un redespliegue, en lugar de usar una copia en caché obsoleta.
 

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### Encabezados de seguridad
 
-La distribución de CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` y `Referrer-Policy` en todas las respuestas. Intencionalmente no se establece una `Content-Security-Policy` por defecto, ya que una CSP útil es específica de tu aplicación - añade una a la política de encabezados de respuesta (CDK) o al recurso `aws_cloudfront_response_headers_policy` (Terraform) una vez que sepas qué orígenes, scripts y estilos carga tu sitio.
+La distribución de CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` y una `Content-Security-Policy` en todas las respuestas.
+
+Una `Content-Security-Policy` inicial conservadora (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) se entrega en **modo solo-reporte** por defecto. El modo solo-reporte reporta violaciones de la política a la consola del navegador (y cualquier endpoint de reporte configurado) sin bloquear nada, por lo que te da señales sobre lo que carga tu aplicación sin riesgo de romperla. Una vez que hayas verificado las fuentes de tu aplicación y ajustado la política según sea necesario, cambia a modo de aplicación.
+
+Para personalizar la política o aplicarla, establece las propiedades `contentSecurityPolicy` y `contentSecurityPolicyReportOnly` en el construct `StaticWebsite` (CDK) o las variables `content_security_policy` y `content_security_policy_report_only` (Terraform). Establece `contentSecurityPolicyReportOnly` en `false` para cambiar del encabezado `Content-Security-Policy-Report-Only` al encabezado de aplicación `Content-Security-Policy`.
 
 `runtime-config.json` se sirve con `Cache-Control: no-cache` para que los navegadores siempre obtengan la configuración más reciente después de un redespliegue, en lugar de usar una copia en caché obsoleta.
 

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### En-têtes de sécurité
 
-La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` et `Referrer-Policy` sur toutes les réponses. Une `Content-Security-Policy` n'est intentionnellement pas définie par défaut, car une CSP utile est spécifique à votre application - ajoutez-en une à la politique d'en-têtes de réponse (CDK) ou à la ressource `aws_cloudfront_response_headers_policy` (Terraform) une fois que vous connaissez les origines, scripts et styles que votre site charge.
+La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` et une `Content-Security-Policy` sur toutes les réponses.
+
+Une `Content-Security-Policy` par défaut est appliquée. Elle restreint les scripts et le framing pour atténuer les attaques XSS et de clickjacking, tout en permettant les connexions HTTPS et WSS afin que le site puisse appeler les endpoints de services AWS (tels que API Gateway, Cognito et Bedrock AgentCore) dont les URLs ne sont connues qu'au moment du déploiement. Pour ajuster la politique (par exemple pour restreindre `connect-src` à vos origines spécifiques), modifiez la valeur `content_security_policy` dans votre fichier généré `static-website.ts` (CDK) ou `static-website.tf` (Terraform).
 
 `runtime-config.json` est servi avec `Cache-Control: no-cache` afin que les navigateurs récupèrent toujours la dernière configuration après un redéploiement, plutôt que d'utiliser une copie en cache obsolète.
 

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### En-têtes de sécurité
 
-La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` et `Referrer-Policy` sur toutes les réponses. Une `Content-Security-Policy` n'est intentionnellement pas définie par défaut, car une CSP utile est spécifique à votre application - ajoutez-en une à la politique d'en-têtes de réponse (CDK) ou à la ressource `aws_cloudfront_response_headers_policy` (Terraform) une fois que vous connaissez les origines, scripts et styles que votre site charge.
+La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` et une `Content-Security-Policy` sur toutes les réponses.
+
+Une `Content-Security-Policy` de départ conservatrice (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) est livrée en **mode rapport uniquement** par défaut. Le mode rapport uniquement signale les violations de politique à la console du navigateur (et à tout point de terminaison de rapport configuré) sans rien bloquer, ce qui vous donne des informations sur ce que votre application charge sans risquer de casser quoi que ce soit. Une fois que vous avez vérifié les sources de votre application et renforcé la politique selon vos besoins, passez en mode d'application.
+
+Pour personnaliser la politique ou l'appliquer, définissez les propriétés `contentSecurityPolicy` et `contentSecurityPolicyReportOnly` sur le construct `StaticWebsite` (CDK) ou les variables `content_security_policy` et `content_security_policy_report_only` (Terraform). Définissez `contentSecurityPolicyReportOnly` sur `false` pour passer de l'en-tête `Content-Security-Policy-Report-Only` à l'en-tête d'application `Content-Security-Policy`.
 
 `runtime-config.json` est servi avec `Cache-Control: no-cache` afin que les navigateurs récupèrent toujours la dernière configuration après un redéploiement, plutôt que d'utiliser une copie en cache obsolète.
 

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### En-têtes de sécurité
 
-La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` et une `Content-Security-Policy` sur toutes les réponses.
-
-Une `Content-Security-Policy` de départ conservatrice (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) est livrée en **mode rapport uniquement** par défaut. Le mode rapport uniquement signale les violations de politique à la console du navigateur (et à tout point de terminaison de rapport configuré) sans rien bloquer, ce qui vous donne des informations sur ce que votre application charge sans risquer de casser quoi que ce soit. Une fois que vous avez vérifié les sources de votre application et renforcé la politique selon vos besoins, passez en mode d'application.
-
-Pour personnaliser la politique ou l'appliquer, définissez les propriétés `contentSecurityPolicy` et `contentSecurityPolicyReportOnly` sur le construct `StaticWebsite` (CDK) ou les variables `content_security_policy` et `content_security_policy_report_only` (Terraform). Définissez `contentSecurityPolicyReportOnly` sur `false` pour passer de l'en-tête `Content-Security-Policy-Report-Only` à l'en-tête d'application `Content-Security-Policy`.
+La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` et `Referrer-Policy` sur toutes les réponses. Une `Content-Security-Policy` n'est intentionnellement pas définie par défaut, car une CSP utile est spécifique à votre application - ajoutez-en une à la politique d'en-têtes de réponse (CDK) ou à la ressource `aws_cloudfront_response_headers_policy` (Terraform) une fois que vous connaissez les origines, scripts et styles que votre site charge.
 
 `runtime-config.json` est servi avec `Cache-Control: no-cache` afin que les navigateurs récupèrent toujours la dernière configuration après un redéploiement, plutôt que d'utiliser une copie en cache obsolète.
 

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### Security Headers
 
-La distribuzione CloudFront applica una policy di response headers che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` e `Referrer-Policy` su tutte le risposte. Una `Content-Security-Policy` non è impostata intenzionalmente di default, poiché una CSP utile è specifica per la tua applicazione - aggiungine una alla policy di response headers (CDK) o alla risorsa `aws_cloudfront_response_headers_policy` (Terraform) una volta che sai quali origini, script e stili carica il tuo sito.
+La distribuzione CloudFront applica una policy di response headers che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e una `Content-Security-Policy` su tutte le risposte.
+
+Una `Content-Security-Policy` iniziale conservativa (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) viene fornita in **modalità report-only** di default. La modalità report-only segnala le violazioni della policy alla console del browser (e a qualsiasi endpoint di reporting configurato) senza bloccare nulla, quindi fornisce informazioni su ciò che carica la tua app senza rischiare interruzioni. Una volta verificate le sorgenti della tua applicazione e rafforzata la policy secondo necessità, passa alla modalità di enforcement.
+
+Per personalizzare la policy o applicarla, imposta le proprietà `contentSecurityPolicy` e `contentSecurityPolicyReportOnly` sul construct `StaticWebsite` (CDK) o le variabili `content_security_policy` e `content_security_policy_report_only` (Terraform). Imposta `contentSecurityPolicyReportOnly` a `false` per passare dall'header `Content-Security-Policy-Report-Only` all'header `Content-Security-Policy` che applica la policy.
 
 `runtime-config.json` viene servito con `Cache-Control: no-cache` in modo che i browser recuperino sempre la configurazione più recente dopo un ridistribuzione, invece di usare una copia cache obsoleta.
 

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### Security Headers
 
-La distribuzione CloudFront applica una policy di response headers che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e una `Content-Security-Policy` su tutte le risposte.
-
-Una `Content-Security-Policy` iniziale conservativa (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) viene fornita in **modalità report-only** di default. La modalità report-only segnala le violazioni della policy alla console del browser (e a qualsiasi endpoint di reporting configurato) senza bloccare nulla, quindi fornisce informazioni su ciò che carica la tua app senza rischiare interruzioni. Una volta verificate le sorgenti della tua applicazione e rafforzata la policy secondo necessità, passa alla modalità di enforcement.
-
-Per personalizzare la policy o applicarla, imposta le proprietà `contentSecurityPolicy` e `contentSecurityPolicyReportOnly` sul construct `StaticWebsite` (CDK) o le variabili `content_security_policy` e `content_security_policy_report_only` (Terraform). Imposta `contentSecurityPolicyReportOnly` a `false` per passare dall'header `Content-Security-Policy-Report-Only` all'header `Content-Security-Policy` che applica la policy.
+La distribuzione CloudFront applica una policy di response headers che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` e `Referrer-Policy` su tutte le risposte. Una `Content-Security-Policy` non è impostata intenzionalmente di default, poiché una CSP utile è specifica per la tua applicazione - aggiungine una alla policy di response headers (CDK) o alla risorsa `aws_cloudfront_response_headers_policy` (Terraform) una volta che sai quali origini, script e stili carica il tuo sito.
 
 `runtime-config.json` viene servito con `Cache-Control: no-cache` in modo che i browser recuperino sempre la configurazione più recente dopo un ridistribuzione, invece di usare una copia cache obsoleta.
 

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### Security Headers
 
-La distribuzione CloudFront applica una policy di response headers che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` e `Referrer-Policy` su tutte le risposte. Una `Content-Security-Policy` non è impostata intenzionalmente di default, poiché una CSP utile è specifica per la tua applicazione - aggiungine una alla policy di response headers (CDK) o alla risorsa `aws_cloudfront_response_headers_policy` (Terraform) una volta che sai quali origini, script e stili carica il tuo sito.
+La distribuzione CloudFront applica una policy di response headers che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e una `Content-Security-Policy` su tutte le risposte.
+
+Una `Content-Security-Policy` predefinita viene applicata. Limita script e framing per mitigare XSS e clickjacking, consentendo al contempo connessioni HTTPS e WSS in modo che il sito web possa chiamare endpoint di servizi AWS (come API Gateway, Cognito e Bedrock AgentCore) i cui URL sono noti solo al momento del deploy. Per regolare la policy (ad esempio per restringere `connect-src` alle tue origini specifiche), modifica il valore `content_security_policy` nel tuo `static-website.ts` generato (CDK) o `static-website.tf` (Terraform).
 
 `runtime-config.json` viene servito con `Cache-Control: no-cache` in modo che i browser recuperino sempre la configurazione più recente dopo un ridistribuzione, invece di usare una copia cache obsoleta.
 

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### セキュリティヘッダー
 
-CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`を設定するレスポンスヘッダーポリシーを適用します。`Content-Security-Policy`は意図的にデフォルトでは設定されていません。有用なCSPはアプリケーション固有であるため、サイトが読み込むオリジン、スクリプト、スタイルが判明したら、レスポンスヘッダーポリシー（CDK）または`aws_cloudfront_response_headers_policy`リソース（Terraform）に追加してください。
+CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`、および`Content-Security-Policy`を設定するレスポンスヘッダーポリシーを適用します。
+
+控えめなスターター`Content-Security-Policy`（`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`）は、デフォルトで**レポート専用モード**で配信されます。レポート専用モードは、ポリシー違反をブラウザコンソール（および設定された報告エンドポイント）に報告しますが、何もブロックしません。これにより、破損のリスクなしにアプリが読み込むものについてのシグナルを得ることができます。アプリケーションのソースを確認し、必要に応じてポリシーを厳格化したら、強制モードに切り替えてください。
+
+ポリシーをカスタマイズまたは強制するには、`StaticWebsite`コンストラクト（CDK）の`contentSecurityPolicy`および`contentSecurityPolicyReportOnly`プロパティ、またはTerraformの`content_security_policy`および`content_security_policy_report_only`変数を設定します。`contentSecurityPolicyReportOnly`を`false`に設定すると、`Content-Security-Policy-Report-Only`ヘッダーから強制する`Content-Security-Policy`ヘッダーに切り替わります。
 
 `runtime-config.json`は`Cache-Control: no-cache`で配信されるため、ブラウザは再デプロイ後に古いキャッシュコピーではなく常に最新の設定を取得します。
 

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### セキュリティヘッダー
 
-CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`を設定するレスポンスヘッダーポリシーを適用します。`Content-Security-Policy`は意図的にデフォルトでは設定されていません。有用なCSPはアプリケーション固有であるため、サイトが読み込むオリジン、スクリプト、スタイルが判明したら、レスポンスヘッダーポリシー（CDK）または`aws_cloudfront_response_headers_policy`リソース（Terraform）に追加してください。
+CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`、および`Content-Security-Policy`を設定するレスポンスヘッダーポリシーを適用します。
+
+デフォルトの`Content-Security-Policy`が適用されます。これはXSSやクリックジャッキングを軽減するためにスクリプトとフレーミングを制限しつつ、デプロイ時にのみURLが判明するAWSサービスエンドポイント（API Gateway、Cognito、Bedrock AgentCoreなど）をウェブサイトが呼び出せるようHTTPSおよびWSS接続を許可します。ポリシーを調整する場合（例えば`connect-src`を特定のオリジンに絞り込む場合）、生成された`static-website.ts`（CDK）または`static-website.tf`（Terraform）の`content_security_policy`値を編集してください。
 
 `runtime-config.json`は`Cache-Control: no-cache`で配信されるため、ブラウザは再デプロイ後に古いキャッシュコピーではなく常に最新の設定を取得します。
 

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### セキュリティヘッダー
 
-CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`、および`Content-Security-Policy`を設定するレスポンスヘッダーポリシーを適用します。
-
-控えめなスターター`Content-Security-Policy`（`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`）は、デフォルトで**レポート専用モード**で配信されます。レポート専用モードは、ポリシー違反をブラウザコンソール（および設定された報告エンドポイント）に報告しますが、何もブロックしません。これにより、破損のリスクなしにアプリが読み込むものについてのシグナルを得ることができます。アプリケーションのソースを確認し、必要に応じてポリシーを厳格化したら、強制モードに切り替えてください。
-
-ポリシーをカスタマイズまたは強制するには、`StaticWebsite`コンストラクト（CDK）の`contentSecurityPolicy`および`contentSecurityPolicyReportOnly`プロパティ、またはTerraformの`content_security_policy`および`content_security_policy_report_only`変数を設定します。`contentSecurityPolicyReportOnly`を`false`に設定すると、`Content-Security-Policy-Report-Only`ヘッダーから強制する`Content-Security-Policy`ヘッダーに切り替わります。
+CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`を設定するレスポンスヘッダーポリシーを適用します。`Content-Security-Policy`は意図的にデフォルトでは設定されていません。有用なCSPはアプリケーション固有であるため、サイトが読み込むオリジン、スクリプト、スタイルが判明したら、レスポンスヘッダーポリシー（CDK）または`aws_cloudfront_response_headers_policy`リソース（Terraform）に追加してください。
 
 `runtime-config.json`は`Cache-Control: no-cache`で配信されるため、ブラウザは再デプロイ後に古いキャッシュコピーではなく常に最新の設定を取得します。
 

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### 보안 헤더
 
-CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` 및 `Content-Security-Policy`를 설정하는 응답 헤더 정책을 적용합니다.
-
-보수적인 시작용 `Content-Security-Policy`(`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`)가 기본적으로 **report-only 모드**로 제공됩니다. Report-only 모드는 정책 위반을 브라우저 콘솔(및 구성된 보고 엔드포인트)에 보고하지만 아무것도 차단하지 않으므로, 중단 위험 없이 앱이 로드하는 항목에 대한 신호를 제공합니다. 애플리케이션의 소스를 확인하고 필요에 따라 정책을 강화한 후 강제 모드로 전환하세요.
-
-정책을 사용자 정의하거나 강제하려면 `StaticWebsite` construct(CDK)의 `contentSecurityPolicy` 및 `contentSecurityPolicyReportOnly` 속성 또는 Terraform의 `content_security_policy` 및 `content_security_policy_report_only` 변수를 설정하세요. `contentSecurityPolicyReportOnly`를 `false`로 설정하면 `Content-Security-Policy-Report-Only` 헤더에서 강제 적용되는 `Content-Security-Policy` 헤더로 전환됩니다.
+CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`를 설정하는 응답 헤더 정책을 적용합니다. `Content-Security-Policy`는 의도적으로 기본 설정되지 않습니다. 유용한 CSP는 애플리케이션에 따라 다르므로, 사이트가 로드하는 출처, 스크립트, 스타일을 파악한 후 응답 헤더 정책(CDK) 또는 `aws_cloudfront_response_headers_policy` 리소스(Terraform)에 추가하세요.
 
 `runtime-config.json`은 `Cache-Control: no-cache`로 제공되어 브라우저가 재배포 후 캐시된 오래된 복사본 대신 항상 최신 구성을 가져오도록 합니다.
 

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### 보안 헤더
 
-CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`를 설정하는 응답 헤더 정책을 적용합니다. `Content-Security-Policy`는 의도적으로 기본 설정되지 않습니다. 유용한 CSP는 애플리케이션에 따라 다르므로, 사이트가 로드하는 출처, 스크립트, 스타일을 파악한 후 응답 헤더 정책(CDK) 또는 `aws_cloudfront_response_headers_policy` 리소스(Terraform)에 추가하세요.
+CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` 및 `Content-Security-Policy`를 설정하는 응답 헤더 정책을 적용합니다.
+
+보수적인 시작용 `Content-Security-Policy`(`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`)가 기본적으로 **report-only 모드**로 제공됩니다. Report-only 모드는 정책 위반을 브라우저 콘솔(및 구성된 보고 엔드포인트)에 보고하지만 아무것도 차단하지 않으므로, 중단 위험 없이 앱이 로드하는 항목에 대한 신호를 제공합니다. 애플리케이션의 소스를 확인하고 필요에 따라 정책을 강화한 후 강제 모드로 전환하세요.
+
+정책을 사용자 정의하거나 강제하려면 `StaticWebsite` construct(CDK)의 `contentSecurityPolicy` 및 `contentSecurityPolicyReportOnly` 속성 또는 Terraform의 `content_security_policy` 및 `content_security_policy_report_only` 변수를 설정하세요. `contentSecurityPolicyReportOnly`를 `false`로 설정하면 `Content-Security-Policy-Report-Only` 헤더에서 강제 적용되는 `Content-Security-Policy` 헤더로 전환됩니다.
 
 `runtime-config.json`은 `Cache-Control: no-cache`로 제공되어 브라우저가 재배포 후 캐시된 오래된 복사본 대신 항상 최신 구성을 가져오도록 합니다.
 

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### 보안 헤더
 
-CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`를 설정하는 응답 헤더 정책을 적용합니다. `Content-Security-Policy`는 의도적으로 기본 설정되지 않습니다. 유용한 CSP는 애플리케이션에 따라 다르므로, 사이트가 로드하는 출처, 스크립트, 스타일을 파악한 후 응답 헤더 정책(CDK) 또는 `aws_cloudfront_response_headers_policy` 리소스(Terraform)에 추가하세요.
+CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` 및 `Content-Security-Policy`를 설정하는 응답 헤더 정책을 적용합니다.
+
+기본 `Content-Security-Policy`가 적용됩니다. 이는 XSS 및 클릭재킹을 완화하기 위해 스크립트와 프레이밍을 제한하면서, 배포 시점에만 알 수 있는 URL을 가진 AWS 서비스 엔드포인트(API Gateway, Cognito, Bedrock AgentCore 등)를 웹사이트가 호출할 수 있도록 HTTPS 및 WSS 연결을 허용합니다. 정책을 조정하려면(예: `connect-src`를 특정 출처로 제한) 생성된 `static-website.ts`(CDK) 또는 `static-website.tf`(Terraform)의 `content_security_policy` 값을 편집하세요.
 
 `runtime-config.json`은 `Cache-Control: no-cache`로 제공되어 브라우저가 재배포 후 캐시된 오래된 복사본 대신 항상 최신 구성을 가져오도록 합니다.
 

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### Cabeçalhos de Segurança
 
-A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` e `Referrer-Policy` em todas as respostas. Um `Content-Security-Policy` não é definido por padrão intencionalmente, pois um CSP útil é específico para sua aplicação - adicione um à política de cabeçalhos de resposta (CDK) ou recurso `aws_cloudfront_response_headers_policy` (Terraform) assim que souber quais origens, scripts e estilos seu site carrega.
+A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e um `Content-Security-Policy` em todas as respostas.
+
+Um `Content-Security-Policy` padrão é aplicado. Ele restringe scripts e framing para mitigar XSS e clickjacking, enquanto permite conexões HTTPS e WSS para que o website possa chamar endpoints de serviços AWS (como API Gateway, Cognito e Bedrock AgentCore) cujas URLs são conhecidas apenas no momento da implantação. Para ajustar a política (por exemplo, para restringir `connect-src` às suas origens específicas), edite o valor `content_security_policy` no seu `static-website.ts` (CDK) ou `static-website.tf` (Terraform) gerado.
 
 `runtime-config.json` é servido com `Cache-Control: no-cache` para que os navegadores sempre busquem a configuração mais recente após uma reimplantação, em vez de usar uma cópia em cache desatualizada.
 

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### Cabeçalhos de Segurança
 
-A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e um `Content-Security-Policy` em todas as respostas.
-
-Um `Content-Security-Policy` inicial conservador (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) é entregue em **modo somente relatório** por padrão. O modo somente relatório reporta violações de política ao console do navegador (e qualquer endpoint de relatório configurado) sem bloquear nada, então fornece sinais sobre o que sua aplicação carrega sem risco de quebra. Depois de verificar as fontes da sua aplicação e ajustar a política conforme necessário, mude para o modo de aplicação.
-
-Para personalizar a política ou aplicá-la, defina as propriedades `contentSecurityPolicy` e `contentSecurityPolicyReportOnly` no construct `StaticWebsite` (CDK) ou as variáveis `content_security_policy` e `content_security_policy_report_only` (Terraform). Defina `contentSecurityPolicyReportOnly` como `false` para mudar do cabeçalho `Content-Security-Policy-Report-Only` para o cabeçalho de aplicação `Content-Security-Policy`.
+A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` e `Referrer-Policy` em todas as respostas. Um `Content-Security-Policy` não é definido por padrão intencionalmente, pois um CSP útil é específico para sua aplicação - adicione um à política de cabeçalhos de resposta (CDK) ou recurso `aws_cloudfront_response_headers_policy` (Terraform) assim que souber quais origens, scripts e estilos seu site carrega.
 
 `runtime-config.json` é servido com `Cache-Control: no-cache` para que os navegadores sempre busquem a configuração mais recente após uma reimplantação, em vez de usar uma cópia em cache desatualizada.
 

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### Cabeçalhos de Segurança
 
-A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` e `Referrer-Policy` em todas as respostas. Um `Content-Security-Policy` não é definido por padrão intencionalmente, pois um CSP útil é específico para sua aplicação - adicione um à política de cabeçalhos de resposta (CDK) ou recurso `aws_cloudfront_response_headers_policy` (Terraform) assim que souber quais origens, scripts e estilos seu site carrega.
+A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e um `Content-Security-Policy` em todas as respostas.
+
+Um `Content-Security-Policy` inicial conservador (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) é entregue em **modo somente relatório** por padrão. O modo somente relatório reporta violações de política ao console do navegador (e qualquer endpoint de relatório configurado) sem bloquear nada, então fornece sinais sobre o que sua aplicação carrega sem risco de quebra. Depois de verificar as fontes da sua aplicação e ajustar a política conforme necessário, mude para o modo de aplicação.
+
+Para personalizar a política ou aplicá-la, defina as propriedades `contentSecurityPolicy` e `contentSecurityPolicyReportOnly` no construct `StaticWebsite` (CDK) ou as variáveis `content_security_policy` e `content_security_policy_report_only` (Terraform). Defina `contentSecurityPolicyReportOnly` como `false` para mudar do cabeçalho `Content-Security-Policy-Report-Only` para o cabeçalho de aplicação `Content-Security-Policy`.
 
 `runtime-config.json` é servido com `Cache-Control: no-cache` para que os navegadores sempre busquem a configuração mais recente após uma reimplantação, em vez de usar uma cópia em cache desatualizada.
 

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### Security Headers
 
-CloudFront distribution áp dụng một response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` và `Referrer-Policy` trên tất cả các response. `Content-Security-Policy` cố ý không được thiết lập mặc định, vì CSP hữu ích là cụ thể cho ứng dụng của bạn - thêm một vào response headers policy (CDK) hoặc resource `aws_cloudfront_response_headers_policy` (Terraform) khi bạn biết ứng dụng của bạn tải những origin, script và style nào.
+CloudFront distribution áp dụng một response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và `Content-Security-Policy` trên tất cả các response.
+
+Một `Content-Security-Policy` khởi đầu bảo thủ (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) được cung cấp ở **chế độ chỉ báo cáo** theo mặc định. Chế độ chỉ báo cáo sẽ báo cáo các vi phạm chính sách vào console của trình duyệt (và bất kỳ điểm cuối báo cáo nào được cấu hình) mà không chặn bất cứ thứ gì, vì vậy nó cung cấp cho bạn tín hiệu về những gì ứng dụng của bạn tải mà không gây rủi ro hỏng hóc. Sau khi bạn đã xác minh các nguồn của ứng dụng và thắt chặt chính sách khi cần thiết, hãy chuyển sang chế độ thực thi.
+
+Để tùy chỉnh chính sách hoặc thực thi nó, hãy đặt các thuộc tính `contentSecurityPolicy` và `contentSecurityPolicyReportOnly` trên construct `StaticWebsite` (CDK) hoặc các biến `content_security_policy` và `content_security_policy_report_only` (Terraform). Đặt `contentSecurityPolicyReportOnly` thành `false` để chuyển từ header `Content-Security-Policy-Report-Only` sang header `Content-Security-Policy` thực thi.
 
 `runtime-config.json` được phục vụ với `Cache-Control: no-cache` để trình duyệt luôn tải cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được lưu trong cache cũ.
 

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### Security Headers
 
-CloudFront distribution áp dụng một response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và `Content-Security-Policy` trên tất cả các response.
-
-Một `Content-Security-Policy` khởi đầu bảo thủ (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`) được cung cấp ở **chế độ chỉ báo cáo** theo mặc định. Chế độ chỉ báo cáo sẽ báo cáo các vi phạm chính sách vào console của trình duyệt (và bất kỳ điểm cuối báo cáo nào được cấu hình) mà không chặn bất cứ thứ gì, vì vậy nó cung cấp cho bạn tín hiệu về những gì ứng dụng của bạn tải mà không gây rủi ro hỏng hóc. Sau khi bạn đã xác minh các nguồn của ứng dụng và thắt chặt chính sách khi cần thiết, hãy chuyển sang chế độ thực thi.
-
-Để tùy chỉnh chính sách hoặc thực thi nó, hãy đặt các thuộc tính `contentSecurityPolicy` và `contentSecurityPolicyReportOnly` trên construct `StaticWebsite` (CDK) hoặc các biến `content_security_policy` và `content_security_policy_report_only` (Terraform). Đặt `contentSecurityPolicyReportOnly` thành `false` để chuyển từ header `Content-Security-Policy-Report-Only` sang header `Content-Security-Policy` thực thi.
+CloudFront distribution áp dụng một response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` và `Referrer-Policy` trên tất cả các response. `Content-Security-Policy` cố ý không được thiết lập mặc định, vì CSP hữu ích là cụ thể cho ứng dụng của bạn - thêm một vào response headers policy (CDK) hoặc resource `aws_cloudfront_response_headers_policy` (Terraform) khi bạn biết ứng dụng của bạn tải những origin, script và style nào.
 
 `runtime-config.json` được phục vụ với `Cache-Control: no-cache` để trình duyệt luôn tải cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được lưu trong cache cũ.
 

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### Security Headers
 
-CloudFront distribution áp dụng một response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` và `Referrer-Policy` trên tất cả các response. `Content-Security-Policy` cố ý không được thiết lập mặc định, vì CSP hữu ích là cụ thể cho ứng dụng của bạn - thêm một vào response headers policy (CDK) hoặc resource `aws_cloudfront_response_headers_policy` (Terraform) khi bạn biết ứng dụng của bạn tải những origin, script và style nào.
+CloudFront distribution áp dụng một response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và `Content-Security-Policy` trên tất cả các response.
+
+Một `Content-Security-Policy` mặc định được thực thi. Nó hạn chế các script và framing để giảm thiểu XSS và clickjacking, trong khi cho phép các kết nối HTTPS và WSS để trang web có thể gọi các endpoint dịch vụ AWS (như API Gateway, Cognito và Bedrock AgentCore) mà các URL chỉ được biết tại thời điểm triển khai. Để điều chỉnh policy (ví dụ để thắt chặt `connect-src` cho các origin cụ thể của bạn), hãy chỉnh sửa giá trị `content_security_policy` trong `static-website.ts` (CDK) hoặc `static-website.tf` (Terraform) được tạo của bạn.
 
 `runtime-config.json` được phục vụ với `Cache-Control: no-cache` để trình duyệt luôn tải cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được lưu trong cache cũ.
 

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -129,7 +129,9 @@ cloudfront -> s3
 
 #### 安全头
 
-CloudFront 分发应用响应头策略，在所有响应中设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY` 和 `Referrer-Policy`。默认情况下不设置 `Content-Security-Policy`，因为有用的 CSP 是特定于您的应用程序的 - 一旦您知道您的站点加载哪些来源、脚本和样式，请将其添加到响应头策略（CDK）或 `aws_cloudfront_response_headers_policy` 资源（Terraform）中。
+CloudFront 分发应用响应头策略，在所有响应中设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy` 和 `Content-Security-Policy`。
+
+默认会强制执行 `Content-Security-Policy`。它限制脚本和框架以缓解 XSS 和点击劫持攻击，同时允许 HTTPS 和 WSS 连接，以便网站可以调用仅在部署时才知道 URL 的 AWS 服务端点（如 API Gateway、Cognito 和 Bedrock AgentCore）。要调整策略（例如将 `connect-src` 收紧到您的特定来源），请编辑生成的 `static-website.ts`（CDK）或 `static-website.tf`（Terraform）中的 `content_security_policy` 值。
 
 `runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用过时的缓存副本。
 

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -129,7 +129,11 @@ cloudfront -> s3
 
 #### 安全头
 
-CloudFront 分发应用响应头策略，在所有响应中设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY` 和 `Referrer-Policy`。默认情况下不设置 `Content-Security-Policy`，因为有用的 CSP 是特定于您的应用程序的 - 一旦您知道您的站点加载哪些来源、脚本和样式，请将其添加到响应头策略（CDK）或 `aws_cloudfront_response_headers_policy` 资源（Terraform）中。
+CloudFront 分发应用响应头策略，在所有响应中设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy` 和 `Content-Security-Policy`。
+
+默认情况下，系统提供一个保守的入门级 `Content-Security-Policy`（`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`），以**仅报告模式**运行。仅报告模式会将策略违规报告到浏览器控制台（以及任何已配置的报告端点），但不会阻止任何内容，因此它可以让您了解应用加载的内容，而不会造成功能中断。在验证应用的资源来源并根据需要收紧策略后，可以切换到强制模式。
+
+要自定义策略或启用强制模式，请在 `StaticWebsite` 构造（CDK）上设置 `contentSecurityPolicy` 和 `contentSecurityPolicyReportOnly` 属性，或在 Terraform 中设置 `content_security_policy` 和 `content_security_policy_report_only` 变量。将 `contentSecurityPolicyReportOnly` 设置为 `false` 可从 `Content-Security-Policy-Report-Only` 头切换到强制执行的 `Content-Security-Policy` 头。
 
 `runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用过时的缓存副本。
 

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -129,11 +129,7 @@ cloudfront -> s3
 
 #### 安全头
 
-CloudFront 分发应用响应头策略，在所有响应中设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy` 和 `Content-Security-Policy`。
-
-默认情况下，系统提供一个保守的入门级 `Content-Security-Policy`（`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'`），以**仅报告模式**运行。仅报告模式会将策略违规报告到浏览器控制台（以及任何已配置的报告端点），但不会阻止任何内容，因此它可以让您了解应用加载的内容，而不会造成功能中断。在验证应用的资源来源并根据需要收紧策略后，可以切换到强制模式。
-
-要自定义策略或启用强制模式，请在 `StaticWebsite` 构造（CDK）上设置 `contentSecurityPolicy` 和 `contentSecurityPolicyReportOnly` 属性，或在 Terraform 中设置 `content_security_policy` 和 `content_security_policy_report_only` 变量。将 `contentSecurityPolicyReportOnly` 设置为 `false` 可从 `Content-Security-Policy-Report-Only` 头切换到强制执行的 `Content-Security-Policy` 头。
+CloudFront 分发应用响应头策略，在所有响应中设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY` 和 `Referrer-Policy`。默认情况下不设置 `Content-Security-Policy`，因为有用的 CSP 是特定于您的应用程序的 - 一旦您知道您的站点加载哪些来源、脚本和样式，请将其添加到响应头策略（CDK）或 `aws_cloudfront_response_headers_policy` 资源（Terraform）中。
 
 `runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用过时的缓存副本。
 

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -160,6 +160,18 @@ variable "website_file_path" {
   type        = string
 }
 
+variable "content_security_policy" {
+  description = "The Content-Security-Policy to apply to all responses. Defaults to a conservative policy suitable for a single page application."
+  type        = string
+  default     = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'"
+}
+
+variable "content_security_policy_report_only" {
+  description = "When true, the Content-Security-Policy is delivered via the Content-Security-Policy-Report-Only header rather than being enforced. Report-only mode lets you observe what the policy would block without breaking your application. Tighten the policy to your app's sources, verify nothing legitimate is reported as blocked, then set this to false to switch to enforcement."
+  type        = bool
+  default     = true
+}
+
 
 # Data sources
 data "aws_caller_identity" "current" {}
@@ -520,8 +532,9 @@ resource "aws_cloudfront_origin_access_control" "website_oac" {
   signing_protocol                  = "sigv4"
 }
 
-# Security headers applied to all responses. A Content-Security-Policy is
-# intentionally omitted as it is application specific - add one for your app.
+# Security headers applied to all responses. The Content-Security-Policy is
+# delivered in report-only mode by default so it can be tuned to your app
+# without breaking it - switch to enforcement via content_security_policy_report_only.
 resource "aws_cloudfront_response_headers_policy" "website" {
   name = "\${aws_s3_bucket.website.bucket}-security-headers"
 
@@ -542,6 +555,26 @@ resource "aws_cloudfront_response_headers_policy" "website" {
     referrer_policy {
       referrer_policy = "strict-origin-when-cross-origin"
       override        = true
+    }
+    # CloudFront only supports an enforcing Content-Security-Policy here.
+    # Report-only is delivered via the custom header below.
+    dynamic "content_security_policy" {
+      for_each = var.content_security_policy_report_only ? [] : [1]
+      content {
+        content_security_policy = var.content_security_policy
+        override                = true
+      }
+    }
+  }
+
+  dynamic "custom_headers_config" {
+    for_each = var.content_security_policy_report_only ? [1] : []
+    content {
+      items {
+        header   = "Content-Security-Policy-Report-Only"
+        value    = var.content_security_policy
+        override = true
+      }
     }
   }
 }

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -160,16 +160,13 @@ variable "website_file_path" {
   type        = string
 }
 
-variable "content_security_policy" {
-  description = "The Content-Security-Policy to apply to all responses. Defaults to a conservative policy suitable for a single page application."
-  type        = string
-  default     = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'"
-}
-
-variable "content_security_policy_report_only" {
-  description = "When true, the Content-Security-Policy is delivered via the Content-Security-Policy-Report-Only header rather than being enforced. Report-only mode lets you observe what the policy would block without breaking your application. Tighten the policy to your app's sources, verify nothing legitimate is reported as blocked, then set this to false to switch to enforcement."
-  type        = bool
-  default     = true
+# Content-Security-Policy enforced on all responses. Restricts scripts and
+# framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
+# (connect-src) to AWS service endpoints such as API Gateway, Cognito and
+# Bedrock AgentCore which are only known at deploy time. Edit this to tighten
+# connect-src to your specific origins once they are known.
+locals {
+  content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
 }
 
 
@@ -532,9 +529,7 @@ resource "aws_cloudfront_origin_access_control" "website_oac" {
   signing_protocol                  = "sigv4"
 }
 
-# Security headers applied to all responses. The Content-Security-Policy is
-# delivered in report-only mode by default so it can be tuned to your app
-# without breaking it - switch to enforcement via content_security_policy_report_only.
+# Security headers applied to all responses.
 resource "aws_cloudfront_response_headers_policy" "website" {
   name = "\${aws_s3_bucket.website.bucket}-security-headers"
 
@@ -556,25 +551,9 @@ resource "aws_cloudfront_response_headers_policy" "website" {
       referrer_policy = "strict-origin-when-cross-origin"
       override        = true
     }
-    # CloudFront only supports an enforcing Content-Security-Policy here.
-    # Report-only is delivered via the custom header below.
-    dynamic "content_security_policy" {
-      for_each = var.content_security_policy_report_only ? [] : [1]
-      content {
-        content_security_policy = var.content_security_policy
-        override                = true
-      }
-    }
-  }
-
-  dynamic "custom_headers_config" {
-    for_each = var.content_security_policy_report_only ? [1] : []
-    content {
-      items {
-        header   = "Content-Security-Policy-Report-Only"
-        value    = var.content_security_policy
-        override = true
-      }
+    content_security_policy {
+      content_security_policy = local.content_security_policy
+      override                = true
     }
   }
 }
@@ -1603,6 +1582,23 @@ import { suppressRules } from './checkov.js';
 
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
+// Content-Security-Policy enforced on all responses. Restricts scripts and
+// framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
+// (connect-src) to AWS service endpoints such as API Gateway, Cognito and
+// Bedrock AgentCore which are only known at deploy time. Edit this to tighten
+// connect-src to your specific origins once they are known.
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self' https: wss:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 export interface StaticWebsiteProps {
   readonly websiteName: string;
   readonly websiteFilePath: string;
@@ -1694,8 +1690,7 @@ export class StaticWebsite extends Construct {
       'Distribution log bucket does not need versioning enabled',
     );
 
-    // Security headers applied to all responses. A Content-Security-Policy is
-    // intentionally omitted as it is application specific - add one for your app.
+    // Security headers applied to all responses.
     const responseHeadersPolicy = new ResponseHeadersPolicy(
       this,
       'ResponseHeadersPolicy',
@@ -1715,6 +1710,10 @@ export class StaticWebsite extends Construct {
           referrerPolicy: {
             referrerPolicy:
               HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            override: true,
+          },
+          contentSecurityPolicy: {
+            contentSecurityPolicy: CONTENT_SECURITY_POLICY,
             override: true,
           },
         },
@@ -3230,6 +3229,23 @@ import { suppressRules } from './checkov.js';
 
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
+// Content-Security-Policy enforced on all responses. Restricts scripts and
+// framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
+// (connect-src) to AWS service endpoints such as API Gateway, Cognito and
+// Bedrock AgentCore which are only known at deploy time. Edit this to tighten
+// connect-src to your specific origins once they are known.
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self' https: wss:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 export interface StaticWebsiteProps {
   readonly websiteName: string;
   readonly websiteFilePath: string;
@@ -3321,8 +3337,7 @@ export class StaticWebsite extends Construct {
       'Distribution log bucket does not need versioning enabled',
     );
 
-    // Security headers applied to all responses. A Content-Security-Policy is
-    // intentionally omitted as it is application specific - add one for your app.
+    // Security headers applied to all responses.
     const responseHeadersPolicy = new ResponseHeadersPolicy(
       this,
       'ResponseHeadersPolicy',
@@ -3342,6 +3357,10 @@ export class StaticWebsite extends Construct {
           referrerPolicy: {
             referrerPolicy:
               HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            override: true,
+          },
+          contentSecurityPolicy: {
+            contentSecurityPolicy: CONTENT_SECURITY_POLICY,
             override: true,
           },
         },
@@ -4776,6 +4795,23 @@ import { suppressRules } from './checkov.js';
 
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
+// Content-Security-Policy enforced on all responses. Restricts scripts and
+// framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
+// (connect-src) to AWS service endpoints such as API Gateway, Cognito and
+// Bedrock AgentCore which are only known at deploy time. Edit this to tighten
+// connect-src to your specific origins once they are known.
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self' https: wss:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 export interface StaticWebsiteProps {
   readonly websiteName: string;
   readonly websiteFilePath: string;
@@ -4867,8 +4903,7 @@ export class StaticWebsite extends Construct {
       'Distribution log bucket does not need versioning enabled',
     );
 
-    // Security headers applied to all responses. A Content-Security-Policy is
-    // intentionally omitted as it is application specific - add one for your app.
+    // Security headers applied to all responses.
     const responseHeadersPolicy = new ResponseHeadersPolicy(
       this,
       'ResponseHeadersPolicy',
@@ -4888,6 +4923,10 @@ export class StaticWebsite extends Construct {
           referrerPolicy: {
             referrerPolicy:
               HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            override: true,
+          },
+          contentSecurityPolicy: {
+            contentSecurityPolicy: CONTENT_SECURITY_POLICY,
             override: true,
           },
         },

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -166,7 +166,7 @@ variable "website_file_path" {
 # Bedrock AgentCore which are only known at deploy time. Edit this to tighten
 # connect-src to your specific origins once they are known.
 locals {
-  content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+  content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
 }
 
 
@@ -1592,7 +1592,7 @@ const CONTENT_SECURITY_POLICY = [
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data:",
-  "font-src 'self'",
+  "font-src 'self' data:",
   "connect-src 'self' https: wss:",
   "object-src 'none'",
   "base-uri 'self'",
@@ -3239,7 +3239,7 @@ const CONTENT_SECURITY_POLICY = [
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data:",
-  "font-src 'self'",
+  "font-src 'self' data:",
   "connect-src 'self' https: wss:",
   "object-src 'none'",
   "base-uri 'self'",
@@ -4805,7 +4805,7 @@ const CONTENT_SECURITY_POLICY = [
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data:",
-  "font-src 'self'",
+  "font-src 'self' data:",
   "connect-src 'self' https: wss:",
   "object-src 'none'",
   "base-uri 'self'",

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -27,9 +27,45 @@ import { suppressRules } from './checkov.js';
 
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
+/**
+ * Conservative starter Content-Security-Policy.
+ *
+ * It restricts most resources to the site's own origin, which is a sensible
+ * baseline for a single page application, while allowing inline styles and
+ * data: images which are commonly required by frontend frameworks.
+ */
+const DEFAULT_CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 export interface StaticWebsiteProps {
   readonly websiteName: string;
   readonly websiteFilePath: string;
+  /**
+   * The Content-Security-Policy to apply to all responses.
+   *
+   * @default a conservative policy suitable for a single page application
+   */
+  readonly contentSecurityPolicy?: string;
+  /**
+   * When true, the Content-Security-Policy is delivered via the
+   * Content-Security-Policy-Report-Only header rather than being enforced.
+   *
+   * Report-only mode lets you observe what the policy would block (via the
+   * browser console and any configured report-to endpoint) without breaking
+   * your application. This is the safe default: tighten your policy to your
+   * app's actual sources, verify nothing legitimate is reported as blocked,
+   * then set this to false to switch to enforcement.
+   *
+   * @default true
+   */
+  readonly contentSecurityPolicyReportOnly?: boolean;
 }
 
 /**
@@ -48,7 +84,12 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    { websiteFilePath, websiteName }: StaticWebsiteProps
+    {
+      websiteFilePath,
+      websiteName,
+      contentSecurityPolicy = DEFAULT_CONTENT_SECURITY_POLICY,
+      contentSecurityPolicyReportOnly = true,
+    }: StaticWebsiteProps
   ) {
     super(scope, id);
     this.node.setContext(
@@ -118,8 +159,9 @@ export class StaticWebsite extends Construct {
       'Distribution log bucket does not need versioning enabled',
     );
 
-    // Security headers applied to all responses. A Content-Security-Policy is
-    // intentionally omitted as it is application specific - add one for your app.
+    // Security headers applied to all responses. The Content-Security-Policy is
+    // delivered in report-only mode by default so it can be tuned to your app
+    // without breaking it - switch to enforcement via contentSecurityPolicyReportOnly.
     const responseHeadersPolicy = new ResponseHeadersPolicy(
       this,
       'ResponseHeadersPolicy',
@@ -140,7 +182,30 @@ export class StaticWebsite extends Construct {
             referrerPolicy: HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
             override: true,
           },
+          // CloudFront only supports an enforcing Content-Security-Policy here.
+          // Report-only is delivered via a custom header below.
+          ...(contentSecurityPolicyReportOnly
+            ? {}
+            : {
+                contentSecurityPolicy: {
+                  contentSecurityPolicy,
+                  override: true,
+                },
+              }),
         },
+        ...(contentSecurityPolicyReportOnly
+          ? {
+              customHeadersBehavior: {
+                customHeaders: [
+                  {
+                    header: 'Content-Security-Policy-Report-Only',
+                    value: contentSecurityPolicy,
+                    override: true,
+                  },
+                ],
+              },
+            }
+          : {}),
       },
     );
 

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -37,7 +37,7 @@ const CONTENT_SECURITY_POLICY = [
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data:",
-  "font-src 'self'",
+  "font-src 'self' data:",
   "connect-src 'self' https: wss:",
   "object-src 'none'",
   "base-uri 'self'",

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -27,45 +27,26 @@ import { suppressRules } from './checkov.js';
 
 const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
 
-/**
- * Conservative starter Content-Security-Policy.
- *
- * It restricts most resources to the site's own origin, which is a sensible
- * baseline for a single page application, while allowing inline styles and
- * data: images which are commonly required by frontend frameworks.
- */
-const DEFAULT_CONTENT_SECURITY_POLICY = [
+// Content-Security-Policy enforced on all responses. Restricts scripts and
+// framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
+// (connect-src) to AWS service endpoints such as API Gateway, Cognito and
+// Bedrock AgentCore which are only known at deploy time. Edit this to tighten
+// connect-src to your specific origins once they are known.
+const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data:",
   "font-src 'self'",
-  "connect-src 'self'",
+  "connect-src 'self' https: wss:",
+  "object-src 'none'",
+  "base-uri 'self'",
   "frame-ancestors 'none'",
 ].join('; ');
 
 export interface StaticWebsiteProps {
   readonly websiteName: string;
   readonly websiteFilePath: string;
-  /**
-   * The Content-Security-Policy to apply to all responses.
-   *
-   * @default a conservative policy suitable for a single page application
-   */
-  readonly contentSecurityPolicy?: string;
-  /**
-   * When true, the Content-Security-Policy is delivered via the
-   * Content-Security-Policy-Report-Only header rather than being enforced.
-   *
-   * Report-only mode lets you observe what the policy would block (via the
-   * browser console and any configured report-to endpoint) without breaking
-   * your application. This is the safe default: tighten your policy to your
-   * app's actual sources, verify nothing legitimate is reported as blocked,
-   * then set this to false to switch to enforcement.
-   *
-   * @default true
-   */
-  readonly contentSecurityPolicyReportOnly?: boolean;
 }
 
 /**
@@ -84,12 +65,7 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    {
-      websiteFilePath,
-      websiteName,
-      contentSecurityPolicy = DEFAULT_CONTENT_SECURITY_POLICY,
-      contentSecurityPolicyReportOnly = true,
-    }: StaticWebsiteProps
+    { websiteFilePath, websiteName }: StaticWebsiteProps
   ) {
     super(scope, id);
     this.node.setContext(
@@ -159,9 +135,7 @@ export class StaticWebsite extends Construct {
       'Distribution log bucket does not need versioning enabled',
     );
 
-    // Security headers applied to all responses. The Content-Security-Policy is
-    // delivered in report-only mode by default so it can be tuned to your app
-    // without breaking it - switch to enforcement via contentSecurityPolicyReportOnly.
+    // Security headers applied to all responses.
     const responseHeadersPolicy = new ResponseHeadersPolicy(
       this,
       'ResponseHeadersPolicy',
@@ -182,30 +156,11 @@ export class StaticWebsite extends Construct {
             referrerPolicy: HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
             override: true,
           },
-          // CloudFront only supports an enforcing Content-Security-Policy here.
-          // Report-only is delivered via a custom header below.
-          ...(contentSecurityPolicyReportOnly
-            ? {}
-            : {
-                contentSecurityPolicy: {
-                  contentSecurityPolicy,
-                  override: true,
-                },
-              }),
+          contentSecurityPolicy: {
+            contentSecurityPolicy: CONTENT_SECURITY_POLICY,
+            override: true,
+          },
         },
-        ...(contentSecurityPolicyReportOnly
-          ? {
-              customHeadersBehavior: {
-                customHeaders: [
-                  {
-                    header: 'Content-Security-Policy-Report-Only',
-                    value: contentSecurityPolicy,
-                    override: true,
-                  },
-                ],
-              },
-            }
-          : {}),
       },
     );
 

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -29,7 +29,7 @@ variable "website_file_path" {
 # Bedrock AgentCore which are only known at deploy time. Edit this to tighten
 # connect-src to your specific origins once they are known.
 locals {
-  content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+  content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
 }
 
 

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -23,6 +23,18 @@ variable "website_file_path" {
   type        = string
 }
 
+variable "content_security_policy" {
+  description = "The Content-Security-Policy to apply to all responses. Defaults to a conservative policy suitable for a single page application."
+  type        = string
+  default     = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'"
+}
+
+variable "content_security_policy_report_only" {
+  description = "When true, the Content-Security-Policy is delivered via the Content-Security-Policy-Report-Only header rather than being enforced. Report-only mode lets you observe what the policy would block without breaking your application. Tighten the policy to your app's sources, verify nothing legitimate is reported as blocked, then set this to false to switch to enforcement."
+  type        = bool
+  default     = true
+}
+
 
 # Data sources
 data "aws_caller_identity" "current" {}
@@ -383,8 +395,9 @@ resource "aws_cloudfront_origin_access_control" "website_oac" {
   signing_protocol                  = "sigv4"
 }
 
-# Security headers applied to all responses. A Content-Security-Policy is
-# intentionally omitted as it is application specific - add one for your app.
+# Security headers applied to all responses. The Content-Security-Policy is
+# delivered in report-only mode by default so it can be tuned to your app
+# without breaking it - switch to enforcement via content_security_policy_report_only.
 resource "aws_cloudfront_response_headers_policy" "website" {
   name = "${aws_s3_bucket.website.bucket}-security-headers"
 
@@ -405,6 +418,26 @@ resource "aws_cloudfront_response_headers_policy" "website" {
     referrer_policy {
       referrer_policy = "strict-origin-when-cross-origin"
       override        = true
+    }
+    # CloudFront only supports an enforcing Content-Security-Policy here.
+    # Report-only is delivered via the custom header below.
+    dynamic "content_security_policy" {
+      for_each = var.content_security_policy_report_only ? [] : [1]
+      content {
+        content_security_policy = var.content_security_policy
+        override                = true
+      }
+    }
+  }
+
+  dynamic "custom_headers_config" {
+    for_each = var.content_security_policy_report_only ? [1] : []
+    content {
+      items {
+        header   = "Content-Security-Policy-Report-Only"
+        value    = var.content_security_policy
+        override = true
+      }
     }
   }
 }

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -23,16 +23,13 @@ variable "website_file_path" {
   type        = string
 }
 
-variable "content_security_policy" {
-  description = "The Content-Security-Policy to apply to all responses. Defaults to a conservative policy suitable for a single page application."
-  type        = string
-  default     = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'"
-}
-
-variable "content_security_policy_report_only" {
-  description = "When true, the Content-Security-Policy is delivered via the Content-Security-Policy-Report-Only header rather than being enforced. Report-only mode lets you observe what the policy would block without breaking your application. Tighten the policy to your app's sources, verify nothing legitimate is reported as blocked, then set this to false to switch to enforcement."
-  type        = bool
-  default     = true
+# Content-Security-Policy enforced on all responses. Restricts scripts and
+# framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
+# (connect-src) to AWS service endpoints such as API Gateway, Cognito and
+# Bedrock AgentCore which are only known at deploy time. Edit this to tighten
+# connect-src to your specific origins once they are known.
+locals {
+  content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
 }
 
 
@@ -395,9 +392,7 @@ resource "aws_cloudfront_origin_access_control" "website_oac" {
   signing_protocol                  = "sigv4"
 }
 
-# Security headers applied to all responses. The Content-Security-Policy is
-# delivered in report-only mode by default so it can be tuned to your app
-# without breaking it - switch to enforcement via content_security_policy_report_only.
+# Security headers applied to all responses.
 resource "aws_cloudfront_response_headers_policy" "website" {
   name = "${aws_s3_bucket.website.bucket}-security-headers"
 
@@ -419,25 +414,9 @@ resource "aws_cloudfront_response_headers_policy" "website" {
       referrer_policy = "strict-origin-when-cross-origin"
       override        = true
     }
-    # CloudFront only supports an enforcing Content-Security-Policy here.
-    # Report-only is delivered via the custom header below.
-    dynamic "content_security_policy" {
-      for_each = var.content_security_policy_report_only ? [] : [1]
-      content {
-        content_security_policy = var.content_security_policy
-        override                = true
-      }
-    }
-  }
-
-  dynamic "custom_headers_config" {
-    for_each = var.content_security_policy_report_only ? [1] : []
-    content {
-      items {
-        header   = "Content-Security-Policy-Report-Only"
-        value    = var.content_security_policy
-        override = true
-      }
+    content_security_policy {
+      content_security_policy = local.content_security_policy
+      override                = true
     }
   }
 }


### PR DESCRIPTION
### Reason for this change

The generated static website (CloudFront) already sets `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY` and `Referrer-Policy`, but had no `Content-Security-Policy`. A CSP is the primary defense-in-depth control against cross-site scripting and content injection.

### Description of changes

Adds an **enforcing** `Content-Security-Policy` to the generated CloudFront `ResponseHeadersPolicy` for both the CDK and Terraform variants of the `StaticWebsite` construct/module, using CloudFront's native `securityHeadersBehavior.contentSecurityPolicy` (CDK) / `security_headers_config.content_security_policy` (Terraform).

The policy is hardcoded inline in the construct (no new props or Terraform variables):

```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
```

Key decisions:

- **`script-src 'self'` / `object-src 'none'` / `base-uri 'self'` / `frame-ancestors 'none'`** provide the core XSS and clickjacking protection.
- **`connect-src 'self' https: wss:`** is deliberately permissive. The generated website makes cross-origin calls to AWS service endpoints whose hostnames are only known at deploy time (API Gateway `*.execute-api.<region>.amazonaws.com`, Cognito `cognito-idp.<region>.amazonaws.com` and `*.auth.<region>.amazoncognito.com`, and Bedrock AgentCore `bedrock-agentcore.<region>.amazonaws.com` over both HTTPS and WSS). Allowing `https:`/`wss:` ensures login and API calls work out of the box; consumers can tighten this to their specific origins.
- **`style-src 'unsafe-inline'`, `img-src data:` and `font-src data:`** are required by the default Cloudscape frontend, which inlines styles and embeds icon/glyph fonts as `data:` URIs.

Consumers who want to adjust the policy can edit the `content_security_policy` value directly in their generated `static-website.ts` (CDK) or `static-website.tf` (Terraform). The react-website guide documents this.

### Description of how you validated changes

- Updated and ran the affected unit/snapshot tests (CDK + Terraform static-website snapshots).
- **Real browser-based end-to-end validation** against a deployed stack: scaffolded a `ts#react-website` with Cognito auth (`ts#react-website#auth`) + a connected `ts#trpc-api` (`--auth=cognito`) + `ts#infra`, `cdk deploy`ed the full stack, then drove a headless Chromium (Playwright) through the deployed CloudFront website:
  - confirmed the enforcing `content-security-policy` header (not `-Report-Only`) is present,
  - performed a real Cognito login through the managed-login UI (username + password + TOTP MFA),
  - confirmed the authenticated app renders with **zero CSP violations** on the website origin,
  - made a cross-origin tRPC API call from within the browser and asserted it returned **HTTP 200** (not blocked by `connect-src`).
  - The browser test initially revealed the Cloudscape UI's `data:` fonts were blocked by `font-src 'self'`; this PR widens `font-src` to `'self' data:` to fix that, re-verified in the browser with no violations.

  Full (infra-redacted) browser transcript is in a PR comment below.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*