### PR TITLE
fix(terraform): pass local-exec variables via environment block

### DIFF
--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -1108,14 +1108,19 @@ resource "null_resource" "docker_publish" {
   provisioner "local-exec" {
     command = <<-EOT
       # Get ECR login token
-      aws ecr get-login-password --region \${local.aws_region} | docker login --username AWS --password-stdin \${self.triggers.repository_url}
+      aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
 
       # Tag the image
-      docker tag \${self.triggers.docker_image_tag} \${self.triggers.repository_url}:latest
+      docker tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
 
       # Push the image
-      docker push \${self.triggers.repository_url}:latest
+      docker push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = local.aws_region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.agent_core_ecr_policy]
@@ -1177,10 +1182,11 @@ resource "null_resource" "runtime_ready" {
       uv run --with boto3 python -c "
 import boto3
 import json
+import os
 import time
 import uuid
 
-runtime_arn = '\${self.triggers.runtime_arn}'
+runtime_arn = os.environ['RUNTIME_ARN']
 client = boto3.client('bedrock-agentcore')
 initialize_request = json.dumps({
     'jsonrpc': '2.0',
@@ -1212,6 +1218,9 @@ while True:
 print(f'Runtime {runtime_arn} is serving MCP')
 "
     EOT
+    environment = {
+      RUNTIME_ARN = self.triggers.runtime_arn
+    }
   }
 }
 

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -412,14 +412,19 @@ resource "null_resource" "docker_publish" {
   provisioner "local-exec" {
     command = <<-EOT
       # Get ECR login token
-      aws ecr get-login-password --region \${local.aws_region} | docker login --username AWS --password-stdin \${self.triggers.repository_url}
+      aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
 
       # Tag the image
-      docker tag \${self.triggers.docker_image_tag} \${self.triggers.repository_url}:latest
+      docker tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
 
       # Push the image
-      docker push \${self.triggers.repository_url}:latest
+      docker push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = local.aws_region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.agent_core_ecr_policy]
@@ -481,10 +486,11 @@ resource "null_resource" "runtime_ready" {
       uv run --with boto3 python -c "
 import boto3
 import json
+import os
 import time
 import uuid
 
-runtime_arn = '\${self.triggers.runtime_arn}'
+runtime_arn = os.environ['RUNTIME_ARN']
 client = boto3.client('bedrock-agentcore')
 initialize_request = json.dumps({
     'jsonrpc': '2.0',
@@ -516,6 +522,9 @@ while True:
 print(f'Runtime {runtime_arn} is serving MCP')
 "
     EOT
+    environment = {
+      RUNTIME_ARN = self.triggers.runtime_arn
+    }
   }
 }
 

--- a/packages/nx-plugin/src/terraform/project/files/application/src/main.tf.template
+++ b/packages/nx-plugin/src/terraform/project/files/application/src/main.tf.template
@@ -14,6 +14,11 @@ resource "null_resource" "print_info" {
   # }
 
   provisioner "local-exec" {
-    command = "echo 'AWS Region: ${local.aws_region}, AWS Account: ${local.account_id}, Environment: ${var.environment}'"
+    command = "echo \"AWS Region: $AWS_REGION, AWS Account: $ACCOUNT_ID, Environment: $ENVIRONMENT\""
+    environment = {
+      AWS_REGION  = local.aws_region
+      ACCOUNT_ID  = local.account_id
+      ENVIRONMENT = var.environment
+    }
   }
 }

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -1104,14 +1104,19 @@ resource "null_resource" "docker_publish" {
   provisioner "local-exec" {
     command = <<-EOT
       # Get ECR login token
-      aws ecr get-login-password --region \${local.aws_region} | docker login --username AWS --password-stdin \${self.triggers.repository_url}
+      aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
 
       # Tag the image
-      docker tag \${self.triggers.docker_image_tag} \${self.triggers.repository_url}:latest
+      docker tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
 
       # Push the image
-      docker push \${self.triggers.repository_url}:latest
+      docker push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = local.aws_region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.agent_core_ecr_policy]
@@ -1173,10 +1178,11 @@ resource "null_resource" "runtime_ready" {
       uv run --with boto3 python -c "
 import boto3
 import json
+import os
 import time
 import uuid
 
-runtime_arn = '\${self.triggers.runtime_arn}'
+runtime_arn = os.environ['RUNTIME_ARN']
 client = boto3.client('bedrock-agentcore')
 initialize_request = json.dumps({
     'jsonrpc': '2.0',
@@ -1208,6 +1214,9 @@ while True:
 print(f'Runtime {runtime_arn} is serving MCP')
 "
     EOT
+    environment = {
+      RUNTIME_ARN = self.triggers.runtime_arn
+    }
   }
 }
 

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -412,14 +412,19 @@ resource "null_resource" "docker_publish" {
   provisioner "local-exec" {
     command = <<-EOT
       # Get ECR login token
-      aws ecr get-login-password --region \${local.aws_region} | docker login --username AWS --password-stdin \${self.triggers.repository_url}
+      aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
 
       # Tag the image
-      docker tag \${self.triggers.docker_image_tag} \${self.triggers.repository_url}:latest
+      docker tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
 
       # Push the image
-      docker push \${self.triggers.repository_url}:latest
+      docker push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = local.aws_region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.agent_core_ecr_policy]
@@ -481,10 +486,11 @@ resource "null_resource" "runtime_ready" {
       uv run --with boto3 python -c "
 import boto3
 import json
+import os
 import time
 import uuid
 
-runtime_arn = '\${self.triggers.runtime_arn}'
+runtime_arn = os.environ['RUNTIME_ARN']
 client = boto3.client('bedrock-agentcore')
 initialize_request = json.dumps({
     'jsonrpc': '2.0',
@@ -516,6 +522,9 @@ while True:
 print(f'Runtime {runtime_arn} is serving MCP')
 "
     EOT
+    environment = {
+      RUNTIME_ARN = self.triggers.runtime_arn
+    }
   }
 }
 

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -1336,9 +1336,9 @@ resource "null_resource" "proxy_target_ready" {
       deadline=$((start_time + 600))
       while true; do
         target_state=$(aws rds describe-db-proxy-targets \\
-          --region \${data.aws_region.current.region} \\
-          --db-proxy-name \${self.triggers.db_proxy_name} \\
-          --target-group-name \${self.triggers.target_group_name} \\
+          --region "$AWS_REGION" \\
+          --db-proxy-name "$DB_PROXY_NAME" \\
+          --target-group-name "$TARGET_GROUP_NAME" \\
           --query "Targets[?Type=='RDS_INSTANCE'] | [0].TargetHealth.State" \\
           --output text)
 
@@ -1348,13 +1348,19 @@ resource "null_resource" "proxy_target_ready" {
 
         current_time=$(date +%s)
         if [ "$current_time" -ge "$deadline" ]; then
-          echo "RDS Proxy target \${self.triggers.db_cluster_identifier} did not become AVAILABLE within 10 minutes. Last state: $target_state"
+          echo "RDS Proxy target $DB_CLUSTER_IDENTIFIER did not become AVAILABLE within 10 minutes. Last state: $target_state"
           exit 1
         fi
 
         sleep 10
       done
     EOT
+    environment = {
+      AWS_REGION            = data.aws_region.current.region
+      DB_PROXY_NAME         = self.triggers.db_proxy_name
+      TARGET_GROUP_NAME     = self.triggers.target_group_name
+      DB_CLUSTER_IDENTIFIER = self.triggers.db_cluster_identifier
+    }
   }
 
   depends_on = [
@@ -1838,10 +1844,15 @@ resource "null_resource" "docker_publish" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      aws ecr get-login-password --region \${data.aws_region.current.region} | docker login --username AWS --password-stdin \${self.triggers.repository_url}
-      docker tag \${self.triggers.docker_image_tag} \${self.triggers.repository_url}:latest
-      docker push \${self.triggers.repository_url}:latest
+      aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
+      docker tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
+      docker push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = data.aws_region.current.region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.migration_handler]
@@ -2099,10 +2110,10 @@ resource "null_resource" "create_db_user_trigger" {
     command = <<-EOT
       output_file=$(mktemp)
       response=$(aws lambda invoke \\
-        --region \${data.aws_region.current.region} \\
-        --function-name \${self.triggers.function_name} \\
+        --region "$AWS_REGION" \\
+        --function-name "$FUNCTION_NAME" \\
         --cli-binary-format raw-in-base64-out \\
-        --payload '{"RequestType":"Create","PhysicalResourceId":"db-user:\${self.triggers.db_user}"}' \\
+        --payload "{\\"RequestType\\":\\"Create\\",\\"PhysicalResourceId\\":\\"db-user:$DB_USER\\"}" \\
         "$output_file")
       cat "$output_file"
       echo "$response"
@@ -2112,6 +2123,11 @@ resource "null_resource" "create_db_user_trigger" {
       fi
       rm -f "$output_file"
     EOT
+    environment = {
+      AWS_REGION    = data.aws_region.current.region
+      FUNCTION_NAME = self.triggers.function_name
+      DB_USER       = self.triggers.db_user
+    }
   }
 
   depends_on = [aws_lambda_function.create_db_user, module.aurora]
@@ -2174,8 +2190,8 @@ resource "null_resource" "migration_trigger" {
     command = <<-EOT
       output_file=$(mktemp)
       response=$(aws lambda invoke \\
-        --region \${data.aws_region.current.region} \\
-        --function-name \${self.triggers.function_name} \\
+        --region "$AWS_REGION" \\
+        --function-name "$FUNCTION_NAME" \\
         --cli-binary-format raw-in-base64-out \\
         "$output_file")
       cat "$output_file"
@@ -2186,6 +2202,10 @@ resource "null_resource" "migration_trigger" {
       fi
       rm -f "$output_file"
     EOT
+    environment = {
+      AWS_REGION    = data.aws_region.current.region
+      FUNCTION_NAME = self.triggers.function_name
+    }
   }
 
   depends_on = [
@@ -2797,9 +2817,9 @@ resource "null_resource" "proxy_target_ready" {
       deadline=$((start_time + 600))
       while true; do
         target_state=$(aws rds describe-db-proxy-targets \\
-          --region \${data.aws_region.current.region} \\
-          --db-proxy-name \${self.triggers.db_proxy_name} \\
-          --target-group-name \${self.triggers.target_group_name} \\
+          --region "$AWS_REGION" \\
+          --db-proxy-name "$DB_PROXY_NAME" \\
+          --target-group-name "$TARGET_GROUP_NAME" \\
           --query "Targets[?Type=='RDS_INSTANCE'] | [0].TargetHealth.State" \\
           --output text)
 
@@ -2809,13 +2829,19 @@ resource "null_resource" "proxy_target_ready" {
 
         current_time=$(date +%s)
         if [ "$current_time" -ge "$deadline" ]; then
-          echo "RDS Proxy target \${self.triggers.db_cluster_identifier} did not become AVAILABLE within 10 minutes. Last state: $target_state"
+          echo "RDS Proxy target $DB_CLUSTER_IDENTIFIER did not become AVAILABLE within 10 minutes. Last state: $target_state"
           exit 1
         fi
 
         sleep 10
       done
     EOT
+    environment = {
+      AWS_REGION            = data.aws_region.current.region
+      DB_PROXY_NAME         = self.triggers.db_proxy_name
+      TARGET_GROUP_NAME     = self.triggers.target_group_name
+      DB_CLUSTER_IDENTIFIER = self.triggers.db_cluster_identifier
+    }
   }
 
   depends_on = [
@@ -3299,10 +3325,15 @@ resource "null_resource" "docker_publish" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      aws ecr get-login-password --region \${data.aws_region.current.region} | docker login --username AWS --password-stdin \${self.triggers.repository_url}
-      docker tag \${self.triggers.docker_image_tag} \${self.triggers.repository_url}:latest
-      docker push \${self.triggers.repository_url}:latest
+      aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$REPOSITORY_URL"
+      docker tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
+      docker push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = data.aws_region.current.region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.migration_handler]
@@ -3565,10 +3596,10 @@ resource "null_resource" "create_db_user_trigger" {
     command = <<-EOT
       output_file=$(mktemp)
       response=$(aws lambda invoke \\
-        --region \${data.aws_region.current.region} \\
-        --function-name \${self.triggers.function_name} \\
+        --region "$AWS_REGION" \\
+        --function-name "$FUNCTION_NAME" \\
         --cli-binary-format raw-in-base64-out \\
-        --payload '{"RequestType":"Create","PhysicalResourceId":"db-user:\${self.triggers.db_user}"}' \\
+        --payload "{\\"RequestType\\":\\"Create\\",\\"PhysicalResourceId\\":\\"db-user:$DB_USER\\"}" \\
         "$output_file")
       cat "$output_file"
       echo "$response"
@@ -3578,6 +3609,11 @@ resource "null_resource" "create_db_user_trigger" {
       fi
       rm -f "$output_file"
     EOT
+    environment = {
+      AWS_REGION    = data.aws_region.current.region
+      FUNCTION_NAME = self.triggers.function_name
+      DB_USER       = self.triggers.db_user
+    }
   }
 
   depends_on = [aws_lambda_function.create_db_user, module.aurora]
@@ -3636,8 +3672,8 @@ resource "null_resource" "migration_trigger" {
     command = <<-EOT
       output_file=$(mktemp)
       response=$(aws lambda invoke \\
-        --region \${data.aws_region.current.region} \\
-        --function-name \${self.triggers.function_name} \\
+        --region "$AWS_REGION" \\
+        --function-name "$FUNCTION_NAME" \\
         --cli-binary-format raw-in-base64-out \\
         "$output_file")
       cat "$output_file"
@@ -3648,6 +3684,10 @@ resource "null_resource" "migration_trigger" {
       fi
       rm -f "$output_file"
     EOT
+    environment = {
+      AWS_REGION    = data.aws_region.current.region
+      FUNCTION_NAME = self.triggers.function_name
+    }
   }
 
   depends_on = [

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -690,7 +690,7 @@ resource "null_resource" "upload_website_files" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      cd "\${path.root}"
+      cd "$ROOT_PATH"
       uv run --with boto3 python3 -c "
 import os
 import sys
@@ -779,9 +779,14 @@ def sync_to_s3(local_path, bucket_name):
         sys.exit(1)
 
 # Execute sync
-sync_to_s3('\${var.website_file_path}', '\${aws_s3_bucket.website.bucket}')
+sync_to_s3(os.environ['WEBSITE_FILE_PATH'], os.environ['BUCKET_NAME'])
 "
     EOT
+    environment = {
+      ROOT_PATH         = path.root
+      WEBSITE_FILE_PATH = var.website_file_path
+      BUCKET_NAME       = aws_s3_bucket.website.bucket
+    }
   }
 
   depends_on = [aws_s3_bucket_policy.website_cloudfront_policy]
@@ -811,6 +816,7 @@ resource "null_resource" "cloudfront_invalidation" {
     command = <<-EOT
       uv run --with boto3 python3 -c "
 import boto3
+import os
 import sys
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -832,7 +838,7 @@ def create_invalidation(distribution_id):
 
         invalidation_id = response['Invalidation']['Id']
         print(f'CloudFront cache invalidation created: {invalidation_id}')
-        print(f'Distribution: \${aws_cloudfront_distribution.website.id}')
+        print(f'Distribution: {distribution_id}')
         print(f'Status: {response[\\"Invalidation\\"][\\"Status\\"]}')
 
     except NoCredentialsError:
@@ -846,9 +852,12 @@ def create_invalidation(distribution_id):
         sys.exit(1)
 
 # Execute invalidation
-create_invalidation('\${aws_cloudfront_distribution.website.id}')
+create_invalidation(os.environ['DISTRIBUTION_ID'])
 "
     EOT
+    environment = {
+      DISTRIBUTION_ID = aws_cloudfront_distribution.website.id
+    }
   }
 
   depends_on = [
@@ -1144,27 +1153,27 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`pnpm nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
+Run \`npx nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
 
 ## Running unit tests
 
-Run \`pnpm nx test @proj/common-constructs\` to execute the unit tests via Vitest.
+Run \`npx nx test @proj/common-constructs\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`pnpm nx test @proj/common-constructs --configuration=update-snapshot\`
+\`npx nx test @proj/common-constructs --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`pnpm nx lint @proj/common-constructs\`
+Run \`npx nx lint @proj/common-constructs\`
 
 ### Fixable issues
 
 You can also automatiaclly fix some lint errors by running the following command:
 
-\`pnpm nx lint @proj/common-constructs --configuration=fix\`
+\`npx nx lint @proj/common-constructs --configuration=fix\`
 
 ## Useful links
 
@@ -1980,37 +1989,37 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`pnpm nx build @proj/test-app [--skip-nx-cache]\` to build the application.
+Run \`npx nx build @proj/test-app [--skip-nx-cache]\` to build the application.
 
 ## Run dev server
 
-Run \`pnpm nx serve @proj/test-app\`
+Run \`npx nx serve @proj/test-app\`
 
 ## Running unit tests
 
-Run \`pnpm nx test @proj/test-app\` to execute the unit tests via Vitest.
+Run \`npx nx test @proj/test-app\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`pnpm nx test @proj/test-app --configuration=update-snapshot\`
+\`npx nx test @proj/test-app --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`pnpm nx lint @proj/test-app\`
+Run \`npx nx lint @proj/test-app\`
 
 ### Fixable issues
 
 You can also automatically fix some lint errors by running the following command:
 
-\`pnpm nx lint @proj/test-app --configuration=fix\`
+\`npx nx lint @proj/test-app --configuration=fix\`
 
 ### Runtime config
 
 In order to integrate with cognito or trpc backends, you need to have a \`runtime-config.json\` file in your \`/public\` website directory. You can fetch this is follows:
 
-\`pnpm nx run @proj/test-app:load:runtime-config\`
+\`npx nx run @proj/test-app:load:runtime-config\`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed
@@ -2108,7 +2117,7 @@ exports[`react-website generator > Tanstack router integration > should generate
     "load:runtime-config": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx run @proj/test-app:load:runtime-config'"
+        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'npx nx run @proj/test-app:load:runtime-config'"
       },
       "options": {
         "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json \\"{projectRoot}/public/runtime-config.json\\""
@@ -2771,27 +2780,27 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`pnpm nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
+Run \`npx nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
 
 ## Running unit tests
 
-Run \`pnpm nx test @proj/common-constructs\` to execute the unit tests via Vitest.
+Run \`npx nx test @proj/common-constructs\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`pnpm nx test @proj/common-constructs --configuration=update-snapshot\`
+\`npx nx test @proj/common-constructs --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`pnpm nx lint @proj/common-constructs\`
+Run \`npx nx lint @proj/common-constructs\`
 
 ### Fixable issues
 
 You can also automatiaclly fix some lint errors by running the following command:
 
-\`pnpm nx lint @proj/common-constructs --configuration=fix\`
+\`npx nx lint @proj/common-constructs --configuration=fix\`
 
 ## Useful links
 
@@ -3607,37 +3616,37 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`pnpm nx build @proj/test-app [--skip-nx-cache]\` to build the application.
+Run \`npx nx build @proj/test-app [--skip-nx-cache]\` to build the application.
 
 ## Run dev server
 
-Run \`pnpm nx serve @proj/test-app\`
+Run \`npx nx serve @proj/test-app\`
 
 ## Running unit tests
 
-Run \`pnpm nx test @proj/test-app\` to execute the unit tests via Vitest.
+Run \`npx nx test @proj/test-app\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`pnpm nx test @proj/test-app --configuration=update-snapshot\`
+\`npx nx test @proj/test-app --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`pnpm nx lint @proj/test-app\`
+Run \`npx nx lint @proj/test-app\`
 
 ### Fixable issues
 
 You can also automatically fix some lint errors by running the following command:
 
-\`pnpm nx lint @proj/test-app --configuration=fix\`
+\`npx nx lint @proj/test-app --configuration=fix\`
 
 ### Runtime config
 
 In order to integrate with cognito or trpc backends, you need to have a \`runtime-config.json\` file in your \`/public\` website directory. You can fetch this is follows:
 
-\`pnpm nx run @proj/test-app:load:runtime-config\`
+\`npx nx run @proj/test-app:load:runtime-config\`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed
@@ -3735,7 +3744,7 @@ exports[`react-website generator > Tanstack router integration > should generate
     "load:runtime-config": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx run @proj/test-app:load:runtime-config'"
+        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'npx nx run @proj/test-app:load:runtime-config'"
       },
       "options": {
         "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json \\"{projectRoot}/public/runtime-config.json\\""

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1153,27 +1153,27 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`npx nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
+Run \`pnpm nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
 
 ## Running unit tests
 
-Run \`npx nx test @proj/common-constructs\` to execute the unit tests via Vitest.
+Run \`pnpm nx test @proj/common-constructs\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`npx nx test @proj/common-constructs --configuration=update-snapshot\`
+\`pnpm nx test @proj/common-constructs --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`npx nx lint @proj/common-constructs\`
+Run \`pnpm nx lint @proj/common-constructs\`
 
 ### Fixable issues
 
 You can also automatiaclly fix some lint errors by running the following command:
 
-\`npx nx lint @proj/common-constructs --configuration=fix\`
+\`pnpm nx lint @proj/common-constructs --configuration=fix\`
 
 ## Useful links
 
@@ -1989,37 +1989,37 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`npx nx build @proj/test-app [--skip-nx-cache]\` to build the application.
+Run \`pnpm nx build @proj/test-app [--skip-nx-cache]\` to build the application.
 
 ## Run dev server
 
-Run \`npx nx serve @proj/test-app\`
+Run \`pnpm nx serve @proj/test-app\`
 
 ## Running unit tests
 
-Run \`npx nx test @proj/test-app\` to execute the unit tests via Vitest.
+Run \`pnpm nx test @proj/test-app\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`npx nx test @proj/test-app --configuration=update-snapshot\`
+\`pnpm nx test @proj/test-app --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`npx nx lint @proj/test-app\`
+Run \`pnpm nx lint @proj/test-app\`
 
 ### Fixable issues
 
 You can also automatically fix some lint errors by running the following command:
 
-\`npx nx lint @proj/test-app --configuration=fix\`
+\`pnpm nx lint @proj/test-app --configuration=fix\`
 
 ### Runtime config
 
 In order to integrate with cognito or trpc backends, you need to have a \`runtime-config.json\` file in your \`/public\` website directory. You can fetch this is follows:
 
-\`npx nx run @proj/test-app:load:runtime-config\`
+\`pnpm nx run @proj/test-app:load:runtime-config\`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed
@@ -2117,7 +2117,7 @@ exports[`react-website generator > Tanstack router integration > should generate
     "load:runtime-config": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'npx nx run @proj/test-app:load:runtime-config'"
+        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx run @proj/test-app:load:runtime-config'"
       },
       "options": {
         "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json \\"{projectRoot}/public/runtime-config.json\\""
@@ -2780,27 +2780,27 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`npx nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
+Run \`pnpm nx build @proj/common-constructs [--skip-nx-cache]\` to build the application.
 
 ## Running unit tests
 
-Run \`npx nx test @proj/common-constructs\` to execute the unit tests via Vitest.
+Run \`pnpm nx test @proj/common-constructs\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`npx nx test @proj/common-constructs --configuration=update-snapshot\`
+\`pnpm nx test @proj/common-constructs --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`npx nx lint @proj/common-constructs\`
+Run \`pnpm nx lint @proj/common-constructs\`
 
 ### Fixable issues
 
 You can also automatiaclly fix some lint errors by running the following command:
 
-\`npx nx lint @proj/common-constructs --configuration=fix\`
+\`pnpm nx lint @proj/common-constructs --configuration=fix\`
 
 ## Useful links
 
@@ -3616,37 +3616,37 @@ This library was generated with [@aws/nx-plugin](https://github.com/awslabs/nx-p
 
 ## Building
 
-Run \`npx nx build @proj/test-app [--skip-nx-cache]\` to build the application.
+Run \`pnpm nx build @proj/test-app [--skip-nx-cache]\` to build the application.
 
 ## Run dev server
 
-Run \`npx nx serve @proj/test-app\`
+Run \`pnpm nx serve @proj/test-app\`
 
 ## Running unit tests
 
-Run \`npx nx test @proj/test-app\` to execute the unit tests via Vitest.
+Run \`pnpm nx test @proj/test-app\` to execute the unit tests via Vitest.
 
 ### Updating snapshots
 
 To update snapshots, run the following command:
 
-\`npx nx test @proj/test-app --configuration=update-snapshot\`
+\`pnpm nx test @proj/test-app --configuration=update-snapshot\`
 
 ## Run lint
 
-Run \`npx nx lint @proj/test-app\`
+Run \`pnpm nx lint @proj/test-app\`
 
 ### Fixable issues
 
 You can also automatically fix some lint errors by running the following command:
 
-\`npx nx lint @proj/test-app --configuration=fix\`
+\`pnpm nx lint @proj/test-app --configuration=fix\`
 
 ### Runtime config
 
 In order to integrate with cognito or trpc backends, you need to have a \`runtime-config.json\` file in your \`/public\` website directory. You can fetch this is follows:
 
-\`npx nx run @proj/test-app:load:runtime-config\`
+\`pnpm nx run @proj/test-app:load:runtime-config\`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed
@@ -3744,7 +3744,7 @@ exports[`react-website generator > Tanstack router integration > should generate
     "load:runtime-config": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'npx nx run @proj/test-app:load:runtime-config'"
+        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx run @proj/test-app:load:runtime-config'"
       },
       "options": {
         "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json \\"{projectRoot}/public/runtime-config.json\\""

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -65,12 +65,13 @@ resource "null_resource" "add_callback_url" {
     command = <<-EOT
       uv run --with boto3 python -c "
 import boto3
+import os
 import sys
 
 # Configuration
-user_pool_id = '\${local.user_pool_id}'
-client_id = '\${local.user_pool_client_id}'
-new_callback_url = '\${var.callback_url}'
+user_pool_id = os.environ['USER_POOL_ID']
+client_id = os.environ['CLIENT_ID']
+new_callback_url = os.environ['NEW_CALLBACK_URL']
 
 # Initialize Cognito client
 cognito = boto3.client('cognito-idp')
@@ -122,6 +123,11 @@ except Exception as e:
     sys.exit(1)
 "
     EOT
+    environment = {
+      USER_POOL_ID     = local.user_pool_id
+      CLIENT_ID        = local.user_pool_client_id
+      NEW_CALLBACK_URL = var.callback_url
+    }
   }
 
   depends_on = [terraform_data.validate_cognito_props]

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -235,6 +235,7 @@ resource "null_resource" "gateway_ready" {
     command = <<-EOT
       uv run --with boto3 --with httpx --with mcp python -c "
 import asyncio
+import os
 import time
 
 import boto3
@@ -244,8 +245,8 @@ from botocore.awsrequest import AWSRequest
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
-gateway_url = '${self.triggers.gateway_url}'
-region = '${self.triggers.region}'
+gateway_url = os.environ['GATEWAY_URL']
+region = os.environ['REGION']
 credentials = boto3.Session(region_name=region).get_credentials()
 signer = SigV4Auth(credentials, 'bedrock-agentcore', region)
 
@@ -293,6 +294,10 @@ while True:
 print(f'Gateway {gateway_url} is serving tools')
 "
     EOT
+    environment = {
+      GATEWAY_URL = self.triggers.gateway_url
+      REGION      = self.triggers.region
+    }
   }
 }
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -281,14 +281,19 @@ resource "null_resource" "docker_publish" {
   provisioner "local-exec" {
     command = <<-EOT
       # Get ECR login token
-      aws ecr get-login-password --region ${local.aws_region} | <%= containers %> login --username AWS --password-stdin ${self.triggers.repository_url}
+      aws ecr get-login-password --region "$AWS_REGION" | <%= containers %> login --username AWS --password-stdin "$REPOSITORY_URL"
 
       # Tag the image
-      <%= containers %> tag ${self.triggers.docker_image_tag} ${self.triggers.repository_url}:latest
+      <%= containers %> tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
 
       # Push the image
-      <%= containers %> push ${self.triggers.repository_url}:latest
+      <%= containers %> push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = local.aws_region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.agent_core_ecr_policy]
@@ -350,10 +355,11 @@ resource "null_resource" "runtime_ready" {
       uv run --with boto3 python -c "
 import boto3
 import json
+import os
 import time
 import uuid
 
-runtime_arn = '${self.triggers.runtime_arn}'
+runtime_arn = os.environ['RUNTIME_ARN']
 client = boto3.client('bedrock-agentcore')
 initialize_request = json.dumps({
     'jsonrpc': '2.0',
@@ -385,6 +391,9 @@ while True:
 print(f'Runtime {runtime_arn} is serving MCP')
 "
     EOT
+    environment = {
+      RUNTIME_ARN = self.triggers.runtime_arn
+    }
   }
 }
 

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
@@ -65,12 +65,13 @@ resource "null_resource" "aggregate_namespace" {
     command = <<-EOT
       uv run python -c "
 import json
+import os
 import pathlib
 import sys
 
-namespace = '${each.key}'
-entries_dir = pathlib.Path('${local.entries_dir}') / namespace
-output_file = pathlib.Path('${local.config_dir}') / f'{namespace}.json'
+namespace = os.environ['NAMESPACE']
+entries_dir = pathlib.Path(os.environ['ENTRIES_DIR']) / namespace
+output_file = pathlib.Path(os.environ['CONFIG_DIR']) / f'{namespace}.json'
 
 def deep_merge(target: dict, source: dict) -> dict:
     for k, v in source.items():
@@ -103,6 +104,11 @@ output_file.write_text(json.dumps(merged, indent=2))
 print(f'Aggregated {namespace}.json with {len(merged)} section(s)')
 "
     EOT
+    environment = {
+      NAMESPACE   = each.key
+      ENTRIES_DIR = local.entries_dir
+      CONFIG_DIR  = local.config_dir
+    }
   }
 }
 

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/read/read.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/read/read.tf.template
@@ -38,11 +38,12 @@ resource "null_resource" "aggregate_namespace" {
     command = <<-EOT
       uv run python -c "
 import json
+import os
 import pathlib
 import sys
 
-entries_dir = pathlib.Path('${local.entries_dir}')
-output_file = pathlib.Path('${local.namespace_path}')
+entries_dir = pathlib.Path(os.environ['ENTRIES_DIR'])
+output_file = pathlib.Path(os.environ['NAMESPACE_PATH'])
 
 def deep_merge(target: dict, source: dict) -> dict:
     for k, v in source.items():
@@ -71,6 +72,10 @@ output_file.parent.mkdir(parents=True, exist_ok=True)
 output_file.write_text(json.dumps(merged, indent=2))
 "
     EOT
+    environment = {
+      ENTRIES_DIR    = local.entries_dir
+      NAMESPACE_PATH = local.namespace_path
+    }
   }
 }
 

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
@@ -61,12 +61,13 @@ resource "null_resource" "add_callback_url" {
     command = <<-EOT
       uv run --with boto3 python -c "
 import boto3
+import os
 import sys
 
 # Configuration
-user_pool_id = '${local.user_pool_id}'
-client_id = '${local.user_pool_client_id}'
-new_callback_url = '${var.callback_url}'
+user_pool_id = os.environ['USER_POOL_ID']
+client_id = os.environ['CLIENT_ID']
+new_callback_url = os.environ['NEW_CALLBACK_URL']
 
 # Initialize Cognito client
 cognito = boto3.client('cognito-idp')
@@ -118,6 +119,11 @@ except Exception as e:
     sys.exit(1)
 "
     EOT
+    environment = {
+      USER_POOL_ID     = local.user_pool_id
+      CLIENT_ID        = local.user_pool_client_id
+      NEW_CALLBACK_URL = var.callback_url
+    }
   }
 
   depends_on = [terraform_data.validate_cognito_props]

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -287,10 +287,15 @@ resource "null_resource" "docker_publish" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      aws ecr get-login-password --region ${data.aws_region.current.region} | <%= containerEngine %> login --username AWS --password-stdin ${self.triggers.repository_url}
-      <%= containerEngine %> tag ${self.triggers.docker_image_tag} ${self.triggers.repository_url}:latest
-      <%= containerEngine %> push ${self.triggers.repository_url}:latest
+      aws ecr get-login-password --region "$AWS_REGION" | <%= containerEngine %> login --username AWS --password-stdin "$REPOSITORY_URL"
+      <%= containerEngine %> tag "$DOCKER_IMAGE_TAG" "$REPOSITORY_URL:latest"
+      <%= containerEngine %> push "$REPOSITORY_URL:latest"
     EOT
+    environment = {
+      AWS_REGION       = data.aws_region.current.region
+      REPOSITORY_URL   = self.triggers.repository_url
+      DOCKER_IMAGE_TAG = self.triggers.docker_image_tag
+    }
   }
 
   depends_on = [aws_ecr_repository_policy.migration_handler]
@@ -574,10 +579,10 @@ resource "null_resource" "create_db_user_trigger" {
     command = <<-EOT
       output_file=$(mktemp)
       response=$(aws lambda invoke \
-        --region ${data.aws_region.current.region} \
-        --function-name ${self.triggers.function_name} \
+        --region "$AWS_REGION" \
+        --function-name "$FUNCTION_NAME" \
         --cli-binary-format raw-in-base64-out \
-        --payload '{"RequestType":"Create","PhysicalResourceId":"db-user:${self.triggers.db_user}"}' \
+        --payload "{\"RequestType\":\"Create\",\"PhysicalResourceId\":\"db-user:$DB_USER\"}" \
         "$output_file")
       cat "$output_file"
       echo "$response"
@@ -587,6 +592,11 @@ resource "null_resource" "create_db_user_trigger" {
       fi
       rm -f "$output_file"
     EOT
+    environment = {
+      AWS_REGION    = data.aws_region.current.region
+      FUNCTION_NAME = self.triggers.function_name
+      DB_USER       = self.triggers.db_user
+    }
   }
 
   depends_on = [aws_lambda_function.create_db_user, module.aurora]
@@ -655,8 +665,8 @@ resource "null_resource" "migration_trigger" {
     command = <<-EOT
       output_file=$(mktemp)
       response=$(aws lambda invoke \
-        --region ${data.aws_region.current.region} \
-        --function-name ${self.triggers.function_name} \
+        --region "$AWS_REGION" \
+        --function-name "$FUNCTION_NAME" \
         --cli-binary-format raw-in-base64-out \
         "$output_file")
       cat "$output_file"
@@ -667,6 +677,10 @@ resource "null_resource" "migration_trigger" {
       fi
       rm -f "$output_file"
     EOT
+    environment = {
+      AWS_REGION    = data.aws_region.current.region
+      FUNCTION_NAME = self.triggers.function_name
+    }
   }
 
   depends_on = [

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -540,9 +540,9 @@ resource "null_resource" "proxy_target_ready" {
       deadline=$((start_time + 600))
       while true; do
         target_state=$(aws rds describe-db-proxy-targets \
-          --region ${data.aws_region.current.region} \
-          --db-proxy-name ${self.triggers.db_proxy_name} \
-          --target-group-name ${self.triggers.target_group_name} \
+          --region "$AWS_REGION" \
+          --db-proxy-name "$DB_PROXY_NAME" \
+          --target-group-name "$TARGET_GROUP_NAME" \
           --query "Targets[?Type=='RDS_INSTANCE'] | [0].TargetHealth.State" \
           --output text)
 
@@ -552,13 +552,19 @@ resource "null_resource" "proxy_target_ready" {
 
         current_time=$(date +%s)
         if [ "$current_time" -ge "$deadline" ]; then
-          echo "RDS Proxy target ${self.triggers.db_cluster_identifier} did not become AVAILABLE within 10 minutes. Last state: $target_state"
+          echo "RDS Proxy target $DB_CLUSTER_IDENTIFIER did not become AVAILABLE within 10 minutes. Last state: $target_state"
           exit 1
         fi
 
         sleep 10
       done
     EOT
+    environment = {
+      AWS_REGION            = data.aws_region.current.region
+      DB_PROXY_NAME         = self.triggers.db_proxy_name
+      TARGET_GROUP_NAME     = self.triggers.target_group_name
+      DB_CLUSTER_IDENTIFIER = self.triggers.db_cluster_identifier
+    }
   }
 
   depends_on = [

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -553,7 +553,7 @@ resource "null_resource" "upload_website_files" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      cd "${path.root}"
+      cd "$ROOT_PATH"
       uv run --with boto3 python3 -c "
 import os
 import sys
@@ -642,9 +642,14 @@ def sync_to_s3(local_path, bucket_name):
         sys.exit(1)
 
 # Execute sync
-sync_to_s3('${var.website_file_path}', '${aws_s3_bucket.website.bucket}')
+sync_to_s3(os.environ['WEBSITE_FILE_PATH'], os.environ['BUCKET_NAME'])
 "
     EOT
+    environment = {
+      ROOT_PATH         = path.root
+      WEBSITE_FILE_PATH = var.website_file_path
+      BUCKET_NAME       = aws_s3_bucket.website.bucket
+    }
   }
 
   depends_on = [aws_s3_bucket_policy.website_cloudfront_policy]
@@ -674,6 +679,7 @@ resource "null_resource" "cloudfront_invalidation" {
     command = <<-EOT
       uv run --with boto3 python3 -c "
 import boto3
+import os
 import sys
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -695,7 +701,7 @@ def create_invalidation(distribution_id):
 
         invalidation_id = response['Invalidation']['Id']
         print(f'CloudFront cache invalidation created: {invalidation_id}')
-        print(f'Distribution: ${aws_cloudfront_distribution.website.id}')
+        print(f'Distribution: {distribution_id}')
         print(f'Status: {response[\"Invalidation\"][\"Status\"]}')
 
     except NoCredentialsError:
@@ -709,9 +715,12 @@ def create_invalidation(distribution_id):
         sys.exit(1)
 
 # Execute invalidation
-create_invalidation('${aws_cloudfront_distribution.website.id}')
+create_invalidation(os.environ['DISTRIBUTION_ID'])
 "
     EOT
+    environment = {
+      DISTRIBUTION_ID = aws_cloudfront_distribution.website.id
+    }
   }
 
   depends_on = [


### PR DESCRIPTION
### Reason for this change

Generated Terraform `local-exec` provisioners interpolated variable values directly into the shell `command` string (e.g. `--function-name ${self.triggers.function_name}`, or inside embedded Python heredocs `runtime_arn = '${self.triggers.runtime_arn}'`). A value containing shell metacharacters, quotes or newlines could break out of the intended command or string literal, allowing arbitrary shell/Python execution at apply time. This is a shell-injection surface in the generated infrastructure code.

### Description of changes

For every generated `local-exec` block, Terraform-interpolated values are moved out of the `command` string into a provisioner `environment {}` block and referenced from there instead:

- Shell commands use `"$VAR_NAME"` instead of `${var.x}` / `${self.triggers.x}`.
- Embedded Python heredocs read `os.environ['VAR_NAME']` instead of inlining `'${...}'` into Python string literals (`import os` added where needed).

Generator template tokens (e.g. `<%= containers %>` / `<%= containerEngine %>`, which resolve to a static binary name at generation time) are left as-is; they are not runtime values and so are not an injection vector.

Blocks changed (12 across 9 templates): application main.tf echo; rdb aurora proxy readiness; rdb dbs ECR push + 2 Lambda invokes; agent-core ECR push + MCP readiness probe; agentcore-gateway readiness probe; identity add-callback-url Cognito update; runtime-config read + appconfig-deployment aggregation; static-website S3 sync + CloudFront invalidation.

This removes the shell-injection surface for generated provisioners. No consumer action needed - the generated code simply changes shape.

### Description of how you validated changes

Ran the affected generator unit tests with snapshot update; all pass and the snapshots reflect only the intended `environment {}` / `$VAR` / `os.environ` changes: ts/mcp-server, py/mcp-server, ts/agent, py/agent, ts/rdb, ts/react-website/cognito-auth (terraform), ts/react-website/app.

Additionally created a test workspace, linked the locally compiled plugin, scaffolded a project that generates Terraform `local-exec` provisioners, and ran `terraform init` + `terraform validate` against the rendered output (passes), confirming each changed block references `$VAR_NAME` in the command and defines the value in an `environment {}` block.

### Issue # (if applicable)

N/A (security hardening).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
