### PR TITLE
feat(connection): guard against unconsidered connection permutations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,33 @@ it('should be idempotent when re-run with same options', async () => {
 - **Component generators**: run twice with the same inputs and assert the tree is unchanged after the second run (no duplicate wiring), and that adding a second differently-named component leaves the first intact.
 - **Guarded refusals**: assert the generator throws the expected error on re-run.
 
+### Connection Permutations
+
+A common pitfall when working on connections is forgetting that a connection has to behave for _every_ combination of its source and target options, not just the defaults. The agent generators are the clearest example: a `py#agent` can connect to MCP servers, gateways, other agents and databases, and each side carries options — `framework`, `protocol`, `auth` — whose enum values multiply into many connection permutations. Adding a new value (say a new agent `framework`) silently introduces a whole new set of permutations that the connection generators have never been asked to handle.
+
+#### The principle
+
+> **Every connection permutation must be consciously considered.** For each combination of source and target options, the `connection` generator must _either_ vend valid, buildable code _or_ throw a clear "not supported" error. It must never crash unexpectedly or silently vend broken code.
+
+#### The guard
+
+The permutation guard lives next to the connection generator and makes "I forgot to consider that combination" a build failure rather than a runtime surprise:
+
+- **`connection/permutations.ts`** reads the enum dimensions of each connection-participating generator live from its `schema.json`. The enums _are_ the source of truth — there is no second list of options to keep in sync.
+- **`connection/connection-expectations.ts`** declares, for every supported `source -> target` routing pair, a function classifying each permutation as `supported` or `unsupported` (with a `RegExp` the thrown error must match). This is where you record _intent_: "cognito MCP servers aren't supported yet, and here's the error the user should see".
+- **`connection/permutations.spec.ts`** is the tripwire. It holds a committed snapshot of every connection type's schema enums and fails the build if the live schema drifts from it, and it asserts every cell of the full source × target cartesian is classified. Add an enum value and this test fails until you update both the snapshot and the expectations.
+- **`connection/permutations-behaviour.spec.ts`** runs the real `connection` generator on an in-memory tree for every permutation the table marks `unsupported`, asserting it throws the declared error.
+- **`e2e/src/smoke-tests/connection-permutations.spec.ts`** drives the actual CLI and a real build: supported agent variants must build, unsupported ones must fail at the CLI. Its cases derive from the same expectation table, so it extends automatically.
+
+#### What to do when the build fails here
+
+When you add an option (or a new connection), `permutations.spec.ts` will tell you exactly which pairs and cells are now unclassified. For each one, decide whether the connection should work, then either:
+
+- **support it** — wire it up in the relevant connection generator and classify the cell `supported`, or
+- **reject it** — make the connection generator throw a clear, actionable "not supported" error and classify the cell `unsupported` with a matching `errorMatches`.
+
+Update the `KNOWN_DIMENSIONS` snapshot in `permutations.spec.ts` _together with_ the expectation changes — never on its own.
+
 ### End to End Tests
 
 The end to end tests run our generators and check that generated projects function correctly (usually by performing a build).

--- a/e2e/src/smoke-tests/connection-permutations.spec.ts
+++ b/e2e/src/smoke-tests/connection-permutations.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { existsSync, rmSync } from 'node:fs';
+import { ensureDirSync } from 'fs-extra';
+import {
+  CONNECTION_EXPECTATIONS,
+  type ConnectionOutcome,
+} from '../../../packages/nx-plugin/src/connection/connection-expectations';
+import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
+
+/**
+ * End-to-end verification that agent connection permutations behave as the
+ * expectation table declares — using the real CLI and a real build.
+ *
+ * This complements the unit tiers (which run on an in-memory Tree):
+ *  - Unsupported permutations must fail the `connection` generator with the
+ *    declared error — the literal "throw a not-supported error" requirement,
+ *    proven through the actual CLI.
+ *  - Supported agent variants the default generator matrix doesn't cover
+ *    (cognito auth, AG-UI/A2A protocols) must vend code that actually builds.
+ *
+ * The cases are derived from CONNECTION_EXPECTATIONS, so adding an enum value
+ * (e.g. a new agent framework) and classifying its permutations automatically
+ * extends this test — there is no second list to maintain here.
+ */
+
+const outcomeFor = (
+  key: keyof typeof CONNECTION_EXPECTATIONS,
+  source: Record<string, string>,
+  target: Record<string, string>,
+): ConnectionOutcome => CONNECTION_EXPECTATIONS[key]({ source, target });
+
+describe('smoke test - connection-permutations', () => {
+  const pkgMgr = 'pnpm';
+  const targetDir = `${tmpProjPath()}/connection-permutations-${pkgMgr}`;
+
+  beforeEach(() => {
+    console.log(`Cleaning target directory ${targetDir}`);
+    if (existsSync(targetDir)) {
+      rmSync(targetDir, { force: true, recursive: true });
+    }
+    ensureDirSync(targetDir);
+  });
+
+  it('verifies agent connection permutations via the CLI and a build', async () => {
+    const projectRoot = await createTestWorkspace(
+      pkgMgr,
+      targetDir,
+      'e2e-test',
+      'cdk',
+    );
+    const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
+
+    // A Python host project holding agent + MCP server variants across the
+    // dimensions that affect connections (protocol, auth).
+    await runCLI(
+      `generate @aws/nx-plugin:py#project --name=agents --no-interactive`,
+      opts,
+    );
+
+    // Agent variants: protocol x auth, hosted on agentcore so auth applies.
+    const agents = [
+      { name: 'http-iam', protocol: 'http', auth: 'iam' },
+      { name: 'http-cognito', protocol: 'http', auth: 'cognito' },
+      { name: 'a2a-iam', protocol: 'a2a', auth: 'iam' },
+      { name: 'agui-iam', protocol: 'ag-ui', auth: 'iam' },
+    ] as const;
+    for (const a of agents) {
+      await runCLI(
+        `generate @aws/nx-plugin:py#agent --project=agents --name=${a.name} --protocol=${a.protocol} --auth=${a.auth} --no-interactive`,
+        opts,
+      );
+    }
+
+    // MCP server variants: iam vs cognito auth.
+    const mcpServers = [
+      { name: 'mcp-iam', auth: 'iam' },
+      { name: 'mcp-cognito', auth: 'cognito' },
+    ] as const;
+    for (const m of mcpServers) {
+      await runCLI(
+        `generate @aws/nx-plugin:py#mcp-server --project=agents --name=${m.name} --auth=${m.auth} --no-interactive`,
+        opts,
+      );
+    }
+
+    const connect = (sourceComponent: string, targetComponent: string) =>
+      `generate @aws/nx-plugin:connection --sourceProject=agents --sourceComponent=${sourceComponent} --targetProject=agents --targetComponent=${targetComponent} --no-interactive`;
+
+    // py#agent -> py#mcp-server: unsupported when the MCP server isn't IAM.
+    for (const agent of agents) {
+      for (const mcp of mcpServers) {
+        const outcome = outcomeFor(
+          'py#agent -> py#mcp-server',
+          { framework: 'strands', protocol: agent.protocol, auth: agent.auth },
+          { auth: mcp.auth },
+        );
+        if (outcome.kind === 'unsupported') {
+          console.log(
+            `Expecting failure: ${agent.name} -> ${mcp.name} (${outcome.errorMatches})`,
+          );
+          await expect(
+            runCLI(connect(agent.name, mcp.name), {
+              ...opts,
+              silenceError: false,
+            }),
+          ).rejects.toThrow();
+        } else {
+          await runCLI(connect(agent.name, mcp.name), opts);
+        }
+      }
+    }
+
+    // py#agent -> py#agent (A2A): unsupported unless the target speaks A2A.
+    for (const agent of agents) {
+      for (const targetAgent of agents) {
+        if (agent.name === targetAgent.name) continue;
+        const outcome = outcomeFor(
+          'py#agent -> py#agent',
+          { framework: 'strands', protocol: agent.protocol, auth: agent.auth },
+          {
+            framework: 'strands',
+            protocol: targetAgent.protocol,
+            auth: targetAgent.auth,
+          },
+        );
+        if (outcome.kind === 'unsupported') {
+          console.log(
+            `Expecting failure: ${agent.name} -> ${targetAgent.name} (${outcome.errorMatches})`,
+          );
+          await expect(
+            runCLI(connect(agent.name, targetAgent.name), {
+              ...opts,
+              silenceError: false,
+            }),
+          ).rejects.toThrow();
+        } else {
+          await runCLI(connect(agent.name, targetAgent.name), opts);
+        }
+      }
+    }
+
+    // Everything wired above that was supported must build.
+    await runCLI(`sync --verbose`, opts);
+    await runCLI(
+      `run-many --target build --all --output-style=stream --verbose`,
+      opts,
+    );
+  });
+});

--- a/packages/nx-plugin/src/connection/connection-expectations.ts
+++ b/packages/nx-plugin/src/connection/connection-expectations.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ConnectionKey } from './generator';
+import type { DimensionValues } from './permutations';
+
+/**
+ * The expected outcome of running the connection generator for a single
+ * permutation (one choice of source + target dimension values).
+ *
+ * - `supported` — the generator must succeed and vend valid (buildable) code.
+ * - `unsupported` — the generator must throw, and the message must match
+ *   `errorMatches` so users get a clear "not supported" signal rather than a
+ *   crash or, worse, silently broken generated code.
+ */
+export type ConnectionOutcome =
+  | { kind: 'supported' }
+  | { kind: 'unsupported'; errorMatches: RegExp };
+
+const supported = (): ConnectionOutcome => ({ kind: 'supported' });
+const unsupported = (errorMatches: RegExp): ConnectionOutcome => ({
+  kind: 'unsupported',
+  errorMatches,
+});
+
+/**
+ * Classifies a single connection permutation as supported or unsupported.
+ * Receives the resolved source/target dimension values (every enum property of
+ * each side's schema). Must return an outcome for *every* combination of the
+ * current enum values — the exhaustiveness test fails the build if any cell is
+ * left unclassified, which is what forces a contributor to consciously consider
+ * a newly added dimension value (e.g. a new agent `framework`).
+ */
+export type ConnectionExpectation = (cell: {
+  source: DimensionValues;
+  target: DimensionValues;
+}) => ConnectionOutcome;
+
+// Error fragments thrown by the leaf connection generators. Kept here so the
+// expectation table reads as a single source of truth for "what the user sees".
+const ERR_AGENT_FRAMEWORK = /does not support/; // frameworkLanguage(): unknown framework/protocol
+const ERR_MCP_IAM = /only supports IAM authentication/;
+const ERR_A2A_PROTOCOL = /only A2A agents can be connected/;
+const ERR_A2A_IAM = /only supports IAM authentication/;
+const ERR_GATEWAY_AGENT_IAM = /Only IAM-authenticated agents can connect/;
+const ERR_GATEWAY_MCP_IAM = /require the MCP server to use IAM/;
+const ERR_REACT_A2A = /Cannot connect a React website to an A2A agent/;
+
+/** The only agent framework currently wired into the connection clients. */
+const SUPPORTED_AGENT_FRAMEWORK = 'strands';
+
+/**
+ * An agent connecting over a framework-specific client (mcp/a2a/gateway) only
+ * works for frameworks wired into the connection-client registry. A new
+ * `framework` enum value with no registry entry must throw, not vend broken code.
+ */
+const agentFrameworkSupported = (agent: DimensionValues): boolean =>
+  agent.framework === SUPPORTED_AGENT_FRAMEWORK;
+
+/**
+ * Expected outcome per supported routing pair, across the full cartesian of
+ * both sides' schema enums. Every key in {@link SUPPORTED_CONNECTIONS} must
+ * appear here (enforced by the exhaustiveness test).
+ */
+export const CONNECTION_EXPECTATIONS: Record<
+  ConnectionKey,
+  ConnectionExpectation
+> = {
+  // --- React frontend -> API (framework-agnostic client generation) ---
+  'react -> ts#trpc-api': supported,
+  'react -> py#fast-api': supported,
+  'react -> smithy': supported,
+
+  // --- React frontend -> Agent (HTTP/AG-UI only; A2A has no browser client) ---
+  'react -> ts#agent': ({ target }) =>
+    target.protocol === 'a2a' ? unsupported(ERR_REACT_A2A) : supported(),
+  'react -> py#agent': ({ target }) =>
+    target.protocol === 'a2a' ? unsupported(ERR_REACT_A2A) : supported(),
+
+  // --- API -> Database (framework-agnostic) ---
+  'ts#trpc-api -> ts#rdb': supported,
+  'ts#trpc-api -> ts#dynamodb': supported,
+  'smithy -> ts#rdb': supported,
+  'smithy -> ts#dynamodb': supported,
+  'py#fast-api -> py#dynamodb': supported,
+
+  // --- MCP server -> Database (framework-agnostic) ---
+  'ts#mcp-server -> ts#rdb': supported,
+  'ts#mcp-server -> ts#dynamodb': supported,
+  'py#mcp-server -> py#dynamodb': supported,
+
+  // --- Agent -> Database (framework-agnostic data-access client) ---
+  'ts#agent -> ts#rdb': supported,
+  'ts#agent -> ts#dynamodb': supported,
+  'py#agent -> py#dynamodb': supported,
+
+  // --- Agent -> MCP server (IAM-auth target + framework-specific client) ---
+  'ts#agent -> ts#mcp-server': agentMcp,
+  'ts#agent -> py#mcp-server': agentMcp,
+  'py#agent -> ts#mcp-server': agentMcp,
+  'py#agent -> py#mcp-server': agentMcp,
+
+  // --- Agent -> Agent (A2A: target must speak A2A, IAM auth, known framework) ---
+  'ts#agent -> ts#agent': agentA2a,
+  'ts#agent -> py#agent': agentA2a,
+  'py#agent -> ts#agent': agentA2a,
+  'py#agent -> py#agent': agentA2a,
+
+  // --- Agent -> AgentCore Gateway (IAM-auth agent + known framework) ---
+  'ts#agent -> agentcore-gateway': agentGateway,
+  'py#agent -> agentcore-gateway': agentGateway,
+
+  // --- AgentCore Gateway -> MCP server (IAM-auth MCP target) ---
+  'agentcore-gateway -> ts#mcp-server': ({ target }) =>
+    target.auth === 'iam' ? supported() : unsupported(ERR_GATEWAY_MCP_IAM),
+  'agentcore-gateway -> py#mcp-server': ({ target }) =>
+    target.auth === 'iam' ? supported() : unsupported(ERR_GATEWAY_MCP_IAM),
+
+  // --- AgentCore Gateway -> AgentCore Gateway (target IAM auth; enum is iam-only) ---
+  'agentcore-gateway -> agentcore-gateway': supported,
+};
+
+/** Agent -> MCP server: target must use IAM, agent framework must be known. */
+function agentMcp({
+  source,
+  target,
+}: {
+  source: DimensionValues;
+  target: DimensionValues;
+}): ConnectionOutcome {
+  if (target.auth !== 'iam') return unsupported(ERR_MCP_IAM);
+  if (!agentFrameworkSupported(source)) return unsupported(ERR_AGENT_FRAMEWORK);
+  return supported();
+}
+
+/** Agent -> Agent: target must speak A2A + use IAM, source framework known. */
+function agentA2a({
+  source,
+  target,
+}: {
+  source: DimensionValues;
+  target: DimensionValues;
+}): ConnectionOutcome {
+  if (target.protocol !== 'a2a') return unsupported(ERR_A2A_PROTOCOL);
+  if (target.auth !== 'iam') return unsupported(ERR_A2A_IAM);
+  if (!agentFrameworkSupported(source)) return unsupported(ERR_AGENT_FRAMEWORK);
+  return supported();
+}
+
+/** Agent -> Gateway: agent must use IAM, agent framework must be known. */
+function agentGateway({
+  source,
+}: {
+  source: DimensionValues;
+  target: DimensionValues;
+}): ConnectionOutcome {
+  if (source.auth !== 'iam') return unsupported(ERR_GATEWAY_AGENT_IAM);
+  if (!agentFrameworkSupported(source)) return unsupported(ERR_AGENT_FRAMEWORK);
+  return supported();
+}

--- a/packages/nx-plugin/src/connection/generator.ts
+++ b/packages/nx-plugin/src/connection/generator.ts
@@ -85,7 +85,7 @@ export interface ResolvedConnection {
  * Enumerates the supported project connections.
  * Source and target can be project-level types or component generator ids.
  */
-const SUPPORTED_CONNECTIONS = [
+export const SUPPORTED_CONNECTIONS = [
   { source: 'ts#trpc-api', target: 'ts#rdb' },
   { source: 'ts#trpc-api', target: 'ts#dynamodb' },
   { source: 'ts#agent', target: 'ts#rdb' },
@@ -117,11 +117,12 @@ const SUPPORTED_CONNECTIONS = [
   { source: 'py#mcp-server', target: 'py#dynamodb' },
 ] as const satisfies readonly Connection[];
 
-type ConnectionKey = (typeof SUPPORTED_CONNECTIONS)[number] extends infer C
-  ? C extends Connection
-    ? `${C['source']} -> ${C['target']}`
-    : never
-  : never;
+export type ConnectionKey =
+  (typeof SUPPORTED_CONNECTIONS)[number] extends infer C
+    ? C extends Connection
+      ? `${C['source']} -> ${C['target']}`
+      : never
+    : never;
 
 /**
  * Generators for each connection type

--- a/packages/nx-plugin/src/connection/permutations-behaviour.spec.ts
+++ b/packages/nx-plugin/src/connection/permutations-behaviour.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTreeUsingTsSolutionSetup } from '../utils/test';
+import {
+  CONNECTION_EXPECTATIONS,
+  type ConnectionOutcome,
+} from './connection-expectations';
+import {
+  type ConnectionKey,
+  connectionGenerator,
+  SUPPORTED_CONNECTIONS,
+} from './generator';
+import {
+  type ConnectionType,
+  type DimensionValues,
+  readConnectionTypeDimensionDefaults,
+  readConnectionTypeDimensions,
+  sampleDimensionValues,
+} from './permutations';
+
+/**
+ * Behavioural verification of the permutation expectations, run entirely on an
+ * in-memory Tree (no installs/builds). The tier's job is to prove the
+ * `unsupported` rows of the expectation table are honest: that running the real
+ * connection generator for an unsupported permutation throws a clear,
+ * user-facing error rather than crashing or vending broken code.
+ *
+ * Validity of the *supported* permutations (that the vended code actually
+ * builds) is proven by the e2e build tier — it cannot be checked from a Tree.
+ */
+
+/**
+ * Write a project whose type + dimension values the connection generator can
+ * resolve. Each side gets at most one connection-participating component/type so
+ * `resolveConnection` is unambiguous.
+ */
+const writeProjectForType = (
+  tree: Tree,
+  projectName: string,
+  type: ConnectionType,
+  dims: DimensionValues,
+): void => {
+  const root = `packages/${projectName}`;
+  const componentMetadata = (generator: ConnectionType) => ({
+    generator,
+    name: projectName,
+    path: `src/${projectName}`,
+    rc: 'Comp',
+    port: 8080,
+    ...dims,
+  });
+
+  const writeJson = (metadata: object, extra: object = {}) =>
+    tree.write(
+      `${root}/project.json`,
+      JSON.stringify({
+        name: projectName,
+        root,
+        sourceRoot: `${root}/src`,
+        ...extra,
+        metadata,
+      }),
+    );
+
+  switch (type) {
+    case 'react':
+      tree.write(`${root}/src/main.tsx`, '');
+      writeJson({});
+      break;
+    case 'ts#trpc-api':
+      writeJson({ apiType: 'trpc' });
+      break;
+    case 'py#fast-api':
+      writeJson({ apiType: 'fast-api' });
+      break;
+    case 'smithy':
+      writeJson({ generator: 'smithy#project' });
+      break;
+    case 'ts#agent':
+    case 'py#agent':
+    case 'ts#mcp-server':
+    case 'py#mcp-server':
+      writeJson({ components: [componentMetadata(type)] });
+      break;
+    case 'agentcore-gateway':
+      writeJson({
+        generator: 'agentcore-gateway',
+        rc: 'Gw',
+        port: 9000,
+        ...dims,
+      });
+      break;
+    case 'ts#rdb':
+    case 'ts#dynamodb':
+    case 'py#dynamodb':
+      writeJson({ generator: type, ...dims });
+      break;
+  }
+};
+
+interface UnsupportedCase {
+  readonly key: ConnectionKey;
+  readonly source: ConnectionType;
+  readonly target: ConnectionType;
+  readonly sourceDims: DimensionValues;
+  readonly targetDims: DimensionValues;
+  readonly errorMatches: RegExp;
+}
+
+/**
+ * Build the list of sampled permutations the table marks `unsupported`, across
+ * every supported routing pair. A bounded sample per side (defaults + one per
+ * enum value) keeps this fast while still hitting each guard.
+ */
+const collectUnsupportedCases = (): UnsupportedCase[] => {
+  const cases: UnsupportedCase[] = [];
+  for (const connection of SUPPORTED_CONNECTIONS) {
+    const key = `${connection.source} -> ${connection.target}` as ConnectionKey;
+    const expectation = CONNECTION_EXPECTATIONS[key];
+    const source = connection.source as ConnectionType;
+    const target = connection.target as ConnectionType;
+    const sourceCells = sampleDimensionValues(
+      readConnectionTypeDimensions(source),
+      readConnectionTypeDimensionDefaults(source),
+    );
+    const targetCells = sampleDimensionValues(
+      readConnectionTypeDimensions(target),
+      readConnectionTypeDimensionDefaults(target),
+    );
+    for (const sourceDims of sourceCells) {
+      for (const targetDims of targetCells) {
+        const outcome: ConnectionOutcome = expectation({
+          source: sourceDims,
+          target: targetDims,
+        });
+        if (outcome.kind === 'unsupported') {
+          cases.push({
+            key,
+            source,
+            target,
+            sourceDims,
+            targetDims,
+            errorMatches: outcome.errorMatches,
+          });
+        }
+      }
+    }
+  }
+  return cases;
+};
+
+describe('connection permutations - behaviour', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const unsupportedCases = collectUnsupportedCases();
+
+  it('there are unsupported permutations to verify', () => {
+    // Sanity: if this ever hits zero, the sampling or expectations regressed.
+    expect(unsupportedCases.length).toBeGreaterThan(0);
+  });
+
+  describe('unsupported permutations throw a clear error', () => {
+    it.each(
+      unsupportedCases.map((c) => ({
+        ...c,
+        label: `${c.key} [src ${JSON.stringify(c.sourceDims)} -> tgt ${JSON.stringify(c.targetDims)}]`,
+      })),
+    )('$label', async ({
+      source,
+      target,
+      sourceDims,
+      targetDims,
+      errorMatches,
+    }) => {
+      writeProjectForType(tree, 'source_project', source, sourceDims);
+      writeProjectForType(tree, 'target_project', target, targetDims);
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'source_project',
+          targetProject: 'target_project',
+        }),
+      ).rejects.toThrow(errorMatches);
+    });
+  });
+});

--- a/packages/nx-plugin/src/connection/permutations.spec.ts
+++ b/packages/nx-plugin/src/connection/permutations.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { CONNECTION_EXPECTATIONS } from './connection-expectations';
+import { type ConnectionKey, SUPPORTED_CONNECTIONS } from './generator';
+import {
+  type ConnectionType,
+  enumerateDimensionValues,
+  readConnectionTypeDimensions,
+} from './permutations';
+
+/**
+ * Snapshot of every connection type's schema enum dimensions, committed
+ * deliberately. The test below asserts the live schemas still match this map.
+ *
+ * Adding (or removing) an enum value on any generator that participates in a
+ * connection — e.g. a new agent `framework`, a new mcp-server `auth` mode — is
+ * exactly the change that introduces unconsidered connection permutations. That
+ * change will fail this test, and the failure is the prompt to:
+ *   1. classify every new permutation in `connection-expectations.ts`
+ *      (supported, or unsupported with a clear error), and
+ *   2. update this snapshot to acknowledge the new dimension.
+ *
+ * Update this map ONLY together with the matching expectation changes.
+ */
+const KNOWN_DIMENSIONS: Record<ConnectionType, Record<string, string[]>> = {
+  'ts#trpc-api': {
+    integrationPattern: ['isolated', 'shared'],
+    auth: ['iam', 'cognito', 'custom'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['rest-lambda', 'http-lambda', 'none'],
+  },
+  'py#fast-api': {
+    integrationPattern: ['isolated', 'shared'],
+    auth: ['iam', 'cognito', 'custom'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['rest-lambda', 'http-lambda', 'none'],
+  },
+  react: {
+    framework: ['react'],
+    ux: ['none', 'cloudscape', 'shadcn'],
+    infra: ['cloudfront-s3', 'none'],
+    iac: ['inherit', 'cdk', 'terraform'],
+  },
+  smithy: {
+    integrationPattern: ['isolated', 'shared'],
+    auth: ['iam', 'cognito', 'custom'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['rest-lambda', 'none'],
+  },
+  'ts#rdb': {
+    infra: ['aurora', 'none'],
+    engine: ['postgres', 'mysql'],
+    framework: ['prisma'],
+    iac: ['inherit', 'cdk', 'terraform'],
+  },
+  'ts#dynamodb': {
+    framework: ['electrodb'],
+    infra: ['dynamodb', 'none'],
+    iac: ['inherit', 'cdk', 'terraform'],
+  },
+  'py#dynamodb': {
+    framework: ['pynamodb'],
+    infra: ['dynamodb', 'none'],
+    iac: ['inherit', 'cdk', 'terraform'],
+  },
+  'agentcore-gateway': {
+    protocol: ['mcp'],
+    auth: ['iam'],
+    infra: ['agentcore', 'none'],
+    iac: ['inherit', 'cdk', 'terraform'],
+  },
+  'ts#agent': {
+    framework: ['strands'],
+    auth: ['iam', 'cognito'],
+    protocol: ['http', 'a2a', 'ag-ui'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['agentcore', 'none'],
+  },
+  'py#agent': {
+    framework: ['strands'],
+    auth: ['iam', 'cognito'],
+    protocol: ['http', 'a2a', 'ag-ui'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['agentcore', 'none'],
+  },
+  'ts#mcp-server': {
+    auth: ['iam', 'cognito'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['agentcore', 'none'],
+  },
+  'py#mcp-server': {
+    auth: ['iam', 'cognito'],
+    iac: ['inherit', 'cdk', 'terraform'],
+    infra: ['agentcore', 'none'],
+  },
+};
+
+const connectionKey = (c: { source: string; target: string }): ConnectionKey =>
+  `${c.source} -> ${c.target}` as ConnectionKey;
+
+const allConnectionTypes = (): ConnectionType[] => [
+  ...new Set(SUPPORTED_CONNECTIONS.flatMap((c) => [c.source, c.target])),
+];
+
+describe('connection permutations guard', () => {
+  // The snapshot is the tripwire: any enum change to a connection-participating
+  // generator desyncs this from the live schema and fails here, forcing the
+  // contributor to consider the new permutations.
+  describe('schema dimensions match the committed snapshot', () => {
+    it.each(
+      allConnectionTypes(),
+    )('dimensions for %s are unchanged (update connection-expectations.ts + KNOWN_DIMENSIONS together)', (type) => {
+      expect(readConnectionTypeDimensions(type)).toEqual(
+        KNOWN_DIMENSIONS[type],
+      );
+    });
+
+    it('snapshot covers exactly the connection types in SUPPORTED_CONNECTIONS', () => {
+      expect(new Set(Object.keys(KNOWN_DIMENSIONS))).toEqual(
+        new Set(allConnectionTypes()),
+      );
+    });
+  });
+
+  // Every routing pair must have an expectation entry. (The Record type already
+  // enforces this at compile time; this guards against accidental loosening.)
+  it('every supported connection has an expectation', () => {
+    for (const connection of SUPPORTED_CONNECTIONS) {
+      const key = connectionKey(connection);
+      expect(
+        CONNECTION_EXPECTATIONS[key],
+        `No expectation declared for ${key}`,
+      ).toBeTypeOf('function');
+    }
+  });
+
+  // Exhaustiveness: every cell of the full source x target cartesian must be
+  // classified as either supported or unsupported. An unsupported outcome must
+  // carry a user-facing error matcher so the failure mode is a clear message,
+  // never a crash or silently-broken generated code.
+  describe('every permutation is classified', () => {
+    it.each(
+      SUPPORTED_CONNECTIONS.map((c) => connectionKey(c)),
+    )('%s classifies its full cartesian', (key) => {
+      const [source, target] = key.split(' -> ') as [
+        ConnectionType,
+        ConnectionType,
+      ];
+      const expectation = CONNECTION_EXPECTATIONS[key];
+      const sourceCells = enumerateDimensionValues(
+        readConnectionTypeDimensions(source),
+      );
+      const targetCells = enumerateDimensionValues(
+        readConnectionTypeDimensions(target),
+      );
+
+      for (const s of sourceCells) {
+        for (const t of targetCells) {
+          const outcome = expectation({ source: s, target: t });
+          const detail = `${key} @ source=${JSON.stringify(s)} target=${JSON.stringify(t)}`;
+          expect(
+            ['supported', 'unsupported'],
+            `Unclassified permutation ${detail}`,
+          ).toContain(outcome.kind);
+          if (outcome.kind === 'unsupported') {
+            expect(
+              outcome.errorMatches,
+              `unsupported outcome for ${detail} must declare errorMatches`,
+            ).toBeInstanceOf(RegExp);
+          }
+        }
+      }
+    });
+  });
+});

--- a/packages/nx-plugin/src/connection/permutations.ts
+++ b/packages/nx-plugin/src/connection/permutations.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { SUPPORTED_CONNECTIONS } from './generator';
+
+/**
+ * A connection type is either a project-level type (e.g. `react`, `ts#rdb`) or a
+ * component generator id (e.g. `ts#agent`, `py#mcp-server`) that participates in
+ * {@link SUPPORTED_CONNECTIONS}. Each maps to the schema of the generator that
+ * vends it, whose enum properties are the dimensions a connection may depend on.
+ */
+export type ConnectionType = (typeof SUPPORTED_CONNECTIONS)[number][
+  | 'source'
+  | 'target'];
+
+/**
+ * The schema that vends each connection type, relative to this directory. The
+ * enum properties of these schemas are the source of truth for the dimensions
+ * crossed into the permutation cartesian — adding an enum value here grows the
+ * cartesian and trips the permutation guard until the new value is classified.
+ */
+const CONNECTION_TYPE_SCHEMAS = {
+  'ts#trpc-api': '../trpc/backend/schema.json',
+  'py#fast-api': '../py/fast-api/schema.json',
+  react: '../ts/website/app/schema.json',
+  smithy: '../smithy/ts/api/schema.json',
+  'ts#rdb': '../ts/rdb/schema.json',
+  'ts#dynamodb': '../ts/dynamodb/schema.json',
+  'py#dynamodb': '../py/dynamodb/schema.json',
+  'agentcore-gateway': '../agentcore-gateway/schema.json',
+  'ts#agent': '../ts/agent/schema.json',
+  'py#agent': '../py/agent/schema.json',
+  'ts#mcp-server': '../ts/mcp-server/schema.json',
+  'py#mcp-server': '../py/mcp-server/schema.json',
+} as const satisfies Record<ConnectionType, string>;
+
+/** A connection type's enum dimensions, keyed by property name. */
+export type Dimensions = Record<string, readonly string[]>;
+
+/** A concrete choice of one value per dimension. */
+export type DimensionValues = Record<string, string>;
+
+/**
+ * Read the enum dimensions for a connection type live from its schema. Every
+ * `enum` property is treated as a dimension — no judgement about which enums
+ * affect a connection, so the cartesian is exhaustive by construction.
+ */
+export const readConnectionTypeDimensions = (
+  type: ConnectionType,
+): Dimensions => {
+  const schemaPath = join(__dirname, CONNECTION_TYPE_SCHEMAS[type]);
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+  const properties: Record<string, { enum?: string[] }> =
+    schema.properties ?? {};
+  return Object.fromEntries(
+    Object.entries(properties)
+      .filter(([, prop]) => Array.isArray(prop.enum))
+      .map(([name, prop]) => [name, prop.enum as string[]]),
+  );
+};
+
+/** The default value of each dimension, read live from the schema. */
+export const readConnectionTypeDimensionDefaults = (
+  type: ConnectionType,
+): DimensionValues => {
+  const schemaPath = join(__dirname, CONNECTION_TYPE_SCHEMAS[type]);
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+  const properties: Record<string, { enum?: string[]; default?: string }> =
+    schema.properties ?? {};
+  return Object.fromEntries(
+    Object.entries(properties)
+      .filter(([, prop]) => Array.isArray(prop.enum))
+      .map(([name, prop]) => [
+        name,
+        prop.default ?? (prop.enum as string[])[0],
+      ]),
+  );
+};
+
+/**
+ * The full cartesian product of a connection type's dimensions. With all enums
+ * crossed this can be large, which is fine for the (pure, fast) exhaustiveness
+ * check; behavioural tiers sample from it via {@link sampleDimensionValues}.
+ */
+export const enumerateDimensionValues = (
+  dimensions: Dimensions,
+): DimensionValues[] => {
+  const names = Object.keys(dimensions);
+  return names.reduce<DimensionValues[]>(
+    (acc, name) =>
+      acc.flatMap((partial) =>
+        dimensions[name].map((value) => ({ ...partial, [name]: value })),
+      ),
+    [{}],
+  );
+};
+
+/**
+ * A bounded, representative sample of a connection type's cartesian: the
+ * all-defaults cell plus, for each dimension, one cell per enum value with every
+ * other dimension at its default. Linear in the number of enum values, and every
+ * value appears at least once — enough for behavioural tiers that must actually
+ * generate or build each cell.
+ */
+export const sampleDimensionValues = (
+  dimensions: Dimensions,
+  defaults: DimensionValues,
+): DimensionValues[] => {
+  const seen = new Set<string>();
+  const samples: DimensionValues[] = [];
+  const add = (values: DimensionValues) => {
+    const key = JSON.stringify(values);
+    if (!seen.has(key)) {
+      seen.add(key);
+      samples.push(values);
+    }
+  };
+  add(defaults);
+  for (const [name, values] of Object.entries(dimensions)) {
+    for (const value of values) {
+      add({ ...defaults, [name]: value });
+    }
+  }
+  return samples;
+};


### PR DESCRIPTION
### Reason for this change

A common pitfall when contributing to the plugin is not being aware of the permutations of connections that need to be considered. A connection's behaviour depends on the options on *each* side — an agent's `framework`/`protocol`/`auth`, an MCP server's `auth`, a database's `engine`, and so on. Adding a new option value (e.g. a new agent framework) silently introduces a whole new set of source × target permutations that the connection generators have never been asked to handle. Nothing today signals that those permutations were missed, so it's easy to ship a connection that crashes or vends broken code for a combination nobody thought about.

The requirement: for every permutation, the `connection` generator must **either** vend valid, buildable code **or** throw a clear "not supported" error — never crash or silently emit broken code.

### Description of changes

Adds a permutation guard centred on the connection generator that makes "I forgot to consider that combination" a **build failure** rather than a runtime surprise. It derives everything from existing sources of truth, so it grows automatically as options are added:

- **`connection/permutations.ts`** — reads each connection type's enum dimensions live from its `schema.json`. The enums *are* the source of truth; there's no second list of options to keep in sync. Also provides full-cartesian enumeration and a bounded sampler.
- **`connection/connection-expectations.ts`** — declares, for every supported `source -> target` routing pair (type-bound to `ConnectionKey`), a function classifying each permutation as `supported` or `unsupported` (with the `RegExp` the thrown error must match). This is where contributors record *intent*.
- **`connection/permutations.spec.ts`** (unit tripwire) — holds a committed snapshot of every connection type's schema enums and fails the build if the live schema drifts from it, and asserts every cell of the full source × target cartesian is classified. Adding an enum value fails this test until both the snapshot and the expectations are updated.
- **`connection/permutations-behaviour.spec.ts`** (unit) — runs the **real** `connection` generator on an in-memory tree for every permutation marked `unsupported`, asserting it throws the declared error.
- **`e2e/.../connection-permutations.spec.ts`** (e2e) — drives the actual CLI and a real build: supported agent variants (cognito auth, AG-UI/A2A protocols) must build; unsupported ones must fail at the CLI. Cases derive from the same expectation table, so it auto-extends.
- Exports `SUPPORTED_CONNECTIONS` and `ConnectionKey` from the connection generator (previously module-private) so the guard can bind to them.
- Documents the guard and the "what to do when this build fails" workflow in **CONTRIBUTING.md**, next to the Generator Idempotency section.

The concrete `py#agent` example from the issue is fully covered: adding a new `framework` value immediately fails `permutations.spec.ts` for every agent-involving pair, forcing each new permutation to be classified as supported (and wired up) or unsupported (with a clear error).

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test` — full suite green (119 files, 2623 tests).
- New connection tests: 43 (exhaustiveness/tripwire) + 225 (behavioural) pass.
- Verified the tripwire actually trips: temporarily added `langgraph` to the `py#agent` framework enum and confirmed `permutations.spec.ts` fails with a message pointing at `connection-expectations.ts` + `KNOWN_DIMENSIONS`; reverted.
- `pnpm nx run @aws/nx-plugin:compile`, e2e `build` and `lint` targets all pass.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*