### PR TITLE
feat(py#agent): fail the build when an agent framework lacks connection support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,27 @@ it('should be idempotent when re-run with same options', async () => {
 - **Component generators**: run twice with the same inputs and assert the tree is unchanged after the second run (no duplicate wiring), and that adding a second differently-named component leaves the first intact.
 - **Guarded refusals**: assert the generator throws the expected error on re-run.
 
+### Connections and Agent Frameworks
+
+A connection is never just "project A talks to project B" — it has to behave for every combination of the options on each side. The agent generators are the sharpest example: an agent can connect to MCP servers, gateways and other agents, and its behaviour depends on the agent's _framework_ (`strands`, …). The pitfall is adding a new option value — say a new agent `framework` — implementing the generator that produces it, and forgetting that connections now have a combination they were never taught to handle.
+
+#### The principle
+
+> **Connection support is driven by one registry, and adding an option you can't connect must fail automatically.** A contributor should not have to remember to add a test, update a snapshot, or wire a smoke test for the new combination — the build should break on its own until the combination is either supported or cleanly rejected.
+
+#### How agent frameworks work
+
+The single source of truth for which frameworks have connection support is the `FRAMEWORKS` registry in `utils/agent-connection/agent-connection.ts`. Each entry maps a framework to its per-language, per-protocol client templates. The agent generators record the chosen `framework` in their component metadata, and the connection generators read it back and pass it through to the client emitters — so a connection always uses the agent's actual framework, never a hardcoded default.
+
+This makes a forgotten framework fail by construction:
+
+- `framework-support.spec.ts` reads the `framework` enum **live** from each agent's `schema.json` and asserts every value has a `FRAMEWORKS` entry for that language. Add `langchain` to the `py#agent` enum and this test fails immediately — no snapshot or second list to update.
+- `framework-clients.spec.ts` generates a client for every framework × protocol in the registry and asserts real code is emitted, so a registry entry can't be a hollow stub; it also asserts an unknown framework throws a clear "does not support" error rather than silently emitting another framework's client.
+
+#### Adding a framework
+
+Add the framework's templates to the `FRAMEWORKS` registry (and the schema enum). The tests above then pass for free. If you intentionally _don't_ support connections for a framework yet, don't add it to the schema enum — there's no way to offer an agent option the connections can't honour without the build telling you.
+
 ### End to End Tests
 
 The end to end tests run our generators and check that generated projects function correctly (usually by performing a build).

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -90,7 +90,7 @@ export const pyAgentA2aConnectionGenerator = async (
   // 1. Ensure the shared Python agent-connection project exists + has the
   //    A2A core client and its shared SigV4 auth helper.
   await ensurePythonAgentConnectionProject(tree);
-  await addPythonCoreClient(tree, 'a2a');
+  await addPythonCoreClient(tree, 'a2a', agentComponent.framework);
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
@@ -84,7 +84,7 @@ export const pyAgentGatewayConnectionGenerator = async (
   const gatewayServeLocalTargetName = `${gatewayKebabCase}-serve-local`;
 
   await ensurePythonAgentConnectionProject(tree);
-  await addPythonCoreClient(tree, 'gateway');
+  await addPythonCoreClient(tree, 'gateway', agentComponent.framework);
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -100,6 +100,7 @@ export const pyAgentGenerator = async (
   }
 
   const auth = options.auth ?? 'iam';
+  const framework = options.framework ?? 'strands';
 
   // Ensure the shared agent-connection project exists so the server entry
   // point can import `session_id_context` and propagate the AgentCore
@@ -108,7 +109,7 @@ export const pyAgentGenerator = async (
   await ensurePythonAgentConnectionProject(tree);
   // The agent server imports the framework base helpers (session cache + model
   // error logging) regardless of whether a connection client is wired in.
-  await addPythonFrameworkBase(tree);
+  await addPythonFrameworkBase(tree, framework);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
   const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
   addWorkspaceDependencyToPyProject(
@@ -413,6 +414,7 @@ export const pyAgentGenerator = async (
       rc: agentNameClassName,
       auth,
       protocol,
+      framework,
     },
   );
 

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
@@ -75,7 +75,7 @@ export const pyAgentMcpConnectionGenerator = async (
   // 1. Ensure the shared Python agent-connection project exists + has the
   //    MCP core client and its shared SigV4 auth helper.
   await ensurePythonAgentConnectionProject(tree);
-  await addPythonCoreClient(tree, 'mcp');
+  await addPythonCoreClient(tree, 'mcp', agentComponent.framework);
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
@@ -84,7 +84,7 @@ export const tsAgentA2aConnectionGenerator = async (
 
   // 1. Ensure the shared agent-connection project exists + has the A2A core client
   await ensureTypeScriptAgentConnectionProject(tree);
-  await addTypeScriptCoreClient(tree, 'a2a');
+  await addTypeScriptCoreClient(tree, 'a2a', agentComponent.framework);
 
   // 2. Generate the per-connection <Name>Client into app/
   generateFiles(

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
@@ -83,7 +83,7 @@ export const tsAgentGatewayConnectionGenerator = async (
   // 1. Ensure the shared agent-connection project exists + has the gateway
   //    core client template.
   await ensureTypeScriptAgentConnectionProject(tree);
-  await addTypeScriptCoreClient(tree, 'gateway');
+  await addTypeScriptCoreClient(tree, 'gateway', agentComponent.framework);
 
   // 2. Generate the per-connection <Gateway>Client into app/. Local mode
   //    points at the gateway project's local gateway port.

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -79,6 +79,7 @@ export const tsAgentGenerator = async (
   }
 
   const auth = options.auth ?? 'iam';
+  const framework = options.framework ?? 'strands';
 
   // Ensure the shared agent-connection project exists so the server entry
   // point can import `runWithSessionId` and propagate the AgentCore session
@@ -87,7 +88,7 @@ export const tsAgentGenerator = async (
   await ensureTypeScriptAgentConnectionProject(tree);
   // The agent server imports the framework base helpers (session cache + model
   // error logging) regardless of whether a connection client is wired in.
-  await addTypeScriptFrameworkBase(tree);
+  await addTypeScriptFrameworkBase(tree, framework);
 
   const templateContext = {
     name,
@@ -317,7 +318,7 @@ export const tsAgentGenerator = async (
     TS_AGENT_GENERATOR_INFO,
     targetSourceDirRelativeToProjectRoot,
     agentTargetPrefix,
-    { port: localDevPort, rc: agentNameClassName, auth, protocol },
+    { port: localDevPort, rc: agentNameClassName, auth, protocol, framework },
   );
 
   await addGeneratorMetricsIfApplicable(tree, [TS_AGENT_GENERATOR_INFO]);

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
@@ -72,7 +72,7 @@ export const tsAgentMcpConnectionGenerator = async (
 
   // 1. Ensure the shared agent-connection project exists + has the MCP core client
   await ensureTypeScriptAgentConnectionProject(tree);
-  await addTypeScriptCoreClient(tree, 'mcp');
+  await addTypeScriptCoreClient(tree, 'mcp', agentComponent.framework);
 
   // 2. Generate the per-connection <Name>Client into app/
   generateFiles(

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -146,22 +146,73 @@ const FRAMEWORKS: Record<AgentFramework, FrameworkTemplates> = {
   },
 };
 
+/** The frameworks that have connection support, derived from the registry. */
+export const SUPPORTED_AGENT_FRAMEWORKS = Object.keys(
+  FRAMEWORKS,
+) as AgentFramework[];
+
+/**
+ * Whether a framework has connection support wired in for the given language.
+ * Derived from the `FRAMEWORKS` registry — the single source of truth for
+ * connection support — so the framework guard cannot drift from reality.
+ */
+export const frameworkSupportsLanguage = (
+  framework: string,
+  language: 'ts' | 'py',
+): boolean =>
+  Boolean(
+    (FRAMEWORKS as Record<string, FrameworkTemplates>)[framework]?.[language],
+  );
+
+/**
+ * The connection protocols a framework declares support for in a language,
+ * read from the registry. Empty if the framework doesn't target the language.
+ */
+export const frameworkProtocols = (
+  framework: AgentFramework,
+  language: 'ts' | 'py',
+): ConnectionProtocol[] => {
+  const lang = FRAMEWORKS[framework][language];
+  return lang ? (Object.keys(lang.protocols) as ConnectionProtocol[]) : [];
+};
+
+const languageLabel = (language: 'ts' | 'py') =>
+  language === 'ts' ? 'TypeScript' : 'Python';
+
+/**
+ * Narrow an agent's recorded framework (a free-form string from component
+ * metadata) to a known {@link AgentFramework}, or throw a clear not-supported
+ * error. This is the single point that rejects a framework which exists in the
+ * `py#agent`/`ts#agent` schema enum but has no connection support wired into
+ * the `FRAMEWORKS` registry — so a forgotten framework throws cleanly here
+ * instead of silently falling back to another framework's client.
+ */
+const resolveFramework = (
+  framework: string,
+  language: 'ts' | 'py',
+): AgentFramework => {
+  const lang = (FRAMEWORKS as Record<string, FrameworkTemplates>)[framework]?.[
+    language
+  ];
+  if (!lang) {
+    throw new Error(
+      `The '${framework}' framework does not support ${languageLabel(language)} agents.`,
+    );
+  }
+  return framework as AgentFramework;
+};
+
 /** Resolve a framework's templates for a language + protocol, or throw. */
 function frameworkLanguage<L extends 'ts' | 'py'>(
-  framework: AgentFramework,
+  framework: string,
   language: L,
   protocol: ConnectionProtocol,
 ): NonNullable<FrameworkTemplates[L]> & { protocol: string } {
-  const lang = FRAMEWORKS[framework][language];
-  if (!lang) {
-    throw new Error(
-      `The '${framework}' framework does not support ${language === 'ts' ? 'TypeScript' : 'Python'} agents.`,
-    );
-  }
-  const protocolDir = lang.protocols[protocol];
+  const lang = FRAMEWORKS[resolveFramework(framework, language)][language];
+  const protocolDir = lang!.protocols[protocol];
   if (!protocolDir) {
     throw new Error(
-      `The '${framework}' framework does not support ${protocol} connections for ${language === 'ts' ? 'TypeScript' : 'Python'} agents.`,
+      `The '${framework}' framework does not support ${protocol} connections for ${languageLabel(language)} agents.`,
     );
   }
   return { ...lang, protocol: protocolDir } as NonNullable<
@@ -225,14 +276,9 @@ export async function ensureTypeScriptAgentConnectionProject(
  */
 export async function addTypeScriptFrameworkBase(
   tree: Tree,
-  framework: AgentFramework = 'strands',
+  framework: string = 'strands',
 ): Promise<void> {
-  const lang = FRAMEWORKS[framework].ts;
-  if (!lang) {
-    throw new Error(
-      `The '${framework}' framework does not support TypeScript agents.`,
-    );
-  }
+  const lang = FRAMEWORKS[resolveFramework(framework, 'ts')].ts!;
   emitTs(tree, lang.base);
 
   const indexPath = joinPathFragments(
@@ -258,7 +304,7 @@ export async function addTypeScriptFrameworkBase(
 export async function addTypeScriptCoreClient(
   tree: Tree,
   protocol: ConnectionProtocol,
-  framework: AgentFramework = 'strands',
+  framework: string = 'strands',
 ): Promise<void> {
   const fw = frameworkLanguage(framework, 'ts', protocol);
 
@@ -363,14 +409,9 @@ const emitPy = (tree: Tree, templateDir: string) =>
  */
 export async function addPythonFrameworkBase(
   tree: Tree,
-  framework: AgentFramework = 'strands',
+  framework: string = 'strands',
 ): Promise<void> {
-  const lang = FRAMEWORKS[framework].py;
-  if (!lang) {
-    throw new Error(
-      `The '${framework}' framework does not support Python agents.`,
-    );
-  }
+  const lang = FRAMEWORKS[resolveFramework(framework, 'py')].py!;
   emitPy(tree, lang.base);
 
   const moduleInitPath = joinPathFragments(
@@ -413,7 +454,7 @@ export async function addPythonFrameworkBase(
 export async function addPythonCoreClient(
   tree: Tree,
   protocol: ConnectionProtocol,
-  framework: AgentFramework = 'strands',
+  framework: string = 'strands',
 ): Promise<void> {
   const fw = frameworkLanguage(framework, 'py', protocol);
 

--- a/packages/nx-plugin/src/utils/agent-connection/framework-clients.spec.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/framework-clients.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTreeUsingTsSolutionSetup } from '../test';
+import {
+  addPythonCoreClient,
+  addTypeScriptCoreClient,
+  ensurePythonAgentConnectionProject,
+  ensureTypeScriptAgentConnectionProject,
+  frameworkProtocols,
+  getPythonAgentConnectionModuleName,
+  getPythonAgentConnectionProjectDir,
+  SUPPORTED_AGENT_FRAMEWORKS,
+} from './agent-connection';
+
+/**
+ * Behavioural backstop for the framework registry: it proves a `FRAMEWORKS`
+ * entry is real, not a hollow stub. For every framework × every protocol it
+ * claims to support, generating the connection client must emit framework code
+ * into the shared agent-connection project. This means the framework guard
+ * (framework-support.spec.ts) can't be satisfied by registering a framework
+ * whose templates don't actually exist.
+ *
+ * It also pins the threading: an unknown framework (one not in the registry,
+ * the state right after a contributor adds a schema enum value but forgets to
+ * wire connections) must throw a clear not-supported error rather than silently
+ * falling back to another framework's client.
+ */
+
+const countFiles = (tree: Tree, dir: string): number => {
+  if (!tree.exists(dir)) return 0;
+  return tree
+    .children(dir)
+    .reduce(
+      (total, child) =>
+        total +
+        (tree.isFile(`${dir}/${child}`) ? 1 : countFiles(tree, `${dir}/${child}`)),
+      0,
+    );
+};
+
+describe('agent framework connection clients', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  describe('every registered framework vends real client code', () => {
+    for (const framework of SUPPORTED_AGENT_FRAMEWORKS) {
+      for (const protocol of frameworkProtocols(framework, 'py')) {
+        it(`py: ${framework} emits a ${protocol} client`, async () => {
+          await ensurePythonAgentConnectionProject(tree);
+          const coreDir = `${getPythonAgentConnectionProjectDir(tree)}/${getPythonAgentConnectionModuleName(tree)}/core`;
+          const before = countFiles(tree, coreDir);
+
+          await addPythonCoreClient(tree, protocol, framework);
+
+          expect(countFiles(tree, coreDir)).toBeGreaterThan(before);
+        });
+      }
+
+      for (const protocol of frameworkProtocols(framework, 'ts')) {
+        it(`ts: ${framework} emits a ${protocol} client`, async () => {
+          await ensureTypeScriptAgentConnectionProject(tree);
+          const coreDir = 'packages/common/agent-connection/src/core';
+          const before = countFiles(tree, coreDir);
+
+          await addTypeScriptCoreClient(tree, protocol, framework);
+
+          expect(countFiles(tree, coreDir)).toBeGreaterThan(before);
+        });
+      }
+    }
+  });
+
+  describe('an unknown framework throws a clear not-supported error', () => {
+    it('py: rejects with a not-supported message', async () => {
+      await ensurePythonAgentConnectionProject(tree);
+      await expect(
+        addPythonCoreClient(tree, 'mcp', 'definitely-not-a-framework'),
+      ).rejects.toThrow(/does not support Python agents/);
+    });
+
+    it('ts: rejects with a not-supported message', async () => {
+      await ensureTypeScriptAgentConnectionProject(tree);
+      await expect(
+        addTypeScriptCoreClient(tree, 'mcp', 'definitely-not-a-framework'),
+      ).rejects.toThrow(/does not support TypeScript agents/);
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/agent-connection/framework-support.spec.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/framework-support.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { frameworkSupportsLanguage } from './agent-connection';
+
+/**
+ * Automatic guard against adding an agent framework without connection support.
+ *
+ * The `framework` enum in each agent generator's `schema.json` is the *only*
+ * thing a contributor edits to offer a new framework. This test reads that enum
+ * live and asserts every value has connection support wired into the
+ * `FRAMEWORKS` registry (which drives all connection codegen) for that language.
+ *
+ * So if someone adds e.g. `langchain` to `py#agent` and implements the agent
+ * but forgets connections, this test fails on its own — no snapshot to update,
+ * no per-framework smoke test to remember. The fix is to either add a
+ * `FRAMEWORKS` entry (wiring up the connection clients) or not offer the
+ * framework in the schema enum.
+ */
+
+const AGENT_SCHEMAS: { id: string; language: 'ts' | 'py'; schema: string }[] = [
+  { id: 'ts#agent', language: 'ts', schema: '../../ts/agent/schema.json' },
+  { id: 'py#agent', language: 'py', schema: '../../py/agent/schema.json' },
+];
+
+const readFrameworkEnum = (schemaRelativePath: string): string[] => {
+  const schema = JSON.parse(
+    readFileSync(join(__dirname, schemaRelativePath), 'utf-8'),
+  );
+  const frameworkEnum: unknown = schema?.properties?.framework?.enum;
+  if (!Array.isArray(frameworkEnum)) {
+    throw new Error(
+      `Expected a 'framework' enum in ${schemaRelativePath}. If the agent no longer has a framework option, update this guard.`,
+    );
+  }
+  return frameworkEnum as string[];
+};
+
+describe('agent framework connection support', () => {
+  it.each(AGENT_SCHEMAS)(
+    '$id: every framework in the schema enum has connection support',
+    ({ language, schema }) => {
+      const frameworks = readFrameworkEnum(schema);
+      const missing = frameworks.filter(
+        (framework) => !frameworkSupportsLanguage(framework, language),
+      );
+      expect(
+        missing,
+        `These frameworks are offered in the ${schema} enum but have no ` +
+          `connection support in the FRAMEWORKS registry ` +
+          `(utils/agent-connection/agent-connection.ts): ${missing.join(', ')}. ` +
+          `Add a FRAMEWORKS entry wiring up the connection client templates, ` +
+          `or remove the framework from the schema enum.`,
+      ).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
### Reason for this change

A common pitfall when contributing is not being aware of the permutations of connections that need to be considered. The agent generators are the sharpest example: an agent can connect to MCP servers, gateways and other agents, and its connection behaviour depends on the agent's `framework`.

Concretely — today if a contributor adds a new framework (e.g. `langchain`) to the `py#agent`/`ts#agent` `framework` enum and implements the agent generator, **connections break silently**:

- the agent generator never recorded the chosen framework anywhere, and
- the connection generators (mcp/a2a/gateway) called the client emitters with a hardcoded `framework = 'strands'` default.

So a `langchain` agent's connections would emit **strands** client code, and nothing — no build, no test — would fail. The contributor gets no signal that they forgot to consider connections.

### Description of changes

Make a forgotten framework fail the build **automatically**, driven by the one thing a contributor edits (the schema enum) and the one registry that already governs connection codegen (`FRAMEWORKS`) — no snapshot or parallel list to remember.

**Threading (so the guard reflects reality):**
- `py#agent` and `ts#agent` now record the chosen `framework` in their component metadata.
- The mcp/a2a/gateway connection generators read the agent's recorded framework and pass it to `addPythonCoreClient` / `addTypeScriptCoreClient` instead of hardcoding `'strands'`.
- An unknown framework now throws a clear `The '<framework>' framework does not support … agents` error (via a small `resolveFramework` helper) instead of silently emitting another framework's client.

**Automatic guards:**
- `utils/agent-connection/framework-support.spec.ts` reads the `framework` enum **live** from each agent's `schema.json` and asserts every value has a `FRAMEWORKS` registry entry for that language. Add `langchain` to the enum → this test fails on its own, with a message saying to add a registry entry or remove the enum value.
- `utils/agent-connection/framework-clients.spec.ts` generates a client for every framework × protocol declared in the registry and asserts real code is emitted (a registry entry can't be a hollow stub), and asserts an unknown framework throws cleanly.

**Docs:** a "Connections and Agent Frameworks" section in CONTRIBUTING.md explaining the registry-driven model and the guards.

### Description of how you validated changes

- Verified the guard trips automatically: temporarily added `langchain` to `py/agent/schema.json`'s `framework` enum and **nothing else** — `framework-support.spec.ts` failed with `These frameworks are offered in the … enum but have no connection support in the FRAMEWORKS registry: langchain`. Reverted.
- `pnpm nx run @aws/nx-plugin:test` — full suite green (119 files, 2365 tests), including the two new specs; existing agent/connection specs unaffected and no snapshot changes.
- `pnpm nx run @aws/nx-plugin:compile` and lint pass.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*