### PR TITLE
fix(py#agent): drop doubled /invocations in HTTP agent serve-local URL

### DIFF
--- a/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
@@ -449,9 +449,15 @@ describe('py strands agent react connection with real projects', {
       'utf-8',
     );
 
-    // Verify that the runtime config includes the agent runtime override
+    // Verify that the runtime config includes the agent runtime override. The
+    // HTTP agent is invoked through the generated OpenAPI client, which appends
+    // the `/invocations` operation path itself, so the serve-local base URL
+    // must omit it (otherwise requests hit `/invocations/invocations`).
     expect(runtimeConfigContent).toContain('runtimeConfig.agentRuntimes.');
-    expect(runtimeConfigContent).toContain('http://localhost:');
+    expect(runtimeConfigContent).toMatch(
+      /runtimeConfig\.agentRuntimes\.\w+ = 'http:\/\/localhost:\d+';/,
+    );
+    expect(runtimeConfigContent).not.toContain('/invocations');
 
     // Re-read agent project config after connection generator ran
     const updatedAgentConfig = readProjectConfiguration(

--- a/packages/nx-plugin/src/py/agent/react-connection/serve-local.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/serve-local.ts
@@ -25,12 +25,22 @@ export const addPyAgentTargetToServeLocal = async (
   targetProjectName: string,
   options: PyAgentServeLocalOptions,
 ) => {
+  // AG-UI clients POST to the runtime config URL directly, so it must point at
+  // the agent's `/invocations` endpoint. HTTP agents go through the generated
+  // OpenAPI client, which appends the `/invocations` operation path itself, so
+  // its base URL must omit it (otherwise the request hits `/invocations/invocations`).
+  const protocol = (options.targetComponent?.protocol ?? 'http').toLowerCase();
+  const localUrl =
+    protocol === 'ag-ui'
+      ? `http://localhost:${options.port}/invocations`
+      : `http://localhost:${options.port}`;
+
   await addAgentTargetToServeLocal(tree, sourceProjectName, targetProjectName, {
     agentNameClassName: options.agentNameClassName,
     port: options.port,
     targetComponent: options.targetComponent,
     runtimeConfigNamespace: 'agentRuntimes',
-    localUrl: `http://localhost:${options.port}/invocations`,
+    localUrl,
     additionalDependencyTargets: options.additionalDependencyTargets,
   });
 };


### PR DESCRIPTION
### Reason for this change

When a React website is connected to a Python **HTTP** agent, the `serve-local` runtime-config override pointed at `http://localhost:PORT/invocations`. The website's generated OpenAPI client appends the `/invocations` operation path itself, so a browser request from the locally-served website hits `http://localhost:PORT/invocations/invocations` and returns 404.

The deployed path was unaffected: there the base URL is derived from the AgentCore runtime ARN (no `/invocations` suffix), so the client appends it once.

### Description of changes

Base the serve-local override URL on the agent's protocol, matching the existing chat-target convention in `py#agent`:

- **AG-UI** agents: the CopilotKit/`@ag-ui/client` client POSTs to the runtime-config URL directly, so it keeps `http://localhost:PORT/invocations`.
- **HTTP** agents: invoked through the generated OpenAPI client (which appends `/invocations`), so the base URL is now the bare `http://localhost:PORT`.

### Description of how you validated changes

- Updated the `py#agent` react-connection unit test to assert the HTTP agent's serve-local base URL is `http://localhost:PORT` with no `/invocations` suffix; the full `py/agent/react-connection` spec passes (37/37).
- Originally surfaced by a browser-driven website integration test (separate PR) where a locally-served website failed to reach its connected Python HTTP agent.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*