### PR TITLE
feat(py#agent): support langchain http and a2a protocols

### DIFF
--- a/docs/src/content/docs/en/guides/py-agent.mdx
+++ b/docs/src/content/docs/en/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 Generate a Python AI agent for building agents with tools, and optionally deploy it to [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Choose the agent framework with the `framework` option: [Strands](https://strandsagents.com/) (the default) or [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (built on [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-The generator exposes your agent over a server `protocol`. Strands agents support [HTTP](https://fastapi.tiangolo.com/) (the default), the [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) protocol for interoperability with other A2A-compatible agents, and the [AG-UI](https://docs.ag-ui.com/) protocol for direct frontend integration via [CopilotKit](https://docs.copilotkit.ai/). LangChain agents support the `ag-ui` protocol.
+The generator exposes your agent over a server `protocol`. Both frameworks support [HTTP](https://fastapi.tiangolo.com/) (the default), the [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) protocol for interoperability with other A2A-compatible agents, and the [AG-UI](https://docs.ag-ui.com/) protocol for direct frontend integration via [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Usage
 
@@ -55,10 +55,10 @@ The generator will add the following files to your existing Python project. The 
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### A2A Protocol
 
-The entry point uses the [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) instead of FastAPI:
+The entry point exposes your agent over the A2A protocol (Strands uses the [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain wraps the graph in an [`a2a-sdk`](https://a2a-protocol.org/) executor), mounted onto a FastAPI app:
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ The entry point uses the [Strands A2A Server](https://strandsagents.com/docs/use
         - agent.py Main agent definition with sample tools
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
-    - pyproject.toml Updated with Strands dependencies
+    - pyproject.toml Updated with framework and A2A dependencies
     - project.json Updated with agent serve targets
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ For a more in-depth guide to writing agents, refer to the [Strands](https://stra
 Your agent's server protocol determines how it communicates. All options are served by [FastAPI](https://fastapi.tiangolo.com/) — the entry point differs:
 
 - **HTTP** (default): A standard FastAPI server with a custom `/invocations` endpoint, CORS, and streaming. Best for custom client integrations.
-- **A2A**: The [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) mounted onto a FastAPI app. Best when your agent needs to be discoverable and invokable by other A2A-compatible agents.
-- **AG-UI**: The [ag-ui-strands](https://docs.ag-ui.com/) integration, which exposes the [AG-UI protocol](https://docs.ag-ui.com/) over SSE. Best for direct frontend integration with [CopilotKit](https://docs.copilotkit.ai/) in a React website.
+- **A2A**: An [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) server mounted onto a FastAPI app (Strands uses the [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain uses the framework-agnostic [`a2a-sdk`](https://a2a-protocol.org/)). Best when your agent needs to be discoverable and invokable by other A2A-compatible agents.
+- **AG-UI**: The [AG-UI protocol](https://docs.ag-ui.com/) over SSE (Strands uses `ag-ui-strands`; LangChain uses `ag-ui-langgraph`). Best for direct frontend integration with [CopilotKit](https://docs.copilotkit.ai/) in a React website.
+
+The server entry point differs by framework (Strands yields a context-managed `Agent`, while LangChain drives a compiled `create_agent` graph), but the external contract for each protocol is the same.
 
 All protocols expose `/ping` for the AgentCore runtime health check contract. A2A agents listen on port `9000`; HTTP and AG-UI agents listen on port `8080`. The generated Dockerfile and infrastructure are configured for you.
-
-:::note[LangChain supports AG-UI only]
-The `langchain` framework currently supports only the `ag-ui` protocol. Choose the default `strands` framework if you need the `http` or `a2a` protocol.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPI Server (HTTP protocol)
@@ -373,9 +371,9 @@ Since the generator vends CDK or Terraform infrastructure which manages deployin
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A Server (A2A protocol)
 
-The generated `main.py` mounts `A2AServer.to_fastapi_app()` onto a parent FastAPI app that also exposes `/ping`. When deployed to AgentCore, the entry point resolves the runtime's public ARN from AppConfig and advertises it in the agent card.
+The generated `main.py` mounts an A2A server onto a parent FastAPI app that also exposes `/ping`. Strands agents use the Strands `A2AServer`; LangChain agents wrap the compiled graph in an [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`. When deployed to AgentCore, the entry point resolves the runtime's public ARN from AppConfig and advertises it in the agent card.
 
-Most users will not need to modify this file — edit `agent.py` to change tools or the system prompt. The A2A server populates the agent card (`/.well-known/agent-card.json`) from the `Agent` constructor's `name` and `description`.
+Most users will not need to modify this file; edit `agent.py` to change tools or the system prompt. The A2A server populates the agent card (`/.well-known/agent-card.json`) from the agent's `name` and `description`.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/es/guides/py-agent.mdx
+++ b/docs/src/content/docs/es/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 Genera un agente de IA en Python para construir agentes con herramientas, y opcionalmente desplegarlo en [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Elige el framework del agente con la opción `framework`: [Strands](https://strandsagents.com/) (el predeterminado) o [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (construido sobre [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-El generador expone tu agente mediante un `protocol` de servidor. Los agentes Strands soportan [HTTP](https://fastapi.tiangolo.com/) (el predeterminado), el protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidad con otros agentes compatibles con A2A, y el protocolo [AG-UI](https://docs.ag-ui.com/) para integración directa con el frontend mediante [CopilotKit](https://docs.copilotkit.ai/). Los agentes LangChain soportan el protocolo `ag-ui`.
+El generador expone tu agente mediante un `protocol` de servidor. Ambos frameworks soportan [HTTP](https://fastapi.tiangolo.com/) (el predeterminado), el protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidad con otros agentes compatibles con A2A, y el protocolo [AG-UI](https://docs.ag-ui.com/) para integración directa con el frontend mediante [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Uso
 
@@ -55,10 +55,10 @@ El generador añadirá los siguientes archivos a tu proyecto Python existente. L
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### Protocolo A2A
 
-El punto de entrada usa el [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) en lugar de FastAPI:
+El punto de entrada expone tu agente mediante el protocolo A2A (Strands usa el [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain envuelve el grafo en un ejecutor [`a2a-sdk`](https://a2a-protocol.org/)), montado sobre una aplicación FastAPI:
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ El punto de entrada usa el [Strands A2A Server](https://strandsagents.com/docs/u
         - agent.py Definición principal del agente con herramientas de ejemplo
         - main.py Punto de entrada del servidor A2A
         - Dockerfile Punto de entrada para alojar tu agente (excluido cuando `infra` es `None`)
-    - pyproject.toml Actualizado con dependencias de Strands
+    - pyproject.toml Actualizado con dependencias del framework y A2A
     - project.json Actualizado con objetivos de servicio del agente
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ Para una guía más detallada sobre cómo escribir agentes, consulta la document
 El protocolo de servidor de tu agente determina cómo se comunica. Todas las opciones son servidas por [FastAPI](https://fastapi.tiangolo.com/) — el punto de entrada difiere:
 
 - **HTTP** (por defecto): Un servidor FastAPI estándar con un endpoint personalizado `/invocations`, CORS y streaming. Mejor para integraciones de clientes personalizados.
-- **A2A**: El [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) montado sobre una aplicación FastAPI. Mejor cuando tu agente necesita ser descubrible e invocable por otros agentes compatibles con A2A.
-- **AG-UI**: La integración [ag-ui-strands](https://docs.ag-ui.com/), que expone el [protocolo AG-UI](https://docs.ag-ui.com/) mediante SSE. Mejor para integración directa con el frontend usando [CopilotKit](https://docs.copilotkit.ai/) en un sitio web React.
+- **A2A**: Un servidor [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) montado sobre una aplicación FastAPI (Strands usa el [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain usa el [`a2a-sdk`](https://a2a-protocol.org/) agnóstico del framework). Mejor cuando tu agente necesita ser descubrible e invocable por otros agentes compatibles con A2A.
+- **AG-UI**: El [protocolo AG-UI](https://docs.ag-ui.com/) mediante SSE (Strands usa `ag-ui-strands`; LangChain usa `ag-ui-langgraph`). Mejor para integración directa con el frontend usando [CopilotKit](https://docs.copilotkit.ai/) en un sitio web React.
+
+El punto de entrada del servidor difiere según el framework (Strands produce un `Agent` gestionado por contexto, mientras que LangChain ejecuta un grafo `create_agent` compilado), pero el contrato externo para cada protocolo es el mismo.
 
 Todos los protocolos exponen `/ping` para el contrato de verificación de salud del runtime de AgentCore. Los agentes A2A escuchan en el puerto `9000`; los agentes HTTP y AG-UI escuchan en el puerto `8080`. El Dockerfile y la infraestructura generados están configurados para ti.
-
-:::note[LangChain solo soporta AG-UI]
-El framework `langchain` actualmente solo soporta el protocolo `ag-ui`. Elige el framework predeterminado `strands` si necesitas el protocolo `http` o `a2a`.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## Servidor FastAPI (protocolo HTTP)
@@ -373,9 +371,9 @@ Como el generador provee infraestructura CDK/Terraform para desplegar tu agente,
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Servidor A2A (protocolo A2A)
 
-El `main.py` generado monta `A2AServer.to_fastapi_app()` sobre una aplicación FastAPI padre que también expone `/ping`. Cuando se despliega en AgentCore, el punto de entrada resuelve el ARN público del runtime desde AppConfig y lo anuncia en la tarjeta del agente.
+El `main.py` generado monta un servidor A2A sobre una aplicación FastAPI padre que también expone `/ping`. Los agentes Strands usan el `A2AServer` de Strands; los agentes LangChain envuelven el grafo compilado en un `AgentExecutor` de [`a2a-sdk`](https://a2a-protocol.org/). Cuando se despliega en AgentCore, el punto de entrada resuelve el ARN público del runtime desde AppConfig y lo anuncia en la tarjeta del agente.
 
-La mayoría de los usuarios no necesitarán modificar este archivo — edita `agent.py` para cambiar herramientas o el prompt del sistema. El servidor A2A puebla la tarjeta del agente (`/.well-known/agent-card.json`) desde el `name` y `description` del constructor `Agent`.
+La mayoría de los usuarios no necesitarán modificar este archivo; edita `agent.py` para cambiar herramientas o el prompt del sistema. El servidor A2A puebla la tarjeta del agente (`/.well-known/agent-card.json`) desde el `name` y `description` del agente.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/fr/guides/py-agent.mdx
+++ b/docs/src/content/docs/fr/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 Générer un agent IA Python pour créer des agents avec des outils, et optionnellement le déployer sur [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Choisissez le framework d'agent avec l'option `framework` : [Strands](https://strandsagents.com/) (par défaut) ou [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (basé sur [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-Le générateur expose votre agent via un `protocol` de serveur. Les agents Strands supportent [HTTP](https://fastapi.tiangolo.com/) (par défaut), le protocole [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) pour l'interopérabilité avec d'autres agents compatibles A2A, et le protocole [AG-UI](https://docs.ag-ui.com/) pour une intégration frontend directe via [CopilotKit](https://docs.copilotkit.ai/). Les agents LangChain supportent le protocole `ag-ui`.
+Le générateur expose votre agent via un `protocol` de serveur. Les deux frameworks supportent [HTTP](https://fastapi.tiangolo.com/) (par défaut), le protocole [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) pour l'interopérabilité avec d'autres agents compatibles A2A, et le protocole [AG-UI](https://docs.ag-ui.com/) pour une intégration frontend directe via [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Utilisation
 
@@ -55,10 +55,10 @@ Le générateur ajoutera les fichiers suivants à votre projet Python existant. 
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### Protocole A2A
 
-Le point d'entrée utilise le [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) au lieu de FastAPI :
+Le point d'entrée expose votre agent via le protocole A2A (Strands utilise le [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) ; LangChain enveloppe le graphe dans un exécuteur [`a2a-sdk`](https://a2a-protocol.org/)), monté sur une application FastAPI :
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ Le point d'entrée utilise le [Strands A2A Server](https://strandsagents.com/doc
         - agent.py Définition principale de l'agent avec des outils exemples
         - main.py Point d'entrée du serveur A2A
         - Dockerfile Point d'entrée pour héberger votre agent (exclu si `infra` est `None`)
-    - pyproject.toml Mis à jour avec les dépendances Strands
+    - pyproject.toml Mis à jour avec les dépendances du framework et A2A
     - project.json Mis à jour avec les cibles de service de l'agent
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ Pour un guide plus détaillé sur l'écriture d'agents, consultez la documentati
 Le protocole serveur de votre agent détermine comment il communique. Toutes les options sont servies par [FastAPI](https://fastapi.tiangolo.com/) — le point d'entrée diffère :
 
 - **HTTP** (par défaut) : Un serveur FastAPI standard avec un point de terminaison `/invocations` personnalisé, CORS et streaming. Idéal pour les intégrations client personnalisées.
-- **A2A** : Le [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) monté sur une application FastAPI. Idéal lorsque votre agent doit être découvrable et invocable par d'autres agents compatibles A2A.
-- **AG-UI** : L'intégration [ag-ui-strands](https://docs.ag-ui.com/), qui expose le [protocole AG-UI](https://docs.ag-ui.com/) via SSE. Idéal pour une intégration frontend directe avec [CopilotKit](https://docs.copilotkit.ai/) dans un site web React.
+- **A2A** : Un serveur [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) monté sur une application FastAPI (Strands utilise le [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) ; LangChain utilise le [`a2a-sdk`](https://a2a-protocol.org/) agnostique du framework). Idéal lorsque votre agent doit être découvrable et invocable par d'autres agents compatibles A2A.
+- **AG-UI** : Le [protocole AG-UI](https://docs.ag-ui.com/) via SSE (Strands utilise `ag-ui-strands` ; LangChain utilise `ag-ui-langgraph`). Idéal pour une intégration frontend directe avec [CopilotKit](https://docs.copilotkit.ai/) dans un site web React.
+
+Le point d'entrée du serveur diffère selon le framework (Strands produit un `Agent` géré par contexte, tandis que LangChain pilote un graphe `create_agent` compilé), mais le contrat externe pour chaque protocole est le même.
 
 Tous les protocoles exposent `/ping` pour le contrat de vérification de santé du runtime AgentCore. Les agents A2A écoutent sur le port `9000` ; les agents HTTP et AG-UI écoutent sur le port `8080`. Le Dockerfile et l'infrastructure générés sont configurés pour vous.
-
-:::note[LangChain supporte uniquement AG-UI]
-Le framework `langchain` ne supporte actuellement que le protocole `ag-ui`. Choisissez le framework `strands` par défaut si vous avez besoin du protocole `http` ou `a2a`.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## Serveur FastAPI (protocole HTTP)
@@ -373,9 +371,9 @@ Le générateur fournissant une infrastructure CDK ou Terraform pour déployer v
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Serveur A2A (protocole A2A)
 
-Le fichier `main.py` généré monte `A2AServer.to_fastapi_app()` sur une application FastAPI parente qui expose également `/ping`. Lorsqu'il est déployé sur AgentCore, le point d'entrée résout l'ARN public du runtime depuis AppConfig et l'annonce dans la carte d'agent.
+Le fichier `main.py` généré monte un serveur A2A sur une application FastAPI parente qui expose également `/ping`. Les agents Strands utilisent le `A2AServer` de Strands ; les agents LangChain enveloppent le graphe compilé dans un `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). Lorsqu'il est déployé sur AgentCore, le point d'entrée résout l'ARN public du runtime depuis AppConfig et l'annonce dans la carte d'agent.
 
-La plupart des utilisateurs n'auront pas besoin de modifier ce fichier — éditez `agent.py` pour changer les outils ou le prompt système. Le serveur A2A remplit la carte d'agent (`/.well-known/agent-card.json`) à partir du `name` et de la `description` du constructeur `Agent`.
+La plupart des utilisateurs n'auront pas besoin de modifier ce fichier ; éditez `agent.py` pour changer les outils ou le prompt système. Le serveur A2A remplit la carte d'agent (`/.well-known/agent-card.json`) à partir du `name` et de la `description` de l'agent.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/it/guides/py-agent.mdx
+++ b/docs/src/content/docs/it/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 Genera un agente AI Python per costruire agenti con strumenti, e opzionalmente distribuiscilo su [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Scegli il framework dell'agente con l'opzione `framework`: [Strands](https://strandsagents.com/) (predefinito) o [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (basato su [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-Il generatore espone il tuo agente tramite un `protocol` del server. Gli agenti Strands supportano [HTTP](https://fastapi.tiangolo.com/) (predefinito), il protocollo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) per l'interoperabilità con altri agenti compatibili A2A, e il protocollo [AG-UI](https://docs.ag-ui.com/) per l'integrazione diretta con il frontend tramite [CopilotKit](https://docs.copilotkit.ai/). Gli agenti LangChain supportano il protocollo `ag-ui`.
+Il generatore espone il tuo agente tramite un `protocol` del server. Entrambi i framework supportano [HTTP](https://fastapi.tiangolo.com/) (predefinito), il protocollo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) per l'interoperabilità con altri agenti compatibili A2A, e il protocollo [AG-UI](https://docs.ag-ui.com/) per l'integrazione diretta con il frontend tramite [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Utilizzo
 
@@ -55,10 +55,10 @@ Il generatore aggiungerà i seguenti file al tuo progetto Python esistente. I fi
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### Protocollo A2A
 
-Il punto d'ingresso utilizza lo [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) invece di FastAPI:
+Il punto d'ingresso espone il tuo agente tramite il protocollo A2A (Strands utilizza lo [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain avvolge il grafo in un executor [`a2a-sdk`](https://a2a-protocol.org/)), montato su un'app FastAPI:
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ Il punto d'ingresso utilizza lo [Strands A2A Server](https://strandsagents.com/d
         - agent.py Definizione principale dell'agente con strumenti di esempio
         - main.py Punto d'ingresso server A2A
         - Dockerfile Punto d'ingresso per ospitare il tuo agente (escluso se `infra` è impostato a `None`)
-    - pyproject.toml Aggiornato con le dipendenze Strands
+    - pyproject.toml Aggiornato con le dipendenze del framework e A2A
     - project.json Aggiornato con i target di servizio dell'agente
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ Per una guida più dettagliata sulla scrittura di agenti, consulta la documentaz
 Il protocollo del server del tuo agente determina come comunica. Tutte le opzioni sono servite da [FastAPI](https://fastapi.tiangolo.com/) — il punto d'ingresso è diverso:
 
 - **HTTP** (predefinito): Un server FastAPI standard con un endpoint personalizzato `/invocations`, CORS e streaming. Ideale per integrazioni client personalizzate.
-- **A2A**: Lo [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) montato su un'app FastAPI. Ideale quando il tuo agente deve essere individuabile e invocabile da altri agenti compatibili A2A.
-- **AG-UI**: L'integrazione [ag-ui-strands](https://docs.ag-ui.com/), che espone il [protocollo AG-UI](https://docs.ag-ui.com/) tramite SSE. Ideale per l'integrazione diretta con il frontend tramite [CopilotKit](https://docs.copilotkit.ai/) in un sito web React.
+- **A2A**: Un server [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) montato su un'app FastAPI (Strands utilizza lo [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain utilizza l'[`a2a-sdk`](https://a2a-protocol.org/) agnostico al framework). Ideale quando il tuo agente deve essere individuabile e invocabile da altri agenti compatibili A2A.
+- **AG-UI**: Il [protocollo AG-UI](https://docs.ag-ui.com/) tramite SSE (Strands utilizza `ag-ui-strands`; LangChain utilizza `ag-ui-langgraph`). Ideale per l'integrazione diretta con il frontend tramite [CopilotKit](https://docs.copilotkit.ai/) in un sito web React.
+
+Il punto d'ingresso del server differisce per framework (Strands produce un `Agent` gestito tramite contesto, mentre LangChain guida un grafo `create_agent` compilato), ma il contratto esterno per ogni protocollo è lo stesso.
 
 Tutti i protocolli espongono `/ping` per il contratto di controllo dello stato del runtime AgentCore. Gli agenti A2A ascoltano sulla porta `9000`; gli agenti HTTP e AG-UI ascoltano sulla porta `8080`. Il Dockerfile e l'infrastruttura generati sono configurati per te.
-
-:::note[LangChain supporta solo AG-UI]
-Il framework `langchain` attualmente supporta solo il protocollo `ag-ui`. Scegli il framework predefinito `strands` se hai bisogno del protocollo `http` o `a2a`.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## Server FastAPI (protocollo HTTP)
@@ -373,9 +371,9 @@ Poiché il generatore fornisce infrastruttura CDK o Terraform che gestisce la di
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Server A2A (protocollo A2A)
 
-Il `main.py` generato monta `A2AServer.to_fastapi_app()` su un'app FastAPI padre che espone anche `/ping`. Quando distribuito su AgentCore, il punto d'ingresso risolve l'ARN pubblico del runtime da AppConfig e lo pubblicizza nella scheda dell'agente.
+Il `main.py` generato monta un server A2A su un'app FastAPI padre che espone anche `/ping`. Gli agenti Strands utilizzano lo Strands `A2AServer`; gli agenti LangChain avvolgono il grafo compilato in un `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). Quando distribuito su AgentCore, il punto d'ingresso risolve l'ARN pubblico del runtime da AppConfig e lo pubblicizza nella scheda dell'agente.
 
-La maggior parte degli utenti non avrà bisogno di modificare questo file — modifica `agent.py` per cambiare strumenti o il prompt di sistema. Il server A2A popola la scheda dell'agente (`/.well-known/agent-card.json`) dal `name` e dalla `description` del costruttore `Agent`.
+La maggior parte degli utenti non avrà bisogno di modificare questo file; modifica `agent.py` per cambiare strumenti o il prompt di sistema. Il server A2A popola la scheda dell'agente (`/.well-known/agent-card.json`) dal `name` e dalla `description` dell'agente.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/jp/guides/py-agent.mdx
+++ b/docs/src/content/docs/jp/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 ツールを使用してエージェントを構築するためのPython AIエージェントを生成し、オプションで[Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)にデプロイします。`framework`オプションでエージェントフレームワークを選択できます：[Strands](https://strandsagents.com/)（デフォルト）または[LangChain](https://docs.langchain.com/oss/python/langchain/overview)（[LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)上に構築）。
 
-ジェネレーターはサーバー`protocol`を介してエージェントを公開します。Strandsエージェントは[HTTP](https://fastapi.tiangolo.com/)（デフォルト）、他のA2A互換エージェントとの相互運用性のための[Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)プロトコル、および[CopilotKit](https://docs.copilotkit.ai/)を介した直接的なフロントエンド統合のための[AG-UI](https://docs.ag-ui.com/)プロトコルをサポートします。LangChainエージェントは`ag-ui`プロトコルをサポートします。
+ジェネレーターはサーバー`protocol`を介してエージェントを公開します。両方のフレームワークは[HTTP](https://fastapi.tiangolo.com/)（デフォルト）、他のA2A互換エージェントとの相互運用性のための[Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)プロトコル、および[CopilotKit](https://docs.copilotkit.ai/)を介した直接的なフロントエンド統合のための[AG-UI](https://docs.ag-ui.com/)プロトコルをサポートします。
 
 ## 使用方法
 
@@ -55,10 +55,10 @@ import OptionFilter from '@components/option-filter.astro';
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### A2Aプロトコル
 
-エントリーポイントはFastAPIの代わりに[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)を使用します：
+エントリーポイントはA2Aプロトコル経由でエージェントを公開します（Strandsは[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)を使用し、LangChainはグラフを[`a2a-sdk`](https://a2a-protocol.org/)エグゼキューターでラップします）。FastAPIアプリにマウントされます：
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ import OptionFilter from '@components/option-filter.astro';
         - agent.py サンプルツール付きメインエージェント定義
         - main.py A2Aサーバーエントリーポイント
         - Dockerfile エージェントホスティング用Dockerfile（`infra`が`None`の場合は生成されない）
-    - pyproject.toml Strands依存関係が追加された設定ファイル
+    - pyproject.toml フレームワークとA2A依存関係が追加された設定ファイル
     - project.json エージェントサーブターゲットが追加された設定ファイル
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ model = ChatBedrockConverse(
 エージェントのサーバープロトコルは通信方法を決定します。すべてのオプションは[FastAPI](https://fastapi.tiangolo.com/)で提供されますが、エントリーポイントが異なります：
 
 - **HTTP**（デフォルト）：カスタム`/invocations`エンドポイント、CORS、ストリーミングを備えた標準的なFastAPIサーバー。カスタムクライアント統合に最適です。
-- **A2A**：FastAPIアプリにマウントされた[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)。エージェントが他のA2A互換エージェントから検出・呼び出し可能である必要がある場合に最適です。
-- **AG-UI**：[ag-ui-strands](https://docs.ag-ui.com/)統合で、SSE経由で[AG-UIプロトコル](https://docs.ag-ui.com/)を公開します。Reactウェブサイトでの[CopilotKit](https://docs.copilotkit.ai/)との直接的なフロントエンド統合に最適です。
+- **A2A**：FastAPIアプリにマウントされた[Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)サーバー（Strandsは[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)を使用し、LangChainはフレームワーク非依存の[`a2a-sdk`](https://a2a-protocol.org/)を使用します）。エージェントが他のA2A互換エージェントから検出・呼び出し可能である必要がある場合に最適です。
+- **AG-UI**：SSE経由の[AG-UIプロトコル](https://docs.ag-ui.com/)（Strandsは`ag-ui-strands`を使用し、LangChainは`ag-ui-langgraph`を使用します）。Reactウェブサイトでの[CopilotKit](https://docs.copilotkit.ai/)との直接的なフロントエンド統合に最適です。
+
+サーバーエントリーポイントはフレームワークによって異なります（Strandsはコンテキスト管理された`Agent`を生成し、LangChainはコンパイルされた`create_agent`グラフを駆動します）が、各プロトコルの外部契約は同じです。
 
 すべてのプロトコルは、AgentCoreランタイムのヘルスチェック契約用に`/ping`を公開します。A2Aエージェントはポート`9000`でリッスンします。HTTPとAG-UIエージェントはポート`8080`でリッスンします。生成されるDockerfileとインフラストラクチャは自動的に設定されます。
-
-:::note[LangChainはAG-UIのみをサポート]
-`langchain`フレームワークは現在`ag-ui`プロトコルのみをサポートしています。`http`または`a2a`プロトコルが必要な場合は、デフォルトの`strands`フレームワークを選択してください。
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPIサーバー（HTTPプロトコル）
@@ -373,9 +371,9 @@ SDKの詳細は[ドキュメント](https://aws.github.io/bedrock-agentcore-star
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2Aサーバー（A2Aプロトコル）
 
-生成される`main.py`は`A2AServer.to_fastapi_app()`を親FastAPIアプリにマウントし、`/ping`も公開します。AgentCoreにデプロイすると、エントリーポイントはAppConfigからランタイムのパブリックARNを解決し、エージェントカードに通知します。
+生成される`main.py`は親FastAPIアプリにA2Aサーバーをマウントし、`/ping`も公開します。StrandsエージェントはStrandsの`A2AServer`を使用し、LangChainエージェントはコンパイルされたグラフを[`a2a-sdk`](https://a2a-protocol.org/)の`AgentExecutor`でラップします。AgentCoreにデプロイすると、エントリーポイントはAppConfigからランタイムのパブリックARNを解決し、エージェントカードに通知します。
 
-ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには`agent.py`を編集してください。A2Aサーバーは、`Agent`コンストラクタの`name`と`description`からエージェントカード（`/.well-known/agent-card.json`）を生成します。
+ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには`agent.py`を編集してください。A2Aサーバーは、エージェントの`name`と`description`からエージェントカード（`/.well-known/agent-card.json`）を生成します。
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/ko/guides/py-agent.mdx
+++ b/docs/src/content/docs/ko/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 도구를 갖춘 에이전트를 구축하고 선택적으로 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)에 배포할 수 있는 Python AI 에이전트를 생성합니다. `framework` 옵션으로 에이전트 프레임워크를 선택하세요: [Strands](https://strandsagents.com/) (기본값) 또는 [LangChain](https://docs.langchain.com/oss/python/langchain/overview) ([LangGraph](https://docs.langchain.com/oss/python/langgraph/overview) 기반).
 
-생성기는 서버 `protocol`을 통해 에이전트를 노출합니다. Strands 에이전트는 [HTTP](https://fastapi.tiangolo.com/) (기본값), 다른 A2A 호환 에이전트와의 상호 운용성을 위한 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 프로토콜, [CopilotKit](https://docs.copilotkit.ai/)을 통한 직접적인 프론트엔드 통합을 위한 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 지원합니다. LangChain 에이전트는 `ag-ui` 프로토콜을 지원합니다.
+생성기는 서버 `protocol`을 통해 에이전트를 노출합니다. 두 프레임워크 모두 [HTTP](https://fastapi.tiangolo.com/) (기본값), 다른 A2A 호환 에이전트와의 상호 운용성을 위한 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 프로토콜, [CopilotKit](https://docs.copilotkit.ai/)을 통한 직접적인 프론트엔드 통합을 위한 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 지원합니다.
 
 ## 사용 방법
 
@@ -55,10 +55,10 @@ import OptionFilter from '@components/option-filter.astro';
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### A2A 프로토콜
 
-진입점은 FastAPI 대신 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용합니다:
+진입점은 A2A 프로토콜을 통해 에이전트를 노출합니다(Strands는 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용하고, LangChain은 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) 실행자로 래핑합니다). FastAPI 앱에 마운트됩니다:
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ import OptionFilter from '@components/option-filter.astro';
         - agent.py 샘플 도구가 포함된 주요 에이전트 정의
         - main.py A2A 서버 진입점
         - Dockerfile 에이전트 호스팅용 진입점 (`infra`이 `None`으로 설정된 경우 제외)
-    - pyproject.toml Strands 종속성으로 업데이트
+    - pyproject.toml 프레임워크 및 A2A 종속성으로 업데이트
     - project.json 에이전트 서빙 타겟으로 업데이트
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ model = ChatBedrockConverse(
 에이전트의 서버 프로토콜은 통신 방식을 결정합니다. 모든 옵션은 [FastAPI](https://fastapi.tiangolo.com/)에서 제공되며 진입점이 다릅니다:
 
 - **HTTP** (기본값): 사용자 정의 `/invocations` 엔드포인트, CORS 및 스트리밍이 포함된 표준 FastAPI 서버. 사용자 정의 클라이언트 통합에 최적.
-- **A2A**: FastAPI 앱에 마운트된 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent). 에이전트가 다른 A2A 호환 에이전트에 의해 검색 및 호출 가능해야 할 때 최적.
-- **AG-UI**: SSE를 통해 [AG-UI 프로토콜](https://docs.ag-ui.com/)을 노출하는 [ag-ui-strands](https://docs.ag-ui.com/) 통합. React 웹사이트에서 [CopilotKit](https://docs.copilotkit.ai/)과의 직접적인 프론트엔드 통합에 최적.
+- **A2A**: FastAPI 앱에 마운트된 [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 서버(Strands는 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용하고, LangChain은 프레임워크 독립적인 [`a2a-sdk`](https://a2a-protocol.org/)를 사용합니다). 에이전트가 다른 A2A 호환 에이전트에 의해 검색 및 호출 가능해야 할 때 최적.
+- **AG-UI**: SSE를 통한 [AG-UI 프로토콜](https://docs.ag-ui.com/)(Strands는 `ag-ui-strands`를 사용하고, LangChain은 `ag-ui-langgraph`를 사용합니다). React 웹사이트에서 [CopilotKit](https://docs.copilotkit.ai/)과의 직접적인 프론트엔드 통합에 최적.
+
+서버 진입점은 프레임워크에 따라 다릅니다(Strands는 컨텍스트 관리되는 `Agent`를 생성하고, LangChain은 컴파일된 `create_agent` 그래프를 구동합니다). 하지만 각 프로토콜의 외부 계약은 동일합니다.
 
 모든 프로토콜은 AgentCore 런타임 헬스 체크 계약을 위해 `/ping`을 노출합니다. A2A 에이전트는 포트 `9000`에서 수신하고, HTTP 및 AG-UI 에이전트는 포트 `8080`에서 수신합니다. 생성된 Dockerfile 및 인프라가 자동으로 구성됩니다.
-
-:::note[LangChain은 AG-UI만 지원]
-`langchain` 프레임워크는 현재 `ag-ui` 프로토콜만 지원합니다. `http` 또는 `a2a` 프로토콜이 필요한 경우 기본 `strands` 프레임워크를 선택하세요.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPI 서버 (HTTP 프로토콜)
@@ -373,9 +371,9 @@ SDK 기능에 대한 자세한 내용은 [문서](https://aws.github.io/bedrock-
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A 서버 (A2A 프로토콜)
 
-생성된 `main.py`는 `/ping`도 노출하는 상위 FastAPI 앱에 `A2AServer.to_fastapi_app()`을 마운트합니다. AgentCore에 배포되면 진입점은 AppConfig에서 런타임의 공개 ARN을 확인하고 에이전트 카드에 광고합니다.
+생성된 `main.py`는 `/ping`도 노출하는 상위 FastAPI 앱에 A2A 서버를 마운트합니다. Strands 에이전트는 Strands `A2AServer`를 사용하고, LangChain 에이전트는 컴파일된 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`로 래핑합니다. AgentCore에 배포되면 진입점은 AppConfig에서 런타임의 공개 ARN을 확인하고 에이전트 카드에 광고합니다.
 
-대부분의 사용자는 이 파일을 수정할 필요가 없습니다 — 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요. A2A 서버는 `Agent` 생성자의 `name` 및 `description`에서 에이전트 카드(`/.well-known/agent-card.json`)를 채웁니다.
+대부분의 사용자는 이 파일을 수정할 필요가 없습니다. 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요. A2A 서버는 에이전트의 `name` 및 `description`에서 에이전트 카드(`/.well-known/agent-card.json`)를 채웁니다.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/pt/guides/py-agent.mdx
+++ b/docs/src/content/docs/pt/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 Gere um agente de IA em Python para construir agentes com ferramentas, e opcionalmente implante-o no [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Escolha o framework do agente com a opção `framework`: [Strands](https://strandsagents.com/) (o padrão) ou [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (construído sobre [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-O gerador expõe seu agente através de um `protocol` de servidor. Agentes Strands suportam [HTTP](https://fastapi.tiangolo.com/) (o padrão), o protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidade com outros agentes compatíveis com A2A, e o protocolo [AG-UI](https://docs.ag-ui.com/) para integração direta com frontend via [CopilotKit](https://docs.copilotkit.ai/). Agentes LangChain suportam o protocolo `ag-ui`.
+O gerador expõe seu agente através de um `protocol` de servidor. Ambos os frameworks suportam [HTTP](https://fastapi.tiangolo.com/) (o padrão), o protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidade com outros agentes compatíveis com A2A, e o protocolo [AG-UI](https://docs.ag-ui.com/) para integração direta com frontend via [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Uso
 
@@ -55,10 +55,10 @@ O gerador adicionará os seguintes arquivos ao seu projeto Python existente. Os 
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### Protocolo A2A
 
-O ponto de entrada usa o [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) em vez do FastAPI:
+O ponto de entrada expõe seu agente através do protocolo A2A (Strands usa o [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain envolve o grafo em um executor [`a2a-sdk`](https://a2a-protocol.org/)), montado em uma aplicação FastAPI:
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ O ponto de entrada usa o [Strands A2A Server](https://strandsagents.com/docs/use
         - agent.py Definição principal do agente com ferramentas de exemplo
         - main.py Ponto de entrada do servidor A2A
         - Dockerfile Ponto de entrada para hospedar seu agente (excluído quando `infra` é `None`)
-    - pyproject.toml Atualizado com dependências do Strands
+    - pyproject.toml Atualizado com dependências do framework e A2A
     - project.json Atualizado com alvos de serviço do agente
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ Para um guia mais detalhado sobre escrita de agentes, consulte a documentação 
 O protocolo de servidor do seu agente determina como ele se comunica. Todas as opções são servidas pelo [FastAPI](https://fastapi.tiangolo.com/) — o ponto de entrada difere:
 
 - **HTTP** (padrão): Um servidor FastAPI padrão com um endpoint `/invocations` personalizado, CORS e streaming. Melhor para integrações de clientes personalizados.
-- **A2A**: O [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) montado em uma aplicação FastAPI. Melhor quando seu agente precisa ser descoberto e invocado por outros agentes compatíveis com A2A.
-- **AG-UI**: A integração [ag-ui-strands](https://docs.ag-ui.com/), que expõe o [protocolo AG-UI](https://docs.ag-ui.com/) via SSE. Melhor para integração direta com frontend usando [CopilotKit](https://docs.copilotkit.ai/) em um website React.
+- **A2A**: Um servidor [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) montado em uma aplicação FastAPI (Strands usa o [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain usa o [`a2a-sdk`](https://a2a-protocol.org/) agnóstico de framework). Melhor quando seu agente precisa ser descoberto e invocado por outros agentes compatíveis com A2A.
+- **AG-UI**: O [protocolo AG-UI](https://docs.ag-ui.com/) via SSE (Strands usa `ag-ui-strands`; LangChain usa `ag-ui-langgraph`). Melhor para integração direta com frontend usando [CopilotKit](https://docs.copilotkit.ai/) em um website React.
+
+O ponto de entrada do servidor difere por framework (Strands produz um `Agent` gerenciado por contexto, enquanto LangChain dirige um grafo `create_agent` compilado), mas o contrato externo para cada protocolo é o mesmo.
 
 Todos os protocolos expõem `/ping` para o contrato de verificação de saúde do runtime AgentCore. Agentes A2A escutam na porta `9000`; agentes HTTP e AG-UI escutam na porta `8080`. O Dockerfile e a infraestrutura gerados são configurados para você.
-
-:::note[LangChain suporta apenas AG-UI]
-O framework `langchain` atualmente suporta apenas o protocolo `ag-ui`. Escolha o framework padrão `strands` se você precisar do protocolo `http` ou `a2a`.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## Servidor FastAPI (protocolo HTTP)
@@ -373,9 +371,9 @@ Como o gerador fornece infraestrutura CDK ou Terraform que gerencia a implantaç
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Servidor A2A (protocolo A2A)
 
-O `main.py` gerado monta `A2AServer.to_fastapi_app()` em uma aplicação FastAPI pai que também expõe `/ping`. Quando implantado no AgentCore, o ponto de entrada resolve o ARN público do runtime do AppConfig e o anuncia no cartão do agente.
+O `main.py` gerado monta um servidor A2A em uma aplicação FastAPI pai que também expõe `/ping`. Agentes Strands usam o `A2AServer` do Strands; agentes LangChain envolvem o grafo compilado em um `AgentExecutor` do [`a2a-sdk`](https://a2a-protocol.org/). Quando implantado no AgentCore, o ponto de entrada resolve o ARN público do runtime do AppConfig e o anuncia no cartão do agente.
 
-A maioria dos usuários não precisará modificar este arquivo — edite `agent.py` para alterar ferramentas ou o prompt do sistema. O servidor A2A popula o cartão do agente (`/.well-known/agent-card.json`) a partir do `name` e `description` do construtor `Agent`.
+A maioria dos usuários não precisará modificar este arquivo; edite `agent.py` para alterar ferramentas ou o prompt do sistema. O servidor A2A popula o cartão do agente (`/.well-known/agent-card.json`) a partir do `name` e `description` do agente.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/vi/guides/py-agent.mdx
+++ b/docs/src/content/docs/vi/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 Tạo một Python AI agent để xây dựng các agent với các công cụ, và tùy chọn triển khai nó lên [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Chọn framework agent với tùy chọn `framework`: [Strands](https://strandsagents.com/) (mặc định) hoặc [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (được xây dựng trên [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-Generator expose agent của bạn qua một `protocol` server. Các Strands agent hỗ trợ [HTTP](https://fastapi.tiangolo.com/) (mặc định), giao thức [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) để tương tác với các agent tương thích A2A khác, và giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp trực tiếp với frontend thông qua [CopilotKit](https://docs.copilotkit.ai/). Các LangChain agent hỗ trợ giao thức `ag-ui`.
+Generator expose agent của bạn qua một `protocol` server. Cả hai framework đều hỗ trợ [HTTP](https://fastapi.tiangolo.com/) (mặc định), giao thức [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) để tương tác với các agent tương thích A2A khác, và giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp trực tiếp với frontend thông qua [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Cách sử dụng
 
@@ -55,10 +55,10 @@ Generator sẽ thêm các file sau vào Python project hiện có của bạn. C
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### A2A Protocol
 
-Entry point sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) thay vì FastAPI:
+Entry point expose agent của bạn qua giao thức A2A (Strands sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain wrap graph trong một executor [`a2a-sdk`](https://a2a-protocol.org/)), được mount lên một ứng dụng FastAPI:
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ Entry point sử dụng [Strands A2A Server](https://strandsagents.com/docs/user
         - agent.py Định nghĩa agent chính với các công cụ mẫu
         - main.py A2A server entry point
         - Dockerfile Entry point để host agent của bạn (bị loại trừ khi `infra` được đặt thành `None`)
-    - pyproject.toml Được cập nhật với các dependencies của Strands
+    - pyproject.toml Được cập nhật với các dependencies của framework và A2A
     - project.json Được cập nhật với các target serve agent
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ Tham khảo <Link path="/guides/connection/py-agent-mcp">hướng dẫn `connect
 Giao thức server của agent xác định cách nó giao tiếp. Tất cả các tùy chọn đều được phục vụ bởi [FastAPI](https://fastapi.tiangolo.com/) — entry point khác nhau:
 
 - **HTTP** (mặc định): Một FastAPI server tiêu chuẩn với endpoint `/invocations` tùy chỉnh, CORS và streaming. Tốt nhất cho các tích hợp client tùy chỉnh.
-- **A2A**: [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) được mount lên một ứng dụng FastAPI. Tốt nhất khi agent của bạn cần có thể được phát hiện và gọi bởi các agent tương thích A2A khác.
-- **AG-UI**: Tích hợp [ag-ui-strands](https://docs.ag-ui.com/), expose [giao thức AG-UI](https://docs.ag-ui.com/) qua SSE. Tốt nhất cho tích hợp trực tiếp với frontend thông qua [CopilotKit](https://docs.copilotkit.ai/) trong React website.
+- **A2A**: Một server [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) được mount lên một ứng dụng FastAPI (Strands sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain sử dụng [`a2a-sdk`](https://a2a-protocol.org/) không phụ thuộc framework). Tốt nhất khi agent của bạn cần có thể được phát hiện và gọi bởi các agent tương thích A2A khác.
+- **AG-UI**: [Giao thức AG-UI](https://docs.ag-ui.com/) qua SSE (Strands sử dụng `ag-ui-strands`; LangChain sử dụng `ag-ui-langgraph`). Tốt nhất cho tích hợp trực tiếp với frontend thông qua [CopilotKit](https://docs.copilotkit.ai/) trong React website.
+
+Entry point của server khác nhau theo framework (Strands tạo ra một `Agent` được quản lý bằng context, trong khi LangChain điều khiển một graph `create_agent` đã được biên dịch), nhưng hợp đồng bên ngoài cho mỗi giao thức là giống nhau.
 
 Tất cả các giao thức đều expose `/ping` cho hợp đồng health check của AgentCore runtime. Các agent A2A lắng nghe trên port `9000`; các agent HTTP và AG-UI lắng nghe trên port `8080`. Dockerfile và infrastructure được tạo đã được cấu hình cho bạn.
-
-:::note[LangChain chỉ hỗ trợ AG-UI]
-Framework `langchain` hiện chỉ hỗ trợ giao thức `ag-ui`. Chọn framework `strands` mặc định nếu bạn cần giao thức `http` hoặc `a2a`.
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPI Server (HTTP protocol)
@@ -373,9 +371,9 @@ Vì generator tạo ra hạ tầng CDK hoặc Terraform để quản lý việc 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A Server (A2A protocol)
 
-File `main.py` được tạo mount `A2AServer.to_fastapi_app()` lên một ứng dụng FastAPI cha cũng expose `/ping`. Khi được triển khai lên AgentCore, entry point resolve ARN công khai của runtime từ AppConfig và quảng cáo nó trong agent card.
+File `main.py` được tạo mount một A2A server lên một ứng dụng FastAPI cha cũng expose `/ping`. Các Strands agent sử dụng Strands `A2AServer`; các LangChain agent wrap compiled graph trong một [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`. Khi được triển khai lên AgentCore, entry point resolve ARN công khai của runtime từ AppConfig và quảng cáo nó trong agent card.
 
-Hầu hết người dùng sẽ không cần sửa đổi file này — chỉnh sửa `agent.py` để thay đổi các công cụ hoặc system prompt. A2A server điền thông tin agent card (`/.well-known/agent-card.json`) từ `name` và `description` trong constructor của `Agent`.
+Hầu hết người dùng sẽ không cần sửa đổi file này; chỉnh sửa `agent.py` để thay đổi các công cụ hoặc system prompt. A2A server điền thông tin agent card (`/.well-known/agent-card.json`) từ `name` và `description` của agent.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/docs/src/content/docs/zh/guides/py-agent.mdx
+++ b/docs/src/content/docs/zh/guides/py-agent.mdx
@@ -16,7 +16,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 生成一个用于构建带工具的AI代理的Python代理，并可选部署到[Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)。使用`framework`选项选择代理框架：[Strands](https://strandsagents.com/)（默认）或[LangChain](https://docs.langchain.com/oss/python/langchain/overview)（基于[LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)构建）。
 
-生成器通过服务器`protocol`暴露您的代理。Strands代理支持[HTTP](https://fastapi.tiangolo.com/)（默认）、用于与其他A2A兼容代理互操作的[Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)协议，以及通过[CopilotKit](https://docs.copilotkit.ai/)直接集成前端的[AG-UI](https://docs.ag-ui.com/)协议。LangChain代理支持`ag-ui`协议。
+生成器通过服务器`protocol`暴露您的代理。两个框架都支持[HTTP](https://fastapi.tiangolo.com/)（默认）、用于与其他A2A兼容代理互操作的[Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)协议，以及通过[CopilotKit](https://docs.copilotkit.ai/)直接集成前端的[AG-UI](https://docs.ag-ui.com/)协议。
 
 ## 使用方式
 
@@ -55,10 +55,10 @@ import OptionFilter from '@components/option-filter.astro';
 </FileTree>
 </OptionFilter>
 
-<OptionFilter when={{ protocol: 'a2a' }} description="Strands A2A server layout">
+<OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### A2A协议
 
-入口点使用[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)而非FastAPI：
+入口点通过A2A协议暴露您的代理（Strands使用[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)；LangChain将图包装在[`a2a-sdk`](https://a2a-protocol.org/)执行器中），挂载到FastAPI应用上：
 
 <FileTree>
   - your-project/
@@ -68,7 +68,7 @@ import OptionFilter from '@components/option-filter.astro';
         - agent.py 主智能体定义（含示例工具）
         - main.py A2A服务器入口点
         - Dockerfile 智能体托管入口文件（当`infra`设为`None`时不生成）
-    - pyproject.toml 更新Strands依赖
+    - pyproject.toml 更新框架和A2A依赖
     - project.json 更新服务目标配置
 </FileTree>
 </OptionFilter>
@@ -277,14 +277,12 @@ model = ChatBedrockConverse(
 智能体的服务器协议决定其通信方式。所有选项都由[FastAPI](https://fastapi.tiangolo.com/)提供服务——区别在于入口点：
 
 - **HTTP**（默认）：标准FastAPI服务器，带有自定义`/invocations`端点、CORS和流式传输。最适合自定义客户端集成。
-- **A2A**：将[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)挂载到FastAPI应用上。最适合需要被其他A2A兼容智能体发现和调用的场景。
-- **AG-UI**：[ag-ui-strands](https://docs.ag-ui.com/)集成，通过SSE暴露[AG-UI协议](https://docs.ag-ui.com/)。最适合在React网站中通过[CopilotKit](https://docs.copilotkit.ai/)直接集成前端。
+- **A2A**：将[Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)服务器挂载到FastAPI应用上（Strands使用[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)；LangChain使用框架无关的[`a2a-sdk`](https://a2a-protocol.org/)）。最适合需要被其他A2A兼容智能体发现和调用的场景。
+- **AG-UI**：通过SSE暴露[AG-UI协议](https://docs.ag-ui.com/)（Strands使用`ag-ui-strands`；LangChain使用`ag-ui-langgraph`）。最适合在React网站中通过[CopilotKit](https://docs.copilotkit.ai/)直接集成前端。
+
+服务器入口点因框架而异（Strands产生上下文管理的`Agent`，而LangChain驱动编译的`create_agent`图），但每个协议的外部契约是相同的。
 
 所有协议都暴露`/ping`端点以满足AgentCore运行时健康检查契约。A2A智能体监听端口`9000`；HTTP和AG-UI智能体监听端口`8080`。生成的Dockerfile和基础设施已为您配置。
-
-:::note[LangChain仅支持AG-UI]
-`langchain`框架目前仅支持`ag-ui`协议。如果您需要`http`或`a2a`协议，请选择默认的`strands`框架。
-:::
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPI服务器（HTTP协议）
@@ -373,9 +371,9 @@ SDK功能详情请参阅[文档](https://aws.github.io/bedrock-agentcore-starter
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A服务器（A2A协议）
 
-生成的`main.py`将`A2AServer.to_fastapi_app()`挂载到父FastAPI应用上，该应用同时暴露`/ping`端点。部署到AgentCore时，入口点会从AppConfig解析运行时的公共ARN，并在智能体卡片中发布。
+生成的`main.py`将A2A服务器挂载到父FastAPI应用上，该应用同时暴露`/ping`端点。Strands代理使用Strands `A2AServer`；LangChain代理将编译的图包装在[`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`中。部署到AgentCore时，入口点会从AppConfig解析运行时的公共ARN，并在智能体卡片中发布。
 
-大多数用户无需修改此文件——编辑`agent.py`即可更改工具或系统提示。A2A服务器从`Agent`构造函数的`name`和`description`填充智能体卡片（`/.well-known/agent-card.json`）。
+大多数用户无需修改此文件；编辑`agent.py`即可更改工具或系统提示。A2A服务器从智能体的`name`和`description`填充智能体卡片（`/.well-known/agent-card.json`）。
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -704,11 +704,11 @@ dependencies = [
   "boto3==1.43.29",
   "fastapi==0.137.1",
   "mcp==1.27.2",
-  "ag-ui-protocol==0.1.19",
-  "ag-ui-langgraph==0.0.42",
   "langchain==1.3.9",
   "langchain-aws==1.5.1",
   "langgraph==1.2.5",
+  "ag-ui-protocol==0.1.19",
+  "ag-ui-langgraph==0.0.42",
   "uvicorn==0.49.0"
 ]
 

--- a/packages/nx-plugin/src/py/agent/files/a2a-langchain/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/a2a-langchain/main.py.template
@@ -1,0 +1,81 @@
+import logging
+import os
+import uuid
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard
+from a2a.utils.message import new_agent_text_message
+from fastapi import FastAPI, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
+
+from .agent import get_agent
+
+logging.basicConfig(level=logging.INFO)
+
+PORT = int(os.environ.get("PORT", "9000"))
+RUNTIME_URL = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://localhost:{PORT}/")
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+DEFAULT_MODES = ["text/plain"]
+
+_graph = get_agent()
+
+
+class _GraphAgentExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        # The session bound by the middleware drives the LangGraph thread, keeping
+        # checkpointed conversation state separate per caller session.
+        session_id = get_current_session_id() or context.context_id or str(uuid.uuid4())
+        result = await _graph.ainvoke(
+            {"messages": [{"role": "user", "content": context.get_user_input()}]},
+            {"configurable": {"thread_id": session_id}},
+        )
+        await event_queue.enqueue_event(new_agent_text_message(result["messages"][-1].content))
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        raise NotImplementedError("Cancellation is not supported.")
+
+
+_handler = DefaultRequestHandler(
+    agent_executor=_GraphAgentExecutor(),
+    task_store=InMemoryTaskStore(),
+)
+
+_agent_card = AgentCard(
+    name="<%= agentNameClassName %>",
+    description="A LangChain/LangGraph Agent exposed via the Agent-to-Agent (A2A) protocol.",
+    url=RUNTIME_URL,
+    version="1.0.0",
+    default_input_modes=DEFAULT_MODES,
+    default_output_modes=DEFAULT_MODES,
+    capabilities=AgentCapabilities(streaming=False),
+    skills=[],
+)
+
+a2a_app = A2AStarletteApplication(agent_card=_agent_card, http_handler=_handler).build()
+
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the inbound session (or a fresh UUID) to async context."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
+app = FastAPI(title="<%= agentNameClassName %>")
+app.add_middleware(_SessionIdMiddleware)
+
+
+@app.get("/ping")
+def ping() -> dict[str, str]:
+    return {"status": "Healthy"}
+
+
+app.mount("/", a2a_app)

--- a/packages/nx-plugin/src/py/agent/files/http-langchain/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/http-langchain/main.py.template
@@ -1,0 +1,72 @@
+import uuid
+
+import uvicorn
+from bedrock_agentcore.runtime.models import PingStatus
+from fastapi import Request
+from pydantic import BaseModel, Field
+from starlette.middleware.base import BaseHTTPMiddleware
+from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
+
+from .agent import get_agent
+from .init import JsonStreamingResponse, app
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+_graph = get_agent()
+
+
+class InvokeInput(BaseModel):
+    message: str = Field(max_length=100000)
+
+
+class StreamChunk(BaseModel):
+    content: str
+
+
+async def handle_invoke(input: InvokeInput, session_id: str):
+    """Streaming handler for agent invocation"""
+    # The session id is the LangGraph thread id, so the checkpointer keeps memory per session.
+    config = {"configurable": {"thread_id": session_id}}
+    # Re-bind the session: the streaming body runs outside the middleware scope.
+    with session_id_context(session_id):
+        stream = _graph.astream(
+            {"messages": [{"role": "user", "content": input.message}]},
+            config,
+            stream_mode="messages",
+        )
+        async for message_chunk, _metadata in stream:
+            if isinstance(message_chunk.content, str) and message_chunk.content:
+                yield StreamChunk(content=message_chunk.content)
+
+
+@app.post(
+    "/invocations",
+    response_class=JsonStreamingResponse,
+    responses={200: JsonStreamingResponse.openapi_response(StreamChunk, "Stream of agent response chunks")},
+)
+async def invoke(input: InvokeInput) -> JsonStreamingResponse:
+    """Entry point for agent invocation"""
+    session_id = get_current_session_id() or str(uuid.uuid4())
+    return JsonStreamingResponse(handle_invoke(input, session_id))
+
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the inbound session (or a fresh UUID) to async context."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
+app.add_middleware(_SessionIdMiddleware)
+
+
+@app.get("/ping")
+def ping() -> str:
+    # TODO: if running an async task, return PingStatus.HEALTHY_BUSY
+    return PingStatus.HEALTHY
+
+
+if __name__ == "__main__":
+    uvicorn.run("<%- moduleName %>.<%- agentNameSnakeCase %>.main:app", port=8080)

--- a/packages/nx-plugin/src/py/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.spec.ts
@@ -1555,36 +1555,118 @@ dev-dependencies = []
       expect(hasDep('ag-ui-strands')).toBe(false);
     });
 
-    it('should reject langchain with non-ag-ui protocols', async () => {
-      // Default protocol is http
-      await expect(
-        pyAgentGenerator(tree, {
-          project: 'test-project',
-          framework: 'langchain',
-          infra: 'none',
-          iac: 'cdk',
-        }),
-      ).rejects.toThrow(/langchain/);
+    it('should generate langchain HTTP agent reusing the shared FastAPI app', async () => {
+      await pyAgentGenerator(tree, {
+        project: 'test-project',
+        framework: 'langchain',
+        protocol: 'http',
+        infra: 'none',
+        iac: 'cdk',
+      });
 
-      await expect(
-        pyAgentGenerator(tree, {
-          project: 'test-project',
-          framework: 'langchain',
-          protocol: 'http',
-          infra: 'none',
-          iac: 'cdk',
-        }),
-      ).rejects.toThrow(/langchain/);
+      // The langchain http main.py drives the compiled LangGraph graph and
+      // reuses the framework-agnostic init.py (app + JsonStreamingResponse).
+      const mainContent = tree.read(
+        'apps/test-project/proj_test_project/agent/main.py',
+        'utf-8',
+      );
+      expect(mainContent).toContain(
+        'from .init import JsonStreamingResponse, app',
+      );
+      expect(mainContent).toContain('get_agent');
+      expect(mainContent).toContain('astream');
+      expect(mainContent).toContain('/invocations');
+      // No Strands streaming shape leaked in.
+      expect(mainContent).not.toContain('stream_async');
+      expect(mainContent).not.toContain('with_session_id');
+      expect(mainContent).not.toContain('from strands');
 
-      await expect(
-        pyAgentGenerator(tree, {
-          project: 'test-project',
+      // The shared framework-agnostic init.py is emitted alongside it.
+      const initContent = tree.read(
+        'apps/test-project/proj_test_project/agent/init.py',
+        'utf-8',
+      );
+      expect(initContent).toContain('class JsonStreamingResponse');
+      expect(initContent).toContain('app = FastAPI(');
+
+      // The agent.py builds a compiled LangGraph graph, not a Strands agent.
+      const agentContent = tree.read(
+        'apps/test-project/proj_test_project/agent/agent.py',
+        'utf-8',
+      );
+      expect(agentContent).toContain('create_agent');
+      expect(agentContent).not.toContain('from strands');
+    });
+
+    it('should generate langchain A2A agent', async () => {
+      await pyAgentGenerator(tree, {
+        project: 'test-project',
+        framework: 'langchain',
+        protocol: 'a2a',
+        infra: 'none',
+        iac: 'cdk',
+      });
+
+      // The langchain a2a main.py exposes the LangGraph graph over the
+      // framework-agnostic a2a-sdk, not the Strands A2AServer.
+      const mainContent = tree.read(
+        'apps/test-project/proj_test_project/agent/main.py',
+        'utf-8',
+      );
+      expect(mainContent).toContain('get_agent');
+      expect(mainContent).toContain('/ping');
+      expect(mainContent).toContain('session_id_context');
+      expect(mainContent).toContain(
+        'x-amzn-bedrock-agentcore-runtime-session-id',
+      );
+      // No Strands A2A server shape leaked in.
+      expect(mainContent).not.toContain('strands.multiagent.a2a');
+      expect(mainContent).not.toContain('A2AServer');
+      expect(mainContent).not.toContain('from strands');
+    });
+
+    it('should add per-protocol langchain dependencies', async () => {
+      // Each protocol needs a clean project (deps accumulate in a shared
+      // pyproject.toml across generator runs), so build an isolated tree per
+      // call and return its langchain agent's resolved dependency list.
+      const depsFor = async (protocol: 'http' | 'a2a' | 'ag-ui') => {
+        const t = createTreeUsingTsSolutionSetup();
+        addProjectConfiguration(t, 'p', {
+          root: 'apps/p',
+          sourceRoot: 'apps/p/proj_p',
+          targets: {},
+        });
+        t.write(
+          'apps/p/pyproject.toml',
+          `[project]\nname = "proj.p"\nversion = "0.1.0"\ndependencies = []\n\n[dependency-groups]\ndev = []\n\n[tool.uv]\ndev-dependencies = []\n`,
+        );
+        await pyAgentGenerator(t, {
+          project: 'p',
           framework: 'langchain',
-          protocol: 'a2a',
+          protocol,
           infra: 'none',
           iac: 'cdk',
-        }),
-      ).rejects.toThrow(/langchain/);
+        });
+        const pyProjectToml = parse(
+          t.read('apps/p/pyproject.toml', 'utf-8'),
+        ) as UVPyprojectToml;
+        const deps = pyProjectToml.project.dependencies;
+        return (name: string) => deps.some((d) => d.startsWith(`${name}==`));
+      };
+
+      // a2a langchain pulls a2a-sdk (and never the ag-ui adapter or Strands).
+      const a2a = await depsFor('a2a');
+      expect(a2a('a2a-sdk')).toBe(true);
+      expect(a2a('langchain')).toBe(true);
+      expect(a2a('ag-ui-langgraph')).toBe(false);
+      expect(a2a('strands-agents[a2a]')).toBe(false);
+
+      // http langchain pulls only the base langchain deps (FastAPI is common).
+      const http = await depsFor('http');
+      expect(http('langchain')).toBe(true);
+      expect(http('a2a-sdk')).toBe(false);
+      expect(http('ag-ui-langgraph')).toBe(false);
+      expect(http('strands-agents')).toBe(false);
     });
 
     it('should match snapshot for langchain generated files', async () => {

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -12,6 +12,8 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { ensureLicenseExceptions } from '../../license/config';
+import { AG_UI_LANGGRAPH_EXCEPTIONS } from '../../license/known-exceptions';
 import { addAgentChatScripts } from '../../utils/agent-chat/agent-chat';
 import {
   addPythonFrameworkBase,
@@ -26,8 +28,6 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { updateGitIgnore } from '../../utils/git';
 import { resolveIac } from '../../utils/iac';
-import { ensureLicenseExceptions } from '../../license/config';
-import { AG_UI_LANGGRAPH_EXCEPTIONS } from '../../license/known-exceptions';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -96,18 +96,6 @@ export const pyAgentGenerator = async (
   const protocol = options.protocol ?? 'http';
   const framework = options.framework ?? 'strands';
 
-  // The langchain framework currently ships only an AG-UI server template. The
-  // http and a2a server templates are Strands-specific by construction (http's
-  // main.py consumes a contextmanager yielding a strands.Agent; a2a uses
-  // strands.multiagent.a2a.A2AServer), and create_agent returns a compiled
-  // LangGraph graph that is incompatible with those. Fail fast rather than emit
-  // a Strands server over langchain dependencies.
-  if (framework === 'langchain' && protocol !== 'ag-ui') {
-    throw new Error(
-      `The 'langchain' framework currently supports only the 'ag-ui' protocol (got '${protocol}').`,
-    );
-  }
-
   if (infra === 'none' && options.auth && options.auth !== 'iam') {
     console.warn(
       'Warning: auth is ignored when no infrastructure is configured (no infrastructure is generated)',
@@ -170,13 +158,13 @@ export const pyAgentGenerator = async (
     );
   }
 
-  // Generate protocol-specific files. The ag-ui server is framework-specific
-  // (Strands has create_strands_app; langchain hand-rolls the FastAPI loop over
-  // ag_ui_langgraph). http and a2a are Strands-only (guarded above).
+  // Generate protocol-specific files. Each protocol's server entry point is
+  // framework-specific (Strands yields a contextmanaged Agent; LangChain drives
+  // a compiled create_agent graph), so it comes from a per-framework dir
+  // `<protocol>-langchain` for LangChain, or `<protocol>` for Strands.
+  const protocolLower = protocol.toLowerCase();
   const protocolTemplateDir =
-    protocol === 'ag-ui' && framework === 'langchain'
-      ? 'ag-ui-langchain'
-      : protocol.toLowerCase();
+    framework === 'langchain' ? `${protocolLower}-langchain` : protocolLower;
   generateFiles(
     tree,
     joinPathFragments(__dirname, 'files', protocolTemplateDir),
@@ -184,6 +172,20 @@ export const pyAgentGenerator = async (
     templateContext,
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
+  // The HTTP server's init.py (the FastAPI app + JsonStreamingResponse) is
+  // framework-agnostic and the LangChain http main.py reuses it, so emit it
+  // from the shared `http` dir. Emitted after the langchain main.py above so
+  // KeepExisting preserves that main.py and only adds init.py (the shared dir's
+  // own Strands main.py is skipped).
+  if (protocolLower === 'http' && framework === 'langchain') {
+    generateFiles(
+      tree,
+      joinPathFragments(__dirname, 'files', 'http'),
+      targetSourceDir,
+      templateContext,
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
+    );
+  }
 
   addDependenciesToPyProjectToml(tree, project.root, [
     'aws-lambda-powertools',
@@ -193,15 +195,19 @@ export const pyAgentGenerator = async (
     'fastapi',
     'mcp',
     ...(framework === 'langchain'
-      ? // langchain is restricted to ag-ui (guarded above) and pulls no
-        // Strands dependencies — the LangGraph AG-UI adapter + the langchain
-        // model binding only.
+      ? // langchain pulls no Strands dependencies — the langchain model binding
+        // (langchain, langchain-aws, langgraph) plus the per-protocol server
+        // adapter: ag-ui-langgraph for AG-UI, a2a-sdk for A2A, nothing extra for
+        // HTTP (FastAPI is added above for every agent).
         ([
-          'ag-ui-protocol',
-          'ag-ui-langgraph',
           'langchain',
           'langchain-aws',
           'langgraph',
+          ...(protocol === 'ag-ui'
+            ? (['ag-ui-protocol', 'ag-ui-langgraph'] as const)
+            : protocol === 'a2a'
+              ? (['a2a-sdk'] as const)
+              : ([] as const)),
         ] as const)
       : protocol === 'a2a'
         ? (['strands-agents[a2a]', 'strands-agents-tools'] as const)
@@ -478,10 +484,11 @@ export const pyAgentGenerator = async (
 
   await addGeneratorMetricsIfApplicable(tree, [PY_AGENT_GENERATOR_INFO]);
 
-  // The ag-ui agent's framework adapter ships without resolvable SPDX license
-  // metadata for a couple of transitive deps, so register those exceptions so
-  // the workspace license check still passes.
-  if (protocol === 'ag-ui' && framework === 'langchain') {
+  // langchain-core (pulled by every langchain agent regardless of protocol)
+  // brings jsonpatch/jsonpointer, whose wheels ship without resolvable SPDX
+  // license metadata, so register those exceptions so the workspace license
+  // check still passes.
+  if (framework === 'langchain') {
     await ensureLicenseExceptions(tree, AG_UI_LANGGRAPH_EXCEPTIONS);
   }
 


### PR DESCRIPTION
#841 is authored by @nx-plugin-for-aws itself, so I can't compete ;)

### Reason for this change

#836 added LangChain as a second `py#agent` framework, but only for the `ag-ui` protocol; the `http` and `a2a` server templates were Strands-specific (http's main.py consumes a contextmanager yielding a `strands.Agent`; a2a uses `strands.multiagent.a2a.A2AServer`). A team wanting a LangChain agent behind a plain HTTP API, or discoverable over A2A, had to fall back to Strands. This closes that gap so LangChain supports every protocol Strands does.

### Description of changes

- **http (LangChain):** a FastAPI `/invocations` server that streams the compiled LangGraph graph via `graph.astream(..., stream_mode="messages")`, reusing the framework-agnostic `init.py` (the shared `app` + `JsonStreamingResponse`). Same external contract as the Strands HTTP server (`InvokeInput{message}` → JSON-lines `StreamChunk`, `/ping`, session-id middleware). The session id drives the LangGraph `thread_id` so the `InMemorySaver` checkpointer keeps memory per session.
- **a2a (LangChain):** exposes the graph over the framework-agnostic [`a2a-sdk`](https://a2a-protocol.org/) by wrapping it in an `AgentExecutor`, served via `A2AStarletteApplication` and mounted on a parent FastAPI app carrying `/ping` + the session-id middleware. Same external contract as the Strands A2A server.
- **generator:** drop the `langchain != ag-ui` fail-fast guard; dispatch the protocol template on framework (`<protocol>-langchain` for LangChain, `<protocol>` for Strands) and emit the shared `http/init.py` for the LangChain http case; add per-protocol LangChain dependencies (`a2a-sdk` for a2a, the ag-ui adapter for ag-ui, base langchain only for http). Broaden the jsonpatch/jsonpointer license exception to **any** langchain agent, since `langchain-core` pulls them regardless of protocol.
- **docs:** make the Protocol section framework-aware rather than Strands-specific.

The external HTTP/A2A contracts are identical to the Strands servers, so existing clients and the generated CDK/Terraform infrastructure are unaffected.

### Description of how you validated changes

- New unit tests in the `langchain framework` describe block: generate a LangChain HTTP agent (asserts it reuses the shared `init.py`, drives `astream`, and leaks no Strands streaming shape), generate a LangChain A2A agent (asserts the a2a-sdk shape, no `strands.multiagent.a2a`/`A2AServer`), and per-protocol dependency selection (a2a→`a2a-sdk`, http→base langchain only, neither pulls Strands). The obsolete "reject langchain non-ag-ui" test is replaced by these. All `py#agent` generator tests pass (74), full `py/agent` tree passes (188), snapshots updated only for the LangChain pyproject dep ordering.
- `tsc --noEmit` on `@aws/nx-plugin` is clean; biome reports no new issues.
- The two server templates were authored and verified against the current APIs: the LangGraph `astream(stream_mode="messages")` token shape against the LangChain/LangGraph 1.x docs, and the a2a-sdk 0.3.26 `AgentExecutor`/`AgentCard`/`A2AStarletteApplication` signatures against a live `a2a-sdk==0.3.26` install (import-tested).

### Issue # (if applicable)

Extends the LangChain support added in #836.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
