### PR TITLE
fix(py#agent): isolate langchain agents in e2e matrix to keep Lambda bundle under 250 MB

### DIFF
--- a/e2e/src/smoke-tests/generator-matrix.ts
+++ b/e2e/src/smoke-tests/generator-matrix.ts
@@ -169,16 +169,24 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   );
   // Python LangChain agents across all three protocols, deployed on AgentCore so
   // the smoke tests cover building, bundling and deploying a langchain runtime.
+  // LangChain pulls a large dependency closure (langchain + langgraph), so these
+  // live in their own project — co-locating them with the zip-bundled
+  // `py-project/my-function` Lambda would push that Lambda past the 250 MB
+  // unzipped limit, since the bundle exports the whole package's deps.
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-langchain-agent --framework=langchain --protocol=ag-ui --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#project --name=py-langchain-project --projectType=application --no-interactive`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-langchain-http-agent --framework=langchain --protocol=http --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-agent --framework=langchain --protocol=ag-ui --infra=agentcore --no-interactive`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-langchain-a2a-agent --framework=langchain --protocol=a2a --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-http-agent --framework=langchain --protocol=http --infra=agentcore --no-interactive`,
+    opts,
+  );
+  await runCLI(
+    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-a2a-agent --framework=langchain --protocol=a2a --infra=agentcore --no-interactive`,
     opts,
   );
 
@@ -217,7 +225,7 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   );
   // LangChain agent -> Python MCP server (langchain-mcp-adapters tool loading).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive`,
     opts,
   );
 
@@ -241,7 +249,7 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   // LangChain (AG-UI) agent -> Python A2A agent: delegates to a remote agent as
   // a langchain tool (reusing the framework-agnostic A2A transport).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive`,
     opts,
   );
 
@@ -262,7 +270,7 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   );
   // LangChain agent -> gateway (langchain gateway MCP client).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-langchain-agent --targetProject=@e2e-test/my-gateway --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=@e2e-test/my-gateway --no-interactive`,
     opts,
   );
   await runCLI(
@@ -304,7 +312,7 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   );
   // Website -> Python LangChain (AG-UI/CopilotKit) agent.
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_project --targetComponent=my-py-langchain-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_langchain_project --targetComponent=my-py-langchain-agent --no-interactive`,
     opts,
   );
 
@@ -353,7 +361,7 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   );
   // LangChain agent -> DynamoDB table (framework-agnostic workspace + serve-local wiring).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-langchain-http-agent --targetProject=my_py_table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-http-agent --targetProject=my_py_table --no-interactive`,
     opts,
   );
 


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy` and `cdk-deploy` smoke tests on `main` are failing during deployment with:

```
Error: creating Lambda Function (py-project-my-function-…): InvalidParameterValueException:
Unzipped size must be smaller than 262144000 bytes
```

The generator matrix crammed the LangChain agents into the **same** `py_project` Python package as the generic `py#lambda-function` (`my-function`). The Python bundle target exports the whole package's dependency closure (`uv export --frozen --package <project>`), so LangChain's heavy transitive deps (`langchain`, `langgraph`, `langchain-aws`, `ag-ui-langgraph`, plus the langchain connection-client deps) were baked into the unrelated zip-bundled Lambda — pushing it past Lambda's 250 MB unzipped limit and failing the deploy.

This regression was introduced when LangChain support landed (#836) and grew with the http/a2a protocol support (#841), which added two more LangChain agents into `py_project`.

### Description of changes

Move all three LangChain agents (ag-ui, http, a2a) into a dedicated `py_langchain_project` so their dependency closure no longer leaks into the zip-bundled `my-function` Lambda in `py_project`. All LangChain connection edges (MCP server, A2A agent, gateway, DynamoDB table, website) are repointed at the new `sourceProject`/`targetProject`.

AgentCore agents deploy as containers keyed by agent **name** (`agents/<agent-name>`), independent of the owning Nx project, so the CDK and Terraform deploy templates need no changes.

### Description of how you validated changes

This is an e2e-matrix-only change exercised by the `cdk-deploy` / `terraform-deploy` smoke tests. `@aws/nx-plugin-e2e:lint` passes. The deploy smoke tests in CI will validate end-to-end that both `py_project` (with the plain Lambda) and `py_langchain_project` build, bundle and deploy.

### Issue # (if applicable)

N/A — caught by CI on `main`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*