### PR TITLE
fix(preset): remove Prettier in favour of Biome

### DIFF
--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -57,8 +57,6 @@ exports[`preset generator > should run successfully > .mcp.json 1`] = `
 "
 `;
 
-exports[`preset generator > should run successfully > .prettierrc 1`] = `"{"singleQuote":true}"`;
-
 exports[`preset generator > should run successfully > .vscode/mcp.json 1`] = `
 "{
   "servers": {

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readJson, readNxJson, type Tree } from '@nx/devkit';
+import { readJson, readNxJson, type Tree, updateJson } from '@nx/devkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
 import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from '../utils/test';
@@ -106,6 +106,25 @@ describe('preset generator', () => {
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.scripts.prepare).toContain('husky');
     expect(packageJson.devDependencies.husky).toBeDefined();
+  });
+
+  it('should remove Prettier in favour of Biome', async () => {
+    // The base Nx workspace scaffolds Prettier; seed it to verify removal.
+    tree.write('.prettierrc', '{ "singleQuote": true }\n');
+    tree.write('.prettierignore', '/dist\n');
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = { ...json.devDependencies, prettier: '^3.6.2' };
+      return json;
+    });
+
+    await presetGenerator(tree, { addTsPlugin: false, iac: 'cdk' });
+
+    expect(tree.exists('.prettierrc')).toBe(false);
+    expect(tree.exists('.prettierignore')).toBe(false);
+    expect(tree.exists('biome.json')).toBe(true);
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies?.prettier).toBeUndefined();
+    expect(packageJson.dependencies?.prettier).toBeUndefined();
   });
 
   it('should configure MCP servers by default', async () => {

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -254,6 +254,20 @@ export const presetGenerator = async (
     tree.write('biome.json', JSON.stringify(DEFAULT_BIOME_CONFIG, null, 2));
   }
 
+  // Remove Prettier in favour of Biome. The base Nx workspace scaffolds a
+  // Prettier config and dependency, which would otherwise sit unused alongside
+  // Biome and compete for formatting.
+  for (const prettierFile of ['.prettierrc', '.prettierignore']) {
+    if (tree.exists(prettierFile)) {
+      tree.delete(prettierFile);
+    }
+  }
+  updateJson(tree, 'package.json', (packageJson) => {
+    delete packageJson.dependencies?.prettier;
+    delete packageJson.devDependencies?.prettier;
+    return packageJson;
+  });
+
   generateFiles(
     tree, // the virtual file system
     joinPathFragments(__dirname, 'files'),


### PR DESCRIPTION
### Reason for this change

The base Nx workspace created by `create-nx-workspace` scaffolds a Prettier config (`.prettierrc`, `.prettierignore`) and a `prettier` devDependency. The preset generator adds Biome for formatting and linting, but left Prettier in place. As a result, generated workspaces shipped with **both** formatters — an unused `prettier` dependency competing with Biome.

This was confirmed by generating a fresh workspace with the current (1.0 RC) plugin: after running the preset, `biome.json` is present but `.prettierrc`, `.prettierignore`, and `"prettier"` in `package.json` remained.

### Description of changes

In the preset generator, after writing `biome.json`:
- Delete `.prettierrc` and `.prettierignore` if present.
- Remove `prettier` from the workspace `dependencies`/`devDependencies`.

### Description of how you validated changes

- Added a unit test that seeds a Prettier config + `prettier` devDependency and asserts the preset removes both while keeping `biome.json`.
- Updated the preset snapshot (the `.prettierrc` snapshot is removed).
- Verified end-to-end against a freshly generated 1.0 RC workspace: running the updated preset removes `prettier 3.8.4` from the install and deletes the config files.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*