### PR TITLE
fix(py#project): use PEP 503 distribution names so nx infers workspace edges

### DIFF
--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -1537,7 +1537,7 @@ exports[`py#agent generator > should match snapshot for generated files > update
 name = "proj.test_project"
 version = "0.1.0"
 dependencies = [
-  "proj.agent_connection",
+  "proj-agent-connection",
   "aws-lambda-powertools==3.29.0",
   "aws-opentelemetry-distro==0.17.1",
   "bedrock-agentcore==1.14.1",
@@ -1555,7 +1555,7 @@ dev = [ "fastapi[standard]==0.137.1" ]
 [tool.uv]
 dev-dependencies = [ ]
 
-[tool.uv.sources."proj.agent_connection"]
+[tool.uv.sources.proj-agent-connection]
 workspace = true
 "
 `;

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -697,7 +697,7 @@ exports[`py#agent generator > langchain framework > should match snapshot for la
 name = "proj.test_project"
 version = "0.1.0"
 dependencies = [
-  "proj.agent_connection",
+  "proj-agent-connection",
   "aws-lambda-powertools==3.29.0",
   "aws-opentelemetry-distro==0.17.1",
   "bedrock-agentcore==1.14.1",
@@ -718,7 +718,7 @@ dev = [ "fastapi[standard]==0.137.1" ]
 [tool.uv]
 dev-dependencies = [ ]
 
-[tool.uv.sources."proj.agent_connection"]
+[tool.uv.sources.proj-agent-connection]
 workspace = true
 "
 `;

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -17,7 +17,7 @@ import {
   addPythonReExport,
   ensurePythonAgentConnectionProject,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
   getPythonAgentConnectionProjectDir,
   PY_CLIENT_NAMING,
   resolveAgentFramework,
@@ -130,7 +130,6 @@ export const pyAgentA2aConnectionGenerator = async (
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
 
   // A2A client config + shared auth helper deps, plus the framework's A2A
   // transport dep (see A2A_TRANSPORT_DEP).
@@ -212,8 +211,8 @@ export const pyAgentA2aConnectionGenerator = async (
   // 4. Add workspace dependency from agent project to agent-connection project
   addWorkspaceDependencyToPyProject(
     tree,
-    sourceProject.root,
-    agentConnectionPackageName,
+    sourceProject,
+    getPythonAgentConnectionProject(tree),
   );
 
   // 5. Set up serve-local target dependencies — chain onto the target agent

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
@@ -17,7 +17,7 @@ import {
   addPythonReExport,
   ensurePythonAgentConnectionProject,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
   getPythonAgentConnectionProjectDir,
   PY_MCP_FAMILY_CONNECTIONS,
   resolveAgentFramework,
@@ -96,7 +96,6 @@ export const pyAgentGatewayConnectionGenerator = async (
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
 
   // Shared MCP transport + signed httpx auth deps, plus whatever extra deps the
   // framework's MCP client needs (e.g. langchain-mcp-adapters for LangChain).
@@ -169,8 +168,8 @@ export const pyAgentGatewayConnectionGenerator = async (
 
   addWorkspaceDependencyToPyProject(
     tree,
-    sourceProject.root,
-    agentConnectionPackageName,
+    sourceProject,
+    getPythonAgentConnectionProject(tree),
   );
 
   const agentName = agentComponent.name ?? 'agent';

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -19,7 +19,7 @@ import {
   addPythonFrameworkBase,
   ensurePythonAgentConnectionProject,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
 } from '../../utils/agent-connection/agent-connection';
 import { addAgentInfra } from '../../utils/agent-core-constructs/agent-core-constructs';
 import { addPythonBundleTarget } from '../../utils/bundle/bundle';
@@ -115,11 +115,10 @@ export const pyAgentGenerator = async (
   // framework-agnostic session context), so this is a no-op for langchain.
   await addPythonFrameworkBase(tree, framework);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
   addWorkspaceDependencyToPyProject(
     tree,
-    project.root,
-    agentConnectionPackageName,
+    project,
+    getPythonAgentConnectionProject(tree),
   );
 
   const templateContext = {

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
@@ -265,8 +265,9 @@ dependencies = ["strands-agents"]
       'utf-8',
     )!;
 
-    // Check workspace dependency was added
-    expect(pyprojectContent).toContain('proj.agent_connection');
+    // Check workspace dependency was added, keyed by the PEP 503 distribution
+    // name (hyphenated, not the dotted Nx id) so @nxlv/python infers the edge.
+    expect(pyprojectContent).toContain('proj-agent-connection');
   });
 
   it('should update serve-local target with MCP dependency', async () => {

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
@@ -16,7 +16,7 @@ import {
   addPythonReExport,
   ensurePythonAgentConnectionProject,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
   getPythonAgentConnectionProjectDir,
   PY_MCP_FAMILY_CONNECTIONS,
   resolveAgentFramework,
@@ -86,7 +86,6 @@ export const pyAgentMcpConnectionGenerator = async (
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
 
   // Shared MCP transport + signed httpx auth deps, plus whatever extra deps the
   // framework's MCP client needs (e.g. langchain-mcp-adapters for LangChain).
@@ -163,8 +162,8 @@ export const pyAgentMcpConnectionGenerator = async (
   // 4. Add workspace dependency from agent project to agent-connection project
   addWorkspaceDependencyToPyProject(
     tree,
-    sourceProject.root,
-    agentConnectionPackageName,
+    sourceProject,
+    getPythonAgentConnectionProject(tree),
   );
 
   // 5. Set up serve-local target dependencies

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.spec.ts
@@ -70,23 +70,32 @@ describe('py#dynamodb agent-connection generator', () => {
 
   it('should add dynamodb package as workspace dependency to pyproject.toml', async () => {
     setupAgentProject();
-    setupDynamoDBProject();
+    setupDynamoDBProject('test.db');
+
+    tree.write(
+      'packages/test.db/pyproject.toml',
+      `[project]\nname = "test-db"\nversion = "1.0.0"\ndependencies = []\n`,
+    );
 
     tree.write(
       'packages/my-agent/pyproject.toml',
-      `[project]\nname = "test.my_agent"\nversion = "1.0.0"\ndependencies = []\n`,
+      `[project]\nname = "test-my-agent"\nversion = "1.0.0"\ndependencies = []\n`,
     );
 
     await pyDynamoDBAgentConnectionGenerator(tree, {
       sourceProject: 'my-agent',
-      targetProject: 'db',
+      targetProject: 'test.db',
     });
 
     const pyprojectContent = tree.read(
       'packages/my-agent/pyproject.toml',
       'utf-8',
     )!;
-    expect(pyprojectContent).toContain('db');
+    // The dependency and [tool.uv.sources] key must be the PEP 503 distribution
+    // name (hyphenated) so @nxlv/python infers the workspace dependency edge,
+    // not the dotted Nx project id.
+    expect(pyprojectContent).toContain('test-db');
+    expect(pyprojectContent).not.toContain('test.db');
   });
 
   it('should not add dependency when source has no matching serve-local', async () => {

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
@@ -36,11 +36,7 @@ export const pyDynamoDBAgentConnectionGenerator = async (
     options.targetProject,
   );
 
-  addWorkspaceDependencyToPyProject(
-    tree,
-    sourceProject.root,
-    targetProject.name!,
-  );
+  addWorkspaceDependencyToPyProject(tree, sourceProject, targetProject);
 
   const agentName = options.sourceComponent?.name ?? 'agent';
   const serveLocalTarget = `${agentName}-serve-local`;

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.spec.ts
@@ -54,20 +54,29 @@ describe('py#dynamodb fast-api-connection generator', () => {
 
   it('should add dynamodb package as workspace dependency to pyproject.toml', async () => {
     setupFastApiProject();
-    setupDynamoDBProject();
+    setupDynamoDBProject('test.db');
+
+    tree.write(
+      'packages/test.db/pyproject.toml',
+      `[project]\nname = "test-db"\nversion = "1.0.0"\ndependencies = []\n`,
+    );
 
     tree.write(
       'packages/api/pyproject.toml',
-      `[project]\nname = "test.api"\nversion = "1.0.0"\ndependencies = []\n`,
+      `[project]\nname = "test-api"\nversion = "1.0.0"\ndependencies = []\n`,
     );
 
     await pyDynamoDBFastApiConnectionGenerator(tree, {
       sourceProject: 'api',
-      targetProject: 'db',
+      targetProject: 'test.db',
     });
 
     const pyprojectContent = tree.read('packages/api/pyproject.toml', 'utf-8')!;
-    expect(pyprojectContent).toContain('db');
+    // The dependency and [tool.uv.sources] key must be the PEP 503 distribution
+    // name (hyphenated) so @nxlv/python infers the workspace dependency edge,
+    // not the dotted Nx project id.
+    expect(pyprojectContent).toContain('test-db');
+    expect(pyprojectContent).not.toContain('test.db');
   });
 
   it('should not add dependency when source has no serve-local', async () => {

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
@@ -36,11 +36,7 @@ export const pyDynamoDBFastApiConnectionGenerator = async (
     options.targetProject,
   );
 
-  addWorkspaceDependencyToPyProject(
-    tree,
-    sourceProject.root,
-    targetProject.name!,
-  );
+  addWorkspaceDependencyToPyProject(tree, sourceProject, targetProject);
 
   if (sourceProject.targets?.['serve-local']) {
     addDependencyToTargetIfNotPresent(sourceProject, 'serve-local', {

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.spec.ts
@@ -76,23 +76,32 @@ describe('py#dynamodb mcp-server-connection generator', () => {
 
   it('should add dynamodb package as workspace dependency to pyproject.toml', async () => {
     setupMcpServerProject();
-    setupDynamoDBProject();
+    setupDynamoDBProject('test.db');
+
+    tree.write(
+      'packages/test.db/pyproject.toml',
+      `[project]\nname = "test-db"\nversion = "1.0.0"\ndependencies = []\n`,
+    );
 
     tree.write(
       'packages/my-mcp-server/pyproject.toml',
-      `[project]\nname = "test.my_mcp_server"\nversion = "1.0.0"\ndependencies = []\n`,
+      `[project]\nname = "test-my-mcp-server"\nversion = "1.0.0"\ndependencies = []\n`,
     );
 
     await pyDynamoDBMcpServerConnectionGenerator(tree, {
       sourceProject: 'my-mcp-server',
-      targetProject: 'db',
+      targetProject: 'test.db',
     });
 
     const pyprojectContent = tree.read(
       'packages/my-mcp-server/pyproject.toml',
       'utf-8',
     )!;
-    expect(pyprojectContent).toContain('db');
+    // The dependency and [tool.uv.sources] key must be the PEP 503 distribution
+    // name (hyphenated) so @nxlv/python infers the workspace dependency edge,
+    // not the dotted Nx project id.
+    expect(pyprojectContent).toContain('test-db');
+    expect(pyprojectContent).not.toContain('test.db');
   });
 
   it('should not add dependency when source has no matching serve-local', async () => {

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
@@ -36,11 +36,7 @@ export const pyDynamoDBMcpServerConnectionGenerator = async (
     options.targetProject,
   );
 
-  addWorkspaceDependencyToPyProject(
-    tree,
-    sourceProject.root,
-    targetProject.name!,
-  );
+  addWorkspaceDependencyToPyProject(tree, sourceProject, targetProject);
 
   const mcpServerName = options.sourceComponent?.name ?? 'mcp-server';
   const serveLocalTarget = `${mcpServerName}-serve-local`;

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -20,7 +20,7 @@ import {
 } from '../../license/config';
 import { updateGitIgnore } from '../../utils/git';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { toSnakeCase } from '../../utils/names';
+import { normalizeDistributionName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
 import {
   addDependencyToTargetIfNotPresent,
@@ -47,9 +47,22 @@ export const PY_PROJECT_GENERATOR_INFO: NxGeneratorInfo =
 
 export interface PyProjectDetails {
   /**
-   * Full package name including scope (eg foo.bar)
+   * Fully qualified Nx project id including scope, in dot notation (eg foo.bar).
+   * This is the identifier Nx uses (readProjectConfiguration, the project
+   * graph, target references) and is intentionally kept dotted.
    */
   readonly fullyQualifiedName: string;
+  /**
+   * PEP 503 normalised Python distribution name (eg foo-bar). This is the name
+   * written to the project's `[project].name`, the root `[tool.uv.sources]`
+   * key, and any inter-project dependency string. It is hyphenated (not dotted)
+   * so `uv` and `@nxlv/python` can match it: uv writes `uv.lock` keyed by the
+   * PEP 503 hyphenated name, and `@nxlv/python`'s dependency inference splits a
+   * dotted name on `.` and so would otherwise drop the edge entirely. Keeping
+   * the distribution name decoupled from `fullyQualifiedName` is what lets the
+   * workspace dependency edge appear in the Nx project graph.
+   */
+  readonly distributionName: string;
   /**
    * Directory of the library relative to the root
    */
@@ -78,12 +91,15 @@ export const getPyProjectDetails = (
     schema.moduleName ?? `${scope}_${normalizedName}`,
   );
   const fullyQualifiedName = `${scope}.${normalizedName}`;
+  // The Python distribution name is the PEP 503 normalised form of the
+  // fully qualified name: hyphenated, never dotted. See PyProjectDetails.
+  const distributionName = normalizeDistributionName(fullyQualifiedName);
   // NB: interactive nx generator cli can pass empty string
   const dir = joinPathFragments(
     schema.directory || '.',
     schema.subDirectory || normalizedName,
   );
-  return { dir, fullyQualifiedName, normalizedModuleName };
+  return { dir, fullyQualifiedName, distributionName, normalizedModuleName };
 };
 
 /**
@@ -93,10 +109,8 @@ export const pyProjectGenerator = async (
   tree: Tree,
   schema: PyProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
-  const { dir, normalizedModuleName, fullyQualifiedName } = getPyProjectDetails(
-    tree,
-    schema,
-  );
+  const { dir, normalizedModuleName, fullyQualifiedName, distributionName } =
+    getPyProjectDetails(tree, schema);
 
   const pythonPlugin = withVersions(['@nxlv/python']);
   addDependenciesToPackageJson(tree, {}, pythonPlugin);
@@ -143,7 +157,14 @@ export const pyProjectGenerator = async (
     }
 
     await uvProjectGenerator(tree, {
+      // The Nx project id (and `uv.workspace.members` etc.) keys off `name`, so
+      // keep it dotted. `packageName` is the separate PEP 503 distribution name
+      // written to `[project].name` and the root `[tool.uv.sources]` key; it is
+      // hyphenated so `@nxlv/python` infers the workspace dependency edge (it
+      // splits a dotted name on `.` and would otherwise drop it). This split is
+      // the whole fix (see PyProjectDetails.distributionName).
       name: fullyQualifiedName,
+      packageName: distributionName,
       publishable: false,
       buildLockedVersions: true,
       buildBundleLocalDependencies: true,

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -54,20 +54,20 @@ export function getPythonAgentConnectionModuleName(tree: Tree): string {
 }
 
 /**
- * Get the Python distribution name of the shared agent-connection project.
- *
- * This is the PEP 503 hyphenated name (eg `scope-agent-connection`), NOT the
- * dotted Nx id. It is the value written into a dependent project's
- * `[project].dependencies` and `[tool.uv.sources]`, so it must be the
- * distribution name: `@nxlv/python` matches workspace dependency edges by the
- * normalised hyphenated name (it splits a dotted name on `.` and drops it).
+ * Get the shared agent-connection project as `{ name, root }`, suitable for
+ * passing to {@link addWorkspaceDependencyToPyProject} (which derives the
+ * dependency's PEP 503 distribution name from the project itself, so callers
+ * never construct the name).
  */
-export function getPythonAgentConnectionPackageName(tree: Tree): string {
-  const { distributionName } = getPyProjectDetails(tree, {
+export function getPythonAgentConnectionProject(tree: Tree): {
+  name: string;
+  root: string;
+} {
+  const { fullyQualifiedName, dir } = getPyProjectDetails(tree, {
     name: PY_AGENT_CONNECTION_NAME,
     directory: joinPathFragments(PACKAGES_DIR, COMMON_DIR),
   });
-  return distributionName;
+  return { name: fullyQualifiedName, root: dir };
 }
 
 /**

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -54,14 +54,20 @@ export function getPythonAgentConnectionModuleName(tree: Tree): string {
 }
 
 /**
- * Get the fully qualified Python package name of the shared agent-connection project.
+ * Get the Python distribution name of the shared agent-connection project.
+ *
+ * This is the PEP 503 hyphenated name (eg `scope-agent-connection`), NOT the
+ * dotted Nx id. It is the value written into a dependent project's
+ * `[project].dependencies` and `[tool.uv.sources]`, so it must be the
+ * distribution name: `@nxlv/python` matches workspace dependency edges by the
+ * normalised hyphenated name (it splits a dotted name on `.` and drops it).
  */
 export function getPythonAgentConnectionPackageName(tree: Tree): string {
-  const { fullyQualifiedName } = getPyProjectDetails(tree, {
+  const { distributionName } = getPyProjectDetails(tree, {
     name: PY_AGENT_CONNECTION_NAME,
     directory: joinPathFragments(PACKAGES_DIR, COMMON_DIR),
   });
-  return fullyQualifiedName;
+  return distributionName;
 }
 
 /**

--- a/packages/nx-plugin/src/utils/names.spec.ts
+++ b/packages/nx-plugin/src/utils/names.spec.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   kebabCase,
+  normalizeDistributionName,
   snakeCase,
   toClassName,
   toDotNotation,
@@ -590,6 +591,45 @@ describe('names utils', () => {
         expect(kebabCase('DataTableComponent')).toBe('data-table-component');
         expect(kebabCase('SearchInputField')).toBe('search-input-field');
       });
+    });
+  });
+
+  describe('normalizeDistributionName', () => {
+    it('should hyphenate dotted scope-qualified names', () => {
+      // The crux: a dotted nx id with an underscored project segment becomes a
+      // fully hyphenated PEP 503 distribution name.
+      expect(normalizeDistributionName('sojourner.agent_connection')).toBe(
+        'sojourner-agent-connection',
+      );
+      expect(normalizeDistributionName('sojourner.agent')).toBe(
+        'sojourner-agent',
+      );
+      expect(normalizeDistributionName('proj.test_project')).toBe(
+        'proj-test-project',
+      );
+    });
+
+    it('should lower-case the name', () => {
+      expect(normalizeDistributionName('MyScope.MyLib')).toBe('myscope-mylib');
+      expect(normalizeDistributionName('Foo_Bar')).toBe('foo-bar');
+    });
+
+    it('should collapse runs of ., _ and - to a single hyphen', () => {
+      expect(normalizeDistributionName('a..b__c--d')).toBe('a-b-c-d');
+      expect(normalizeDistributionName('a._-b')).toBe('a-b');
+    });
+
+    it('should leave an already-normalised name unchanged (idempotent)', () => {
+      expect(normalizeDistributionName('sojourner-agent-connection')).toBe(
+        'sojourner-agent-connection',
+      );
+      const once = normalizeDistributionName('Some.Mixed_Name');
+      expect(normalizeDistributionName(once)).toBe(once);
+    });
+
+    it('should not split camelCase humps (this is not kebab-case)', () => {
+      // PEP 503 only touches ., _ and -; camelCase boundaries are preserved.
+      expect(normalizeDistributionName('myScope.myLib')).toBe('myscope-mylib');
     });
   });
 

--- a/packages/nx-plugin/src/utils/names.ts
+++ b/packages/nx-plugin/src/utils/names.ts
@@ -59,6 +59,24 @@ export const kebabCase = (str: string): string => {
   );
 };
 
+/**
+ * Normalise a string to a PEP 503 distribution name.
+ *
+ * PEP 503 (https://peps.python.org/pep-0503/#normalized-names) defines the
+ * canonical form of a Python project distribution name: lower-cased, with any
+ * run of `.`, `_` or `-` collapsed to a single `-`. This is the name uv writes
+ * into `uv.lock` and the form `@nxlv/python` expects when inferring workspace
+ * dependency edges from `[project].dependencies` / `[tool.uv.sources]`.
+ *
+ * Importantly this is NOT kebab-case: it does not split on camelCase humps,
+ * spaces or other punctuation, so a dotted nx id like `scope.my_lib` becomes
+ * `scope-my-lib` (and only those three separators are touched).
+ *
+ * eg. `sojourner.agent_connection` -> `sojourner-agent-connection`
+ */
+export const normalizeDistributionName = (str: string): string =>
+  str.toLowerCase().replace(/[._-]+/g, '-');
+
 // Convert a string to a dot notation string (eg. lambda_handler/my_handler.py -> lambda_handler.my_handler)
 export const toDotNotation = (str: string): string =>
   str

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -503,6 +503,23 @@ describe('addDependenciesToPyProjectToml', () => {
 describe('addWorkspaceDependencyToPyProject', () => {
   let tree: Tree;
 
+  const dependent = { name: 'scope.consumer', root: 'packages/consumer' };
+
+  // Helper to register a dependency project with a given [project].name.
+  const writeDependency = (
+    name: string,
+    pyprojectName: string,
+    root: string,
+  ) => {
+    tree.write(
+      `${root}/pyproject.toml`,
+      stringify({
+        project: { name: pyprojectName, version: '0.1.0', dependencies: [] },
+      } as UVPyprojectToml),
+    );
+    return { name, root };
+  };
+
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
     tree.write(
@@ -518,15 +535,17 @@ describe('addWorkspaceDependencyToPyProject', () => {
       tree.read('packages/consumer/pyproject.toml', 'utf-8'),
     ) as UVPyprojectToml;
 
-  it('should write the PEP 503 distribution name when given a dotted Nx id', () => {
-    // Callers (eg the dynamodb connection generators) pass the dotted Nx
-    // project id; the dependency string and source key must be the hyphenated
-    // distribution name so @nxlv/python infers the workspace edge.
-    addWorkspaceDependencyToPyProject(
-      tree,
-      'packages/consumer',
+  it('should derive the distribution name from the dependency project pyproject', () => {
+    // The dependency's [project].name is the authoritative distribution name
+    // uv writes to uv.lock; the dependent must reference that exact value so
+    // @nxlv/python infers the workspace edge.
+    const dependency = writeDependency(
       'scope.my_lib',
+      'scope-my-lib',
+      'packages/my_lib',
     );
+
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
 
     const toml = readToml();
     expect(toml.project.dependencies).toContain('scope-my-lib');
@@ -537,12 +556,16 @@ describe('addWorkspaceDependencyToPyProject', () => {
     expect((toml.tool as any).uv.sources['scope.my_lib']).toBeUndefined();
   });
 
-  it('should be idempotent for an already-normalised name', () => {
-    addWorkspaceDependencyToPyProject(
-      tree,
-      'packages/consumer',
-      'scope-my-lib',
+  it('should normalise a dotted distribution name from an older dependency project', () => {
+    // Defensive: even if a dependency still carries a dotted [project].name,
+    // the value written into the dependent is the normalised hyphenated form.
+    const dependency = writeDependency(
+      'scope.my_lib',
+      'scope.my_lib',
+      'packages/my_lib',
     );
+
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
 
     const toml = readToml();
     expect(toml.project.dependencies).toEqual(['scope-my-lib']);
@@ -551,17 +574,25 @@ describe('addWorkspaceDependencyToPyProject', () => {
     });
   });
 
-  it('should not add a duplicate when called twice with different name forms', () => {
-    addWorkspaceDependencyToPyProject(
-      tree,
-      'packages/consumer',
+  it('should fall back to the Nx project id when the dependency has no pyproject', () => {
+    addWorkspaceDependencyToPyProject(tree, dependent, {
+      name: 'scope.my_lib',
+      root: 'packages/missing',
+    });
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toEqual(['scope-my-lib']);
+  });
+
+  it('should not add a duplicate when re-run', () => {
+    const dependency = writeDependency(
       'scope.my_lib',
-    );
-    addWorkspaceDependencyToPyProject(
-      tree,
-      'packages/consumer',
       'scope-my-lib',
+      'packages/my_lib',
     );
+
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
 
     const toml = readToml();
     expect(toml.project.dependencies).toEqual(['scope-my-lib']);

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -7,7 +7,10 @@ import { parse, stringify } from '@iarna/toml';
 import type { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import type { UVPyprojectToml } from './nxlv-python';
-import { addDependenciesToPyProjectToml } from './py';
+import {
+  addDependenciesToPyProjectToml,
+  addWorkspaceDependencyToPyProject,
+} from './py';
 import type { IPyDepVersion } from './versions';
 
 describe('addDependenciesToPyProjectToml', () => {
@@ -129,7 +132,10 @@ describe('addDependenciesToPyProjectToml', () => {
         },
       }),
     );
-    addDependenciesToPyProjectToml(tree, 'test-project', ['fastapi', 'uvicorn']);
+    addDependenciesToPyProjectToml(tree, 'test-project', [
+      'fastapi',
+      'uvicorn',
+    ]);
 
     const afterFirstAdd = (
       parse(
@@ -139,7 +145,10 @@ describe('addDependenciesToPyProjectToml', () => {
 
     // Re-adding the same deps must leave the list byte-identical, not move the
     // entries to the end.
-    addDependenciesToPyProjectToml(tree, 'test-project', ['fastapi', 'uvicorn']);
+    addDependenciesToPyProjectToml(tree, 'test-project', [
+      'fastapi',
+      'uvicorn',
+    ]);
 
     const afterSecondAdd = (
       parse(
@@ -488,5 +497,73 @@ describe('addDependenciesToPyProjectToml', () => {
     expect(updatedToml.project.dependencies).not.toContain('fastapi>=0.100.0');
 
     expect(updatedToml.project.dependencies).toHaveLength(4);
+  });
+});
+
+describe('addWorkspaceDependencyToPyProject', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'packages/consumer/pyproject.toml',
+      stringify({
+        project: { name: 'scope-consumer', version: '0.1.0', dependencies: [] },
+      } as UVPyprojectToml),
+    );
+  });
+
+  const readToml = () =>
+    parse(
+      tree.read('packages/consumer/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+  it('should write the PEP 503 distribution name when given a dotted Nx id', () => {
+    // Callers (eg the dynamodb connection generators) pass the dotted Nx
+    // project id; the dependency string and source key must be the hyphenated
+    // distribution name so @nxlv/python infers the workspace edge.
+    addWorkspaceDependencyToPyProject(
+      tree,
+      'packages/consumer',
+      'scope.my_lib',
+    );
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toContain('scope-my-lib');
+    expect(toml.project.dependencies).not.toContain('scope.my_lib');
+    expect((toml.tool as any).uv.sources['scope-my-lib']).toEqual({
+      workspace: true,
+    });
+    expect((toml.tool as any).uv.sources['scope.my_lib']).toBeUndefined();
+  });
+
+  it('should be idempotent for an already-normalised name', () => {
+    addWorkspaceDependencyToPyProject(
+      tree,
+      'packages/consumer',
+      'scope-my-lib',
+    );
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toEqual(['scope-my-lib']);
+    expect((toml.tool as any).uv.sources['scope-my-lib']).toEqual({
+      workspace: true,
+    });
+  });
+
+  it('should not add a duplicate when called twice with different name forms', () => {
+    addWorkspaceDependencyToPyProject(
+      tree,
+      'packages/consumer',
+      'scope.my_lib',
+    );
+    addWorkspaceDependencyToPyProject(
+      tree,
+      'packages/consumer',
+      'scope-my-lib',
+    );
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toEqual(['scope-my-lib']);
   });
 });

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -5,6 +5,7 @@
 import { parse, stringify } from '@iarna/toml';
 import { joinPathFragments, type Tree } from '@nx/devkit';
 import { parsePipRequirementsLine } from 'pip-requirements-js';
+import { normalizeDistributionName } from './names';
 import type { UVPyprojectToml } from './nxlv-python';
 import { updateToml } from './toml';
 import { type IPyDepVersion, withPyVersions } from './versions';
@@ -123,25 +124,33 @@ export const addWorkspaceDependencyToPyProject = (
     return;
   }
 
+  // The dependency string and [tool.uv.sources] key must be the PEP 503
+  // distribution name (hyphenated), not the dotted Nx project id, so that uv
+  // and @nxlv/python match it to the workspace member and the dependency edge
+  // appears in the Nx project graph. Callers may pass either form (eg a dotted
+  // `targetProject.name`); normalizing here is idempotent for names that are
+  // already normalised.
+  const distributionName = normalizeDistributionName(dependencyPackageName);
+
   updateToml(tree, pyprojectPath, (toml: UVPyprojectToml) => {
     // Add to [project].dependencies if not already present
     const deps = toml.project?.dependencies ?? [];
     if (
       !deps.some(
         (d) =>
-          d === dependencyPackageName ||
-          d.startsWith(`${dependencyPackageName}>=`) ||
-          d.startsWith(`${dependencyPackageName}==`),
+          d === distributionName ||
+          d.startsWith(`${distributionName}>=`) ||
+          d.startsWith(`${distributionName}==`),
       )
     ) {
-      toml.project.dependencies = [...deps, dependencyPackageName];
+      toml.project.dependencies = [...deps, distributionName];
     }
 
     // Add to [tool.uv.sources] with workspace = true
     toml.tool = toml.tool ?? {};
     (toml.tool as any).uv = (toml.tool as any).uv ?? {};
     (toml.tool as any).uv.sources = (toml.tool as any).uv.sources ?? {};
-    (toml.tool as any).uv.sources[dependencyPackageName] = {
+    (toml.tool as any).uv.sources[distributionName] = {
       workspace: true,
     };
 

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -7,7 +7,7 @@ import { joinPathFragments, type Tree } from '@nx/devkit';
 import { parsePipRequirementsLine } from 'pip-requirements-js';
 import { normalizeDistributionName } from './names';
 import type { UVPyprojectToml } from './nxlv-python';
-import { updateToml } from './toml';
+import { readToml, updateToml } from './toml';
 import { type IPyDepVersion, withPyVersions } from './versions';
 
 // Dedup key that distinguishes bare packages from the same package with
@@ -111,26 +111,52 @@ export const uvxCommand = (
 };
 
 /**
+ * Resolve the PEP 503 distribution name of a Python project from its
+ * `pyproject.toml` `[project].name`, falling back to normalising the supplied
+ * Nx project id when the project has no readable pyproject yet.
+ *
+ * This is the authoritative name uv writes into `uv.lock`, so it is the value
+ * that must appear in a dependent's `[project].dependencies` /
+ * `[tool.uv.sources]` for `@nxlv/python` to infer the workspace dependency
+ * edge. Always normalised so the result is a valid distribution name even if
+ * an older project still carries a dotted `[project].name`.
+ */
+const getPyDistributionName = (
+  tree: Tree,
+  project: { name?: string; root: string },
+): string => {
+  const pyprojectPath = joinPathFragments(project.root, 'pyproject.toml');
+  const projectName = tree.exists(pyprojectPath)
+    ? (readToml(tree, pyprojectPath) as unknown as UVPyprojectToml).project?.name
+    : undefined;
+  return normalizeDistributionName(projectName ?? project.name ?? '');
+};
+
+/**
  * Add a workspace dependency from one Python project to another.
  * Adds the dependency to [project].dependencies and [tool.uv.sources].
+ *
+ * Both projects are passed as Nx project configurations (not names): the
+ * dependency's PEP 503 distribution name is derived from its own
+ * `pyproject.toml` here, so callers cannot accidentally pass the dotted Nx id
+ * (which @nxlv/python splits on `.` and drops, losing the project-graph edge).
+ * This is the single entry point all generators use to wire a Python workspace
+ * dependency.
  */
 export const addWorkspaceDependencyToPyProject = (
   tree: Tree,
-  projectRoot: string,
-  dependencyPackageName: string,
+  dependentProject: { name?: string; root: string },
+  dependencyProject: { name?: string; root: string },
 ): void => {
-  const pyprojectPath = joinPathFragments(projectRoot, 'pyproject.toml');
+  const pyprojectPath = joinPathFragments(
+    dependentProject.root,
+    'pyproject.toml',
+  );
   if (!tree.exists(pyprojectPath)) {
     return;
   }
 
-  // The dependency string and [tool.uv.sources] key must be the PEP 503
-  // distribution name (hyphenated), not the dotted Nx project id, so that uv
-  // and @nxlv/python match it to the workspace member and the dependency edge
-  // appears in the Nx project graph. Callers may pass either form (eg a dotted
-  // `targetProject.name`); normalizing here is idempotent for names that are
-  // already normalised.
-  const distributionName = normalizeDistributionName(dependencyPackageName);
+  const distributionName = getPyDistributionName(tree, dependencyProject);
 
   updateToml(tree, pyprojectPath, (toml: UVPyprojectToml) => {
     // Add to [project].dependencies if not already present


### PR DESCRIPTION
## Problem

`py#project` assigns a single name to **both** the nx project id and the Python distribution name: `getPyProjectDetails` builds ``const fullyQualifiedName = `${scope}.${normalizedName}` `` (e.g. `sojourner.agent`) and passes it to `uvProjectGenerator` as `name`, which writes it into the project's `pyproject.toml` `[project].name`, the root `[tool.uv.sources]` key, and inter-project `[project].dependencies` strings.

The dot in the **distribution** name breaks `@nxlv/python`'s nx-graph dependency inference, so a Python workspace dependency (for example an agent that bundles its `agent_connection` library) never becomes an edge in the nx project graph. Two independent reasons, both confirmed in `@nxlv/python` 22.1.4 and 22.2.0:

1. `normalizeDependencyName` splits on `.`, so a dotted dependency string is truncated (e.g. `sojourner.agent_connection` becomes `sojourner`) and dropped before any lookup.
2. The provider looks up `uv.lock` by the dotted `pyproject.project.name`, but uv writes the lockfile keyed by the PEP 503 normalised (hyphenated) name, so the lookup misses.

The practical impact downstream: because the agent has no graph edge to the library it bundles into its container image, a change confined to that library does not invalidate the agent build's cache, and a stale image can be produced and deployed.

## Fix

Emit a PEP 503 normalised **distribution** name (lower-cased, runs of `.`/`_`/`-` collapsed to a single `-`) while keeping the nx **project id** dotted. These two were already conflated into one value; this decouples them.

`@nxlv/python`'s `uvProjectGenerator` already accepts a separate `packageName` option distinct from `name` (`name` becomes the nx project id, `packageName` is templated into the pyproject `[project].name` and `[tool.uv.sources]` key), so the decoupling needs no post-processing of generated TOML:

- `name: fullyQualifiedName` (dotted, the nx project id, unchanged)
- `packageName: distributionName` (hyphenated, PEP 503)

The inter-project dependency wiring shared by the `py#agent` and connection generators routes through the same normalisation, so the dependency string and `[tool.uv.sources]` key it writes match the hyphenated lockfile name.

## Changes

- `utils/names.ts`: add `normalizeDistributionName` (PEP 503: lowercase, collapse `.`/`_`/`-` runs to `-`; deliberately not kebab-case, so camelCase humps are not split) + unit tests.
- `py/project/generator.ts`: derive `distributionName` in `getPyProjectDetails`, add it to `PyProjectDetails`, pass it as `uvProjectGenerator`'s `packageName`. nx-id writes are unchanged.
- `utils/agent-connection/agent-connection.ts`: the shared inter-project dependency helper now returns the distribution name, fixing the `py#agent` generator and the a2a/mcp/gateway connection sub-generators at their single chokepoint.
- Update the one affected snapshot + assertion.

The only snapshot change is the distribution name in `[project].name` / `[tool.uv.sources]` becoming hyphenated; nx project ids stay dotted and Python module names are unchanged.

## Verification

Drove the real generators against an on-disk workspace under a dotted scope, then invoked `@nxlv/python`'s `createDependencies` (the function that builds the nx project graph):

- With the hyphenated distribution name: the edge is inferred (`scope.backend -> scope.agent_connection`), with the nx project ids still dotted.
- With the dotted distribution name (the current behaviour): no edge.

`pnpm nx run @aws/nx-plugin:test` and the affected generator specs pass.

## Notes for reviewers

- Scope was deliberately limited to the **distribution** name. The nx project id stays dotted (the existing "fully qualified" convention) to avoid a breaking change to project ids and everything that derives from them.
- This is opened as a **draft** to discuss the approach before any e2e/tutorial-snapshot work. Happy to open a tracking issue if preferred per CONTRIBUTING.


---

### Update (rebased onto `main` + follow-up commits)

The branch was rebased onto current `main` and two follow-up commits were added to make the fix complete and CI-green:

**`fix(py#project): normalize workspace dep names at the shared chokepoint`**
- The original change fixed `py#project` and the agent-connection wiring, but the `py#dynamodb` connection sub-generators (`fast-api-connection`, `mcp-server-connection`, `agent-connection`) passed the dotted Nx id straight through `addWorkspaceDependencyToPyProject`, so they still wrote a dotted dependency / `[tool.uv.sources]` key and produced **no project-graph edge** (verified end-to-end: editing a `py#dynamodb` table did not invalidate a consuming FastAPI bundle's cache). Normalised at the helper so all callers are covered.
- Regenerated the **langchain** `py#agent` snapshot, whose `agent_connection` distribution name is now hyphenated. (The langchain agent feature landed in `main` after this PR's original base, so its snapshot was not covered by the original change and made the rebased branch red.)

**`refactor(py#project): derive workspace dep name from the dependency project`**
- Makes `addWorkspaceDependencyToPyProject` the single, hard-to-misuse entry point: it now takes the **dependent** and **dependency** projects (not a free-form name string) and derives the dependency's PEP 503 distribution name from that project's own `pyproject.toml`. Callers can no longer pass the dotted Nx id by mistake — this removes the footgun that caused the gap above. All seven call sites (py#agent + agent mcp/a2a/gateway connections + dynamodb fast-api/mcp-server/agent connections) route through it.

**Validation:** added unit tests for `normalizeDistributionName` and `addWorkspaceDependencyToPyProject`; strengthened the three `py#dynamodb` connection specs to assert the hyphenated name; full `pnpm nx run @aws/nx-plugin:test` passes (2386 tests). End-to-end verified in a `@next` workspace that the agent→agent_connection and dynamodb→fast-api/agent/mcp edges are inferred and cache-invalidation works.

The same fix has been ported to `release/0.x` in #846.
