### PR TITLE
fix(py#project): use PEP 503 distribution names so nx infers workspace edges

### DIFF
--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -745,7 +745,7 @@ exports[`py#agent generator > should match snapshot for generated files > update
 name = "proj.test_project"
 version = "0.1.0"
 dependencies = [
-  "proj.agent_connection",
+  "proj-agent-connection",
   "aws-lambda-powertools==3.29.0",
   "aws-opentelemetry-distro==0.17.1",
   "bedrock-agentcore==1.13.0",
@@ -763,7 +763,7 @@ dev = [ "fastapi[standard]==0.136.3" ]
 [tool.uv]
 dev-dependencies = [ ]
 
-[tool.uv.sources."proj.agent_connection"]
+[tool.uv.sources.proj-agent-connection]
 workspace = true
 "
 `;

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -30,7 +30,7 @@ import {
   addPythonCoreClient,
   getPythonAgentConnectionProjectDir,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
   addPythonReExport,
 } from '../../../utils/agent-connection/agent-connection';
 import {
@@ -92,7 +92,6 @@ export const pyAgentA2aConnectionGenerator = async (
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
 
   // Python deps required by the A2A core client + shared auth helper.
   addDependenciesToPyProjectToml(tree, agentConnectionProjectDir, [
@@ -171,8 +170,8 @@ export const pyAgentA2aConnectionGenerator = async (
   // 4. Add workspace dependency from agent project to agent-connection project
   addWorkspaceDependencyToPyProject(
     tree,
-    sourceProject.root,
-    agentConnectionPackageName,
+    sourceProject,
+    getPythonAgentConnectionProject(tree),
   );
 
   // 5. Set up serve-local target dependencies — chain onto the target agent

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -34,7 +34,7 @@ import { addAgentInfra } from '../../utils/agent-core-constructs/agent-core-cons
 import {
   ensurePythonAgentConnectionProject,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
 } from '../../utils/agent-connection/agent-connection';
 import { addWorkspaceDependencyToPyProject } from '../../utils/py';
 
@@ -106,11 +106,10 @@ export const pyAgentGenerator = async (
   // generator wires into this agent.
   await ensurePythonAgentConnectionProject(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
   addWorkspaceDependencyToPyProject(
     tree,
-    project.root,
-    agentConnectionPackageName,
+    project,
+    getPythonAgentConnectionProject(tree),
   );
 
   const templateContext = {

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
@@ -248,8 +248,9 @@ dependencies = ["strands-agents"]
       'utf-8',
     )!;
 
-    // Check workspace dependency was added
-    expect(pyprojectContent).toContain('proj.agent_connection');
+    // Check workspace dependency was added, keyed by the PEP 503 distribution
+    // name (hyphenated, not the dotted Nx id) so @nxlv/python infers the edge.
+    expect(pyprojectContent).toContain('proj-agent-connection');
   });
 
   it('should update serve-local target with MCP dependency', async () => {

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
@@ -30,7 +30,7 @@ import {
   addPythonCoreClient,
   getPythonAgentConnectionProjectDir,
   getPythonAgentConnectionModuleName,
-  getPythonAgentConnectionPackageName,
+  getPythonAgentConnectionProject,
   addPythonReExport,
 } from '../../../utils/agent-connection/agent-connection';
 import {
@@ -86,7 +86,6 @@ export const pyAgentMcpConnectionGenerator = async (
 
   const agentConnectionProjectDir = getPythonAgentConnectionProjectDir(tree);
   const agentConnectionModuleName = getPythonAgentConnectionModuleName(tree);
-  const agentConnectionPackageName = getPythonAgentConnectionPackageName(tree);
 
   // Python deps required by the MCP core client + shared auth helper.
   addDependenciesToPyProjectToml(tree, agentConnectionProjectDir, [
@@ -163,8 +162,8 @@ export const pyAgentMcpConnectionGenerator = async (
   // 4. Add workspace dependency from agent project to agent-connection project
   addWorkspaceDependencyToPyProject(
     tree,
-    sourceProject.root,
-    agentConnectionPackageName,
+    sourceProject,
+    getPythonAgentConnectionProject(tree),
   );
 
   // 5. Set up serve-local target dependencies

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -23,7 +23,7 @@ import {
 } from '../../utils/nxlv-python';
 import { withVersions } from '../../utils/versions';
 import { getNpmScope } from '../../utils/npm-scope';
-import { toSnakeCase } from '../../utils/names';
+import { normalizeDistributionName, toSnakeCase } from '../../utils/names';
 import { sortObjectKeys } from '../../utils/object';
 import { updateGitIgnore } from '../../utils/git';
 import {
@@ -41,9 +41,22 @@ export const PY_PROJECT_GENERATOR_INFO: NxGeneratorInfo =
 
 export interface PyProjectDetails {
   /**
-   * Full package name including scope (eg foo.bar)
+   * Fully qualified Nx project id including scope, in dot notation (eg foo.bar).
+   * This is the identifier Nx uses (readProjectConfiguration, the project
+   * graph, target references) and is intentionally kept dotted.
    */
   readonly fullyQualifiedName: string;
+  /**
+   * PEP 503 normalised Python distribution name (eg foo-bar). This is the name
+   * written to the project's `[project].name`, the root `[tool.uv.sources]`
+   * key, and any inter-project dependency string. It is hyphenated (not dotted)
+   * so `uv` and `@nxlv/python` can match it: uv writes `uv.lock` keyed by the
+   * PEP 503 hyphenated name, and `@nxlv/python`'s dependency inference splits a
+   * dotted name on `.` and so would otherwise drop the edge entirely. Keeping
+   * the distribution name decoupled from `fullyQualifiedName` is what lets the
+   * workspace dependency edge appear in the Nx project graph.
+   */
+  readonly distributionName: string;
   /**
    * Directory of the library relative to the root
    */
@@ -72,12 +85,15 @@ export const getPyProjectDetails = (
     schema.moduleName ?? `${scope}_${normalizedName}`,
   );
   const fullyQualifiedName = `${scope}.${normalizedName}`;
+  // The Python distribution name is the PEP 503 normalised form of the
+  // fully qualified name: hyphenated, never dotted. See PyProjectDetails.
+  const distributionName = normalizeDistributionName(fullyQualifiedName);
   // NB: interactive nx generator cli can pass empty string
   const dir = joinPathFragments(
     schema.directory || '.',
     schema.subDirectory || normalizedName,
   );
-  return { dir, fullyQualifiedName, normalizedModuleName };
+  return { dir, fullyQualifiedName, distributionName, normalizedModuleName };
 };
 
 /**
@@ -87,10 +103,8 @@ export const pyProjectGenerator = async (
   tree: Tree,
   schema: PyProjectGeneratorSchema,
 ): Promise<GeneratorCallback> => {
-  const { dir, normalizedModuleName, fullyQualifiedName } = getPyProjectDetails(
-    tree,
-    schema,
-  );
+  const { dir, normalizedModuleName, fullyQualifiedName, distributionName } =
+    getPyProjectDetails(tree, schema);
 
   const pythonPlugin = withVersions(['@nxlv/python']);
   addDependenciesToPackageJson(tree, {}, pythonPlugin);
@@ -132,7 +146,14 @@ export const pyProjectGenerator = async (
   }
 
   await uvProjectGenerator(tree, {
+    // The Nx project id (and `uv.workspace.members` etc.) keys off `name`, so
+    // keep it dotted. `packageName` is the separate PEP 503 distribution name
+    // written to `[project].name` and the root `[tool.uv.sources]` key; it is
+    // hyphenated so `@nxlv/python` infers the workspace dependency edge (it
+    // splits a dotted name on `.` and would otherwise drop it). This split is
+    // the whole fix (see PyProjectDetails.distributionName).
     name: fullyQualifiedName,
+    packageName: distributionName,
     publishable: false,
     buildLockedVersions: true,
     buildBundleLocalDependencies: true,

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -53,14 +53,20 @@ export function getPythonAgentConnectionModuleName(tree: Tree): string {
 }
 
 /**
- * Get the fully qualified Python package name of the shared agent-connection project.
+ * Get the shared agent-connection project as `{ name, root }`, suitable for
+ * passing to {@link addWorkspaceDependencyToPyProject} (which derives the
+ * dependency's PEP 503 distribution name from the project itself, so callers
+ * never construct the name).
  */
-export function getPythonAgentConnectionPackageName(tree: Tree): string {
-  const { fullyQualifiedName } = getPyProjectDetails(tree, {
+export function getPythonAgentConnectionProject(tree: Tree): {
+  name: string;
+  root: string;
+} {
+  const { fullyQualifiedName, dir } = getPyProjectDetails(tree, {
     name: PY_AGENT_CONNECTION_NAME,
     directory: joinPathFragments(PACKAGES_DIR, COMMON_DIR),
   });
-  return fullyQualifiedName;
+  return { name: fullyQualifiedName, root: dir };
 }
 
 /**

--- a/packages/nx-plugin/src/utils/names.spec.ts
+++ b/packages/nx-plugin/src/utils/names.spec.ts
@@ -9,6 +9,7 @@ import {
   toSnakeCase,
   toDotNotation,
   kebabCase,
+  normalizeDistributionName,
   snakeCase,
 } from './names';
 
@@ -590,6 +591,45 @@ describe('names utils', () => {
         expect(kebabCase('DataTableComponent')).toBe('data-table-component');
         expect(kebabCase('SearchInputField')).toBe('search-input-field');
       });
+    });
+  });
+
+  describe('normalizeDistributionName', () => {
+    it('should hyphenate dotted scope-qualified names', () => {
+      // The crux: a dotted nx id with an underscored project segment becomes a
+      // fully hyphenated PEP 503 distribution name.
+      expect(normalizeDistributionName('sojourner.agent_connection')).toBe(
+        'sojourner-agent-connection',
+      );
+      expect(normalizeDistributionName('sojourner.agent')).toBe(
+        'sojourner-agent',
+      );
+      expect(normalizeDistributionName('proj.test_project')).toBe(
+        'proj-test-project',
+      );
+    });
+
+    it('should lower-case the name', () => {
+      expect(normalizeDistributionName('MyScope.MyLib')).toBe('myscope-mylib');
+      expect(normalizeDistributionName('Foo_Bar')).toBe('foo-bar');
+    });
+
+    it('should collapse runs of ., _ and - to a single hyphen', () => {
+      expect(normalizeDistributionName('a..b__c--d')).toBe('a-b-c-d');
+      expect(normalizeDistributionName('a._-b')).toBe('a-b');
+    });
+
+    it('should leave an already-normalised name unchanged (idempotent)', () => {
+      expect(normalizeDistributionName('sojourner-agent-connection')).toBe(
+        'sojourner-agent-connection',
+      );
+      const once = normalizeDistributionName('Some.Mixed_Name');
+      expect(normalizeDistributionName(once)).toBe(once);
+    });
+
+    it('should not split camelCase humps (this is not kebab-case)', () => {
+      // PEP 503 only touches ., _ and -; camelCase boundaries are preserved.
+      expect(normalizeDistributionName('myScope.myLib')).toBe('myscope-mylib');
     });
   });
 

--- a/packages/nx-plugin/src/utils/names.ts
+++ b/packages/nx-plugin/src/utils/names.ts
@@ -59,6 +59,24 @@ export const kebabCase = (str: string): string => {
   );
 };
 
+/**
+ * Normalise a string to a PEP 503 distribution name.
+ *
+ * PEP 503 (https://peps.python.org/pep-0503/#normalized-names) defines the
+ * canonical form of a Python project distribution name: lower-cased, with any
+ * run of `.`, `_` or `-` collapsed to a single `-`. This is the name uv writes
+ * into `uv.lock` and the form `@nxlv/python` expects when inferring workspace
+ * dependency edges from `[project].dependencies` / `[tool.uv.sources]`.
+ *
+ * Importantly this is NOT kebab-case: it does not split on camelCase humps,
+ * spaces or other punctuation, so a dotted nx id like `scope.my_lib` becomes
+ * `scope-my-lib` (and only those three separators are touched).
+ *
+ * eg. `sojourner.agent_connection` -> `sojourner-agent-connection`
+ */
+export const normalizeDistributionName = (str: string): string =>
+  str.toLowerCase().replace(/[._-]+/g, '-');
+
 // Convert a string to a dot notation string (eg. lambda_handler/my_handler.py -> lambda_handler.my_handler)
 export const toDotNotation = (str: string): string =>
   str

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -6,7 +6,10 @@ import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { parse, stringify } from '@iarna/toml';
 import type { UVPyprojectToml } from './nxlv-python';
-import { addDependenciesToPyProjectToml } from './py';
+import {
+  addDependenciesToPyProjectToml,
+  addWorkspaceDependencyToPyProject,
+} from './py';
 import { IPyDepVersion } from './versions';
 
 describe('addDependenciesToPyProjectToml', () => {
@@ -454,5 +457,104 @@ describe('addDependenciesToPyProjectToml', () => {
     expect(updatedToml.project.dependencies).not.toContain('fastapi>=0.100.0');
 
     expect(updatedToml.project.dependencies).toHaveLength(4);
+  });
+});
+
+describe('addWorkspaceDependencyToPyProject', () => {
+  let tree: Tree;
+
+  const dependent = { name: 'scope.consumer', root: 'packages/consumer' };
+
+  // Helper to register a dependency project with a given [project].name.
+  const writeDependency = (
+    name: string,
+    pyprojectName: string,
+    root: string,
+  ) => {
+    tree.write(
+      `${root}/pyproject.toml`,
+      stringify({
+        project: { name: pyprojectName, version: '0.1.0', dependencies: [] },
+      } as UVPyprojectToml),
+    );
+    return { name, root };
+  };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'packages/consumer/pyproject.toml',
+      stringify({
+        project: { name: 'scope-consumer', version: '0.1.0', dependencies: [] },
+      } as UVPyprojectToml),
+    );
+  });
+
+  const readToml = () =>
+    parse(
+      tree.read('packages/consumer/pyproject.toml', 'utf-8'),
+    ) as UVPyprojectToml;
+
+  it('should derive the distribution name from the dependency project pyproject', () => {
+    // The dependency's [project].name is the authoritative distribution name
+    // uv writes to uv.lock; the dependent must reference that exact value so
+    // @nxlv/python infers the workspace edge.
+    const dependency = writeDependency(
+      'scope.my_lib',
+      'scope-my-lib',
+      'packages/my_lib',
+    );
+
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toContain('scope-my-lib');
+    expect(toml.project.dependencies).not.toContain('scope.my_lib');
+    expect((toml.tool as any).uv.sources['scope-my-lib']).toEqual({
+      workspace: true,
+    });
+    expect((toml.tool as any).uv.sources['scope.my_lib']).toBeUndefined();
+  });
+
+  it('should normalise a dotted distribution name from an older dependency project', () => {
+    // Defensive: even if a dependency still carries a dotted [project].name,
+    // the value written into the dependent is the normalised hyphenated form.
+    const dependency = writeDependency(
+      'scope.my_lib',
+      'scope.my_lib',
+      'packages/my_lib',
+    );
+
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toEqual(['scope-my-lib']);
+    expect((toml.tool as any).uv.sources['scope-my-lib']).toEqual({
+      workspace: true,
+    });
+  });
+
+  it('should fall back to the Nx project id when the dependency has no pyproject', () => {
+    addWorkspaceDependencyToPyProject(tree, dependent, {
+      name: 'scope.my_lib',
+      root: 'packages/missing',
+    });
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toEqual(['scope-my-lib']);
+  });
+
+  it('should not add a duplicate when re-run', () => {
+    const dependency = writeDependency(
+      'scope.my_lib',
+      'scope-my-lib',
+      'packages/my_lib',
+    );
+
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
+    addWorkspaceDependencyToPyProject(tree, dependent, dependency);
+
+    const toml = readToml();
+    expect(toml.project.dependencies).toEqual(['scope-my-lib']);
   });
 });

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -4,10 +4,11 @@
  */
 import { parse, stringify } from '@iarna/toml';
 import { joinPathFragments, Tree } from '@nx/devkit';
+import { normalizeDistributionName } from './names';
 import type { UVPyprojectToml } from './nxlv-python';
 import { IPyDepVersion, withPyVersions } from './versions';
 import { parsePipRequirementsLine } from 'pip-requirements-js';
-import { updateToml } from './toml';
+import { readToml, updateToml } from './toml';
 
 // Dedup key that distinguishes bare packages from the same package with
 // extras (e.g. `foo` vs `foo[bar]`), so adding a bare dep doesn't drop a
@@ -101,18 +102,52 @@ export const uvxCommand = (
 };
 
 /**
+ * Resolve the PEP 503 distribution name of a Python project from its
+ * `pyproject.toml` `[project].name`, falling back to normalising the supplied
+ * Nx project id when the project has no readable pyproject yet.
+ *
+ * This is the authoritative name uv writes into `uv.lock`, so it is the value
+ * that must appear in a dependent's `[project].dependencies` /
+ * `[tool.uv.sources]` for `@nxlv/python` to infer the workspace dependency
+ * edge. Always normalised so the result is a valid distribution name even if
+ * an older project still carries a dotted `[project].name`.
+ */
+const getPyDistributionName = (
+  tree: Tree,
+  project: { name?: string; root: string },
+): string => {
+  const pyprojectPath = joinPathFragments(project.root, 'pyproject.toml');
+  const projectName = tree.exists(pyprojectPath)
+    ? (readToml(tree, pyprojectPath) as unknown as UVPyprojectToml).project?.name
+    : undefined;
+  return normalizeDistributionName(projectName ?? project.name ?? '');
+};
+
+/**
  * Add a workspace dependency from one Python project to another.
  * Adds the dependency to [project].dependencies and [tool.uv.sources].
+ *
+ * Both projects are passed as Nx project configurations (not names): the
+ * dependency's PEP 503 distribution name is derived from its own
+ * `pyproject.toml` here, so callers cannot accidentally pass the dotted Nx id
+ * (which @nxlv/python splits on `.` and drops, losing the project-graph edge).
+ * This is the single entry point all generators use to wire a Python workspace
+ * dependency.
  */
 export const addWorkspaceDependencyToPyProject = (
   tree: Tree,
-  projectRoot: string,
-  dependencyPackageName: string,
+  dependentProject: { name?: string; root: string },
+  dependencyProject: { name?: string; root: string },
 ): void => {
-  const pyprojectPath = joinPathFragments(projectRoot, 'pyproject.toml');
+  const pyprojectPath = joinPathFragments(
+    dependentProject.root,
+    'pyproject.toml',
+  );
   if (!tree.exists(pyprojectPath)) {
     return;
   }
+
+  const distributionName = getPyDistributionName(tree, dependencyProject);
 
   updateToml(tree, pyprojectPath, (toml: UVPyprojectToml) => {
     // Add to [project].dependencies if not already present
@@ -120,19 +155,19 @@ export const addWorkspaceDependencyToPyProject = (
     if (
       !deps.some(
         (d) =>
-          d === dependencyPackageName ||
-          d.startsWith(`${dependencyPackageName}>=`) ||
-          d.startsWith(`${dependencyPackageName}==`),
+          d === distributionName ||
+          d.startsWith(`${distributionName}>=`) ||
+          d.startsWith(`${distributionName}==`),
       )
     ) {
-      toml.project.dependencies = [...deps, dependencyPackageName];
+      toml.project.dependencies = [...deps, distributionName];
     }
 
     // Add to [tool.uv.sources] with workspace = true
     toml.tool = toml.tool ?? {};
     (toml.tool as any).uv = (toml.tool as any).uv ?? {};
     (toml.tool as any).uv.sources = (toml.tool as any).uv.sources ?? {};
-    (toml.tool as any).uv.sources[dependencyPackageName] = {
+    (toml.tool as any).uv.sources[distributionName] = {
       workspace: true,
     };
 


### PR DESCRIPTION
### Reason for this change

`py#project` assigns a single name to **both** the Nx project id and the Python distribution name (`` `${scope}.${normalizedName}` ``, e.g. `sojourner.agent`). The dot in the **distribution** name breaks `@nxlv/python`'s nx-graph dependency inference:

1. `normalizeDependencyName` splits on `.`, so a dotted dependency string is truncated and dropped before lookup.
2. The provider looks up `uv.lock` by the dotted `pyproject.project.name`, but uv writes the lockfile keyed by the PEP 503 normalised (hyphenated) name, so the lookup misses.

The practical impact: a Python workspace dependency (for example an agent that bundles its `agent_connection` library) never becomes an edge in the Nx project graph, so a change confined to that library does not invalidate the dependent build's cache and a stale image can be produced and deployed.

This is the `release/0.x` port of the same fix being applied to `main` (PR #845).

### Description of changes

- `utils/names.ts`: add `normalizeDistributionName` (PEP 503: lowercase, collapse `.`/`_`/`-` runs to `-`; deliberately not kebab-case, so camelCase humps are not split) + unit tests.
- `py/project/generator.ts`: derive a `distributionName` in `getPyProjectDetails` and pass it as `uvProjectGenerator`'s `packageName` (hyphenated `[project].name` / `[tool.uv.sources]` key) while keeping `name` the dotted Nx id.
- `utils/py.ts`: `addWorkspaceDependencyToPyProject` is now the single, hard-to-misuse entry point for wiring a Python workspace dependency. It takes the **dependent** and **dependency** projects (not a free-form name string) and derives the dependency's PEP 503 distribution name from that project's own `pyproject.toml` `[project].name`, so callers cannot accidentally pass the dotted Nx id (the footgun that caused the bug). All agent connection generators route through it.
- `utils/agent-connection/agent-connection.ts`: expose `getPythonAgentConnectionProject` (returns the shared project) in place of the name-returning helper.
- Update the affected snapshot + assertions.

The nx project ids stay dotted (the existing "fully qualified" convention) and Python module names are unchanged, so this is not a breaking change to project ids.

### Description of how you validated changes

- Added unit tests for `normalizeDistributionName` and `addWorkspaceDependencyToPyProject` (derives the name from the dependency's pyproject, normalises a dotted name, falls back to the Nx id, idempotent / no duplicate on re-run).
- Updated the `py#agent` snapshot + `mcp-connection` assertion to the hyphenated distribution name.
- `pnpm nx run @aws/nx-plugin:test` passes (240 tests across the affected suites; full suite green).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
