### PR TITLE
test(e2e): order terraform website after connected agents

### DIFF
--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -575,6 +575,11 @@ module "website" {
     aws.us_east_1 = aws.us_east_1
   }
 
+  # The website serves a runtime-config.json aggregated from the 'connection'
+  # namespace entries each connected API and agent writes. Depend on every
+  # connected module so all entries are written before the website reads and
+  # uploads the config — otherwise the agentRuntimes map can be incomplete and
+  # the vended clients fail to resolve an agent's endpoint.
   depends_on = [
     module.user_identity,
     module.my_api,
@@ -586,6 +591,12 @@ module "website" {
     module.my_api_custom_http,
     module.py_api_custom,
     module.py_api_custom_http,
+    module.ts_agent,
+    module.ts_agui_agent,
+    module.py_agent,
+    module.py_agui_agent,
+    module.py_langchain_agent,
+    module.py_langchain_http_agent,
   ]
 }
 


### PR DESCRIPTION
### Reason for this change

After #835 merged, the `terraform-deploy` smoke test started failing on `main` (cdk-deploy + serve-local + terraform-deploy-rdb all pass).

The terraform apply itself succeeds (all agent runtimes deploy, direct invocations pass), but the **browser-driven website integration step times out**: the deployed site's React page crashes on render with `Cannot read properties of undefined (reading 'startsWith')`, so the `run-integration-test` button never appears and the Playwright `click()` hits its 120s timeout.

Root cause: the static website serves a `runtime-config.json` that the terraform `runtime-config/read` module aggregates by globbing the `connection` namespace's entry files. Each connected API and agent writes its entry during apply. The website module's `depends_on` listed only the APIs — **not the agents** — so terraform could run the website's runtime-config aggregation before the agent entry files were written. The resulting `agentRuntimes` map was missing a key, and the vended agent client crashed on `agentRuntimeValue.startsWith('arn:')` for the undefined value.

#835 exposed this latent ordering gap by connecting six agents to the website (more entries → higher chance the aggregation races ahead of one). It did not surface on CDK (runtime-config is composed in-process during synth, with no file-glob race).

### Description of changes

Add the six website-connected agent modules (`ts_agent`, `ts_agui_agent`, `py_agent`, `py_agui_agent`, `py_langchain_agent`, `py_langchain_http_agent`) to the website module's `depends_on` in the terraform-deploy `main.tf` template, so every `connection` entry is written before the website reads and uploads the aggregated config.

### Description of how you validated changes

Diagnosed from the failed `main` CI run's log (browser pageerror + the website module's `depends_on` omitting the agents). Validated with a real `terraform-deploy` run against AWS off this branch (see PR checks / comments).

### Issue # (if applicable)

Follow-up to #835.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*