### PR TITLE
fix(ts#rdb): retry Prisma P1001/P1002 during database migration

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -297,6 +297,8 @@ const transientErrorPatterns = [
   'ECONNREFUSED',
   'ENOTFOUND',
   'P1000', // Prisma: authentication failed
+  'P1001', // Prisma: can't reach database server
+  'P1002', // Prisma: database server reached but timed out
   'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
 ];
 
@@ -4104,6 +4106,8 @@ const transientErrorPatterns = [
   'ECONNREFUSED',
   'ENOTFOUND',
   'P1000', // Prisma: authentication failed
+  'P1001', // Prisma: can't reach database server
+  'P1002', // Prisma: database server reached but timed out
   'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
 ];
 

--- a/packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template
@@ -95,6 +95,8 @@ const transientErrorPatterns = [
   'ECONNREFUSED',
   'ENOTFOUND',
   'P1000', // Prisma: authentication failed
+  'P1001', // Prisma: can't reach database server
+  'P1002', // Prisma: database server reached but timed out
   'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
 ];
 


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy-rdb` smoke test failed on `main` with the database migration custom resource erroring out:

```
🛑 Received response status [FAILED] ... Error: Command failed: npx prisma migrate deploy
Error: P1001: Can't reach database server at `...rds.amazonaws.com:5432`
```

The migration handler already wraps `prisma migrate deploy` in `withConnectionRetry`, and the code comment notes that a freshly created Aurora cluster is briefly unreachable right after it reports ready. But the transient-error pattern list omitted Prisma's `P1001` ("can't reach database server"), so the error was treated as non-transient and thrown on the first attempt — no retry log line was emitted in the failed run, confirming the retry never fired.

### Description of changes

Add `P1001` and `P1002` (database server reached but timed out) to `transientErrorPatterns` in the vended `rdb` migration `utils.ts`, so the existing retry/backoff (6 attempts, linear backoff up to ~2.5 min) covers the brief post-provision unreachability. Updated the rdb generator snapshots (postgres + mysql variants).

### Description of how you validated changes

Diagnosed from the failed `cdk-deploy-rdb` job log: the error was `P1001`, and no `withConnectionRetry` retry line was logged (proving `P1001` was not matched as transient). Updated + verified the rdb generator unit tests/snapshots. The deploy path is validated by the `cdk-deploy-rdb` / `terraform-deploy-rdb` smoke tests on `main`.

### Issue # (if applicable)

Follow-up to #835 / #847 (surfaced while stabilising the deploy smoke tests).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*