### PR TITLE
feat(preset): always enable ts plugin and remove addTsPlugin option

### DIFF
--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -153,17 +153,6 @@
     }
   },
   "preset": {
-    "addTsPlugin": {
-      "en": "Whether to add the ts plugin.",
-      "jp": "tsプラグインを追加するかどうか。",
-      "ko": "ts 플러그인을 추가할지 여부입니다.",
-      "es": "Si se debe agregar el plugin de ts.",
-      "pt": "Se deve adicionar o plugin ts.",
-      "it": "Se aggiungere il plugin ts.",
-      "fr": "Indique s'il faut ajouter le plugin ts.",
-      "zh": "是否添加 TypeScript 插件。",
-      "vi": "Có thêm ts plugin hay không."
-    },
     "gitSecrets": {
       "en": "Whether to configure git-secrets to prevent committing AWS credentials.",
       "ko": "AWS 자격 증명 커밋을 방지하기 위해 git-secrets를 구성할지 여부입니다.",

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -308,6 +308,22 @@ exports[`preset generator > should run successfully > nx.json 1`] = `
       "syncGenerators": ["@nx/js:typescript-sync", "@aws/nx-plugin:ts#sync"]
     }
   },
+  "plugins": [
+    {
+      "plugin": "@nx/js/typescript",
+      "options": {
+        "typecheck": {
+          "targetName": "typecheck"
+        },
+        "build": {
+          "targetName": "build",
+          "configName": "tsconfig.lib.json",
+          "buildDepsName": "build-deps",
+          "watchDepsName": "watch-deps"
+        }
+      }
+    }
+  ],
   "analytics": false
 }
 "

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -38,7 +38,6 @@ describe('preset generator', () => {
 
   it('should run successfully', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       gitSecrets: false,
       containers: 'docker',
@@ -49,7 +48,6 @@ describe('preset generator', () => {
 
   it('should store CDK iac provider in config', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'terraform',
       containers: 'docker',
     });
@@ -59,7 +57,6 @@ describe('preset generator', () => {
 
   it('should store container engine in config', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       containers: 'finch',
     });
@@ -69,7 +66,6 @@ describe('preset generator', () => {
 
   it('should store Terraform iac provider in config', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       containers: 'docker',
     });
@@ -79,7 +75,6 @@ describe('preset generator', () => {
 
   it('should not generate git-secrets files when gitSecrets is false', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       gitSecrets: false,
     });
@@ -93,7 +88,7 @@ describe('preset generator', () => {
   });
 
   it('should generate git-secrets files by default', async () => {
-    await presetGenerator(tree, { addTsPlugin: false, iac: 'cdk' });
+    await presetGenerator(tree, { iac: 'cdk' });
 
     expect(tree.exists('.git-secrets/git-secrets')).toBe(true);
     expect(tree.exists('.husky/pre-commit')).toBe(true);
@@ -109,7 +104,7 @@ describe('preset generator', () => {
   });
 
   it('should configure MCP servers by default', async () => {
-    await presetGenerator(tree, { addTsPlugin: false, iac: 'cdk' });
+    await presetGenerator(tree, { iac: 'cdk' });
 
     for (const filePath of [
       '.mcp.json',
@@ -131,7 +126,6 @@ describe('preset generator', () => {
 
   it('should not configure MCP servers when mcp is false', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       mcp: false,
     });
@@ -150,7 +144,6 @@ describe('preset generator', () => {
 
   it('should disable analytics in nx.json', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       containers: 'docker',
     });
@@ -160,7 +153,6 @@ describe('preset generator', () => {
 
   it('should register the TypeScript sync generators for compile targets', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       containers: 'docker',
     });
@@ -174,7 +166,6 @@ describe('preset generator', () => {
 
   it('should add a workspace dev script that runs the dev target across projects', async () => {
     await presetGenerator(tree, {
-      addTsPlugin: false,
       iac: 'cdk',
       containers: 'docker',
     });

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -160,7 +160,7 @@ const setUpGitSecrets = (tree: Tree) => {
 
 export const presetGenerator = async (
   tree: Tree,
-  { addTsPlugin, iac, gitSecrets, mcp, containers }: PresetGeneratorSchema,
+  { iac, gitSecrets, mcp, containers }: PresetGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const resolvedContainers =
     !containers || containers === 'infer' ? inferContainers() : containers;
@@ -195,7 +195,7 @@ export const presetGenerator = async (
 
   await initGenerator(tree, {
     formatter: 'none',
-    addTsPlugin: addTsPlugin ?? true,
+    addTsPlugin: true,
   });
 
   tree.delete('apps/.gitkeep');

--- a/packages/nx-plugin/src/preset/schema.d.ts
+++ b/packages/nx-plugin/src/preset/schema.d.ts
@@ -9,7 +9,6 @@ import { Iac } from '../utils/iac';
 export type PresetContainersOption = Containers | 'infer';
 
 export interface PresetGeneratorSchema {
-  readonly addTsPlugin?: boolean;
   readonly iac: Iac;
   readonly gitSecrets?: boolean;
   readonly mcp?: boolean;

--- a/packages/nx-plugin/src/preset/schema.json
+++ b/packages/nx-plugin/src/preset/schema.json
@@ -5,11 +5,6 @@
   "description": "The @aws/nx-plugin preset.",
   "type": "object",
   "properties": {
-    "addTsPlugin": {
-      "type": "boolean",
-      "description": "Whether to add the ts plugin.",
-      "default": true
-    },
     "iac": {
       "type": "string",
       "description": "The preferred IaC provider.",


### PR DESCRIPTION
### Reason for this change

The preset generator exposed an `addTsPlugin` option (defaulting to `true`) that controlled whether the `@nx/js` `initGenerator` registered the `@nx/js/typescript` plugin. In practice no caller ever set this option — production usage always relied on the default, and the only place it was passed was the unit tests (which set it to `false` to avoid re-registering the plugin in the test tree). Presenting it as a user-facing preset option added needless surface area for a value that should always be `true`.

### Description of changes

- Removed the `addTsPlugin` property from the preset `schema.json` and `schema.d.ts`.
- Hardcoded `addTsPlugin: true` in the `initGenerator` call in the preset generator.
- Removed the `addTsPlugin` overrides from the preset unit tests.
- Removed the `addTsPlugin` entry from the i18n schema translations.
- Updated the `nx.json` snapshot to include the always-registered `@nx/js/typescript` plugin.

### Description of how you validated changes

Updated and ran the preset generator unit tests (`@aws/nx-plugin:test`). The pre-commit hook (full test suite + lint) passed.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*