### PR TITLE
ci: disable uv cache for main smoke tests to fix release-blocking flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
       - uses: ./.github/actions/init-monorepo
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
+          # local-dev (and other) smoke tests spawn many uv dev servers that
+          # are killed mid-run; the post-job `uv cache prune` can then hang and
+          # fail the job even when all tests passed. The cache buys little here.
+          enable-uv-cache: 'false'
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
### Reason for this change

The main CI workflow's smoke-test matrix runs `init-monorepo` **with the uv cache enabled**, unlike the PR workflow which passes `enable-uv-cache: 'false'`. uv-heavy smoke tests (e.g. `local-dev`) spawn many uv dev servers that are killed mid-run, leaving the uv cache in a state where the post-job `uv cache prune` (from `astral-sh/setup-uv`) exits with code 2.

This fails the smoke-test job **even though every test passes**, and because the `Release` job `needs: [..., smoke_tests, ...]`, it deterministically **blocks releases on main**. Observed on the merge of #806: `Smoke Test - local-dev` passed but `Post Run ./.github/actions/init-monorepo` failed (uv cache prune, exit 2), repeatedly across reruns.

### Description of changes

Pass `enable-uv-cache: 'false'` to `init-monorepo` in the `smoke_tests` job of `ci.yml`, mirroring the existing setting in `pr.yml`.

### Description of how you validated changes

Root-caused from the failing main CI run: the test step passes; only the post-job uv-cache-prune fails, and only on `ci.yml` (which lacked the flag `pr.yml` already has). YAML validated.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*