### PR TITLE
feat(ts#website): default ux provider to shadcn instead of cloudscape

### DIFF
--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -18,12 +18,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-This generator creates a new [React](https://react.dev/) website with [Cloudscape](http://cloudscape.design/) configured by default, along with the AWS CDK or Terraform infrastructure to deploy your website to the cloud as a static website hosted in [S3](https://aws.amazon.com/s3/), served by [CloudFront](https://aws.amazon.com/cloudfront/) and protected by [WAF](https://aws.amazon.com/waf/).
+This generator creates a new [React](https://react.dev/) website with [shadcn/ui](https://ui.shadcn.com/) configured by default, along with the AWS CDK or Terraform infrastructure to deploy your website to the cloud as a static website hosted in [S3](https://aws.amazon.com/s3/), served by [CloudFront](https://aws.amazon.com/cloudfront/) and protected by [WAF](https://aws.amazon.com/waf/).
 
 The generated application uses [Vite](https://vite.dev/) as the build tool and bundler. It uses [TanStack Router](https://tanstack.com/router/v1) for type-safe routing.
 
 :::note[UX Provider]
-The default `uxProvider` is [Cloudscape](http://cloudscape.design/). You can also select [shadcn/ui](https://ui.shadcn.com/) or `None` (bring your own component library).
+The default `uxProvider` is [shadcn/ui](https://ui.shadcn.com/). You can also select [Cloudscape](http://cloudscape.design/) or `None` (bring your own component library).
 :::
 
 ## Usage

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -286,7 +286,7 @@ export class ApplicationStack extends Stack {
 
 ### Website Infrastructure
 
-If you have used the <Link path="guides/react-website">CloudScape website</Link> generator, you will notice you already have a construct in `packages/common/constructs` to deploy it. For example:
+If you have used the <Link path="guides/react-website">React Website</Link> generator, you will notice you already have a construct in `packages/common/constructs` to deploy it. For example:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Este generador crea un nuevo sitio web en [React](https://react.dev/) configurado con [Cloudscape](http://cloudscape.design/) por defecto, junto con la infraestructura de AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
+Este generador crea un nuevo sitio web en [React](https://react.dev/) configurado con [shadcn/ui](https://ui.shadcn.com/) por defecto, junto con la infraestructura de AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
 
 La aplicación generada utiliza [Vite](https://vite.dev/) como herramienta de construcción y empaquetado. Emplea [TanStack Router](https://tanstack.com/router/v1) para enrutamiento tipado.
 
 :::note[Proveedor de UX]
-El `uxProvider` predeterminado es [Cloudscape](http://cloudscape.design/). También puedes seleccionar [shadcn/ui](https://ui.shadcn.com/) o `None` (trae tu propia biblioteca de componentes).
+El `uxProvider` predeterminado es [shadcn/ui](https://ui.shadcn.com/). También puedes seleccionar [Cloudscape](http://cloudscape.design/) o `None` (trae tu propia biblioteca de componentes).
 :::
 
 ## Uso

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### Infraestructura para sitios web
 
-Si has usado el generador <Link path="guides/react-website">sitio web CloudScape</Link>, notarás que ya tienes un constructo en `packages/common/constructs` para desplegarlo. Por ejemplo:
+Si has usado el generador <Link path="guides/react-website">sitio web React</Link>, notarás que ya tienes un constructo en `packages/common/constructs` para desplegarlo. Por ejemplo:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Ce générateur crée un nouveau site [React](https://react.dev/) configuré avec [Cloudscape](http://cloudscape.design/) par défaut, ainsi que l'infrastructure AWS CDK ou Terraform pour déployer votre site web dans le cloud en tant que site statique hébergé dans [S3](https://aws.amazon.com/s3/), servi par [CloudFront](https://aws.amazon.com/cloudfront/) et protégé par [WAF](https://aws.amazon.com/waf/).
+Ce générateur crée un nouveau site [React](https://react.dev/) configuré avec [shadcn/ui](https://ui.shadcn.com/) par défaut, ainsi que l'infrastructure AWS CDK ou Terraform pour déployer votre site web dans le cloud en tant que site statique hébergé dans [S3](https://aws.amazon.com/s3/), servi par [CloudFront](https://aws.amazon.com/cloudfront/) et protégé par [WAF](https://aws.amazon.com/waf/).
 
 L'application générée utilise [Vite](https://vite.dev/) comme outil de build et bundler. Elle utilise [TanStack Router](https://tanstack.com/router/v1) pour le routage type-safe.
 
 :::note[Fournisseur UX]
-Le `uxProvider` par défaut est [Cloudscape](http://cloudscape.design/). Vous pouvez également sélectionner [shadcn/ui](https://ui.shadcn.com/) ou `None` (apportez votre propre bibliothèque de composants).
+Le `uxProvider` par défaut est [shadcn/ui](https://ui.shadcn.com/). Vous pouvez également sélectionner [Cloudscape](http://cloudscape.design/) ou `None` (apportez votre propre bibliothèque de composants).
 :::
 
 ## Utilisation
@@ -491,3 +491,4 @@ Utilisez le générateur <Link path="guides/connection">`connection`</Link> pour
     target="copilotkit"
   />
 </CardGrid>
+id>

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### Infrastructure de site web
 
-Si vous avez utilisé le générateur <Link path="guides/react-website">site web CloudScape</Link>, vous remarquerez qu'un construct est déjà disponible dans `packages/common/constructs` pour le déployer. Par exemple :
+Si vous avez utilisé le générateur <Link path="guides/react-website">site web React</Link>, vous remarquerez qu'un construct est déjà disponible dans `packages/common/constructs` pour le déployer. Par exemple :
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Questo generatore crea un nuovo sito web [React](https://react.dev/) con [Cloudscape](http://cloudscape.design/) configurato di default, insieme all'infrastruttura AWS CDK o Terraform per distribuire il tuo sito web sul cloud come sito statico ospitato in [S3](https://aws.amazon.com/s3/), servito da [CloudFront](https://aws.amazon.com/cloudfront/) e protetto da [WAF](https://aws.amazon.com/waf/).
+Questo generatore crea un nuovo sito web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurato di default, insieme all'infrastruttura AWS CDK o Terraform per distribuire il tuo sito web sul cloud come sito statico ospitato in [S3](https://aws.amazon.com/s3/), servito da [CloudFront](https://aws.amazon.com/cloudfront/) e protetto da [WAF](https://aws.amazon.com/waf/).
 
 L'applicazione generata utilizza [Vite](https://vite.dev/) come strumento di build e bundler. Utilizza [TanStack Router](https://tanstack.com/router/v1) per il routing type-safe.
 
 :::note[UX Provider]
-Il `uxProvider` predefinito è [Cloudscape](http://cloudscape.design/). Puoi anche selezionare [shadcn/ui](https://ui.shadcn.com/) o `None` (porta la tua libreria di componenti).
+Il `uxProvider` predefinito è [shadcn/ui](https://ui.shadcn.com/). Puoi anche selezionare [Cloudscape](http://cloudscape.design/) o `None` (porta la tua libreria di componenti).
 :::
 
 ## Utilizzo
@@ -491,3 +491,4 @@ Usa il generatore <Link path="guides/connection">`connection`</Link> per integra
     target="copilotkit"
   />
 </CardGrid>
+id>

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### Infrastruttura per website
 
-Se hai usato il generatore <Link path="guides/react-website">CloudScape website</Link>, noterai di avere già un costrutto in `packages/common/constructs` per deployarlo. Ad esempio:
+Se hai usato il generatore <Link path="guides/react-website">React Website</Link>, noterai di avere già un costrutto in `packages/common/constructs` per deployarlo. Ad esempio:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-このジェネレータは[React](https://react.dev/)ウェブサイトを新規作成し、デフォルトで[Cloudscape](http://cloudscape.design/)の設定と、静的ウェブサイトをクラウドにデプロイするためのAWS CDKまたはTerraformインフラストラクチャ（[S3](https://aws.amazon.com/s3/)ホスティング、[CloudFront](https://aws.amazon.com/cloudfront/)配信、[WAF](https://aws.amazon.com/waf/)保護）を構成します。
+このジェネレータは[React](https://react.dev/)ウェブサイトを新規作成し、デフォルトで[shadcn/ui](https://ui.shadcn.com/)の設定と、静的ウェブサイトをクラウドにデプロイするためのAWS CDKまたはTerraformインフラストラクチャ（[S3](https://aws.amazon.com/s3/)ホスティング、[CloudFront](https://aws.amazon.com/cloudfront/)配信、[WAF](https://aws.amazon.com/waf/)保護）を構成します。
 
 生成されるアプリケーションはビルドツールとバンドラーに[Vite](https://vite.dev/)を使用し、型安全なルーティングに[TanStack Router](https://tanstack.com/router/v1)を採用しています。
 
 :::note[UX Provider]
-デフォルトの`uxProvider`は[Cloudscape](http://cloudscape.design/)です。[shadcn/ui](https://ui.shadcn.com/)または`None`（独自のコンポーネントライブラリを使用）も選択できます。
+デフォルトの`uxProvider`は[shadcn/ui](https://ui.shadcn.com/)です。[Cloudscape](http://cloudscape.design/)または`None`（独自のコンポーネントライブラリを使用）も選択できます。
 :::
 
 ## 使用方法
@@ -491,3 +491,4 @@ provider "aws" {
     target="copilotkit"
   />
 </CardGrid>
+id>

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### ウェブサイトインフラストラクチャ
 
-<Link path="guides/react-website">CloudScapeウェブサイト</Link>ジェネレータを使用した場合、`packages/common/constructs`にデプロイ用のコンストラクトが存在します。例:
+<Link path="guides/react-website">Reactウェブサイト</Link>ジェネレータを使用した場合、`packages/common/constructs`にデプロイ用のコンストラクトが既に存在します。例:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-이 생성기는 기본적으로 [Cloudscape](http://cloudscape.design/)이 구성된 새로운 [React](https://react.dev/) 웹사이트와 S3에 호스팅된 정적 웹사이트를 [CloudFront](https://aws.amazon.com/cloudfront/)로 서비스하고 [WAF](https://aws.amazon.com/waf/)로 보호하는 클라우드 배포 인프라를 AWS CDK 또는 Terraform으로 생성합니다.
+이 생성기는 기본적으로 [shadcn/ui](https://ui.shadcn.com/)가 구성된 새로운 [React](https://react.dev/) 웹사이트와 [S3](https://aws.amazon.com/s3/)에 호스팅된 정적 웹사이트를 [CloudFront](https://aws.amazon.com/cloudfront/)로 서비스하고 [WAF](https://aws.amazon.com/waf/)로 보호하는 클라우드 배포 인프라를 AWS CDK 또는 Terraform으로 생성합니다.
 
 생성된 애플리케이션은 빌드 도구 및 번들러로 [Vite](https://vite.dev/)를 사용하며, 타입 안전 라우팅을 위해 [TanStack Router](https://tanstack.com/router/v1)를 사용합니다.
 
 :::note[UX Provider]
-기본 `uxProvider`는 [Cloudscape](http://cloudscape.design/)입니다. [shadcn/ui](https://ui.shadcn.com/) 또는 `None`(자체 컴포넌트 라이브러리 사용)을 선택할 수도 있습니다.
+기본 `uxProvider`는 [shadcn/ui](https://ui.shadcn.com/)입니다. [Cloudscape](http://cloudscape.design/) 또는 `None`(자체 컴포넌트 라이브러리 사용)을 선택할 수도 있습니다.
 :::
 
 ## 사용 방법

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### 웹사이트 인프라
 
-<Link path="guides/react-website">CloudScape 웹사이트</Link> 생성기를 사용한 경우 `packages/common/constructs`에 배포용 구문이 존재합니다. 예시:
+<Link path="guides/react-website">React Website</Link> 생성기를 사용한 경우 `packages/common/constructs`에 배포용 구문이 존재합니다. 예시:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Este gerador cria um novo website [React](https://react.dev/) com [Cloudscape](http://cloudscape.design/) configurado por padrão, juntamente com a infraestrutura AWS CDK ou Terraform para implantar seu website na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
+Este gerador cria um novo website [React](https://react.dev/) com [shadcn/ui](https://ui.shadcn.com/) configurado por padrão, juntamente com a infraestrutura AWS CDK ou Terraform para implantar seu website na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
 
 A aplicação gerada utiliza [Vite](https://vite.dev/) como ferramenta de build e bundler. Usa [TanStack Router](https://tanstack.com/router/v1) para roteamento type-safe.
 
 :::note[Provedor UX]
-O `uxProvider` padrão é [Cloudscape](http://cloudscape.design/). Você também pode selecionar [shadcn/ui](https://ui.shadcn.com/) ou `None` (traga sua própria biblioteca de componentes).
+O `uxProvider` padrão é [shadcn/ui](https://ui.shadcn.com/). Você também pode selecionar [Cloudscape](http://cloudscape.design/) ou `None` (traga sua própria biblioteca de componentes).
 :::
 
 ## Utilização

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### Infraestrutura de Website
 
-Se você usou o gerador <Link path="guides/react-website">CloudScape website</Link>, notará que já tem um construct em `packages/common/constructs` para implantá-lo. Por exemplo:
+Se você usou o gerador <Link path="guides/react-website">React Website</Link>, notará que já tem um construct em `packages/common/constructs` para implantá-lo. Por exemplo:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Generator này tạo một trang web [React](https://react.dev/) mới với [Cloudscape](http://cloudscape.design/) được cấu hình mặc định, cùng với cơ sở hạ tầng AWS CDK hoặc Terraform để triển khai trang web của bạn lên đám mây dưới dạng trang web tĩnh được lưu trữ trong [S3](https://aws.amazon.com/s3/), phân phối bởi [CloudFront](https://aws.amazon.com/cloudfront/) và được bảo vệ bởi [WAF](https://aws.amazon.com/waf/).
+Generator này tạo một trang web [React](https://react.dev/) mới với [shadcn/ui](https://ui.shadcn.com/) được cấu hình mặc định, cùng với cơ sở hạ tầng AWS CDK hoặc Terraform để triển khai trang web của bạn lên đám mây dưới dạng trang web tĩnh được lưu trữ trong [S3](https://aws.amazon.com/s3/), phân phối bởi [CloudFront](https://aws.amazon.com/cloudfront/) và được bảo vệ bởi [WAF](https://aws.amazon.com/waf/).
 
 Ứng dụng được tạo ra sử dụng [Vite](https://vite.dev/) làm công cụ xây dựng và đóng gói. Nó sử dụng [TanStack Router](https://tanstack.com/router/v1) cho định tuyến an toàn kiểu.
 
 :::note[UX Provider]
-`uxProvider` mặc định là [Cloudscape](http://cloudscape.design/). Bạn cũng có thể chọn [shadcn/ui](https://ui.shadcn.com/) hoặc `None` (tự mang thư viện component của bạn).
+`uxProvider` mặc định là [shadcn/ui](https://ui.shadcn.com/). Bạn cũng có thể chọn [Cloudscape](http://cloudscape.design/) hoặc `None` (tự mang thư viện component của bạn).
 :::
 
 ## Cách sử dụng

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### Cơ sở hạ tầng Website
 
-Nếu bạn đã sử dụng trình tạo <Link path="guides/react-website">CloudScape website</Link>, bạn sẽ nhận thấy bạn đã có một construct trong `packages/common/constructs` để triển khai nó. Ví dụ:
+Nếu bạn đã sử dụng trình tạo <Link path="guides/react-website">React Website</Link>, bạn sẽ nhận thấy bạn đã có một construct trong `packages/common/constructs` để triển khai nó. Ví dụ:
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -19,12 +19,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-该生成器会创建一个默认配置了 [Cloudscape](http://cloudscape.design/) 的新 [React](https://react.dev/) 网站，并生成 AWS CDK 或 Terraform 基础设施代码，用于将您的网站作为静态站点部署到云端，托管在 [S3](https://aws.amazon.com/s3/) 中，通过 [CloudFront](https://aws.amazon.com/cloudfront/) 分发，并通过 [WAF](https://aws.amazon.com/waf/) 提供保护。
+该生成器会创建一个默认配置了 [shadcn/ui](https://ui.shadcn.com/) 的新 [React](https://react.dev/) 网站，并生成 AWS CDK 或 Terraform 基础设施代码，用于将您的网站作为静态站点部署到云端，托管在 [S3](https://aws.amazon.com/s3/) 中，通过 [CloudFront](https://aws.amazon.com/cloudfront/) 分发，并通过 [WAF](https://aws.amazon.com/waf/) 提供保护。
 
 生成的应用程序使用 [Vite](https://vite.dev/) 作为构建工具和打包器，并采用 [TanStack Router](https://tanstack.com/router/v1) 实现类型安全的路由。
 
 :::note[UX Provider]
-默认的 `uxProvider` 是 [Cloudscape](http://cloudscape.design/)。您也可以选择 [shadcn/ui](https://ui.shadcn.com/) 或 `None`（自带组件库）。
+默认的 `uxProvider` 是 [shadcn/ui](https://ui.shadcn.com/)。您也可以选择 [Cloudscape](http://cloudscape.design/) 或 `None`（自带组件库）。
 :::
 
 ## 使用方式

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -287,7 +287,7 @@ export class ApplicationStack extends Stack {
 
 ### 网站基础设施
 
-如果您使用过 <Link path="guides/react-website">CloudScape 网站</Link> 生成器，您会注意到 `packages/common/constructs` 中已有部署所需的构造。例如：
+如果您使用过 <Link path="guides/react-website">React 网站</Link> 生成器，您会注意到 `packages/common/constructs` 中已有部署所需的构造。例如：
 
 ```ts title="src/stacks/application-stack.ts" {3, 9-10}
 import { Stack, StackProps } from 'aws-cdk-lib';

--- a/e2e/src/smoke-tests/react-website.spec.ts
+++ b/e2e/src/smoke-tests/react-website.spec.ts
@@ -40,6 +40,11 @@ describe('smoke test - react-website', () => {
         tanstackRouter: true,
       },
       {
+        name: 'website-cloudscape',
+        ux: 'cloudscape',
+        tanstackRouter: true,
+      },
+      {
         name: 'website-none-no-router',
         ux: 'none',
         tanstackRouter: false,
@@ -47,6 +52,11 @@ describe('smoke test - react-website', () => {
       {
         name: 'website-shadcn-no-router',
         ux: 'shadcn',
+        tanstackRouter: false,
+      },
+      {
+        name: 'website-cloudscape-no-router',
+        ux: 'cloudscape',
         tanstackRouter: false,
       },
     ] as const;

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -61,7 +61,7 @@ export async function tsReactWebsiteGenerator(
 ) {
   const tailwind = schema.tailwind ?? true;
   const tanstackRouter = schema.tanstackRouter ?? true;
-  const ux: Ux = schema.ux ?? 'cloudscape';
+  const ux: Ux = schema.ux ?? 'shadcn';
   if (ux === 'shadcn' && !tailwind) {
     throw new Error('Shadcn requires TailwindCSS to be enabled.');
   }

--- a/packages/nx-plugin/src/ts/react-website/app/schema.json
+++ b/packages/nx-plugin/src/ts/react-website/app/schema.json
@@ -40,7 +40,7 @@
       "description": "The preferred UX provider.",
       "enum": ["none", "cloudscape", "shadcn"],
       "x-priority": "important",
-      "default": "cloudscape",
+      "default": "shadcn",
       "x-prompt": {
         "message": "Which UX provider should we scaffold for this app?",
         "type": "list",
@@ -50,15 +50,15 @@
             "label": "None (plain React/Vite without a UI kit)"
           },
           {
-            "value": "cloudscape",
-            "label": "Cloudscape (AWS-first components with ready-made layouts)"
-          },
-          {
             "value": "shadcn",
             "label": "Shadcn (shared UI library under packages/common/shadcn)"
+          },
+          {
+            "value": "cloudscape",
+            "label": "Cloudscape (AWS-first components with ready-made layouts)"
           }
         ],
-        "default": "cloudscape"
+        "default": "shadcn"
       }
     },
     "tailwind": {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -115,7 +115,7 @@ export async function tsReactWebsiteAuthGenerator(
   );
 
   const ux = (
-    (projectConfiguration.metadata as any)?.ux ?? 'cloudscape'
+    (projectConfiguration.metadata as any)?.ux ?? 'shadcn'
   ).toLowerCase();
 
   await applyGritQL(tree, mainTsxPath, readGritPattern('cognito-auth-wrapper'));

--- a/packages/nx-plugin/src/ts/website/app/schema.json
+++ b/packages/nx-plugin/src/ts/website/app/schema.json
@@ -48,7 +48,7 @@
       "description": "The preferred UX provider.",
       "enum": ["none", "cloudscape", "shadcn"],
       "x-priority": "important",
-      "default": "cloudscape",
+      "default": "shadcn",
       "x-prompt": {
         "message": "Which UX provider should we scaffold for this app?",
         "type": "list",
@@ -58,15 +58,15 @@
             "label": "None (plain React/Vite without a UI kit)"
           },
           {
-            "value": "cloudscape",
-            "label": "Cloudscape (AWS-first components with ready-made layouts)"
-          },
-          {
             "value": "shadcn",
             "label": "Shadcn (shared UI library under packages/common/shadcn)"
+          },
+          {
+            "value": "cloudscape",
+            "label": "Cloudscape (AWS-first components with ready-made layouts)"
           }
         ],
-        "default": "cloudscape"
+        "default": "shadcn"
       }
     },
     "tailwind": {


### PR DESCRIPTION
### Reason for this change

The `ts#website` / `ts#react-website` generators defaulted the `ux` (design system) option to `cloudscape`. shadcn/ui is a better general-purpose default for new websites — it's a widely adopted, framework-agnostic component library and is scaffolded as a shared library under `packages/common/shadcn`. This switches the default while keeping `cloudscape` and `none` fully selectable.

### Description of changes

- **Schemas** (`ts#website` and `ts#react-website` `schema.json`): changed the `ux` property `default` and `x-prompt` default from `cloudscape` to `shadcn`, and reordered the prompt list so `shadcn` appears before `cloudscape`.
- **Generator fallbacks**: `tsReactWebsiteGenerator` now falls back to `shadcn` when `ux` is unspecified, and the `cognito-auth` generator falls back to `shadcn` when a project's metadata has no recorded `ux`.
- **Docs**: updated `guides/react-website.mdx` to state shadcn/ui is the default, and fixed the misleading "CloudScape website" link text in `guides/typescript-infrastructure.mdx`.

No template/output behaviour changed for users who explicitly select a `ux` value — only the default selection differs.

### Description of how you validated changes

- Ran the website, react-website and cognito-auth UX-provider unit tests. The pre-commit hook (full `@aws/nx-plugin:test` suite + lint) passed.
- Verified the dungeon-adventure tutorial and react-website e2e smoke test already pass an explicit `--ux`/`ux:` value, so they are unaffected by the default change.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*