### PR TITLE
fix(ts#api): configure throttling on terraform rest api stage

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -4753,6 +4753,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
+}
+
 # API Gateway Resource Policy
 resource "aws_api_gateway_rest_api_policy" "api_policy" {
   rest_api_id = module.rest_api.api_id
@@ -5558,6 +5570,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   tags = var.tags
 
   depends_on = [aws_api_gateway_deployment.api_deployment]
+}
+
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
 }
 
 # API Gateway Resource Policy
@@ -6470,6 +6494,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   tags = var.tags
 
   depends_on = [aws_api_gateway_deployment.api_deployment]
+}
+
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -4755,6 +4755,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -5574,6 +5575,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -6498,6 +6500,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1099,6 +1099,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
+}
+
 # API Gateway Resource Policy
 resource "aws_api_gateway_rest_api_policy" "api_policy" {
   rest_api_id = module.rest_api.api_id
@@ -2299,6 +2311,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
+}
+
 # API Gateway Resource Policy
 resource "aws_api_gateway_rest_api_policy" "api_policy" {
   rest_api_id = module.rest_api.api_id
@@ -3075,6 +3099,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
+}
+
 # API Gateway Resource Policy
 resource "aws_api_gateway_rest_api_policy" "api_policy" {
   rest_api_id = module.rest_api.api_id
@@ -3688,6 +3724,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   tags = var.tags
 
   depends_on = [aws_api_gateway_deployment.api_deployment]
+}
+
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1101,6 +1101,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -2313,6 +2314,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -3101,6 +3103,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -3728,6 +3731,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -5752,6 +5752,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -6541,6 +6542,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"
@@ -7435,6 +7437,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -5750,6 +5750,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
+}
+
 # API Gateway Resource Policy
 resource "aws_api_gateway_rest_api_policy" "api_policy" {
   rest_api_id = module.rest_api.api_id
@@ -6525,6 +6537,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   tags = var.tags
 
   depends_on = [aws_api_gateway_deployment.api_deployment]
+}
+
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
 }
 
 # API Gateway Resource Policy
@@ -7407,6 +7431,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   tags = var.tags
 
   depends_on = [aws_api_gateway_deployment.api_deployment]
+}
+
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -526,6 +526,18 @@ resource "aws_api_gateway_stage" "api_stage" {
   depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
+# Default throttling applied to all resource paths and methods
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = module.rest_api.api_id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_rate_limit  = 10000
+    throttling_burst_limit = 5000
+  }
+}
+
 # API Gateway Resource Policy
 resource "aws_api_gateway_rest_api_policy" "api_policy" {
   rest_api_id = module.rest_api.api_id

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -528,6 +528,7 @@ resource "aws_api_gateway_stage" "api_stage" {
 
 # Default throttling applied to all resource paths and methods
 resource "aws_api_gateway_method_settings" "throttling" {
+  #checkov:skip=CKV_AWS_225:API Gateway caching not required for this use case
   rest_api_id = module.rest_api.api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   method_path = "*/*"


### PR DESCRIPTION

### Reason for this change

Terraform REST APIs vended by the plugin were missing default request throttling. This is inconsistent with the other API constructs the plugin generates:

| Construct | Throttling configured |
|---|---|
| CDK REST API | yes - `deployOptions.methodOptions['/*/*']` -> rate 10000, burst 5000 |
| CDK HTTP API | yes - `HttpStage` throttle -> rate 10000, burst 5000 |
| Terraform HTTP API | yes - stage `default_route_settings` -> rate 10000, burst 5000 |
| Terraform REST API | **no throttling** |

Without throttling, generated Terraform REST APIs have no protection against request floods, leaving them open to runaway cost and potential denial of service.

### Description of changes

Added an `aws_api_gateway_method_settings` resource to the Terraform REST API app template. It applies the same defaults used everywhere else (rate limit 10000, burst limit 5000) to all methods on the stage via `method_path = "*/*"` - the Terraform equivalent of CDK's `methodOptions['/*/*']`.

### Description of how you validated changes

Updated and ran the generator unit tests (`pnpm nx run @aws/nx-plugin:test -u`); all 2395 tests pass. Snapshot updates for the trpc, fastapi and smithy generators confirm the new resource renders correctly in the vended Terraform.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
