### PR TITLE
feat(ts#website-auth): enable cognito threat protection and add WAF

### DIFF
--- a/docs/src/content/docs/en/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/react-website-auth.mdx
@@ -98,6 +98,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### Threat protection
+
+The User Pool is created on the Cognito [Plus feature plan](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) with [threat protection](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) set to `AUDIT` mode for standard authentication. In audit mode, Cognito assigns a risk level to each sign-in and logs the assessment to CloudWatch without blocking users.
+
+Once you have observed the risk assessments for your users, you can switch to full-function enforcement to automatically respond to risky activity (for example requiring MFA or blocking sign-in):
+
+<Infrastructure>
+<Fragment slot="cdk">
+Set `standardThreatProtectionMode` to `StandardThreatProtectionMode.FULL_FUNCTION` in `packages/common/constructs/src/core/user-identity.ts`.
+</Fragment>
+<Fragment slot="terraform">
+Set `advanced_security_mode` to `ENFORCED` in the `user_pool_add_ons` block in `packages/common/terraform/src/core/user-identity/identity/identity.tf`.
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+By default the User Pool is associated with an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL using the `AWSManagedRulesCommonRuleSet` and `AWSManagedRulesKnownBadInputsRuleSet` managed rule groups. You can disable this if you wish to manage your own Web ACL or do not require one:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## Infrastructure Usage
 
 <Infrastructure>

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -101,6 +101,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### Protección contra amenazas
+
+El User Pool se crea en el [plan de funciones Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) de Cognito con [protección contra amenazas](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) configurada en modo `AUDIT` para autenticación estándar. En modo auditoría, Cognito asigna un nivel de riesgo a cada inicio de sesión y registra la evaluación en CloudWatch sin bloquear a los usuarios.
+
+Una vez que hayas observado las evaluaciones de riesgo para tus usuarios, puedes cambiar a la aplicación de función completa para responder automáticamente a actividades riesgosas (por ejemplo, requerir MFA o bloquear el inicio de sesión):
+
+<Infrastructure>
+<Fragment slot="cdk">
+Establece `standardThreatProtectionMode` a `StandardThreatProtectionMode.FULL_FUNCTION` en `packages/common/constructs/src/core/user-identity.ts`.
+</Fragment>
+<Fragment slot="terraform">
+Establece `advanced_security_mode` a `ENFORCED` en el bloque `user_pool_add_ons` en `packages/common/terraform/src/core/user-identity/identity/identity.tf`.
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+Por defecto, el User Pool está asociado con una Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) usando los grupos de reglas administradas `AWSManagedRulesCommonRuleSet` y `AWSManagedRulesKnownBadInputsRuleSet`. Puedes desactivar esto si deseas administrar tu propia Web ACL o no requieres una:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## Uso de la Infraestructura
 
 <Infrastructure>

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -101,6 +101,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### Threat protection
+
+Le User Pool est créé sur le [plan de fonctionnalités Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) de Cognito avec la [protection contre les menaces](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) définie en mode `AUDIT` pour l'authentification standard. En mode audit, Cognito attribue un niveau de risque à chaque connexion et enregistre l'évaluation dans CloudWatch sans bloquer les utilisateurs.
+
+Une fois que vous avez observé les évaluations de risque pour vos utilisateurs, vous pouvez passer à l'application complète pour répondre automatiquement aux activités à risque (par exemple en exigeant MFA ou en bloquant la connexion) :
+
+<Infrastructure>
+<Fragment slot="cdk">
+Définissez `standardThreatProtectionMode` sur `StandardThreatProtectionMode.FULL_FUNCTION` dans `packages/common/constructs/src/core/user-identity.ts`.
+</Fragment>
+<Fragment slot="terraform">
+Définissez `advanced_security_mode` sur `ENFORCED` dans le bloc `user_pool_add_ons` dans `packages/common/terraform/src/core/user-identity/identity/identity.tf`.
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+Par défaut, le User Pool est associé à une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) utilisant les groupes de règles gérées `AWSManagedRulesCommonRuleSet` et `AWSManagedRulesKnownBadInputsRuleSet`. Vous pouvez désactiver cela si vous souhaitez gérer votre propre Web ACL ou si vous n'en avez pas besoin :
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## Utilisation de l'infrastructure
 
 <Infrastructure>

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -98,6 +98,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### Protezione dalle minacce
+
+Il User Pool viene creato sul [piano funzionalità Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) di Cognito con la [protezione dalle minacce](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) impostata in modalità `AUDIT` per l'autenticazione standard. In modalità audit, Cognito assegna un livello di rischio a ogni accesso e registra la valutazione in CloudWatch senza bloccare gli utenti.
+
+Una volta osservate le valutazioni del rischio per i tuoi utenti, puoi passare all'applicazione completa per rispondere automaticamente alle attività rischiose (ad esempio richiedendo MFA o bloccando l'accesso):
+
+<Infrastructure>
+<Fragment slot="cdk">
+Imposta `standardThreatProtectionMode` su `StandardThreatProtectionMode.FULL_FUNCTION` in `packages/common/constructs/src/core/user-identity.ts`.
+</Fragment>
+<Fragment slot="terraform">
+Imposta `advanced_security_mode` su `ENFORCED` nel blocco `user_pool_add_ons` in `packages/common/terraform/src/core/user-identity/identity/identity.tf`.
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+Per impostazione predefinita, il User Pool è associato a un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL utilizzando i gruppi di regole gestite `AWSManagedRulesCommonRuleSet` e `AWSManagedRulesKnownBadInputsRuleSet`. Puoi disabilitarlo se desideri gestire il tuo Web ACL o se non ne hai bisogno:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## Utilizzo dell'Infrastruttura
 
 <Infrastructure>

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -101,6 +101,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### 脅威保護
+
+ユーザープールは Cognito [Plus 機能プラン](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)で作成され、標準認証の[脅威保護](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)が `AUDIT` モードに設定されています。監査モードでは、Cognito は各サインインにリスクレベルを割り当て、ユーザーをブロックすることなく評価を CloudWatch にログ記録します。
+
+ユーザーのリスク評価を観察した後、フル機能の強制に切り替えて、リスクの高いアクティビティに自動的に対応できます（例：MFA の要求やサインインのブロック）:
+
+<Infrastructure>
+<Fragment slot="cdk">
+`packages/common/constructs/src/core/user-identity.ts` で `standardThreatProtectionMode` を `StandardThreatProtectionMode.FULL_FUNCTION` に設定してください。
+</Fragment>
+<Fragment slot="terraform">
+`packages/common/terraform/src/core/user-identity/identity/identity.tf` の `user_pool_add_ons` ブロックで `advanced_security_mode` を `ENFORCED` に設定してください。
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+デフォルトでは、ユーザープールは `AWSManagedRulesCommonRuleSet` と `AWSManagedRulesKnownBadInputsRuleSet` マネージドルールグループを使用する [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL に関連付けられています。独自の Web ACL を管理したい場合や、Web ACL が不要な場合は、これを無効にできます:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## インフラストラクチャの使用方法
 
 <Infrastructure>

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -101,6 +101,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### 위협 보호
+
+사용자 풀은 Cognito [Plus 기능 플랜](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)에서 생성되며, 표준 인증에 대해 [위협 보호](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)가 `AUDIT` 모드로 설정됩니다. 감사 모드에서 Cognito는 각 로그인에 위험 수준을 할당하고 사용자를 차단하지 않고 평가를 CloudWatch에 기록합니다.
+
+사용자에 대한 위험 평가를 관찰한 후, 위험한 활동에 자동으로 대응하도록(예: MFA 요구 또는 로그인 차단) 전체 기능 적용 모드로 전환할 수 있습니다:
+
+<Infrastructure>
+<Fragment slot="cdk">
+`packages/common/constructs/src/core/user-identity.ts`에서 `standardThreatProtectionMode`를 `StandardThreatProtectionMode.FULL_FUNCTION`으로 설정하세요.
+</Fragment>
+<Fragment slot="terraform">
+`packages/common/terraform/src/core/user-identity/identity/identity.tf`의 `user_pool_add_ons` 블록에서 `advanced_security_mode`를 `ENFORCED`로 설정하세요.
+</Fragment>
+</Infrastructure>
+
+#### 웹 애플리케이션 방화벽 (WAF)
+
+기본적으로 사용자 풀은 `AWSManagedRulesCommonRuleSet` 및 `AWSManagedRulesKnownBadInputsRuleSet` 관리형 규칙 그룹을 사용하는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL과 연결됩니다. 자체 Web ACL을 관리하거나 필요하지 않은 경우 이 기능을 비활성화할 수 있습니다:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## 인프라 사용 방법
 
 <Infrastructure>

--- a/docs/src/content/docs/pt/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/react-website-auth.mdx
@@ -101,6 +101,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### Proteção contra ameaças
+
+O User Pool é criado no [plano de recursos Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) do Cognito com [proteção contra ameaças](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) definida no modo `AUDIT` para autenticação padrão. No modo de auditoria, o Cognito atribui um nível de risco a cada login e registra a avaliação no CloudWatch sem bloquear usuários.
+
+Depois de observar as avaliações de risco para seus usuários, você pode alternar para a aplicação de função completa para responder automaticamente a atividades arriscadas (por exemplo, exigindo MFA ou bloqueando o login):
+
+<Infrastructure>
+<Fragment slot="cdk">
+Defina `standardThreatProtectionMode` como `StandardThreatProtectionMode.FULL_FUNCTION` em `packages/common/constructs/src/core/user-identity.ts`.
+</Fragment>
+<Fragment slot="terraform">
+Defina `advanced_security_mode` como `ENFORCED` no bloco `user_pool_add_ons` em `packages/common/terraform/src/core/user-identity/identity/identity.tf`.
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+Por padrão, o User Pool é associado a um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL usando os grupos de regras gerenciadas `AWSManagedRulesCommonRuleSet` e `AWSManagedRulesKnownBadInputsRuleSet`. Você pode desabilitar isso se desejar gerenciar seu próprio Web ACL ou não precisar de um:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## Uso da Infraestrutura
 
 <Infrastructure>

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -99,6 +99,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### Bảo vệ khỏi mối đe dọa
+
+User Pool được tạo trên [gói tính năng Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) của Cognito với [bảo vệ khỏi mối đe dọa](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) được đặt ở chế độ `AUDIT` cho xác thực tiêu chuẩn. Ở chế độ kiểm toán, Cognito gán một mức độ rủi ro cho mỗi lần đăng nhập và ghi lại đánh giá vào CloudWatch mà không chặn người dùng.
+
+Sau khi bạn đã quan sát các đánh giá rủi ro cho người dùng của mình, bạn có thể chuyển sang chế độ thực thi đầy đủ chức năng để tự động phản hồi các hoạt động có rủi ro (ví dụ: yêu cầu MFA hoặc chặn đăng nhập):
+
+<Infrastructure>
+<Fragment slot="cdk">
+Đặt `standardThreatProtectionMode` thành `StandardThreatProtectionMode.FULL_FUNCTION` trong `packages/common/constructs/src/core/user-identity.ts`.
+</Fragment>
+<Fragment slot="terraform">
+Đặt `advanced_security_mode` thành `ENFORCED` trong khối `user_pool_add_ons` trong `packages/common/terraform/src/core/user-identity/identity/identity.tf`.
+</Fragment>
+</Infrastructure>
+
+#### Web Application Firewall (WAF)
+
+Theo mặc định, User Pool được liên kết với [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL sử dụng các nhóm quy tắc được quản lý `AWSManagedRulesCommonRuleSet` và `AWSManagedRulesKnownBadInputsRuleSet`. Bạn có thể tắt tính năng này nếu muốn quản lý Web ACL của riêng mình hoặc không yêu cầu:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## Sử dụng Hạ tầng
 
 <Infrastructure>

--- a/docs/src/content/docs/zh/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/react-website-auth.mdx
@@ -101,6 +101,42 @@ cognito -> iam
 browser -> backend: IAM/Cognito
 ```
 
+#### 威胁防护
+
+用户池在 Cognito [Plus 功能计划](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)上创建，并为标准身份验证启用了[威胁防护](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)，设置为 `AUDIT` 模式。在审计模式下，Cognito 会为每次登录分配风险级别，并将评估结果记录到 CloudWatch，而不会阻止用户。
+
+在观察了用户的风险评估结果后，您可以切换到全功能强制模式，以自动响应风险活动（例如要求 MFA 或阻止登录）：
+
+<Infrastructure>
+<Fragment slot="cdk">
+在 `packages/common/constructs/src/core/user-identity.ts` 中将 `standardThreatProtectionMode` 设置为 `StandardThreatProtectionMode.FULL_FUNCTION`。
+</Fragment>
+<Fragment slot="terraform">
+在 `packages/common/terraform/src/core/user-identity/identity/identity.tf` 的 `user_pool_add_ons` 块中将 `advanced_security_mode` 设置为 `ENFORCED`。
+</Fragment>
+</Infrastructure>
+
+#### Web 应用程序防火墙 (WAF)
+
+默认情况下，用户池与 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 关联，使用 `AWSManagedRulesCommonRuleSet` 和 `AWSManagedRulesKnownBadInputsRuleSet` 托管规则组。如果您希望管理自己的 Web ACL 或不需要 Web ACL，可以禁用此功能：
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new UserIdentity(this, 'Identity', { enableWaf: false });
+```
+</Fragment>
+<Fragment slot="terraform">
+```hcl
+module "user_identity" {
+  source = "../../common/terraform/src/core/user-identity"
+
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
 ## 基础设施使用
 
 <Infrastructure>

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -212,7 +212,7 @@ export class UserIdentity extends Construct {
       mfa: Mfa.REQUIRED,
       featurePlan: FeaturePlan.PLUS,
       // Audit-only logs threat assessments without blocking sign-in. Switch to FULL_FUNCTION to enforce automatic responses.
-      standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT,
+      standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT_ONLY,
       mfaSecondFactor: { sms: true, otp: true },
       signInCaseSensitive: false,
       signInAliases: { username: true, email: true },

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -90,7 +90,14 @@ exports[`cognito-auth generator > should generate files > user-identity 1`] = `
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import { CfnOutput, CfnResource, Duration, Lazy, Stack } from 'aws-cdk-lib';
+import {
+  CfnOutput,
+  CfnResource,
+  Duration,
+  Lazy,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -98,15 +105,34 @@ import {
   FeaturePlan,
   Mfa,
   OAuthScope,
+  StandardThreatProtectionMode,
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
+import {
+  CfnLoggingConfiguration,
+  CfnWebACL,
+  CfnWebACLAssociation,
+} from 'aws-cdk-lib/aws-wafv2';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import { suppressRules } from './checkov.js';
 
 const WEB_CLIENT_ID = 'WebClient';
+
+export interface UserIdentityProps {
+  /**
+   * Whether to enable AWS WAFv2 with the default managed ruleset
+   * (AWSManagedRulesCommonRuleSet and AWSManagedRulesKnownBadInputsRuleSet)
+   * and associate it with the user pool.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+}
+
 /**
  * Creates a UserPool and Identity Pool with sane defaults configured intended for usage from a web client.
  */
@@ -117,11 +143,22 @@ export class UserIdentity extends Construct {
   public readonly userPoolClient: UserPoolClient;
   public readonly userPoolDomain: CfnUserPoolDomain;
 
-  constructor(scope: Construct, id: string) {
+  /** The WAFv2 Web ACL associated with the user pool, if WAF is enabled */
+  public readonly webAcl?: CfnWebACL;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { enableWaf = true }: UserIdentityProps = {},
+  ) {
     super(scope, id);
 
     this.region = Stack.of(this).region;
     this.userPool = this.createUserPool();
+
+    if (enableWaf) {
+      this.webAcl = this.createWebAcl(id, this.userPool);
+    }
     this.userPoolDomain = this.createUserPoolDomain(this.userPool);
     this.userPoolClient = this.createUserPoolClient(this.userPool);
     this.identityPool = this.createIdentityPool(
@@ -174,6 +211,8 @@ export class UserIdentity extends Construct {
       },
       mfa: Mfa.REQUIRED,
       featurePlan: FeaturePlan.PLUS,
+      // Audit-only logs threat assessments without blocking sign-in. Switch to FULL_FUNCTION to enforce automatic responses.
+      standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT,
       mfaSecondFactor: { sms: true, otp: true },
       signInCaseSensitive: false,
       signInAliases: { username: true, email: true },
@@ -204,6 +243,81 @@ export class UserIdentity extends Construct {
         poolCfn.cfnOptions.updateReplacePolicy;
     }
     return userPool;
+  };
+
+  private createWebAcl = (id: string, userPool: UserPool) => {
+    const webAcl = new CfnWebACL(this, 'WebAcl', {
+      defaultAction: { allow: {} },
+      scope: 'REGIONAL',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: \`\${id}WebAcl\`,
+        sampledRequestsEnabled: true,
+      },
+      rules: [
+        {
+          name: 'CRSRule',
+          priority: 0,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesCommonRuleSet',
+              vendorName: 'AWS',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: \`\${id}WebAcl-CRS\`,
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
+        {
+          name: 'KnownBadInputsRule',
+          priority: 1,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesKnownBadInputsRuleSet',
+              vendorName: 'AWS',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: \`\${id}WebAcl-KnownBadInputs\`,
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
+      ],
+    });
+
+    new CfnWebACLAssociation(this, 'WebAclAssociation', {
+      resourceArn: userPool.userPoolArn,
+      webAclArn: webAcl.attrArn,
+    });
+
+    // Send WAF request logs to CloudWatch. The log group name must start with
+    // \`aws-waf-logs-\` to satisfy the WAFv2 logging destination requirement.
+    const wafLogGroup = new LogGroup(this, 'WebAclLogs', {
+      logGroupName: \`aws-waf-logs-\${id}-\${this.node.addr.slice(-8)}\`,
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    suppressRules(
+      wafLogGroup,
+      ['CKV_AWS_158'],
+      'Using default CloudWatch log encryption for WAF logs',
+    );
+
+    new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {
+      resourceArn: webAcl.attrArn,
+      logDestinationConfigs: [wafLogGroup.logGroupArn],
+    });
+
+    return webAcl;
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -147,11 +147,18 @@ except Exception as e:
 }
 
 ",
-  "user-identity.tf": "module "identity" {
+  "user-identity.tf": "variable "enable_waf" {
+  description = "Whether to enable AWS WAFv2 with the default managed ruleset and associate it with the user pool"
+  type        = bool
+  default     = true
+}
+
+module "identity" {
   source = "./identity"
 
   user_pool_domain_prefix = "test"
   allow_signup = true
+  enable_waf = var.enable_waf
 }
 
 # Outputs

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -2,7 +2,14 @@ import {
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from 'aws-cdk-lib/aws-cognito-identitypool';
-import { CfnOutput, CfnResource, Duration, Lazy, Stack } from 'aws-cdk-lib';
+import {
+  CfnOutput,
+  CfnResource,
+  Duration,
+  Lazy,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
@@ -10,15 +17,34 @@ import {
   FeaturePlan,
   Mfa,
   OAuthScope,
+  StandardThreatProtectionMode,
   UserPool,
   UserPoolClient,
 } from 'aws-cdk-lib/aws-cognito';
+import {
+  CfnLoggingConfiguration,
+  CfnWebACL,
+  CfnWebACLAssociation,
+} from 'aws-cdk-lib/aws-wafv2';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import { suppressRules } from './checkov.js';
 
 const WEB_CLIENT_ID = 'WebClient';
+
+export interface UserIdentityProps {
+  /**
+   * Whether to enable AWS WAFv2 with the default managed ruleset
+   * (AWSManagedRulesCommonRuleSet and AWSManagedRulesKnownBadInputsRuleSet)
+   * and associate it with the user pool.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+}
+
 /**
  * Creates a UserPool and Identity Pool with sane defaults configured intended for usage from a web client.
  */
@@ -29,11 +55,18 @@ export class UserIdentity extends Construct {
   public readonly userPoolClient: UserPoolClient;
   public readonly userPoolDomain: CfnUserPoolDomain;
 
-  constructor(scope: Construct, id: string) {
+  /** The WAFv2 Web ACL associated with the user pool, if WAF is enabled */
+  public readonly webAcl?: CfnWebACL;
+
+  constructor(scope: Construct, id: string, { enableWaf = true }: UserIdentityProps = {}) {
     super(scope, id);
 
     this.region = Stack.of(this).region;
     this.userPool = this.createUserPool();
+
+    if (enableWaf) {
+      this.webAcl = this.createWebAcl(id, this.userPool);
+    }
     this.userPoolDomain = this.createUserPoolDomain(this.userPool);
     this.userPoolClient = this.createUserPoolClient(this.userPool);
     this.identityPool = this.createIdentityPool(
@@ -86,6 +119,8 @@ export class UserIdentity extends Construct {
       },
       mfa: Mfa.REQUIRED,
       featurePlan: FeaturePlan.PLUS,
+      // Audit-only logs threat assessments without blocking sign-in. Switch to FULL_FUNCTION to enforce automatic responses.
+      standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT,
       mfaSecondFactor: { sms: true, otp: true },
       signInCaseSensitive: false,
       signInAliases: { username: true, email: true },
@@ -116,6 +151,81 @@ export class UserIdentity extends Construct {
         poolCfn.cfnOptions.updateReplacePolicy;
     }
     return userPool;
+  };
+
+  private createWebAcl = (id: string, userPool: UserPool) => {
+    const webAcl = new CfnWebACL(this, 'WebAcl', {
+      defaultAction: { allow: {} },
+      scope: 'REGIONAL',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: `${id}WebAcl`,
+        sampledRequestsEnabled: true,
+      },
+      rules: [
+        {
+          name: 'CRSRule',
+          priority: 0,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesCommonRuleSet',
+              vendorName: 'AWS',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: `${id}WebAcl-CRS`,
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
+        {
+          name: 'KnownBadInputsRule',
+          priority: 1,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesKnownBadInputsRuleSet',
+              vendorName: 'AWS',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: `${id}WebAcl-KnownBadInputs`,
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
+      ],
+    });
+
+    new CfnWebACLAssociation(this, 'WebAclAssociation', {
+      resourceArn: userPool.userPoolArn,
+      webAclArn: webAcl.attrArn,
+    });
+
+    // Send WAF request logs to CloudWatch. The log group name must start with
+    // `aws-waf-logs-` to satisfy the WAFv2 logging destination requirement.
+    const wafLogGroup = new LogGroup(this, 'WebAclLogs', {
+      logGroupName: `aws-waf-logs-${id}-${this.node.addr.slice(-8)}`,
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    suppressRules(
+      wafLogGroup,
+      ['CKV_AWS_158'],
+      'Using default CloudWatch log encryption for WAF logs',
+    );
+
+    new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {
+      resourceArn: webAcl.attrArn,
+      logDestinationConfigs: [wafLogGroup.logGroupArn],
+    });
+
+    return webAcl;
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -120,7 +120,7 @@ export class UserIdentity extends Construct {
       mfa: Mfa.REQUIRED,
       featurePlan: FeaturePlan.PLUS,
       // Audit-only logs threat assessments without blocking sign-in. Switch to FULL_FUNCTION to enforce automatic responses.
-      standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT,
+      standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT_ONLY,
       mfaSecondFactor: { sms: true, otp: true },
       signInCaseSensitive: false,
       signInAliases: { username: true, email: true },

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
@@ -22,6 +22,12 @@ variable "allow_signup" {
   type        = bool
 }
 
+variable "enable_waf" {
+  description = "Whether to enable AWS WAFv2 with the default managed ruleset (AWSManagedRulesCommonRuleSet and AWSManagedRulesKnownBadInputsRuleSet) and associate it with the user pool"
+  type        = bool
+  default     = true
+}
+
 variable "callback_urls" {
   description = "Additional callback URLs for the user pool client"
   type        = list(string)
@@ -150,6 +156,11 @@ resource "aws_cognito_user_pool" "user_pool" {
   # User pool tier (equivalent to FeaturePlan.PLUS)
   user_pool_tier = "PLUS"
 
+  # Threat protection. AUDIT logs threat assessments without blocking sign-in; switch to ENFORCED to apply automatic responses.
+  user_pool_add_ons {
+    advanced_security_mode = "AUDIT"
+  }
+
   # Schema attributes
   schema {
     attribute_data_type = "String"
@@ -223,6 +234,97 @@ resource "aws_cognito_user_pool_domain" "user_pool_domain" {
   domain                   = "${var.user_pool_domain_prefix}-${data.aws_caller_identity.current.account_id}-${random_id.unique_suffix.hex}"
   user_pool_id            = aws_cognito_user_pool.user_pool.id
   managed_login_version   = 2
+}
+
+# WAFv2 Web ACL for the user pool
+resource "aws_wafv2_web_acl" "user_pool_waf" {
+  #checkov:skip=CKV2_AWS_31:Logging configuration is defined below in aws_wafv2_web_acl_logging_configuration.user_pool_waf_logging; Checkov does not resolve the separate resource
+  count = var.enable_waf ? 1 : 0
+
+  name  = "UserPool-${random_id.unique_suffix.hex}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "CRSRule"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "UserPoolWebAcl-CRS"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KnownBadInputsRule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "UserPoolWebAcl-KnownBadInputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "UserPoolWebAcl"
+    sampled_requests_enabled   = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "user_pool_waf_association" {
+  count = var.enable_waf ? 1 : 0
+
+  resource_arn = aws_cognito_user_pool.user_pool.arn
+  web_acl_arn  = aws_wafv2_web_acl.user_pool_waf[0].arn
+}
+
+# CloudWatch Log Group for WAF request logs. Name must start with `aws-waf-logs-`.
+resource "aws_cloudwatch_log_group" "user_pool_waf_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:Log retention set to one month which is sufficient for WAF logs
+  count = var.enable_waf ? 1 : 0
+
+  name              = "aws-waf-logs-UserPool-${random_id.unique_suffix.hex}"
+  retention_in_days = 30
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "user_pool_waf_logging" {
+  count = var.enable_waf ? 1 : 0
+
+  log_destination_configs = [aws_cloudwatch_log_group.user_pool_waf_logs[0].arn]
+  resource_arn            = aws_wafv2_web_acl.user_pool_waf[0].arn
 }
 
 # User Pool Client

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/main.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/main.tf.template
@@ -1,8 +1,15 @@
+variable "enable_waf" {
+  description = "Whether to enable AWS WAFv2 with the default managed ruleset and associate it with the user pool"
+  type        = bool
+  default     = true
+}
+
 module "identity" {
   source = "./identity"
 
   user_pool_domain_prefix = "<%= cognitoDomain %>"
   allow_signup = <%= allowSignup %>
+  enable_waf = var.enable_waf
 }
 
 # Outputs


### PR DESCRIPTION
### Reason for this change

The generated Cognito User Pool is created on the **Plus** feature plan (`FeaturePlan.PLUS` / `user_pool_tier = "PLUS"`), which is the most expensive tier and exists specifically to unlock **threat protection** (adaptive authentication, compromised-credentials detection, and user-activity logging). However, threat protection enforcement defaults to `NO_ENFORCEMENT`, so the pool was paying for Plus while receiving none of its benefits.

Additionally, AWS threat protection explicitly does **not** provide rate-limiting or volumetric/DDoS protection — AWS guidance is to associate an AWS WAF web ACL with the user pool for that. The generator previously attached no WAF to the user pool, unlike the REST API generator which adds one by default.

### Description of changes

- **Enable threat protection (audit mode)** on the user pool so the Plus plan is actually used:
  - CDK: `standardThreatProtectionMode: StandardThreatProtectionMode.AUDIT`
  - Terraform: `user_pool_add_ons { advanced_security_mode = "AUDIT" }`
  - Audit mode logs risk assessments to CloudWatch without blocking users — the AWS-recommended starting point before switching to full-function enforcement.
- **Add an AWS WAFv2 Web ACL** (`AWSManagedRulesCommonRuleSet` + `AWSManagedRulesKnownBadInputsRuleSet`) associated with the user pool, with CloudWatch logging. Enabled by default, disableable via:
  - CDK: `new UserIdentity(this, 'Identity', { enableWaf: false })`
  - Terraform: `enable_waf = false`

  This mirrors the existing `enableWaf` pattern in the REST API constructs.
- Updated the React Website Authentication guide documenting threat protection mode and how to disable/configure the WAF.

### Description of how you validated changes

- Unit tests updated (`pnpm nx run @aws/nx-plugin:test -u`) — all 2395 pass, snapshots reflect the new CDK construct prop, threat protection mode, and WAF resources for both CDK and Terraform.
- End-to-end `cdk-deploy` and `terraform-deploy` smoke tests run against a real AWS account: deploy a website + auth + connected APIs, log in through the Cognito hosted UI, and make authenticated API requests — exercising the modified `UserIdentity` construct/module with WAF enabled.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*