### PR TITLE
feat(ts#trpc-api): align terraform/cdk api consistency

### DIFF
--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -995,7 +995,7 @@ exports[`py#agent generator > should match snapshot for Terraform generated file
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -192,7 +192,7 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -249,7 +249,7 @@ import {
   HttpApiIntegration,
   OperationDetails,
 } from './utils.js';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Stack } from 'aws-cdk-lib';
 import {
   HttpApi as _HttpApi,
   HttpApiProps as _HttpApiProps,
@@ -259,6 +259,8 @@ import {
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { suppressRules } from '../checkov.js';
 
 /**
@@ -335,12 +337,18 @@ export class HttpApi<
       ...props,
     });
 
-    const accessLogGroup = new LogGroup(this, 'AccessLogs');
-    suppressRules(
-      accessLogGroup,
-      ['CKV_AWS_158'],
-      'Using default CloudWatch log encryption',
+    // Customer-managed key for access log encryption at rest
+    const logsKey = new Key(this, 'AccessLogsKey', {
+      enableKeyRotation: true,
+    });
+    const stack = Stack.of(this);
+    logsKey.grantEncryptDecrypt(
+      new ServicePrincipal(\`logs.\${stack.region}.amazonaws.com\`),
     );
+
+    const accessLogGroup = new LogGroup(this, 'AccessLogs', {
+      encryptionKey: logsKey,
+    });
     suppressRules(
       accessLogGroup,
       ['CKV_AWS_66', 'CKV_AWS_338'],
@@ -2051,7 +2059,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -2298,7 +2306,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -2366,12 +2374,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -2422,7 +2424,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags
@@ -2722,7 +2723,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -2969,7 +2970,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -3027,12 +3028,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -3083,7 +3078,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags
@@ -3465,7 +3459,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -3712,7 +3706,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -3770,12 +3764,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -3826,7 +3814,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags
@@ -4113,7 +4100,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -4375,7 +4362,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -4942,7 +4929,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -5204,7 +5191,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -5760,7 +5747,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -6022,7 +6009,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -70,7 +70,7 @@ exports[`lambda-handler project generator > terraform iac > should generate terr
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     archive = {
       source  = "hashicorp/archive"
@@ -251,7 +251,7 @@ exports[`lambda-handler project generator > terraform iac > should match snapsho
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -135,7 +135,7 @@ exports[`py#mcp-server generator > should match snapshot for Terraform generated
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -403,7 +403,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -668,7 +668,7 @@ exports[`tsSmithyApiGenerator > should generate smithy ts api with Terraform pro
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -1678,7 +1678,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -1940,7 +1940,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -2476,7 +2476,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -2738,7 +2738,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -3259,7 +3259,7 @@ exports[`tsSmithyApiGenerator > terraform iac > should generate terraform with c
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/terraform/project/files/application/src/providers.tf.template
+++ b/packages/nx-plugin/src/terraform/project/files/application/src/providers.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -1202,7 +1202,7 @@ import {
   HttpApiIntegration,
   OperationDetails,
 } from './utils.js';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Stack } from 'aws-cdk-lib';
 import {
   HttpApi as _HttpApi,
   HttpApiProps as _HttpApiProps,
@@ -1212,6 +1212,8 @@ import {
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { suppressRules } from '../checkov.js';
 
 /**
@@ -1288,12 +1290,18 @@ export class HttpApi<
       ...props,
     });
 
-    const accessLogGroup = new LogGroup(this, 'AccessLogs');
-    suppressRules(
-      accessLogGroup,
-      ['CKV_AWS_158'],
-      'Using default CloudWatch log encryption',
+    // Customer-managed key for access log encryption at rest
+    const logsKey = new Key(this, 'AccessLogsKey', {
+      enableKeyRotation: true,
+    });
+    const stack = Stack.of(this);
+    logsKey.grantEncryptDecrypt(
+      new ServicePrincipal(\`logs.\${stack.region}.amazonaws.com\`),
     );
+
+    const accessLogGroup = new LogGroup(this, 'AccessLogs', {
+      encryptionKey: logsKey,
+    });
     suppressRules(
       accessLogGroup,
       ['CKV_AWS_66', 'CKV_AWS_338'],
@@ -3120,7 +3128,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -3367,7 +3375,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -3435,12 +3443,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -3491,7 +3493,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags
@@ -3773,7 +3774,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -4020,7 +4021,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -4078,12 +4079,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -4134,7 +4129,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags
@@ -4498,7 +4492,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -4745,7 +4739,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -4803,12 +4797,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -4859,7 +4847,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags
@@ -5128,7 +5115,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -5390,7 +5377,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -5927,7 +5914,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -6189,7 +6176,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }
@@ -6715,7 +6702,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"
@@ -6977,7 +6964,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -827,7 +827,7 @@ exports[`ts#agent generator > should match snapshot for Terraform generated file
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -192,7 +192,7 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -139,7 +139,7 @@ exports[`ts-lambda-function generator > terraform iac > should generate terrafor
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     archive = {
       source  = "hashicorp/archive"
@@ -320,7 +320,7 @@ exports[`ts-lambda-function generator > terraform iac > should match snapshot fo
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -135,7 +135,7 @@ exports[`ts#mcp-server generator > should match snapshot for Terraform generated
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -804,7 +804,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"
@@ -1566,7 +1566,7 @@ exports[`ts#rdb generator > should generate terraform modules when iac is Terraf
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"
@@ -2291,7 +2291,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"
@@ -3053,7 +3053,7 @@ exports[`ts#rdb generator > should generate terraform modules with MySQL engine 
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -131,7 +131,7 @@ exports[`react-website generator > TailwindCSS integration > terraform iac > sho
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
       configuration_aliases = [aws.us_east_1]
     }
     random = {
@@ -904,7 +904,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
       configuration_aliases = [aws.us_east_1]
     }
   }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`cognito-auth generator terraform iac > should generate terraform files 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.50"
+      version = "~> 6.52"
     }
 <%_ if (cedarPolicy) { _%>
     external = {

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agentcore-gateway/gateway.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agentcore-gateway/gateway.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.50"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/http/http-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/http/http-api.ts.template
@@ -5,7 +5,7 @@ import {
   HttpApiIntegration,
   OperationDetails,
 } from './utils.js';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Stack } from 'aws-cdk-lib';
 import {
   HttpApi as _HttpApi,
   HttpApiProps as _HttpApiProps,
@@ -15,6 +15,8 @@ import {
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { suppressRules } from '../checkov.js';
 
 /**
@@ -91,12 +93,18 @@ export class HttpApi<
       ...props,
     });
 
-    const accessLogGroup = new LogGroup(this, 'AccessLogs');
-    suppressRules(
-      accessLogGroup,
-      ['CKV_AWS_158'],
-      'Using default CloudWatch log encryption',
+    // Customer-managed key for access log encryption at rest
+    const logsKey = new Key(this, 'AccessLogsKey', {
+      enableKeyRotation: true,
+    });
+    const stack = Stack.of(this);
+    logsKey.grantEncryptDecrypt(
+      new ServicePrincipal(`logs.${stack.region}.amazonaws.com`),
     );
+
+    const accessLogGroup = new LogGroup(this, 'AccessLogs', {
+      encryptionKey: logsKey,
+    });
     suppressRules(
       accessLogGroup,
       ['CKV_AWS_66', 'CKV_AWS_338'],

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }
@@ -74,12 +74,6 @@ variable "cors_expose_headers" {
   default     = []
 }
 
-variable "cors_max_age" {
-  description = "Maximum age for CORS preflight requests in seconds"
-  type        = number
-  default     = 0
-}
-
 # Tags
 variable "tags" {
   description = "Tags to apply to all resources"
@@ -130,7 +124,6 @@ module "http_api" {
   cors_allow_methods     = var.cors_allow_methods
   cors_allow_origins     = var.cors_allow_origins
   cors_expose_headers    = var.cors_expose_headers
-  cors_max_age           = var.cors_max_age
 
   # Tags
   tags = var.tags

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/http/http-api/http-api.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/http/http-api/http-api.tf.template
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/rest-api/rest-api.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/rest-api/rest-api.tf.template
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.52"
     }
     local = {
       source  = "hashicorp/local"

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
     }
     random = {
       source  = "hashicorp/random"

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "~> 6.52"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
       configuration_aliases = [aws.us_east_1]
     }
   }

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 6.52"
       configuration_aliases = [aws.us_east_1]
     }
     random = {


### PR DESCRIPTION

### Reason for this change

While closing the Terraform REST API throttling gap (#855), a review of the REST/HTTP API constructs across both CDK and Terraform surfaced three further inconsistencies:

1. **CDK HTTP API access logs were not encrypted with a customer-managed key.** The Terraform HTTP API module creates a dedicated KMS key for its access log group, but the CDK HTTP construct used the default CloudWatch encryption and suppressed `CKV_AWS_158`. The two should be consistent, and the more secure (Terraform) behaviour is the right baseline.
2. **The Terraform HTTP API app module overrode the core `cors_max_age` default.** The core module defaults `cors_max_age` to `86400`, but the app module re-declared the variable with a default of `0` and passed it through, effectively disabling preflight caching.
3. **The AWS Terraform provider pin was inconsistent across vended modules** - ranging between `~> 6.0`, `~> 6.33`, `>= 6.23` and `>= 6.50`.

### Description of changes

1. The CDK HTTP API construct now creates a customer-managed `Key` (with rotation) and uses it to encrypt the access log group, granting the CloudWatch Logs service principal encrypt/decrypt - matching the Terraform module.
2. Removed the `cors_max_age` variable and its module passthrough from the Terraform HTTP API app module so the core module default (`86400`) applies.
3. Pinned the AWS provider to `~> 6.52` (latest at time of writing) across all vended Terraform modules.

### Description of how you validated changes

Updated and ran the generator unit tests (`pnpm nx run @aws/nx-plugin:test -u`); all 2395 tests pass. Snapshot diffs across the trpc, fastapi, smithy and other generators confirm the rendered Terraform and CDK reflect the changes. Smoke tests (terraform build + checkov, CDK build) exercise the generated projects end to end.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
