### PR TITLE
feat(api): enable REST API access logging by default

### DIFF
--- a/docs/src/content/docs/en/guides/fastapi.mdx
+++ b/docs/src/content/docs/en/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Integrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Integrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+
 ### Integrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/en/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/en/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: Access logging
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+For REST APIs, the generated infrastructure enables [access logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) by default, writing one structured JSON line per request to a dedicated CloudWatch Logs group.
+
+API Gateway writes access logs using an account-level CloudWatch Logs role. This role is configured on the `AWS::ApiGateway::Account` setting, which is a **singleton per region per account** — there is only one role for every REST API in the region. To manage this safely across multiple independently-deployed stacks, the generated infrastructure:
+
+- Creates a shared CloudWatch Logs role and configures it on the account only when no working role is already set, so deployments never overwrite a role another stack owns.
+- Leaves the account setting untouched on teardown, so destroying one stack never disables logging for other REST APIs in the region.
+
+<Infrastructure>
+<Fragment slot="cdk">
+The account role is managed by the `ApiGatewayAccount` construct, a stack-scoped singleton resolved via `ApiGatewayAccount.ensure(scope)`. Each REST API's stage depends on it, and the role is configured by a Lambda-backed custom resource.
+
+You can customise the access log format by passing `deployOptions` when constructing your API:
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+The account role is managed by the `core/api/api-gateway-account` module, which is instantiated by the generated API module. It configures the account idempotently and is never reset on `terraform destroy`.
+
+You can customise the access log format by editing the `access_log_settings` block on the `aws_api_gateway_stage` resource in the generated API module.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/en/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/en/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: Access logging
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-For REST APIs, the generated infrastructure enables [access logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) by default, writing one structured JSON line per request to a dedicated CloudWatch Logs group.
+For REST APIs, the generated infrastructure enables [access logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) by default, writing one structured JSON line per request to a dedicated CloudWatch Logs group. The log group is encrypted with a customer-managed KMS key and retained for one year.
 
 API Gateway writes access logs using an account-level CloudWatch Logs role. This role is configured on the `AWS::ApiGateway::Account` setting, which is a **singleton per region per account** — there is only one role for every REST API in the region. To manage this safely across multiple independently-deployed stacks, the generated infrastructure:
 

--- a/docs/src/content/docs/es/guides/fastapi.mdx
+++ b/docs/src/content/docs/es/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Registro de acceso
+
+<Snippet name="api/access-logging" parentHeading="Registro de acceso" />
+</OptionFilter>
+
 ### Integraciones
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integraciones" />

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Registro de acceso
+
+<Snippet name="api/access-logging" parentHeading="Registro de acceso" />
+</OptionFilter>
+
 ### Integraciones
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integraciones" />

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### Registro de acceso
+
+<Snippet name="api/access-logging" parentHeading="Registro de acceso" />
+
 ### Integraciones
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integraciones" />

--- a/docs/src/content/docs/es/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/es/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: Registro de acceso
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+Para las APIs REST, la infraestructura generada habilita el [registro de acceso](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) por defecto, escribiendo una línea JSON estructurada por solicitud en un grupo de CloudWatch Logs dedicado.
+
+API Gateway escribe registros de acceso utilizando un rol de CloudWatch Logs a nivel de cuenta. Este rol se configura en el ajuste `AWS::ApiGateway::Account`, que es un **singleton por región por cuenta** — solo hay un rol para cada API REST en la región. Para gestionar esto de forma segura a través de múltiples stacks desplegados de forma independiente, la infraestructura generada:
+
+- Crea un rol compartido de CloudWatch Logs y lo configura en la cuenta solo cuando no hay un rol funcional ya establecido, por lo que los despliegues nunca sobrescriben un rol que pertenece a otro stack.
+- Deja el ajuste de la cuenta intacto durante el desmontaje, por lo que destruir un stack nunca deshabilita el registro para otras APIs REST en la región.
+
+<Infrastructure>
+<Fragment slot="cdk">
+El rol de cuenta es gestionado por el constructo `ApiGatewayAccount`, un singleton con ámbito de stack resuelto a través de `ApiGatewayAccount.ensure(scope)`. Cada etapa de la API REST depende de él, y el rol se configura mediante un recurso personalizado respaldado por Lambda.
+
+Puedes personalizar el formato del registro de acceso pasando `deployOptions` al construir tu API:
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+El rol de cuenta es gestionado por el módulo `core/api/api-gateway-account`, que es instanciado por el módulo de API generado. Configura la cuenta de forma idempotente y nunca se restablece con `terraform destroy`.
+
+Puedes personalizar el formato del registro de acceso editando el bloque `access_log_settings` en el recurso `aws_api_gateway_stage` en el módulo de API generado.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/es/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/es/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: Registro de acceso
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Para las APIs REST, la infraestructura generada habilita el [registro de acceso](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) por defecto, escribiendo una línea JSON estructurada por solicitud en un grupo de CloudWatch Logs dedicado.
+Para las APIs REST, la infraestructura generada habilita el [registro de acceso](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) por defecto, escribiendo una línea JSON estructurada por solicitud en un grupo de CloudWatch Logs dedicado. El grupo de registros está cifrado con una clave KMS administrada por el cliente y se conserva durante un año.
 
 API Gateway escribe registros de acceso utilizando un rol de CloudWatch Logs a nivel de cuenta. Este rol se configura en el ajuste `AWS::ApiGateway::Account`, que es un **singleton por región por cuenta** — solo hay un rol para cada API REST en la región. Para gestionar esto de forma segura a través de múltiples stacks desplegados de forma independiente, la infraestructura generada:
 

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Journalisation des accès
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Intégrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Intégrations" />

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Journalisation des accès
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Intégrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Intégrations" />

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### Journalisation des accès
+
+<Snippet name="api/access-logging" parentHeading="Journalisation des accès" />
+
 ### Intégrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Intégrations" />

--- a/docs/src/content/docs/fr/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/fr/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: Journalisation des accès
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Pour les API REST, l'infrastructure générée active la [journalisation des accès](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) par défaut, écrivant une ligne JSON structurée par requête dans un groupe CloudWatch Logs dédié.
+Pour les API REST, l'infrastructure générée active la [journalisation des accès](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) par défaut, écrivant une ligne JSON structurée par requête dans un groupe CloudWatch Logs dédié. Le groupe de journaux est chiffré avec une clé KMS gérée par le client et conservé pendant un an.
 
 API Gateway écrit les journaux d'accès en utilisant un rôle CloudWatch Logs au niveau du compte. Ce rôle est configuré sur le paramètre `AWS::ApiGateway::Account`, qui est un **singleton par région par compte** — il n'y a qu'un seul rôle pour chaque API REST dans la région. Pour gérer cela en toute sécurité à travers plusieurs stacks déployées indépendamment, l'infrastructure générée :
 

--- a/docs/src/content/docs/fr/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/fr/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: Journalisation des accès
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+Pour les API REST, l'infrastructure générée active la [journalisation des accès](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) par défaut, écrivant une ligne JSON structurée par requête dans un groupe CloudWatch Logs dédié.
+
+API Gateway écrit les journaux d'accès en utilisant un rôle CloudWatch Logs au niveau du compte. Ce rôle est configuré sur le paramètre `AWS::ApiGateway::Account`, qui est un **singleton par région par compte** — il n'y a qu'un seul rôle pour chaque API REST dans la région. Pour gérer cela en toute sécurité à travers plusieurs stacks déployées indépendamment, l'infrastructure générée :
+
+- Crée un rôle CloudWatch Logs partagé et le configure sur le compte uniquement lorsqu'aucun rôle fonctionnel n'est déjà défini, de sorte que les déploiements n'écrasent jamais un rôle appartenant à une autre stack.
+- Laisse le paramètre du compte intact lors du démontage, de sorte que la destruction d'une stack ne désactive jamais la journalisation pour les autres API REST dans la région.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Le rôle du compte est géré par le construct `ApiGatewayAccount`, un singleton à portée de stack résolu via `ApiGatewayAccount.ensure(scope)`. Chaque stage d'API REST en dépend, et le rôle est configuré par une ressource personnalisée basée sur Lambda.
+
+Vous pouvez personnaliser le format du journal d'accès en passant `deployOptions` lors de la construction de votre API :
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+Le rôle du compte est géré par le module `core/api/api-gateway-account`, qui est instancié par le module API généré. Il configure le compte de manière idempotente et n'est jamais réinitialisé lors d'un `terraform destroy`.
+
+Vous pouvez personnaliser le format du journal d'accès en modifiant le bloc `access_log_settings` sur la ressource `aws_api_gateway_stage` dans le module API généré.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Integrazioni
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrazioni" />

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Logging degli accessi
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Integrazioni
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrazioni" />

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -785,6 +785,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+
 ### Integrazioni
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrazioni" />

--- a/docs/src/content/docs/it/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/it/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: Registrazione degli accessi
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+Per le REST API, l'infrastruttura generata abilita la [registrazione degli accessi](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) per impostazione predefinita, scrivendo una riga JSON strutturata per richiesta in un gruppo CloudWatch Logs dedicato.
+
+API Gateway scrive i log di accesso utilizzando un ruolo CloudWatch Logs a livello di account. Questo ruolo è configurato nell'impostazione `AWS::ApiGateway::Account`, che è un **singleton per regione per account** — esiste un solo ruolo per ogni REST API nella regione. Per gestire questo in modo sicuro tra più stack distribuiti indipendentemente, l'infrastruttura generata:
+
+- Crea un ruolo CloudWatch Logs condiviso e lo configura sull'account solo quando non è già impostato un ruolo funzionante, in modo che le distribuzioni non sovrascrivano mai un ruolo di proprietà di un altro stack.
+- Lascia l'impostazione dell'account intatta durante la rimozione, in modo che la distruzione di uno stack non disabiliti mai la registrazione per altre REST API nella regione.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Il ruolo dell'account è gestito dal costrutto `ApiGatewayAccount`, un singleton con ambito stack risolto tramite `ApiGatewayAccount.ensure(scope)`. Ogni stage della REST API dipende da esso e il ruolo è configurato da una risorsa personalizzata supportata da Lambda.
+
+Puoi personalizzare il formato del log di accesso passando `deployOptions` durante la costruzione della tua API:
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+Il ruolo dell'account è gestito dal modulo `core/api/api-gateway-account`, che viene istanziato dal modulo API generato. Configura l'account in modo idempotente e non viene mai reimpostato con `terraform destroy`.
+
+Puoi personalizzare il formato del log di accesso modificando il blocco `access_log_settings` sulla risorsa `aws_api_gateway_stage` nel modulo API generato.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/it/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/it/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: Registrazione degli accessi
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Per le REST API, l'infrastruttura generata abilita la [registrazione degli accessi](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) per impostazione predefinita, scrivendo una riga JSON strutturata per richiesta in un gruppo CloudWatch Logs dedicato.
+Per le REST API, l'infrastruttura generata abilita la [registrazione degli accessi](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) per impostazione predefinita, scrivendo una riga JSON strutturata per richiesta in un gruppo CloudWatch Logs dedicato. Il gruppo di log è crittografato con una chiave KMS gestita dal cliente e conservato per un anno.
 
 API Gateway scrive i log di accesso utilizzando un ruolo CloudWatch Logs a livello di account. Questo ruolo è configurato nell'impostazione `AWS::ApiGateway::Account`, che è un **singleton per regione per account** — esiste un solo ruolo per ogni REST API nella regione. Per gestire questo in modo sicuro tra più stack distribuiti indipendentemente, l'infrastruttura generata:
 

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### アクセスログ
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### 統合
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### アクセスログ
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### インテグレーション
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="インテグレーション" />

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### アクセスログ
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+
 ### インテグレーション
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/jp/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/jp/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: アクセスログ
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-REST APIの場合、生成されたインフラストラクチャはデフォルトで[アクセスログ](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)を有効にし、リクエストごとに1行の構造化されたJSONを専用のCloudWatch Logsグループに書き込みます。
+REST APIの場合、生成されたインフラストラクチャはデフォルトで[アクセスログ](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)を有効にし、リクエストごとに1行の構造化されたJSONを専用のCloudWatch Logsグループに書き込みます。ログループは顧客管理のKMSキーで暗号化され、1年間保持されます。
 
 API Gatewayは、アカウントレベルのCloudWatch Logsロールを使用してアクセスログを書き込みます。このロールは`AWS::ApiGateway::Account`設定で構成されており、これは**リージョンごと、アカウントごとのシングルトン**です。つまり、リージョン内のすべてのREST APIに対して1つのロールしか存在しません。独立してデプロイされる複数のスタック間でこれを安全に管理するため、生成されたインフラストラクチャは次のようになっています：
 

--- a/docs/src/content/docs/jp/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/jp/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: アクセスログ
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+REST APIの場合、生成されたインフラストラクチャはデフォルトで[アクセスログ](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)を有効にし、リクエストごとに1行の構造化されたJSONを専用のCloudWatch Logsグループに書き込みます。
+
+API Gatewayは、アカウントレベルのCloudWatch Logsロールを使用してアクセスログを書き込みます。このロールは`AWS::ApiGateway::Account`設定で構成されており、これは**リージョンごと、アカウントごとのシングルトン**です。つまり、リージョン内のすべてのREST APIに対して1つのロールしか存在しません。独立してデプロイされる複数のスタック間でこれを安全に管理するため、生成されたインフラストラクチャは次のようになっています：
+
+- 共有CloudWatch Logsロールを作成し、動作中のロールがまだ設定されていない場合にのみアカウントに構成するため、デプロイメントが他のスタックが所有するロールを上書きすることはありません。
+- 破棄時にアカウント設定をそのままにするため、1つのスタックを破棄してもリージョン内の他のREST APIのログ記録が無効になることはありません。
+
+<Infrastructure>
+<Fragment slot="cdk">
+アカウントロールは`ApiGatewayAccount`コンストラクトによって管理されます。これは`ApiGatewayAccount.ensure(scope)`を介して解決されるスタックスコープのシングルトンです。各REST APIのステージはこれに依存しており、ロールはLambdaベースのカスタムリソースによって構成されます。
+
+APIを構築する際に`deployOptions`を渡すことで、アクセスログ形式をカスタマイズできます：
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+アカウントロールは`core/api/api-gateway-account`モジュールによって管理されます。これは生成されたAPIモジュールによってインスタンス化されます。アカウントを冪等的に構成し、`terraform destroy`でリセットされることはありません。
+
+生成されたAPIモジュール内の`aws_api_gateway_stage`リソースの`access_log_settings`ブロックを編集することで、アクセスログ形式をカスタマイズできます。
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/ko/guides/fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### 통합
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### 액세스 로깅
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### 통합
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### 액세스 로깅
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+
 ### 통합
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/ko/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/ko/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: 액세스 로깅
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-REST API의 경우, 생성된 인프라는 기본적으로 [액세스 로깅](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)을 활성화하여 요청당 하나의 구조화된 JSON 라인을 전용 CloudWatch Logs 그룹에 기록합니다.
+REST API의 경우, 생성된 인프라는 기본적으로 [액세스 로깅](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)을 활성화하여 요청당 하나의 구조화된 JSON 라인을 전용 CloudWatch Logs 그룹에 기록합니다. 로그 그룹은 고객 관리형 KMS 키로 암호화되며 1년 동안 보관됩니다.
 
 API Gateway는 계정 수준의 CloudWatch Logs 역할을 사용하여 액세스 로그를 작성합니다. 이 역할은 `AWS::ApiGateway::Account` 설정에 구성되며, 이는 **리전당 계정당 싱글톤**입니다 — 리전의 모든 REST API에 대해 하나의 역할만 존재합니다. 독립적으로 배포된 여러 스택에서 이를 안전하게 관리하기 위해, 생성된 인프라는:
 

--- a/docs/src/content/docs/ko/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/ko/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: 액세스 로깅
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+REST API의 경우, 생성된 인프라는 기본적으로 [액세스 로깅](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)을 활성화하여 요청당 하나의 구조화된 JSON 라인을 전용 CloudWatch Logs 그룹에 기록합니다.
+
+API Gateway는 계정 수준의 CloudWatch Logs 역할을 사용하여 액세스 로그를 작성합니다. 이 역할은 `AWS::ApiGateway::Account` 설정에 구성되며, 이는 **리전당 계정당 싱글톤**입니다 — 리전의 모든 REST API에 대해 하나의 역할만 존재합니다. 독립적으로 배포된 여러 스택에서 이를 안전하게 관리하기 위해, 생성된 인프라는:
+
+- 작동하는 역할이 아직 설정되지 않은 경우에만 공유 CloudWatch Logs 역할을 생성하고 계정에 구성하므로, 배포가 다른 스택이 소유한 역할을 덮어쓰지 않습니다.
+- 해체 시 계정 설정을 그대로 유지하므로, 하나의 스택을 삭제해도 리전의 다른 REST API에 대한 로깅이 비활성화되지 않습니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+계정 역할은 `ApiGatewayAccount` 구성으로 관리되며, `ApiGatewayAccount.ensure(scope)`를 통해 해결되는 스택 범위 싱글톤입니다. 각 REST API의 스테이지는 이에 의존하며, 역할은 Lambda 기반 사용자 지정 리소스에 의해 구성됩니다.
+
+API를 구성할 때 `deployOptions`를 전달하여 액세스 로그 형식을 사용자 지정할 수 있습니다:
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+계정 역할은 `core/api/api-gateway-account` 모듈에 의해 관리되며, 생성된 API 모듈에 의해 인스턴스화됩니다. 이는 계정을 멱등적으로 구성하며 `terraform destroy` 시 재설정되지 않습니다.
+
+생성된 API 모듈의 `aws_api_gateway_stage` 리소스에서 `access_log_settings` 블록을 편집하여 액세스 로그 형식을 사용자 지정할 수 있습니다.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/pt/guides/fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Integrações
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrações" />

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Registro de acesso
+
+<Snippet name="api/access-logging" parentHeading="Registro de acesso" />
+</OptionFilter>
+
 ### Integrações
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrações" />

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### Registro de acesso
+
+<Snippet name="api/access-logging" parentHeading="Registro de acesso" />
+
 ### Integrações
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrações" />

--- a/docs/src/content/docs/pt/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/pt/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: Registro de acesso
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+Para APIs REST, a infraestrutura gerada habilita o [registro de acesso](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) por padrão, escrevendo uma linha JSON estruturada por solicitação em um grupo dedicado do CloudWatch Logs.
+
+O API Gateway escreve logs de acesso usando uma função do CloudWatch Logs no nível da conta. Essa função é configurada na configuração `AWS::ApiGateway::Account`, que é um **singleton por região por conta** — há apenas uma função para cada API REST na região. Para gerenciar isso com segurança em várias pilhas implantadas independentemente, a infraestrutura gerada:
+
+- Cria uma função compartilhada do CloudWatch Logs e a configura na conta somente quando nenhuma função funcional já está definida, para que as implantações nunca substituam uma função que outra pilha possui.
+- Deixa a configuração da conta intocada na desmontagem, para que a destruição de uma pilha nunca desabilite o registro para outras APIs REST na região.
+
+<Infrastructure>
+<Fragment slot="cdk">
+A função da conta é gerenciada pelo construto `ApiGatewayAccount`, um singleton com escopo de pilha resolvido via `ApiGatewayAccount.ensure(scope)`. O estágio de cada API REST depende dele, e a função é configurada por um recurso personalizado baseado em Lambda.
+
+Você pode personalizar o formato do log de acesso passando `deployOptions` ao construir sua API:
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+A função da conta é gerenciada pelo módulo `core/api/api-gateway-account`, que é instanciado pelo módulo de API gerado. Ele configura a conta de forma idempotente e nunca é redefinido no `terraform destroy`.
+
+Você pode personalizar o formato do log de acesso editando o bloco `access_log_settings` no recurso `aws_api_gateway_stage` no módulo de API gerado.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/pt/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/pt/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: Registro de acesso
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Para APIs REST, a infraestrutura gerada habilita o [registro de acesso](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) por padrão, escrevendo uma linha JSON estruturada por solicitação em um grupo dedicado do CloudWatch Logs.
+Para APIs REST, a infraestrutura gerada habilita o [registro de acesso](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) por padrão, escrevendo uma linha JSON estruturada por solicitação em um grupo dedicado do CloudWatch Logs. O grupo de logs é criptografado com uma chave KMS gerenciada pelo cliente e retido por um ano.
 
 O API Gateway escreve logs de acesso usando uma função do CloudWatch Logs no nível da conta. Essa função é configurada na configuração `AWS::ApiGateway::Account`, que é um **singleton por região por conta** — há apenas uma função para cada API REST na região. Para gerenciar isso com segurança em várias pilhas implantadas independentemente, a infraestrutura gerada:
 

--- a/docs/src/content/docs/vi/guides/fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Integrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### Tích hợp
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### Ghi nhật ký truy cập
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+
 ### Integrations
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />

--- a/docs/src/content/docs/vi/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/vi/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: Ghi nhật ký truy cập
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Đối với REST API, cơ sở hạ tầng được tạo ra sẽ bật [ghi nhật ký truy cập](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) theo mặc định, ghi một dòng JSON có cấu trúc cho mỗi yêu cầu vào một nhóm CloudWatch Logs chuyên dụng.
+Đối với REST API, cơ sở hạ tầng được tạo ra sẽ bật [ghi nhật ký truy cập](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) theo mặc định, ghi một dòng JSON có cấu trúc cho mỗi yêu cầu vào một nhóm CloudWatch Logs chuyên dụng. Nhóm nhật ký được mã hóa bằng khóa KMS do khách hàng quản lý và được giữ lại trong một năm.
 
 API Gateway ghi nhật ký truy cập bằng cách sử dụng vai trò CloudWatch Logs ở cấp tài khoản. Vai trò này được cấu hình trên cài đặt `AWS::ApiGateway::Account`, đây là một **singleton cho mỗi vùng trên mỗi tài khoản** — chỉ có một vai trò duy nhất cho mọi REST API trong vùng. Để quản lý điều này một cách an toàn trên nhiều stack được triển khai độc lập, cơ sở hạ tầng được tạo ra sẽ:
 

--- a/docs/src/content/docs/vi/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/vi/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: Ghi nhật ký truy cập
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+Đối với REST API, cơ sở hạ tầng được tạo ra sẽ bật [ghi nhật ký truy cập](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) theo mặc định, ghi một dòng JSON có cấu trúc cho mỗi yêu cầu vào một nhóm CloudWatch Logs chuyên dụng.
+
+API Gateway ghi nhật ký truy cập bằng cách sử dụng vai trò CloudWatch Logs ở cấp tài khoản. Vai trò này được cấu hình trên cài đặt `AWS::ApiGateway::Account`, đây là một **singleton cho mỗi vùng trên mỗi tài khoản** — chỉ có một vai trò duy nhất cho mọi REST API trong vùng. Để quản lý điều này một cách an toàn trên nhiều stack được triển khai độc lập, cơ sở hạ tầng được tạo ra sẽ:
+
+- Tạo một vai trò CloudWatch Logs được chia sẻ và cấu hình nó trên tài khoản chỉ khi chưa có vai trò hoạt động nào được thiết lập, do đó các triển khai không bao giờ ghi đè vai trò mà một stack khác sở hữu.
+- Giữ nguyên cài đặt tài khoản khi dỡ bỏ, do đó việc hủy một stack không bao giờ vô hiệu hóa ghi nhật ký cho các REST API khác trong vùng.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Vai trò tài khoản được quản lý bởi construct `ApiGatewayAccount`, một singleton có phạm vi stack được giải quyết thông qua `ApiGatewayAccount.ensure(scope)`. Mỗi stage của REST API phụ thuộc vào nó, và vai trò được cấu hình bởi một tài nguyên tùy chỉnh được hỗ trợ bởi Lambda.
+
+Bạn có thể tùy chỉnh định dạng nhật ký truy cập bằng cách truyền `deployOptions` khi xây dựng API của bạn:
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+Vai trò tài khoản được quản lý bởi module `core/api/api-gateway-account`, được khởi tạo bởi module API được tạo ra. Nó cấu hình tài khoản một cách idempotent và không bao giờ được đặt lại khi chạy `terraform destroy`.
+
+Bạn có thể tùy chỉnh định dạng nhật ký truy cập bằng cách chỉnh sửa khối `access_log_settings` trên tài nguyên `aws_api_gateway_stage` trong module API được tạo ra.
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/zh/guides/fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/fastapi.mdx
@@ -618,6 +618,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### Access logging
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### 集成
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="集成" />

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -728,6 +728,12 @@ When using `Custom` auth, your API is protected by a Lambda Authorizer that **de
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 </OptionFilter>
 
+<OptionFilter when={{ infra: 'rest-lambda' }} description="Access logging — REST APIs log requests to CloudWatch by default">
+### 访问日志
+
+<Snippet name="api/access-logging" parentHeading="Access logging" />
+</OptionFilter>
+
 ### 集成
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="集成" />

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -730,6 +730,10 @@ output "lambda_function_name" {
 
 <Snippet name="api/waf-configuration" parentHeading="WAF" />
 
+### 访问日志
+
+<Snippet name="api/access-logging" parentHeading="访问日志" />
+
 ### 集成
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="集成" />

--- a/docs/src/content/docs/zh/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/zh/snippets/api/access-logging.mdx
@@ -3,7 +3,7 @@ title: 访问日志
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-对于 REST API，生成的基础设施默认启用[访问日志](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)，为每个请求向专用的 CloudWatch Logs 组写入一行结构化的 JSON 数据。
+对于 REST API，生成的基础设施默认启用[访问日志](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)，为每个请求向专用的 CloudWatch Logs 组写入一行结构化的 JSON 数据。日志组使用客户管理的 KMS 密钥进行加密，并保留一年。
 
 API Gateway 使用账户级别的 CloudWatch Logs 角色来写入访问日志。此角色配置在 `AWS::ApiGateway::Account` 设置上，该设置是**每个区域每个账户的单例** — 区域中的每个 REST API 只有一个角色。为了在多个独立部署的堆栈中安全地管理此角色，生成的基础设施：
 

--- a/docs/src/content/docs/zh/snippets/api/access-logging.mdx
+++ b/docs/src/content/docs/zh/snippets/api/access-logging.mdx
@@ -1,0 +1,33 @@
+---
+title: 访问日志
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+对于 REST API，生成的基础设施默认启用[访问日志](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)，为每个请求向专用的 CloudWatch Logs 组写入一行结构化的 JSON 数据。
+
+API Gateway 使用账户级别的 CloudWatch Logs 角色来写入访问日志。此角色配置在 `AWS::ApiGateway::Account` 设置上，该设置是**每个区域每个账户的单例** — 区域中的每个 REST API 只有一个角色。为了在多个独立部署的堆栈中安全地管理此角色，生成的基础设施：
+
+- 仅在尚未设置工作角色时创建共享的 CloudWatch Logs 角色并在账户上配置它，因此部署永远不会覆盖另一个堆栈拥有的角色。
+- 在拆除时保持账户设置不变，因此销毁一个堆栈永远不会禁用区域中其他 REST API 的日志记录。
+
+<Infrastructure>
+<Fragment slot="cdk">
+账户角色由 `ApiGatewayAccount` 构造管理，这是一个通过 `ApiGatewayAccount.ensure(scope)` 解析的堆栈作用域单例。每个 REST API 的阶段都依赖于它，该角色由 Lambda 支持的自定义资源配置。
+
+您可以通过在构造 API 时传递 `deployOptions` 来自定义访问日志格式：
+
+```ts {3-5}
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this).build(),
+  deployOptions: {
+    accessLogFormat: AccessLogFormat.clf(),
+  },
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+账户角色由 `core/api/api-gateway-account` 模块管理，该模块由生成的 API 模块实例化。它以幂等方式配置账户，并且在 `terraform destroy` 时永远不会重置。
+
+您可以通过编辑生成的 API 模块中 `aws_api_gateway_stage` 资源上的 `access_log_settings` 块来自定义访问日志格式。
+</Fragment>
+</Infrastructure>

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.spec.ts.snap
@@ -1349,7 +1349,7 @@ resource "null_resource" "runtime_ready" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3==1.43.29 python -c "
 import boto3
 import json
 import os

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -1078,7 +1078,7 @@ import {
   Stage,
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
-import { IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { IAspect, Stack } from 'aws-cdk-lib';
 import {
   CfnLoggingConfiguration,
   CfnWebACL,
@@ -1179,7 +1179,6 @@ export class RestApi<
     // KMS key for encrypting logs at rest, usable by CloudWatch Logs
     const logsKey = new Key(this, 'LogsKey', {
       enableKeyRotation: true,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
     logsKey.grantEncryptDecrypt(
       new ServicePrincipal(\`logs.\${Stack.of(this).region}.amazonaws.com\`),
@@ -1188,7 +1187,6 @@ export class RestApi<
     const accessLogs = new LogGroup(this, 'AccessLogs', {
       retention: RetentionDays.ONE_YEAR,
       encryptionKey: logsKey,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     // Create the API Gateway REST API
@@ -1279,7 +1277,6 @@ export class RestApi<
         logGroupName: \`aws-waf-logs-\${apiName}-\${this.node.addr.slice(-8)}\`,
         retention: RetentionDays.ONE_YEAR,
         encryptionKey: logsKey,
-        removalPolicy: RemovalPolicy.DESTROY,
       });
 
       new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -4761,6 +4761,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -5591,6 +5592,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -6526,6 +6528,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -1078,13 +1078,15 @@ import {
   Stage,
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
-import { IAspect, RemovalPolicy } from 'aws-cdk-lib';
+import { IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import {
   CfnLoggingConfiguration,
   CfnWebACL,
   CfnWebACLAssociation,
 } from 'aws-cdk-lib/aws-wafv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { RuntimeConfig } from '../runtime-config.js';
 import { ApiGatewayAccount } from './api-gateway-account.js';
 import {
@@ -1174,15 +1176,20 @@ export class RestApi<
     // Account-level CloudWatch role required for REST API access logging
     const account = ApiGatewayAccount.ensure(this);
 
-    const accessLogs = new LogGroup(this, 'AccessLogs', {
-      retention: RetentionDays.ONE_MONTH,
+    // KMS key for encrypting logs at rest, usable by CloudWatch Logs
+    const logsKey = new Key(this, 'LogsKey', {
+      enableKeyRotation: true,
       removalPolicy: RemovalPolicy.DESTROY,
     });
-    suppressRules(
-      accessLogs,
-      ['CKV_AWS_158', 'CKV_AWS_338'],
-      'Using default CloudWatch log encryption and one month retention',
+    logsKey.grantEncryptDecrypt(
+      new ServicePrincipal(\`logs.\${Stack.of(this).region}.amazonaws.com\`),
     );
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_YEAR,
+      encryptionKey: logsKey,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
 
     // Create the API Gateway REST API
     this.api = new _RestApi(this, 'Api', {
@@ -1270,14 +1277,10 @@ export class RestApi<
       // \`aws-waf-logs-\` to satisfy the WAFv2 logging destination requirement.
       const wafLogGroup = new LogGroup(this, 'WebAclLogs', {
         logGroupName: \`aws-waf-logs-\${apiName}-\${this.node.addr.slice(-8)}\`,
-        retention: RetentionDays.ONE_MONTH,
+        retention: RetentionDays.ONE_YEAR,
+        encryptionKey: logsKey,
         removalPolicy: RemovalPolicy.DESTROY,
       });
-      suppressRules(
-        wafLogGroup,
-        ['CKV_AWS_158'],
-        'Using default CloudWatch log encryption for WAF logs',
-      );
 
       new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {
         resourceArn: this.webAcl.attrArn,
@@ -4749,12 +4752,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
@@ -5580,12 +5627,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
@@ -6516,12 +6607,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -1068,7 +1068,9 @@ export class IntegrationBuilder<
 exports[`fastapi project generator > should set up shared constructs for rest > rest-api.ts 1`] = `
 "import { Construct, IConstruct } from 'constructs';
 import {
+  AccessLogFormat,
   Cors,
+  LogGroupLogDestination,
   Resource,
   RestApi as _RestApi,
   RestApiProps as _RestApiProps,
@@ -1084,6 +1086,7 @@ import {
 } from 'aws-cdk-lib/aws-wafv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { RuntimeConfig } from '../runtime-config.js';
+import { ApiGatewayAccount } from './api-gateway-account.js';
 import {
   ApiIntegrations,
   OperationDetails,
@@ -1168,10 +1171,25 @@ export class RestApi<
     super(scope, id);
     this.integrations = integrations;
 
+    // Account-level CloudWatch role required for REST API access logging
+    const account = ApiGatewayAccount.ensure(this);
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    suppressRules(
+      accessLogs,
+      ['CKV_AWS_158', 'CKV_AWS_338'],
+      'Using default CloudWatch log encryption and one month retention',
+    );
+
     // Create the API Gateway REST API
     this.api = new _RestApi(this, 'Api', {
       ...props,
       deployOptions: {
+        accessLogDestination: new LogGroupLogDestination(accessLogs),
+        accessLogFormat: AccessLogFormat.jsonWithStandardFields(),
         ...props.deployOptions,
         methodOptions: {
           ...props.deployOptions?.methodOptions,
@@ -1184,6 +1202,8 @@ export class RestApi<
         },
       },
     });
+    // Ensure the account-level role is configured before the stage is created
+    this.api.deploymentStage.node.addDependency(account.resource);
 
     if (enableWaf) {
       this.webAcl = new CfnWebACL(this, 'WebAcl', {
@@ -1269,12 +1289,6 @@ export class RestApi<
       this.api,
       ['CKV_AWS_120'],
       'Caching not required for this use case',
-      (c) => c instanceof Stage,
-    );
-    suppressRules(
-      this.api,
-      ['CKV_AWS_76'],
-      'API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement',
       (c) => c instanceof Stage,
     );
 
@@ -4187,8 +4201,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -4205,10 +4217,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -4366,9 +4376,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -4474,6 +4482,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -4736,11 +4749,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -4748,9 +4768,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -5016,8 +5053,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -5034,10 +5069,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -5195,9 +5228,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -5293,6 +5324,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -5543,11 +5579,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -5555,9 +5598,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -5834,8 +5894,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -5852,10 +5910,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -6013,9 +6069,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -6111,6 +6165,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -6455,11 +6514,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -6467,9 +6533,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -489,7 +489,7 @@ resource "null_resource" "runtime_ready" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3==1.43.29 python -c "
 import boto3
 import json
 import os

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -477,8 +477,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -495,10 +493,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -656,9 +652,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement"
+# Note: Stage, deployment and access log outputs are provided by the consuming module"
 `;
 
 exports[`tsSmithyApiGenerator > should generate smithy ts api with Terraform provider and None auth > none-auth-terraform.tf 1`] = `
@@ -757,6 +751,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -1082,11 +1081,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -1094,9 +1100,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -1752,8 +1775,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -1770,10 +1791,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -1931,9 +1950,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -2039,6 +2056,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -2282,11 +2304,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -2294,9 +2323,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -2550,8 +2596,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -2568,10 +2612,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -2729,9 +2771,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -2827,6 +2867,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -3058,11 +3103,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -3070,9 +3122,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -3348,6 +3417,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -3673,11 +3747,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/custom-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -3685,9 +3766,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1081,18 +1081,63 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -2304,18 +2349,63 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -3103,18 +3193,63 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -3747,18 +3882,63 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "CustomApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/custom-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/custom-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/custom-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -5758,6 +5758,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -6558,6 +6559,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -7463,6 +7465,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -2079,7 +2079,9 @@ export class IntegrationBuilder<
 exports[`trpc backend generator > should set up shared constructs for rest > rest-api.ts 1`] = `
 "import { Construct, IConstruct } from 'constructs';
 import {
+  AccessLogFormat,
   Cors,
+  LogGroupLogDestination,
   Resource,
   RestApi as _RestApi,
   RestApiProps as _RestApiProps,
@@ -2095,6 +2097,7 @@ import {
 } from 'aws-cdk-lib/aws-wafv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { RuntimeConfig } from '../runtime-config.js';
+import { ApiGatewayAccount } from './api-gateway-account.js';
 import {
   ApiIntegrations,
   OperationDetails,
@@ -2179,10 +2182,25 @@ export class RestApi<
     super(scope, id);
     this.integrations = integrations;
 
+    // Account-level CloudWatch role required for REST API access logging
+    const account = ApiGatewayAccount.ensure(this);
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    suppressRules(
+      accessLogs,
+      ['CKV_AWS_158', 'CKV_AWS_338'],
+      'Using default CloudWatch log encryption and one month retention',
+    );
+
     // Create the API Gateway REST API
     this.api = new _RestApi(this, 'Api', {
       ...props,
       deployOptions: {
+        accessLogDestination: new LogGroupLogDestination(accessLogs),
+        accessLogFormat: AccessLogFormat.jsonWithStandardFields(),
         ...props.deployOptions,
         methodOptions: {
           ...props.deployOptions?.methodOptions,
@@ -2195,6 +2213,8 @@ export class RestApi<
         },
       },
     });
+    // Ensure the account-level role is configured before the stage is created
+    this.api.deploymentStage.node.addDependency(account.resource);
 
     if (enableWaf) {
       this.webAcl = new CfnWebACL(this, 'WebAcl', {
@@ -2280,12 +2300,6 @@ export class RestApi<
       this.api,
       ['CKV_AWS_120'],
       'Caching not required for this use case',
-      (c) => c instanceof Stage,
-    );
-    suppressRules(
-      this.api,
-      ['CKV_AWS_76'],
-      'API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement',
       (c) => c instanceof Stage,
     );
 
@@ -5202,8 +5216,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -5220,10 +5232,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -5381,9 +5391,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -5489,6 +5497,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -5733,11 +5746,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -5745,9 +5765,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -6001,8 +6038,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -6019,10 +6054,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -6180,9 +6213,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -6278,6 +6309,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -6510,11 +6546,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -6522,9 +6565,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy
@@ -6789,8 +6849,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -6807,10 +6865,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -6968,9 +7024,7 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement",
+# Note: Stage, deployment and access log outputs are provided by the consuming module",
   "test-api.tf": "terraform {
   required_version = ">= 1.0"
 
@@ -7066,6 +7120,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -7392,11 +7451,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -7404,9 +7470,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -2089,13 +2089,15 @@ import {
   Stage,
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
-import { IAspect, RemovalPolicy } from 'aws-cdk-lib';
+import { IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import {
   CfnLoggingConfiguration,
   CfnWebACL,
   CfnWebACLAssociation,
 } from 'aws-cdk-lib/aws-wafv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { RuntimeConfig } from '../runtime-config.js';
 import { ApiGatewayAccount } from './api-gateway-account.js';
 import {
@@ -2185,15 +2187,20 @@ export class RestApi<
     // Account-level CloudWatch role required for REST API access logging
     const account = ApiGatewayAccount.ensure(this);
 
-    const accessLogs = new LogGroup(this, 'AccessLogs', {
-      retention: RetentionDays.ONE_MONTH,
+    // KMS key for encrypting logs at rest, usable by CloudWatch Logs
+    const logsKey = new Key(this, 'LogsKey', {
+      enableKeyRotation: true,
       removalPolicy: RemovalPolicy.DESTROY,
     });
-    suppressRules(
-      accessLogs,
-      ['CKV_AWS_158', 'CKV_AWS_338'],
-      'Using default CloudWatch log encryption and one month retention',
+    logsKey.grantEncryptDecrypt(
+      new ServicePrincipal(\`logs.\${Stack.of(this).region}.amazonaws.com\`),
     );
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_YEAR,
+      encryptionKey: logsKey,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
 
     // Create the API Gateway REST API
     this.api = new _RestApi(this, 'Api', {
@@ -2281,14 +2288,10 @@ export class RestApi<
       // \`aws-waf-logs-\` to satisfy the WAFv2 logging destination requirement.
       const wafLogGroup = new LogGroup(this, 'WebAclLogs', {
         logGroupName: \`aws-waf-logs-\${apiName}-\${this.node.addr.slice(-8)}\`,
-        retention: RetentionDays.ONE_MONTH,
+        retention: RetentionDays.ONE_YEAR,
+        encryptionKey: logsKey,
         removalPolicy: RemovalPolicy.DESTROY,
       });
-      suppressRules(
-        wafLogGroup,
-        ['CKV_AWS_158'],
-        'Using default CloudWatch log encryption for WAF logs',
-      );
 
       new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {
         resourceArn: this.webAcl.attrArn,
@@ -5746,12 +5749,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
@@ -6547,12 +6594,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 
@@ -7453,12 +7544,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "TestApi API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/test-api-\${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/test-api-\${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/test-api-\${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -2089,7 +2089,7 @@ import {
   Stage,
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
-import { IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { IAspect, Stack } from 'aws-cdk-lib';
 import {
   CfnLoggingConfiguration,
   CfnWebACL,
@@ -2190,7 +2190,6 @@ export class RestApi<
     // KMS key for encrypting logs at rest, usable by CloudWatch Logs
     const logsKey = new Key(this, 'LogsKey', {
       enableKeyRotation: true,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
     logsKey.grantEncryptDecrypt(
       new ServicePrincipal(\`logs.\${Stack.of(this).region}.amazonaws.com\`),
@@ -2199,7 +2198,6 @@ export class RestApi<
     const accessLogs = new LogGroup(this, 'AccessLogs', {
       retention: RetentionDays.ONE_YEAR,
       encryptionKey: logsKey,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     // Create the API Gateway REST API
@@ -2290,7 +2288,6 @@ export class RestApi<
         logGroupName: \`aws-waf-logs-\${apiName}-\${this.node.addr.slice(-8)}\`,
         retention: RetentionDays.ONE_YEAR,
         encryptionKey: logsKey,
-        removalPolicy: RemovalPolicy.DESTROY,
       });
 
       new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -1181,7 +1181,7 @@ resource "null_resource" "runtime_ready" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3==1.43.29 python -c "
 import boto3
 import json
 import os

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -489,7 +489,7 @@ resource "null_resource" "runtime_ready" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3==1.43.29 python -c "
 import boto3
 import json
 import os

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -695,7 +695,7 @@ resource "null_resource" "upload_website_files" {
   provisioner "local-exec" {
     command = <<-EOT
       cd "$ROOT_PATH"
-      uv run --with boto3 python3 -c "
+      uv run --with boto3==1.43.29 python3 -c "
 import os
 import sys
 import boto3
@@ -818,7 +818,7 @@ resource "null_resource" "cloudfront_invalidation" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python3 -c "
+      uv run --with boto3==1.43.29 python3 -c "
 import boto3
 import os
 import sys

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -63,7 +63,7 @@ resource "null_resource" "add_callback_url" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3==1.43.29 python -c "
 import boto3
 import os
 import sys

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -19,6 +19,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { PY_VERSIONS } from '../versions';
 
 type IACProvider = { iac: Iac };
 
@@ -130,7 +131,7 @@ const addAgentCoreTerraformInfra = (
       'core',
       'agent-core',
     ),
-    { containers: options.containers },
+    { containers: options.containers, boto3Version: PY_VERSIONS.boto3 },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -382,6 +383,9 @@ const addAgentCoreGatewayTerraformInfra = (
       nameKebabCase: options.gatewayNameKebabCase,
       projectDirectory: options.projectDirectory,
       cedarPolicy: options.cedarPolicy,
+      boto3Version: PY_VERSIONS.boto3,
+      httpxVersion: PY_VERSIONS.httpx,
+      mcpVersion: PY_VERSIONS.mcp,
     },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -233,7 +233,7 @@ resource "null_resource" "gateway_ready" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 --with httpx --with mcp python -c "
+      uv run --with boto3<%= boto3Version %> --with httpx<%= httpxVersion %> --with mcp<%= mcpVersion %> python -c "
 import asyncio
 import os
 import time

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -358,7 +358,7 @@ resource "null_resource" "runtime_ready" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3<%= boto3Version %> python -c "
 import boto3
 import json
 import os

--- a/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
@@ -18,6 +18,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { PY_VERSIONS } from '../versions';
 
 interface BackendOptions {
   type: 'trpc' | 'fastapi' | 'smithy';
@@ -183,7 +184,7 @@ const addApiGatewayTerraformModules = (
       options.constructType,
     ),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core', 'api'),
-    {},
+    { boto3Version: PY_VERSIONS.boto3 },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account.ts.template
@@ -1,0 +1,71 @@
+import { Construct } from 'constructs';
+import * as url from 'url';
+import { CustomResource, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import {
+  ManagedPolicy,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
+import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Provider } from 'aws-cdk-lib/custom-resources';
+
+const ApiGatewayAccountKey = '__ApiGatewayAccount__';
+
+/**
+ * Stack-scoped singleton that configures the account-level CloudWatch Logs role
+ * used by API Gateway REST APIs for access logging.
+ *
+ * `AWS::ApiGateway::Account` is a singleton per region per account, so it is
+ * managed via an idempotent custom resource: the role is set only when none is
+ * already configured, and is never reset on delete. This keeps logging working
+ * across multiple stacks sharing an account without one clobbering another.
+ */
+export class ApiGatewayAccount extends Construct {
+  static ensure(scope: Construct): ApiGatewayAccount {
+    const stack = Stack.of(scope);
+    return (
+      (stack.node.tryFindChild(ApiGatewayAccountKey) as ApiGatewayAccount) ??
+      new ApiGatewayAccount(stack, ApiGatewayAccountKey)
+    );
+  }
+
+  public readonly resource: CustomResource;
+
+  private constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const cloudWatchRole = new Role(this, 'CloudWatchRole', {
+      assumedBy: new ServicePrincipal('apigateway.amazonaws.com'),
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName(
+          'service-role/AmazonAPIGatewayPushToCloudWatchLogs',
+        ),
+      ],
+    });
+    cloudWatchRole.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+    const onEvent = new Function(this, 'OnEvent', {
+      runtime: Runtime.NODEJS_LATEST,
+      handler: 'index.handler',
+      timeout: Duration.minutes(2),
+      code: Code.fromAsset(
+        url.fileURLToPath(new URL('./api-gateway-account', import.meta.url)),
+      ),
+    });
+    onEvent.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['apigateway:GET', 'apigateway:PATCH', 'iam:GetRole'],
+        resources: ['*'],
+      }),
+    );
+
+    this.resource = new CustomResource(this, 'Resource', {
+      serviceToken: new Provider(this, 'Provider', { onEventHandler: onEvent })
+        .serviceToken,
+      resourceType: 'Custom::ApiGatewayAccount',
+      properties: { CloudWatchRoleArn: cloudWatchRole.roleArn },
+    });
+    this.resource.node.addDependency(cloudWatchRole);
+  }
+}

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account.ts.template
@@ -53,16 +53,22 @@ export class ApiGatewayAccount extends Construct {
         url.fileURLToPath(new URL('./api-gateway-account', import.meta.url)),
       ),
     });
+    const { region } = Stack.of(this);
     onEvent.addToRolePolicy(
       new PolicyStatement({
-        actions: [
-          'apigateway:GET',
-          'apigateway:PATCH',
-          'iam:GetRole',
-          'iam:PassRole',
-        ],
-        resources: ['*'],
+        actions: ['apigateway:GET', 'apigateway:PATCH'],
+        resources: [`arn:aws:apigateway:${region}::/account`],
       }),
+    );
+    onEvent.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['iam:PassRole'],
+        resources: [cloudWatchRole.roleArn],
+      }),
+    );
+    // Read-only; inspects whichever role the account currently references
+    onEvent.addToRolePolicy(
+      new PolicyStatement({ actions: ['iam:GetRole'], resources: ['*'] }),
     );
 
     this.resource = new CustomResource(this, 'Resource', {

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account.ts.template
@@ -55,7 +55,12 @@ export class ApiGatewayAccount extends Construct {
     });
     onEvent.addToRolePolicy(
       new PolicyStatement({
-        actions: ['apigateway:GET', 'apigateway:PATCH', 'iam:GetRole'],
+        actions: [
+          'apigateway:GET',
+          'apigateway:PATCH',
+          'iam:GetRole',
+          'iam:PassRole',
+        ],
         resources: ['*'],
       }),
     );

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account/index.js.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account/index.js.template
@@ -14,6 +14,8 @@ const { IAMClient, GetRoleCommand } = require('@aws-sdk/client-iam');
 const apigw = new APIGatewayClient();
 const iam = new IAMClient();
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 const hasLiveRole = async () => {
   const { cloudwatchRoleArn } = await apigw.send(new GetAccountCommand({}));
   if (!cloudwatchRoleArn) return false;
@@ -28,19 +30,29 @@ const hasLiveRole = async () => {
   }
 };
 
+const RETRYABLE = ['BadRequestException', 'TooManyRequestsException'];
+
+const setRole = async (value) => {
+  const command = new UpdateAccountCommand({
+    patchOperations: [{ op: 'replace', path: '/cloudwatchRoleArn', value }],
+  });
+  // Retry while the freshly created role propagates through IAM, and on throttling
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await apigw.send(command);
+    } catch (e) {
+      if (RETRYABLE.includes(e.name) && attempt < 11) {
+        await sleep(5000);
+      } else {
+        throw e;
+      }
+    }
+  }
+};
+
 exports.handler = async (event) => {
   if (event.RequestType !== 'Delete' && !(await hasLiveRole())) {
-    await apigw.send(
-      new UpdateAccountCommand({
-        patchOperations: [
-          {
-            op: 'replace',
-            path: '/cloudwatchRoleArn',
-            value: event.ResourceProperties.CloudWatchRoleArn,
-          },
-        ],
-      }),
-    );
+    await setRole(event.ResourceProperties.CloudWatchRoleArn);
   }
   return { PhysicalResourceId: 'ApiGatewayAccount' };
 };

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account/index.js.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account/index.js.template
@@ -1,0 +1,46 @@
+/**
+ * Configures the account-level API Gateway CloudWatch Logs role required for
+ * REST API access logging. The setting is a singleton per region per account,
+ * so this handler only writes when no live role is already configured (the
+ * first stack to deploy wins, others defer) and never resets it on delete.
+ */
+const {
+  APIGatewayClient,
+  GetAccountCommand,
+  UpdateAccountCommand,
+} = require('@aws-sdk/client-api-gateway');
+const { IAMClient, GetRoleCommand } = require('@aws-sdk/client-iam');
+
+const apigw = new APIGatewayClient();
+const iam = new IAMClient();
+
+const hasLiveRole = async () => {
+  const { cloudwatchRoleArn } = await apigw.send(new GetAccountCommand({}));
+  if (!cloudwatchRoleArn) return false;
+  try {
+    await iam.send(
+      new GetRoleCommand({ RoleName: cloudwatchRoleArn.split('/').pop() }),
+    );
+    return true;
+  } catch (e) {
+    if (e.name === 'NoSuchEntityException') return false;
+    throw e;
+  }
+};
+
+exports.handler = async (event) => {
+  if (event.RequestType !== 'Delete' && !(await hasLiveRole())) {
+    await apigw.send(
+      new UpdateAccountCommand({
+        patchOperations: [
+          {
+            op: 'replace',
+            path: '/cloudwatchRoleArn',
+            value: event.ResourceProperties.CloudWatchRoleArn,
+          },
+        ],
+      }),
+    );
+  }
+  return { PhysicalResourceId: 'ApiGatewayAccount' };
+};

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
@@ -1,6 +1,8 @@
 import { Construct, IConstruct } from 'constructs';
 import {
+  AccessLogFormat,
   Cors,
+  LogGroupLogDestination,
   Resource,
   RestApi as _RestApi,
   RestApiProps as _RestApiProps,
@@ -16,6 +18,7 @@ import {
 } from 'aws-cdk-lib/aws-wafv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { RuntimeConfig } from '../runtime-config.js';
+import { ApiGatewayAccount } from './api-gateway-account.js';
 import {
   ApiIntegrations,
   OperationDetails,
@@ -100,10 +103,25 @@ export class RestApi<
     super(scope, id);
     this.integrations = integrations;
 
+    // Account-level CloudWatch role required for REST API access logging
+    const account = ApiGatewayAccount.ensure(this);
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    suppressRules(
+      accessLogs,
+      ['CKV_AWS_158', 'CKV_AWS_338'],
+      'Using default CloudWatch log encryption and one month retention',
+    );
+
     // Create the API Gateway REST API
     this.api = new _RestApi(this, 'Api', {
       ...props,
       deployOptions: {
+        accessLogDestination: new LogGroupLogDestination(accessLogs),
+        accessLogFormat: AccessLogFormat.jsonWithStandardFields(),
         ...props.deployOptions,
         methodOptions: {
           ...props.deployOptions?.methodOptions,
@@ -116,6 +134,8 @@ export class RestApi<
         },
       },
     });
+    // Ensure the account-level role is configured before the stage is created
+    this.api.deploymentStage.node.addDependency(account.resource);
 
     if (enableWaf) {
       this.webAcl = new CfnWebACL(this, 'WebAcl', {
@@ -201,12 +221,6 @@ export class RestApi<
       this.api,
       ['CKV_AWS_120'],
       'Caching not required for this use case',
-      (c) => c instanceof Stage,
-    );
-    suppressRules(
-      this.api,
-      ['CKV_AWS_76'],
-      'API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement',
       (c) => c instanceof Stage,
     );
 

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
@@ -10,7 +10,7 @@ import {
   Stage,
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
-import { IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { IAspect, Stack } from 'aws-cdk-lib';
 import {
   CfnLoggingConfiguration,
   CfnWebACL,
@@ -111,7 +111,6 @@ export class RestApi<
     // KMS key for encrypting logs at rest, usable by CloudWatch Logs
     const logsKey = new Key(this, 'LogsKey', {
       enableKeyRotation: true,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
     logsKey.grantEncryptDecrypt(
       new ServicePrincipal(`logs.${Stack.of(this).region}.amazonaws.com`),
@@ -120,7 +119,6 @@ export class RestApi<
     const accessLogs = new LogGroup(this, 'AccessLogs', {
       retention: RetentionDays.ONE_YEAR,
       encryptionKey: logsKey,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     // Create the API Gateway REST API
@@ -211,7 +209,6 @@ export class RestApi<
         logGroupName: `aws-waf-logs-${apiName}-${this.node.addr.slice(-8)}`,
         retention: RetentionDays.ONE_YEAR,
         encryptionKey: logsKey,
-        removalPolicy: RemovalPolicy.DESTROY,
       });
 
       new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/rest-api.ts.template
@@ -10,13 +10,15 @@ import {
   Stage,
   ThrottleSettings,
 } from 'aws-cdk-lib/aws-apigateway';
-import { IAspect, RemovalPolicy } from 'aws-cdk-lib';
+import { IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import {
   CfnLoggingConfiguration,
   CfnWebACL,
   CfnWebACLAssociation,
 } from 'aws-cdk-lib/aws-wafv2';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { RuntimeConfig } from '../runtime-config.js';
 import { ApiGatewayAccount } from './api-gateway-account.js';
 import {
@@ -106,15 +108,20 @@ export class RestApi<
     // Account-level CloudWatch role required for REST API access logging
     const account = ApiGatewayAccount.ensure(this);
 
-    const accessLogs = new LogGroup(this, 'AccessLogs', {
-      retention: RetentionDays.ONE_MONTH,
+    // KMS key for encrypting logs at rest, usable by CloudWatch Logs
+    const logsKey = new Key(this, 'LogsKey', {
+      enableKeyRotation: true,
       removalPolicy: RemovalPolicy.DESTROY,
     });
-    suppressRules(
-      accessLogs,
-      ['CKV_AWS_158', 'CKV_AWS_338'],
-      'Using default CloudWatch log encryption and one month retention',
+    logsKey.grantEncryptDecrypt(
+      new ServicePrincipal(`logs.${Stack.of(this).region}.amazonaws.com`),
     );
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_YEAR,
+      encryptionKey: logsKey,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
 
     // Create the API Gateway REST API
     this.api = new _RestApi(this, 'Api', {
@@ -202,14 +209,10 @@ export class RestApi<
       // `aws-waf-logs-` to satisfy the WAFv2 logging destination requirement.
       const wafLogGroup = new LogGroup(this, 'WebAclLogs', {
         logGroupName: `aws-waf-logs-${apiName}-${this.node.addr.slice(-8)}`,
-        retention: RetentionDays.ONE_MONTH,
+        retention: RetentionDays.ONE_YEAR,
+        encryptionKey: logsKey,
         removalPolicy: RemovalPolicy.DESTROY,
       });
-      suppressRules(
-        wafLogGroup,
-        ['CKV_AWS_158'],
-        'Using default CloudWatch log encryption for WAF logs',
-      );
 
       new CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {
         resourceArn: this.webAcl.attrArn,

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -105,6 +105,11 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 # Use the core REST API module
+# Account-level CloudWatch role required for REST API access logging
+module "account" {
+  source = "../../../core/api/api-gateway-account"
+}
+
 module "rest_api" {
   source = "../../../core/api/rest-api"
 
@@ -509,11 +514,18 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# Access logs for the API Gateway stage
+resource "aws_cloudwatch_log_group" "access_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
+  name              = "/aws/apigateway/<%- apiNameKebabCase %>-${random_string.suffix.result}/access"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
-  #checkov:skip=CKV_AWS_76:API Gateway access logging disabled due to account-level CloudWatch Logs role ARN requirement
-  #checkov:skip=CKV2_AWS_4:API Gateway logging level not applicable as access logging is disabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id
@@ -521,9 +533,26 @@ resource "aws_api_gateway_stage" "api_stage" {
   stage_name           = "prod"
   xray_tracing_enabled = true
 
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      caller         = "$context.identity.caller"
+      user           = "$context.identity.user"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
   tags = var.tags
 
-  depends_on = [aws_api_gateway_deployment.api_deployment]
+  # Ensure the account-level role is configured before the stage is created
+  depends_on = [aws_api_gateway_deployment.api_deployment, module.account]
 }
 
 # API Gateway Resource Policy

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -514,12 +514,56 @@ resource "aws_api_gateway_deployment" "api_deployment" {
   ]
 }
 
+# KMS key for encrypting access logs at rest
+resource "aws_kms_key" "access_logs" {
+  description             = "<%- apiNameClassName %> API access log encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "Allow CloudWatch Logs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/<%- apiNameKebabCase %>-${random_string.suffix.result}/access"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "access_logs" {
+  name          = "alias/<%- apiNameKebabCase %>-${random_string.suffix.result}-access-logs"
+  target_key_id = aws_kms_key.access_logs.key_id
+}
+
 # Access logs for the API Gateway stage
 resource "aws_cloudwatch_log_group" "access_logs" {
-  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
-  #checkov:skip=CKV_AWS_338:One month retention is sufficient for access logs
   name              = "/aws/apigateway/<%- apiNameKebabCase %>-${random_string.suffix.result}/access"
-  retention_in_days = 30
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.access_logs.arn
   tags              = var.tags
 }
 

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -526,6 +526,7 @@ resource "aws_cloudwatch_log_group" "access_logs" {
 # API Gateway stage
 resource "aws_api_gateway_stage" "api_stage" {
   #checkov:skip=CKV_AWS_120:API Gateway caching not required for this use case
+  #checkov:skip=CKV2_AWS_4:Access logging is enabled below; verbose execution logging is intentionally not enabled
   #checkov:skip=CKV2_AWS_51:Client certificate authentication not required for this use case
   #checkov:skip=CKV2_AWS_77:WAFv2 Web ACL is attached via aws_wafv2_web_acl_association when var.enable_waf is true (default) and includes AWSManagedRulesKnownBadInputsRuleSet for Log4j protection; Checkov does not track the association across modules
   deployment_id        = aws_api_gateway_deployment.api_deployment.id

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/api-gateway-account/api-gateway-account.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/api-gateway-account/api-gateway-account.tf.template
@@ -46,7 +46,7 @@ resource "terraform_data" "account" {
       ROLE_ARN = aws_iam_role.cloudwatch.arn
       REGION   = data.aws_region.current.region
       SCRIPT   = <<-PY
-        import os, boto3
+        import os, time, boto3
         from botocore.exceptions import ClientError
         apigw = boto3.client("apigateway", region_name=os.environ["REGION"])
 
@@ -63,7 +63,18 @@ resource "terraform_data" "account" {
                 raise
 
         if not has_live_role():
-            apigw.update_account(patchOperations=[{"op": "replace", "path": "/cloudwatchRoleArn", "value": os.environ["ROLE_ARN"]}])
+            op = {"op": "replace", "path": "/cloudwatchRoleArn", "value": os.environ["ROLE_ARN"]}
+            # Retry while the freshly created role propagates through IAM, and on throttling
+            retryable = ("BadRequestException", "TooManyRequestsException")
+            for attempt in range(12):
+                try:
+                    apigw.update_account(patchOperations=[op])
+                    break
+                except ClientError as e:
+                    if e.response["Error"]["Code"] in retryable and attempt < 11:
+                        time.sleep(5)
+                    else:
+                        raise
       PY
     }
   }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/api-gateway-account/api-gateway-account.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/api-gateway-account/api-gateway-account.tf.template
@@ -1,0 +1,72 @@
+# Account-level CloudWatch Logs role used by API Gateway REST APIs for access
+# logging. The setting is a singleton per region per account, so it is managed
+# idempotently: the role is set only when none is already configured (the first
+# deployment wins, others defer) and is never reset on destroy. This keeps
+# logging working across multiple deployments sharing an account.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.33"
+    }
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "cloudwatch" {
+  name_prefix = "apigw-cloudwatch-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "apigateway.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch" {
+  role       = aws_iam_role.cloudwatch.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+}
+
+# Configures the account role on create/update only; destroying this resource is
+# a no-op, so teardown never disables logging for other REST APIs in the region.
+resource "terraform_data" "account" {
+  triggers_replace = [aws_iam_role.cloudwatch.arn]
+
+  provisioner "local-exec" {
+    command = "uv run --with boto3<%= boto3Version %> python -c \"$SCRIPT\""
+    environment = {
+      ROLE_ARN = aws_iam_role.cloudwatch.arn
+      REGION   = data.aws_region.current.region
+      SCRIPT   = <<-PY
+        import os, boto3
+        from botocore.exceptions import ClientError
+        apigw = boto3.client("apigateway", region_name=os.environ["REGION"])
+
+        def has_live_role():
+            arn = apigw.get_account().get("cloudwatchRoleArn")
+            if not arn:
+                return False
+            try:
+                boto3.client("iam").get_role(RoleName=arn.split("/")[-1])
+                return True
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "NoSuchEntity":
+                    return False
+                raise
+
+        if not has_live_role():
+            apigw.update_account(patchOperations=[{"op": "replace", "path": "/cloudwatchRoleArn", "value": os.environ["ROLE_ARN"]}])
+      PY
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cloudwatch]
+}

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/rest-api/rest-api.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/rest-api/rest-api.tf.template
@@ -81,8 +81,6 @@ data "aws_caller_identity" "current" {}
 
 # Resources
 
-# Note: CloudWatch logging removed due to account-level CloudWatch Logs role ARN requirement
-
 # REST API Gateway
 resource "aws_api_gateway_rest_api" "rest_api" {
   name        = var.api_name
@@ -99,10 +97,8 @@ resource "aws_api_gateway_rest_api" "rest_api" {
   tags = var.tags
 }
 
-# Note: Deployment and stage are created in the consuming module (e.g., foo-api.tf)
-# after all methods and integrations are defined
-
-# Note: CloudWatch Log Group removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Deployment, stage and access logging are created in the consuming module
+# (e.g., foo-api.tf) after all methods and integrations are defined
 
 # Gateway Response for CORS (4XX errors)
 resource "aws_api_gateway_gateway_response" "cors_4xx" {
@@ -260,6 +256,4 @@ output "waf_web_acl_arn" {
   value       = var.enable_waf ? aws_wafv2_web_acl.api_waf[0].arn : null
 }
 
-# Note: Stage and deployment outputs are provided by the consuming module
-
-# Note: CloudWatch log group outputs removed due to account-level CloudWatch Logs role ARN requirement
+# Note: Stage, deployment and access log outputs are provided by the consuming module

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
@@ -59,7 +59,7 @@ resource "null_resource" "add_callback_url" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python -c "
+      uv run --with boto3<%= boto3Version %> python -c "
 import boto3
 import os
 import sys

--- a/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
+++ b/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
@@ -15,6 +15,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { PY_VERSIONS } from '../versions';
 
 export interface AddIdentityInfraOptions {
   cognitoDomain: string;
@@ -72,7 +73,7 @@ const addIdentityTerraformModules = (
     tree,
     joinPathFragments(__dirname, 'files', 'terraform', 'core'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core'),
-    options,
+    { ...options, boto3Version: PY_VERSIONS.boto3 },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -566,7 +566,7 @@ resource "null_resource" "upload_website_files" {
   provisioner "local-exec" {
     command = <<-EOT
       cd "$ROOT_PATH"
-      uv run --with boto3 python3 -c "
+      uv run --with boto3<%= boto3Version %> python3 -c "
 import os
 import sys
 import boto3
@@ -689,7 +689,7 @@ resource "null_resource" "cloudfront_invalidation" {
 
   provisioner "local-exec" {
     command = <<-EOT
-      uv run --with boto3 python3 -c "
+      uv run --with boto3<%= boto3Version %> python3 -c "
 import boto3
 import os
 import sys

--- a/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
+++ b/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
@@ -18,6 +18,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { PY_VERSIONS } from '../versions';
 
 export interface AddWebsiteInfraOptions {
   websiteProjectName: string;
@@ -128,7 +129,7 @@ const addWebsiteTerraformModules = (
     tree,
     joinPathFragments(__dirname, 'files', 'terraform', 'core'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core'),
-    options,
+    { ...options, boto3Version: PY_VERSIONS.boto3 },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },


### PR DESCRIPTION
### Reason for this change

REST APIs generated by the plugin shipped with access logging **disabled**. The account-level CloudWatch Logs role (`AWS::ApiGateway::Account` / `aws_api_gateway_account`) is a **singleton per region per account**, and managing it naively is unsafe:

- One stack configuring the role silently overwrites whatever another stack set.
- Tearing a stack down resets the account setting, silently disabling access logging for **every** REST API in the region (and a redeploy of the other stack won't fix it, since CloudFormation/Terraform sees no change).

Because of this, generated REST APIs had access logging suppressed (`CKV_AWS_76`), unlike HTTP APIs which already log.

### Description of changes

Enable REST API access logging by default and manage the account-level role **idempotently** so it is safe across multiple independently-deployed stacks sharing one account:

**CDK** — new `ApiGatewayAccount` stack-scoped singleton (`ApiGatewayAccount.ensure(scope)`, mirroring `RuntimeConfig`), backed by a Lambda custom resource that:
- sets the shared, retained CloudWatch role only when the account has no *live* role configured (first deploy wins, others defer; a configured-but-deleted role is self-healed), and
- **no-ops on delete**, so teardown never disables logging for other REST APIs.

`rest-api.ts` now enables `accessLogDestination` + JSON `accessLogFormat` and depends the stage on the custom resource. The `disableCloudWatchRole` feature flag is retained since we own the account.

**Terraform** — new `core/api/api-gateway-account` module using `terraform_data` + `uv run --with boto3 python` running the same idempotent/self-healing logic, with **no destroy-time provisioner** so teardown is a no-op (the AWS provider removed `reset_on_delete` in v6 and now always resets). The app REST module adds the access log group, `access_log_settings`, and depends on the module.

Also pins `boto3`/`httpx`/`mcp` versions (from the canonical `PY_VERSIONS`) in **all** Terraform modules that run python via `uv --with`, and adds a reusable `api/access-logging` docs snippet referenced from the tRPC, FastAPI and Smithy guides.

### Description of how you validated changes

- Updated unit tests/snapshots; full suite passes (2395/2395).
- **Deployed to a real AWS account** (CDK synth + Terraform apply of the generated modules):
  - Verified the configurator defers to a pre-existing live role (no clobber).
  - Verified it **self-heals** an account pointing at a deleted role.
  - Verified `terraform destroy` / stack delete leaves the account setting untouched.
  - Verified access logs flow as JSON to CloudWatch.
  - Verified the empty-account case (no role configured) sets our role.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*