### PR TITLE
fix(py#project): exclude transient coverage files from compile copy

### DIFF
--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -162,12 +162,38 @@ describe('python project generator', () => {
       tree.read('apps/test_project/.gitignore', 'utf-8')?.split('\n') ?? [];
     expect(projectGitIgnorePatterns).toContain('**/__pycache__');
     expect(projectGitIgnorePatterns).toContain('.coverage');
+    // pytest-cov's per-process data files, deleted after they are combined.
+    expect(projectGitIgnorePatterns).toContain('.coverage.*');
     // Tool cache directories — also keeps `ty` from scanning pytest's transient
     // `pytest-cache-files-*` dirs (it respects .gitignore) and failing the
     // concurrent typecheck with an I/O error.
     expect(projectGitIgnorePatterns).toContain('.pytest_cache');
     expect(projectGitIgnorePatterns).toContain('pytest-cache-files-*');
     expect(projectGitIgnorePatterns).toContain('.ruff_cache');
+  });
+
+  it('should exclude transient artifacts from the compile copy', async () => {
+    await pyProjectGenerator(tree, {
+      name: 'test-project',
+      directory: 'apps',
+      type: 'application',
+    });
+
+    const projectConfig = JSON.parse(
+      tree.read('apps/test_project/project.json', 'utf-8'),
+    );
+
+    // The build executor copies the project to a temp folder honouring
+    // `ignorePaths` (not .gitignore), so the transient files a concurrent
+    // test/typecheck target deletes must be excluded here to avoid an ENOENT
+    // race mid-copy.
+    const ignorePaths = projectConfig.targets.compile.options.ignorePaths;
+    expect(ignorePaths).toContain('tests');
+    expect(ignorePaths).toContain('.coverage');
+    expect(ignorePaths).toContain('.coverage.*');
+    expect(ignorePaths).toContain('.pytest_cache');
+    expect(ignorePaths).toContain('pytest-cache-files-*');
+    expect(ignorePaths).toContain('.ruff_cache');
   });
 
   it('should add a dependency on the python plugin', async () => {

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -46,6 +46,21 @@ export const PY_PROJECT_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
   import.meta.filename,
 );
 
+// Transient artifacts that pytest, coverage and ruff create and remove while
+// the test, typecheck and compile targets run concurrently. `.coverage.*` are
+// the per-process data files pytest-cov writes (`.coverage.<host>.<pid>.<rand>`)
+// before combining them. Both `ty` (which respects .gitignore) and the
+// `@nxlv/python:build` copy (which respects `ignorePaths`) would otherwise fail
+// when they read one of these mid-deletion.
+const PYTHON_TRANSIENT_ARTIFACTS = [
+  '__pycache__',
+  '.coverage',
+  '.coverage.*',
+  '.pytest_cache',
+  'pytest-cache-files-*',
+  '.ruff_cache',
+];
+
 export interface PyProjectDetails {
   /**
    * Fully qualified Nx project id including scope, in dot notation (eg foo.bar).
@@ -220,6 +235,10 @@ export const pyProjectGenerator = async (
       options: {
         ...buildTarget.options,
         outputPath: buildOutputPath,
+        // The build executor copies the project to a temp folder; exclude the
+        // executor defaults plus transient artifacts so the copy does not race
+        // a concurrent test/typecheck target deleting a file mid-copy.
+        ignorePaths: ['.venv', '.tox', 'tests', ...PYTHON_TRANSIENT_ARTIFACTS],
       },
     };
     projectConfiguration.targets.build = {
@@ -296,10 +315,7 @@ export const pyProjectGenerator = async (
   updateGitIgnore(tree, dir, (patterns) => [
     ...patterns,
     '**/__pycache__',
-    '.coverage',
-    '.pytest_cache',
-    'pytest-cache-files-*',
-    '.ruff_cache',
+    ...PYTHON_TRANSIENT_ARTIFACTS.filter((p) => p !== '__pycache__'),
   ]);
 
   await addGeneratorMetricsIfApplicable(tree, [PY_PROJECT_GENERATOR_INFO]);


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy-rdb` smoke test on `main` intermittently fails during `nx apply infra` with:

```
e2e_test.agent_connection:   ERROR  ENOENT: no such file or directory, lstat 'packages/common/agent_connection/.coverage.<host>.pid<N>.<rand>'
- e2e_test.agent_connection:compile
```

This is a race condition. `nx apply infra` builds the project's dependency graph in parallel, so a Python project's `compile` target (executor `@nxlv/python:build`) runs concurrently with its `test` target. The build executor copies the project to a temp folder by `readdirSync`-ing the project root and then `lstat`-ing each entry. Meanwhile `pytest-cov` writes per-process `.coverage.<host>.<pid>.<rand>` data files and removes them after combining. If a data file is deleted between the `readdir` and the `lstat`, the copy fails with ENOENT and the whole `apply` fails.

This is the same class of bug already handled for `ty` and `pytest-cache-files-*` via `.gitignore`, but the build copy honours its `ignorePaths` option rather than `.gitignore`, and `.coverage.*` was not previously ignored at all.

### Description of changes

- Set `ignorePaths` on the generated Python `compile` target to exclude transient pytest/coverage/ruff artifacts (in addition to the executor defaults `.venv`, `.tox`, `tests`), so the build copy cannot race a concurrent target deleting a file mid-copy.
- Add `.coverage.*` to the project `.gitignore` so `ty` (which respects `.gitignore`) also skips these files.
- Factor the transient-artifact patterns into a shared constant reused by both the `.gitignore` and `ignorePaths`.

### Description of how you validated changes

- Added a unit test asserting the `compile` target's `ignorePaths` excludes the transient artifacts, and extended the `.gitignore` test to assert `.coverage.*`.
- Ran the full `@aws/nx-plugin` test suite (2395+ tests pass); no snapshot changes were required.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*