### PR TITLE
fix(ts#smithy-api): ensure SSDK node_modules persists for rolldown bundle

### DIFF
--- a/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
@@ -173,12 +173,10 @@ WORKDIR /project/build/smithy/source/typescript-ssdk-codegen
 
 # Install SSDK dependencies with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
-    --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \\
     pnpm install --prefer-offline
 
 # Install rolldown plugins with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
-    --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \\
     pnpm add -D rolldown-plugin-dts@0.16.5 @rollup/plugin-esm-shim@0.1.8
 
 RUN cat <<EOF > rolldown.config.js
@@ -225,8 +223,7 @@ export default {
 EOF
 
 # Create SSDK bundle with rolldown
-RUN --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \\
-    rolldown -c
+RUN rolldown -c
 
 RUN mkdir -p /out/ssdk
 RUN cp dist/* /out/ssdk/
@@ -416,12 +413,10 @@ WORKDIR /project/build/smithy/source/typescript-ssdk-codegen
 
 # Install SSDK dependencies with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
-    --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \\
     pnpm install --prefer-offline
 
 # Install rolldown plugins with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
-    --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \\
     pnpm add -D rolldown-plugin-dts@0.16.5 @rollup/plugin-esm-shim@0.1.8
 
 RUN cat <<EOF > rolldown.config.js
@@ -468,8 +463,7 @@ export default {
 EOF
 
 # Create SSDK bundle with rolldown
-RUN --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \\
-    rolldown -c
+RUN rolldown -c
 
 RUN mkdir -p /out/ssdk
 RUN cp dist/* /out/ssdk/

--- a/packages/nx-plugin/src/smithy/project/files/build.Dockerfile.template
+++ b/packages/nx-plugin/src/smithy/project/files/build.Dockerfile.template
@@ -35,12 +35,10 @@ WORKDIR /project/build/smithy/source/typescript-ssdk-codegen
 
 # Install SSDK dependencies with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \
     pnpm install --prefer-offline
 
 # Install rolldown plugins with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \
     pnpm add -D rolldown-plugin-dts@0.16.5 @rollup/plugin-esm-shim@0.1.8
 
 RUN cat <<EOF > rolldown.config.js
@@ -87,8 +85,7 @@ export default {
 EOF
 
 # Create SSDK bundle with rolldown
-RUN --mount=type=cache,target=/project/build/smithy/source/typescript-ssdk-codegen/node_modules,id=ssdk-node-modules \
-    rolldown -c
+RUN rolldown -c
 
 RUN mkdir -p /out/ssdk
 RUN cp dist/* /out/ssdk/


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy-rdb`, `terraform-deploy-rdb` and `terraform-deploy` smoke tests have been failing on `main`. All three fail in the `nx run-many --target build --all` step when building the generated Smithy API model project's SSDK Docker image:

```
#21 [builder 17/19] RUN ... rolldown -c
[error] Error happened while loading config.
  [cause]: Cannot find package 'rolldown-plugin-dts' imported from
    /project/build/smithy/source/typescript-ssdk-codegen/rolldown.config.js
ERROR: process "/bin/sh -c rolldown -c" did not complete successfully: exit code: 1
```

In `build.Dockerfile`, `node_modules` for the SSDK build was a BuildKit cache mount (`id=ssdk-node-modules`) shared across three separate `RUN` steps (`pnpm install`, `pnpm add -D rolldown-plugin-dts ...`, and `rolldown -c`). Cache mounts are not baked into the image layer and can be evicted between steps. When the install layers were cache-hit (so the install steps were skipped) but the cache-mounted `node_modules` had been emptied/evicted, `rolldown -c` ran against an empty `node_modules` and could not resolve `rolldown-plugin-dts` — which is why the failure was intermittent and only hit some jobs.

### Description of changes

Removed the `node_modules` cache mount from the three SSDK build `RUN` steps in `packages/nx-plugin/src/smithy/project/files/build.Dockerfile.template`. `node_modules` now materializes into the image layer and is guaranteed present for the `rolldown -c` bundle step. The `pnpm-store` cache mount is retained, so installs remain fast via hardlinks.

### Description of how you validated changes

Updated and ran the smithy project generator unit tests (snapshots regenerated to reflect the new Dockerfile). The deploy smoke tests that exercise this Dockerfile only run on push to `main`, so final validation will occur on merge.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*