### PR TITLE
feat(ts#rdb): enable database audit logging by default

### DIFF
--- a/docs/src/content/docs/en/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/en/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### Audit Logging
+
+Audit logging is **enabled by default** and exports a query-level audit trail to [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html), giving you a record of who connected and what schema and privilege changes were made. This provides an audit trail for detecting and investigating unauthorized data access. Aurora PostgreSQL uses the [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html) extension; Aurora MySQL uses [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html).
+
+To minimize the risk of recording personally identifiable information (PII), the default configuration audits **connection, schema (DDL) and privilege (DCL) events only** — it deliberately excludes statement and data manipulation (DML) logging, which would capture row values embedded in queries. pgAudit additionally redacts cleartext passwords from the log.
+
+:::caution[Audit logs and PII]
+Expanding `auditLog` to include data reads/writes (`read,write` for PostgreSQL or `QUERY`/`QUERY_DML` for MySQL) will capture full statement text, including any values in `WHERE` and `VALUES` clauses. Only do this if your compliance requirements justify it, and ensure the destination log group's access is tightly restricted. Consider a [CloudWatch Logs data protection policy](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) to mask sensitive data, and tune log retention to your compliance needs.
+:::
+
+You can customize the audited event classes, or disable audit logging entirely:
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+For stricter compliance requirements where the audit trail must be tamper-resistant and beyond the reach of database administrators, consider [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html). Note that activity streams capture the full SQL text of every statement, including any PII.
+
 ### Encryption Key Rotation
 
 The KMS key used to encrypt the Aurora cluster and its credentials secret has automatic key rotation enabled by default. Disable it if your security policy manages rotation externally.

--- a/docs/src/content/docs/es/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/es/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### Registro de Auditoría
+
+El registro de auditoría está **habilitado por defecto** y exporta un registro de auditoría a nivel de consulta a [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html), proporcionándote un registro de quién se conectó y qué cambios de esquema y privilegios se realizaron. Esto proporciona un registro de auditoría para detectar e investigar el acceso no autorizado a datos. Aurora PostgreSQL utiliza la extensión [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html); Aurora MySQL utiliza [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html).
+
+Para minimizar el riesgo de registrar información de identificación personal (PII), la configuración predeterminada audita **solo eventos de conexión, esquema (DDL) y privilegios (DCL)** — excluye deliberadamente el registro de sentencias y manipulación de datos (DML), que capturaría valores de filas incrustados en las consultas. pgAudit además redacta contraseñas en texto claro del registro.
+
+:::caution[Registros de auditoría y PII]
+Expandir `auditLog` para incluir lecturas/escrituras de datos (`read,write` para PostgreSQL o `QUERY`/`QUERY_DML` para MySQL) capturará el texto completo de las sentencias, incluyendo cualquier valor en las cláusulas `WHERE` y `VALUES`. Solo haz esto si tus requisitos de cumplimiento lo justifican, y asegúrate de que el acceso al grupo de registros de destino esté estrictamente restringido. Considera una [política de protección de datos de CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) para enmascarar datos sensibles, y ajusta la retención de registros según tus necesidades de cumplimiento.
+:::
+
+Puedes personalizar las clases de eventos auditados, o deshabilitar el registro de auditoría por completo:
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+Para requisitos de cumplimiento más estrictos donde el registro de auditoría debe ser resistente a manipulaciones y estar fuera del alcance de los administradores de bases de datos, considera [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html). Ten en cuenta que los flujos de actividad capturan el texto SQL completo de cada sentencia, incluyendo cualquier PII.
+
 ### Rotación de Clave de Cifrado
 
 La clave KMS utilizada para cifrar el clúster Aurora y su secreto de credenciales tiene habilitada la rotación automática de claves por defecto. Deshabilítala si tu política de seguridad gestiona la rotación externamente.

--- a/docs/src/content/docs/fr/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### Journalisation d'audit
+
+La journalisation d'audit est **activée par défaut** et exporte une piste d'audit au niveau des requêtes vers [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html), vous donnant un enregistrement de qui s'est connecté et quels changements de schéma et de privilèges ont été effectués. Cela fournit une piste d'audit pour détecter et enquêter sur les accès non autorisés aux données. Aurora PostgreSQL utilise l'extension [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html) ; Aurora MySQL utilise [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html).
+
+Pour minimiser le risque d'enregistrer des informations personnellement identifiables (PII), la configuration par défaut audite **uniquement les événements de connexion, de schéma (DDL) et de privilèges (DCL)** — elle exclut délibérément la journalisation des instructions et de la manipulation de données (DML), qui capturerait les valeurs de lignes intégrées dans les requêtes. pgAudit masque en outre les mots de passe en texte clair du journal.
+
+:::caution[Journaux d'audit et PII]
+L'extension de `auditLog` pour inclure les lectures/écritures de données (`read,write` pour PostgreSQL ou `QUERY`/`QUERY_DML` pour MySQL) capturera le texte complet des instructions, y compris toutes les valeurs dans les clauses `WHERE` et `VALUES`. Ne faites cela que si vos exigences de conformité le justifient, et assurez-vous que l'accès au groupe de journaux de destination est étroitement restreint. Envisagez une [politique de protection des données CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) pour masquer les données sensibles, et ajustez la rétention des journaux selon vos besoins de conformité.
+:::
+
+Vous pouvez personnaliser les classes d'événements auditées, ou désactiver complètement la journalisation d'audit :
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+Pour des exigences de conformité plus strictes où la piste d'audit doit être inviolable et hors de portée des administrateurs de base de données, envisagez [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html). Notez que les flux d'activité capturent le texte SQL complet de chaque instruction, y compris toutes les PII.
+
 ### Rotation de clé de chiffrement
 
 La clé KMS utilisée pour chiffrer le cluster Aurora et son secret d'identifiants a la rotation automatique de clé activée par défaut. Désactivez-la si votre politique de sécurité gère la rotation en externe.

--- a/docs/src/content/docs/it/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/it/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### Audit Logging
+
+L'audit logging è **abilitato per impostazione predefinita** ed esporta una traccia di audit a livello di query su [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html), fornendoti una registrazione di chi si è connesso e quali modifiche allo schema e ai privilegi sono state apportate. Questo fornisce una traccia di audit per rilevare e investigare accessi non autorizzati ai dati. Aurora PostgreSQL utilizza l'estensione [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html); Aurora MySQL utilizza [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html).
+
+Per ridurre al minimo il rischio di registrare informazioni personali identificabili (PII), la configurazione predefinita audita **solo eventi di connessione, schema (DDL) e privilegi (DCL)** — esclude deliberatamente il logging di istruzioni e manipolazione dati (DML), che catturerebbe i valori delle righe incorporati nelle query. pgAudit inoltre oscura le password in chiaro dal log.
+
+:::caution[Log di audit e PII]
+Espandere `auditLog` per includere letture/scritture di dati (`read,write` per PostgreSQL o `QUERY`/`QUERY_DML` per MySQL) catturerà il testo completo delle istruzioni, inclusi eventuali valori nelle clausole `WHERE` e `VALUES`. Fallo solo se i tuoi requisiti di conformità lo giustificano, e assicurati che l'accesso al gruppo di log di destinazione sia strettamente limitato. Considera una [policy di protezione dati di CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) per mascherare i dati sensibili e regola la retention dei log in base alle tue esigenze di conformità.
+:::
+
+Puoi personalizzare le classi di eventi auditate o disabilitare completamente l'audit logging:
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+Per requisiti di conformità più rigorosi in cui la traccia di audit deve essere resistente alle manomissioni e al di fuori della portata degli amministratori di database, considera [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html). Nota che gli activity stream catturano il testo SQL completo di ogni istruzione, incluse eventuali PII.
+
 ### Rotazione della Chiave di Crittografia
 
 La chiave KMS utilizzata per crittografare il cluster Aurora e il suo secret delle credenziali ha la rotazione automatica della chiave abilitata per impostazione predefinita. Disabilitala se la tua policy di sicurezza gestisce la rotazione esternamente.

--- a/docs/src/content/docs/jp/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### 監査ログ
+
+監査ログは**デフォルトで有効**になっており、クエリレベルの監査証跡を[CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html)にエクスポートします。これにより、誰が接続し、どのようなスキーマや権限の変更が行われたかの記録が得られます。これは、不正なデータアクセスを検出・調査するための監査証跡を提供します。Aurora PostgreSQLは[pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html)拡張機能を使用し、Aurora MySQLは[Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html)を使用します。
+
+個人識別情報（PII）を記録するリスクを最小限に抑えるため、デフォルト設定では**接続、スキーマ（DDL）、権限（DCL）イベントのみ**を監査します。これは、クエリに埋め込まれた行の値をキャプチャするステートメントおよびデータ操作（DML）ログを意図的に除外しています。pgAuditはさらに、ログから平文パスワードを編集します。
+
+:::caution[監査ログとPII]
+`auditLog`を拡張してデータの読み取り/書き込みを含める（PostgreSQLの場合は`read,write`、MySQLの場合は`QUERY`/`QUERY_DML`）と、`WHERE`句や`VALUES`句の値を含む完全なステートメントテキストがキャプチャされます。コンプライアンス要件がそれを正当化する場合にのみこれを行い、宛先ログループへのアクセスが厳しく制限されていることを確認してください。機密データをマスクするために[CloudWatch Logsデータ保護ポリシー](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html)を検討し、コンプライアンスニーズに合わせてログ保持期間を調整してください。
+:::
+
+監査対象のイベントクラスをカスタマイズしたり、監査ログを完全に無効にしたりできます：
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+監査証跡が改ざん防止され、データベース管理者の手の届かないところにある必要があるより厳格なコンプライアンス要件については、[Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html)を検討してください。アクティビティストリームは、PIIを含むすべてのステートメントの完全なSQLテキストをキャプチャすることに注意してください。
+
 ### 暗号化キーのローテーション
 
 Auroraクラスターとその認証情報シークレットの暗号化に使用されるKMSキーは、デフォルトで自動キーローテーションが有効になっています。セキュリティポリシーが外部でローテーションを管理している場合は、無効にします。

--- a/docs/src/content/docs/ko/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### 감사 로깅
+
+감사 로깅은 **기본적으로 활성화**되어 있으며 쿼리 수준의 감사 추적을 [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html)로 내보내어 누가 연결했고 어떤 스키마 및 권한 변경이 이루어졌는지 기록합니다. 이는 무단 데이터 액세스를 탐지하고 조사하기 위한 감사 추적을 제공합니다. Aurora PostgreSQL은 [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html) 확장을 사용하고, Aurora MySQL은 [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html)을 사용합니다.
+
+개인 식별 정보(PII) 기록 위험을 최소화하기 위해 기본 구성은 **연결, 스키마(DDL) 및 권한(DCL) 이벤트만** 감사합니다. 쿼리에 포함된 행 값을 캡처하는 문장 및 데이터 조작(DML) 로깅은 의도적으로 제외됩니다. pgAudit는 추가로 로그에서 평문 비밀번호를 편집합니다.
+
+:::caution[감사 로그와 PII]
+`auditLog`를 확장하여 데이터 읽기/쓰기를 포함하면(PostgreSQL의 경우 `read,write` 또는 MySQL의 경우 `QUERY`/`QUERY_DML`) `WHERE` 및 `VALUES` 절의 값을 포함한 전체 문장 텍스트가 캡처됩니다. 규정 준수 요구 사항이 정당화하는 경우에만 이를 수행하고, 대상 로그 그룹의 액세스가 엄격하게 제한되도록 하세요. 민감한 데이터를 마스킹하려면 [CloudWatch Logs 데이터 보호 정책](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html)을 고려하고, 규정 준수 요구 사항에 맞게 로그 보존 기간을 조정하세요.
+:::
+
+감사되는 이벤트 클래스를 사용자 정의하거나 감사 로깅을 완전히 비활성화할 수 있습니다:
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+감사 추적이 변조 방지되어야 하고 데이터베이스 관리자의 범위를 벗어나야 하는 더 엄격한 규정 준수 요구 사항의 경우 [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html)를 고려하세요. 활동 스트림은 PII를 포함한 모든 문장의 전체 SQL 텍스트를 캡처한다는 점에 유의하세요.
+
 ### 암호화 키 로테이션
 
 Aurora 클러스터와 자격 증명 시크릿을 암호화하는 데 사용되는 KMS 키는 기본적으로 자동 키 로테이션이 활성화되어 있습니다. 보안 정책이 외부에서 로테이션을 관리하는 경우 비활성화하세요.

--- a/docs/src/content/docs/pt/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### Registro de Auditoria
+
+O registro de auditoria está **habilitado por padrão** e exporta uma trilha de auditoria em nível de consulta para o [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html), fornecendo um registro de quem se conectou e quais alterações de esquema e privilégios foram feitas. Isso fornece uma trilha de auditoria para detectar e investigar acesso não autorizado a dados. O Aurora PostgreSQL usa a extensão [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html); o Aurora MySQL usa [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html).
+
+Para minimizar o risco de registrar informações de identificação pessoal (PII), a configuração padrão audita **apenas eventos de conexão, esquema (DDL) e privilégio (DCL)** — ela deliberadamente exclui o registro de instruções e manipulação de dados (DML), que capturaria valores de linha incorporados em consultas. O pgAudit também oculta senhas em texto claro do log.
+
+:::caution[Logs de auditoria e PII]
+Expandir `auditLog` para incluir leituras/gravações de dados (`read,write` para PostgreSQL ou `QUERY`/`QUERY_DML` para MySQL) capturará o texto completo da instrução, incluindo quaisquer valores nas cláusulas `WHERE` e `VALUES`. Faça isso apenas se seus requisitos de conformidade justificarem, e garanta que o acesso ao grupo de logs de destino seja rigidamente restrito. Considere uma [política de proteção de dados do CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) para mascarar dados sensíveis, e ajuste a retenção de logs às suas necessidades de conformidade.
+:::
+
+Você pode personalizar as classes de eventos auditados ou desabilitar o registro de auditoria completamente:
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+Para requisitos de conformidade mais rigorosos onde a trilha de auditoria deve ser resistente a adulteração e além do alcance dos administradores de banco de dados, considere [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html). Observe que os activity streams capturam o texto SQL completo de cada instrução, incluindo qualquer PII.
+
 ### Rotação de Chave de Criptografia
 
 A chave KMS usada para criptografar o cluster Aurora e seu secret de credenciais tem rotação automática de chave habilitada por padrão. Desabilite-a se sua política de segurança gerenciar a rotação externamente.

--- a/docs/src/content/docs/vi/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/ts-rdb.mdx
@@ -710,6 +710,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### Audit Logging
+
+Audit logging được **bật theo mặc định** và xuất audit trail ở cấp độ query sang [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html), cung cấp cho bạn bản ghi về ai đã kết nối và những thay đổi schema và privilege nào đã được thực hiện. Điều này cung cấp audit trail để phát hiện và điều tra truy cập dữ liệu trái phép. Aurora PostgreSQL sử dụng extension [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html); Aurora MySQL sử dụng [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html).
+
+Để giảm thiểu rủi ro ghi lại thông tin nhận dạng cá nhân (PII), cấu hình mặc định chỉ audit **các sự kiện connection, schema (DDL) và privilege (DCL)** — nó cố ý loại trừ statement và data manipulation (DML) logging, vốn sẽ ghi lại các giá trị hàng được nhúng trong các query. pgAudit cũng ẩn các mật khẩu dạng cleartext khỏi log.
+
+:::caution[Audit logs và PII]
+Mở rộng `auditLog` để bao gồm data reads/writes (`read,write` cho PostgreSQL hoặc `QUERY`/`QUERY_DML` cho MySQL) sẽ ghi lại toàn bộ văn bản statement, bao gồm bất kỳ giá trị nào trong các mệnh đề `WHERE` và `VALUES`. Chỉ làm điều này nếu yêu cầu tuân thủ của bạn biện minh cho nó, và đảm bảo quyền truy cập vào log group đích được hạn chế chặt chẽ. Cân nhắc sử dụng [CloudWatch Logs data protection policy](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) để che giấu dữ liệu nhạy cảm, và điều chỉnh thời gian lưu giữ log theo nhu cầu tuân thủ của bạn.
+:::
+
+Bạn có thể tùy chỉnh các lớp sự kiện được audit, hoặc tắt hoàn toàn audit logging:
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+Đối với các yêu cầu tuân thủ nghiêm ngặt hơn khi audit trail phải chống giả mạo và nằm ngoài tầm với của database administrators, hãy cân nhắc [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html). Lưu ý rằng activity streams ghi lại toàn bộ văn bản SQL của mọi statement, bao gồm cả PII.
+
 ### Encryption Key Rotation
 
 KMS key được sử dụng để mã hóa Aurora cluster và credentials secret của nó có tính năng tự động xoay key được bật theo mặc định. Tắt nó nếu chính sách bảo mật của bạn quản lý việc xoay key từ bên ngoài.

--- a/docs/src/content/docs/zh/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/ts-rdb.mdx
@@ -701,6 +701,46 @@ module "my_database" {
 </Fragment>
 </Infrastructure>
 
+### 审计日志
+
+审计日志**默认启用**，并将查询级别的审计跟踪导出到 [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html)，为您提供谁连接以及进行了哪些架构和权限更改的记录。这为检测和调查未经授权的数据访问提供了审计跟踪。Aurora PostgreSQL 使用 [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html) 扩展；Aurora MySQL 使用[高级审计](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html)。
+
+为了最小化记录个人身份信息 (PII) 的风险，默认配置**仅审计连接、架构 (DDL) 和权限 (DCL) 事件** — 它故意排除语句和数据操作 (DML) 日志记录，后者会捕获查询中嵌入的行值。pgAudit 还会从日志中编辑明文密码。
+
+:::caution[审计日志和 PII]
+扩展 `auditLog` 以包含数据读取/写入（PostgreSQL 的 `read,write` 或 MySQL 的 `QUERY`/`QUERY_DML`）将捕获完整的语句文本，包括 `WHERE` 和 `VALUES` 子句中的任何值。仅当您的合规要求证明其合理性时才这样做，并确保目标日志组的访问受到严格限制。考虑使用 [CloudWatch Logs 数据保护策略](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html)来屏蔽敏感数据，并根据您的合规需求调整日志保留期。
+:::
+
+您可以自定义审计的事件类别，或完全禁用审计日志：
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyDatabase } from ':my-scope/common-constructs';
+
+const db = new MyDatabase(this, 'Db', {
+  ...
+  enableAuditLogging: true, // default
+  auditLog: 'ddl,role,misc', // pgAudit classes (PostgreSQL); default shown
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_database" {
+  source = "../../common/terraform/src/app/dbs/my-database"
+  ...
+  enable_audit_logging = true               # default
+  audit_log            = "ddl,role,misc"    # pgAudit classes (PostgreSQL); default shown
+}
+```
+</Fragment>
+</Infrastructure>
+
+对于更严格的合规要求，其中审计跟踪必须防篡改且超出数据库管理员的控制范围，请考虑使用 [Database Activity Streams](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html)。请注意，活动流会捕获每个语句的完整 SQL 文本，包括任何 PII。
+
 ### 加密密钥轮换
 
 用于加密 Aurora 集群及其凭证密钥的 KMS 密钥默认启用自动密钥轮换。如果您的安全策略在外部管理轮换，请禁用它。

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -379,6 +379,7 @@ import {
   DatabaseProxy,
   DefaultAuthScheme,
   IClusterEngine,
+  ParameterGroup,
 } from 'aws-cdk-lib/aws-rds';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Trigger } from 'aws-cdk-lib/triggers';
@@ -404,6 +405,26 @@ export interface AuroraDatabaseEngine {
    * Builds the CDK cluster engine for the provided engine version.
    */
   clusterEngine(version: AuroraDatabaseEngineVersion): IClusterEngine;
+
+  /**
+   * Default audit event classes captured when audit logging is enabled.
+   */
+  readonly defaultAuditLog: string;
+
+  /**
+   * Cluster parameter group parameters that enable audit logging for the engine.
+   */
+  auditParameters(auditLog: string): Record<string, string>;
+
+  /**
+   * CloudWatch log types exported when audit logging is enabled.
+   */
+  readonly auditLogExports: string[];
+
+  /**
+   * CloudWatch log types exported when general engine log export is enabled.
+   */
+  readonly cloudwatchLogExports: string[];
 }
 
 export class AuroraDatabaseEngines {
@@ -419,6 +440,15 @@ export class AuroraDatabaseEngines {
         DatabaseClusterEngine.auroraMysql({
           version: version as AuroraMysqlEngineVersion,
         }),
+      // Connection, schema and privilege events only - excludes QUERY/QUERY_DML
+      // which would log statement text and data values (potential PII).
+      defaultAuditLog: 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE',
+      auditParameters: (auditLog) => ({
+        server_audit_logging: '1',
+        server_audit_events: auditLog,
+      }),
+      auditLogExports: ['audit'],
+      cloudwatchLogExports: ['error', 'general', 'slowquery'],
     };
   }
 
@@ -434,6 +464,17 @@ export class AuroraDatabaseEngines {
         DatabaseClusterEngine.auroraPostgres({
           version: version as AuroraPostgresEngineVersion,
         }),
+      // Schema, privilege and admin events only - excludes 'read,write' which
+      // would log statement text and data values (potential PII). pgAudit also
+      // redacts cleartext passwords.
+      defaultAuditLog: 'ddl,role,misc',
+      auditParameters: (auditLog) => ({
+        shared_preload_libraries: 'pgaudit',
+        'pgaudit.log': auditLog,
+        'pgaudit.log_parameter': 'off',
+      }),
+      auditLogExports: ['postgresql'],
+      cloudwatchLogExports: ['postgresql'],
     };
   }
 }
@@ -540,6 +581,27 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
   readonly enableCloudwatchLogs?: boolean;
 
   /**
+   * Whether to enable database audit logging and export the audit log to CloudWatch Logs.
+   * Postgres uses the pgAudit extension; MySQL uses Advanced Auditing. To avoid capturing
+   * data values (potential PII), only schema, privilege and connection events are audited
+   * by default - see auditLog to customize.
+   * See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html
+   *
+   * @default true
+   */
+  readonly enableAuditLogging?: boolean;
+
+  /**
+   * Audit event classes to capture when audit logging is enabled.
+   * Postgres values map to pgaudit.log (e.g. 'ddl,role,misc'); MySQL values map to
+   * server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). The defaults
+   * deliberately exclude statement/DML logging to avoid recording data values.
+   *
+   * @default - schema, privilege and connection events only (excludes data reads/writes)
+   */
+  readonly auditLog?: string;
+
+  /**
    * Whether to enable Performance Insights on the Aurora writer instance.
    *
    * @default true
@@ -575,6 +637,8 @@ export abstract class AuroraDatabase extends Construct {
       removalPolicy = RemovalPolicy.RETAIN,
       enableKeyRotation = true,
       enableCloudwatchLogs = false,
+      enableAuditLogging = true,
+      auditLog,
       enablePerformanceInsights = true,
       engine,
       engineVersion,
@@ -585,12 +649,33 @@ export abstract class AuroraDatabase extends Construct {
 
     this.adminUser = adminUser;
 
+    const clusterEngine = engine.clusterEngine(
+      engineVersion ?? engine.defaultVersion,
+    );
+
+    const parameterGroup = enableAuditLogging
+      ? new ParameterGroup(this, 'ParameterGroup', {
+          engine: clusterEngine,
+          parameters: engine.auditParameters(
+            auditLog ?? engine.defaultAuditLog,
+          ),
+        })
+      : undefined;
+
+    const cloudwatchLogsExports = [
+      ...new Set([
+        ...(enableCloudwatchLogs ? engine.cloudwatchLogExports : []),
+        ...(enableAuditLogging ? engine.auditLogExports : []),
+      ]),
+    ];
+
     const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
     this.cluster = new DatabaseCluster(this, 'DatabaseCluster', {
       ...clusterProps,
       vpc,
       vpcSubnets,
-      engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      engine: clusterEngine,
+      parameterGroup,
       writer:
         writer ??
         ClusterInstance.serverlessV2('writer', {
@@ -604,11 +689,8 @@ export abstract class AuroraDatabase extends Construct {
       }),
       iamAuthentication: true,
       monitoringInterval: Duration.seconds(5),
-      cloudwatchLogsExports: enableCloudwatchLogs
-        ? engine.type === 'mysql'
-          ? ['audit', 'error', 'general', 'slowquery']
-          : ['postgresql']
-        : undefined,
+      cloudwatchLogsExports:
+        cloudwatchLogsExports.length > 0 ? cloudwatchLogsExports : undefined,
       defaultDatabaseName: databaseName,
       storageEncrypted: true,
       storageEncryptionKey: key,
@@ -657,6 +739,7 @@ export abstract class AuroraDatabase extends Construct {
       environment: {
         DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
         NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
+        ENABLE_AUDIT_LOGGING: String(enableAuditLogging),
       },
       architecture: Architecture.ARM_64,
     });
@@ -921,9 +1004,21 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs (error, general, slow query for MySQL; postgresql for PostgreSQL) to CloudWatch."
   type        = bool
   default     = false
+}
+
+variable "enable_audit_logging" {
+  description = "Whether to enable database audit logging and export the audit log to CloudWatch. PostgreSQL uses pgAudit; MySQL uses Advanced Auditing. Defaults to schema, privilege and connection events only to avoid recording data values (potential PII)."
+  type        = bool
+  default     = true
+}
+
+variable "audit_log" {
+  description = "Audit event classes captured when audit logging is enabled. PostgreSQL maps to pgaudit.log (e.g. 'ddl,role,misc'); MySQL maps to server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). Defaults exclude statement/DML logging to avoid recording data values."
+  type        = string
+  default     = null
 }
 
 variable "enable_performance_insights" {
@@ -969,20 +1064,43 @@ locals {
   default_engine_version = var.engine == "aurora-mysql" ? "8.0.mysql_aurora.3.12.0" : "17.7"
   parameter_group_family = var.engine == "aurora-mysql" ? "aurora-mysql8.0" : "aurora-postgresql\${split(".", coalesce(var.engine_version, local.default_engine_version))[0]}"
   cluster_name           = "\${var.name}-aurora-\${random_string.suffix.result}"
+
+  # Connection, schema and privilege events only - excludes statement/DML
+  # logging which would record data values (potential PII).
+  default_audit_log = var.engine == "aurora-mysql" ? "CONNECT,QUERY_DDL,QUERY_DCL,TABLE" : "ddl,role,misc"
+  audit_log         = coalesce(var.audit_log, local.default_audit_log)
+
+  audit_parameters = var.engine == "aurora-mysql" ? {
+    server_audit_logging = "1"
+    server_audit_events  = local.audit_log
+    } : {
+    shared_preload_libraries = "pgaudit"
+    "pgaudit.log"            = local.audit_log
+    "pgaudit.log_parameter"  = "off"
+  }
+
+  create_parameter_group = var.enable_audit_logging
+
+  cloudwatch_logs_exports = distinct(concat(
+    var.enable_cloudwatch_logs ? (var.engine == "aurora-mysql" ? ["error", "general", "slowquery"] : ["postgresql"]) : [],
+    var.enable_audit_logging ? (var.engine == "aurora-mysql" ? ["audit"] : ["postgresql"]) : [],
+  ))
 }
 
 resource "aws_rds_cluster_parameter_group" "database" {
-  count = var.enable_cloudwatch_logs ? 1 : 0
+  count = local.create_parameter_group ? 1 : 0
 
   name_prefix = "\${var.name}-"
   family      = local.parameter_group_family
   description = "Parameter group for \${var.name} Aurora cluster"
 
   dynamic "parameter" {
-    for_each = var.engine == "aurora-postgresql" ? [1] : []
+    for_each = var.enable_audit_logging ? local.audit_parameters : {}
     content {
-      name  = "log_statement"
-      value = "all"
+      name  = parameter.key
+      value = parameter.value
+      # pgaudit requires shared_preload_libraries to be set at instance boot
+      apply_method = parameter.key == "shared_preload_libraries" ? "pending-reboot" : "immediate"
     }
   }
 
@@ -1104,7 +1222,7 @@ resource "aws_secretsmanager_secret_version" "credentials" {
 }
 
 resource "aws_rds_cluster" "database" {
-  #checkov:skip=CKV2_AWS_27:Query logging can be enabled with enable_cloudwatch_logs; this module defaults to CDK-equivalent behavior unless logging is requested
+  #checkov:skip=CKV2_AWS_27:Audit logging is enabled by default via enable_audit_logging; query/DML logging is intentionally excluded to avoid recording potential PII
   #checkov:skip=CKV_AWS_139:Deletion protection is enabled but checkov is unable to detect it correctly
   cluster_identifier                  = local.cluster_name
   engine                              = var.engine
@@ -1113,7 +1231,7 @@ resource "aws_rds_cluster" "database" {
   master_username                     = var.admin_user
   master_password                     = random_password.master_password.result
   db_subnet_group_name                = aws_db_subnet_group.database.name
-  db_cluster_parameter_group_name     = var.enable_cloudwatch_logs ? aws_rds_cluster_parameter_group.database[0].name : null
+  db_cluster_parameter_group_name     = local.create_parameter_group ? aws_rds_cluster_parameter_group.database[0].name : null
   vpc_security_group_ids              = [aws_security_group.database.id]
   port                                = coalesce(var.port, local.default_port)
   storage_encrypted                   = true
@@ -1125,7 +1243,7 @@ resource "aws_rds_cluster" "database" {
   monitoring_interval                 = 5
   monitoring_role_arn                 = aws_iam_role.enhanced_monitoring.arn
   copy_tags_to_snapshot               = true
-  enabled_cloudwatch_logs_exports     = var.enable_cloudwatch_logs ? (var.engine == "aurora-mysql" ? ["audit", "error", "general", "slowquery"] : ["postgresql"]) : null
+  enabled_cloudwatch_logs_exports     = length(local.cloudwatch_logs_exports) > 0 ? local.cloudwatch_logs_exports : null
 
   serverlessv2_scaling_configuration {
     min_capacity = var.serverless_min_capacity
@@ -1649,9 +1767,21 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs (error, general, slow query for MySQL; postgresql for PostgreSQL) to CloudWatch."
   type        = bool
   default     = false
+}
+
+variable "enable_audit_logging" {
+  description = "Whether to enable database audit logging and export the audit log to CloudWatch. PostgreSQL uses pgAudit; MySQL uses Advanced Auditing. Defaults to schema, privilege and connection events only to avoid recording data values (potential PII)."
+  type        = bool
+  default     = true
+}
+
+variable "audit_log" {
+  description = "Audit event classes captured when audit logging is enabled. PostgreSQL maps to pgaudit.log (e.g. 'ddl,role,misc'); MySQL maps to server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). Defaults exclude statement/DML logging to avoid recording data values."
+  type        = string
+  default     = null
 }
 
 variable "enable_performance_insights" {
@@ -1727,6 +1857,8 @@ module "aurora" {
   enable_rds_proxy                      = var.enable_rds_proxy
   enable_credential_rotation            = var.enable_credential_rotation
   enable_cloudwatch_logs                = var.enable_cloudwatch_logs
+  enable_audit_logging                  = var.enable_audit_logging
+  audit_log                             = var.audit_log
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
@@ -2087,8 +2219,9 @@ resource "aws_lambda_function" "create_db_user" {
 
   environment {
     variables = {
-      DATABASE_SECRET_ARN = module.aurora.secret_arn
-      NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
+      DATABASE_SECRET_ARN  = module.aurora.secret_arn
+      NODE_EXTRA_CA_CERTS  = "/var/runtime/ca-cert.pem"
+      ENABLE_AUDIT_LOGGING = tostring(var.enable_audit_logging)
     }
   }
 
@@ -2107,10 +2240,11 @@ resource "aws_lambda_function" "create_db_user" {
 
 resource "null_resource" "create_db_user_trigger" {
   triggers = {
-    cluster_arn   = module.aurora.cluster_arn
-    function_name = aws_lambda_function.create_db_user.function_name
-    db_user       = local.database_runtime_user
-    bundle_hash   = data.archive_file.create_db_user_zip.output_base64sha256
+    cluster_arn          = module.aurora.cluster_arn
+    function_name        = aws_lambda_function.create_db_user.function_name
+    db_user              = local.database_runtime_user
+    bundle_hash          = data.archive_file.create_db_user_zip.output_base64sha256
+    enable_audit_logging = tostring(var.enable_audit_logging)
   }
 
   provisioner "local-exec" {
@@ -2408,9 +2542,21 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs (error, general, slow query for MySQL; postgresql for PostgreSQL) to CloudWatch."
   type        = bool
   default     = false
+}
+
+variable "enable_audit_logging" {
+  description = "Whether to enable database audit logging and export the audit log to CloudWatch. PostgreSQL uses pgAudit; MySQL uses Advanced Auditing. Defaults to schema, privilege and connection events only to avoid recording data values (potential PII)."
+  type        = bool
+  default     = true
+}
+
+variable "audit_log" {
+  description = "Audit event classes captured when audit logging is enabled. PostgreSQL maps to pgaudit.log (e.g. 'ddl,role,misc'); MySQL maps to server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). Defaults exclude statement/DML logging to avoid recording data values."
+  type        = string
+  default     = null
 }
 
 variable "enable_performance_insights" {
@@ -2456,20 +2602,43 @@ locals {
   default_engine_version = var.engine == "aurora-mysql" ? "8.0.mysql_aurora.3.12.0" : "17.7"
   parameter_group_family = var.engine == "aurora-mysql" ? "aurora-mysql8.0" : "aurora-postgresql\${split(".", coalesce(var.engine_version, local.default_engine_version))[0]}"
   cluster_name           = "\${var.name}-aurora-\${random_string.suffix.result}"
+
+  # Connection, schema and privilege events only - excludes statement/DML
+  # logging which would record data values (potential PII).
+  default_audit_log = var.engine == "aurora-mysql" ? "CONNECT,QUERY_DDL,QUERY_DCL,TABLE" : "ddl,role,misc"
+  audit_log         = coalesce(var.audit_log, local.default_audit_log)
+
+  audit_parameters = var.engine == "aurora-mysql" ? {
+    server_audit_logging = "1"
+    server_audit_events  = local.audit_log
+    } : {
+    shared_preload_libraries = "pgaudit"
+    "pgaudit.log"            = local.audit_log
+    "pgaudit.log_parameter"  = "off"
+  }
+
+  create_parameter_group = var.enable_audit_logging
+
+  cloudwatch_logs_exports = distinct(concat(
+    var.enable_cloudwatch_logs ? (var.engine == "aurora-mysql" ? ["error", "general", "slowquery"] : ["postgresql"]) : [],
+    var.enable_audit_logging ? (var.engine == "aurora-mysql" ? ["audit"] : ["postgresql"]) : [],
+  ))
 }
 
 resource "aws_rds_cluster_parameter_group" "database" {
-  count = var.enable_cloudwatch_logs ? 1 : 0
+  count = local.create_parameter_group ? 1 : 0
 
   name_prefix = "\${var.name}-"
   family      = local.parameter_group_family
   description = "Parameter group for \${var.name} Aurora cluster"
 
   dynamic "parameter" {
-    for_each = var.engine == "aurora-postgresql" ? [1] : []
+    for_each = var.enable_audit_logging ? local.audit_parameters : {}
     content {
-      name  = "log_statement"
-      value = "all"
+      name  = parameter.key
+      value = parameter.value
+      # pgaudit requires shared_preload_libraries to be set at instance boot
+      apply_method = parameter.key == "shared_preload_libraries" ? "pending-reboot" : "immediate"
     }
   }
 
@@ -2591,7 +2760,7 @@ resource "aws_secretsmanager_secret_version" "credentials" {
 }
 
 resource "aws_rds_cluster" "database" {
-  #checkov:skip=CKV2_AWS_27:Query logging can be enabled with enable_cloudwatch_logs; this module defaults to CDK-equivalent behavior unless logging is requested
+  #checkov:skip=CKV2_AWS_27:Audit logging is enabled by default via enable_audit_logging; query/DML logging is intentionally excluded to avoid recording potential PII
   #checkov:skip=CKV_AWS_139:Deletion protection is enabled but checkov is unable to detect it correctly
   cluster_identifier                  = local.cluster_name
   engine                              = var.engine
@@ -2600,7 +2769,7 @@ resource "aws_rds_cluster" "database" {
   master_username                     = var.admin_user
   master_password                     = random_password.master_password.result
   db_subnet_group_name                = aws_db_subnet_group.database.name
-  db_cluster_parameter_group_name     = var.enable_cloudwatch_logs ? aws_rds_cluster_parameter_group.database[0].name : null
+  db_cluster_parameter_group_name     = local.create_parameter_group ? aws_rds_cluster_parameter_group.database[0].name : null
   vpc_security_group_ids              = [aws_security_group.database.id]
   port                                = coalesce(var.port, local.default_port)
   storage_encrypted                   = true
@@ -2612,7 +2781,7 @@ resource "aws_rds_cluster" "database" {
   monitoring_interval                 = 5
   monitoring_role_arn                 = aws_iam_role.enhanced_monitoring.arn
   copy_tags_to_snapshot               = true
-  enabled_cloudwatch_logs_exports     = var.enable_cloudwatch_logs ? (var.engine == "aurora-mysql" ? ["audit", "error", "general", "slowquery"] : ["postgresql"]) : null
+  enabled_cloudwatch_logs_exports     = length(local.cloudwatch_logs_exports) > 0 ? local.cloudwatch_logs_exports : null
 
   serverlessv2_scaling_configuration {
     min_capacity = var.serverless_min_capacity
@@ -3136,9 +3305,21 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs (error, general, slow query for MySQL; postgresql for PostgreSQL) to CloudWatch."
   type        = bool
   default     = false
+}
+
+variable "enable_audit_logging" {
+  description = "Whether to enable database audit logging and export the audit log to CloudWatch. PostgreSQL uses pgAudit; MySQL uses Advanced Auditing. Defaults to schema, privilege and connection events only to avoid recording data values (potential PII)."
+  type        = bool
+  default     = true
+}
+
+variable "audit_log" {
+  description = "Audit event classes captured when audit logging is enabled. PostgreSQL maps to pgaudit.log (e.g. 'ddl,role,misc'); MySQL maps to server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). Defaults exclude statement/DML logging to avoid recording data values."
+  type        = string
+  default     = null
 }
 
 variable "enable_performance_insights" {
@@ -3214,6 +3395,8 @@ module "aurora" {
   enable_rds_proxy                      = var.enable_rds_proxy
   enable_credential_rotation            = var.enable_credential_rotation
   enable_cloudwatch_logs                = var.enable_cloudwatch_logs
+  enable_audit_logging                  = var.enable_audit_logging
+  audit_log                             = var.audit_log
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
@@ -3579,8 +3762,9 @@ resource "aws_lambda_function" "create_db_user" {
 
   environment {
     variables = {
-      DATABASE_SECRET_ARN = module.aurora.secret_arn
-      NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
+      DATABASE_SECRET_ARN  = module.aurora.secret_arn
+      NODE_EXTRA_CA_CERTS  = "/var/runtime/ca-cert.pem"
+      ENABLE_AUDIT_LOGGING = tostring(var.enable_audit_logging)
     }
   }
 
@@ -3599,10 +3783,11 @@ resource "aws_lambda_function" "create_db_user" {
 
 resource "null_resource" "create_db_user_trigger" {
   triggers = {
-    cluster_arn   = module.aurora.cluster_arn
-    function_name = aws_lambda_function.create_db_user.function_name
-    db_user       = local.database_runtime_user
-    bundle_hash   = data.archive_file.create_db_user_zip.output_base64sha256
+    cluster_arn          = module.aurora.cluster_arn
+    function_name        = aws_lambda_function.create_db_user.function_name
+    db_user              = local.database_runtime_user
+    bundle_hash          = data.archive_file.create_db_user_zip.output_base64sha256
+    enable_audit_logging = tostring(var.enable_audit_logging)
   }
 
   provisioner "local-exec" {
@@ -3829,6 +4014,10 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
 
   try {
     await client.query('BEGIN');
+
+    if (process.env.ENABLE_AUDIT_LOGGING === 'true') {
+      await client.query('CREATE EXTENSION IF NOT EXISTS pgaudit;');
+    }
 
     const roleExists = await client.query(
       'SELECT 1 FROM pg_roles WHERE rolname = $1',
@@ -4187,6 +4376,7 @@ import {
   DatabaseProxy,
   DefaultAuthScheme,
   IClusterEngine,
+  ParameterGroup,
 } from 'aws-cdk-lib/aws-rds';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Trigger } from 'aws-cdk-lib/triggers';
@@ -4212,6 +4402,26 @@ export interface AuroraDatabaseEngine {
    * Builds the CDK cluster engine for the provided engine version.
    */
   clusterEngine(version: AuroraDatabaseEngineVersion): IClusterEngine;
+
+  /**
+   * Default audit event classes captured when audit logging is enabled.
+   */
+  readonly defaultAuditLog: string;
+
+  /**
+   * Cluster parameter group parameters that enable audit logging for the engine.
+   */
+  auditParameters(auditLog: string): Record<string, string>;
+
+  /**
+   * CloudWatch log types exported when audit logging is enabled.
+   */
+  readonly auditLogExports: string[];
+
+  /**
+   * CloudWatch log types exported when general engine log export is enabled.
+   */
+  readonly cloudwatchLogExports: string[];
 }
 
 export class AuroraDatabaseEngines {
@@ -4227,6 +4437,15 @@ export class AuroraDatabaseEngines {
         DatabaseClusterEngine.auroraMysql({
           version: version as AuroraMysqlEngineVersion,
         }),
+      // Connection, schema and privilege events only - excludes QUERY/QUERY_DML
+      // which would log statement text and data values (potential PII).
+      defaultAuditLog: 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE',
+      auditParameters: (auditLog) => ({
+        server_audit_logging: '1',
+        server_audit_events: auditLog,
+      }),
+      auditLogExports: ['audit'],
+      cloudwatchLogExports: ['error', 'general', 'slowquery'],
     };
   }
 
@@ -4242,6 +4461,17 @@ export class AuroraDatabaseEngines {
         DatabaseClusterEngine.auroraPostgres({
           version: version as AuroraPostgresEngineVersion,
         }),
+      // Schema, privilege and admin events only - excludes 'read,write' which
+      // would log statement text and data values (potential PII). pgAudit also
+      // redacts cleartext passwords.
+      defaultAuditLog: 'ddl,role,misc',
+      auditParameters: (auditLog) => ({
+        shared_preload_libraries: 'pgaudit',
+        'pgaudit.log': auditLog,
+        'pgaudit.log_parameter': 'off',
+      }),
+      auditLogExports: ['postgresql'],
+      cloudwatchLogExports: ['postgresql'],
     };
   }
 }
@@ -4348,6 +4578,27 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
   readonly enableCloudwatchLogs?: boolean;
 
   /**
+   * Whether to enable database audit logging and export the audit log to CloudWatch Logs.
+   * Postgres uses the pgAudit extension; MySQL uses Advanced Auditing. To avoid capturing
+   * data values (potential PII), only schema, privilege and connection events are audited
+   * by default - see auditLog to customize.
+   * See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html
+   *
+   * @default true
+   */
+  readonly enableAuditLogging?: boolean;
+
+  /**
+   * Audit event classes to capture when audit logging is enabled.
+   * Postgres values map to pgaudit.log (e.g. 'ddl,role,misc'); MySQL values map to
+   * server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). The defaults
+   * deliberately exclude statement/DML logging to avoid recording data values.
+   *
+   * @default - schema, privilege and connection events only (excludes data reads/writes)
+   */
+  readonly auditLog?: string;
+
+  /**
    * Whether to enable Performance Insights on the Aurora writer instance.
    *
    * @default true
@@ -4383,6 +4634,8 @@ export abstract class AuroraDatabase extends Construct {
       removalPolicy = RemovalPolicy.RETAIN,
       enableKeyRotation = true,
       enableCloudwatchLogs = false,
+      enableAuditLogging = true,
+      auditLog,
       enablePerformanceInsights = true,
       engine,
       engineVersion,
@@ -4393,12 +4646,33 @@ export abstract class AuroraDatabase extends Construct {
 
     this.adminUser = adminUser;
 
+    const clusterEngine = engine.clusterEngine(
+      engineVersion ?? engine.defaultVersion,
+    );
+
+    const parameterGroup = enableAuditLogging
+      ? new ParameterGroup(this, 'ParameterGroup', {
+          engine: clusterEngine,
+          parameters: engine.auditParameters(
+            auditLog ?? engine.defaultAuditLog,
+          ),
+        })
+      : undefined;
+
+    const cloudwatchLogsExports = [
+      ...new Set([
+        ...(enableCloudwatchLogs ? engine.cloudwatchLogExports : []),
+        ...(enableAuditLogging ? engine.auditLogExports : []),
+      ]),
+    ];
+
     const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
     this.cluster = new DatabaseCluster(this, 'DatabaseCluster', {
       ...clusterProps,
       vpc,
       vpcSubnets,
-      engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      engine: clusterEngine,
+      parameterGroup,
       writer:
         writer ??
         ClusterInstance.serverlessV2('writer', {
@@ -4412,11 +4686,8 @@ export abstract class AuroraDatabase extends Construct {
       }),
       iamAuthentication: true,
       monitoringInterval: Duration.seconds(5),
-      cloudwatchLogsExports: enableCloudwatchLogs
-        ? engine.type === 'mysql'
-          ? ['audit', 'error', 'general', 'slowquery']
-          : ['postgresql']
-        : undefined,
+      cloudwatchLogsExports:
+        cloudwatchLogsExports.length > 0 ? cloudwatchLogsExports : undefined,
       defaultDatabaseName: databaseName,
       storageEncrypted: true,
       storageEncryptionKey: key,
@@ -4465,6 +4736,7 @@ export abstract class AuroraDatabase extends Construct {
       environment: {
         DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
         NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
+        ENABLE_AUDIT_LOGGING: String(enableAuditLogging),
       },
       architecture: Architecture.ARM_64,
     });

--- a/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
@@ -76,7 +76,11 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
 
   try {
     await client.query('BEGIN');
-    
+
+    if (process.env.ENABLE_AUDIT_LOGGING === 'true') {
+      await client.query('CREATE EXTENSION IF NOT EXISTS pgaudit;');
+    }
+
     const roleExists = await client.query(
       'SELECT 1 FROM pg_roles WHERE rolname = $1',
       [dbUser],

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
@@ -24,6 +24,7 @@ import {
   DatabaseProxy,
   DefaultAuthScheme,
   IClusterEngine,
+  ParameterGroup,
 } from 'aws-cdk-lib/aws-rds';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Trigger } from 'aws-cdk-lib/triggers';
@@ -49,6 +50,26 @@ export interface AuroraDatabaseEngine {
    * Builds the CDK cluster engine for the provided engine version.
    */
   clusterEngine(version: AuroraDatabaseEngineVersion): IClusterEngine;
+
+  /**
+   * Default audit event classes captured when audit logging is enabled.
+   */
+  readonly defaultAuditLog: string;
+
+  /**
+   * Cluster parameter group parameters that enable audit logging for the engine.
+   */
+  auditParameters(auditLog: string): Record<string, string>;
+
+  /**
+   * CloudWatch log types exported when audit logging is enabled.
+   */
+  readonly auditLogExports: string[];
+
+  /**
+   * CloudWatch log types exported when general engine log export is enabled.
+   */
+  readonly cloudwatchLogExports: string[];
 }
 
 export class AuroraDatabaseEngines {
@@ -64,6 +85,15 @@ export class AuroraDatabaseEngines {
         DatabaseClusterEngine.auroraMysql({
           version: version as AuroraMysqlEngineVersion,
         }),
+      // Connection, schema and privilege events only - excludes QUERY/QUERY_DML
+      // which would log statement text and data values (potential PII).
+      defaultAuditLog: 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE',
+      auditParameters: (auditLog) => ({
+        server_audit_logging: '1',
+        server_audit_events: auditLog,
+      }),
+      auditLogExports: ['audit'],
+      cloudwatchLogExports: ['error', 'general', 'slowquery'],
     };
   }
 
@@ -79,6 +109,17 @@ export class AuroraDatabaseEngines {
         DatabaseClusterEngine.auroraPostgres({
           version: version as AuroraPostgresEngineVersion,
         }),
+      // Schema, privilege and admin events only - excludes 'read,write' which
+      // would log statement text and data values (potential PII). pgAudit also
+      // redacts cleartext passwords.
+      defaultAuditLog: 'ddl,role,misc',
+      auditParameters: (auditLog) => ({
+        shared_preload_libraries: 'pgaudit',
+        'pgaudit.log': auditLog,
+        'pgaudit.log_parameter': 'off',
+      }),
+      auditLogExports: ['postgresql'],
+      cloudwatchLogExports: ['postgresql'],
     };
   }
 }
@@ -185,6 +226,27 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
   readonly enableCloudwatchLogs?: boolean;
 
   /**
+   * Whether to enable database audit logging and export the audit log to CloudWatch Logs.
+   * Postgres uses the pgAudit extension; MySQL uses Advanced Auditing. To avoid capturing
+   * data values (potential PII), only schema, privilege and connection events are audited
+   * by default - see auditLog to customize.
+   * See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html
+   *
+   * @default true
+   */
+  readonly enableAuditLogging?: boolean;
+
+  /**
+   * Audit event classes to capture when audit logging is enabled.
+   * Postgres values map to pgaudit.log (e.g. 'ddl,role,misc'); MySQL values map to
+   * server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). The defaults
+   * deliberately exclude statement/DML logging to avoid recording data values.
+   *
+   * @default - schema, privilege and connection events only (excludes data reads/writes)
+   */
+  readonly auditLog?: string;
+
+  /**
    * Whether to enable Performance Insights on the Aurora writer instance.
    *
    * @default true
@@ -220,6 +282,8 @@ export abstract class AuroraDatabase extends Construct {
       removalPolicy = RemovalPolicy.RETAIN,
       enableKeyRotation = true,
       enableCloudwatchLogs = false,
+      enableAuditLogging = true,
+      auditLog,
       enablePerformanceInsights = true,
       engine,
       engineVersion,
@@ -230,12 +294,31 @@ export abstract class AuroraDatabase extends Construct {
 
     this.adminUser = adminUser;
 
+    const clusterEngine = engine.clusterEngine(
+      engineVersion ?? engine.defaultVersion,
+    );
+
+    const parameterGroup = enableAuditLogging
+      ? new ParameterGroup(this, 'ParameterGroup', {
+          engine: clusterEngine,
+          parameters: engine.auditParameters(auditLog ?? engine.defaultAuditLog),
+        })
+      : undefined;
+
+    const cloudwatchLogsExports = [
+      ...new Set([
+        ...(enableCloudwatchLogs ? engine.cloudwatchLogExports : []),
+        ...(enableAuditLogging ? engine.auditLogExports : []),
+      ]),
+    ];
+
     const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
     this.cluster = new DatabaseCluster(this, 'DatabaseCluster', {
       ...clusterProps,
       vpc,
       vpcSubnets,
-      engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      engine: clusterEngine,
+      parameterGroup,
       writer:
         writer ??
         ClusterInstance.serverlessV2('writer', {
@@ -249,11 +332,8 @@ export abstract class AuroraDatabase extends Construct {
       }),
       iamAuthentication: true,
       monitoringInterval: Duration.seconds(5),
-      cloudwatchLogsExports: enableCloudwatchLogs
-        ? engine.type === 'mysql'
-          ? ['audit', 'error', 'general', 'slowquery']
-          : ['postgresql']
-        : undefined,
+      cloudwatchLogsExports:
+        cloudwatchLogsExports.length > 0 ? cloudwatchLogsExports : undefined,
       defaultDatabaseName: databaseName,
       storageEncrypted: true,
       storageEncryptionKey: key,
@@ -302,6 +382,7 @@ export abstract class AuroraDatabase extends Construct {
       environment: {
         DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
         NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
+        ENABLE_AUDIT_LOGGING: String(enableAuditLogging),
       },
       architecture: Architecture.ARM_64,
     });

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -91,9 +91,21 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs (error, general, slow query for MySQL; postgresql for PostgreSQL) to CloudWatch."
   type        = bool
   default     = false
+}
+
+variable "enable_audit_logging" {
+  description = "Whether to enable database audit logging and export the audit log to CloudWatch. PostgreSQL uses pgAudit; MySQL uses Advanced Auditing. Defaults to schema, privilege and connection events only to avoid recording data values (potential PII)."
+  type        = bool
+  default     = true
+}
+
+variable "audit_log" {
+  description = "Audit event classes captured when audit logging is enabled. PostgreSQL maps to pgaudit.log (e.g. 'ddl,role,misc'); MySQL maps to server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). Defaults exclude statement/DML logging to avoid recording data values."
+  type        = string
+  default     = null
 }
 
 variable "enable_performance_insights" {
@@ -169,6 +181,8 @@ module "aurora" {
   enable_rds_proxy                      = var.enable_rds_proxy
   enable_credential_rotation            = var.enable_credential_rotation
   enable_cloudwatch_logs                = var.enable_cloudwatch_logs
+  enable_audit_logging                  = var.enable_audit_logging
+  audit_log                             = var.audit_log
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
@@ -555,8 +569,9 @@ resource "aws_lambda_function" "create_db_user" {
 
   environment {
     variables = {
-      DATABASE_SECRET_ARN = module.aurora.secret_arn
-      NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
+      DATABASE_SECRET_ARN  = module.aurora.secret_arn
+      NODE_EXTRA_CA_CERTS  = "/var/runtime/ca-cert.pem"
+      ENABLE_AUDIT_LOGGING = tostring(var.enable_audit_logging)
     }
   }
 
@@ -575,10 +590,11 @@ resource "aws_lambda_function" "create_db_user" {
 
 resource "null_resource" "create_db_user_trigger" {
   triggers = {
-    cluster_arn   = module.aurora.cluster_arn
-    function_name = aws_lambda_function.create_db_user.function_name
-    db_user       = local.database_runtime_user
-    bundle_hash   = data.archive_file.create_db_user_zip.output_base64sha256
+    cluster_arn          = module.aurora.cluster_arn
+    function_name        = aws_lambda_function.create_db_user.function_name
+    db_user              = local.database_runtime_user
+    bundle_hash          = data.archive_file.create_db_user_zip.output_base64sha256
+    enable_audit_logging = tostring(var.enable_audit_logging)
   }
 
   provisioner "local-exec" {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -124,9 +124,21 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs (error, general, slow query for MySQL; postgresql for PostgreSQL) to CloudWatch."
   type        = bool
   default     = false
+}
+
+variable "enable_audit_logging" {
+  description = "Whether to enable database audit logging and export the audit log to CloudWatch. PostgreSQL uses pgAudit; MySQL uses Advanced Auditing. Defaults to schema, privilege and connection events only to avoid recording data values (potential PII)."
+  type        = bool
+  default     = true
+}
+
+variable "audit_log" {
+  description = "Audit event classes captured when audit logging is enabled. PostgreSQL maps to pgaudit.log (e.g. 'ddl,role,misc'); MySQL maps to server_audit_events (e.g. 'CONNECT,QUERY_DDL,QUERY_DCL,TABLE'). Defaults exclude statement/DML logging to avoid recording data values."
+  type        = string
+  default     = null
 }
 
 variable "enable_performance_insights" {
@@ -172,20 +184,43 @@ locals {
   default_engine_version = var.engine == "aurora-mysql" ? "8.0.mysql_aurora.3.12.0" : "17.7"
   parameter_group_family = var.engine == "aurora-mysql" ? "aurora-mysql8.0" : "aurora-postgresql${split(".", coalesce(var.engine_version, local.default_engine_version))[0]}"
   cluster_name           = "${var.name}-aurora-${random_string.suffix.result}"
+
+  # Connection, schema and privilege events only - excludes statement/DML
+  # logging which would record data values (potential PII).
+  default_audit_log = var.engine == "aurora-mysql" ? "CONNECT,QUERY_DDL,QUERY_DCL,TABLE" : "ddl,role,misc"
+  audit_log         = coalesce(var.audit_log, local.default_audit_log)
+
+  audit_parameters = var.engine == "aurora-mysql" ? {
+    server_audit_logging = "1"
+    server_audit_events  = local.audit_log
+    } : {
+    shared_preload_libraries = "pgaudit"
+    "pgaudit.log"            = local.audit_log
+    "pgaudit.log_parameter"  = "off"
+  }
+
+  create_parameter_group = var.enable_audit_logging
+
+  cloudwatch_logs_exports = distinct(concat(
+    var.enable_cloudwatch_logs ? (var.engine == "aurora-mysql" ? ["error", "general", "slowquery"] : ["postgresql"]) : [],
+    var.enable_audit_logging ? (var.engine == "aurora-mysql" ? ["audit"] : ["postgresql"]) : [],
+  ))
 }
 
 resource "aws_rds_cluster_parameter_group" "database" {
-  count = var.enable_cloudwatch_logs ? 1 : 0
+  count = local.create_parameter_group ? 1 : 0
 
   name_prefix = "${var.name}-"
   family      = local.parameter_group_family
   description = "Parameter group for ${var.name} Aurora cluster"
 
   dynamic "parameter" {
-    for_each = var.engine == "aurora-postgresql" ? [1] : []
+    for_each = var.enable_audit_logging ? local.audit_parameters : {}
     content {
-      name  = "log_statement"
-      value = "all"
+      name  = parameter.key
+      value = parameter.value
+      # pgaudit requires shared_preload_libraries to be set at instance boot
+      apply_method = parameter.key == "shared_preload_libraries" ? "pending-reboot" : "immediate"
     }
   }
 
@@ -307,7 +342,7 @@ resource "aws_secretsmanager_secret_version" "credentials" {
 }
 
 resource "aws_rds_cluster" "database" {
-  #checkov:skip=CKV2_AWS_27:Query logging can be enabled with enable_cloudwatch_logs; this module defaults to CDK-equivalent behavior unless logging is requested
+  #checkov:skip=CKV2_AWS_27:Audit logging is enabled by default via enable_audit_logging; query/DML logging is intentionally excluded to avoid recording potential PII
   #checkov:skip=CKV_AWS_139:Deletion protection is enabled but checkov is unable to detect it correctly
   cluster_identifier                  = local.cluster_name
   engine                              = var.engine
@@ -316,7 +351,7 @@ resource "aws_rds_cluster" "database" {
   master_username                     = var.admin_user
   master_password                     = random_password.master_password.result
   db_subnet_group_name                = aws_db_subnet_group.database.name
-  db_cluster_parameter_group_name     = var.enable_cloudwatch_logs ? aws_rds_cluster_parameter_group.database[0].name : null
+  db_cluster_parameter_group_name     = local.create_parameter_group ? aws_rds_cluster_parameter_group.database[0].name : null
   vpc_security_group_ids              = [aws_security_group.database.id]
   port                                = coalesce(var.port, local.default_port)
   storage_encrypted                   = true
@@ -328,7 +363,7 @@ resource "aws_rds_cluster" "database" {
   monitoring_interval                 = 5
   monitoring_role_arn                 = aws_iam_role.enhanced_monitoring.arn
   copy_tags_to_snapshot               = true
-  enabled_cloudwatch_logs_exports     = var.enable_cloudwatch_logs ? (var.engine == "aurora-mysql" ? ["audit", "error", "general", "slowquery"] : ["postgresql"]) : null
+  enabled_cloudwatch_logs_exports     = length(local.cloudwatch_logs_exports) > 0 ? local.cloudwatch_logs_exports : null
 
   serverlessv2_scaling_configuration {
     min_capacity = var.serverless_min_capacity


### PR DESCRIPTION
### Reason for this change

Aurora databases generated by the `ts#rdb` generator previously had **no query-level audit trail** by default. The only logging knob was `enableCloudwatchLogs` (off by default), and even when enabled it was insufficient:

- **CDK** exported the `audit`/`postgresql` log streams but never created a DB cluster parameter group, so the audit subsystem that actually *produces* the trail was never turned on (the MySQL `audit` stream was empty; PostgreSQL exported only engine logs).
- **Terraform** created a parameter group but used `log_statement = 'all'` for PostgreSQL, which logs full statement text including data values (PII).

This left the following threat effectively unmitigated:

> An attacker exfiltrating data through the database where Aurora has no CloudWatch Logs exports or audit logging enabled can run queries without leaving a query-level audit trail, leading to undetected data access and weakened forensics/compliance.

### Description of changes

Enable database audit logging **by default** and export the audit log to CloudWatch Logs, using AWS-recommended, PII-conscious mechanisms:

- New `enableAuditLogging` prop (CDK) / `enable_audit_logging` variable (Terraform), defaulting to `true`.
- **PostgreSQL** uses the [pgAudit](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.html) extension (created in the create-db-user handler when audit logging is enabled). pgAudit also redacts cleartext passwords.
- **MySQL** uses [Advanced Auditing](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html) (`server_audit_logging`/`server_audit_events`).
- **PII-safe defaults**: only connection, schema (DDL) and privilege (DCL) events are audited. Statement/DML logging (`read,write` for PG, `QUERY`/`QUERY_DML` for MySQL) is deliberately excluded so data values in queries are not recorded. Customizable via the new `auditLog` / `audit_log` option.
- Replaces the previous PII-unsafe Terraform `log_statement = 'all'` behaviour.
- Documents the feature and PII-avoidance best practices in the `ts#rdb` guide, including a pointer to Database Activity Streams for stricter compliance needs.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — all 2399 unit tests pass; 7 snapshots updated and reviewed.
- Generated a real workspace and built the shared constructs for **both** `postgres` and `mysql` engines (CDK) — the generated Aurora construct and create-db-user handler type-check and build successfully.
- `pnpm nx run @aws/nx-plugin:compile` and lint pass.

### Issue # (if applicable)

N/A — addresses a threat-model finding for the `ts#rdb` generator.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*