### PR TITLE
fix(ts#dynamodb): add random suffix to terraform table name

### DIFF
--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -194,6 +194,10 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
       source  = "hashicorp/aws"
       version = "~> 6.52"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 
@@ -221,6 +225,12 @@ variable "enable_key_rotation" {
   default     = true
 }
 
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
   dynamodb_config = jsondecode(file("\${path.module}/../../../../../../../packages/my_table/config.json"))
   global_secondary_indexes = [for gsi in local.dynamodb_config.tableConfig.globalSecondaryIndexes : {
@@ -233,7 +243,7 @@ locals {
 
 module "dynamodb_table" {
   source                         = "../../../core/dynamodb"
-  name                           = "proj-my-table"
+  name                           = "proj-my-table-\${random_string.suffix.result}"
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled    = var.deletion_protection_enabled

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -194,6 +194,10 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
       source  = "hashicorp/aws"
       version = "~> 6.52"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 
@@ -221,6 +225,12 @@ variable "enable_key_rotation" {
   default     = true
 }
 
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
   dynamodb_config = jsondecode(file("\${path.module}/../../../../../../../packages/my-table/config.json"))
   global_secondary_indexes = [for gsi in local.dynamodb_config.tableConfig.globalSecondaryIndexes : {
@@ -233,7 +243,7 @@ locals {
 
 module "dynamodb_table" {
   source                         = "../../../core/dynamodb"
-  name                           = "proj-my-table"
+  name                           = "proj-my-table-\${random_string.suffix.result}"
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled    = var.deletion_protection_enabled

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.52"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 
@@ -31,6 +35,12 @@ variable "enable_key_rotation" {
   default     = true
 }
 
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 locals {
   dynamodb_config = jsondecode(file("${path.module}/../../../../../../../<%= projectRoot %>/config.json"))
   global_secondary_indexes = [for gsi in local.dynamodb_config.tableConfig.globalSecondaryIndexes : {
@@ -43,7 +53,7 @@ locals {
 
 module "dynamodb_table" {
   source                         = "../../../core/dynamodb"
-  name                           = "<%= tableName %>"
+  name                           = "<%= tableName %>-${random_string.suffix.result}"
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled    = var.deletion_protection_enabled


### PR DESCRIPTION
### Reason for this change

The Terraform DynamoDB app module set the table name to `<npmScope>-<name>` (`<%= tableName %>`) with no per-deployment disambiguation. Deploying the same generated application twice into the same AWS account and region would therefore fail with a DynamoDB table name collision.

This was found while auditing all Terraform templates for resource names that must be unique within an account/region but lacked a random suffix. The DynamoDB table was the only resource missing such disambiguation — all other named resources across the construct families (api, rdb/aurora, function, website, identity, agent-core, metrics, asset-bucket) already use a `random_string`/`random_id` suffix, Terraform's `name_prefix`, or a caller-populated variable that includes a random suffix.

### Description of changes

- Append a `random_string` suffix to the DynamoDB table name in the app module, matching the pattern already used by the lambda-function and api Terraform modules.
- Declare the `hashicorp/random` provider in `required_providers`.

Consumers read the resolved table name from runtime config (`module.dynamodb_table.table_name`), so no consumer changes are required.

### Description of how you validated changes

- Updated and ran the `@aws/nx-plugin` unit tests (2399 passing), which include the dynamodb generator snapshots covering the generated Terraform.
- Ran a full `@aws/nx-plugin` build.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*