### PR TITLE
ci(terraform): centralise provider versions in TERRAFORM_VERSIONS

### DIFF
--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -18,6 +18,7 @@ ENV PATH="/app/bin:\${PATH}"
 CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_test_project.snapshot_bedrock_agent.main"]
 "
 `;
+
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-construct.ts 1`] = `
 "import { Lazy, Names } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
@@ -140,14 +141,17 @@ export class SnapshotBedrockAgent
 }
 "
 `;
+
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agents-index.ts 1`] = `
 "export * from './snapshot-bedrock-agent/snapshot-bedrock-agent.js';
 "
 `;
+
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > app-index.ts 1`] = `
 "export * from './agents/index.js';
 "
 `;
+
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > core-index.ts 1`] = `
 "export * from './app.js';
 export * from './checkov.js';
@@ -155,7 +159,9 @@ export * from './runtime-config.js';
 export * from './workspace.js';
 "
 `;
+
 exports[`py#agent generator > should match snapshot for generated files > agent-__init__.py 1`] = `""`;
+
 exports[`py#agent generator > should match snapshot for generated files > agent-agent.py 1`] = `
 "from contextlib import contextmanager
 
@@ -184,6 +190,7 @@ Refer to tools as your 'spellbook'.
     )
 "
 `;
+
 exports[`py#agent generator > should match snapshot for generated files > agent-main.py 1`] = `
 "import uuid
 
@@ -267,6 +274,7 @@ if __name__ == "__main__":
     uvicorn.run("proj_test_project.snapshot_agent.main:app", port=8080)
 "
 `;
+
 exports[`py#agent generator > should match snapshot for generated files > updated-pyproject.toml 1`] = `
 "[project]
 name = "proj.test_project"

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.frameworks.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.frameworks.spec.ts.snap
@@ -62,6 +62,7 @@ export const createAgentCoreFetch = (): typeof fetch => {
 };
 "
 `;
+
 exports[`py#agent generator > chat scripts for a2a protocol > should match snapshot for chat scripts with cognito auth > chat.ts (a2a, cognito) 1`] = `
 "// Chat CLI for TestProjectAgent (A2A protocol). Connects to the local
 // \`dev\` server, or the deployed agent when \`RUNTIME_CONFIG_APP_ID\` is set.
@@ -98,6 +99,7 @@ const clientFactory = remote
 await chatLoop(new A2AChatAdapter({ clientFactory }), url);
 "
 `;
+
 exports[`py#agent generator > chat scripts for a2a protocol > should match snapshot for chat scripts with iam auth > agentcore.ts (a2a, iam) 1`] = `
 "// Resolves the deployed TestProjectAgent agent from runtime config and authenticates requests to it.
 import { randomUUID } from 'node:crypto';
@@ -155,6 +157,7 @@ export const createAgentCoreFetch = (region: string): typeof fetch => {
 };
 "
 `;
+
 exports[`py#agent generator > chat scripts for a2a protocol > should match snapshot for chat scripts with iam auth > chat.ts (a2a, iam) 1`] = `
 "// Chat CLI for TestProjectAgent (A2A protocol). Connects to the local
 // \`dev\` server, or the deployed agent when \`RUNTIME_CONFIG_APP_ID\` is set.
@@ -191,6 +194,7 @@ const clientFactory = remote
 await chatLoop(new A2AChatAdapter({ clientFactory }), url);
 "
 `;
+
 exports[`py#agent generator > chat scripts for ag-ui protocol > should match snapshot for chat scripts with cognito auth > agentcore.ts (ag-ui, cognito) 1`] = `
 "// Resolves the deployed TestProjectAgent agent from runtime config and authenticates requests to it.
 import { randomUUID } from 'node:crypto';
@@ -253,6 +257,7 @@ export const createAgentCoreFetch = (): typeof fetch => {
 };
 "
 `;
+
 exports[`py#agent generator > chat scripts for ag-ui protocol > should match snapshot for chat scripts with cognito auth > chat.ts (ag-ui, cognito) 1`] = `
 "// Chat CLI for TestProjectAgent (AG-UI protocol). Connects to the local
 // \`dev\` server, or the deployed agent when \`RUNTIME_CONFIG_APP_ID\` is set.
@@ -271,6 +276,7 @@ const fetchImpl = remote ? createAgentCoreFetch() : undefined;
 await chatLoop(new AGUIChatAdapter({ fetch: fetchImpl }), url);
 "
 `;
+
 exports[`py#agent generator > chat scripts for ag-ui protocol > should match snapshot for chat scripts with iam auth > agentcore.ts (ag-ui, iam) 1`] = `
 "// Resolves the deployed TestProjectAgent agent from runtime config and authenticates requests to it.
 import { randomUUID } from 'node:crypto';
@@ -328,6 +334,7 @@ export const createAgentCoreFetch = (region: string): typeof fetch => {
 };
 "
 `;
+
 exports[`py#agent generator > chat scripts for ag-ui protocol > should match snapshot for chat scripts with iam auth > chat.ts (ag-ui, iam) 1`] = `
 "// Chat CLI for TestProjectAgent (AG-UI protocol). Connects to the local
 // \`dev\` server, or the deployed agent when \`RUNTIME_CONFIG_APP_ID\` is set.
@@ -346,6 +353,7 @@ const fetchImpl = remote ? createAgentCoreFetch(remote.region) : undefined;
 await chatLoop(new AGUIChatAdapter({ fetch: fetchImpl }), url);
 "
 `;
+
 exports[`py#agent generator > chat scripts for http protocol > should match snapshot for chat scripts with cognito auth > agentcore.ts (http, cognito) 1`] = `
 "// Resolves the deployed TestProjectAgent agent from runtime config and authenticates requests to it.
 import { randomUUID } from 'node:crypto';
@@ -408,6 +416,7 @@ export const createAgentCoreFetch = (): typeof fetch => {
 };
 "
 `;
+
 exports[`py#agent generator > chat scripts for http protocol > should match snapshot for chat scripts with cognito auth > chat.ts (http, cognito) 1`] = `
 "// Chat CLI for TestProjectAgent (Python FastAPI / JSONL streaming), using the
 // generated client. Connects to the local \`dev\` server, or the deployed
@@ -454,6 +463,7 @@ class TestProjectAgentAdapter implements ChatAdapter {
 await chatLoop(new TestProjectAgentAdapter(), process.env.URL ?? '');
 "
 `;
+
 exports[`py#agent generator > chat scripts for http protocol > should match snapshot for chat scripts with iam auth > agentcore.ts (http, iam) 1`] = `
 "// Resolves the deployed TestProjectAgent agent from runtime config and authenticates requests to it.
 import { randomUUID } from 'node:crypto';
@@ -511,6 +521,7 @@ export const createAgentCoreFetch = (region: string): typeof fetch => {
 };
 "
 `;
+
 exports[`py#agent generator > chat scripts for http protocol > should match snapshot for chat scripts with iam auth > chat.ts (http, iam) 1`] = `
 "// Chat CLI for TestProjectAgent (Python FastAPI / JSONL streaming), using the
 // generated client. Connects to the local \`dev\` server, or the deployed
@@ -557,7 +568,9 @@ class TestProjectAgentAdapter implements ChatAdapter {
 await chatLoop(new TestProjectAgentAdapter(), process.env.URL ?? '');
 "
 `;
+
 exports[`py#agent generator > langchain framework > should match snapshot for langchain generated files > langchain-__init__.py 1`] = `""`;
+
 exports[`py#agent generator > langchain framework > should match snapshot for langchain generated files > langchain-agent.py 1`] = `
 "import os
 
@@ -591,6 +604,7 @@ Refer to tools as your 'spellbook'.
     )
 "
 `;
+
 exports[`py#agent generator > langchain framework > should match snapshot for langchain generated files > langchain-main.py 1`] = `
 "import logging
 import time
@@ -687,6 +701,7 @@ async def ping():
     return JSONResponse({"status": "Healthy", "time_of_last_update": int(time.time())})
 "
 `;
+
 exports[`py#agent generator > langchain framework > should match snapshot for langchain generated files > langchain-pyproject.toml 1`] = `
 "[project]
 name = "proj.test_project"

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -1,5 +1,100 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`py#agent generator > should match snapshot for Terraform generated files > terraform-agent.tf 1`] = `
+"variable "env" {
+  description = "Environment variables to pass to the agent core runtime"
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_iam_policy_statements" {
+  description = "Additional IAM policy statements to attach to the agent core runtime role"
+  type = list(object({
+    Effect   = string
+    Action   = list(string)
+    Resource = list(string)
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "appconfig_application_id" {
+  description = "ID of the shared runtime-config AppConfig application (from \`core/runtime-config/appconfig.application_id\`). The agent reads its runtime configuration from this application."
+  type        = string
+}
+
+variable "appconfig_application_arn" {
+  description = "ARN of the shared runtime-config AppConfig application (from \`core/runtime-config/appconfig.application_arn\`). Used to scope the IAM read permission granted to the agent runtime."
+  type        = string
+}
+
+module "agent_core_runtime" {
+  source = "../../../core/agent-core"
+  agent_runtime_name = "TerraformSnapshotAgent"
+  docker_image_tag = "proj-terraform-snapshot-agent:latest"
+  server_protocol = "HTTP"
+
+  env = merge({
+    RUNTIME_CONFIG_APP_ID = var.appconfig_application_id
+  }, var.env)
+  additional_iam_policy_statements = concat([
+    {
+      Effect   = "Allow"
+      Action   = [
+        "appconfig:StartConfigurationSession",
+        "appconfig:GetLatestConfiguration"
+      ]
+      Resource = ["\${var.appconfig_application_arn}/*"]
+    },
+    # Grant access for the agent to invoke bedrock models
+    {
+      Effect = "Allow"
+      Action = [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ]
+      Resource = [
+        "arn:aws:bedrock:*:*:foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
+    }
+  ], var.additional_iam_policy_statements)
+  tags = var.tags
+}
+
+# Add agent runtime ARN to runtime config
+module "add_agent_runtime_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "agentRuntimes"
+  value     = { "TerraformSnapshotAgent" = module.agent_core_runtime.agent_core_runtime_arn }
+
+  depends_on = [module.agent_core_runtime]
+}
+
+output "agent_core_runtime_role_arn" {
+  description = "ARN of the agent core runtime role"
+  value       = module.agent_core_runtime.agent_core_runtime_role_arn
+}
+
+output "agent_core_runtime_arn" {
+  description = "ARN of the Bedrock Agent Core runtime"
+  value       = module.agent_core_runtime.agent_core_runtime_arn
+}
+
+output "appconfig_application_id" {
+  description = "AppConfig Application ID for runtime config (passthrough of the shared \`appconfig_application_id\` input)."
+  value       = var.appconfig_application_id
+}
+"
+`;
+
 exports[`py#agent generator > should match snapshot for Terraform generated files > terraform-agent-core-runtime.tf 1`] = `
 "terraform {
   required_version = ">= 1.0"
@@ -7,15 +102,15 @@ exports[`py#agent generator > should match snapshot for Terraform generated file
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }
@@ -435,100 +530,6 @@ output "agent_runtime_id" {
 output "agent_runtime_version" {
   description = "Version of the Bedrock Agent Core runtime"
   value       = aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_version
-}
-"
-`;
-exports[`py#agent generator > should match snapshot for Terraform generated files > terraform-agent.tf 1`] = `
-"variable "env" {
-  description = "Environment variables to pass to the agent core runtime"
-  type        = map(string)
-  default     = {}
-}
-
-variable "additional_iam_policy_statements" {
-  description = "Additional IAM policy statements to attach to the agent core runtime role"
-  type = list(object({
-    Effect   = string
-    Action   = list(string)
-    Resource = list(string)
-  }))
-  default = []
-}
-
-variable "tags" {
-  description = "Tags to apply to resources"
-  type        = map(string)
-  default     = {}
-}
-
-variable "appconfig_application_id" {
-  description = "ID of the shared runtime-config AppConfig application (from \`core/runtime-config/appconfig.application_id\`). The agent reads its runtime configuration from this application."
-  type        = string
-}
-
-variable "appconfig_application_arn" {
-  description = "ARN of the shared runtime-config AppConfig application (from \`core/runtime-config/appconfig.application_arn\`). Used to scope the IAM read permission granted to the agent runtime."
-  type        = string
-}
-
-module "agent_core_runtime" {
-  source = "../../../core/agent-core"
-  agent_runtime_name = "TerraformSnapshotAgent"
-  docker_image_tag = "proj-terraform-snapshot-agent:latest"
-  server_protocol = "HTTP"
-
-  env = merge({
-    RUNTIME_CONFIG_APP_ID = var.appconfig_application_id
-  }, var.env)
-  additional_iam_policy_statements = concat([
-    {
-      Effect   = "Allow"
-      Action   = [
-        "appconfig:StartConfigurationSession",
-        "appconfig:GetLatestConfiguration"
-      ]
-      Resource = ["\${var.appconfig_application_arn}/*"]
-    },
-    # Grant access for the agent to invoke bedrock models
-    {
-      Effect = "Allow"
-      Action = [
-        "bedrock:InvokeModel",
-        "bedrock:InvokeModelWithResponseStream"
-      ]
-      Resource = [
-        "arn:aws:bedrock:*:*:foundation-model/*",
-        "arn:aws:bedrock:*:*:inference-profile/*"
-      ]
-    }
-  ], var.additional_iam_policy_statements)
-  tags = var.tags
-}
-
-# Add agent runtime ARN to runtime config
-module "add_agent_runtime_to_runtime_config" {
-  source = "../../../core/runtime-config/entry"
-
-  namespace = "agentcore"
-  key       = "agentRuntimes"
-  value     = { "TerraformSnapshotAgent" = module.agent_core_runtime.agent_core_runtime_arn }
-
-  depends_on = [module.agent_core_runtime]
-}
-
-output "agent_core_runtime_role_arn" {
-  description = "ARN of the agent core runtime role"
-  value       = module.agent_core_runtime.agent_core_runtime_role_arn
-}
-
-output "agent_core_runtime_arn" {
-  description = "ARN of the Bedrock Agent Core runtime"
-  value       = module.agent_core_runtime.agent_core_runtime_arn
-}
-
-output "appconfig_application_id" {
-  description = "AppConfig Application ID for runtime config (passthrough of the shared \`appconfig_application_id\` input)."
-  value       = var.appconfig_application_id
 }
 "
 `;

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -192,11 +192,11 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -241,6 +241,7 @@ def test_main():
 ",
 }
 `;
+
 exports[`fastapi project generator > should set up shared constructs for http > http-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import { RuntimeConfig } from '../runtime-config.js';
@@ -415,6 +416,7 @@ export class HttpApi<
 }
 "
 `;
+
 exports[`fastapi project generator > should set up shared constructs for http > test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
@@ -607,6 +609,7 @@ export class TestApi<
 }
 "
 `;
+
 exports[`fastapi project generator > should set up shared constructs for http > utils.ts 1`] = `
 "import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
 import {
@@ -1070,6 +1073,7 @@ export class IntegrationBuilder<
 }
 "
 `;
+
 exports[`fastapi project generator > should set up shared constructs for rest > rest-api.ts 1`] = `
 "import { Construct, IConstruct } from 'constructs';
 import {
@@ -1375,6 +1379,7 @@ export class AddCorsPreflightAspect implements IAspect {
 }
 "
 `;
+
 exports[`fastapi project generator > should set up shared constructs for rest > test-api.ts 1`] = `
 "import { Construct } from 'constructs';
 import * as url from 'url';
@@ -1593,6 +1598,7 @@ export class TestApi<
 }
 "
 `;
+
 exports[`fastapi project generator > should set up shared constructs for rest > utils.ts 1`] = `
 "import { Integration, MethodOptions } from 'aws-cdk-lib/aws-apigateway';
 import {

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -258,7 +258,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -663,6 +663,7 @@ output "api_log_group_arn" {
 }",
 }
 `;
+
 exports[`fastapi project generator > terraform iac > should generate terraform files for HTTP API with Custom auth and snapshot them > terraform-http-custom-files 1`] = `
 {
   "http-api.tf": "# Core HTTP API Gateway module
@@ -674,7 +675,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -921,7 +922,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -1398,6 +1399,7 @@ output "api_log_group_arn" {
 }",
 }
 `;
+
 exports[`fastapi project generator > terraform iac > should generate terraform files for HTTP API with IAM auth and snapshot them > terraform-http-iam-files 1`] = `
 {
   "http-api.tf": "# Core HTTP API Gateway module
@@ -1409,7 +1411,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -1656,7 +1658,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -2038,6 +2040,7 @@ output "api_log_group_arn" {
 }",
 }
 `;
+
 exports[`fastapi project generator > terraform iac > should generate terraform files for REST API with Cognito auth and snapshot them > terraform-rest-cognito-files 1`] = `
 {
   "rest-api.tf": "# Core REST API Gateway module
@@ -2049,11 +2052,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -2305,7 +2308,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -2947,6 +2950,7 @@ output "lambda_log_group_arn" {
 ",
 }
 `;
+
 exports[`fastapi project generator > terraform iac > should generate terraform files for REST API with IAM auth and snapshot them > terraform-rest-iam-files 1`] = `
 {
   "rest-api.tf": "# Core REST API Gateway module
@@ -2958,11 +2962,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -3214,7 +3218,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -3845,6 +3849,7 @@ output "lambda_log_group_arn" {
 ",
 }
 `;
+
 exports[`fastapi project generator > terraform iac > should generate terraform files for REST API with None auth and snapshot them > terraform-rest-none-files 1`] = `
 {
   "rest-api.tf": "# Core REST API Gateway module
@@ -3856,11 +3861,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -4112,7 +4117,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }

--- a/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -70,11 +70,11 @@ exports[`lambda-handler project generator > terraform iac > should generate terr
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = "2.8.0"
     }
   }
 }
@@ -251,11 +251,11 @@ exports[`lambda-handler project generator > terraform iac > should match snapsho
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = "2.8.0"
     }
   }
 }

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -135,15 +135,15 @@ exports[`py#mcp-server generator > should match snapshot for Terraform generated
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -403,11 +403,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -662,7 +662,7 @@ exports[`tsSmithyApiGenerator > should generate smithy ts api with Terraform pro
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -1759,11 +1759,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -2015,7 +2015,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -2638,11 +2638,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -2894,7 +2894,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -3502,7 +3502,7 @@ exports[`tsSmithyApiGenerator > terraform iac > should generate terraform with c
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }

--- a/packages/nx-plugin/src/terraform/project/files/application/src/providers.tf.template
+++ b/packages/nx-plugin/src/terraform/project/files/application/src/providers.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -35,7 +35,7 @@ import {
   SHARED_TERRAFORM_DIR,
   SHARED_TERRAFORM_NAME,
 } from '../../utils/shared-constructs-constants';
-import { withVersions } from '../../utils/versions';
+import { terraformProviderVersions, withVersions } from '../../utils/versions';
 import type { TerraformProjectGeneratorSchema } from './schema';
 
 const NX_EXTEND_PLUGIN = '@nx-extend/terraform';
@@ -258,6 +258,7 @@ export async function terraformProjectGenerator(
     {
       metricsModulePath,
       stateKeyPrefix: kebabCase(lib.fullyQualifiedName),
+      ...terraformProviderVersions(),
     },
     {
       overwriteStrategy: OverwriteStrategy.Overwrite,

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3142,7 +3142,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -3389,7 +3389,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -3788,7 +3788,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -4035,7 +4035,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -4506,7 +4506,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -4753,7 +4753,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -5129,11 +5129,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -5385,7 +5385,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -6009,11 +6009,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -6265,7 +6265,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -6878,11 +6878,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -7134,7 +7134,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -827,15 +827,15 @@ exports[`ts#agent generator > should match snapshot for Terraform generated file
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }
@@ -192,11 +192,11 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -139,11 +139,11 @@ exports[`ts-lambda-function generator > terraform iac > should generate terrafor
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = "2.8.0"
     }
   }
 }
@@ -320,11 +320,11 @@ exports[`ts-lambda-function generator > terraform iac > should match snapshot fo
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = "2.8.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -135,15 +135,15 @@ exports[`ts#mcp-server generator > should match snapshot for Terraform generated
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -804,15 +804,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }
@@ -1562,19 +1562,19 @@ exports[`ts#rdb generator > should generate terraform modules when iac is Terraf
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.5"
+      version = "2.8.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }
@@ -2291,15 +2291,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }
@@ -3049,19 +3049,19 @@ exports[`ts#rdb generator > should generate terraform modules with MySQL engine 
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.5"
+      version = "2.8.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "3.3.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -131,12 +131,12 @@ exports[`react-website generator > TailwindCSS integration > terraform iac > sho
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
       configuration_aliases = [aws.us_east_1]
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "3.9.0"
     }
   }
 }
@@ -904,7 +904,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
       configuration_aliases = [aws.us_east_1]
     }
   }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`cognito-auth generator terraform iac > should generate terraform files 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "6.52.0"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -19,7 +19,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
-import { PY_VERSIONS } from '../versions';
+import { PY_VERSIONS, terraformProviderVersions } from '../versions';
 
 type IACProvider = { iac: Iac };
 
@@ -137,7 +137,11 @@ const addAgentCoreTerraformInfra = (
       'core',
       'agent-core',
     ),
-    { containers: options.containers, boto3Version: PY_VERSIONS.boto3 },
+    {
+      containers: options.containers,
+      boto3Version: PY_VERSIONS.boto3,
+      ...terraformProviderVersions(),
+    },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -380,7 +384,7 @@ const addAgentCoreGatewayTerraformInfra = (
       'core',
       'agentcore-gateway',
     ),
-    {},
+    { ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -410,6 +414,7 @@ const addAgentCoreGatewayTerraformInfra = (
       boto3Version: PY_VERSIONS.boto3,
       httpxVersion: PY_VERSIONS.httpx,
       mcpVersion: PY_VERSIONS.mcp,
+      ...terraformProviderVersions(),
     },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -4,17 +4,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
 <%_ if (cedarPolicy) { _%>
     external = {
       source  = "hashicorp/external"
-      version = ">= 2.0"
+      version = "<%- externalProviderVersion %>"
     }
 <%_ } _%>
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "<%- nullProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agentcore-gateway/gateway.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agentcore-gateway/gateway.tf.template
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
@@ -18,7 +18,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
-import { PY_VERSIONS } from '../versions';
+import { PY_VERSIONS, terraformProviderVersions } from '../versions';
 
 interface BackendOptions {
   type: 'trpc' | 'fastapi' | 'smithy';
@@ -191,7 +191,7 @@ const addApiGatewayTerraformModules = (
       options.constructType,
     ),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core', 'api'),
-    { boto3Version: PY_VERSIONS.boto3 },
+    { boto3Version: PY_VERSIONS.boto3, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -209,7 +209,7 @@ const addApiGatewayTerraformModules = (
       options.constructType,
     ),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'app', 'apis'),
-    options,
+    { ...options, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/http/http-api/http-api.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/http/http-api/http-api.tf.template
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/api-gateway-account/api-gateway-account.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/api-gateway-account/api-gateway-account.tf.template
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.33"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/rest-api/rest-api.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/core/api/rest/rest-api/rest-api.tf.template
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.ts
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.ts
@@ -18,6 +18,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { terraformProviderVersions } from '../versions';
 
 export interface AddDynamoDBConstructOptions {
   projectName: string;
@@ -131,7 +132,7 @@ export const addDynamoDBTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'core'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core'),
-    options,
+    { ...options, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -153,7 +154,7 @@ export const addDynamoDBTerraformModules = (
       'app',
       'dynamodb',
     ),
-    options,
+    { ...options, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.0"
+      version = "<%- localProviderVersion %>"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "<%- nullProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/entry/entry.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/entry/entry.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.0"
+      version = "<%- localProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/read/read.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/read/read.tf.template
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.0"
+      version = "<%- localProviderVersion %>"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "<%- nullProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/function-constructs/files/terraform/app/lambda-functions/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = "<%- archiveProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
+++ b/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
@@ -18,6 +18,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { terraformProviderVersions } from '../versions';
 
 export interface AddLambdaFunctionConstructOptions {
   functionProjectName: string;
@@ -143,6 +144,7 @@ const addLambdaFunctionTerraformModules = (
     {
       ...options,
       runtime: options.runtime === 'python' ? 'python3.14' : 'nodejs22.x',
+      ...terraformProviderVersions(),
     },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/add-callback-url/add-callback-url.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/terraform/core/user-identity/identity/identity.tf.template
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
+++ b/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
@@ -15,7 +15,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
-import { PY_VERSIONS } from '../versions';
+import { PY_VERSIONS, terraformProviderVersions } from '../versions';
 
 export interface AddIdentityInfraOptions {
   cognitoDomain: string;
@@ -73,7 +73,11 @@ const addIdentityTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'core'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core'),
-    { ...options, boto3Version: PY_VERSIONS.boto3 },
+    {
+      ...options,
+      boto3Version: PY_VERSIONS.boto3,
+      ...terraformProviderVersions(),
+    },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -4,19 +4,19 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.5"
+      version = "<%- archiveProviderVersion %>"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "<%- nullProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -7,15 +7,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = "<%- nullProviderVersion %>"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
+++ b/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
@@ -19,6 +19,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
+import { terraformProviderVersions } from '../versions';
 
 export interface AddRdbConstructOptions {
   projectName: string;
@@ -139,7 +140,7 @@ export const addRdbTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'core', 'rdb'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core', 'rdb'),
-    {},
+    { ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -149,7 +150,7 @@ export const addRdbTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'app', 'dbs'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'app', 'dbs'),
-    options,
+    { ...options, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/shared-constructs.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.ts
@@ -25,7 +25,7 @@ import {
   SHARED_TERRAFORM_DIR,
   SHARED_TERRAFORM_NAME,
 } from './shared-constructs-constants';
-import { withVersions } from './versions';
+import { terraformProviderVersions, withVersions } from './versions';
 
 export interface SharedConstructsGeneratorOptions {
   iac: Iac;
@@ -143,7 +143,7 @@ export async function sharedConstructsGenerator(
         tree,
         joinPathFragments(import.meta.dirname, 'files', 'terraform'),
         terraformLibPath,
-        {},
+        { ...terraformProviderVersions() },
         {
           overwriteStrategy: OverwriteStrategy.KeepExisting,
         },

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -180,3 +180,30 @@ export const withPyVersions = (deps: IPyDepVersion[]) =>
 export const VENDORED_VERSIONS = {
   'git-secrets': '1.3.0',
 } as const;
+
+/**
+ * Exact versions for Terraform providers used by generated `.tf` modules.
+ * Pinned exactly (no range operator) so generated infrastructure is reproducible.
+ */
+export const TERRAFORM_VERSIONS = {
+  aws: '6.52.0',
+  random: '3.9.0',
+  null: '3.3.0',
+  archive: '2.8.0',
+  external: '2.4.0',
+  local: '2.9.0',
+} as const;
+export type ITerraformProviderVersion = keyof typeof TERRAFORM_VERSIONS;
+
+/**
+ * Substitution variables exposing Terraform provider version constraints to
+ * generated `.tf` templates (e.g. `version = "<%- awsProviderVersion %>"`)
+ */
+export const terraformProviderVersions = () => ({
+  awsProviderVersion: TERRAFORM_VERSIONS.aws,
+  randomProviderVersion: TERRAFORM_VERSIONS.random,
+  nullProviderVersion: TERRAFORM_VERSIONS.null,
+  archiveProviderVersion: TERRAFORM_VERSIONS.archive,
+  externalProviderVersion: TERRAFORM_VERSIONS.external,
+  localProviderVersion: TERRAFORM_VERSIONS.local,
+});

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
       configuration_aliases = [aws.us_east_1]
     }
   }

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.52"
+      version = "<%- awsProviderVersion %>"
       configuration_aliases = [aws.us_east_1]
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "<%- randomProviderVersion %>"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
+++ b/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
@@ -18,7 +18,7 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants';
-import { PY_VERSIONS } from '../versions';
+import { PY_VERSIONS, terraformProviderVersions } from '../versions';
 
 export interface AddWebsiteInfraOptions {
   websiteProjectName: string;
@@ -129,7 +129,11 @@ const addWebsiteTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'core'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core'),
-    { ...options, boto3Version: PY_VERSIONS.boto3 },
+    {
+      ...options,
+      boto3Version: PY_VERSIONS.boto3,
+      ...terraformProviderVersions(),
+    },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -139,7 +143,7 @@ const addWebsiteTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'app'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'app'),
-    options,
+    { ...options, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -6,6 +6,7 @@ import {
   TS_VERSIONS,
   PY_VERSIONS,
   VENDORED_VERSIONS,
+  TERRAFORM_VERSIONS,
 } from '../packages/nx-plugin/src/utils/versions';
 import {
   mkdtempSync,
@@ -151,6 +152,63 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
   });
 
   console.log('Updated Python versions:', updatedVersions);
+  return updatedVersions;
+};
+
+/**
+ * Compares two `major.minor.patch` version strings.
+ * @returns positive if a > b, negative if a < b, zero if equal
+ */
+const compareSemver = (a: string, b: string): number => {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) {
+      return pa[i] - pb[i];
+    }
+  }
+  return 0;
+};
+
+/**
+ * Gets updated Terraform provider versions by querying the Terraform Registry.
+ * Each provider is pinned to the latest stable release within its current major
+ * version (e.g. `6.52.0` may bump to `6.61.0`, but never to `7.x`).
+ * @returns Updated versions mapping
+ */
+const getUpdatedTerraformVersions = async (): Promise<
+  Record<string, string>
+> => {
+  const updatedVersions: Record<string, string> = {};
+
+  for (const [provider, currentVersion] of Object.entries(TERRAFORM_VERSIONS)) {
+    const major = Number(currentVersion.split('.')[0]);
+
+    // Fetch all published versions for the provider
+    const response = await fetch(
+      `https://registry.terraform.io/v1/providers/hashicorp/${provider}/versions`,
+    );
+    const { versions } = (await response.json()) as {
+      versions: { version: string }[];
+    };
+
+    // Find the latest stable release within the current major version
+    let latest = currentVersion;
+    for (const { version } of versions) {
+      // Only consider stable `major.minor.patch` releases (no pre-release tags)
+      const parsed = version.match(/^(\d+)\.\d+\.\d+$/);
+      if (!parsed || Number(parsed[1]) !== major) {
+        continue;
+      }
+      if (compareSemver(version, latest) > 0) {
+        latest = version;
+      }
+    }
+
+    updatedVersions[provider] = latest;
+  }
+
+  console.log('Updated Terraform versions:', updatedVersions);
   return updatedVersions;
 };
 
@@ -331,6 +389,18 @@ const main = async () => {
       'PY_VERSIONS',
     );
 
+    // Get updated Terraform provider versions
+    const updatedTerraformVersions = await getUpdatedTerraformVersions();
+
+    // Apply updated Terraform provider versions to the versions file
+    const terraformChanges = await applyUpdatedVersions(
+      tree,
+      TERRAFORM_VERSIONS,
+      updatedTerraformVersions,
+      'packages/nx-plugin/src/utils/versions.ts',
+      'TERRAFORM_VERSIONS',
+    );
+
     // Update vendored git-secrets
     const gitSecretsChange = await updateGitSecrets(tree);
     const vendoredChanges: VersionChange[] = gitSecretsChange
@@ -348,6 +418,7 @@ const main = async () => {
     writeReport([
       { title: 'TypeScript Dependencies', changes: tsChanges },
       { title: 'Python Dependencies', changes: pyChanges },
+      { title: 'Terraform Providers', changes: terraformChanges },
       ...(vendoredChanges.length > 0
         ? [{ title: 'Vendored Tools', changes: vendoredChanges }]
         : []),


### PR DESCRIPTION
### Reason for this change

Terraform templates hardcoded the AWS provider version (`~> 6.52`, plus a `~> 6.33` outlier) and other hashicorp provider constraints across ~22 `.tf.template` files. There was no single source of truth for these versions, and the weekly version-upgrade workflow had no way to keep the Terraform provider versions current the way it does for `TS_VERSIONS` (npm) and `PY_VERSIONS` (PyPI).

### Description of changes

- **New `TERRAFORM_VERSIONS` constant** in `packages/nx-plugin/src/utils/versions.ts`, alongside `TS_VERSIONS` / `PY_VERSIONS`, covering every hashicorp provider used by the templates (`aws`, `random`, `null`, `archive`, `external`, `local`). Providers are **pinned exactly** (e.g. `aws: '6.52.0'`, no range operator) so generated infrastructure is reproducible — mirroring how `PY_VERSIONS` pins exact versions. Added a `terraformProviderVersions()` helper that maps the constant to EJS substitution variables.
- **Templates** — replaced every hardcoded `version = "..."` inside `required_providers` blocks with `version = "<%- xxxProviderVersion %>"`, rendering to an exact pin such as `version = "6.52.0"`.
- **Generators** — threaded `...terraformProviderVersions()` into the substitution object of all `generateFiles` calls that emit provider-block templates (terraform project generator + the api/function/agent-core/rdb/website/identity/dynamodb/shared constructs).
- **Version upgrade workflow** — `scripts/update-versions.ts` now queries the Terraform Registry (`/v1/providers/hashicorp/<name>/versions`) and pins each provider to the **latest stable release within its current major version** (e.g. `6.52.0` may bump to `6.61.0`, but never to `7.x`), applying the change via the existing GritQL rewrite and reporting it under a new "Terraform Providers" section. No change to `update-versions.yml` was needed since it already runs this script.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test -u` — all unit tests pass; snapshots updated, verified to contain **only** provider-version line changes (every `~> X.Y` constraint replaced with an exact `X.Y.Z` pin).
- `pnpm nx run @aws/nx-plugin:compile`, `lint`, and `build` pass.
- Verified the registry resolver end-to-end against the live Terraform Registry (returns exact latest-stable-within-major pins) and confirmed GritQL correctly rewrites the version strings in `versions.ts`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
