### PR TITLE
ci: cache npm/yarn downloads and shallow-clone smoke tests

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -131,6 +131,32 @@ runs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
+    # Smoke tests generate workspaces that install with npm and yarn, hitting
+    # the public registry uncached on every run. Persist their download caches
+    # (keyed on the versions the generators pin) to avoid re-downloading.
+    - name: Get npm/yarn cache directories
+      id: pm-cache
+      shell: bash
+      run: |
+        echo "NPM_PATH=$(npm config get cache)" >> $GITHUB_OUTPUT
+        echo "YARN_CLASSIC_PATH=${HOME}/.cache/yarn" >> $GITHUB_OUTPUT
+        echo "YARN_BERRY_PATH=${HOME}/.yarn/berry/cache" >> $GITHUB_OUTPUT
+    - uses: actions/cache@v4
+      name: Setup npm cache
+      with:
+        path: ${{ steps.pm-cache.outputs.NPM_PATH }}
+        key: ${{ runner.os }}-npm-cache-${{ hashFiles('packages/nx-plugin/src/utils/versions.ts') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-cache-
+    - uses: actions/cache@v4
+      name: Setup yarn cache
+      with:
+        path: |
+          ${{ steps.pm-cache.outputs.YARN_CLASSIC_PATH }}
+          ${{ steps.pm-cache.outputs.YARN_BERRY_PATH }}
+        key: ${{ runner.os }}-yarn-cache-${{ hashFiles('packages/nx-plugin/src/utils/versions.ts') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-cache-
     - name: Update NPM
       if: ${{ runner.os != 'Windows' }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Smoke tests run a fixed test, not `nx affected`, so they don't need
+          # git history.
+          fetch-depth: 1
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -140,7 +142,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Smoke tests run a fixed test, not `nx affected`, so they don't need
+          # git history.
+          fetch-depth: 1
       - name: Disable Windows Defender real-time monitoring
         run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Download build artifacts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,7 +94,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Smoke tests run a fixed test, not `nx affected`, so they don't need
+          # git history.
+          fetch-depth: 1
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -123,7 +125,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Smoke tests run a fixed test, not `nx affected`, so they don't need
+          # git history.
+          fetch-depth: 1
       - name: Disable Windows Defender real-time monitoring
         run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Download build artifacts


### PR DESCRIPTION
### Reason for this change

Smoke test jobs are the long pole of PR/CI runs. Investigating step-level timings on a recent run, the slowest matrix jobs (notably `npm` at ~16m) are dominated by **repeated package downloads**: smoke tests generate a fresh workspace and install it with the target package manager, hitting the public registry **uncached on every run**. The pnpm store is already cached in `init-monorepo` (logs show `reused 1916` of 1919), but npm and yarn get no cache and re-download every tarball.

Two avenues, both low-risk:
1. Cache the npm and yarn download directories like pnpm's store already is.
2. Smoke test jobs check out with `fetch-depth: 0` (full history) but run a **fixed** test rather than `nx affected`, so they don't need history.

### Description of changes

- **`init-monorepo` action**: add `actions/cache` entries for the npm cache dir (`npm config get cache`) and the yarn classic + berry global cache dirs, keyed on `packages/nx-plugin/src/utils/versions.ts` (the file that pins what the generators install into test workspaces) with a prefix `restore-keys` fallback for broad hits.
- **`pr.yml` / `ci.yml`**: switch the Linux and Windows smoke test job checkouts to `fetch-depth: 1`. The package/build/release jobs keep `fetch-depth: 0` (nx-set-shas and release tagging need history).

Note: bun is intentionally **not** cached — the e2e `global-setup.ts` disables bun's install cache (`[install.cache] disable = true`), so a cache would never be populated.

### Description of how you validated changes

- Validated all three YAML files parse (`js-yaml`).
- Confirmed `fetch-depth` changes are scoped correctly: only the four smoke test checkouts changed to `1`; package/build/release remain `0`.
- Cache effectiveness will be confirmed by watching this PR's smoke test timings (first run primes the cache; the effect compounds on subsequent runs).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*