### PR TITLE
fix(ts#rdb): retry Postgres migration on P1010 IAM auth propagation delay

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -298,6 +298,7 @@ const transientErrorPatterns = [
   'P1000', // Prisma: authentication failed
   'P1001', // Prisma: can't reach database server
   'P1002', // Prisma: database server reached but timed out
+  'P1010', // Prisma: user denied access (IAM auth grant not yet propagated)
   'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
 ];
 
@@ -4106,6 +4107,7 @@ const transientErrorPatterns = [
   'P1000', // Prisma: authentication failed
   'P1001', // Prisma: can't reach database server
   'P1002', // Prisma: database server reached but timed out
+  'P1010', // Prisma: user denied access (IAM auth grant not yet propagated)
   'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
 ];
 

--- a/packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template
@@ -97,6 +97,7 @@ const transientErrorPatterns = [
   'P1000', // Prisma: authentication failed
   'P1001', // Prisma: can't reach database server
   'P1002', // Prisma: database server reached but timed out
+  'P1010', // Prisma: user denied access (IAM auth grant not yet propagated)
   'ER_ACCESS_DENIED_ERROR', // MySQL: access denied
 ];
 


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy-rdb` smoke test failed during deployment when the Postgres database migration custom resource ran:

```
PostgresDbMigrationTrigger ... CREATE_FAILED
Error: Command failed: npx prisma migrate deploy
Error: P1010: User was denied access on the database `(not available)`
```

The Postgres migration handler connects using **IAM database authentication**. Immediately after the create-db-user custom resource grants `rds_iam` to the new role, the IAM auth permission can take tens of seconds to propagate before RDS accepts an auth token. During that window Prisma returns `P1010` (user denied access).

The migration is already wrapped in `withConnectionRetry` for exactly this kind of propagation delay, but the retry only fires for errors matching `transientErrorPatterns` — which did **not** include `P1010`. So the migration failed on its first attempt instead of retrying (the CI log shows zero retry attempts).

The MySQL migration was unaffected: it authenticates with a password from the admin secret (no IAM propagation delay), and its denial code `ER_ACCESS_DENIED_ERROR` was already covered. In the failing run, both migration triggers started at the same instant and MySQL completed successfully while Postgres failed.

### Description of changes

Added `P1010` to `transientErrorPatterns` in `packages/nx-plugin/src/ts/rdb/files/src/utils.ts.template` so the Postgres migration retries until the IAM grant propagates. Updated the generator snapshots accordingly.

### Description of how you validated changes

Ran the rdb generator unit tests (snapshots regenerated). The deploy smoke test that exercises this path (`cdk-deploy-rdb`) runs on push to `main`, so it will be validated on merge.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*