### PR TITLE
feat(nx-plugin): add preferInstallDependencies option to defer installs when batching generators

### DIFF
--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -44,16 +44,16 @@
       "zh": "要连接到的目标组件（组件名称、相对于目标项目根目录的路径或生成器 ID）。使用 '.' 显式选择项目作为目标。",
       "vi": "Component đích để kết nối tới (tên component, đường dẫn tương đối so với thư mục gốc của dự án đích, hoặc generator id). Sử dụng '.' để chọn rõ ràng dự án làm đích."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "license": {
@@ -90,16 +90,16 @@
       "zh": "配置一个 license-check 目标，当依赖项声明的许可证不在配置的允许列表中时失败。",
       "vi": "Cấu hình một target license-check sẽ thất bại khi các dependency khai báo giấy phép nằm ngoài danh sách cho phép đã cấu hình."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator cùng lúc (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "open-api#ts-client": {
@@ -125,16 +125,16 @@
       "vi": "Đường dẫn đến thư mục nơi tạo client tương đối so với thư mục gốc của monorepo",
       "zh": "生成客户端的目标目录相对于 monorepo 根目录的路径"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "open-api#ts-hooks": {
@@ -160,16 +160,16 @@
       "zh": "生成 hooks 的目录相对于 monorepo 根目录的路径",
       "vi": "Đường dẫn đến thư mục nơi tạo các hooks tương đối so với thư mục gốc của monorepo"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装(如果后续生成器需要计算 Nx 项目图,仍会运行安装);最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "open-api#ts-metadata": {
@@ -195,16 +195,16 @@
       "zh": "生成元数据的目录相对于 monorepo 根目录的路径",
       "vi": "Đường dẫn đến thư mục nơi tạo metadata tương đối so với thư mục gốc của monorepo"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装(如果后续生成器需要计算 Nx 项目图,仍会运行安装);最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "preset": {
@@ -252,16 +252,16 @@
       "it": "Se configurare il Plugin Nx per il server AWS MCP per l'uso da parte di agenti di codifica.",
       "vi": "Có cấu hình Nx Plugin cho AWS MCP server để sử dụng bởi các coding agent hay không."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#agent": {
@@ -342,16 +342,16 @@
       "zh": "用于托管 Agent 的基础设施类型。",
       "it": "Il tipo di infrastruttura per ospitare il tuo Agent."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện hàng loạt nhiều generator, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam computar o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#agent#a2a-connection": {
@@ -399,16 +399,16 @@
       "it": "Il nome del componente dell'agent A2A target",
       "vi": "Tên component của agent A2A đích"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán đồ thị dự án Nx); cài đặt một lần vào cuối."
     }
   },
   "py#agent#mcp-connection": {
@@ -456,16 +456,16 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component của MCP server"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam computar o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#agent#react-connection": {
@@ -513,16 +513,16 @@
       "zh": "agent 组件名称",
       "vi": "Tên component của agent"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#api": {
@@ -625,16 +625,16 @@
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "py#fast-api": {
@@ -726,16 +726,16 @@
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại cơ sở hạ tầng được sử dụng để triển khai API này."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy xong hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán project graph của Nx); cài đặt một lần vào cuối."
     }
   },
   "py#lambda-function": {
@@ -805,16 +805,16 @@
       "zh": "首选的 IaC 提供商。默认情况下,这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#mcp-server": {
@@ -873,16 +873,16 @@
       "zh": "托管 MCP 服务器的基础设施类型。选择 none 表示不托管。",
       "vi": "Loại hạ tầng để lưu trữ MCP server của bạn. Chọn none để không có lưu trữ."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#project": {
@@ -941,16 +941,16 @@
       "pt": "Se o projeto é uma aplicação ou biblioteca",
       "vi": "Dự án là ứng dụng hay thư viện"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator cùng lúc (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "smithy#project": {
@@ -1009,16 +1009,16 @@
       "zh": "Smithy 项目放置的子目录。默认为项目名称。",
       "vi": "Thư mục con nơi dự án Smithy được đặt. Mặc định là tên dự án."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 실행할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "terraform#project": {
@@ -1066,16 +1066,16 @@
       "zh": "项目所在的子目录。默认为项目名称。",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy xong hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#agent": {
@@ -1156,16 +1156,16 @@
       "zh": "用于托管 Agent 的基础设施类型。",
       "vi": "Loại hạ tầng để lưu trữ Agent của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#agent#a2a-connection": {
@@ -1213,16 +1213,16 @@
       "zh": "目标 A2A agent 组件名称",
       "vi": "Tên component của agent A2A đích"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。"
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#agent#mcp-connection": {
@@ -1270,16 +1270,16 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component của MCP server"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam computar o grafo de projetos Nx); instale uma vez no final.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#agent#react-connection": {
@@ -1327,16 +1327,16 @@
       "zh": "Agent 组件名称",
       "vi": "Tên của Agent component"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#api": {
@@ -1439,16 +1439,16 @@
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#astro-docs": {
@@ -1507,16 +1507,16 @@
       "it": "Escludere il plugin `starlight-blog` e il post del blog di esempio.",
       "vi": "Từ chối plugin `starlight-blog` và bài viết blog mẫu."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy xong hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#docs": {
@@ -1586,16 +1586,16 @@
       "zh": "选择退出 `starlight-blog` 插件和示例博客文章。",
       "vi": "Từ chối plugin `starlight-blog` và bài viết blog mẫu."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 실행할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#infra": {
@@ -1643,16 +1643,16 @@
       "zh": "为多环境 CDK 部署启用集中式阶段配置（凭证、账户、区域）。",
       "vi": "Bật cấu hình stage tập trung (thông tin xác thực, tài khoản, vùng) cho triển khai CDK đa môi trường."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 실행할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#lambda-function": {
@@ -1722,16 +1722,16 @@
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#mcp-server": {
@@ -1790,16 +1790,16 @@
       "vi": "Loại hạ tầng để lưu trữ MCP server của bạn. Chọn none để không có lưu trữ.",
       "zh": "托管 MCP 服务器的基础设施类型。选择 none 表示不托管。"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam computar o grafo de projetos do Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "ts#nx-generator": {
@@ -1847,16 +1847,16 @@
       "zh": "插件项目源文件夹中用于添加生成器的目录（默认：<name>）",
       "vi": "Thư mục trong thư mục nguồn của dự án plugin để thêm generator vào (mặc định: <name>)"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#nx-plugin": {
@@ -1893,16 +1893,16 @@
       "zh": "库所放置的子目录。默认情况下，这是库的名称。",
       "vi": "Thư mục con nơi thư viện được đặt. Mặc định đây là tên thư viện."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực thi nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos do Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator cùng lúc (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#project": {
@@ -1939,16 +1939,16 @@
       "it": "La sotto-directory in cui viene posizionata la libreria. Per impostazione predefinita corrisponde al nome della libreria.",
       "vi": "Thư mục con nơi thư viện được đặt. Mặc định đây là tên thư viện."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực thi nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên ưu tiên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#rdb": {
@@ -2051,16 +2051,16 @@
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare a false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#rdb#agent-connection": {
@@ -2097,16 +2097,16 @@
       "zh": "代理组件名称",
       "vi": "Tên component agent"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#rdb#mcp-server-connection": {
@@ -2143,16 +2143,16 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#rdb#smithy-connection": {
@@ -2178,16 +2178,16 @@
       "it": "Il progetto ts#rdb a cui connettersi",
       "vi": "Dự án ts#rdb để kết nối tới"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar vários geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#rdb#trpc-connection": {
@@ -2213,16 +2213,16 @@
       "vi": "Dự án ts#rdb để kết nối tới",
       "zh": "要连接到的目标 ts#rdb 项目"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#react-website": {
@@ -2303,16 +2303,16 @@
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn.",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar vários geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos do Nx); instale uma vez no final.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#react-website#auth": {
@@ -2360,16 +2360,16 @@
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#react-website#runtime-config": {
@@ -2384,16 +2384,16 @@
       "it": "Il progetto di destinazione.",
       "vi": "Dự án đích."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#smithy-api": {
@@ -2485,16 +2485,16 @@
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "ts#trpc-api": {
@@ -2575,16 +2575,16 @@
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam computar o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#website": {
@@ -2687,16 +2687,16 @@
       "zh": "首选的 IaC 提供商。默认情况下,这将继承您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#website#auth": {
@@ -2744,16 +2744,16 @@
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#dynamodb": {
@@ -2834,16 +2834,16 @@
       "zh": "用于 DynamoDB 实体的框架。",
       "vi": "Framework sử dụng cho các entity DynamoDB."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 실행할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#dynamodb#trpc-connection": {
@@ -2869,16 +2869,16 @@
       "it": "Il progetto ts#dynamodb a cui connettersi",
       "vi": "Dự án ts#dynamodb để kết nối tới"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#dynamodb#smithy-connection": {
@@ -2904,16 +2904,16 @@
       "zh": "要连接到的 ts#dynamodb 项目",
       "vi": "Dự án ts#dynamodb để kết nối tới"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "ts#dynamodb#agent-connection": {
@@ -2950,16 +2950,16 @@
       "zh": "agent 组件名称",
       "vi": "Tên component agent"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos do Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치하세요.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#dynamodb#mcp-server-connection": {
@@ -2996,16 +2996,16 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치하세요.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar vários geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#agent#gateway-connection": {
@@ -3053,16 +3053,16 @@
       "zh": "目标项目中的 gateway 组件",
       "vi": "Component gateway trong dự án đích"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al procesar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#agent#gateway-connection": {
@@ -3110,16 +3110,16 @@
       "vi": "Component gateway trong dự án đích",
       "zh": "目标项目中的 gateway 组件"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "jp": "ジェネレータ実行後に依存関係をインストールするかどうか。複数のジェネレータをバッチ処理する場合はfalseに設定し、最後のジェネレータのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "agentcore-gateway": {
@@ -3211,16 +3211,16 @@
       "zh": "托管网关的基础设施类型。选择 none 表示不托管。",
       "vi": "Loại hạ tầng để lưu trữ gateway của bạn. Chọn none để không lưu trữ."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos do Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "agentcore-gateway#mcp-connection": {
@@ -3268,16 +3268,16 @@
       "zh": "目标项目中的 MCP 服务器组件",
       "vi": "Component MCP server trong dự án đích"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#dynamodb": {
@@ -3358,16 +3358,16 @@
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán đồ thị dự án Nx); cài đặt một lần vào cuối."
     }
   },
   "py#dynamodb#fast-api-connection": {
@@ -3393,16 +3393,16 @@
       "zh": "要连接到的目标 py#dynamodb 项目",
       "vi": "Dự án py#dynamodb để kết nối tới"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que os geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치하세요.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán đồ thị dự án Nx); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "py#dynamodb#agent-connection": {
@@ -3439,16 +3439,16 @@
       "zh": "agent 组件名称",
       "vi": "Tên component agent"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán đồ thị dự án Nx); cài đặt một lần vào cuối."
     }
   },
   "py#dynamodb#mcp-server-connection": {
@@ -3485,16 +3485,16 @@
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện hàng loạt nhiều generator, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번만 설치합니다.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo del progetto Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán đồ thị dự án Nx); cài đặt một lần vào cuối."
     }
   },
   "agentcore-gateway#gateway-connection": {
@@ -3542,81 +3542,81 @@
       "it": "Il componente gateway nel progetto di destinazione",
       "vi": "Component gateway trong dự án đích"
     },
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "license#sync": {
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên ưu tiên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "py#fast-api#react-connection": {
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 실행할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "smithy#react-connection": {
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir à false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "ts#sync": {
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
-      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
-      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#trpc-api#react-connection": {
-    "installDependencies": {
-      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
-      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
-      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
-      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
-      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
-      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。",
-      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
-      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
-      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    "preferInstallDependencies": {
+      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合は false に設定します（後続のジェネレーターが Nx プロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
+      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
+      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
+      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
+      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
+      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
+      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
+      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   }
 }

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -43,6 +43,17 @@
       "fr": "Le composant cible auquel se connecter (nom du composant, chemin relatif à la racine du projet cible, ou identifiant du générateur). Utilisez '.' pour sélectionner explicitement le projet comme cible.",
       "zh": "要连接到的目标组件（组件名称、相对于目标项目根目录的路径或生成器 ID）。使用 '.' 显式选择项目作为目标。",
       "vi": "Component đích để kết nối tới (tên component, đường dẫn tương đối so với thư mục gốc của dự án đích, hoặc generator id). Sử dụng '.' để chọn rõ ràng dự án làm đích."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "license": {
@@ -78,6 +89,17 @@
       "it": "Configura un target license-check che fallisce quando le dipendenze dichiarano licenze al di fuori della lista consentita configurata.",
       "zh": "配置一个 license-check 目标，当依赖项声明的许可证不在配置的允许列表中时失败。",
       "vi": "Cấu hình một target license-check sẽ thất bại khi các dependency khai báo giấy phép nằm ngoài danh sách cho phép đã cấu hình."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "open-api#ts-client": {
@@ -102,6 +124,17 @@
       "it": "Percorso della directory in cui generare il client relativo alla radice del monorepo",
       "vi": "Đường dẫn đến thư mục nơi tạo client tương đối so với thư mục gốc của monorepo",
       "zh": "生成客户端的目标目录相对于 monorepo 根目录的路径"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "open-api#ts-hooks": {
@@ -126,6 +159,17 @@
       "it": "Percorso della directory in cui generare gli hooks relativo alla radice del monorepo",
       "zh": "生成 hooks 的目录相对于 monorepo 根目录的路径",
       "vi": "Đường dẫn đến thư mục nơi tạo các hooks tương đối so với thư mục gốc của monorepo"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "open-api#ts-metadata": {
@@ -150,6 +194,17 @@
       "fr": "Chemin vers le répertoire dans lequel générer les métadonnées relatif à la racine du monorepo",
       "zh": "生成元数据的目录相对于 monorepo 根目录的路径",
       "vi": "Đường dẫn đến thư mục nơi tạo metadata tương đối so với thư mục gốc của monorepo"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "preset": {
@@ -196,6 +251,17 @@
       "zh": "是否配置 Nx Plugin for AWS MCP server 以供编码代理使用。",
       "it": "Se configurare il Plugin Nx per il server AWS MCP per l'uso da parte di agenti di codifica.",
       "vi": "Có cấu hình Nx Plugin cho AWS MCP server để sử dụng bởi các coding agent hay không."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#agent": {
@@ -275,6 +341,17 @@
       "vi": "Loại hạ tầng để lưu trữ Agent của bạn.",
       "zh": "用于托管 Agent 的基础设施类型。",
       "it": "Il tipo di infrastruttura per ospitare il tuo Agent."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện hàng loạt nhiều generator, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#agent#a2a-connection": {
@@ -321,6 +398,17 @@
       "zh": "目标 A2A agent 组件名称",
       "it": "Il nome del componente dell'agent A2A target",
       "vi": "Tên component của agent A2A đích"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#agent#mcp-connection": {
@@ -367,6 +455,17 @@
       "fr": "Le nom du composant serveur MCP",
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component của MCP server"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
     }
   },
   "py#agent#react-connection": {
@@ -413,6 +512,17 @@
       "it": "Il nome del componente dell'agent",
       "zh": "agent 组件名称",
       "vi": "Tên component của agent"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo."
     }
   },
   "py#api": {
@@ -514,6 +624,17 @@
       "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#fast-api": {
@@ -604,6 +725,17 @@
       "fr": "Le type d'infrastructure à utiliser pour déployer cette API.",
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại cơ sở hạ tầng được sử dụng để triển khai API này."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#lambda-function": {
@@ -672,6 +804,17 @@
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "zh": "首选的 IaC 提供商。默认情况下,这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#mcp-server": {
@@ -729,6 +872,17 @@
       "it": "Il tipo di infrastruttura per ospitare il tuo server MCP. Seleziona none per nessun hosting.",
       "zh": "托管 MCP 服务器的基础设施类型。选择 none 表示不托管。",
       "vi": "Loại hạ tầng để lưu trữ MCP server của bạn. Chọn none để không có lưu trữ."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#project": {
@@ -786,6 +940,17 @@
       "it": "Se il progetto è un'applicazione o una libreria",
       "pt": "Se o projeto é uma aplicação ou biblioteca",
       "vi": "Dự án là ứng dụng hay thư viện"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
     }
   },
   "smithy#project": {
@@ -843,6 +1008,17 @@
       "it": "La sotto-directory in cui viene posizionato il progetto Smithy. Per impostazione predefinita corrisponde al nome del progetto.",
       "zh": "Smithy 项目放置的子目录。默认为项目名称。",
       "vi": "Thư mục con nơi dự án Smithy được đặt. Mặc định là tên dự án."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "terraform#project": {
@@ -889,6 +1065,17 @@
       "pt": "O subdiretório onde o projeto é colocado. Por padrão, este é o nome do projeto.",
       "zh": "项目所在的子目录。默认为项目名称。",
       "vi": "Thư mục con mà dự án được đặt trong đó. Mặc định đây là tên dự án."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#agent": {
@@ -968,6 +1155,17 @@
       "it": "Il tipo di infrastruttura per ospitare il tuo Agent.",
       "zh": "用于托管 Agent 的基础设施类型。",
       "vi": "Loại hạ tầng để lưu trữ Agent của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#agent#a2a-connection": {
@@ -1014,6 +1212,17 @@
       "it": "Il nome del componente dell'agent A2A target",
       "zh": "目标 A2A agent 组件名称",
       "vi": "Tên component của agent A2A đích"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。"
     }
   },
   "ts#agent#mcp-connection": {
@@ -1060,6 +1269,17 @@
       "it": "Il nome del componente server MCP",
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component của MCP server"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#agent#react-connection": {
@@ -1106,6 +1326,17 @@
       "it": "Il nome del componente Agent",
       "zh": "Agent 组件名称",
       "vi": "Tên của Agent component"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#api": {
@@ -1207,6 +1438,17 @@
       "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo."
     }
   },
   "ts#astro-docs": {
@@ -1265,16 +1507,16 @@
       "it": "Escludere il plugin `starlight-blog` e il post del blog di esempio.",
       "vi": "Từ chối plugin `starlight-blog` và bài viết blog mẫu."
     },
-    "skipInstall": {
-      "en": "Skip installing dependencies after the generator runs.",
-      "es": "Omitir la instalación de dependencias después de ejecutar el generador.",
-      "fr": "Ignorer l'installation des dépendances après l'exécution du générateur.",
-      "pt": "Ignorar a instalação de dependências após a execução do gerador.",
-      "jp": "ジェネレーター実行後の依存関係のインストールをスキップする。",
-      "ko": "생성기 실행 후 의존성 설치를 건너뜁니다.",
-      "zh": "生成器运行后跳过安装依赖项。",
-      "it": "Salta l'installazione delle dipendenze dopo l'esecuzione del generatore.",
-      "vi": "Bỏ qua cài đặt các dependencies sau khi generator chạy."
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#docs": {
@@ -1344,16 +1586,16 @@
       "zh": "选择退出 `starlight-blog` 插件和示例博客文章。",
       "vi": "Từ chối plugin `starlight-blog` và bài viết blog mẫu."
     },
-    "skipInstall": {
-      "en": "Skip installing dependencies after the generator runs.",
-      "pt": "Pular a instalação de dependências após a execução do gerador.",
-      "fr": "Ignorer l'installation des dépendances après l'exécution du générateur.",
-      "ko": "생성기 실행 후 의존성 설치를 건너뜁니다.",
-      "es": "Omitir la instalación de dependencias después de ejecutar el generador.",
-      "jp": "ジェネレーター実行後の依存関係のインストールをスキップする。",
-      "it": "Salta l'installazione delle dipendenze dopo l'esecuzione del generatore.",
-      "zh": "生成器运行后跳过安装依赖项。",
-      "vi": "Bỏ qua cài đặt dependencies sau khi generator chạy."
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#infra": {
@@ -1400,6 +1642,17 @@
       "fr": "Active la configuration centralisée des stages (identifiants, compte, région) pour les déploiements CDK multi-environnements.",
       "zh": "为多环境 CDK 部署启用集中式阶段配置（凭证、账户、区域）。",
       "vi": "Bật cấu hình stage tập trung (thông tin xác thực, tài khoản, vùng) cho triển khai CDK đa môi trường."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#lambda-function": {
@@ -1468,6 +1721,17 @@
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#mcp-server": {
@@ -1525,6 +1789,17 @@
       "fr": "Le type d'infrastructure pour héberger votre serveur MCP. Sélectionnez none pour aucun hébergement.",
       "vi": "Loại hạ tầng để lưu trữ MCP server của bạn. Chọn none để không có lưu trữ.",
       "zh": "托管 MCP 服务器的基础设施类型。选择 none 表示不托管。"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
     }
   },
   "ts#nx-generator": {
@@ -1571,6 +1846,17 @@
       "it": "La directory all'interno della cartella sorgente del progetto plugin in cui aggiungere il generatore (predefinito: <name>)",
       "zh": "插件项目源文件夹中用于添加生成器的目录（默认：<name>）",
       "vi": "Thư mục trong thư mục nguồn của dự án plugin để thêm generator vào (mặc định: <name>)"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#nx-plugin": {
@@ -1606,6 +1892,17 @@
       "it": "La sotto-directory in cui viene posizionata la libreria. Per impostazione predefinita corrisponde al nome della libreria.",
       "zh": "库所放置的子目录。默认情况下，这是库的名称。",
       "vi": "Thư mục con nơi thư viện được đặt. Mặc định đây là tên thư viện."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực thi nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#project": {
@@ -1641,6 +1938,17 @@
       "zh": "库所放置的子目录。默认情况下，这是库的名称。",
       "it": "La sotto-directory in cui viene posizionata la libreria. Per impostazione predefinita corrisponde al nome della libreria.",
       "vi": "Thư mục con nơi thư viện được đặt. Mặc định đây là tên thư viện."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establézcalo en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực thi nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#rdb": {
@@ -1742,6 +2050,17 @@
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare a false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#rdb#agent-connection": {
@@ -1777,6 +2096,17 @@
       "it": "Il nome del componente agent",
       "zh": "代理组件名称",
       "vi": "Tên component agent"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#rdb#mcp-server-connection": {
@@ -1812,6 +2142,17 @@
       "it": "Il nome del componente MCP server",
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#rdb#smithy-connection": {
@@ -1836,6 +2177,17 @@
       "zh": "要连接到的 ts#rdb 项目",
       "it": "Il progetto ts#rdb a cui connettersi",
       "vi": "Dự án ts#rdb để kết nối tới"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#rdb#trpc-connection": {
@@ -1860,6 +2212,17 @@
       "it": "Il progetto ts#rdb a cui connettersi",
       "vi": "Dự án ts#rdb để kết nối tới",
       "zh": "要连接到的目标 ts#rdb 项目"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#react-website": {
@@ -1939,6 +2302,17 @@
       "zh": "首选的 IaC 提供程序。默认情况下，这将继承您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn.",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#react-website#auth": {
@@ -1985,6 +2359,17 @@
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#react-website#runtime-config": {
@@ -1998,6 +2383,17 @@
       "zh": "目标项目。",
       "it": "Il progetto di destinazione.",
       "vi": "Dự án đích."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establece en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#smithy-api": {
@@ -2088,6 +2484,17 @@
       "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#trpc-api": {
@@ -2167,6 +2574,17 @@
       "it": "Il tipo di infrastruttura da utilizzare per distribuire questa API.",
       "zh": "用于部署此 API 的基础设施类型。",
       "vi": "Loại hạ tầng được sử dụng để triển khai API này."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。在批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#website": {
@@ -2268,6 +2686,17 @@
       "fr": "Le fournisseur IaC préféré. Par défaut, il est hérité de votre sélection initiale.",
       "zh": "首选的 IaC 提供商。默认情况下,这将继承您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。"
     }
   },
   "ts#website#auth": {
@@ -2314,6 +2743,17 @@
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "zh": "首选的 IaC 提供商。默认情况下，这继承自您的初始选择。",
       "vi": "Nhà cung cấp IaC ưa thích. Mặc định giá trị này được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#dynamodb": {
@@ -2393,6 +2833,17 @@
       "fr": "Le framework à utiliser pour les entités DynamoDB.",
       "zh": "用于 DynamoDB 实体的框架。",
       "vi": "Framework sử dụng cho các entity DynamoDB."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#dynamodb#trpc-connection": {
@@ -2417,6 +2868,17 @@
       "fr": "Le projet ts#dynamodb auquel se connecter",
       "it": "Il progetto ts#dynamodb a cui connettersi",
       "vi": "Dự án ts#dynamodb để kết nối tới"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#dynamodb#smithy-connection": {
@@ -2441,6 +2903,17 @@
       "it": "Il progetto ts#dynamodb a cui connettersi",
       "zh": "要连接到的 ts#dynamodb 项目",
       "vi": "Dự án ts#dynamodb để kết nối tới"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#dynamodb#agent-connection": {
@@ -2476,6 +2949,17 @@
       "pt": "O nome do componente agent",
       "zh": "agent 组件名称",
       "vi": "Tên component agent"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "ts#dynamodb#mcp-server-connection": {
@@ -2511,6 +2995,17 @@
       "it": "Il nome del componente MCP server",
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo."
     }
   },
   "ts#agent#gateway-connection": {
@@ -2557,6 +3052,17 @@
       "it": "Il componente gateway nel progetto di destinazione",
       "zh": "目标项目中的 gateway 组件",
       "vi": "Component gateway trong dự án đích"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#agent#gateway-connection": {
@@ -2603,6 +3109,17 @@
       "it": "Il componente gateway nel progetto di destinazione",
       "vi": "Component gateway trong dự án đích",
       "zh": "目标项目中的 gateway 组件"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "jp": "ジェネレータ実行後に依存関係をインストールするかどうか。複数のジェネレータをバッチ処理する場合はfalseに設定し、最後のジェネレータのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "agentcore-gateway": {
@@ -2693,6 +3210,17 @@
       "it": "Il tipo di infrastruttura per ospitare il tuo gateway. Seleziona none per nessun hosting.",
       "zh": "托管网关的基础设施类型。选择 none 表示不托管。",
       "vi": "Loại hạ tầng để lưu trữ gateway của bạn. Chọn none để không lưu trữ."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターでのみtrueを渡します。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "agentcore-gateway#mcp-connection": {
@@ -2739,6 +3267,17 @@
       "it": "Il componente server MCP nel progetto di destinazione",
       "zh": "目标项目中的 MCP 服务器组件",
       "vi": "Component MCP server trong dự án đích"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#dynamodb": {
@@ -2818,6 +3357,17 @@
       "zh": "首选的 IaC 提供商。默认情况下继承自您的初始选择。",
       "it": "Il provider IaC preferito. Per impostazione predefinita viene ereditato dalla selezione iniziale.",
       "vi": "Nhà cung cấp IaC ưu tiên. Mặc định được kế thừa từ lựa chọn ban đầu của bạn."
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#dynamodb#fast-api-connection": {
@@ -2842,6 +3392,17 @@
       "fr": "Le projet py#dynamodb auquel se connecter",
       "zh": "要连接到的目标 py#dynamodb 项目",
       "vi": "Dự án py#dynamodb để kết nối tới"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#dynamodb#agent-connection": {
@@ -2877,6 +3438,17 @@
       "it": "Il nome del componente agent",
       "zh": "agent 组件名称",
       "vi": "Tên component agent"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
     }
   },
   "py#dynamodb#mcp-server-connection": {
@@ -2912,6 +3484,17 @@
       "it": "Il nome del componente MCP server",
       "zh": "MCP 服务器组件名称",
       "vi": "Tên component MCP server"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện hàng loạt nhiều generator, chỉ truyền true ở generator cuối cùng."
     }
   },
   "agentcore-gateway#gateway-connection": {
@@ -2958,6 +3541,82 @@
       "zh": "目标项目中的网关组件",
       "it": "Il componente gateway nel progetto di destinazione",
       "vi": "Component gateway trong dự án đích"
+    },
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    }
+  },
+  "license#sync": {
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 처리할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establezca en false cuando agrupe múltiples generadores, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    }
+  },
+  "py#fast-api#react-connection": {
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establece en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
+    }
+  },
+  "smithy#react-connection": {
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "vi": "Có cài đặt các phụ thuộc sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    }
+  },
+  "ts#sync": {
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合は false に設定し、最後のジェネレーターでのみ true を渡します。",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "es": "Si se deben instalar las dependencias después de que se ejecute el generador. Establecer en false cuando se ejecuten múltiples generadores en lote, pasando true solo en el último.",
+      "pt": "Se deve instalar dependências após a execução do gerador. Defina como false ao executar múltiplos geradores em lote, passando true apenas no último.",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir à false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement pour le dernier.",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false，仅在最后一个生成器时传递 true。",
+      "vi": "Có cài đặt dependencies sau khi generator chạy hay không. Đặt thành false khi chạy nhiều generator liên tiếp, chỉ truyền true ở generator cuối cùng."
+    }
+  },
+  "ts#trpc-api#react-connection": {
+    "installDependencies": {
+      "en": "Whether to install dependencies after the generator runs. Set to false when batching multiple generators, passing true only on the last.",
+      "es": "Si se deben instalar las dependencias después de ejecutar el generador. Establecer en false cuando se ejecutan múltiples generadores en lote, pasando true solo en el último.",
+      "ko": "생성기 실행 후 의존성을 설치할지 여부입니다. 여러 생성기를 일괄 실행할 때는 false로 설정하고, 마지막 생성기에만 true를 전달하세요.",
+      "jp": "ジェネレーター実行後に依存関係をインストールするかどうか。複数のジェネレーターをバッチ処理する場合はfalseに設定し、最後のジェネレーターのみtrueを渡します。",
+      "it": "Se installare le dipendenze dopo l'esecuzione del generatore. Impostare su false quando si eseguono più generatori in batch, passando true solo sull'ultimo.",
+      "zh": "是否在生成器运行后安装依赖项。当批量运行多个生成器时设置为 false,仅在最后一个生成器时传递 true。",
+      "fr": "Indique s'il faut installer les dépendances après l'exécution du générateur. Définir sur false lors de l'exécution de plusieurs générateurs en lot, en passant true uniquement sur le dernier.",
+      "pt": "Se deve instalar as dependências após a execução do gerador. Defina como false ao executar vários geradores em lote, passando true apenas no último.",
+      "vi": "Có cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false khi thực hiện nhiều generator cùng lúc, chỉ truyền true ở generator cuối cùng."
     }
   }
 }

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -124,17 +124,6 @@
       "it": "Percorso della directory in cui generare il client relativo alla radice del monorepo",
       "vi": "Đường dẫn đến thư mục nơi tạo client tương đối so với thư mục gốc của monorepo",
       "zh": "生成客户端的目标目录相对于 monorepo 根目录的路径"
-    },
-    "preferInstallDependencies": {
-      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
-      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
-      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
-      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
-      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
-      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
-      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
-      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
     }
   },
   "open-api#ts-hooks": {
@@ -159,17 +148,6 @@
       "it": "Percorso della directory in cui generare gli hooks relativo alla radice del monorepo",
       "zh": "生成 hooks 的目录相对于 monorepo 根目录的路径",
       "vi": "Đường dẫn đến thư mục nơi tạo các hooks tương đối so với thư mục gốc của monorepo"
-    },
-    "preferInstallDependencies": {
-      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
-      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
-      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요(후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
-      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
-      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
-      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
-      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装(如果后续生成器需要计算 Nx 项目图,仍会运行安装);最后统一安装一次。",
-      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "open-api#ts-metadata": {
@@ -194,17 +172,6 @@
       "fr": "Chemin vers le répertoire dans lequel générer les métadonnées relatif à la racine du monorepo",
       "zh": "生成元数据的目录相对于 monorepo 根目录的路径",
       "vi": "Đường dẫn đến thư mục nơi tạo metadata tương đối so với thư mục gốc của monorepo"
-    },
-    "preferInstallDependencies": {
-      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establece en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesario para que los generadores subsiguientes puedan calcular el grafo de proyectos de Nx); instala una vez al final.",
-      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
-      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
-      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
-      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
-      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装(如果后续生成器需要计算 Nx 项目图,仍会运行安装);最后统一安装一次。",
-      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
-      "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "preset": {
@@ -3554,19 +3521,6 @@
       "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
-  "license#sync": {
-    "preferInstallDependencies": {
-      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
-      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다). 마지막에 한 번만 설치하세요.",
-      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación al ejecutar múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
-      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
-      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
-      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
-      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
-      "vi": "Có nên ưu tiên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
-    }
-  },
   "py#fast-api#react-connection": {
     "preferInstallDependencies": {
       "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
@@ -3591,19 +3545,6 @@
       "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
       "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối.",
       "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。"
-    }
-  },
-  "ts#sync": {
-    "preferInstallDependencies": {
-      "en": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "jp": "ジェネレーター実行後に依存関係のインストールを優先するかどうか。複数のジェネレーターをバッチ処理する際にインストールを延期する場合はfalseに設定します（後続のジェネレーターがNxプロジェクトグラフを計算できるよう、必要に応じてインストールは実行されます）。最後に一度だけインストールします。",
-      "ko": "생성기 실행 후 의존성 설치를 선호할지 여부입니다. 여러 생성기를 일괄 처리할 때 설치를 연기하려면 false로 설정하세요 (후속 생성기가 Nx 프로젝트 그래프를 계산할 수 있도록 필요한 경우 설치는 여전히 실행됩니다); 마지막에 한 번 설치합니다.",
-      "es": "Si se prefiere instalar las dependencias después de que se ejecute el generador. Establecer en false para diferir la instalación cuando se ejecutan múltiples generadores en lote (la instalación aún se ejecuta si es necesaria para que los generadores subsecuentes puedan calcular el grafo de proyectos de Nx); instalar una vez al final.",
-      "pt": "Se deve preferir instalar dependências após a execução do gerador. Defina como false para adiar a instalação ao executar múltiplos geradores em lote (uma instalação ainda é executada se necessário para que geradores subsequentes possam calcular o grafo de projetos Nx); instale uma vez no final.",
-      "fr": "Indique s'il faut privilégier l'installation des dépendances après l'exécution du générateur. Définir sur false pour différer l'installation lors de l'exécution de plusieurs générateurs en lot (une installation s'exécute quand même si nécessaire pour que les générateurs suivants puissent calculer le graphe de projet Nx) ; installer une seule fois à la fin.",
-      "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
-      "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
-      "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
     }
   },
   "ts#trpc-api#react-connection": {

--- a/e2e/src/smoke-tests/generator-matrix.ts
+++ b/e2e/src/smoke-tests/generator-matrix.ts
@@ -14,157 +14,176 @@ interface RunCliOpts {
  * must cover. Generators inherit the `iac` selected when the
  * workspace was created, so there's a single place to add a new generator
  * and both the `cdk-deploy` and `terraform-deploy` e2e pipelines exercise it.
+ *
+ * By default every generator runs with `--prefer-install-dependencies=false`
+ * so the dependency install happens once (via `runInstall` after the matrix)
+ * rather than after every generator. Generators still install on their own when
+ * skipping would leave a graph-critical dependency unresolvable (e.g. a website
+ * whose generated `vite.config.mts` imports `@tailwindcss/vite`), so the next
+ * generator can still compute the Nx project graph.
+ *
+ * Pass `{ preferInstallDependencies: true }` to install after every generator
+ * instead — the idempotency test needs this so lockfiles (including `uv.lock`)
+ * are fully synced before it snapshots the workspace.
  */
-export const runGeneratorMatrix = async (opts: RunCliOpts) => {
+export const runGeneratorMatrix = async (
+  opts: RunCliOpts,
+  {
+    preferInstallDependencies = false,
+  }: { preferInstallDependencies?: boolean } = {},
+) => {
+  const deferFlag = preferInstallDependencies
+    ? ''
+    : ' --prefer-install-dependencies=false';
   // Websites (with and without TanStack Router), plus auth on each.
   await runCLI(
-    `generate @aws/nx-plugin:ts#website --name=website --no-interactive`,
+    `generate @aws/nx-plugin:ts#website --name=website --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#website --name=website-no-router --tanstackRouter=false --no-interactive`,
+    `generate @aws/nx-plugin:ts#website --name=website-no-router --tanstackRouter=false --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#astro-docs --name=docs-site --no-interactive`,
+    `generate @aws/nx-plugin:ts#astro-docs --name=docs-site --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#website#auth --project=@e2e-test/website --cognitoDomain=test --no-interactive`,
+    `generate @aws/nx-plugin:ts#website#auth --project=@e2e-test/website --cognitoDomain=test --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#website#auth --project=@e2e-test/website-no-router --cognitoDomain=test-no-router --no-interactive`,
+    `generate @aws/nx-plugin:ts#website#auth --project=@e2e-test/website-no-router --cognitoDomain=test-no-router --no-interactive${deferFlag}`,
     opts,
   );
 
   // tRPC APIs — REST + HTTP variants.
   await runCLI(
-    `generate @aws/nx-plugin:ts#api --name=my-api --infra=rest-lambda --no-interactive`,
+    `generate @aws/nx-plugin:ts#api --name=my-api --infra=rest-lambda --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#api --name=my-api-http --infra=http-lambda --no-interactive`,
+    `generate @aws/nx-plugin:ts#api --name=my-api-http --infra=http-lambda --no-interactive${deferFlag}`,
     opts,
   );
 
   // tRPC APIs with Custom auth — REST + HTTP variants.
   await runCLI(
-    `generate @aws/nx-plugin:ts#api --name=my-api-custom --infra=rest-lambda --auth=custom --no-interactive`,
+    `generate @aws/nx-plugin:ts#api --name=my-api-custom --infra=rest-lambda --auth=custom --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#api --name=my-api-custom-http --infra=http-lambda --auth=custom --no-interactive`,
+    `generate @aws/nx-plugin:ts#api --name=my-api-custom-http --infra=http-lambda --auth=custom --no-interactive${deferFlag}`,
     opts,
   );
 
   // Website -> tRPC API connections
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=@e2e-test/my-api --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=@e2e-test/my-api --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website-no-router --targetProject=@e2e-test/my-api --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website-no-router --targetProject=@e2e-test/my-api --no-interactive${deferFlag}`,
     opts,
   );
 
   // Python FastAPI — REST + HTTP variants.
   await runCLI(
-    `generate @aws/nx-plugin:py#api --name=py-api --infra=rest-lambda --no-interactive`,
+    `generate @aws/nx-plugin:py#api --name=py-api --infra=rest-lambda --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#api --name=py-api-http --infra=http-lambda --no-interactive`,
+    `generate @aws/nx-plugin:py#api --name=py-api-http --infra=http-lambda --no-interactive${deferFlag}`,
     opts,
   );
 
   // Python FastAPI with Custom auth — REST + HTTP variants.
   await runCLI(
-    `generate @aws/nx-plugin:py#api --name=py-api-custom --infra=rest-lambda --auth=custom --no-interactive`,
+    `generate @aws/nx-plugin:py#api --name=py-api-custom --infra=rest-lambda --auth=custom --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#api --name=py-api-custom-http --infra=http-lambda --auth=custom --no-interactive`,
+    `generate @aws/nx-plugin:py#api --name=py-api-custom-http --infra=http-lambda --auth=custom --no-interactive${deferFlag}`,
     opts,
   );
 
   // Python project + lambda function.
   await runCLI(
-    `generate @aws/nx-plugin:py#project --name=py-project --projectType=application --no-interactive`,
+    `generate @aws/nx-plugin:py#project --name=py-project --projectType=application --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#lambda-function --project=e2e_test.py_project --name=my-function --event=Any --no-interactive`,
+    `generate @aws/nx-plugin:py#lambda-function --project=e2e_test.py_project --name=my-function --event=Any --no-interactive${deferFlag}`,
     opts,
   );
 
   // Python MCP + Strands agent (hosted on AgentCore).
   await runCLI(
-    `generate @aws/nx-plugin:py#mcp-server --project=py_project --name=my-mcp-server --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#mcp-server --project=py_project --name=my-mcp-server --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-agent --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-agent --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
 
   // TypeScript project + lambda function.
   await runCLI(
-    `generate @aws/nx-plugin:ts#project --name=ts-project --no-interactive`,
+    `generate @aws/nx-plugin:ts#project --name=ts-project --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#lambda-function --project=ts-project --name=my-function --event=Any --no-interactive`,
+    `generate @aws/nx-plugin:ts#lambda-function --project=ts-project --name=my-function --event=Any --no-interactive${deferFlag}`,
     opts,
   );
 
   // TypeScript MCP servers — uninfra'd (None) and hosted on AgentCore.
   await runCLI(
-    `generate @aws/nx-plugin:ts#mcp-server --project=ts-project --name=my-mcp-server --infra=none --no-interactive`,
+    `generate @aws/nx-plugin:ts#mcp-server --project=ts-project --name=my-mcp-server --infra=none --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#mcp-server --project=ts-project --name=hosted-mcp-server --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:ts#mcp-server --project=ts-project --name=hosted-mcp-server --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
 
   // TypeScript Strands agents — uninfra'd (None) and hosted (HTTP + A2A).
   await runCLI(
-    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-agent --infra=none --no-interactive`,
+    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-agent --infra=none --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#agent --project=ts-project --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:ts#agent --project=ts-project --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
 
   // A2A protocol agents (TypeScript + Python).
   await runCLI(
-    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-a2a-agent --protocol=a2a --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-a2a-agent --protocol=a2a --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-a2a-agent --protocol=a2a --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-a2a-agent --protocol=a2a --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
 
   // Cognito-auth variants to cover the A2A + Cognito permutation.
   await runCLI(
-    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-a2a-agent-cognito --protocol=a2a --auth=cognito --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-a2a-agent-cognito --protocol=a2a --auth=cognito --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-a2a-agent-cognito --protocol=a2a --auth=cognito --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-a2a-agent-cognito --protocol=a2a --auth=cognito --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
 
   // AG-UI protocol agents (TypeScript Strands, Python Strands, Python LangChain).
   await runCLI(
-    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-agui-agent --protocol=ag-ui --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:ts#agent --project=ts-project --name=my-ts-agui-agent --protocol=ag-ui --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-agui-agent --protocol=ag-ui --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_project --name=my-py-agui-agent --protocol=ag-ui --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   // Python LangChain agents across all three protocols, deployed on AgentCore so
@@ -174,82 +193,82 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   // `py-project/my-function` Lambda would push that Lambda past the 250 MB
   // unzipped limit, since the bundle exports the whole package's deps.
   await runCLI(
-    `generate @aws/nx-plugin:py#project --name=py-langchain-project --projectType=application --no-interactive`,
+    `generate @aws/nx-plugin:py#project --name=py-langchain-project --projectType=application --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-agent --framework=langchain --protocol=ag-ui --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-agent --framework=langchain --protocol=ag-ui --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-http-agent --framework=langchain --protocol=http --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-http-agent --framework=langchain --protocol=http --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-a2a-agent --framework=langchain --protocol=a2a --infra=agentcore --no-interactive`,
+    `generate @aws/nx-plugin:py#agent --project=py_langchain_project --name=my-py-langchain-a2a-agent --framework=langchain --protocol=a2a --infra=agentcore --no-interactive${deferFlag}`,
     opts,
   );
 
   // Website <-> FastAPI connection
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=website --targetProject=py_api --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=website --targetProject=py_api --no-interactive${deferFlag}`,
     opts,
   );
 
   // Smithy API + connection
   await runCLI(
-    `generate @aws/nx-plugin:ts#api --framework=smithy --name=my-smithy-api --no-interactive`,
+    `generate @aws/nx-plugin:ts#api --framework=smithy --name=my-smithy-api --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=website --targetProject=my-smithy-api --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=website --targetProject=my-smithy-api --no-interactive${deferFlag}`,
     opts,
   );
 
   // Agent <-> MCP server connections.
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=ts-project --targetComponent=hosted-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=ts-project --targetComponent=hosted-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=my-ts-agui-agent --targetProject=ts-project --targetComponent=hosted-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=my-ts-agui-agent --targetProject=ts-project --targetComponent=hosted-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
   // LangChain agent -> Python MCP server (langchain-mcp-adapters tool loading).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
 
   // HTTP agent <-> A2A agent connections (4 permutations)
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=ts-project --targetComponent=my-ts-a2a-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=ts-project --targetComponent=my-ts-a2a-agent --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=ts-project --targetComponent=my-ts-a2a-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=ts-project --targetComponent=my-ts-a2a-agent --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive${deferFlag}`,
     opts,
   );
   // LangChain (AG-UI) agent -> Python A2A agent: delegates to a remote agent as
   // a langchain tool (reusing the framework-agnostic A2A transport).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive${deferFlag}`,
     opts,
   );
 
@@ -257,143 +276,143 @@ export const runGeneratorMatrix = async (opts: RunCliOpts) => {
   // gateway -> ts/py mcp-server) so each smoke test exercises a deployable
   // gateway with multiple MCP server targets fronting both agent runtimes.
   await runCLI(
-    `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive`,
+    `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=@e2e-test/my-gateway --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent --targetProject=@e2e-test/my-gateway --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=@e2e-test/my-gateway --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=@e2e-test/my-gateway --no-interactive${deferFlag}`,
     opts,
   );
   // LangChain agent -> gateway (langchain gateway MCP client).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=@e2e-test/my-gateway --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-agent --targetProject=@e2e-test/my-gateway --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/my-gateway --targetProject=ts-project --targetComponent=hosted-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/my-gateway --targetProject=ts-project --targetComponent=hosted-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/my-gateway --targetProject=py_project --targetComponent=my-mcp-server --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/my-gateway --targetProject=py_project --targetComponent=my-mcp-server --no-interactive${deferFlag}`,
     opts,
   );
 
   // A parent gateway fronting my-gateway, exercising the
   // gateway -> gateway connection edge (chained gateways).
   await runCLI(
-    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive`,
+    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/parent-gateway --targetProject=@e2e-test/my-gateway --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/parent-gateway --targetProject=@e2e-test/my-gateway --no-interactive${deferFlag}`,
     opts,
   );
 
   // Website -> agent connections (TypeScript HTTP, TypeScript AG-UI, Python HTTP, Python AG-UI/CopilotKit)
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=ts-project --targetComponent=agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=ts-project --targetComponent=agent --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=ts-project --targetComponent=my-ts-agui-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=ts-project --targetComponent=my-ts-agui-agent --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_project --targetComponent=my-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_project --targetComponent=my-agent --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_project --targetComponent=my-py-agui-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_project --targetComponent=my-py-agui-agent --no-interactive${deferFlag}`,
     opts,
   );
   // Website -> Python LangChain (AG-UI/CopilotKit) agent.
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_langchain_project --targetComponent=my-py-langchain-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_langchain_project --targetComponent=my-py-langchain-agent --no-interactive${deferFlag}`,
     opts,
   );
   // Website -> Python LangChain HTTP agent (OpenAPI client, like the Strands
   // Python HTTP agent — exercises the langchain http protocol from the browser).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_langchain_project --targetComponent=my-py-langchain-http-agent --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=@e2e-test/website --targetProject=py_langchain_project --targetComponent=my-py-langchain-http-agent --no-interactive${deferFlag}`,
     opts,
   );
 
   // DynamoDB table — iacProvider inherited.
   await runCLI(
-    `generate @aws/nx-plugin:ts#dynamodb --name=my-table --no-interactive`,
+    `generate @aws/nx-plugin:ts#dynamodb --name=my-table --no-interactive${deferFlag}`,
     opts,
   );
 
   // DynamoDB connections — tRPC, Smithy, TS agent, TS MCP server.
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=my-api --targetProject=@e2e-test/my-table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=my-api --targetProject=@e2e-test/my-table --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=my-smithy-api --targetProject=@e2e-test/my-table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=my-smithy-api --targetProject=@e2e-test/my-table --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=my-ts-agent --targetProject=@e2e-test/my-table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=my-ts-agent --targetProject=@e2e-test/my-table --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=my-mcp-server --targetProject=@e2e-test/my-table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=my-mcp-server --targetProject=@e2e-test/my-table --no-interactive${deferFlag}`,
     opts,
   );
 
   // Python DynamoDB table — iacProvider inherited.
   await runCLI(
-    `generate @aws/nx-plugin:py#dynamodb --name=my-py-table --no-interactive`,
+    `generate @aws/nx-plugin:py#dynamodb --name=my-py-table --no-interactive${deferFlag}`,
     opts,
   );
 
   // Python DynamoDB connections — FastAPI, py agent, py MCP server.
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_api --targetProject=my_py_table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_api --targetProject=my_py_table --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=my_py_table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-agent --targetProject=my_py_table --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-mcp-server --targetProject=my_py_table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-mcp-server --targetProject=my_py_table --no-interactive${deferFlag}`,
     opts,
   );
   // LangChain agent -> DynamoDB table (framework-agnostic workspace + dev wiring).
   await runCLI(
-    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-http-agent --targetProject=my_py_table --no-interactive`,
+    `generate @aws/nx-plugin:connection --sourceProject=py_langchain_project --sourceComponent=my-py-langchain-http-agent --targetProject=my_py_table --no-interactive${deferFlag}`,
     opts,
   );
 
   // Relational databases (Aurora + Prisma) — PostgreSQL and MySQL, iacProvider inherited.
   await runCLI(
-    `generate @aws/nx-plugin:ts#rdb --name=postgres-db --infra=aurora --engine=postgres --framework=prisma --no-interactive`,
+    `generate @aws/nx-plugin:ts#rdb --name=postgres-db --infra=aurora --engine=postgres --framework=prisma --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#rdb --name=my-sql-db --infra=aurora --engine=mysql --framework=prisma --no-interactive`,
+    `generate @aws/nx-plugin:ts#rdb --name=my-sql-db --infra=aurora --engine=mysql --framework=prisma --no-interactive${deferFlag}`,
     opts,
   );
 
-  await runCLI(`generate @aws/nx-plugin:license --no-interactive`, opts);
+  await runCLI(`generate @aws/nx-plugin:license --no-interactive${deferFlag}`, opts);
 
   // Nx plugin + a custom generator (pure TS, not tied to IaC provider)
   await runCLI(
-    `generate @aws/nx-plugin:ts#nx-plugin --name=plugin --directory=tools --no-interactive`,
+    `generate @aws/nx-plugin:ts#nx-plugin --name=plugin --directory=tools --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#nx-generator --project=@e2e-test/plugin --name=my#generator --no-interactive`,
+    `generate @aws/nx-plugin:ts#nx-generator --project=@e2e-test/plugin --name=my#generator --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
-    `generate @e2e-test/plugin:my#generator --exampleOption=test --no-interactive`,
+    `generate @e2e-test/plugin:my#generator --exampleOption=test --no-interactive${deferFlag}`,
     opts,
   );
 };

--- a/e2e/src/smoke-tests/idempotency.spec.ts
+++ b/e2e/src/smoke-tests/idempotency.spec.ts
@@ -51,6 +51,12 @@ describe('smoke test - idempotency', () => {
         maxBuffer: 50 * 1024 * 1024,
       });
 
+    // Install after every generator (preferInstallDependencies: true) so all
+    // lockfiles — including `uv.lock`, which is only synced by an install — are
+    // complete before the baseline snapshot. Deferring would leave lockfiles
+    // partially written, and re-running would complete them, producing a diff
+    // that looks like a (false) idempotency failure.
+
     // CDK-specific infrastructure projects (mirrors runSmokeTest).
     await runCLI(
       `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive`,
@@ -62,7 +68,7 @@ describe('smoke test - idempotency', () => {
     );
 
     // First pass — scaffold the full matrix.
-    await runGeneratorMatrix(opts);
+    await runGeneratorMatrix(opts, { preferInstallDependencies: true });
 
     // Terraform project alongside CDK (mirrors runSmokeTest).
     await runCLI(
@@ -86,7 +92,7 @@ describe('smoke test - idempotency', () => {
       `generate @aws/nx-plugin:ts#infra --name=infra-with-stages --enableStageConfig=true --no-interactive`,
       opts,
     );
-    await runGeneratorMatrix(opts);
+    await runGeneratorMatrix(opts, { preferInstallDependencies: true });
     await runCLI(
       `generate @aws/nx-plugin:terraform#project --name=tf-infra --no-interactive`,
       opts,

--- a/e2e/src/smoke-tests/smoke-test.ts
+++ b/e2e/src/smoke-tests/smoke-test.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import type { PackageManager } from '@nx/devkit';
 import { ensureDirSync } from 'fs-extra';
 import { afterEach, beforeEach, describe, it } from 'vitest';
-import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, runInstall, tmpProjPath } from '../utils';
 import { runGeneratorMatrix } from './generator-matrix';
 
 export const runSmokeTest = async (
@@ -29,13 +29,18 @@ export const runSmokeTest = async (
     onProjectCreate(projectRoot);
   }
 
+  // Every generator runs with `--prefer-install-dependencies=false` to avoid a
+  // slow install after each one; `runInstall` below installs the full
+  // accumulated set once before the build. Generators still self-install when
+  // skipping would leave a graph-critical dependency unresolvable.
+
   // CDK-specific infrastructure projects (not part of the shared matrix).
   await runCLI(
-    `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive`,
+    `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive --prefer-install-dependencies=false`,
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#infra --name=infra-with-stages --enableStageConfig=true --no-interactive`,
+    `generate @aws/nx-plugin:ts#infra --name=infra-with-stages --enableStageConfig=true --no-interactive --prefer-install-dependencies=false`,
     opts,
   );
 
@@ -43,7 +48,7 @@ export const runSmokeTest = async (
 
   // Extra: generate a terraform project alongside CDK to verify both coexist.
   await runCLI(
-    `generate @aws/nx-plugin:terraform#project --name=tf-infra --no-interactive`,
+    `generate @aws/nx-plugin:terraform#project --name=tf-infra --no-interactive --prefer-install-dependencies=false`,
     opts,
   );
 
@@ -68,6 +73,9 @@ export const runSmokeTest = async (
   if (beforeBuild) {
     await beforeBuild(projectRoot);
   }
+
+  // Install the full set of dependencies accumulated across all generators.
+  await runInstall(opts);
 
   await runCLI(`sync --verbose`, opts);
   await runCLI(

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -110,8 +110,9 @@ const syncAndBuild = async (cwd: string) => {
 
 // Each generator runs in its own isolated workspace and keeps the default
 // dependency install, so the build still verifies each generator declares the
-// dependencies it needs.
-describe('smoke test - standalone projects', () => {
+// dependencies it needs. Because the workspaces are fully isolated, the cases
+// run concurrently (bounded by `maxConcurrency` in the vitest config).
+describe.concurrent('smoke test - standalone projects', () => {
   it.each(
     standalone,
   )('should generate and build $generator in isolation', async ({
@@ -127,7 +128,7 @@ describe('smoke test - standalone projects', () => {
   });
 });
 
-describe('smoke test - standalone components', () => {
+describe.concurrent('smoke test - standalone components', () => {
   it.each(
     components,
   )('should generate and build $generator on its own project', async ({

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -108,6 +108,9 @@ const syncAndBuild = async (cwd: string) => {
   );
 };
 
+// Each generator runs in its own isolated workspace and keeps the default
+// dependency install, so the build still verifies each generator declares the
+// dependencies it needs.
 describe('smoke test - standalone projects', () => {
   it.each(
     standalone,

--- a/e2e/src/smoke-tests/terraform-smoke-test.ts
+++ b/e2e/src/smoke-tests/terraform-smoke-test.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
 import { beforeEach, describe, it } from 'vitest';
-import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
+import { createTestWorkspace, runCLI, runInstall, tmpProjPath } from '../utils';
 import { runGeneratorMatrix } from './generator-matrix';
 
 /**
@@ -40,9 +40,14 @@ export const runTerraformSmokeTest = async (
     onProjectCreate(projectRoot);
   }
 
+  // Every generator runs with `--prefer-install-dependencies=false` to avoid a
+  // slow install after each one; `runInstall` below installs the full
+  // accumulated set once before the build. Generators still self-install when
+  // skipping would leave a graph-critical dependency unresolvable.
+
   // Terraform application project that wires everything together.
   await runCLI(
-    `generate @aws/nx-plugin:terraform#project --name=infra --type=application --no-interactive`,
+    `generate @aws/nx-plugin:terraform#project --name=infra --type=application --no-interactive --prefer-install-dependencies=false`,
     opts,
   );
 
@@ -61,6 +66,9 @@ export const runTerraformSmokeTest = async (
   if (beforeBuild) {
     await beforeBuild(projectRoot);
   }
+
+  // Install the full set of dependencies accumulated across all generators.
+  await runInstall(opts);
 
   await runCLI(`sync --verbose`, opts);
   await runCLI(

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -47,22 +47,44 @@ export async function runCLI(
     }`;
     const execCmd = () =>
       new Promise<string>((resolve, reject) => {
-        try {
-          const result = execSync(commandToRun, {
-            cwd: opts.cwd || tmpProjPath(),
-            env: {
-              PATH: process.env.PATH,
-              ...process.env,
-              ...opts.env,
-            },
-            encoding: 'utf-8',
-            stdio: 'inherit',
-            maxBuffer: 50 * 1024 * 1024,
-          });
-          resolve(result);
-        } catch (e) {
-          reject(e);
-        }
+        // `spawn` (not the blocking `execSync`) so multiple `runCLI` calls can
+        // run concurrently — isolated smoke-test cases overlap instead of
+        // serialising on a blocked event loop. Output is streamed through to
+        // the parent as it arrives (preserving live logs) and captured for the
+        // return value and error handling.
+        const child = spawn(commandToRun, {
+          cwd: opts.cwd || tmpProjPath(),
+          env: {
+            PATH: process.env.PATH,
+            ...process.env,
+            ...opts.env,
+          },
+          shell: true,
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout?.on('data', (chunk) => {
+          stdout += chunk;
+          process.stdout.write(chunk);
+        });
+        child.stderr?.on('data', (chunk) => {
+          stderr += chunk;
+          process.stderr.write(chunk);
+        });
+        child.on('error', reject);
+        child.on('close', (code) => {
+          if (code === 0) {
+            resolve(stdout);
+          } else {
+            const err = new Error(
+              `Command failed: ${commandToRun}\n${stderr}`,
+            ) as Error & { stdout: string; stderr: string; status: number };
+            err.stdout = stdout;
+            err.stderr = stderr;
+            err.status = code ?? 1;
+            reject(err);
+          }
+        });
       });
     const logs = await (opts.retry ? backOff(execCmd) : execCmd());
     if (opts.verbose) {

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -152,6 +152,38 @@ function getPackageManagerCommand({
 }
 
 /**
+ * Run a bare dependency install for the package manager detected in `cwd`.
+ *
+ * Used by the smoke tests, which generate every project with
+ * `--prefer-install-dependencies=false` and then install once at the end.
+ *
+ * The generators add dependencies to `package.json` without updating the
+ * lockfile, so the install must be allowed to update it. CI sets each package
+ * manager to a frozen/immutable lockfile by default, hence the explicit flags.
+ */
+export async function runInstall(opts: {
+  cwd: string;
+  env?: RunCmdOpts['env'];
+}) {
+  const pkgMgr = detectPackageManager(opts.cwd);
+  const yarnMajor = Number(getYarnMajorVersion(opts.cwd) ?? '1');
+  const command = {
+    npm: 'npm install --legacy-peer-deps',
+    pnpm: 'pnpm install --no-frozen-lockfile',
+    // Yarn Berry (>=2) treats the lockfile as immutable in CI; classic does not
+    // and rejects the `--no-immutable` flag.
+    yarn: yarnMajor >= 2 ? 'yarn install --no-immutable' : 'yarn install',
+    bun: 'bun install --no-frozen-lockfile',
+  }[pkgMgr];
+  await runCLI(command, {
+    cwd: opts.cwd,
+    env: opts.env,
+    prefixWithPackageManagerCmd: false,
+    redirectStderr: true,
+  });
+}
+
+/**
  * Remove log colors for fail proof string search
  * @param log
  * @returns

--- a/e2e/vite.config.mts
+++ b/e2e/vite.config.mts
@@ -67,6 +67,11 @@ export default defineConfig({
     reporters: [['default', { summary: false }]],
     disableConsoleIntercept: true,
     fileParallelism: false,
+    // Concurrent `it`s (e.g. the standalone smoke test's isolated cases) overlap
+    // up to this many at a time. Each case spawns an nx build that itself uses
+    // multiple cores, so keep this modest to avoid oversubscribing CI runners.
+    // Tunable via NX_E2E_MAX_CONCURRENCY.
+    maxConcurrency: Number(process.env.NX_E2E_MAX_CONCURRENCY ?? 8),
     globalSetup: 'src/global-setup.ts',
     coverage: { reportsDirectory: '../coverage/e2e', provider: 'v8' },
     pool: 'threads',

--- a/e2e/vite.config.mts
+++ b/e2e/vite.config.mts
@@ -69,9 +69,9 @@ export default defineConfig({
     fileParallelism: false,
     // Concurrent `it`s (e.g. the standalone smoke test's isolated cases) overlap
     // up to this many at a time. Each case spawns an nx build that itself uses
-    // multiple cores, so keep this modest to avoid oversubscribing CI runners.
+    // multiple cores, so the wins plateau once the runner's cores are saturated.
     // Tunable via NX_E2E_MAX_CONCURRENCY.
-    maxConcurrency: Number(process.env.NX_E2E_MAX_CONCURRENCY ?? 8),
+    maxConcurrency: Number(process.env.NX_E2E_MAX_CONCURRENCY ?? 16),
     globalSetup: 'src/global-setup.ts',
     coverage: { reportsDirectory: '../coverage/e2e', provider: 'v8' },
     pool: 'threads',

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
@@ -4,7 +4,7 @@
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
@@ -93,9 +93,10 @@ export const agentcoreGatewayGatewayConnectionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 /**

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
@@ -2,12 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-  type GeneratorCallback,
-  installPackagesTask,
-  type Tree,
-} from '@nx/devkit';
+import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
@@ -96,9 +93,9 @@ export const agentcoreGatewayGatewayConnectionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 /**

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.d.ts
@@ -9,4 +9,5 @@ export interface AgentcoreGatewayGatewayConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.json
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The gateway component in the target project"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/agentcore-gateway/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.ts
@@ -7,7 +7,6 @@ import {
   addProjectConfiguration,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type ProjectConfiguration,
@@ -17,6 +16,7 @@ import {
 import { addAgentCoreGatewayInfra } from '../utils/agent-core-constructs/agent-core-constructs';
 import { formatFilesInSubtree } from '../utils/format';
 import { resolveIac } from '../utils/iac';
+import { installDeps } from '../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
 import { kebabCase, toClassName } from '../utils/names';
 import { getNpmScopePrefix } from '../utils/npm-scope';
@@ -159,9 +159,9 @@ export const agentcoreGatewayGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 /**

--- a/packages/nx-plugin/src/agentcore-gateway/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.ts
@@ -16,7 +16,7 @@ import {
 import { addAgentCoreGatewayInfra } from '../utils/agent-core-constructs/agent-core-constructs';
 import { formatFilesInSubtree } from '../utils/format';
 import { resolveIac } from '../utils/iac';
-import { installDeps } from '../utils/install';
+import { installDependencies } from '../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
 import { kebabCase, toClassName } from '../utils/names';
 import { getNpmScopePrefix } from '../utils/npm-scope';
@@ -159,9 +159,10 @@ export const agentcoreGatewayGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 /**

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
@@ -2,12 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-  type GeneratorCallback,
-  installPackagesTask,
-  type Tree,
-} from '@nx/devkit';
+import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
@@ -85,9 +82,9 @@ export const agentcoreGatewayMcpConnectionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default agentcoreGatewayMcpConnectionGenerator;

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
@@ -4,7 +4,7 @@
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
@@ -82,9 +82,10 @@ export const agentcoreGatewayMcpConnectionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default agentcoreGatewayMcpConnectionGenerator;

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/schema.d.ts
@@ -9,4 +9,5 @@ export interface AgentcoreGatewayMcpConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/schema.json
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The MCP server component in the target project"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/agentcore-gateway/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/schema.d.ts
@@ -13,4 +13,5 @@ export interface AgentcoreGatewayGeneratorSchema {
   cedarPolicy?: boolean;
   infra?: 'agentcore' | 'none';
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/agentcore-gateway/schema.json
+++ b/packages/nx-plugin/src/agentcore-gateway/schema.json
@@ -59,6 +59,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/connection/generator.ts
+++ b/packages/nx-plugin/src/connection/generator.ts
@@ -134,6 +134,7 @@ export interface ResolvedConnectionOptions {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }
 
 const CONNECTION_GENERATORS = {
@@ -157,16 +158,19 @@ const CONNECTION_GENERATORS = {
     trpcReactGenerator(tree, {
       frontendProjectName: options.sourceProject,
       backendProjectName: options.targetProject,
+      preferInstallDependencies: options.preferInstallDependencies,
     }),
   'react -> py#fast-api': (tree, options) =>
     fastApiReactGenerator(tree, {
       frontendProjectName: options.sourceProject,
       fastApiProjectName: options.targetProject,
+      preferInstallDependencies: options.preferInstallDependencies,
     }),
   'react -> smithy': (tree, options) =>
     smithyReactConnectionGenerator(tree, {
       frontendProjectName: options.sourceProject,
       smithyModelOrBackendProjectName: options.targetProject,
+      preferInstallDependencies: options.preferInstallDependencies,
     }),
   'react -> ts#agent': (tree, options) =>
     tsAgentReactConnectionGenerator(tree, options),
@@ -226,6 +230,7 @@ export const connectionGenerator = async (
     targetProject: options.targetProject,
     sourceComponent: resolved.sourceComponent,
     targetComponent: resolved.targetComponent,
+    preferInstallDependencies: options.preferInstallDependencies,
   });
 };
 

--- a/packages/nx-plugin/src/connection/schema.d.ts
+++ b/packages/nx-plugin/src/connection/schema.d.ts
@@ -8,4 +8,5 @@ export interface ConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: string;
   targetComponent?: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/connection/schema.json
+++ b/packages/nx-plugin/src/connection/schema.json
@@ -27,6 +27,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The target component to connect to (component name, path relative to target project root, or generator id). Use '.' to explicitly select the project as the target."
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -22,7 +22,7 @@ describe('infra generator', () => {
   const options: TsInfraGeneratorSchema = {
     name: 'test',
     directory: 'packages',
-    skipInstall: true,
+    preferInstallDependencies: false,
   };
 
   beforeEach(() => {
@@ -200,7 +200,7 @@ describe('infra generator', () => {
     const customOptions: TsInfraGeneratorSchema = {
       name: 'custom-infra',
       directory: 'packages',
-      skipInstall: true,
+      preferInstallDependencies: false,
     };
     await tsInfraGenerator(tree, customOptions);
     // Snapshot project configuration with custom name

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -18,7 +18,7 @@ import tsProjectGenerator, { getTsLibDetails } from '../../ts/lib/generator';
 import { mergeTsReferences } from '../../ts/lib/ts-project-utils';
 import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
@@ -251,8 +251,9 @@ export async function tsInfraGenerator(
   await addGeneratorMetricsIfApplicable(tree, [INFRA_APP_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 }
 export default tsInfraGenerator;

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type ProjectConfiguration,
@@ -19,6 +18,7 @@ import tsProjectGenerator, { getTsLibDetails } from '../../ts/lib/generator';
 import { mergeTsReferences } from '../../ts/lib/ts-project-utils';
 import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
@@ -54,7 +54,10 @@ export async function tsInfraGenerator(
   const lib = getTsLibDetails(tree, schema);
 
   if (!projectExists(tree, lib.fullyQualifiedName)) {
-    await tsProjectGenerator(tree, schema);
+    await tsProjectGenerator(tree, {
+      ...schema,
+      preferInstallDependencies: false,
+    });
   }
 
   // CDK shells out to a container engine to build image assets. Default
@@ -248,8 +251,8 @@ export async function tsInfraGenerator(
   await addGeneratorMetricsIfApplicable(tree, [INFRA_APP_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 }
 export default tsInfraGenerator;

--- a/packages/nx-plugin/src/infra/app/schema.d.ts
+++ b/packages/nx-plugin/src/infra/app/schema.d.ts
@@ -8,6 +8,6 @@ export interface TsInfraGeneratorSchema {
   subDirectory?: string;
   //   unitTestRunner?: 'jest' | 'vitest' | 'none';
   //   linter?: Linter;
-  skipInstall?: boolean;
+  preferInstallDependencies?: boolean;
   stageConfig?: boolean;
 }

--- a/packages/nx-plugin/src/infra/app/schema.json
+++ b/packages/nx-plugin/src/infra/app/schema.json
@@ -32,6 +32,11 @@
       "type": "boolean",
       "default": false,
       "x-prompt": "Would you like to enable centralized stage credential configuration?"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/license/schema.d.ts
+++ b/packages/nx-plugin/src/license/schema.d.ts
@@ -19,4 +19,6 @@ export interface LicenseGeneratorSchema {
    * Whether to configure dependency license allowlist checking.
    */
   dependencyCheck?: boolean;
+
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/license/schema.json
+++ b/packages/nx-plugin/src/license/schema.json
@@ -23,6 +23,11 @@
       "description": "Configure a license-check target that fails when dependencies declare licenses outside the configured allowlist.",
       "default": true,
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": []

--- a/packages/nx-plugin/src/license/sync/schema.json
+++ b/packages/nx-plugin/src/license/sync/schema.json
@@ -4,6 +4,12 @@
   "$id": "license-headers",
   "title": "Sync generator for adding license headers to source code",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
+    }
+  },
   "required": []
 }

--- a/packages/nx-plugin/src/license/sync/schema.json
+++ b/packages/nx-plugin/src/license/sync/schema.json
@@ -4,12 +4,6 @@
   "$id": "license-headers",
   "title": "Sync generator for adding license headers to source code",
   "type": "object",
-  "properties": {
-    "preferInstallDependencies": {
-      "type": "boolean",
-      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "default": true
-    }
-  },
+  "properties": {},
   "required": []
 }

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -74,9 +74,27 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 - After running a generator, use the \`nx show projects\` command to check which projects have been added (if any)
 - Carefully examine the files that have been generated and always refer back to the generator guide when working in a generated project
 - Generate all projects into the \`packages/\` directory
-- When running multiple generators in sequence, pass \`--prefer-install-dependencies=false\` on each one to avoid a slow dependency install after every generator, then install once at the end (or let the final generator install by omitting the flag). This is a preference, not a guarantee — a generator still installs on its own if skipping would leave a dependency unresolvable that a later \`nx\` command needs to compute the project graph, so you don't have to reason about which generators are "safe" to defer.
 - After making changes to your projects, fix linting issues, then run a full build
 - When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load:runtime-config target after a deployment to point a local website at a sandbox stack.
+
+## Batching Generators
+
+When scaffolding several projects in one go, chain generators to avoid a slow dependency install after every generator:
+
+- **Chain generators** with \`&&\` in a single command. Pass \`--prefer-install-dependencies=false\` on each generator except the last so dependencies install once at the end, for example:
+
+${PACKAGE_MANAGERS.map(
+  (pm) => `  \`\`\`bash
+  ${buildNxCommand('g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM --prefer-install-dependencies=false', pm)} && \\
+    ${buildNxCommand('g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --prefer-install-dependencies=false', pm)} && \\
+    ${buildNxCommand('g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api --prefer-install-dependencies=false', pm)} && \\
+    ${buildNxCommand('g @aws/nx-plugin:ts#infra --no-interactive --name=infra', pm)} && \\
+    ${buildNxCommand('sync', pm)}
+  \`\`\``,
+).join('\n')}
+
+- **\`--prefer-install-dependencies=false\`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything).
+- **\`nx sync\`** is required before building — generators modify TypeScript project references.
 
 ## Detailed Guides
 

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -74,6 +74,7 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 - After running a generator, use the \`nx show projects\` command to check which projects have been added (if any)
 - Carefully examine the files that have been generated and always refer back to the generator guide when working in a generated project
 - Generate all projects into the \`packages/\` directory
+- When running multiple generators in sequence, pass \`--prefer-install-dependencies=false\` on each one to avoid a slow dependency install after every generator, then install once at the end (or let the final generator install by omitting the flag). This is a preference, not a guarantee — a generator still installs on its own if skipping would leave a dependency unresolvable that a later \`nx\` command needs to compute the project graph, so you don't have to reason about which generators are "safe" to defer.
 - After making changes to your projects, fix linting issues, then run a full build
 - When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load:runtime-config target after a deployment to point a local website at a sandbox stack.
 

--- a/packages/nx-plugin/src/open-api/ts-client/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/schema.d.ts
@@ -6,4 +6,5 @@
 export interface OpenApiTsClientGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/open-api/ts-client/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/schema.d.ts
@@ -6,5 +6,4 @@
 export interface OpenApiTsClientGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
-  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/open-api/ts-client/schema.json
+++ b/packages/nx-plugin/src/open-api/ts-client/schema.json
@@ -14,11 +14,6 @@
       "type": "string",
       "description": "Path to the directory in which to generate the client relative to the monorepo root",
       "x-priority": "important"
-    },
-    "preferInstallDependencies": {
-      "type": "boolean",
-      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "default": true
     }
   },
   "required": ["openApiSpecPath", "outputPath"]

--- a/packages/nx-plugin/src/open-api/ts-client/schema.json
+++ b/packages/nx-plugin/src/open-api/ts-client/schema.json
@@ -14,6 +14,11 @@
       "type": "string",
       "description": "Path to the directory in which to generate the client relative to the monorepo root",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["openApiSpecPath", "outputPath"]

--- a/packages/nx-plugin/src/open-api/ts-hooks/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/schema.d.ts
@@ -6,5 +6,4 @@
 export interface OpenApiTsHooksGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
-  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/open-api/ts-hooks/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/schema.d.ts
@@ -6,4 +6,5 @@
 export interface OpenApiTsHooksGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/open-api/ts-hooks/schema.json
+++ b/packages/nx-plugin/src/open-api/ts-hooks/schema.json
@@ -14,11 +14,6 @@
       "type": "string",
       "description": "Path to the directory in which to generate the hooks relative to the monorepo root",
       "x-priority": "important"
-    },
-    "preferInstallDependencies": {
-      "type": "boolean",
-      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "default": true
     }
   },
   "required": ["openApiSpecPath", "outputPath"]

--- a/packages/nx-plugin/src/open-api/ts-hooks/schema.json
+++ b/packages/nx-plugin/src/open-api/ts-hooks/schema.json
@@ -14,6 +14,11 @@
       "type": "string",
       "description": "Path to the directory in which to generate the hooks relative to the monorepo root",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["openApiSpecPath", "outputPath"]

--- a/packages/nx-plugin/src/open-api/ts-metadata/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-metadata/schema.d.ts
@@ -6,4 +6,5 @@
 export interface OpenApiTsMetadataGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/open-api/ts-metadata/schema.d.ts
+++ b/packages/nx-plugin/src/open-api/ts-metadata/schema.d.ts
@@ -6,5 +6,4 @@
 export interface OpenApiTsMetadataGeneratorSchema {
   openApiSpecPath: string;
   outputPath: string;
-  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/open-api/ts-metadata/schema.json
+++ b/packages/nx-plugin/src/open-api/ts-metadata/schema.json
@@ -14,6 +14,11 @@
       "type": "string",
       "description": "Path to the directory in which to generate the metadata relative to the monorepo root",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["openApiSpecPath", "outputPath"]

--- a/packages/nx-plugin/src/open-api/ts-metadata/schema.json
+++ b/packages/nx-plugin/src/open-api/ts-metadata/schema.json
@@ -14,11 +14,6 @@
       "type": "string",
       "description": "Path to the directory in which to generate the metadata relative to the monorepo root",
       "x-priority": "important"
-    },
-    "preferInstallDependencies": {
-      "type": "boolean",
-      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "default": true
     }
   },
   "required": ["openApiSpecPath", "outputPath"]

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -28,7 +28,7 @@ import {
 } from '../utils/config/utils';
 import { inferContainers } from '../utils/containers';
 import { DEFAULT_BIOME_CONFIG, formatFilesInSubtree } from '../utils/format';
-import { installDeps } from '../utils/install';
+import { installDependencies } from '../utils/install';
 import { configureMcpServers } from '../utils/mcp';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
 import { getNpmScope } from '../utils/npm-scope';
@@ -294,9 +294,10 @@ export const presetGenerator = async (
   }
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default presetGenerator;

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -7,7 +7,6 @@ import {
   detectPackageManager,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   readNxJson,
@@ -29,6 +28,7 @@ import {
 } from '../utils/config/utils';
 import { inferContainers } from '../utils/containers';
 import { DEFAULT_BIOME_CONFIG, formatFilesInSubtree } from '../utils/format';
+import { installDeps } from '../utils/install';
 import { configureMcpServers } from '../utils/mcp';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
 import { getNpmScope } from '../utils/npm-scope';
@@ -161,7 +161,13 @@ const setUpGitSecrets = (tree: Tree) => {
 
 export const presetGenerator = async (
   tree: Tree,
-  { iac, gitSecrets, mcp, containers }: PresetGeneratorSchema,
+  {
+    iac,
+    gitSecrets,
+    mcp,
+    containers,
+    preferInstallDependencies,
+  }: PresetGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   const resolvedContainers =
     !containers || containers === 'infer' ? inferContainers() : containers;
@@ -288,9 +294,9 @@ export const presetGenerator = async (
   }
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default presetGenerator;

--- a/packages/nx-plugin/src/preset/schema.d.ts
+++ b/packages/nx-plugin/src/preset/schema.d.ts
@@ -13,4 +13,5 @@ export interface PresetGeneratorSchema {
   readonly gitSecrets?: boolean;
   readonly mcp?: boolean;
   readonly containers?: PresetContainersOption;
+  readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/preset/schema.json
+++ b/packages/nx-plugin/src/preset/schema.json
@@ -30,6 +30,11 @@
       "default": "infer",
       "x-priority": "important",
       "x-prompt": "Which container engine would you like to use? (default: infer)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   }
 }

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -27,7 +27,7 @@ import {
   matchGritQL,
 } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { snakeCase } from '../../../utils/names';
 import {
@@ -233,9 +233,10 @@ export const pyAgentA2aConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 /**

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -28,6 +27,7 @@ import {
   matchGritQL,
 } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { snakeCase } from '../../../utils/names';
 import {
@@ -233,9 +233,9 @@ export const pyAgentA2aConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 /**

--- a/packages/nx-plugin/src/py/agent/a2a-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/schema.d.ts
@@ -12,4 +12,5 @@ export interface PyAgentA2aConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/agent/a2a-connection/schema.json
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The target A2A agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -24,6 +23,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addPythonDestructuredImport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { snakeCase } from '../../../utils/names';
 import {
@@ -203,9 +203,9 @@ export const pyAgentGatewayConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default pyAgentGatewayConnectionGenerator;

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addPythonDestructuredImport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { snakeCase } from '../../../utils/names';
 import {
@@ -203,9 +203,10 @@ export const pyAgentGatewayConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default pyAgentGatewayConnectionGenerator;

--- a/packages/nx-plugin/src/py/agent/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/schema.d.ts
@@ -9,4 +9,5 @@ export interface PyAgentGatewayConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/agent/gateway-connection/schema.json
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The gateway component in the target project"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -27,7 +27,7 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { updateGitIgnore } from '../../utils/git';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -505,9 +505,10 @@ export const pyAgentGenerator = async (
   }
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 export default pyAgentGenerator;

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -28,6 +27,7 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { updateGitIgnore } from '../../utils/git';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -40,7 +40,6 @@ import {
   normalizeTargetKeyOrder,
   readProjectConfigurationUnqualified,
 } from '../../utils/nx';
-import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { sortObjectKeys } from '../../utils/object';
 import { toProjectRelativePath } from '../../utils/paths';
 import { assignPort } from '../../utils/port';
@@ -506,10 +505,9 @@ export const pyAgentGenerator = async (
   }
 
   await formatFilesInSubtree(tree);
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 export default pyAgentGenerator;

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -23,6 +22,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addPythonDestructuredImport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { snakeCase } from '../../../utils/names';
 import {
@@ -188,9 +188,9 @@ export const pyAgentMcpConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default pyAgentMcpConnectionGenerator;

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addPythonDestructuredImport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { snakeCase } from '../../../utils/names';
 import {
@@ -188,9 +188,10 @@ export const pyAgentMcpConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default pyAgentMcpConnectionGenerator;

--- a/packages/nx-plugin/src/py/agent/mcp-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/schema.d.ts
@@ -12,4 +12,5 @@ export interface PyAgentMcpConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/agent/mcp-connection/schema.json
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The MCP server component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
@@ -395,7 +395,7 @@ describe('py strands agent react connection with real projects', {
     // Generate a React website
     await tsReactWebsiteGenerator(tree, {
       name: 'frontend',
-      skipInstall: true,
+      preferInstallDependencies: false,
       iac: 'cdk',
     });
   });

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../ts/react-website/agui/generator';
 import { addOpenApiReactClient } from '../../../utils/connection/open-api/react';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../../utils/names';
 import {
@@ -168,9 +168,10 @@ export const pyAgentReactConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 /**

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.ts
@@ -4,7 +4,6 @@
  */
 import {
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -18,6 +17,7 @@ import {
 } from '../../../ts/react-website/agui/generator';
 import { addOpenApiReactClient } from '../../../utils/connection/open-api/react';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../../utils/names';
 import {
@@ -168,9 +168,9 @@ export const pyAgentReactConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 /**

--- a/packages/nx-plugin/src/py/agent/react-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/schema.d.ts
@@ -12,4 +12,5 @@ export interface PyAgentReactConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/agent/react-connection/schema.json
+++ b/packages/nx-plugin/src/py/agent/react-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/agent/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/schema.d.ts
@@ -19,4 +19,5 @@ export interface PyAgentGeneratorSchema {
   auth?: PyAgentAuth;
   protocol?: AgentProtocol;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/agent/schema.json
+++ b/packages/nx-plugin/src/py/agent/schema.json
@@ -59,6 +59,11 @@
       "enum": ["agentcore", "none"],
       "default": "agentcore",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/py/api/generator.ts
+++ b/packages/nx-plugin/src/py/api/generator.ts
@@ -28,6 +28,7 @@ export async function pyApiGenerator(
         subDirectory: options.subDirectory,
         moduleName: options.moduleName,
         iac: options.iac,
+        preferInstallDependencies: options.preferInstallDependencies,
       });
   }
 }

--- a/packages/nx-plugin/src/py/api/schema.d.ts
+++ b/packages/nx-plugin/src/py/api/schema.d.ts
@@ -14,4 +14,5 @@ export interface PyApiGeneratorSchema {
   readonly subDirectory?: string;
   readonly moduleName?: string;
   readonly iac: IacOption;
+  readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/api/schema.json
+++ b/packages/nx-plugin/src/py/api/schema.json
@@ -94,6 +94,11 @@
       "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
@@ -8,7 +8,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -52,9 +52,10 @@ export const pyDynamoDBAgentConnectionGenerator = async (
     PY_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO,
   ]);
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 export default pyDynamoDBAgentConnectionGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
@@ -4,11 +4,11 @@
  */
 import {
   type GeneratorCallback,
-  installPackagesTask,
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -16,7 +16,6 @@ import {
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
-import { Logger, UVProvider } from '../../../utils/nxlv-python';
 import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
 import type { PyDynamoDBAgentConnectionGeneratorSchema } from './schema';
 
@@ -53,10 +52,9 @@ export const pyDynamoDBAgentConnectionGenerator = async (
     PY_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO,
   ]);
   await formatFilesInSubtree(tree);
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 export default pyDynamoDBAgentConnectionGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/schema.d.ts
@@ -11,4 +11,5 @@ export interface PyDynamoDBAgentConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   sourceComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/schema.json
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/schema.json
@@ -16,6 +16,11 @@
     "sourceComponent": {
       "type": "string",
       "description": "The agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
@@ -4,11 +4,11 @@
  */
 import {
   type GeneratorCallback,
-  installPackagesTask,
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -16,7 +16,6 @@ import {
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
-import { Logger, UVProvider } from '../../../utils/nxlv-python';
 import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
 import type { PyDynamoDBFastApiConnectionGeneratorSchema } from './schema';
 
@@ -50,10 +49,9 @@ export const pyDynamoDBFastApiConnectionGenerator = async (
     PY_DYNAMODB_FAST_API_CONNECTION_GENERATOR_INFO,
   ]);
   await formatFilesInSubtree(tree);
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 export default pyDynamoDBFastApiConnectionGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
@@ -8,7 +8,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -49,9 +49,10 @@ export const pyDynamoDBFastApiConnectionGenerator = async (
     PY_DYNAMODB_FAST_API_CONNECTION_GENERATOR_INFO,
   ]);
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 export default pyDynamoDBFastApiConnectionGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/schema.d.ts
@@ -9,4 +9,5 @@
 export interface PyDynamoDBFastApiConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/schema.json
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/schema.json
@@ -12,6 +12,11 @@
     "targetProject": {
       "type": "string",
       "description": "The py#dynamodb project to connect to"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/generator.ts
@@ -7,7 +7,6 @@ import { relative } from 'node:path';
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   readProjectConfiguration,
   type Tree,
@@ -17,6 +16,7 @@ import { resolveContainers } from '../../utils/containers';
 import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs';
 import { formatFilesInSubtree } from '../../utils/format';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -26,7 +26,6 @@ import {
   type NxGeneratorInfo,
   projectExists,
 } from '../../utils/nx';
-import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { assignSharedPort } from '../../utils/port';
 import { addDependenciesToPyProjectToml } from '../../utils/py';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
@@ -65,6 +64,7 @@ export const pyDynamoDBGenerator = async (
       directory: options.directory,
       subDirectory: options.subDirectory,
       type: 'library',
+      preferInstallDependencies: false,
     });
   }
 
@@ -148,10 +148,9 @@ export const pyDynamoDBGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [PY_DYNAMODB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 export default pyDynamoDBGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/generator.ts
@@ -16,7 +16,7 @@ import { resolveContainers } from '../../utils/containers';
 import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs';
 import { formatFilesInSubtree } from '../../utils/format';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -148,9 +148,10 @@ export const pyDynamoDBGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [PY_DYNAMODB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 export default pyDynamoDBGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
@@ -4,11 +4,11 @@
  */
 import {
   type GeneratorCallback,
-  installPackagesTask,
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -16,7 +16,6 @@ import {
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../../utils/nx';
-import { Logger, UVProvider } from '../../../utils/nxlv-python';
 import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
 import type { PyDynamoDBMcpServerConnectionGeneratorSchema } from './schema';
 
@@ -53,10 +52,9 @@ export const pyDynamoDBMcpServerConnectionGenerator = async (
     PY_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO,
   ]);
   await formatFilesInSubtree(tree);
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 export default pyDynamoDBMcpServerConnectionGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
@@ -8,7 +8,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -52,9 +52,10 @@ export const pyDynamoDBMcpServerConnectionGenerator = async (
     PY_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO,
   ]);
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 export default pyDynamoDBMcpServerConnectionGenerator;

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/schema.d.ts
@@ -11,4 +11,5 @@ export interface PyDynamoDBMcpServerConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   sourceComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/schema.json
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/schema.json
@@ -16,6 +16,11 @@
     "sourceComponent": {
       "type": "string",
       "description": "The MCP server component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/py/dynamodb/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/schema.d.ts
@@ -12,4 +12,5 @@ export interface PyDynamoDBGeneratorSchema {
   tableName?: string;
   infra: 'dynamodb' | 'none';
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/dynamodb/schema.json
+++ b/packages/nx-plugin/src/py/dynamodb/schema.json
@@ -64,6 +64,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: Inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type ProjectConfiguration,
@@ -19,6 +18,7 @@ import { addPythonBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toClassName, toKebabCase } from '../../utils/names';
 import {
@@ -26,7 +26,6 @@ import {
   getGeneratorInfo,
   type NxGeneratorInfo,
 } from '../../utils/nx';
-import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { sortObjectKeys } from '../../utils/object';
 import { assignPort } from '../../utils/port';
 import {
@@ -78,6 +77,7 @@ export const pyFastApiProjectGenerator = async (
       subDirectory: schema.subDirectory,
       moduleName: normalizedModuleName,
       type: 'application',
+      preferInstallDependencies: false,
     });
   }
 
@@ -227,10 +227,9 @@ export const pyFastApiProjectGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return async () => {
-    await new UVProvider(tree.root, new Logger(), tree).install();
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 const getIntegrationPattern = (

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -18,7 +18,7 @@ import { addPythonBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toClassName, toKebabCase } from '../../utils/names';
 import {
@@ -227,9 +227,10 @@ export const pyFastApiProjectGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 const getIntegrationPattern = (

--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -466,7 +466,7 @@ describe('fastapi react generator with real react and trpc projects', {
     // Generate a react website
     await tsReactWebsiteGenerator(tree, {
       name: 'frontend',
-      skipInstall: true,
+      preferInstallDependencies: false,
       iac: 'cdk',
     });
   });

--- a/packages/nx-plugin/src/py/fast-api/react/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.ts
@@ -2,9 +2,10 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { installPackagesTask, type Tree } from '@nx/devkit';
+import type { Tree } from '@nx/devkit';
 import { addOpenApiReactClient } from '../../../utils/connection/open-api/react';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   getGeneratorInfo,
@@ -55,9 +56,9 @@ export const fastApiReactGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [FAST_API_REACT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default fastApiReactGenerator;

--- a/packages/nx-plugin/src/py/fast-api/react/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.ts
@@ -5,7 +5,7 @@
 import type { Tree } from '@nx/devkit';
 import { addOpenApiReactClient } from '../../../utils/connection/open-api/react';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import {
   getGeneratorInfo,
@@ -56,9 +56,10 @@ export const fastApiReactGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [FAST_API_REACT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default fastApiReactGenerator;

--- a/packages/nx-plugin/src/py/fast-api/react/schema.d.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/schema.d.ts
@@ -5,4 +5,5 @@
 export interface FastApiReactGeneratorSchema {
   frontendProjectName: string;
   fastApiProjectName: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/fast-api/react/schema.json
+++ b/packages/nx-plugin/src/py/fast-api/react/schema.json
@@ -20,6 +20,11 @@
       "description": "",
       "x-prompt": "Package containing your FastAPI backend",
       "x-dropdown": "projects"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["frontendProjectName", "fastApiProjectName"]

--- a/packages/nx-plugin/src/py/fast-api/schema.d.ts
+++ b/packages/nx-plugin/src/py/fast-api/schema.d.ts
@@ -14,4 +14,5 @@ export interface PyFastApiProjectGeneratorSchema {
   readonly subDirectory?: string;
   readonly moduleName?: string;
   readonly iac: IacOption;
+  readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/fast-api/schema.json
+++ b/packages/nx-plugin/src/py/fast-api/schema.json
@@ -76,6 +76,11 @@
       "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -14,7 +14,7 @@ import { addPythonBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import {
   toClassName,
@@ -200,8 +200,9 @@ export const pyLambdaFunctionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 export default pyLambdaFunctionGenerator;

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -15,6 +14,7 @@ import { addPythonBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import {
   toClassName,
@@ -29,7 +29,6 @@ import {
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../utils/nx';
-import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { sortObjectKeys } from '../../utils/object';
 import { toProjectRelativePath } from '../../utils/paths';
 import { addDependenciesToPyProjectToml } from '../../utils/py';
@@ -201,9 +200,8 @@ export const pyLambdaFunctionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return async () => {
-    await new UVProvider(tree.root, new Logger(), tree).install();
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 export default pyLambdaFunctionGenerator;

--- a/packages/nx-plugin/src/py/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/py/lambda-function/schema.d.ts
@@ -56,4 +56,5 @@ export interface PyLambdaFunctionGeneratorSchema {
   readonly event?: EventSource;
   readonly infra?: LambdaInfraOption;
   readonly iac: IacOption;
+  readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/lambda-function/schema.json
+++ b/packages/nx-plugin/src/py/lambda-function/schema.json
@@ -90,6 +90,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project", "name"]

--- a/packages/nx-plugin/src/py/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -20,6 +19,7 @@ import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -31,7 +31,6 @@ import {
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
 } from '../../utils/nx';
-import { Logger, UVProvider } from '../../utils/nxlv-python';
 import { toProjectRelativePath } from '../../utils/paths';
 import { assignPort } from '../../utils/port';
 import { addDependenciesToPyProjectToml } from '../../utils/py';
@@ -286,10 +285,9 @@ export const pyMcpServerGenerator = async (
   await ensureLicenseExceptions(tree, MCP_INSPECTOR_EXCEPTIONS);
 
   await formatFilesInSubtree(tree);
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 
 export default pyMcpServerGenerator;

--- a/packages/nx-plugin/src/py/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.ts
@@ -19,7 +19,7 @@ import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -285,9 +285,10 @@ export const pyMcpServerGenerator = async (
   await ensureLicenseExceptions(tree, MCP_INSPECTOR_EXCEPTIONS);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 
 export default pyMcpServerGenerator;

--- a/packages/nx-plugin/src/py/mcp-server/schema.d.ts
+++ b/packages/nx-plugin/src/py/mcp-server/schema.d.ts
@@ -15,4 +15,5 @@ export interface PyMcpServerGeneratorSchema {
   infra?: PyMcpServerInfra;
   auth?: PyMcpServerAuth;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/mcp-server/schema.json
+++ b/packages/nx-plugin/src/py/mcp-server/schema.json
@@ -43,6 +43,11 @@
       "enum": ["agentcore", "none"],
       "default": "agentcore",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -18,7 +18,7 @@ import {
   ensurePythonLicenseCollector,
 } from '../../license/config';
 import { updateGitIgnore } from '../../utils/git';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { normalizeDistributionName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -326,8 +326,9 @@ export const pyProjectGenerator = async (
   // is added regardless of which generator runs first.
   addLicenseCheckToLintTarget(tree, fullyQualifiedName);
 
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript', 'python'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript', 'python'],
+    });
 };
 export default pyProjectGenerator;

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   ensurePackage,
   type GeneratorCallback,
-  installPackagesTask,
   joinPathFragments,
   readNxJson,
   readProjectConfiguration,
@@ -19,6 +18,7 @@ import {
   ensurePythonLicenseCollector,
 } from '../../license/config';
 import { updateGitIgnore } from '../../utils/git';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { normalizeDistributionName, toSnakeCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -31,9 +31,7 @@ import {
 } from '../../utils/nx';
 import type { UVPyprojectToml } from '../../utils/nxlv-python';
 import {
-  Logger,
   migrateToSharedVenvGenerator,
-  UVProvider,
   uvProjectGenerator,
 } from '../../utils/nxlv-python';
 import { sortObjectKeys } from '../../utils/object';
@@ -328,9 +326,8 @@ export const pyProjectGenerator = async (
   // is added regardless of which generator runs first.
   addLicenseCheckToLintTarget(tree, fullyQualifiedName);
 
-  return async () => {
-    installPackagesTask(tree);
-    await new UVProvider(tree.root, new Logger(), tree).install();
-  };
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript', 'python'],
+  });
 };
 export default pyProjectGenerator;

--- a/packages/nx-plugin/src/py/project/schema.d.ts
+++ b/packages/nx-plugin/src/py/project/schema.d.ts
@@ -9,4 +9,5 @@ export interface PyProjectGeneratorSchema {
   readonly directory?: string;
   readonly subDirectory?: string;
   readonly moduleName?: string;
+  readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/project/schema.json
+++ b/packages/nx-plugin/src/py/project/schema.json
@@ -36,6 +36,11 @@
     "moduleName": {
       "type": "string",
       "description": "Python module name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name", "type"]

--- a/packages/nx-plugin/src/sdk/open-api.ts
+++ b/packages/nx-plugin/src/sdk/open-api.ts
@@ -4,8 +4,8 @@
  */
 
 export {
-  openApiTsClientGenerator,
   buildOpenApiCodeGenerationData,
+  openApiTsClientGenerator,
 } from '../open-api/ts-client/generator';
 export type { OpenApiTsClientGeneratorSchema } from '../open-api/ts-client/schema';
 

--- a/packages/nx-plugin/src/sdk/utils/ast.ts
+++ b/packages/nx-plugin/src/sdk/utils/ast.ts
@@ -2,5 +2,4 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export { applyGritQL } from '../../utils/ast';
-export { matchGritQL } from '../../utils/ast';
+export { applyGritQL, matchGritQL } from '../../utils/ast';

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -13,7 +13,7 @@ import { getTsLibDetails } from '../../ts/lib/generator';
 import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toClassName, toKebabCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -92,9 +92,10 @@ export const smithyProjectGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [SMITHY_PROJECT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default smithyProjectGenerator;

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -6,7 +6,6 @@ import {
   addProjectConfiguration,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   type Tree,
 } from '@nx/devkit';
@@ -14,6 +13,7 @@ import { getTsLibDetails } from '../../ts/lib/generator';
 import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toClassName, toKebabCase } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -92,9 +92,9 @@ export const smithyProjectGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [SMITHY_PROJECT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default smithyProjectGenerator;

--- a/packages/nx-plugin/src/smithy/project/schema.d.ts
+++ b/packages/nx-plugin/src/smithy/project/schema.d.ts
@@ -8,4 +8,5 @@ export interface SmithyProjectGeneratorSchema {
   namespace?: string;
   directory?: string;
   subDirectory?: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/smithy/project/schema.json
+++ b/packages/nx-plugin/src/smithy/project/schema.json
@@ -36,6 +36,11 @@
       "type": "string",
       "description": "The sub directory the Smithy project is placed in. By default this is the project name.",
       "x-prompt": "Which sub directory do you want to create the Smithy project in? (By default this is the project name)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
@@ -981,7 +981,7 @@ export function Main() {
       // Generate a react website
       await tsReactWebsiteGenerator(tree, {
         name: 'frontend',
-        skipInstall: true,
+        preferInstallDependencies: false,
         iac: 'cdk',
       });
     });

--- a/packages/nx-plugin/src/smithy/react-connection/generator.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type ProjectConfiguration,
@@ -13,6 +12,7 @@ import {
 } from '@nx/devkit';
 import { addOpenApiReactClient } from '../../utils/connection/open-api/react';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import {
   getGeneratorInfo,
@@ -87,9 +87,9 @@ export const smithyReactConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 const resolveProjectConfig = (

--- a/packages/nx-plugin/src/smithy/react-connection/generator.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.ts
@@ -12,7 +12,7 @@ import {
 } from '@nx/devkit';
 import { addOpenApiReactClient } from '../../utils/connection/open-api/react';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import {
   getGeneratorInfo,
@@ -87,9 +87,10 @@ export const smithyReactConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 const resolveProjectConfig = (

--- a/packages/nx-plugin/src/smithy/react-connection/schema.d.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/schema.d.ts
@@ -5,4 +5,5 @@
 export interface SmithyReactConnectionGeneratorSchema {
   frontendProjectName: string;
   smithyModelOrBackendProjectName: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/smithy/react-connection/schema.json
+++ b/packages/nx-plugin/src/smithy/react-connection/schema.json
@@ -20,6 +20,11 @@
       "description": "",
       "x-prompt": "Project containing your Smithy API (either model or backend)",
       "x-dropdown": "projects"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["frontendProjectName", "smithyModelOrBackendProjectName"]

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -19,7 +19,7 @@ import { formatFilesInSubtree } from '../../../utils/format';
 import { FsCommands } from '../../../utils/fs';
 import { updateGitIgnore } from '../../../utils/git';
 import { resolveIac } from '../../../utils/iac';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { toClassName, toKebabCase } from '../../../utils/names';
 import {
@@ -321,9 +321,10 @@ export const tsSmithyApiGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_SMITHY_API_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 const getIntegrationPattern = (

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -20,6 +19,7 @@ import { formatFilesInSubtree } from '../../../utils/format';
 import { FsCommands } from '../../../utils/fs';
 import { updateGitIgnore } from '../../../utils/git';
 import { resolveIac } from '../../../utils/iac';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { toClassName, toKebabCase } from '../../../utils/names';
 import {
@@ -77,6 +77,7 @@ export const tsSmithyApiGenerator = async (
       namespace: options.namespace,
       directory: dir,
       subDirectory: 'model',
+      preferInstallDependencies: false,
     });
 
     // Generate the backend project
@@ -84,6 +85,7 @@ export const tsSmithyApiGenerator = async (
       name: options.name,
       directory: dir,
       subDirectory: 'backend',
+      preferInstallDependencies: false,
     });
   }
 
@@ -319,9 +321,9 @@ export const tsSmithyApiGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_SMITHY_API_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 const getIntegrationPattern = (

--- a/packages/nx-plugin/src/smithy/ts/api/schema.d.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/schema.d.ts
@@ -14,4 +14,5 @@ export interface TsSmithyApiGeneratorSchema {
   directory?: TsProjectGeneratorSchema['directory'];
   subDirectory?: TsProjectGeneratorSchema['subDirectory'];
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/smithy/ts/api/schema.json
+++ b/packages/nx-plugin/src/smithy/ts/api/schema.json
@@ -77,6 +77,11 @@
       "enum": ["rest-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "internal"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -19,7 +19,7 @@ import {
 import { join, relative } from 'path';
 import { getTsLibDetails } from '../../ts/lib/generator';
 import { updateGitIgnore } from '../../utils/git';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
@@ -317,9 +317,10 @@ export async function terraformProjectGenerator(
   // `@nx-extend/terraform` is registered as an Nx plugin in nx.json, so Nx
   // loads it when computing the project graph — it must resolve even if the
   // caller would otherwise prefer to defer installing.
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript'],
-    ensureResolvable: [NX_EXTEND_PLUGIN],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript'],
+      ensureResolvable: [NX_EXTEND_PLUGIN],
+    });
 }
 export default terraformProjectGenerator;

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -8,7 +8,6 @@ import {
   detectPackageManager,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   readNxJson,
@@ -20,6 +19,7 @@ import {
 import { join, relative } from 'path';
 import { getTsLibDetails } from '../../ts/lib/generator';
 import { updateGitIgnore } from '../../utils/git';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase } from '../../utils/names';
 import {
@@ -314,8 +314,12 @@ export async function terraformProjectGenerator(
     });
   }
 
-  return () => {
-    installPackagesTask(tree);
-  };
+  // `@nx-extend/terraform` is registered as an Nx plugin in nx.json, so Nx
+  // loads it when computing the project graph — it must resolve even if the
+  // caller would otherwise prefer to defer installing.
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript'],
+    ensureResolvable: [NX_EXTEND_PLUGIN],
+  });
 }
 export default terraformProjectGenerator;

--- a/packages/nx-plugin/src/terraform/project/schema.d.ts
+++ b/packages/nx-plugin/src/terraform/project/schema.d.ts
@@ -13,4 +13,5 @@ export interface TerraformProjectGeneratorSchema {
   type: ProjectType;
   directory?: string;
   subDirectory?: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/terraform/project/schema.json
+++ b/packages/nx-plugin/src/terraform/project/schema.json
@@ -34,6 +34,11 @@
       "type": "string",
       "description": "The sub directory the project is placed in. By default this is the project name.",
       "x-prompt": "Which sub directory do you want to create the project in? (By default this is the project name)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -5,7 +5,6 @@
 import {
   addDependenciesToPackageJson,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -16,6 +15,7 @@ import { addApiGatewayInfra } from '../../utils/api-constructs/api-constructs';
 import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
@@ -74,6 +74,7 @@ export async function tsTrpcApiGenerator(
       name: backendName,
       directory: options.directory,
       subDirectory: options.subDirectory,
+      preferInstallDependencies: false,
     });
   }
 
@@ -247,9 +248,9 @@ export async function tsTrpcApiGenerator(
   await addGeneratorMetricsIfApplicable(tree, [TRPC_BACKEND_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 }
 
 const validateTrpcInfraAndIntegrationPatternCombination = (

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -15,7 +15,7 @@ import { addApiGatewayInfra } from '../../utils/api-constructs/api-constructs';
 import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScopePrefix, toScopeAlias } from '../../utils/npm-scope';
@@ -248,9 +248,10 @@ export async function tsTrpcApiGenerator(
   await addGeneratorMetricsIfApplicable(tree, [TRPC_BACKEND_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 }
 
 const validateTrpcInfraAndIntegrationPatternCombination = (

--- a/packages/nx-plugin/src/trpc/backend/schema.d.ts
+++ b/packages/nx-plugin/src/trpc/backend/schema.d.ts
@@ -14,4 +14,5 @@ export interface TsTrpcApiGeneratorSchema {
   directory?: TsProjectGeneratorSchema['directory'];
   subDirectory?: TsProjectGeneratorSchema['subDirectory'];
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/trpc/backend/schema.json
+++ b/packages/nx-plugin/src/trpc/backend/schema.json
@@ -71,6 +71,11 @@
       "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/trpc/react/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.spec.ts
@@ -404,7 +404,7 @@ describe('trpc react generator with real react and trpc projects', () => {
     // Generate a React website
     await tsReactWebsiteGenerator(tree, {
       name: 'frontend',
-      skipInstall: true,
+      preferInstallDependencies: false,
       iac: 'cdk',
     });
   });

--- a/packages/nx-plugin/src/trpc/react/generator.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.ts
@@ -5,7 +5,6 @@
 import {
   addDependenciesToPackageJson,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -14,6 +13,7 @@ import { addTargetToLocalDev } from '../../connection/local-dev';
 import { runtimeConfigGenerator } from '../../ts/react-website/runtime-config/generator';
 import { addSingleImport, applyGritQL } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toClassName } from '../../utils/names';
 import { toScopeAlias } from '../../utils/npm-scope';
@@ -100,6 +100,7 @@ export async function reactGenerator(
 
   await runtimeConfigGenerator(tree, {
     project: frontendProjectConfig.name,
+    preferInstallDependencies: false,
   });
 
   // update main.tsx
@@ -173,8 +174,8 @@ export async function reactGenerator(
   await addGeneratorMetricsIfApplicable(tree, [TRPC_REACT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 }
 export default reactGenerator;

--- a/packages/nx-plugin/src/trpc/react/generator.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.ts
@@ -13,7 +13,7 @@ import { addTargetToLocalDev } from '../../connection/local-dev';
 import { runtimeConfigGenerator } from '../../ts/react-website/runtime-config/generator';
 import { addSingleImport, applyGritQL } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toClassName } from '../../utils/names';
 import { toScopeAlias } from '../../utils/npm-scope';
@@ -174,8 +174,9 @@ export async function reactGenerator(
   await addGeneratorMetricsIfApplicable(tree, [TRPC_REACT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 }
 export default reactGenerator;

--- a/packages/nx-plugin/src/trpc/react/schema.d.ts
+++ b/packages/nx-plugin/src/trpc/react/schema.d.ts
@@ -5,4 +5,5 @@
 export interface ReactGeneratorSchema {
   frontendProjectName: string;
   backendProjectName: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/trpc/react/schema.json
+++ b/packages/nx-plugin/src/trpc/react/schema.json
@@ -19,6 +19,11 @@
       "description": "",
       "x-prompt": "Package containing your Api Backend.",
       "x-dropdown": "projects"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["frontendProjectName", "backendProjectName"]

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
@@ -22,7 +22,7 @@ import {
   applyGritQL,
 } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase } from '../../../utils/names';
 import { getNpmScope } from '../../../utils/npm-scope';
@@ -202,9 +202,10 @@ export const tsAgentA2aConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsAgentA2aConnectionGenerator;

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -23,6 +22,7 @@ import {
   applyGritQL,
 } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase } from '../../../utils/names';
 import { getNpmScope } from '../../../utils/npm-scope';
@@ -202,9 +202,9 @@ export const tsAgentA2aConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsAgentA2aConnectionGenerator;

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/schema.d.ts
@@ -12,4 +12,5 @@ export interface TsAgentA2aConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/schema.json
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The target A2A agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addDestructuredImport, addStarExport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase } from '../../../utils/names';
 import { getNpmScope } from '../../../utils/npm-scope';
@@ -177,9 +177,10 @@ export const tsAgentGatewayConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsAgentGatewayConnectionGenerator;

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -21,6 +20,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addDestructuredImport, addStarExport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase } from '../../../utils/names';
 import { getNpmScope } from '../../../utils/npm-scope';
@@ -177,9 +177,9 @@ export const tsAgentGatewayConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsAgentGatewayConnectionGenerator;

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/schema.d.ts
@@ -9,4 +9,5 @@ export interface TsAgentGatewayConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/schema.json
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The gateway component in the target project"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -23,6 +22,7 @@ import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -330,9 +330,9 @@ export const tsAgentGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_AGENT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsAgentGenerator;

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -22,7 +22,7 @@ import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -330,9 +330,10 @@ export const tsAgentGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_AGENT_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsAgentGenerator;

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -20,6 +19,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addDestructuredImport, addStarExport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase } from '../../../utils/names';
 import { getNpmScope } from '../../../utils/npm-scope';
@@ -154,9 +154,9 @@ export const tsAgentMcpConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsAgentMcpConnectionGenerator;

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import { addDestructuredImport, addStarExport } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase } from '../../../utils/names';
 import { getNpmScope } from '../../../utils/npm-scope';
@@ -154,9 +154,10 @@ export const tsAgentMcpConnectionGenerator = async (
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsAgentMcpConnectionGenerator;

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/schema.d.ts
@@ -12,4 +12,5 @@ export interface TsAgentMcpConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/schema.json
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The MCP server component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.spec.ts
@@ -359,7 +359,7 @@ describe('ts strands agent react connection with real projects', () => {
     // Generate a React website
     await tsReactWebsiteGenerator(tree, {
       name: 'frontend',
-      skipInstall: true,
+      preferInstallDependencies: false,
       iac: 'cdk',
     });
   });

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
@@ -14,7 +14,7 @@ import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-
 import type { ResolvedConnectionOptions } from '../../../connection/generator';
 import { addSingleImport, applyGritQL } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase, toClassName } from '../../../utils/names';
 import { toScopeAlias } from '../../../utils/npm-scope';
@@ -92,9 +92,10 @@ export async function tsAgentReactConnectionGenerator(
     ]);
 
     await formatFilesInSubtree(tree);
-    return () => installDeps(tree, options.preferInstallDependencies, {
-      languages: ['typescript'],
-    });
+    return () =>
+      installDependencies(tree, options.preferInstallDependencies, {
+        languages: ['typescript'],
+      });
   }
 
   // Ensure the agent project has a wildcard path entry in tsconfig.base.json
@@ -234,9 +235,10 @@ export async function tsAgentReactConnectionGenerator(
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 }
 export default tsAgentReactConnectionGenerator;
 

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
@@ -5,7 +5,6 @@
 import {
   addDependenciesToPackageJson,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -15,6 +14,7 @@ import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-
 import type { ResolvedConnectionOptions } from '../../../connection/generator';
 import { addSingleImport, applyGritQL } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase, toClassName } from '../../../utils/names';
 import { toScopeAlias } from '../../../utils/npm-scope';
@@ -92,9 +92,9 @@ export async function tsAgentReactConnectionGenerator(
     ]);
 
     await formatFilesInSubtree(tree);
-    return () => {
-      installPackagesTask(tree);
-    };
+    return () => installDeps(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
   }
 
   // Ensure the agent project has a wildcard path entry in tsconfig.base.json
@@ -152,6 +152,7 @@ export async function tsAgentReactConnectionGenerator(
 
   await runtimeConfigGenerator(tree, {
     project: frontendProjectConfig.name,
+    preferInstallDependencies: false,
   });
 
   // update main.tsx
@@ -233,9 +234,9 @@ export async function tsAgentReactConnectionGenerator(
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 }
 export default tsAgentReactConnectionGenerator;
 

--- a/packages/nx-plugin/src/ts/agent/react-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/schema.d.ts
@@ -12,4 +12,5 @@ export interface TsAgentReactConnectionGeneratorSchema {
   targetProject: string;
   sourceComponent?: ComponentMetadata;
   targetComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/agent/react-connection/schema.json
+++ b/packages/nx-plugin/src/ts/agent/react-connection/schema.json
@@ -20,6 +20,11 @@
     "targetComponent": {
       "type": "string",
       "description": "The Agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/agent/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/schema.d.ts
@@ -19,4 +19,5 @@ export interface TsAgentGeneratorSchema {
   auth?: TsAgentAuth;
   protocol?: AgentProtocol;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/agent/schema.json
+++ b/packages/nx-plugin/src/ts/agent/schema.json
@@ -59,6 +59,11 @@
       "enum": ["agentcore", "none"],
       "default": "agentcore",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/ts/api/generator.ts
+++ b/packages/nx-plugin/src/ts/api/generator.ts
@@ -28,6 +28,7 @@ export async function tsApiGenerator(
         directory: options.directory,
         subDirectory: options.subDirectory,
         iac: options.iac,
+        preferInstallDependencies: options.preferInstallDependencies,
       });
     case 'smithy':
       return tsSmithyApiGenerator(tree, {
@@ -42,6 +43,7 @@ export async function tsApiGenerator(
         directory: options.directory,
         subDirectory: options.subDirectory,
         iac: options.iac,
+        preferInstallDependencies: options.preferInstallDependencies,
       });
   }
 }

--- a/packages/nx-plugin/src/ts/api/schema.d.ts
+++ b/packages/nx-plugin/src/ts/api/schema.d.ts
@@ -16,4 +16,5 @@ export interface TsApiGeneratorSchema {
   directory?: TsProjectGeneratorSchema['directory'];
   subDirectory?: TsProjectGeneratorSchema['subDirectory'];
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/api/schema.json
+++ b/packages/nx-plugin/src/ts/api/schema.json
@@ -99,6 +99,11 @@
       "enum": ["rest-lambda", "http-lambda", "none"],
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -21,7 +21,7 @@ describe('ts#astro-docs generator', () => {
   it('should generate a docs site with default options (translation + blog enabled)', async () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     // Default directory is '.' and default subDirectory is kebab-case of the name
@@ -83,7 +83,7 @@ describe('ts#astro-docs generator', () => {
   it('should add astro + starlight + translation dependencies to the root package.json', async () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const packageJson = readJson(tree, 'package.json');
@@ -104,7 +104,7 @@ describe('ts#astro-docs generator', () => {
   it('should use the project name as the site title', async () => {
     await tsAstroDocsGenerator(tree, {
       name: 'my-cool-docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const astroConfig = tree.read('my-cool-docs/astro.config.mjs', 'utf-8');
@@ -114,7 +114,7 @@ describe('ts#astro-docs generator', () => {
   it('should default subDirectory to the kebab-case project name', async () => {
     await tsAstroDocsGenerator(tree, {
       name: 'MyDocsSite',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     // Should land at my-docs-site/ (kebab-cased)
@@ -126,7 +126,7 @@ describe('ts#astro-docs generator', () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
       noTranslation: true,
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(tree.exists('docs/scripts/translate.ts')).toBeFalsy();
@@ -148,7 +148,7 @@ describe('ts#astro-docs generator', () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
       noBlog: true,
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(
@@ -172,7 +172,7 @@ describe('ts#astro-docs generator', () => {
       name: 'my-docs',
       directory: 'sites',
       subDirectory: 'docs-site',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(tree.exists('sites/docs-site/project.json')).toBeTruthy();
@@ -186,7 +186,7 @@ describe('ts#astro-docs generator', () => {
   it('should add generator metadata to the project configuration', async () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const projectConfig = readJson(tree, 'docs/project.json');
@@ -204,14 +204,17 @@ describe('ts#astro-docs generator', () => {
 
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expectHasMetricTags(tree, TS_ASTRO_DOCS_GENERATOR_INFO.metric);
   });
 
   it('should be idempotent when re-run with the same options', async () => {
-    await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
+    await tsAstroDocsGenerator(tree, {
+      name: 'docs',
+      preferInstallDependencies: false,
+    });
 
     const projectCountAfterFirstRun = getProjects(tree).size;
     const indexAfterFirstRun = tree.read(
@@ -220,7 +223,10 @@ describe('ts#astro-docs generator', () => {
     );
 
     await expect(
-      tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true }),
+      tsAstroDocsGenerator(tree, {
+        name: 'docs',
+        preferInstallDependencies: false,
+      }),
     ).resolves.toBeDefined();
 
     expect(getProjects(tree).size).toBe(projectCountAfterFirstRun);
@@ -233,14 +239,17 @@ describe('ts#astro-docs generator', () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
       noBlog: true,
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(
       tree.exists('docs/src/content/docs/en/blog/welcome.mdx'),
     ).toBeFalsy();
 
-    await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
+    await tsAstroDocsGenerator(tree, {
+      name: 'docs',
+      preferInstallDependencies: false,
+    });
 
     expect(
       tree.exists('docs/src/content/docs/en/blog/welcome.mdx'),
@@ -255,10 +264,13 @@ describe('ts#astro-docs generator', () => {
   });
 
   it('should create a second independent project when run with a different name', async () => {
-    await tsAstroDocsGenerator(tree, { name: 'docs', skipInstall: true });
+    await tsAstroDocsGenerator(tree, {
+      name: 'docs',
+      preferInstallDependencies: false,
+    });
     await tsAstroDocsGenerator(tree, {
       name: 'other-docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(tree.exists('docs/project.json')).toBeTruthy();

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -7,13 +7,13 @@ import {
   addProjectConfiguration,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toKebabCase } from '../../utils/names';
 import { getNpmScopePrefix } from '../../utils/npm-scope';
@@ -176,11 +176,9 @@ export const tsAstroDocsGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_ASTRO_DOCS_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    if (!schema.skipInstall) {
-      installPackagesTask(tree);
-    }
-  };
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsAstroDocsGenerator;

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -13,7 +13,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toKebabCase } from '../../utils/names';
 import { getNpmScopePrefix } from '../../utils/npm-scope';
@@ -176,9 +176,10 @@ export const tsAstroDocsGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_ASTRO_DOCS_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsAstroDocsGenerator;

--- a/packages/nx-plugin/src/ts/astro-docs/schema.d.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/schema.d.ts
@@ -24,7 +24,7 @@ export interface TsAstroDocsGeneratorSchema {
    */
   noBlog?: boolean;
   /**
-   * Skip installing dependencies after the generator runs.
+   * Whether to prefer installing dependencies after the generator runs.
    */
-  skipInstall?: boolean;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/astro-docs/schema.json
+++ b/packages/nx-plugin/src/ts/astro-docs/schema.json
@@ -52,10 +52,10 @@
       "default": false,
       "x-prompt": "Would you like to opt out of the blog?"
     },
-    "skipInstall": {
-      "description": "Skip installing dependencies after the generator runs.",
+    "preferInstallDependencies": {
       "type": "boolean",
-      "default": false
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/ts/docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/docs/generator.spec.ts
@@ -16,7 +16,7 @@ describe('ts#docs generator', () => {
   it('should delegate to tsAstroDocsGenerator and produce a docs site', async () => {
     await tsDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(tree.exists('docs/project.json')).toBeTruthy();
@@ -28,7 +28,7 @@ describe('ts#docs generator', () => {
   it('should set generator metadata to ts#docs with framework field', async () => {
     await tsDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const projectConfig = readJson(tree, 'docs/project.json');
@@ -39,7 +39,7 @@ describe('ts#docs generator', () => {
   it('should default framework to astro', async () => {
     await tsDocsGenerator(tree, {
       name: 'docs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const projectConfig = readJson(tree, 'docs/project.json');
@@ -50,7 +50,7 @@ describe('ts#docs generator', () => {
     await tsDocsGenerator(tree, {
       name: 'docs',
       framework: 'astro',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const projectConfig = readJson(tree, 'docs/project.json');
@@ -62,7 +62,7 @@ describe('ts#docs generator', () => {
     await tsDocsGenerator(tree, {
       name: 'docs',
       noTranslation: true,
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(tree.exists('docs/scripts/translate.ts')).toBeFalsy();
@@ -74,7 +74,7 @@ describe('ts#docs generator', () => {
     await tsDocsGenerator(tree, {
       name: 'docs',
       noBlog: true,
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(
@@ -87,7 +87,7 @@ describe('ts#docs generator', () => {
       name: 'my-docs',
       directory: 'sites',
       subDirectory: 'docs-site',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(tree.exists('sites/docs-site/project.json')).toBeTruthy();

--- a/packages/nx-plugin/src/ts/docs/schema.d.ts
+++ b/packages/nx-plugin/src/ts/docs/schema.d.ts
@@ -27,8 +27,5 @@ export interface TsDocsGeneratorSchema {
    * Opt out of the starlight-blog plugin and sample blog post.
    */
   noBlog?: boolean;
-  /**
-   * Skip installing dependencies after the generator runs.
-   */
-  skipInstall?: boolean;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/docs/schema.json
+++ b/packages/nx-plugin/src/ts/docs/schema.json
@@ -60,10 +60,10 @@
       "default": false,
       "x-prompt": "Would you like to opt out of the blog?"
     },
-    "skipInstall": {
-      "description": "Skip installing dependencies after the generator runs.",
+    "preferInstallDependencies": {
       "type": "boolean",
-      "default": false
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/ts/dynamodb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/agent-connection/schema.d.ts
@@ -11,4 +11,5 @@ export interface TsDynamoDBAgentConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   sourceComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/dynamodb/agent-connection/schema.json
+++ b/packages/nx-plugin/src/ts/dynamodb/agent-connection/schema.json
@@ -16,6 +16,11 @@
     "sourceComponent": {
       "type": "string",
       "description": "The agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.ts
@@ -8,7 +8,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   readProjectConfiguration,
   type Tree,
@@ -18,6 +17,7 @@ import { resolveContainers } from '../../utils/containers';
 import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs';
 import { formatFilesInSubtree } from '../../utils/format';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -68,6 +68,7 @@ export const tsDynamoDBGenerator = async (
     await tsProjectGenerator(tree, {
       name: options.name,
       directory: options.directory,
+      preferInstallDependencies: false,
     });
   }
 
@@ -154,9 +155,9 @@ export const tsDynamoDBGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_DYNAMODB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsDynamoDBGenerator;

--- a/packages/nx-plugin/src/ts/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.ts
@@ -17,7 +17,7 @@ import { resolveContainers } from '../../utils/containers';
 import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs';
 import { formatFilesInSubtree } from '../../utils/format';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -155,9 +155,10 @@ export const tsDynamoDBGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_DYNAMODB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsDynamoDBGenerator;

--- a/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/schema.d.ts
@@ -11,4 +11,5 @@ export interface TsDynamoDBMcpServerConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   sourceComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/schema.json
+++ b/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/schema.json
@@ -16,6 +16,11 @@
     "sourceComponent": {
       "type": "string",
       "description": "The MCP server component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/dynamodb/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/schema.d.ts
@@ -12,4 +12,5 @@ export interface TsDynamoDBGeneratorSchema {
   tableName?: string;
   infra: 'dynamodb' | 'none';
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/dynamodb/schema.json
+++ b/packages/nx-plugin/src/ts/dynamodb/schema.json
@@ -64,6 +64,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: Inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/ts/dynamodb/smithy-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/smithy-connection/schema.d.ts
@@ -9,4 +9,5 @@
 export interface TsDynamoDBSmithyConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/dynamodb/smithy-connection/schema.json
+++ b/packages/nx-plugin/src/ts/dynamodb/smithy-connection/schema.json
@@ -12,6 +12,11 @@
     "targetProject": {
       "type": "string",
       "description": "The ts#dynamodb project to connect to"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/dynamodb/trpc-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/trpc-connection/schema.d.ts
@@ -9,4 +9,5 @@
 export interface TsDynamoDBTrpcConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/dynamodb/trpc-connection/schema.json
+++ b/packages/nx-plugin/src/ts/dynamodb/trpc-connection/schema.json
@@ -12,6 +12,11 @@
     "targetProject": {
       "type": "string",
       "description": "The ts#dynamodb project to connect to"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -16,7 +16,7 @@ import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { pascalCase, toClassName, toKebabCase } from '../../utils/names';
 import {
@@ -176,9 +176,10 @@ export const tsLambdaFunctionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsLambdaFunctionGenerator;

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -6,7 +6,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -17,6 +16,7 @@ import { addTypeScriptBundleTarget } from '../../utils/bundle/bundle';
 import { formatFilesInSubtree } from '../../utils/format';
 import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { pascalCase, toClassName, toKebabCase } from '../../utils/names';
 import {
@@ -176,9 +176,9 @@ export const tsLambdaFunctionGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsLambdaFunctionGenerator;

--- a/packages/nx-plugin/src/ts/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/schema.d.ts
@@ -58,4 +58,5 @@ export interface TsLambdaFunctionGeneratorSchema {
   readonly event?: EventSource;
   readonly infra?: LambdaInfraOption;
   readonly iac: IacOption;
+  readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/lambda-function/schema.json
+++ b/packages/nx-plugin/src/ts/lambda-function/schema.json
@@ -92,6 +92,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project", "name"]

--- a/packages/nx-plugin/src/ts/lib/biome.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/biome.spec.ts
@@ -14,7 +14,7 @@ describe('configureBiomeLint', () => {
     tree = createTreeUsingTsSolutionSetup();
     await tsProjectGenerator(tree, {
       name: 'test',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
   });
 

--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -19,7 +19,7 @@ describe('ts lib generator', () => {
   it('should generate library with default options', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-lib',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
     // Verify directory structure
     expect(tree.exists('test-lib')).toBeTruthy();
@@ -46,7 +46,7 @@ describe('ts lib generator', () => {
     await tsProjectGenerator(tree, {
       name: 'test-lib',
       directory: 'libs',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
     // Verify directory structure
     expect(tree.exists('libs/test-lib')).toBeTruthy();
@@ -69,7 +69,7 @@ describe('ts lib generator', () => {
       name: 'test-lib',
       subDirectory: 'test-lib',
       directory: 'feature',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
     // Verify directory structure
     expect(tree.exists('feature/test-lib')).toBeTruthy();
@@ -92,7 +92,7 @@ describe('ts lib generator', () => {
       name: 'test-lib',
       directory: 'feature',
       subDirectory: '', // Empty string should fall back to normalized name
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
     // Verify directory structure - should use normalized name (test-lib) as subdirectory
     expect(tree.exists('feature/test-lib')).toBeTruthy();
@@ -103,11 +103,11 @@ describe('ts lib generator', () => {
   it('should not configure duplicate @nx/js/typescript plugin entries', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-1',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
     await tsProjectGenerator(tree, {
       name: 'test-2',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const jsPlugins = readNxJson(tree).plugins.filter(
@@ -119,7 +119,7 @@ describe('ts lib generator', () => {
   it('should configure named inputs in nx.json', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-1',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const namedInputs = readNxJson(tree).namedInputs;
@@ -136,12 +136,12 @@ describe('ts lib generator', () => {
   it('should not duplicate named inputs in nx.json', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-1',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     await tsProjectGenerator(tree, {
       name: 'test-2',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const namedInputs = readNxJson(tree).namedInputs;
@@ -155,7 +155,7 @@ describe('ts lib generator', () => {
   it('should configure target defaults in nx.json', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-1',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const targetDefaults = readNxJson(tree).targetDefaults;
@@ -174,12 +174,12 @@ describe('ts lib generator', () => {
   it('should not configure duplicate inputs in nx.json target defaults', async () => {
     await tsProjectGenerator(tree, {
       name: 'test-1',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     await tsProjectGenerator(tree, {
       name: 'test-2',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     const targetDefaults = readNxJson(tree).targetDefaults;
@@ -199,7 +199,7 @@ describe('ts lib generator', () => {
     // Call the generator function
     await tsProjectGenerator(tree, {
       name: 'test-lib',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     expect(readJson(tree, 'test-lib/project.json').metadata).toHaveProperty(
@@ -212,7 +212,7 @@ describe('ts lib generator', () => {
     // Call the generator function
     await tsProjectGenerator(tree, {
       name: 'test-lib',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     // No vite configuration as we build with tsc
@@ -230,7 +230,7 @@ describe('ts lib generator', () => {
     // Call the generator function
     await tsProjectGenerator(tree, {
       name: 'test-lib',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
 
     // Verify the metric was added to app.ts
@@ -238,7 +238,10 @@ describe('ts lib generator', () => {
   });
 
   it('should be idempotent when re-run with same options', async () => {
-    await tsProjectGenerator(tree, { name: 'test-lib', skipInstall: true });
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
 
     // User edits the generated source
     const indexPath = 'test-lib/src/index.ts';
@@ -249,7 +252,10 @@ describe('ts lib generator', () => {
     // Re-running with the same options must not throw, must preserve user code,
     // and must not change the project's targets.
     await expect(
-      tsProjectGenerator(tree, { name: 'test-lib', skipInstall: true }),
+      tsProjectGenerator(tree, {
+        name: 'test-lib',
+        preferInstallDependencies: false,
+      }),
     ).resolves.toBeDefined();
 
     expect(tree.read(indexPath, 'utf-8')).toBe('// my code\n');

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -15,7 +15,7 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator } from '@nx/js';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toKebabCase } from '../../utils/names';
 import { getNpmScopePrefix } from '../../utils/npm-scope';
@@ -209,11 +209,12 @@ export const tsProjectGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  // `installDeps` ensures vitest resolves for the `typescript` language (the
+  // `installDependencies` ensures vitest resolves for the `typescript` language (the
   // generated vitest.config.mts imports it and Nx loads that config when
   // computing the project graph), so a deferred install still runs when needed.
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 export default tsProjectGenerator;

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   type NxJsonConfiguration,
   OverwriteStrategy,
@@ -16,6 +15,7 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator } from '@nx/js';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { toKebabCase } from '../../utils/names';
 import { getNpmScopePrefix } from '../../utils/npm-scope';
@@ -209,10 +209,11 @@ export const tsProjectGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => {
-    if (!schema.skipInstall) {
-      installPackagesTask(tree);
-    }
-  };
+  // `installDeps` ensures vitest resolves for the `typescript` language (the
+  // generated vitest.config.mts imports it and Nx loads that config when
+  // computing the project graph), so a deferred install still runs when needed.
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 export default tsProjectGenerator;

--- a/packages/nx-plugin/src/ts/lib/schema.d.ts
+++ b/packages/nx-plugin/src/ts/lib/schema.d.ts
@@ -10,5 +10,5 @@ export interface TsProjectGeneratorSchema {
   // TODO: test and consider exposing alternate bundlers
   // bundler?: LibraryGeneratorSchema['bundler'];
   subDirectory?: string;
-  skipInstall?: boolean;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/lib/schema.json
+++ b/packages/nx-plugin/src/ts/lib/schema.json
@@ -26,6 +26,11 @@
       "type": "string",
       "description": "The sub directory the lib is placed in. By default this is the library name.",
       "x-prompt": "Which sub directory do you want to create the library in? (By default this is the library name)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -26,7 +26,7 @@ describe('vitest utils', () => {
     tree = createTreeUsingTsSolutionSetup();
     await tsProjectGenerator(tree, {
       name: 'test',
-      skipInstall: true,
+      preferInstallDependencies: false,
     });
   });
 

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -7,7 +7,6 @@ import {
   detectPackageManager,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   readJson,
@@ -24,6 +23,7 @@ import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -310,9 +310,9 @@ export const tsMcpServerGenerator = async (
   await ensureLicenseExceptions(tree, MCP_INSPECTOR_EXCEPTIONS);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsMcpServerGenerator;

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -23,7 +23,7 @@ import { resolveContainers } from '../../utils/containers';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, toClassName } from '../../utils/names';
 import { getNpmScope } from '../../utils/npm-scope';
@@ -310,9 +310,10 @@ export const tsMcpServerGenerator = async (
   await ensureLicenseExceptions(tree, MCP_INSPECTOR_EXCEPTIONS);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsMcpServerGenerator;

--- a/packages/nx-plugin/src/ts/mcp-server/schema.d.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/schema.d.ts
@@ -15,4 +15,5 @@ export interface TsMcpServerGeneratorSchema {
   infra?: TsMcpServerInfra;
   auth?: TsMcpServerAuth;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/mcp-server/schema.json
+++ b/packages/nx-plugin/src/ts/mcp-server/schema.json
@@ -43,6 +43,11 @@
       "enum": ["agentcore", "none"],
       "default": "agentcore",
       "x-priority": "important"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
@@ -109,15 +109,12 @@ describe('foo#bar generator', () => {
 `;
 
 exports[`nx-generator generator > within @aws/nx-plugin > should generate an example schema, generator and test > generator.ts 1`] = `
-"import {
-  type GeneratorCallback,
-  type Tree,
-  installPackagesTask,
-} from '@nx/devkit';
+"import { type GeneratorCallback, type Tree } from '@nx/devkit';
 import type { FooBarGeneratorSchema } from './schema.js';
 import { type NxGeneratorInfo, getGeneratorInfo } from '../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
 import { formatFilesInSubtree } from '../utils/format';
+import { installDeps } from '../utils/install';
 
 export const FOO_BAR_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
   import.meta.filename,
@@ -132,9 +129,10 @@ export const fooBarGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [FOO_BAR_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () =>
+    installDeps(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default fooBarGenerator;
@@ -149,6 +147,7 @@ exports[`nx-generator generator > within @aws/nx-plugin > should generate an exa
 export interface FooBarGeneratorSchema {
   // Replace with your options
   exampleOption: string;
+  preferInstallDependencies?: boolean;
 }
 "
 `;
@@ -166,6 +165,11 @@ exports[`nx-generator generator > within @aws/nx-plugin > should generate an exa
       "description": "An example option. Refer to https://nx.dev/extending-nx/recipes/generator-options for more info",
       "x-priority": "important",
       "x-prompt": "This is an example option!"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["exampleOption"]
@@ -254,6 +258,7 @@ exports[`nx-generator generator > within another workspace > should generate an 
 export interface FooBarGeneratorSchema {
   // Replace with your options
   exampleOption: string;
+  preferInstallDependencies?: boolean;
 }
 "
 `;
@@ -271,6 +276,11 @@ exports[`nx-generator generator > within another workspace > should generate an 
       "description": "An example option. Refer to https://nx.dev/extending-nx/recipes/generator-options for more info",
       "x-priority": "important",
       "x-prompt": "This is an example option!"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["exampleOption"]

--- a/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
@@ -114,7 +114,7 @@ import type { FooBarGeneratorSchema } from './schema.js';
 import { type NxGeneratorInfo, getGeneratorInfo } from '../utils/nx';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
 import { formatFilesInSubtree } from '../utils/format';
-import { installDeps } from '../utils/install';
+import { installDependencies } from '../utils/install';
 
 export const FOO_BAR_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
   import.meta.filename,
@@ -130,7 +130,7 @@ export const fooBarGenerator = async (
 
   await formatFilesInSubtree(tree);
   return () =>
-    installDeps(tree, options.preferInstallDependencies, {
+    installDependencies(tree, options.preferInstallDependencies, {
       languages: ['typescript'],
     });
 };

--- a/packages/nx-plugin/src/ts/nx-generator/files/common/schema.d.ts.template
+++ b/packages/nx-plugin/src/ts/nx-generator/files/common/schema.d.ts.template
@@ -5,4 +5,5 @@
 export interface <%- namePascalCase %>GeneratorSchema {
   // Replace with your options
   exampleOption: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/nx-generator/files/common/schema.json.template
+++ b/packages/nx-plugin/src/ts/nx-generator/files/common/schema.json.template
@@ -10,6 +10,11 @@
       "description": "An example option. Refer to https://nx.dev/extending-nx/recipes/generator-options for more info",
       "x-priority": "important",
       "x-prompt": "This is an example option!"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["exampleOption"]

--- a/packages/nx-plugin/src/ts/nx-generator/files/nx-plugin-for-aws/generator/generator.ts.template
+++ b/packages/nx-plugin/src/ts/nx-generator/files/nx-plugin-for-aws/generator/generator.ts.template
@@ -3,7 +3,7 @@ import type { <%- namePascalCase %>GeneratorSchema } from './schema.js';
 import { type NxGeneratorInfo, getGeneratorInfo } from '<%- pathToProjectSourceRoot %>utils/nx';
 import { addGeneratorMetricsIfApplicable } from '<%- pathToProjectSourceRoot %>utils/metrics';
 import { formatFilesInSubtree } from '<%- pathToProjectSourceRoot %>utils/format';
-import { installDeps } from '<%- pathToProjectSourceRoot %>utils/install';
+import { installDependencies } from '<%- pathToProjectSourceRoot %>utils/install';
 
 export const <%- nameUpperSnakeCase %>_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(import.meta.filename);
@@ -15,7 +15,7 @@ export const <%- nameCamelCase %>Generator = async (tree: Tree, options: <%- nam
   await addGeneratorMetricsIfApplicable(tree, [<%- nameUpperSnakeCase %>_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, { languages: ['typescript'] });
+  return () => installDependencies(tree, options.preferInstallDependencies, { languages: ['typescript'] });
 };
 
 export default <%- nameCamelCase %>Generator;

--- a/packages/nx-plugin/src/ts/nx-generator/files/nx-plugin-for-aws/generator/generator.ts.template
+++ b/packages/nx-plugin/src/ts/nx-generator/files/nx-plugin-for-aws/generator/generator.ts.template
@@ -1,8 +1,9 @@
-import { type GeneratorCallback, type Tree, installPackagesTask } from "@nx/devkit";
+import { type GeneratorCallback, type Tree } from "@nx/devkit";
 import type { <%- namePascalCase %>GeneratorSchema } from './schema.js';
 import { type NxGeneratorInfo, getGeneratorInfo } from '<%- pathToProjectSourceRoot %>utils/nx';
 import { addGeneratorMetricsIfApplicable } from '<%- pathToProjectSourceRoot %>utils/metrics';
 import { formatFilesInSubtree } from '<%- pathToProjectSourceRoot %>utils/format';
+import { installDeps } from '<%- pathToProjectSourceRoot %>utils/install';
 
 export const <%- nameUpperSnakeCase %>_GENERATOR_INFO: NxGeneratorInfo =
   getGeneratorInfo(import.meta.filename);
@@ -14,9 +15,7 @@ export const <%- nameCamelCase %>Generator = async (tree: Tree, options: <%- nam
   await addGeneratorMetricsIfApplicable(tree, [<%- nameUpperSnakeCase %>_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, { languages: ['typescript'] });
 };
 
 export default <%- nameCamelCase %>Generator;

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   readJson,
@@ -16,6 +15,7 @@ import camelCase from 'lodash.camelcase';
 import PackageJson from '../../../package.json' with { type: 'json' };
 import { addStarExport, applyGritQL } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, pascalCase, snakeCase } from '../../utils/names';
 import {
@@ -190,9 +190,9 @@ export const tsNxGeneratorGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 const incrementMetric = (metrics: string[]): string => {

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -15,7 +15,7 @@ import camelCase from 'lodash.camelcase';
 import PackageJson from '../../../package.json' with { type: 'json' };
 import { addStarExport, applyGritQL } from '../../utils/ast';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, pascalCase, snakeCase } from '../../utils/names';
 import {
@@ -190,9 +190,10 @@ export const tsNxGeneratorGenerator = async (
 
   await formatFilesInSubtree(tree);
 
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 const incrementMetric = (metrics: string[]): string => {

--- a/packages/nx-plugin/src/ts/nx-generator/schema.d.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/schema.d.ts
@@ -8,4 +8,5 @@ export interface TsNxGeneratorGeneratorSchema {
   name: string;
   directory?: string;
   description?: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/nx-generator/schema.json
+++ b/packages/nx-plugin/src/ts/nx-generator/schema.json
@@ -32,6 +32,11 @@
       "type": "string",
       "description": "The directory within the plugin project's source folder to add the generator to (default: <name>)",
       "x-prompt": "Choose the directory you would like to generate the generator in relative to the project's source folder (default: <name>)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project", "name"]

--- a/packages/nx-plugin/src/ts/nx-plugin/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/generator.ts
@@ -5,7 +5,6 @@
 import {
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -13,6 +12,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -37,7 +37,10 @@ export const tsNxPluginGenerator = async (
 ): Promise<GeneratorCallback> => {
   // Generate a TypeScript project as the base
   const { fullyQualifiedName, dir } = getTsLibDetails(tree, options);
-  await tsProjectGenerator(tree, options);
+  await tsProjectGenerator(tree, {
+    ...options,
+    preferInstallDependencies: false,
+  });
 
   // Configure the typescript project as an Nx Plugin
   configureTsProjectAsNxPlugin(tree, fullyQualifiedName);
@@ -96,6 +99,7 @@ export const tsNxPluginGenerator = async (
     project: fullyQualifiedName,
     infra: 'none',
     iac: 'cdk', // not used
+    preferInstallDependencies: false,
   });
 
   const mcpPath = joinPathFragments(project.sourceRoot, 'mcp-server');
@@ -122,9 +126,9 @@ export const tsNxPluginGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_NX_PLUGIN_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsNxPluginGenerator;

--- a/packages/nx-plugin/src/ts/nx-plugin/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/generator.ts
@@ -12,7 +12,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { formatFilesInSubtree } from '../../utils/format';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import {
   addDependencyToTargetIfNotPresent,
@@ -126,9 +126,10 @@ export const tsNxPluginGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_NX_PLUGIN_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsNxPluginGenerator;

--- a/packages/nx-plugin/src/ts/nx-plugin/schema.json
+++ b/packages/nx-plugin/src/ts/nx-plugin/schema.json
@@ -26,6 +26,11 @@
       "type": "string",
       "description": "The sub directory the lib is placed in. By default this is the library name.",
       "x-prompt": "Which sub directory do you want to create the library in? (By default this is the library name)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/ts/rdb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/agent-connection/schema.d.ts
@@ -11,4 +11,5 @@ export interface TsRdbAgentConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   sourceComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/rdb/agent-connection/schema.json
+++ b/packages/nx-plugin/src/ts/rdb/agent-connection/schema.json
@@ -16,6 +16,11 @@
     "sourceComponent": {
       "type": "string",
       "description": "The agent component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -7,7 +7,6 @@ import {
   addDependenciesToPackageJson,
   type GeneratorCallback,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   readProjectConfiguration,
   type Tree,
@@ -20,6 +19,7 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { updateGitIgnore } from '../../utils/git';
 import { resolveIac } from '../../utils/iac';
+import { installDeps } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, snakeCase, toClassName } from '../../utils/names';
 import { getNpmScope, toScopeAlias } from '../../utils/npm-scope';
@@ -74,6 +74,7 @@ export const tsRdbGenerator = async (
     await tsProjectGenerator(tree, {
       name: options.name,
       directory: options.directory,
+      preferInstallDependencies: false,
     });
   }
 
@@ -308,9 +309,9 @@ export const tsRdbGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_RDB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 };
 
 export default tsRdbGenerator;

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -19,7 +19,7 @@ import { formatFilesInSubtree } from '../../utils/format';
 import { FsCommands } from '../../utils/fs';
 import { updateGitIgnore } from '../../utils/git';
 import { resolveIac } from '../../utils/iac';
-import { installDeps } from '../../utils/install';
+import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
 import { kebabCase, snakeCase, toClassName } from '../../utils/names';
 import { getNpmScope, toScopeAlias } from '../../utils/npm-scope';
@@ -309,9 +309,10 @@ export const tsRdbGenerator = async (
   await addGeneratorMetricsIfApplicable(tree, [TS_RDB_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 };
 
 export default tsRdbGenerator;

--- a/packages/nx-plugin/src/ts/rdb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/mcp-server-connection/schema.d.ts
@@ -11,4 +11,5 @@ export interface TsRdbMcpServerConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
   sourceComponent?: ComponentMetadata;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/rdb/mcp-server-connection/schema.json
+++ b/packages/nx-plugin/src/ts/rdb/mcp-server-connection/schema.json
@@ -16,6 +16,11 @@
     "sourceComponent": {
       "type": "string",
       "description": "The MCP server component name"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/rdb/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/schema.d.ts
@@ -14,4 +14,5 @@ export interface TsRdbGeneratorSchema {
   databaseName?: string;
   framework: 'prisma';
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/rdb/schema.json
+++ b/packages/nx-plugin/src/ts/rdb/schema.json
@@ -67,6 +67,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name", "infra", "engine", "framework"]

--- a/packages/nx-plugin/src/ts/rdb/smithy-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/smithy-connection/schema.d.ts
@@ -9,4 +9,5 @@
 export interface TsRdbSmithyConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/rdb/smithy-connection/schema.json
+++ b/packages/nx-plugin/src/ts/rdb/smithy-connection/schema.json
@@ -12,6 +12,11 @@
     "targetProject": {
       "type": "string",
       "description": "The ts#rdb project to connect to"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/rdb/trpc-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/trpc-connection/schema.d.ts
@@ -9,4 +9,5 @@
 export interface TsRdbTrpcConnectionGeneratorSchema {
   sourceProject: string;
   targetProject: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/rdb/trpc-connection/schema.json
+++ b/packages/nx-plugin/src/ts/rdb/trpc-connection/schema.json
@@ -12,6 +12,11 @@
     "targetProject": {
       "type": "string",
       "description": "The ts#rdb project to connect to"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["sourceProject", "targetProject"]

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
 import { resolveIac } from '../../../utils/iac';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase, toClassName, toKebabCase } from '../../../utils/names';
 import { getNpmScopePrefix, toScopeAlias } from '../../../utils/npm-scope';
@@ -521,12 +521,13 @@ export async function tsReactWebsiteGenerator(
   // The generated vite.config.mts imports these, and Nx's inferred `@nx/vite`
   // plugin loads that config when computing the project graph — so they must be
   // installed even if the caller would otherwise prefer to defer.
-  return () => installDeps(tree, schema.preferInstallDependencies, {
-    languages: ['typescript'],
-    ensureResolvable: [
-      ...(tailwind ? ['@tailwindcss/vite'] : []),
-      ...(tanstackRouter ? ['@tanstack/router-plugin'] : []),
-    ],
-  });
+  return () =>
+    installDependencies(tree, schema.preferInstallDependencies, {
+      languages: ['typescript'],
+      ensureResolvable: [
+        ...(tailwind ? (['@tailwindcss/vite'] as const) : []),
+        ...(tanstackRouter ? (['@tanstack/router-plugin'] as const) : []),
+      ],
+    });
 }
 export default tsReactWebsiteGenerator;

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -5,7 +5,6 @@
 import {
   addDependenciesToPackageJson,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   names,
   OverwriteStrategy,
@@ -23,6 +22,7 @@ import {
 } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
 import { resolveIac } from '../../../utils/iac';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { kebabCase, toClassName, toKebabCase } from '../../../utils/names';
 import { getNpmScopePrefix, toScopeAlias } from '../../../utils/npm-scope';
@@ -518,10 +518,15 @@ export async function tsReactWebsiteGenerator(
   ]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    if (!schema.skipInstall) {
-      installPackagesTask(tree);
-    }
-  };
+  // The generated vite.config.mts imports these, and Nx's inferred `@nx/vite`
+  // plugin loads that config when computing the project graph — so they must be
+  // installed even if the caller would otherwise prefer to defer.
+  return () => installDeps(tree, schema.preferInstallDependencies, {
+    languages: ['typescript'],
+    ensureResolvable: [
+      ...(tailwind ? ['@tailwindcss/vite'] : []),
+      ...(tanstackRouter ? ['@tanstack/router-plugin'] : []),
+    ],
+  });
 }
 export default tsReactWebsiteGenerator;

--- a/packages/nx-plugin/src/ts/react-website/app/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/schema.d.ts
@@ -11,7 +11,7 @@ export interface TsReactWebsiteGeneratorSchema {
   name: string;
   directory?: string;
   subDirectory?: string;
-  skipInstall?: boolean;
+  preferInstallDependencies?: boolean;
   tanstackRouter?: boolean;
   tailwind?: boolean;
   ux?: UxOption;

--- a/packages/nx-plugin/src/ts/react-website/app/schema.json
+++ b/packages/nx-plugin/src/ts/react-website/app/schema.json
@@ -82,6 +82,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"],

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -5,7 +5,6 @@
 import {
   addDependenciesToPackageJson,
   generateFiles,
-  installPackagesTask,
   joinPathFragments,
   OverwriteStrategy,
   type Tree,
@@ -21,6 +20,7 @@ import { addHookResultToRouterProviderContext } from '../../../utils/ast/website
 import { formatFilesInSubtree } from '../../../utils/format';
 import { resolveIac } from '../../../utils/iac';
 import { addIdentityInfra } from '../../../utils/identity-constructs/identity-constructs';
+import { installDeps } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { getNpmScope } from '../../../utils/npm-scope';
 import {
@@ -68,6 +68,7 @@ export async function tsReactWebsiteAuthGenerator(
 
   await runtimeConfigGenerator(tree, {
     project: options.project,
+    preferInstallDependencies: false,
   });
 
   const iac = await resolveIac(tree, options.iac);
@@ -179,8 +180,8 @@ export async function tsReactWebsiteAuthGenerator(
   await addGeneratorMetricsIfApplicable(tree, [COGNITO_AUTH_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => {
-    installPackagesTask(tree);
-  };
+  return () => installDeps(tree, options.preferInstallDependencies, {
+    languages: ['typescript'],
+  });
 }
 export default tsReactWebsiteAuthGenerator;

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -20,7 +20,7 @@ import { addHookResultToRouterProviderContext } from '../../../utils/ast/website
 import { formatFilesInSubtree } from '../../../utils/format';
 import { resolveIac } from '../../../utils/iac';
 import { addIdentityInfra } from '../../../utils/identity-constructs/identity-constructs';
-import { installDeps } from '../../../utils/install';
+import { installDependencies } from '../../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
 import { getNpmScope } from '../../../utils/npm-scope';
 import {
@@ -180,8 +180,9 @@ export async function tsReactWebsiteAuthGenerator(
   await addGeneratorMetricsIfApplicable(tree, [COGNITO_AUTH_GENERATOR_INFO]);
 
   await formatFilesInSubtree(tree);
-  return () => installDeps(tree, options.preferInstallDependencies, {
-    languages: ['typescript'],
-  });
+  return () =>
+    installDependencies(tree, options.preferInstallDependencies, {
+      languages: ['typescript'],
+    });
 }
 export default tsReactWebsiteAuthGenerator;

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.d.ts
@@ -10,4 +10,5 @@ export interface TsReactWebsiteAuthGeneratorSchema {
   allowSignup: boolean;
   cognitoDomain?: string;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.json
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.json
@@ -44,6 +44,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/schema.d.ts
@@ -4,4 +4,5 @@
  */
 export interface RuntimeConfigGeneratorSchema {
   project: string;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/schema.json
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/schema.json
@@ -13,6 +13,11 @@
       "x-priority": "important",
       "x-prompt": "the project to target",
       "x-dropdown": "projects"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/ts/sync/schema.json
+++ b/packages/nx-plugin/src/ts/sync/schema.json
@@ -4,5 +4,11 @@
   "title": "TypeScript sync generator",
   "description": "TypeScript path alias sync generator",
   "type": "object",
-  "properties": {}
+  "properties": {
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
+    }
+  }
 }

--- a/packages/nx-plugin/src/ts/sync/schema.json
+++ b/packages/nx-plugin/src/ts/sync/schema.json
@@ -4,11 +4,5 @@
   "title": "TypeScript sync generator",
   "description": "TypeScript path alias sync generator",
   "type": "object",
-  "properties": {
-    "preferInstallDependencies": {
-      "type": "boolean",
-      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
-      "default": true
-    }
-  }
+  "properties": {}
 }

--- a/packages/nx-plugin/src/ts/website/app/schema.d.ts
+++ b/packages/nx-plugin/src/ts/website/app/schema.d.ts
@@ -13,10 +13,10 @@ export interface TsWebsiteGeneratorSchema {
   framework?: WebsiteFramework;
   directory?: string;
   subDirectory?: string;
-  skipInstall?: boolean;
   tanstackRouter?: boolean;
   tailwind?: boolean;
   ux?: UxOption;
   infra?: WebsiteInfraOption;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/website/app/schema.json
+++ b/packages/nx-plugin/src/ts/website/app/schema.json
@@ -98,6 +98,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["name"],

--- a/packages/nx-plugin/src/ts/website/auth/generator.ts
+++ b/packages/nx-plugin/src/ts/website/auth/generator.ts
@@ -20,6 +20,7 @@ export async function tsWebsiteAuthGenerator(
     allowSignup: schema.allowSignup,
     cognitoDomain: schema.cognitoDomain,
     iac: schema.iac,
+    preferInstallDependencies: schema.preferInstallDependencies,
   });
 }
 

--- a/packages/nx-plugin/src/ts/website/auth/schema.d.ts
+++ b/packages/nx-plugin/src/ts/website/auth/schema.d.ts
@@ -9,4 +9,5 @@ export interface TsWebsiteAuthGeneratorSchema {
   allowSignup: boolean;
   cognitoDomain?: string;
   iac: IacOption;
+  preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/website/auth/schema.json
+++ b/packages/nx-plugin/src/ts/website/auth/schema.json
@@ -40,6 +40,11 @@
       "x-priority": "important",
       "default": "inherit",
       "x-prompt": "Which provider would you like to manage your infrastructure? (default: inherit)"
+    },
+    "preferInstallDependencies": {
+      "type": "boolean",
+      "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",
+      "default": true
     }
   },
   "required": ["project"]

--- a/packages/nx-plugin/src/utils/install.spec.ts
+++ b/packages/nx-plugin/src/utils/install.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as devkit from '@nx/devkit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installDeps } from './install';
+
+const install = vi.fn();
+
+vi.mock('@nx/devkit', async () => {
+  const actual = await vi.importActual('@nx/devkit');
+  return {
+    ...actual,
+    installPackagesTask: vi.fn(),
+  };
+});
+
+vi.mock('./nxlv-python', () => ({
+  UVProvider: class {
+    install = install;
+  },
+  Logger: class {},
+}));
+
+/**
+ * Creates a real on-disk workspace directory (the resolvability check reads the
+ * filesystem) and returns a minimal tree-like object pointing at it.
+ */
+const createWorkspace = (installedPackages: string[] = []) => {
+  const root = mkdtempSync(join(tmpdir(), 'install-spec-'));
+  for (const pkg of installedPackages) {
+    const dir = join(root, 'node_modules', pkg);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: pkg, version: '1.0.0' }),
+    );
+  }
+  return { root } as devkit.Tree;
+};
+
+describe('installDeps', () => {
+  const cleanups: string[] = [];
+  const workspace = (installedPackages: string[] = []) => {
+    const tree = createWorkspace(installedPackages);
+    cleanups.push(tree.root);
+    return tree;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const root of cleanups.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('installs typescript dependencies', async () => {
+    await installDeps(workspace(['vitest']), true, {
+      languages: ['typescript'],
+    });
+    expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it('installs python dependencies', async () => {
+    await installDeps(workspace(), true, { languages: ['python'] });
+    expect(install).toHaveBeenCalledOnce();
+    expect(devkit.installPackagesTask).not.toHaveBeenCalled();
+  });
+
+  it('installs both typescript and python dependencies', async () => {
+    await installDeps(workspace(['vitest']), true, {
+      languages: ['typescript', 'python'],
+    });
+    expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it('installs by default when the preference is undefined', async () => {
+    await installDeps(workspace(['vitest']), undefined, {
+      languages: ['typescript'],
+    });
+    expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
+  });
+
+  it('defers when preferInstallDependencies is false and graph deps are installed', async () => {
+    // vitest is implied for typescript and is present in the workspace.
+    await installDeps(workspace(['vitest']), false, {
+      languages: ['typescript'],
+    });
+    expect(devkit.installPackagesTask).not.toHaveBeenCalled();
+  });
+
+  it('installs despite the defer preference when a graph dep is missing', async () => {
+    // `@nxlv/python` (implied for python) is not installed, so the install must
+    // run regardless of the defer preference. Use a scoped name that cannot
+    // exist in any ancestor node_modules so the assertion is deterministic.
+    await installDeps(workspace(), false, { languages: ['python'] });
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it('installs despite the defer preference when an extra ensureResolvable package is missing', async () => {
+    await installDeps(workspace(['vitest']), false, {
+      languages: ['typescript'],
+      ensureResolvable: ['@aws-nx-test/definitely-not-installed'],
+    });
+    expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
+  });
+
+  it('defers when all extra ensureResolvable packages are installed', async () => {
+    await installDeps(workspace(['vitest', '@tailwindcss/vite']), false, {
+      languages: ['typescript'],
+      ensureResolvable: ['@tailwindcss/vite'],
+    });
+    expect(devkit.installPackagesTask).not.toHaveBeenCalled();
+  });
+
+  it('does not count a package linked only in an ancestor node_modules', async () => {
+    // The package is installed in the parent but not the workspace itself. Nx
+    // loads a project's config from inside the workspace's own node_modules, so
+    // an ancestor copy is not usable — the install must still run. (This is why
+    // we check the path directly rather than via `require.resolve`, which would
+    // walk up and wrongly report the ancestor copy as resolvable.)
+    const parent = workspace(['vitest']);
+    const child = join(parent.root, 'child');
+    mkdirSync(child, { recursive: true });
+    await installDeps({ root: child } as devkit.Tree, false, {
+      languages: ['typescript'],
+    });
+    expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
+  });
+
+  it('counts an installed package whose `exports` map hides package.json', async () => {
+    // Packages like `@tailwindcss/vite` define `exports` without `./package.json`,
+    // so `require.resolve('<pkg>/package.json')` throws even though the package
+    // is installed. The direct path check must treat it as present and defer,
+    // otherwise we would force a redundant install on every run.
+    const tree = workspace(['vitest']);
+    const dir = join(tree.root, 'node_modules', '@tailwindcss/vite');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: '@tailwindcss/vite',
+        version: '1.0.0',
+        exports: { '.': './dist/index.mjs' },
+      }),
+    );
+    await installDeps(tree, false, {
+      languages: ['typescript'],
+      ensureResolvable: ['@tailwindcss/vite'],
+    });
+    expect(devkit.installPackagesTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx-plugin/src/utils/install.spec.ts
+++ b/packages/nx-plugin/src/utils/install.spec.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as devkit from '@nx/devkit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { installDeps } from './install';
+import { installDependencies } from './install';
 
 const install = vi.fn();
 
@@ -43,7 +43,7 @@ const createWorkspace = (installedPackages: string[] = []) => {
   return { root } as devkit.Tree;
 };
 
-describe('installDeps', () => {
+describe('installDependencies', () => {
   const cleanups: string[] = [];
   const workspace = (installedPackages: string[] = []) => {
     const tree = createWorkspace(installedPackages);
@@ -62,7 +62,7 @@ describe('installDeps', () => {
   });
 
   it('installs typescript dependencies', async () => {
-    await installDeps(workspace(['vitest']), true, {
+    await installDependencies(workspace(['vitest']), true, {
       languages: ['typescript'],
     });
     expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
@@ -70,13 +70,13 @@ describe('installDeps', () => {
   });
 
   it('installs python dependencies', async () => {
-    await installDeps(workspace(), true, { languages: ['python'] });
+    await installDependencies(workspace(), true, { languages: ['python'] });
     expect(install).toHaveBeenCalledOnce();
     expect(devkit.installPackagesTask).not.toHaveBeenCalled();
   });
 
   it('installs both typescript and python dependencies', async () => {
-    await installDeps(workspace(['vitest']), true, {
+    await installDependencies(workspace(['vitest']), true, {
       languages: ['typescript', 'python'],
     });
     expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
@@ -84,7 +84,7 @@ describe('installDeps', () => {
   });
 
   it('installs by default when the preference is undefined', async () => {
-    await installDeps(workspace(['vitest']), undefined, {
+    await installDependencies(workspace(['vitest']), undefined, {
       languages: ['typescript'],
     });
     expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
@@ -92,7 +92,7 @@ describe('installDeps', () => {
 
   it('defers when preferInstallDependencies is false and graph deps are installed', async () => {
     // vitest is implied for typescript and is present in the workspace.
-    await installDeps(workspace(['vitest']), false, {
+    await installDependencies(workspace(['vitest']), false, {
       languages: ['typescript'],
     });
     expect(devkit.installPackagesTask).not.toHaveBeenCalled();
@@ -102,23 +102,27 @@ describe('installDeps', () => {
     // `@nxlv/python` (implied for python) is not installed, so the install must
     // run regardless of the defer preference. Use a scoped name that cannot
     // exist in any ancestor node_modules so the assertion is deterministic.
-    await installDeps(workspace(), false, { languages: ['python'] });
+    await installDependencies(workspace(), false, { languages: ['python'] });
     expect(install).toHaveBeenCalledOnce();
   });
 
   it('installs despite the defer preference when an extra ensureResolvable package is missing', async () => {
-    await installDeps(workspace(['vitest']), false, {
+    await installDependencies(workspace(['vitest']), false, {
       languages: ['typescript'],
-      ensureResolvable: ['@aws-nx-test/definitely-not-installed'],
+      ensureResolvable: ['@tailwindcss/vite'],
     });
     expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
   });
 
   it('defers when all extra ensureResolvable packages are installed', async () => {
-    await installDeps(workspace(['vitest', '@tailwindcss/vite']), false, {
-      languages: ['typescript'],
-      ensureResolvable: ['@tailwindcss/vite'],
-    });
+    await installDependencies(
+      workspace(['vitest', '@tailwindcss/vite']),
+      false,
+      {
+        languages: ['typescript'],
+        ensureResolvable: ['@tailwindcss/vite'],
+      },
+    );
     expect(devkit.installPackagesTask).not.toHaveBeenCalled();
   });
 
@@ -131,7 +135,7 @@ describe('installDeps', () => {
     const parent = workspace(['vitest']);
     const child = join(parent.root, 'child');
     mkdirSync(child, { recursive: true });
-    await installDeps({ root: child } as devkit.Tree, false, {
+    await installDependencies({ root: child } as devkit.Tree, false, {
       languages: ['typescript'],
     });
     expect(devkit.installPackagesTask).toHaveBeenCalledOnce();
@@ -153,7 +157,7 @@ describe('installDeps', () => {
         exports: { '.': './dist/index.mjs' },
       }),
     );
-    await installDeps(tree, false, {
+    await installDependencies(tree, false, {
       languages: ['typescript'],
       ensureResolvable: ['@tailwindcss/vite'],
     });

--- a/packages/nx-plugin/src/utils/install.ts
+++ b/packages/nx-plugin/src/utils/install.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { installPackagesTask, type Tree } from '@nx/devkit';
+import { Logger, UVProvider } from './nxlv-python';
+
+/**
+ * Languages whose dependencies a generator may install.
+ */
+export type InstallLanguage = 'typescript' | 'python';
+
+export interface InstallDepsOptions {
+  /** Languages to install dependencies for. */
+  languages: InstallLanguage[];
+  /**
+   * Extra packages that MUST be resolvable from the workspace after this
+   * generator, because a config file it writes (e.g. `vite.config.mts`) imports
+   * them and Nx loads that config when computing the project graph on the next
+   * command — for example a website's `@tailwindcss/vite`.
+   *
+   * `vitest` is always included for the `typescript` language (every TypeScript
+   * project this plugin scaffolds has a `vitest.config.mts`), so callers only
+   * list packages beyond that.
+   *
+   * When the user prefers to defer installing, we honour that ONLY if these are
+   * already resolvable; otherwise we install anyway so the next `nx` command
+   * doesn't fail computing the project graph.
+   */
+  ensureResolvable?: string[];
+}
+
+/**
+ * Packages every TypeScript project this plugin generates relies on in a config
+ * file Nx loads during project-graph computation. Ensuring these resolve means
+ * a deferred install still happens whenever it would otherwise break the graph
+ * — so composed generators don't each have to declare them.
+ */
+const LANGUAGE_GRAPH_DEPS: Record<InstallLanguage, string[]> = {
+  // Every TypeScript project has a `vitest.config.mts` (loaded by `@nx/vitest`).
+  typescript: ['vitest'],
+  // Every Python project registers the `@nxlv/python` inference plugin.
+  python: ['@nxlv/python'],
+};
+
+/**
+ * Returns true if every package in `packages` is linked at the top level of the
+ * workspace's `node_modules`, i.e. `<root>/node_modules/<pkg>` exists.
+ *
+ * This is the condition Nx's inferred plugins need when they load a project's
+ * generated config (e.g. `vite.config.mts`) during project-graph computation:
+ * the config's `import 'vitest'` is resolved from a temp file inside the
+ * workspace's own `node_modules`, so the package must be physically present
+ * there. `require.resolve(..., { paths: [root] })` is too permissive — it can
+ * succeed via the resolving module's own ancestor `node_modules` (the compiled
+ * plugin lives under `node_modules/@aws/nx-plugin`) even when the package is not
+ * yet linked into this workspace, causing us to wrongly defer an install the
+ * next `nx` command then fails on.
+ *
+ * `existsSync` follows symlinks, so pnpm's `node_modules/<pkg>` → store link
+ * resolves correctly, and Nx always uses a `node_modules` linker (it writes
+ * `nodeLinker: node-modules` for Yarn Berry, so PnP never applies).
+ */
+const allResolvable = (root: string, packages: string[]): boolean =>
+  packages.every((pkg) => existsSync(join(root, 'node_modules', pkg)));
+
+/**
+ * Installs dependencies for the given languages.
+ *
+ * Call this from a generator's returned callback:
+ * `return () => installDeps(tree, options.preferInstallDependencies, { ... })`.
+ *
+ * `preferInstallDependencies` is a preference, not a guarantee: when `false`,
+ * the install is deferred so a batch of generators can install once at the
+ * end — UNLESS skipping would leave an `ensureResolvable` package missing, in
+ * which case the install runs regardless so the next `nx` command can still
+ * compute the project graph.
+ *
+ * @example
+ * return () =>
+ *   installDeps(tree, options.preferInstallDependencies, {
+ *     languages: ['typescript'],
+ *     ensureResolvable: ['@tailwindcss/vite'],
+ *   });
+ */
+export const installDeps = async (
+  tree: Tree,
+  preferInstallDependencies: boolean | undefined,
+  options: InstallDepsOptions,
+): Promise<void> => {
+  const { languages, ensureResolvable = [] } = options;
+  const mustResolve = [
+    ...ensureResolvable,
+    ...languages.flatMap((language) => LANGUAGE_GRAPH_DEPS[language]),
+  ];
+  if (
+    preferInstallDependencies === false &&
+    allResolvable(tree.root, mustResolve)
+  ) {
+    return;
+  }
+  if (languages.includes('typescript')) {
+    installPackagesTask(tree);
+  }
+  if (languages.includes('python')) {
+    await new UVProvider(tree.root, new Logger(), tree).install();
+  }
+};

--- a/packages/nx-plugin/src/utils/install.ts
+++ b/packages/nx-plugin/src/utils/install.ts
@@ -6,62 +6,46 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { installPackagesTask, type Tree } from '@nx/devkit';
 import { Logger, UVProvider } from './nxlv-python';
+import type { ITsDepVersion } from './versions';
 
 /**
  * Languages whose dependencies a generator may install.
  */
 export type InstallLanguage = 'typescript' | 'python';
 
-export interface InstallDepsOptions {
+export interface InstallDependenciesOptions {
   /** Languages to install dependencies for. */
   languages: InstallLanguage[];
   /**
-   * Extra packages that MUST be resolvable from the workspace after this
-   * generator, because a config file it writes (e.g. `vite.config.mts`) imports
-   * them and Nx loads that config when computing the project graph on the next
-   * command — for example a website's `@tailwindcss/vite`.
+   * Packages that must resolve from the workspace after this generator, because
+   * a config file it writes (e.g. `vite.config.mts`) imports them and Nx loads
+   * that config when computing the project graph. When the caller prefers to
+   * defer installing, we honour that only if these already resolve.
    *
-   * `vitest` is always included for the `typescript` language (every TypeScript
-   * project this plugin scaffolds has a `vitest.config.mts`), so callers only
-   * list packages beyond that.
-   *
-   * When the user prefers to defer installing, we honour that ONLY if these are
-   * already resolvable; otherwise we install anyway so the next `nx` command
-   * doesn't fail computing the project graph.
+   * The per-language graph deps in `LANGUAGE_GRAPH_DEPS` are always included, so
+   * callers only list packages beyond those.
    */
-  ensureResolvable?: string[];
+  ensureResolvable?: ITsDepVersion[];
 }
 
 /**
- * Packages every TypeScript project this plugin generates relies on in a config
- * file Nx loads during project-graph computation. Ensuring these resolve means
- * a deferred install still happens whenever it would otherwise break the graph
- * — so composed generators don't each have to declare them.
+ * Packages each language always needs resolvable for Nx to compute the project
+ * graph, so a deferred install still runs whenever it would otherwise break.
  */
 const LANGUAGE_GRAPH_DEPS: Record<InstallLanguage, string[]> = {
-  // Every TypeScript project has a `vitest.config.mts` (loaded by `@nx/vitest`).
-  typescript: ['vitest'],
-  // Every Python project registers the `@nxlv/python` inference plugin.
-  python: ['@nxlv/python'],
+  typescript: ['vitest'], // every TypeScript project has a `vitest.config.mts`
+  python: ['@nxlv/python'], // every Python project registers this inference plugin
 };
 
 /**
- * Returns true if every package in `packages` is linked at the top level of the
- * workspace's `node_modules`, i.e. `<root>/node_modules/<pkg>` exists.
+ * Returns true if every package is linked at `<root>/node_modules/<pkg>`.
  *
- * This is the condition Nx's inferred plugins need when they load a project's
- * generated config (e.g. `vite.config.mts`) during project-graph computation:
- * the config's `import 'vitest'` is resolved from a temp file inside the
- * workspace's own `node_modules`, so the package must be physically present
- * there. `require.resolve(..., { paths: [root] })` is too permissive — it can
- * succeed via the resolving module's own ancestor `node_modules` (the compiled
- * plugin lives under `node_modules/@aws/nx-plugin`) even when the package is not
- * yet linked into this workspace, causing us to wrongly defer an install the
- * next `nx` command then fails on.
- *
- * `existsSync` follows symlinks, so pnpm's `node_modules/<pkg>` → store link
- * resolves correctly, and Nx always uses a `node_modules` linker (it writes
- * `nodeLinker: node-modules` for Yarn Berry, so PnP never applies).
+ * This is the condition Nx's inferred plugins need when they load a generated
+ * config (e.g. `vite.config.mts`) during graph computation: the config's
+ * imports resolve from inside the workspace's own `node_modules`. We avoid
+ * `require.resolve`, which can succeed via an ancestor `node_modules` even when
+ * the package isn't linked here. `existsSync` follows symlinks, so pnpm's store
+ * links resolve, and Nx always uses a `node_modules` linker (never PnP).
  */
 const allResolvable = (root: string, packages: string[]): boolean =>
   packages.every((pkg) => existsSync(join(root, 'node_modules', pkg)));
@@ -69,26 +53,18 @@ const allResolvable = (root: string, packages: string[]): boolean =>
 /**
  * Installs dependencies for the given languages.
  *
- * Call this from a generator's returned callback:
- * `return () => installDeps(tree, options.preferInstallDependencies, { ... })`.
+ * Call from a generator's returned callback:
+ * `return () => installDependencies(tree, options.preferInstallDependencies, { ... })`.
  *
- * `preferInstallDependencies` is a preference, not a guarantee: when `false`,
- * the install is deferred so a batch of generators can install once at the
- * end — UNLESS skipping would leave an `ensureResolvable` package missing, in
- * which case the install runs regardless so the next `nx` command can still
- * compute the project graph.
- *
- * @example
- * return () =>
- *   installDeps(tree, options.preferInstallDependencies, {
- *     languages: ['typescript'],
- *     ensureResolvable: ['@tailwindcss/vite'],
- *   });
+ * `preferInstallDependencies` is a preference: when `false` the install is
+ * deferred so a batch installs once at the end — unless an `ensureResolvable`
+ * package is missing, in which case it runs anyway so the next `nx` command can
+ * still compute the project graph.
  */
-export const installDeps = async (
+export const installDependencies = async (
   tree: Tree,
   preferInstallDependencies: boolean | undefined,
-  options: InstallDepsOptions,
+  options: InstallDependenciesOptions,
 ): Promise<void> => {
   const { languages, ensureResolvable = [] } = options;
   const mustResolve = [

--- a/powers/nx-plugin-for-aws/POWER.md
+++ b/powers/nx-plugin-for-aws/POWER.md
@@ -152,7 +152,7 @@ Add capabilities to existing projects:
 - Run `nx sync` after adding dependencies between TypeScript projects
 - Install dependencies at the workspace root, not in individual projects
 - Use `nx reset` to reset the Nx daemon when unexpected issues arise
-- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag). It's a preference, not a guarantee — a generator still installs on its own when skipping would leave a dependency unresolvable that a later `nx` command needs for project-graph computation, so you don't have to reason about which generators are safe to defer
+- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag)
 - After running generators, use `nx show projects` to verify what was created
 - Fix lint issues with `nx run-many --target lint --configuration=fix --all`
 - Generate all projects into the `packages/` directory
@@ -182,7 +182,7 @@ When the user wants a full workspace created in one go, you can chain generators
     pnpm build
   ```
 
-- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything). It's a preference, not a guarantee: a generator still installs on its own when skipping would break a later `nx` command's project-graph computation, so the chain is safe regardless of ordering.
+- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything).
 - Use a **timeout of 300000ms** (5 minutes) for workspace creation (downloads dependencies).
 - **`nx sync`** is required before building — generators modify TypeScript project references.
 

--- a/powers/nx-plugin-for-aws/POWER.md
+++ b/powers/nx-plugin-for-aws/POWER.md
@@ -152,6 +152,7 @@ Add capabilities to existing projects:
 - Run `nx sync` after adding dependencies between TypeScript projects
 - Install dependencies at the workspace root, not in individual projects
 - Use `nx reset` to reset the Nx daemon when unexpected issues arise
+- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag). It's a preference, not a guarantee — a generator still installs on its own when skipping would leave a dependency unresolvable that a later `nx` command needs for project-graph computation, so you don't have to reason about which generators are safe to defer
 - After running generators, use `nx show projects` to verify what was created
 - Fix lint issues with `nx run-many --target lint --configuration=fix --all`
 - Generate all projects into the `packages/` directory
@@ -167,20 +168,21 @@ When the user wants a full workspace created in one go, you can chain generators
   pnpm create @aws/nx-workspace my-app --iacProvider=CDK --no-interactive
   ```
 
-- **Chain generators** with `&&` in a single Bash call after workspace creation, for example:
+- **Chain generators** with `&&` in a single Bash call after workspace creation. Pass `--prefer-install-dependencies=false` on each generator except the last so dependencies install once at the end, for example:
 
   ```bash
   cd my-app && \
-    pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM && \
-    pnpm nx g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --uxProvider=Shadcn && \
-    pnpm nx g @aws/nx-plugin:ts#react-website#auth --no-interactive --project=@my-app/my-app-website --cognitoDomain=my-app-auth && \
-    pnpm nx g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api && \
+    pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --uxProvider=Shadcn --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:ts#react-website#auth --no-interactive --project=@my-app/my-app-website --cognitoDomain=my-app-auth --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api --prefer-install-dependencies=false && \
     pnpm nx g @aws/nx-plugin:ts#infra --no-interactive --name=infra && \
     pnpm nx sync && \
     pnpm lint && \
     pnpm build
   ```
 
+- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything). It's a preference, not a guarantee: a generator still installs on its own when skipping would break a later `nx` command's project-graph computation, so the chain is safe regardless of ordering.
 - Use a **timeout of 300000ms** (5 minutes) for workspace creation (downloads dependencies).
 - **`nx sync`** is required before building — generators modify TypeScript project references.
 

--- a/scripts/skill-templates/__fileName__.template
+++ b/scripts/skill-templates/__fileName__.template
@@ -114,6 +114,7 @@ Add capabilities to existing projects:
 - Run `nx sync` after adding dependencies between TypeScript projects
 - Install dependencies at the workspace root, not in individual projects
 - Use `nx reset` to reset the Nx daemon when unexpected issues arise
+- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag). It's a preference, not a guarantee — a generator still installs on its own when skipping would leave a dependency unresolvable that a later `nx` command needs for project-graph computation, so you don't have to reason about which generators are safe to defer
 - After running generators, use `nx show projects` to verify what was created
 - Fix lint issues with `nx run-many --target lint --configuration=fix --all`
 - Generate all projects into the `packages/` directory
@@ -129,20 +130,21 @@ When the user wants a full workspace created in one go, you can chain generators
   pnpm create @aws/nx-workspace my-app --iacProvider=CDK --no-interactive
   ```
 
-- **Chain generators** with `&&` in a single Bash call after workspace creation, for example:
+- **Chain generators** with `&&` in a single Bash call after workspace creation. Pass `--prefer-install-dependencies=false` on each generator except the last so dependencies install once at the end, for example:
 
   ```bash
   cd my-app && \
-    pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM && \
-    pnpm nx g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --uxProvider=Shadcn && \
-    pnpm nx g @aws/nx-plugin:ts#react-website#auth --no-interactive --project=@my-app/my-app-website --cognitoDomain=my-app-auth && \
-    pnpm nx g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api && \
+    pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --uxProvider=Shadcn --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:ts#react-website#auth --no-interactive --project=@my-app/my-app-website --cognitoDomain=my-app-auth --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api --prefer-install-dependencies=false && \
     pnpm nx g @aws/nx-plugin:ts#infra --no-interactive --name=infra && \
     pnpm nx sync && \
     pnpm lint && \
     pnpm build
   ```
 
+- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything). It's a preference, not a guarantee: a generator still installs on its own when skipping would break a later `nx` command's project-graph computation, so the chain is safe regardless of ordering.
 - Use a **timeout of 300000ms** (5 minutes) for workspace creation (downloads dependencies).
 - **`nx sync`** is required before building — generators modify TypeScript project references.
 

--- a/scripts/skill-templates/__fileName__.template
+++ b/scripts/skill-templates/__fileName__.template
@@ -114,7 +114,7 @@ Add capabilities to existing projects:
 - Run `nx sync` after adding dependencies between TypeScript projects
 - Install dependencies at the workspace root, not in individual projects
 - Use `nx reset` to reset the Nx daemon when unexpected issues arise
-- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag). It's a preference, not a guarantee — a generator still installs on its own when skipping would leave a dependency unresolvable that a later `nx` command needs for project-graph computation, so you don't have to reason about which generators are safe to defer
+- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag)
 - After running generators, use `nx show projects` to verify what was created
 - Fix lint issues with `nx run-many --target lint --configuration=fix --all`
 - Generate all projects into the `packages/` directory
@@ -144,7 +144,7 @@ When the user wants a full workspace created in one go, you can chain generators
     pnpm build
   ```
 
-- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything). It's a preference, not a guarantee: a generator still installs on its own when skipping would break a later `nx` command's project-graph computation, so the chain is safe regardless of ordering.
+- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything).
 - Use a **timeout of 300000ms** (5 minutes) for workspace creation (downloads dependencies).
 - **`nx sync`** is required before building — generators modify TypeScript project references.
 

--- a/skills/nx-plugin-for-aws/SKILL.md
+++ b/skills/nx-plugin-for-aws/SKILL.md
@@ -151,7 +151,7 @@ Add capabilities to existing projects:
 - Run `nx sync` after adding dependencies between TypeScript projects
 - Install dependencies at the workspace root, not in individual projects
 - Use `nx reset` to reset the Nx daemon when unexpected issues arise
-- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag). It's a preference, not a guarantee — a generator still installs on its own when skipping would leave a dependency unresolvable that a later `nx` command needs for project-graph computation, so you don't have to reason about which generators are safe to defer
+- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag)
 - After running generators, use `nx show projects` to verify what was created
 - Fix lint issues with `nx run-many --target lint --configuration=fix --all`
 - Generate all projects into the `packages/` directory
@@ -181,7 +181,7 @@ When the user wants a full workspace created in one go, you can chain generators
     pnpm build
   ```
 
-- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything). It's a preference, not a guarantee: a generator still installs on its own when skipping would break a later `nx` command's project-graph computation, so the chain is safe regardless of ordering.
+- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything).
 - Use a **timeout of 300000ms** (5 minutes) for workspace creation (downloads dependencies).
 - **`nx sync`** is required before building — generators modify TypeScript project references.
 

--- a/skills/nx-plugin-for-aws/SKILL.md
+++ b/skills/nx-plugin-for-aws/SKILL.md
@@ -151,6 +151,7 @@ Add capabilities to existing projects:
 - Run `nx sync` after adding dependencies between TypeScript projects
 - Install dependencies at the workspace root, not in individual projects
 - Use `nx reset` to reset the Nx daemon when unexpected issues arise
+- When running several generators in sequence, pass `--prefer-install-dependencies=false` on each to avoid a slow install after every generator, then install once at the end (or let the final generator install by omitting the flag). It's a preference, not a guarantee — a generator still installs on its own when skipping would leave a dependency unresolvable that a later `nx` command needs for project-graph computation, so you don't have to reason about which generators are safe to defer
 - After running generators, use `nx show projects` to verify what was created
 - Fix lint issues with `nx run-many --target lint --configuration=fix --all`
 - Generate all projects into the `packages/` directory
@@ -166,20 +167,21 @@ When the user wants a full workspace created in one go, you can chain generators
   pnpm create @aws/nx-workspace my-app --iacProvider=CDK --no-interactive
   ```
 
-- **Chain generators** with `&&` in a single Bash call after workspace creation, for example:
+- **Chain generators** with `&&` in a single Bash call after workspace creation. Pass `--prefer-install-dependencies=false` on each generator except the last so dependencies install once at the end, for example:
 
   ```bash
   cd my-app && \
-    pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM && \
-    pnpm nx g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --uxProvider=Shadcn && \
-    pnpm nx g @aws/nx-plugin:ts#react-website#auth --no-interactive --project=@my-app/my-app-website --cognitoDomain=my-app-auth && \
-    pnpm nx g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api && \
+    pnpm nx g @aws/nx-plugin:ts#trpc-api --no-interactive --name=my-app-api --auth=IAM --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:ts#react-website --no-interactive --name=my-app-website --uxProvider=Shadcn --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:ts#react-website#auth --no-interactive --project=@my-app/my-app-website --cognitoDomain=my-app-auth --prefer-install-dependencies=false && \
+    pnpm nx g @aws/nx-plugin:connection --no-interactive --sourceProject=@my-app/my-app-website --targetProject=@my-app/my-app-api --prefer-install-dependencies=false && \
     pnpm nx g @aws/nx-plugin:ts#infra --no-interactive --name=infra && \
     pnpm nx sync && \
     pnpm lint && \
     pnpm build
   ```
 
+- **`--prefer-install-dependencies=false`** asks a generator to defer its dependency install so the batch installs once at the end (the final generator above omits the flag and installs everything). It's a preference, not a guarantee: a generator still installs on its own when skipping would break a later `nx` command's project-graph computation, so the chain is safe regardless of ordering.
 - Use a **timeout of 300000ms** (5 minutes) for workspace creation (downloads dependencies).
 - **`nx sync`** is required before building — generators modify TypeScript project references.
 


### PR DESCRIPTION
### Reason for this change

Profiling the slowest smoke-test job (`npm`, ~17 min) showed the generator matrix dominates the wall-clock — ~80 sequential generators, of which many install dependencies. Each generator installs by default, so a batch re-runs a slow install over and over. The same waste hits any real user doing one-shot workspace scaffolding.

The goal: let a batch install **once** instead of after every generator, without the caller having to reason about which generators are safe to skip.

### Description of changes

- **New `installDeps` helper** (`utils/install.ts`): `installDeps(tree, preferInstallDependencies, { languages, ensureResolvable })` performs the install (TypeScript via `installPackagesTask`, Python via `UVProvider().install()`); generators call it from their returned callback (`return () => installDeps(...)`).
- **`preferInstallDependencies` option (default `true`) added to every generator.** It is a *preference*, not a guarantee: when `false`, the install is deferred — **unless** skipping would leave a dependency unresolvable that Nx needs to compute the project graph on the next command. In that case the generator installs anyway. This is why callers can defer uniformly without knowing which generators are "safe".
  - Graph-critical deps are detected by checking whether `<workspaceRoot>/node_modules/<pkg>` exists. This matches what Nx's node-modules linker guarantees and what the inferred plugins need (they load a project's generated config from inside the workspace's own `node_modules`). `require.resolve('<pkg>/package.json')` was deliberately **not** used: it throws for packages whose `exports` map hides `package.json` (e.g. `@tailwindcss/vite`) even when installed — which would force a redundant install every run — and it can walk up into an ancestor `node_modules` the workspace's graph loader can't use.
  - Every TypeScript project implies `vitest` (its `vitest.config.mts` is loaded by `@nx/vitest`); every Python project implies `@nxlv/python`; the website adds `@tailwindcss/vite`/`@tanstack/router-plugin`; the terraform project adds `@nx-extend/terraform`.
- **Replaced the prior `skipInstall` option** (astro-docs, react-website, infra, ts#lib) with `preferInstallDependencies`.
- **Threaded the choice through composed and delegating generators** (the `connection` dispatcher, `ts#api`/`py#api`, etc.).
- **`ts#nx-generator` template** updated so newly-scaffolded generators follow the convention.
- **Guidance updated**: the MCP `general-guidance` tool and the skill recommend `--prefer-install-dependencies=false` when batching, noting the generator still self-installs when needed.
- **Smoke test generator matrix** (`e2e`) now defers per generator and installs once via a new `runInstall` helper before the build (CDK + Terraform flows). The idempotency test opts back into per-generator installs so all lockfiles (including `uv.lock`) are fully synced before it snapshots the workspace.
- **Standalone smoke test now runs its cases concurrently.** The `standalone` job generates and builds every generator in its own fully-isolated workspace, but ran the ~22 cases sequentially (~20 min wall-clock — the batching change above doesn't help it, since each case is a fresh single-generator workspace). Because the workspaces are independent, the cases are safe to overlap:
  - `runCLI` is now non-blocking — it uses `spawn` instead of the blocking `execSync`, so concurrent test cases genuinely overlap instead of serialising on a blocked event loop. Output is still streamed through to the parent as it arrives and captured for the return value / error handling (no caller parses stdout content; they only rely on the throw-on-failure behaviour, which is preserved).
  - The `standalone` `describe` blocks are marked `describe.concurrent`, bounded by a new `maxConcurrency` (tunable via `NX_E2E_MAX_CONCURRENCY`, default 16).
  - **In CI the standalone smoke job drops from ~25m56s (before) to ~7m40s (~3.4x).** Measured step time (`Smoke Test - standalone`) is ~5m30–5m46s; the remainder is the job's checkout/init/artifact-download.
  - All 22 cases pass. The `nx-plugin` and `no-interactive` smoke tests were re-run as canaries to confirm the shared `runCLI` change is backward-compatible.

  **Standalone timing (concurrency sweep):**

  | Environment | Concurrency | Time |
  | --- | --- | --- |
  | Local (32-core) | sequential (before) | 1215s |
  | Local (32-core) | 8 | 214s |
  | Local (32-core) | 16 | 155s |
  | Local (32-core) | 24 | 153s |
  | Local (32-core) | 32 | 149s |
  | CI runner | sequential (before) | ~25m56s |
  | CI runner | 8 | ~7m41s (job) / 5m32s (step) |
  | CI runner | 16 | ~7m37s (job) / 5m46s (step) |

  The default is set to **16**: it captures most of the win on higher-core machines (local 214s → 155s), while CI is core-bound and saturates around 8 concurrent single-project builds, so 8 vs 16 is neutral there (both ~5.5m step). The value stays env-tunable via `NX_E2E_MAX_CONCURRENCY` so it can be raised on beefier runners without a code change.

### Description of how you validated changes

- `utils/install.spec.ts` covers each language, default/undefined, the defer path, the self-install-when-missing path, the ancestor-`node_modules` false-positive guard, and the `exports`-restricted-package case (`@tailwindcss/vite`).
- Reproduced a full deferred matrix locally against a real `@aws/nx-workspace` (built/published to a local verdaccio) and instrumented the helper: confirmed it installs only when a graph-critical dep is genuinely missing (first ts project, first website, first python project) and skips once present — i.e. it genuinely defers rather than installing every time.
- `pnpm nx run @aws/nx-plugin:test` — full suite passes; snapshots updated.
- `pnpm nx run @aws/nx-plugin:typecheck` + lint pass.
- Reproduced the deferral end-to-end locally (generate with `--prefer-install-dependencies=false`, confirm the next `nx generate`'s project-graph computation succeeds).
- Full CI smoke matrix is green (run validating npm, pnpm-10/11, yarn-classic/4, bun, finch, terraform, idempotency and all non-matrix jobs).

### Smoke test timings (before → after)

Baseline = a `main`-based PR run before this change (run 28419320651). After = this PR's green run (28477963445). All smoke jobs are listed; *(matrix)* marks the jobs that run the shared generator matrix this change targets.

| Smoke test | Before | After | Δ |
| --- | --- | --- | --- |
| bun *(matrix)* | 19m00s | 15m34s | -18% |
| finch *(matrix)* | 18m43s | 15m41s | -16% |
| idempotency *(matrix)* | 20m17s | 21m00s | +4% |
| npm *(matrix)* | 19m38s | 15m30s | -21% |
| pnpm-10 *(matrix)* | 17m34s | 14m53s | -15% |
| pnpm-11 *(matrix)* | 19m06s | 15m38s | -18% |
| terraform *(matrix)* | 20m26s | 16m35s | -19% |
| yarn-4 *(matrix)* | 16m01s | 14m23s | -10% |
| yarn-classic *(matrix)* | 17m16s | 15m34s | -10% |
| Windows dungeon-adventure | 38m22s | 40m46s | +6% |
| Windows git-secrets | 7m10s | 7m10s | +0% |
| Windows pnpm-11 | 58m05s | 54m42s | -6% |
| dungeon-adventure | 10m15s | 10m28s | +2% |
| fast-api | 6m21s | 6m53s | +8% |
| git-secrets | 2m36s | 2m35s | -1% |
| infra-none | 6m35s | 6m50s | +4% |
| license-check | 4m13s | 4m26s | +5% |
| license-sync | 3m08s | 3m21s | +7% |
| local-dev | 14m32s | 14m52s | +2% |
| mcp-server | 2m13s | 2m32s | +14% |
| no-interactive | 4m45s | 4m36s | -3% |
| nx-plugin | 3m11s | 3m14s | +2% |
| rdb | 17m38s | 18m00s | +2% |
| react-website | 6m02s | 6m30s | +8% |
| smithy-api | 4m46s | 5m03s | +6% |
| standalone | 25m19s | ~7m40s | **-70%** (now runs cases concurrently — see above) |
| trpc-api | 6m20s | 6m23s | +1% |

**Overall:**
- **Matrix jobs (what this change targets): 168m → 145m, −14%** in aggregate (npm −21%, terraform −19%, bun −18%, pnpm-11 −18%, finch −16%, pnpm-10 −15%, yarn −10%). `idempotency` is ~flat by design (it installs after every generator so its lockfile snapshot is complete).
- **Non-matrix jobs are unchanged** — the small ±2–8% swings are runner-allocation noise (these jobs don't use the shared matrix), not regressions — **except `standalone`, which now runs its isolated cases concurrently and drops ~25m56s → ~7m40s (−70%).**
- **Total PR wall-clock is *not* reduced**, because the longest-running jobs are the Windows ones (`Windows: dungeon-adventure` ~40m, `Windows: pnpm-11` ~55m), which this change doesn't meaningfully affect. The win is real but concentrated in the Linux package-manager matrix jobs, several of which drop ~3–4 minutes each.

> **Note:** I also experimented with enabling the Nx daemon (`NX_DAEMON=true`) for the matrix flows to cache the project graph across generator calls. It produced **no improvement** (npm 15m46s → 16m30s, terraform 16m33s → 17m31s — flat-to-slightly-worse), because each generator mutates the workspace and invalidates the daemon's cached graph anyway, while adding daemon startup/IPC overhead. The daemon change was reverted.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*





