### PR TITLE
fix(ci): use setup-terraform v4 with terraform 1.15.7

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -110,10 +110,18 @@ runs:
         docker buildx ls
     - name: Set up terraform (non-Windows)
       if: ${{ runner.os != 'Windows' && inputs.setup-terraform == 'true' }}
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: '1.13.1'
-        terraform_wrapper: false
+      shell: bash
+      # Download terraform directly with retries rather than via
+      # hashicorp/setup-terraform, which issues a single un-retried request to
+      # the HashiCorp releases API and fails the whole job on a transient 5xx.
+      run: |
+        set -euo pipefail
+        version="1.13.1"
+        url="https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip"
+        curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 --output "${RUNNER_TEMP}/terraform.zip" "$url"
+        unzip -o "${RUNNER_TEMP}/terraform.zip" -d "${RUNNER_TEMP}/terraform-bin"
+        echo "${RUNNER_TEMP}/terraform-bin" >> "$GITHUB_PATH"
+        "${RUNNER_TEMP}/terraform-bin/terraform" version
     - name: Set up terraform (Windows)
       if: ${{ runner.os == 'Windows' && inputs.setup-terraform == 'true' }}
       shell: pwsh
@@ -127,7 +135,11 @@ runs:
         New-Item -ItemType Directory -Path $tfDir -Force | Out-Null
         $url = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_windows_amd64.zip"
         $zip = "$env:RUNNER_TEMP\terraform.zip"
-        Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+        # Retry the download to ride out transient HashiCorp releases API 5xx errors.
+        for ($i = 1; $i -le 5; $i++) {
+          try { Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing; break }
+          catch { if ($i -eq 5) { throw }; Start-Sleep -Seconds 5 }
+        }
         Expand-Archive -Path $zip -DestinationPath $tfDir -Force
         echo "$tfDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "$tfDir;$env:PATH"

--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -110,18 +110,10 @@ runs:
         docker buildx ls
     - name: Set up terraform (non-Windows)
       if: ${{ runner.os != 'Windows' && inputs.setup-terraform == 'true' }}
-      shell: bash
-      # Download terraform directly with retries rather than via
-      # hashicorp/setup-terraform, which issues a single un-retried request to
-      # the HashiCorp releases API and fails the whole job on a transient 5xx.
-      run: |
-        set -euo pipefail
-        version="1.13.1"
-        url="https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip"
-        curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 --output "${RUNNER_TEMP}/terraform.zip" "$url"
-        unzip -o "${RUNNER_TEMP}/terraform.zip" -d "${RUNNER_TEMP}/terraform-bin"
-        echo "${RUNNER_TEMP}/terraform-bin" >> "$GITHUB_PATH"
-        "${RUNNER_TEMP}/terraform-bin/terraform" version
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: '1.15.7'
+        terraform_wrapper: false
     - name: Set up terraform (Windows)
       if: ${{ runner.os == 'Windows' && inputs.setup-terraform == 'true' }}
       shell: pwsh
@@ -130,16 +122,12 @@ runs:
         # Nx's run-commands executor (cmd.exe subprocess) can always see.
         # hashicorp/setup-terraform uses GITHUB_PATH which doesn't propagate
         # reliably to Nx executor subprocesses on Windows.
-        $version = "1.13.1"
+        $version = "1.15.7"
         $tfDir = "C:\terraform"
         New-Item -ItemType Directory -Path $tfDir -Force | Out-Null
         $url = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_windows_amd64.zip"
         $zip = "$env:RUNNER_TEMP\terraform.zip"
-        # Retry the download to ride out transient HashiCorp releases API 5xx errors.
-        for ($i = 1; $i -le 5; $i++) {
-          try { Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing; break }
-          catch { if ($i -eq 5) { throw }; Start-Sleep -Seconds 5 }
-        }
+        Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
         Expand-Archive -Path $zip -DestinationPath $tfDir -Force
         echo "$tfDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "$tfDir;$env:PATH"


### PR DESCRIPTION
### Reason for this change

The `Update Versions` workflow [failed](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/28439338410) during `./.github/actions/init-monorepo` with:

```
##[error]AxiosError: Request failed with status code 502
```

The error came from `hashicorp/setup-terraform@v3`, which resolves the requested version via the HashiCorp release **metadata** endpoint `https://releases.hashicorp.com/terraform/<version>/index.json` before downloading. That endpoint is dynamic (served by an AWS load balancer behind CloudFront, `x-cache: Error from cloudfront`) and is **currently returning 5xx for terraform 1.11–1.13** — the pinned `1.13.1` among them — while the static binary artifacts and the metadata for newer versions are served fine. A plain workflow re-run therefore keeps hitting the same failure.

### Description of changes

- Bumped the pinned Terraform version from `1.13.1` to **`1.15.7`** (the latest release), whose metadata endpoint is healthy.
- Upgraded `hashicorp/setup-terraform` from `v3` to **`v4`** (runs on Node 24, which also clears the Node 20 deprecation warning the action emits).
- Bumped the manual Windows download path to the same `1.15.7` version for consistency.

All Terraform templates in the repo require `>= 1.0`, so they remain compatible with 1.15.7.

### Description of how you validated changes

- Confirmed `1.15.7` is the latest Terraform release and that its `index.json` metadata and `linux_amd64` / `windows_amd64` binaries all return 200 (stable across repeated requests), whereas `1.11–1.13` `index.json` consistently 504s.
- Confirmed `hashicorp/setup-terraform@v4` exists (latest v4.0.1) and that v4.0.0's only change is the Node 24 upgrade.
- Validated the updated `action.yml` parses as valid YAML.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
