### PR TITLE
docs(ts#website#auth): add WAF to authentication architecture diagram

### DIFF
--- a/docs/src/content/docs/en/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/react-website-auth.mdx
@@ -79,6 +79,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg
@@ -93,7 +98,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -96,7 +96,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```
@@ -261,6 +262,13 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
           "execute-api:Invoke"
         ]
         Resource = "${module.my_api.api_execution_arn}/*"
+      }
+    ]
+  })
+}
+```
+</Fragment>
+</Infrastructure>_arn}/*"
       }
     ]
   })

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -268,11 +268,4 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
 }
 ```
 </Fragment>
-</Infrastructure>_arn}/*"
-      }
-    ]
-  })
-}
-```
-</Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -96,7 +96,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```
@@ -261,6 +262,13 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
           "execute-api:Invoke"
         ]
         Resource = "${module.my_api.api_execution_arn}/*"
+      }
+    ]
+  })
+}
+```
+</Fragment>
+</Infrastructure>_arn}/*"
       }
     ]
   })

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -268,11 +268,4 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
 }
 ```
 </Fragment>
-</Infrastructure>_arn}/*"
-      }
-    ]
-  })
-}
-```
-</Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -98,7 +98,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -79,6 +79,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -96,7 +96,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```
@@ -261,6 +262,13 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
           "execute-api:Invoke"
         ]
         Resource = "${module.my_api.api_execution_arn}/*"
+      }
+    ]
+  })
+}
+```
+</Fragment>
+</Infrastructure>_arn}/*"
       }
     ]
   })

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -268,11 +268,4 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
 }
 ```
 </Fragment>
-</Infrastructure>_arn}/*"
-      }
-    ]
-  })
-}
-```
-</Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -96,7 +96,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```
@@ -261,6 +262,13 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
           "execute-api:Invoke"
         ]
         Resource = "${module.my_api.api_execution_arn}/*"
+      }
+    ]
+  })
+}
+```
+</Fragment>
+</Infrastructure>_arn}/*"
       }
     ]
   })

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -268,11 +268,4 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
 }
 ```
 </Fragment>
-</Infrastructure>_arn}/*"
-      }
-    ]
-  })
-}
-```
-</Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/react-website-auth.mdx
@@ -82,6 +82,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg
@@ -96,7 +101,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -94,7 +94,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```
@@ -259,6 +260,13 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
           "execute-api:Invoke"
         ]
         Resource = "${module.my_api.api_execution_arn}/*"
+      }
+    ]
+  })
+}
+```
+</Fragment>
+</Infrastructure>_arn}/*"
       }
     ]
   })

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -266,11 +266,4 @@ resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
 }
 ```
 </Fragment>
-</Infrastructure>_arn}/*"
-      }
-    ]
-  })
-}
-```
-</Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/react-website-auth.mdx
@@ -82,6 +82,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg
@@ -96,7 +101,8 @@ backend: Authenticated\nAWS Resources {
   shape: rectangle
 }
 
-browser -> cognito: Sign in
+browser -> waf: Sign in
+waf -> cognito
 cognito -> iam
 browser -> backend: IAM/Cognito
 ```


### PR DESCRIPTION
### Reason for this change

The React Website Authentication generator now associates an AWS WAFv2 Web ACL with the Cognito User Pool by default (`enableWaf` defaults to `true` in the `UserIdentity` construct). The architecture diagram in the auth guide did not reflect this, so it no longer matched the deployed infrastructure.

### Description of changes

Updated the architecture diagram in `docs/src/content/docs/en/guides/react-website-auth.mdx` to include a WAF node on the sign-in path:

- Added a `waf` node using the standard `icons/aws/waf.svg` icon and `shape: image` style (matching the tRPC/API architecture snippet).
- Routed the sign-in flow through WAF (`browser -> waf: Sign in`, `waf -> cognito`), consistent with the CDK `CfnWebACLAssociation` which attaches the Web ACL to the User Pool ARN.

The existing "Web Application Firewall (WAF)" section below the diagram already documents this default behaviour and how to disable it, so no prose changes were required. Only the English source is edited; translations are regenerated automatically.

### Description of how you validated changes

This is a documentation-only change to a d2 diagram. Verified the WAF icon path (`docs/public/icons/aws/waf.svg`) exists and matches the icon reference used elsewhere in the docs, and confirmed the WAF-to-User-Pool association in the CDK `user-identity.ts.template`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*