### PR TITLE
docs: prevent duplicate drawer portals opening multiple overlapping drawers

### DIFF
--- a/docs/src/components/drawer.astro
+++ b/docs/src/components/drawer.astro
@@ -103,8 +103,10 @@ const { title, trigger, class: className } = Astro.props;
     }
   }
 
-  // Initialize all drawers on the page
-  document.querySelectorAll('.drawer-container').forEach((container) => {
+  // This script is inlined once per drawer instance, so guard against
+  // initializing a container more than once to avoid duplicate portals.
+  document.querySelectorAll('.drawer-container:not([data-drawer-initialized])').forEach((container) => {
+    container.setAttribute('data-drawer-initialized', 'true');
     new DrawerController(container as HTMLElement);
   });
 </script>


### PR DESCRIPTION
### Reason for this change

On documentation pages that contain more than one `<Drawer>` (e.g. the [Dungeon Adventure tutorial](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/tutorials/dungeon-game/1/)), clicking a single drawer trigger opened **multiple overlapping drawers stacked on top of each other**, each of which had to be dismissed individually.

**Root cause:** The drawer component's client script is inlined once per `<Drawer>` instance on a page. Each copy executed a *global* `document.querySelectorAll('.drawer-container').forEach(...)`, so on a page with N drawers the initialization ran N times — creating N portals **per** drawer (N² portals total) and attaching N click listeners to every trigger. Clicking one trigger therefore opened N drawers at once.

Concretely, on tutorial page 1 (13 drawers): the page created **169 portals** (13 × 13) and a single click opened **13 overlapping drawers**.

### Description of changes

Guard each `.drawer-container` with a `data-drawer-initialized` attribute so it is only ever wired up once, regardless of how many times the inlined script runs.

### Description of how you validated changes

Reproduced and verified against a **production build** (`nx build docs`) driven with Playwright:

| | Portals on load | Drawers opened by one click | After one dismiss |
|---|---|---|---|
| **Before** | 169 | 13 (overlapping) | 12 still open |
| **After** | 13 (1:1 with containers) | 1 | 0 (clean) |

Before/after screenshots are attached in a comment below.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*