### PR TITLE
docs(release): note reruns preserve push event

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,3 +64,9 @@ When all v1.0 workstreams are complete (see #718), remove the
 `--specifier premajor --preid rc` logic from the `main` release step in
 `ci.yml` so `nx release` resolves a stable `1.0.0` bump. See #737 for the full
 cutover checklist.
+
+### Re-triggering a release
+
+The release and docs-deploy steps only run on `push` events. Re-running a
+stuck CI run preserves the original `push` event, so a rerun still publishes;
+a manual `workflow_dispatch` run intentionally does not.


### PR DESCRIPTION
### Reason for this change

Small follow-up to #875. During the RC-to-`latest` rollout, the main CI run for the merge got wedged in GitHub Actions and never dispatched jobs. This documents the recovery behaviour so it's clear that re-running a stuck run still publishes (it preserves the original `push` event), whereas a manual `workflow_dispatch` run intentionally does not.

Merging this also produces a fresh push-triggered CI run that publishes the pending RC to `latest`.

### Description of changes

- Add a short "Re-triggering a release" note to `RELEASE.md`.

### Description of how you validated changes

- Docs-only change; no code paths affected.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*