### PR TITLE
ci: speed up Windows CI — cache WSL2 Docker distro + standalone leg on CodeBuild

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -80,23 +80,52 @@ runs:
     - name: Set up Docker Buildx
       if: ${{ runner.os != 'Windows' && inputs.container-tools == 'true' }}
       uses: docker/setup-buildx-action@v3
+    - name: Cache WSL2 Docker distro (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      id: wsl-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}\wsl-distro\ubuntu-docker.tar
+        key: ${{ runner.os }}-wsl-docker-${{ hashFiles('.github/scripts/install-wsl-docker.sh') }}
     - name: Set up WSL2 Docker for Linux builds (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: pwsh
       run: |
         # Windows runners only have Docker in Windows-container mode.
         # Install Ubuntu + Docker Engine in WSL2 to build Linux images.
-        # See .github/scripts/setup-wsl-docker.sh for the full setup.
-        wsl --install Ubuntu-24.04 --no-launch
+        # The configured distro (Ubuntu + Docker Engine + primed buildx/binfmt
+        # images) is cached as an exported tarball; on a cache hit we import it
+        # instead of re-running the apt install and image pulls.
+        $tarDir = "$env:RUNNER_TEMP\wsl-distro"
+        $tar = "$tarDir\ubuntu-docker.tar"
+        $installDir = "$env:RUNNER_TEMP\wsl-ubuntu"
+
+        # Helper: convert a repo script to LF and run it in WSL2 as root.
+        function Invoke-WslScript($relPath) {
+          $script = Get-Content "${{ github.workspace }}/$relPath" -Raw
+          $lfScript = $script -replace "`r`n", "`n"
+          $tmpScript = "$env:RUNNER_TEMP/$(Split-Path $relPath -Leaf)"
+          [System.IO.File]::WriteAllText($tmpScript, $lfScript)
+          $wslPath = wsl -d Ubuntu-24.04 wslpath ($tmpScript -replace '\\','/')
+          wsl -d Ubuntu-24.04 -u root -- bash $wslPath
+          if ($LASTEXITCODE -ne 0) { throw "WSL script $relPath failed with exit code $LASTEXITCODE" }
+        }
+
+        if ("${{ steps.wsl-cache.outputs.cache-hit }}" -eq "true") {
+          New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+          wsl --import Ubuntu-24.04 $installDir $tar
+        } else {
+          wsl --install Ubuntu-24.04 --no-launch
+          Invoke-WslScript ".github/scripts/install-wsl-docker.sh"
+          New-Item -ItemType Directory -Path $tarDir -Force | Out-Null
+          # Terminate the distro so the exported tarball is a clean snapshot.
+          wsl --terminate Ubuntu-24.04
+          wsl --export Ubuntu-24.04 $tar
+        }
         wsl --set-default Ubuntu-24.04
 
-        # Convert setup script to LF line endings and run it in WSL2
-        $script = Get-Content "${{ github.workspace }}/.github/scripts/setup-wsl-docker.sh" -Raw
-        $lfScript = $script -replace "`r`n", "`n"
-        $tmpScript = "$env:RUNNER_TEMP/setup-wsl-docker.sh"
-        [System.IO.File]::WriteAllText($tmpScript, $lfScript)
-        $wslPath = wsl -d Ubuntu-24.04 wslpath ($tmpScript -replace '\\','/')
-        wsl -d Ubuntu-24.04 -u root -- bash $wslPath
+        # Start the daemon and select the buildx builder (runs every job).
+        Invoke-WslScript ".github/scripts/start-wsl-docker.sh"
 
         # Install docker.cmd wrapper that forwards to WSL2 Linux daemon
         # See .github/scripts/docker-wsl.cmd for the wrapper logic.

--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -81,14 +81,14 @@ runs:
       if: ${{ runner.os != 'Windows' && inputs.container-tools == 'true' }}
       uses: docker/setup-buildx-action@v3
     - name: Cache WSL2 Docker distro (Windows)
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && inputs.container-tools == 'true' }}
       id: wsl-cache
       uses: actions/cache@v4
       with:
         path: ${{ runner.temp }}\wsl-distro\ubuntu-docker.tar
         key: ${{ runner.os }}-wsl-docker-${{ hashFiles('.github/scripts/install-wsl-docker.sh') }}
     - name: Set up WSL2 Docker for Linux builds (Windows)
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && inputs.container-tools == 'true' }}
       shell: pwsh
       run: |
         # Windows runners only have Docker in Windows-container mode.

--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -91,11 +91,9 @@ runs:
       if: ${{ runner.os == 'Windows' && inputs.container-tools == 'true' }}
       shell: pwsh
       run: |
-        # Windows runners only have Docker in Windows-container mode.
-        # Install Ubuntu + Docker Engine in WSL2 to build Linux images.
-        # The configured distro (Ubuntu + Docker Engine + primed buildx/binfmt
-        # images) is cached as an exported tarball; on a cache hit we import it
-        # instead of re-running the apt install and image pulls.
+        # Windows runners only have Docker in Windows-container mode, so build
+        # Linux images in WSL2. The configured distro is cached as an exported
+        # tarball; a cache hit imports it instead of re-running the apt install.
         $tarDir = "$env:RUNNER_TEMP\wsl-distro"
         $tar = "$tarDir\ubuntu-docker.tar"
         $installDir = "$env:RUNNER_TEMP\wsl-ubuntu"

--- a/.github/scripts/install-wsl-docker.sh
+++ b/.github/scripts/install-wsl-docker.sh
@@ -2,9 +2,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Sets up Docker Engine with BuildKit + QEMU inside WSL2 Ubuntu.
+# Installs Docker Engine into WSL2 Ubuntu and primes the images needed for
+# multi-arch Linux builds. Everything installed here is baked into the exported
+# distro tarball that CI caches, so this only runs on a cache miss. Runtime
+# setup (starting the daemon, binfmt, buildx) lives in start-wsl-docker.sh and
+# runs on every job.
+#
 # Run as root inside the WSL2 distro:
-#   wsl -d Ubuntu-24.04 -u root -- bash /path/to/setup-wsl-docker.sh
+#   wsl -d Ubuntu-24.04 -u root -- bash /path/to/install-wsl-docker.sh
 set -euo pipefail
 
 # ── Install Docker Engine ────────────────────────────────────────────────────
@@ -23,10 +28,14 @@ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.d
 apt-get update -qq
 apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin >/dev/null 2>&1
 
-# ── Configure DNS & start daemon ─────────────────────────────────────────────
+# ── Configure DNS ────────────────────────────────────────────────────────────
 mkdir -p /etc/docker
 echo '{"dns":["8.8.8.8","8.8.4.4"]}' >/etc/docker/daemon.json
 
+# ── Prime images so they're baked into the cached distro ─────────────────────
+# Start the daemon just long enough to pull the binfmt and buildkit images and
+# create the buildx builder; these then live in /var/lib/docker inside the
+# exported tarball, so cache hits skip the image pulls entirely.
 dockerd >/var/log/dockerd.log 2>&1 &
 
 for i in $(seq 1 15); do
@@ -34,11 +43,11 @@ for i in $(seq 1 15); do
 done
 docker info >/dev/null 2>&1 || { echo "dockerd failed to start"; cat /var/log/dockerd.log; exit 1; }
 
-# ── QEMU + Buildx ────────────────────────────────────────────────────────────
 docker run --rm --privileged tonistiigi/binfmt --install all
-docker buildx create --name linux-builder --driver docker-container --use
+docker buildx create --name linux-builder --driver docker-container
 docker buildx inspect --bootstrap --builder linux-builder
 
-echo "Docker Engine with Buildx is ready."
-docker version
-docker buildx ls
+# Stop the daemon so the exported filesystem is in a clean, restartable state.
+pkill dockerd || true
+
+echo "Docker Engine installed and images primed."

--- a/.github/scripts/start-wsl-docker.sh
+++ b/.github/scripts/start-wsl-docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Starts the WSL2 Docker daemon and selects the buildx builder. Runs on every
+# job (the daemon isn't running in the freshly imported/installed distro).
+# Docker Engine, binfmt and the buildx builder are already installed by
+# install-wsl-docker.sh and baked into the cached distro.
+#
+# Run as root inside the WSL2 distro:
+#   wsl -d Ubuntu-24.04 -u root -- bash /path/to/start-wsl-docker.sh
+set -euo pipefail
+
+dockerd >/var/log/dockerd.log 2>&1 &
+
+for i in $(seq 1 15); do
+  docker info >/dev/null 2>&1 && break || sleep 1
+done
+docker info >/dev/null 2>&1 || { echo "dockerd failed to start"; cat /var/log/dockerd.log; exit 1; }
+
+docker buildx use linux-builder
+docker buildx inspect --bootstrap --builder linux-builder
+
+echo "Docker Engine with Buildx is ready."
+docker version
+docker buildx ls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,29 +206,43 @@ jobs:
           role-duration-seconds: 10800
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
+  # The standalone Windows leg runs on CodeBuild Windows runners, which have no
+  # Docker daemon. NX_E2E_SKIP_DOCKER drops the cases whose build compiles a
+  # Docker image (agents, MCP servers, Smithy, rdb) — those stay covered on the
+  # Linux standalone leg and the windows-latest dungeon-adventure test.
   smoke_tests_windows_standalone:
-    name: Windows Smoke Tests - standalone (${{matrix.shard}}/12)
-    runs-on: windows-latest
+    name: Windows Smoke Tests - standalone (${{matrix.shard}}/6)
+    runs-on: codebuild-nx-plugin-for-aws-windows-runner-${{ github.run_id }}-${{ github.run_attempt }}
     needs: package
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Disable Windows Defender real-time monitoring
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: pwsh
+        run: |
+          # Not present on every Windows image; best-effort.
+          try { Set-MpPreference -DisableRealtimeMonitoring $true } catch { }
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: dist
       - uses: ./.github/actions/init-monorepo
-      - name: Windows Smoke Test - standalone (shard ${{ matrix.shard }}/12)
+        with:
+          # CodeBuild Windows runners have no Docker; skip the WSL2 Docker setup
+          # (container-tools) and Terraform (standalone workspaces use CDK).
+          container-tools: "false"
+          setup-bun: "false"
+          setup-terraform: "false"
+      - name: Windows Smoke Test - standalone (shard ${{ matrix.shard }}/6)
         env:
-          NX_E2E_SHARD: ${{ matrix.shard }}/12
+          NX_E2E_SHARD: ${{ matrix.shard }}/6
+          NX_E2E_SKIP_DOCKER: "true"
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,13 +152,13 @@ jobs:
   # machine's cores, so cases run sequentially within a shard and parallelism
   # comes from sharding across machines (NX_E2E_SHARD=<index>/<total>).
   smoke_tests_standalone:
-    name: Smoke Tests - standalone (${{matrix.shard}}/12)
+    name: Smoke Tests - standalone (${{matrix.shard}}/6)
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
     needs: package
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -172,9 +172,9 @@ jobs:
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
           enable-uv-cache: 'false'
-      - name: Smoke Test - standalone (shard ${{ matrix.shard }}/12)
+      - name: Smoke Test - standalone (shard ${{ matrix.shard }}/6)
         env:
-          NX_E2E_SHARD: ${{ matrix.shard }}/12
+          NX_E2E_SHARD: ${{ matrix.shard }}/6
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,9 +206,8 @@ jobs:
           role-duration-seconds: 10800
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
-  # The standalone Windows leg runs on CodeBuild Windows runners, which have no
-  # Docker daemon. NX_E2E_SKIP_DOCKER drops the cases whose build compiles a
-  # Docker image (agents, MCP servers, Smithy, rdb) — those stay covered on the
+  # Runs on CodeBuild Windows runners. NX_E2E_CODEBUILD_WINDOWS skips the cases
+  # that runner can't build (see standalone.spec.ts); they stay covered on the
   # Linux standalone leg and the windows-latest dungeon-adventure test.
   smoke_tests_windows_standalone:
     name: Windows Smoke Tests - standalone (${{matrix.shard}}/6)
@@ -234,15 +233,14 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
         with:
-          # CodeBuild Windows runners have no Docker; skip the WSL2 Docker setup
-          # (container-tools) and Terraform (standalone workspaces use CDK).
+          # No Docker on this runner; standalone workspaces use CDK, not Terraform.
           container-tools: "false"
           setup-bun: "false"
           setup-terraform: "false"
       - name: Windows Smoke Test - standalone (shard ${{ matrix.shard }}/6)
         env:
           NX_E2E_SHARD: ${{ matrix.shard }}/6
-          NX_E2E_SKIP_DOCKER: "true"
+          NX_E2E_CODEBUILD_WINDOWS: "true"
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
   release:
     name: Release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,13 +138,13 @@ jobs:
   # machine's cores, so cases run sequentially within a shard and parallelism
   # comes from sharding across machines (NX_E2E_SHARD=<index>/<total>).
   smoke_tests_standalone:
-    name: Smoke Tests - standalone (${{matrix.shard}}/12)
+    name: Smoke Tests - standalone (${{matrix.shard}}/6)
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
     needs: package
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -158,9 +158,9 @@ jobs:
         with:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
           enable-uv-cache: 'false'
-      - name: Smoke Test - standalone (shard ${{ matrix.shard }}/12)
+      - name: Smoke Test - standalone (shard ${{ matrix.shard }}/6)
         env:
-          NX_E2E_SHARD: ${{ matrix.shard }}/12
+          NX_E2E_SHARD: ${{ matrix.shard }}/6
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,27 +186,41 @@ jobs:
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
+  # The standalone Windows leg runs on CodeBuild Windows runners, which have no
+  # Docker daemon. NX_E2E_SKIP_DOCKER drops the cases whose build compiles a
+  # Docker image (agents, MCP servers, Smithy, rdb) — those stay covered on the
+  # Linux standalone leg and the windows-latest dungeon-adventure test.
   smoke_tests_windows_standalone:
-    name: Windows Smoke Tests - standalone (${{matrix.shard}}/12)
-    runs-on: windows-latest
+    name: Windows Smoke Tests - standalone (${{matrix.shard}}/6)
+    runs-on: codebuild-nx-plugin-for-aws-windows-runner-${{ github.run_id }}-${{ github.run_attempt }}
     needs: package
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Disable Windows Defender real-time monitoring
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: pwsh
+        run: |
+          # Not present on every Windows image; best-effort.
+          try { Set-MpPreference -DisableRealtimeMonitoring $true } catch { }
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: dist
       - uses: ./.github/actions/init-monorepo
-      - name: Windows Smoke Test - standalone (shard ${{ matrix.shard }}/12)
+        with:
+          # CodeBuild Windows runners have no Docker; skip the WSL2 Docker setup
+          # (container-tools) and Terraform (standalone workspaces use CDK).
+          container-tools: "false"
+          setup-bun: "false"
+          setup-terraform: "false"
+      - name: Windows Smoke Test - standalone (shard ${{ matrix.shard }}/6)
         env:
-          NX_E2E_SHARD: ${{ matrix.shard }}/12
+          NX_E2E_SHARD: ${{ matrix.shard }}/6
+          NX_E2E_SKIP_DOCKER: "true"
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,9 +186,8 @@ jobs:
       - uses: ./.github/actions/init-monorepo
       - name: Windows Smoke Test - ${{ matrix.smoke_test }}
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=${{ matrix.smoke_test }}
-  # The standalone Windows leg runs on CodeBuild Windows runners, which have no
-  # Docker daemon. NX_E2E_SKIP_DOCKER drops the cases whose build compiles a
-  # Docker image (agents, MCP servers, Smithy, rdb) — those stay covered on the
+  # Runs on CodeBuild Windows runners. NX_E2E_CODEBUILD_WINDOWS skips the cases
+  # that runner can't build (see standalone.spec.ts); they stay covered on the
   # Linux standalone leg and the windows-latest dungeon-adventure test.
   smoke_tests_windows_standalone:
     name: Windows Smoke Tests - standalone (${{matrix.shard}}/6)
@@ -214,13 +213,12 @@ jobs:
           path: dist
       - uses: ./.github/actions/init-monorepo
         with:
-          # CodeBuild Windows runners have no Docker; skip the WSL2 Docker setup
-          # (container-tools) and Terraform (standalone workspaces use CDK).
+          # No Docker on this runner; standalone workspaces use CDK, not Terraform.
           container-tools: "false"
           setup-bun: "false"
           setup-terraform: "false"
       - name: Windows Smoke Test - standalone (shard ${{ matrix.shard }}/6)
         env:
           NX_E2E_SHARD: ${{ matrix.shard }}/6
-          NX_E2E_SKIP_DOCKER: "true"
+          NX_E2E_CODEBUILD_WINDOWS: "true"
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -82,6 +82,51 @@ const categorizeGenerators = () => {
 
 const { standalone, components } = categorizeGenerators();
 
+// Generators whose `build` compiles a Docker image (agentcore-hosted agents and
+// MCP servers, the Smithy build container, and the rdb migration image). On
+// runners without a Docker daemon (e.g. CodeBuild Windows), set
+// NX_E2E_SKIP_DOCKER=true to skip these; the Linux jobs still cover them fully.
+const SKIP_DOCKER = process.env.NX_E2E_SKIP_DOCKER === 'true';
+
+// Standalone project/component generators that build a Docker image with their
+// default arguments. `agentcore-gateway` and the DynamoDB generators do not.
+const DOCKER_GENERATORS = new Set([
+  'ts#agent',
+  'py#agent',
+  'ts#mcp-server',
+  'py#mcp-server',
+  'ts#rdb',
+]);
+
+// Connection endpoints (as they appear in a CONNECTION_CASES key) whose project
+// builds a Docker image. Matched exactly against each side of the key so
+// `agentcore-gateway` — which does not build an image — is never caught.
+const DOCKER_CONNECTION_ENDPOINTS = new Set([
+  'ts#agent',
+  'py#agent',
+  'ts#mcp-server',
+  'py#mcp-server',
+  'ts#smithy-api',
+  'ts#rdb',
+]);
+
+const connectionIsDockerBound = (key: string): boolean =>
+  key
+    .split('->')
+    .map((side) => side.trim())
+    .some((endpoint) => DOCKER_CONNECTION_ENDPOINTS.has(endpoint));
+
+const keepForRunner = <T extends { generator?: string; dockerBound?: boolean }>(
+  cases: T[],
+): T[] =>
+  SKIP_DOCKER
+    ? cases.filter(
+        (c) =>
+          !c.dockerBound &&
+          !(c.generator && DOCKER_GENERATORS.has(c.generator)),
+      )
+    : cases;
+
 // Optional cross-machine sharding via NX_E2E_SHARD=<index>/<total> (1-based),
 // round-robin across a cursor shared by all groups in source order. Cases run
 // sequentially within a shard (each build already saturates the cores);
@@ -94,9 +139,10 @@ const forThisShard = <T>(cases: T[]): T[] =>
   cases.filter(() => shardCursor++ % shardTotal === shardIndex - 1);
 
 // Sliced per group; a group can be empty for a shard, so its describe is
-// skipped to avoid vitest's empty-`it.each` error.
-const shardStandalone = forThisShard(standalone);
-const shardComponents = forThisShard(components);
+// skipped to avoid vitest's empty-`it.each` error. Docker-bound cases are
+// dropped first (when NX_E2E_SKIP_DOCKER is set) so the remainder shards evenly.
+const shardStandalone = forThisShard(keepForRunner(standalone));
+const shardComponents = forThisShard(keepForRunner(components));
 
 const freshWorkspace = async (generator: string): Promise<string> => {
   const targetDir = join(
@@ -349,9 +395,10 @@ const connectionCases = Object.entries(CONNECTION_CASES).flatMap(
     factories.map((factory, i) => ({
       key: factories.length > 1 ? `${key} #${i + 1}` : key,
       factory,
+      dockerBound: connectionIsDockerBound(key),
     })),
 );
-const shardConnectionCases = forThisShard(connectionCases);
+const shardConnectionCases = forThisShard(keepForRunner(connectionCases));
 
 // Exercises each supported connection end-to-end (the unit tests mock the
 // underlying connection generators; this proves they wire up buildable projects).

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -82,20 +82,24 @@ const categorizeGenerators = () => {
 
 const { standalone, components } = categorizeGenerators();
 
-// Generators whose `build` compiles a Docker image (agentcore-hosted agents and
-// MCP servers, the Smithy build container, and the rdb migration image). On
-// runners without a Docker daemon (e.g. CodeBuild Windows), set
-// NX_E2E_SKIP_DOCKER=true to skip these; the Linux jobs still cover them fully.
+// The CodeBuild Windows runner has no Docker daemon and no Terraform toolchain
+// (nor the `.py` file association uvx console-script shims like checkov need).
+// NX_E2E_SKIP_DOCKER=true skips the cases that depend on those — every one is
+// still covered in full on the Linux standalone leg and the windows-latest
+// dungeon-adventure test.
 const SKIP_DOCKER = process.env.NX_E2E_SKIP_DOCKER === 'true';
 
-// Standalone project/component generators that build a Docker image with their
-// default arguments. `agentcore-gateway` and the DynamoDB generators do not.
+// Standalone project/component generators skipped on that runner: agents, MCP
+// servers and rdb build a Docker image with their default arguments;
+// `terraform#project`'s build runs Terraform + checkov. `agentcore-gateway`
+// and the DynamoDB generators build neither and are kept.
 const DOCKER_GENERATORS = new Set([
   'ts#agent',
   'py#agent',
   'ts#mcp-server',
   'py#mcp-server',
   'ts#rdb',
+  'terraform#project',
 ]);
 
 // Connection endpoints (as they appear in a CONNECTION_CASES key) whose project

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -82,23 +82,25 @@ const categorizeGenerators = () => {
 
 const { standalone, components } = categorizeGenerators();
 
-// The CodeBuild Windows runner has no Docker daemon and no Terraform toolchain
-// (nor the `.py` file association uvx console-script shims like checkov need).
-// NX_E2E_SKIP_DOCKER=true skips the cases that depend on those — every one is
-// still covered in full on the Linux standalone leg and the windows-latest
+// The CodeBuild Windows runner has no Docker daemon, and its image can't run
+// the checkov build step (uvx installs a console-script shim that needs the
+// `.py` file association, which the image lacks). NX_E2E_SKIP_DOCKER=true skips
+// the cases that depend on either — all are still covered in full on the Linux
+// standalone leg, and CDK+checkov also runs on the windows-latest
 // dungeon-adventure test.
 const SKIP_DOCKER = process.env.NX_E2E_SKIP_DOCKER === 'true';
 
 // Standalone project/component generators skipped on that runner: agents, MCP
-// servers and rdb build a Docker image with their default arguments;
-// `terraform#project`'s build runs Terraform + checkov. `agentcore-gateway`
-// and the DynamoDB generators build neither and are kept.
+// servers and rdb build a Docker image with their default arguments; `ts#infra`
+// and `terraform#project` run checkov as part of their build. `agentcore-gateway`
+// and the DynamoDB generators do neither and are kept.
 const DOCKER_GENERATORS = new Set([
   'ts#agent',
   'py#agent',
   'ts#mcp-server',
   'py#mcp-server',
   'ts#rdb',
+  'ts#infra',
   'terraform#project',
 ]);
 

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -82,19 +82,13 @@ const categorizeGenerators = () => {
 
 const { standalone, components } = categorizeGenerators();
 
-// The CodeBuild Windows runner has no Docker daemon, and its image can't run
-// the checkov build step (uvx installs a console-script shim that needs the
-// `.py` file association, which the image lacks). NX_E2E_SKIP_DOCKER=true skips
-// the cases that depend on either — all are still covered in full on the Linux
-// standalone leg, and CDK+checkov also runs on the windows-latest
+// The CodeBuild Windows runner lacks Docker (agents, MCP servers and rdb build a
+// Docker image) and can't run checkov (ts#infra and terraform#project). These
+// stay covered on the Linux standalone leg and the windows-latest
 // dungeon-adventure test.
-const SKIP_DOCKER = process.env.NX_E2E_SKIP_DOCKER === 'true';
+const CODEBUILD_WINDOWS = process.env.NX_E2E_CODEBUILD_WINDOWS === 'true';
 
-// Standalone project/component generators skipped on that runner: agents, MCP
-// servers and rdb build a Docker image with their default arguments; `ts#infra`
-// and `terraform#project` run checkov as part of their build. `agentcore-gateway`
-// and the DynamoDB generators do neither and are kept.
-const DOCKER_GENERATORS = new Set([
+const CODEBUILD_WINDOWS_UNSUPPORTED = new Set([
   'ts#agent',
   'py#agent',
   'ts#mcp-server',
@@ -104,10 +98,9 @@ const DOCKER_GENERATORS = new Set([
   'terraform#project',
 ]);
 
-// Connection endpoints (as they appear in a CONNECTION_CASES key) whose project
-// builds a Docker image. Matched exactly against each side of the key so
-// `agentcore-gateway` — which does not build an image — is never caught.
-const DOCKER_CONNECTION_ENDPOINTS = new Set([
+// A connection is unsupported when either endpoint's project is. Matched exactly
+// against each side of the key.
+const CONNECTION_UNSUPPORTED_ENDPOINTS = new Set([
   'ts#agent',
   'py#agent',
   'ts#mcp-server',
@@ -116,20 +109,20 @@ const DOCKER_CONNECTION_ENDPOINTS = new Set([
   'ts#rdb',
 ]);
 
-const connectionIsDockerBound = (key: string): boolean =>
+const connectionUnsupported = (key: string): boolean =>
   key
     .split('->')
     .map((side) => side.trim())
-    .some((endpoint) => DOCKER_CONNECTION_ENDPOINTS.has(endpoint));
+    .some((endpoint) => CONNECTION_UNSUPPORTED_ENDPOINTS.has(endpoint));
 
-const keepForRunner = <T extends { generator?: string; dockerBound?: boolean }>(
+const keepForRunner = <T extends { generator?: string; unsupported?: boolean }>(
   cases: T[],
 ): T[] =>
-  SKIP_DOCKER
+  CODEBUILD_WINDOWS
     ? cases.filter(
         (c) =>
-          !c.dockerBound &&
-          !(c.generator && DOCKER_GENERATORS.has(c.generator)),
+          !c.unsupported &&
+          !(c.generator && CODEBUILD_WINDOWS_UNSUPPORTED.has(c.generator)),
       )
     : cases;
 
@@ -145,8 +138,8 @@ const forThisShard = <T>(cases: T[]): T[] =>
   cases.filter(() => shardCursor++ % shardTotal === shardIndex - 1);
 
 // Sliced per group; a group can be empty for a shard, so its describe is
-// skipped to avoid vitest's empty-`it.each` error. Docker-bound cases are
-// dropped first (when NX_E2E_SKIP_DOCKER is set) so the remainder shards evenly.
+// skipped to avoid vitest's empty-`it.each` error. Unsupported cases are dropped
+// first (on the CodeBuild Windows runner) so the remainder shards evenly.
 const shardStandalone = forThisShard(keepForRunner(standalone));
 const shardComponents = forThisShard(keepForRunner(components));
 
@@ -401,7 +394,7 @@ const connectionCases = Object.entries(CONNECTION_CASES).flatMap(
     factories.map((factory, i) => ({
       key: factories.length > 1 ? `${key} #${i + 1}` : key,
       factory,
-      dockerBound: connectionIsDockerBound(key),
+      unsupported: connectionUnsupported(key),
     })),
 );
 const shardConnectionCases = forThisShard(keepForRunner(connectionCases));


### PR DESCRIPTION
### Reason for this change

Two Windows CI-speed improvements, plus a shard consolidation:

1. **Cache the WSL2 Docker distro.** Every Windows smoke test job rebuilt its WSL2 Linux Docker environment from scratch (`wsl --install`, apt-install Docker Engine, pull binfmt + buildkit images) — ~4 min per job, identical run-to-run.
2. **Run the standalone Windows leg on CodeBuild runners.** The `smoke_tests_windows_standalone` matrix ran on `windows-latest`. Moving it to the `nx-plugin-for-aws-windows-runner` CodeBuild fleet reduces reliance on GitHub-hosted Windows minutes. CodeBuild Windows runners have **no Docker daemon** (EC2 has no nested virtualization, so WSL2 Docker isn't available), so the standalone cases whose build compiles a Docker image are skipped there — they remain fully covered on the Linux standalone leg and the `windows-latest` dungeon-adventure test.
3. **Consolidate standalone shards to 6.** The standalone leg isn't the CI critical path (dungeon-adventure is), and each shard pays fixed init/checkout/artifact-download overhead. 12 → 6 shards halves that overhead while keeping the leg well off the critical path.

The Dev Drive idea (from the original investigation) was dropped: WSL2 does not reliably automount ReFS drives, and the `docker-wsl.cmd` wrapper resolves the Docker build context via `wslpath`, so a ReFS workspace would break the Linux image builds. Its main benefit (bypassing the AV filter) is already covered by the existing `Set-MpPreference -DisableRealtimeMonitoring` step.

### Description of changes

**WSL2 Docker distro cache**
- Split `setup-wsl-docker.sh` into `install-wsl-docker.sh` (apt install + primes binfmt/buildkit images and the `linux-builder` builder — baked into the distro) and `start-wsl-docker.sh` (starts the daemon + bootstraps the builder, runs every job).
- `init-monorepo` caches the configured distro as a `wsl --export` tarball keyed on the install script hash. Cache hit → `wsl --import` and skip the apt install + image pulls. Gated on `container-tools`, so the Docker-free CodeBuild Windows runner skips it entirely.

**Standalone leg on CodeBuild**
- `standalone.spec.ts`: `NX_E2E_CODEBUILD_WINDOWS=true` drops the cases the CodeBuild Windows image can't run — those whose `build` compiles a Docker image (`ts#agent`/`py#agent`/`ts#mcp-server`/`py#mcp-server` components, `ts#rdb`, and connection cases touching agents/MCP servers/`ts#smithy-api`/`ts#rdb`), plus `ts#infra` and `terraform#project` (which run `uvx checkov`, unsupported on that image — no `.py` file association). `agentcore-gateway` and DynamoDB build neither and are kept.
- `pr.yml` / `ci.yml`: `smoke_tests_windows_standalone` runs on `codebuild-nx-plugin-for-aws-windows-runner-…` with `container-tools`/`setup-terraform`/`setup-bun` disabled and `NX_E2E_CODEBUILD_WINDOWS=true`. `dungeon-adventure` + `git-secrets` stay on `windows-latest` (they build Docker images via WSL2).

**Shard consolidation**
- Both `smoke_tests_standalone` (Linux) and `smoke_tests_windows_standalone` reduced from 12 → 6 shards.

### Before / after timings

Measured on real CI runs. WSL cache figures are the average of the init-monorepo step across all `windows-latest` jobs on a controlled cache-miss vs cache-hit run.

| Metric | Before | After |
| --- | --- | --- |
| `init-monorepo` on `windows-latest` (avg across jobs) | 3.87 min | **2.70 min** |
| Windows standalone leg | 12 shards on `windows-latest` | 6 shards on CodeBuild |
| &nbsp;&nbsp;— shard time (shortest / longest / avg) | 16.9 / 26.3 / 22.7 min | 20.4 / 23.9 / **21.9** min |
| Linux standalone leg | 12 shards | 6 shards |
| &nbsp;&nbsp;— shard time (shortest / longest / avg) | 7.0 / 9.4 / 8.2 min | 12.3 / 14.9 / **13.9** min |

Notes:
- The CodeBuild Windows shard times include ~6 min of runner provisioning (queue → start); actual test execution is ~15–17 min.
- The standalone legs run in parallel and finish well before the critical path (dungeon-adventure on `windows-latest`, ~40 min), so consolidating shards trades a small per-shard wall-clock increase for halving the machine count and fixed per-shard overhead.
- Shard counts: the Windows leg drops ~53 cases → ~20 (Docker/checkov cases skipped); the Linux leg keeps the full set.

### Description of how you validated changes

- **WSL cache:** all `windows-latest` jobs (git-secrets, dungeon-adventure) pass on both cache-miss and cache-hit runs, confirming Docker builds work from the imported distro. A single 0.89 GB cache entry is created once and reused (verified via the caches API).
- **Standalone on CodeBuild:** the runner label resolves and provisions; all 6 shards pass. Iterating on real runs surfaced two CodeBuild-image gaps (no Docker; `uvx checkov` fails with "File association not found for extension .py") — both handled by the skip list. `ts#infra` + `terraform#project` are the only generators that emit a checkov target, so the skip is complete; checkov-on-CDK is still exercised on the `windows-latest` dungeon-adventure test (195 checks pass).
- **Shard reduction:** a full run passed all 49 jobs green with both legs at 6 shards.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*