### PR TITLE
docs(connection): simplify sidebar and add Usage section to guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -540,20 +540,20 @@ export default defineConfig({
               ],
             },
             {
-              label: 'connection',
+              label: 'Connecting Projects',
+              translations: {
+                jp: 'プロジェクトの接続',
+                ko: '프로젝트 연결',
+                fr: 'Connexion des projets',
+                it: 'Connessione dei progetti',
+                es: 'Conexión de proyectos',
+                pt: 'Conexão de projetos',
+                zh: '连接项目',
+                vi: 'Kết nối dự án',
+              },
               items: [
                 {
-                  label: 'Connecting Projects',
-                  translations: {
-                    jp: 'プロジェクトの接続',
-                    ko: '프로젝트 연결',
-                    fr: 'Connexion des projets',
-                    it: 'Connessione dei progetti',
-                    es: 'Conexión de proyectos',
-                    pt: 'Conexão de projetos',
-                    zh: '连接项目',
-                    vi: 'Kết nối dự án',
-                  },
+                  label: 'connection',
                   link: '/guides/connection',
                 },
                 {
@@ -563,106 +563,6 @@ export default defineConfig({
                 {
                   label: 'Local Development',
                   link: '/guides/local-development',
-                },
-                {
-                  label: 'React → FastAPI',
-                  link: '/guides/connection/react-fastapi',
-                },
-                {
-                  label: 'React → tRPC',
-                  link: '/guides/connection/react-trpc',
-                },
-                {
-                  label: 'React → Smithy',
-                  link: '/guides/connection/react-smithy',
-                },
-                {
-                  label: 'React → Python Agent',
-                  link: '/guides/connection/react-py-agent',
-                },
-                {
-                  label: 'React → TypeScript Agent',
-                  link: '/guides/connection/react-ts-agent',
-                },
-                {
-                  label: 'React → AG-UI Agent',
-                  link: '/guides/connection/react-agui',
-                },
-                {
-                  label: 'Python Agent → MCP Server',
-                  link: '/guides/connection/py-agent-mcp',
-                },
-                {
-                  label: 'TypeScript Agent → MCP Server',
-                  link: '/guides/connection/ts-agent-mcp',
-                },
-                {
-                  label: 'Python Agent → A2A Agent',
-                  link: '/guides/connection/py-agent-a2a',
-                },
-                {
-                  label: 'TypeScript Agent → A2A Agent',
-                  link: '/guides/connection/ts-agent-a2a',
-                },
-                {
-                  label: 'tRPC API → Relational Database',
-                  link: '/guides/connection/trpc-rdb',
-                },
-                {
-                  label: 'Smithy API → Relational Database',
-                  link: '/guides/connection/smithy-rdb',
-                },
-                {
-                  label: 'TypeScript Agent → Relational Database',
-                  link: '/guides/connection/ts-agent-rdb',
-                },
-                {
-                  label: 'MCP Server → Relational Database',
-                  link: '/guides/connection/ts-mcp-server-rdb',
-                },
-                {
-                  label: 'tRPC API → DynamoDB',
-                  link: '/guides/connection/trpc-dynamodb',
-                },
-                {
-                  label: 'Smithy API → DynamoDB',
-                  link: '/guides/connection/smithy-dynamodb',
-                },
-                {
-                  label: 'TypeScript Agent → DynamoDB',
-                  link: '/guides/connection/ts-agent-dynamodb',
-                },
-                {
-                  label: 'MCP Server → DynamoDB',
-                  link: '/guides/connection/ts-mcp-server-dynamodb',
-                },
-                {
-                  label: 'FastAPI → DynamoDB',
-                  link: '/guides/connection/py-fast-api-dynamodb',
-                },
-                {
-                  label: 'Python Agent → DynamoDB',
-                  link: '/guides/connection/py-agent-dynamodb',
-                },
-                {
-                  label: 'Python MCP Server → DynamoDB',
-                  link: '/guides/connection/py-mcp-server-dynamodb',
-                },
-                {
-                  label: 'AgentCore Gateway → MCP Server',
-                  link: '/guides/connection/agentcore-gateway-mcp',
-                },
-                {
-                  label: 'AgentCore Gateway → AgentCore Gateway',
-                  link: '/guides/connection/agentcore-gateway-gateway',
-                },
-                {
-                  label: 'TypeScript Agent → AgentCore Gateway',
-                  link: '/guides/connection/ts-agent-gateway',
-                },
-                {
-                  label: 'Python Agent → AgentCore Gateway',
-                  link: '/guides/connection/py-agent-gateway',
                 },
               ],
             },

--- a/docs/src/content/docs/en/guides/connection.mdx
+++ b/docs/src/content/docs/en/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 This generator is used to connect projects together, such as websites calling APIs. Simply select the source project (for example the project that will call your API) and target project (for example your API project), and this generator will handle integrating the two.
+
+## Usage
+
+### Run the Generator
+
+<RunGenerator generator="connection" />
+
+### Options
+
+<GeneratorParameters generator="connection" />
 
 ### Supported Connections
 

--- a/docs/src/content/docs/es/guides/connection.mdx
+++ b/docs/src/content/docs/es/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 Este generador se utiliza para conectar proyectos entre sí, como sitios web que llaman a APIs. Simplemente selecciona el proyecto origen (por ejemplo, el proyecto que llamará a tu API) y el proyecto destino (por ejemplo, tu proyecto de API), y este generador se encargará de integrar ambos.
+
+## Uso
+
+### Ejecutar el Generador
+
+<RunGenerator generator="connection" />
+
+### Opciones
+
+<GeneratorParameters generator="connection" />
 
 ### Conexiones admitidas
 

--- a/docs/src/content/docs/fr/guides/connection.mdx
+++ b/docs/src/content/docs/fr/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 Ce générateur permet de connecter des projets entre eux, comme des sites web appelant des API. Sélectionnez simplement le projet source (par exemple le projet qui appellera votre API) et le projet cible (par exemple votre projet d'API), et ce générateur se chargera d'intégrer les deux.
+
+## Utilisation
+
+### Exécuter le générateur
+
+<RunGenerator generator="connection" />
+
+### Options
+
+<GeneratorParameters generator="connection" />
 
 ### Connexions prises en charge
 

--- a/docs/src/content/docs/it/guides/connection.mdx
+++ b/docs/src/content/docs/it/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 Questo generatore viene utilizzato per collegare progetti tra loro, come ad esempio siti web che chiamano API. Basta selezionare il progetto sorgente (ad esempio il progetto che effettuerà le chiamate alla tua API) e il progetto di destinazione (ad esempio il tuo progetto API), e questo generatore si occuperà di integrarli.
+
+## Utilizzo
+
+### Esegui il Generatore
+
+<RunGenerator generator="connection" />
+
+### Opzioni
+
+<GeneratorParameters generator="connection" />
 
 ### Connessioni Supportate
 

--- a/docs/src/content/docs/jp/guides/connection.mdx
+++ b/docs/src/content/docs/jp/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 このジェネレータは、ウェブサイトがAPIを呼び出すなど、プロジェクト同士を接続するために使用されます。ソースプロジェクト（例：APIを呼び出すプロジェクト）とターゲットプロジェクト（例：APIプロジェクト）を選択するだけで、このジェネレータが2つのプロジェクトの統合を処理します。
+
+## 使用方法
+
+### ジェネレータの実行
+
+<RunGenerator generator="connection" />
+
+### オプション
+
+<GeneratorParameters generator="connection" />
 
 ### サポートされている接続
 

--- a/docs/src/content/docs/ko/guides/connection.mdx
+++ b/docs/src/content/docs/ko/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 이 생성기는 웹사이트가 API를 호출하는 것과 같이 프로젝트들을 서로 연결하는 데 사용됩니다. 소스 프로젝트(예: API를 호출할 프로젝트)와 타겟 프로젝트(예: API 프로젝트)를 선택하기만 하면 이 생성기가 두 프로젝트의 통합을 처리합니다.
+
+## 사용 방법
+
+### 제너레이터 실행
+
+<RunGenerator generator="connection" />
+
+### 옵션
+
+<GeneratorParameters generator="connection" />
 
 ### 지원되는 연결
 

--- a/docs/src/content/docs/pt/guides/connection.mdx
+++ b/docs/src/content/docs/pt/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 Este gerador é usado para conectar projetos entre si, como sites chamando APIs. Basta selecionar o projeto de origem (por exemplo, o projeto que irá chamar sua API) e o projeto de destino (por exemplo, seu projeto de API), e este gerador cuidará da integração entre os dois.
+
+## Uso
+
+### Executar o Gerador
+
+<RunGenerator generator="connection" />
+
+### Opções
+
+<GeneratorParameters generator="connection" />
 
 ### Conexões Suportadas
 

--- a/docs/src/content/docs/vi/guides/connection.mdx
+++ b/docs/src/content/docs/vi/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 Generator này được sử dụng để kết nối các dự án với nhau, chẳng hạn như các trang web gọi API. Chỉ cần chọn dự án nguồn (ví dụ: dự án sẽ gọi API của bạn) và dự án đích (ví dụ: dự án API của bạn), và generator này sẽ xử lý việc tích hợp hai dự án đó.
+
+## Sử dụng
+
+### Chạy Generator
+
+<RunGenerator generator="connection" />
+
+### Tùy chọn
+
+<GeneratorParameters generator="connection" />
 
 ### Các Kết Nối Được Hỗ Trợ
 

--- a/docs/src/content/docs/zh/guides/connection.mdx
+++ b/docs/src/content/docs/zh/guides/connection.mdx
@@ -6,8 +6,20 @@ import Astro from '@astrojs/react';
 import { CardGrid, LinkButton } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import ConnectionCard from '@components/connection-card.astro';
+import RunGenerator from '@components/run-generator.astro';
+import GeneratorParameters from '@components/generator-parameters.astro';
 
 该生成器用于将项目连接在一起，例如网站调用 API。只需选择源项目（例如将调用您的 API 的项目）和目标项目（例如您的 API 项目），该生成器将处理两者的集成。
+
+## 使用方式
+
+### 运行生成器
+
+<RunGenerator generator="connection" />
+
+### 选项
+
+<GeneratorParameters generator="connection" />
 
 ### 支持的连接
 


### PR DESCRIPTION
### Reason for this change

The `connection` sidebar group listed every individual connection page (25+ entries), making the sidebar long and cluttered. The `connection` generator guide also lacked a Usage section like the individual connection pages have, so there was no clear way to see how to run the generator and its options from the main guide.

### Description of changes

- Removed the individual connection entries from the `connection` sidebar group in `docs/astro.config.mjs`, restructuring it under a "Connecting Projects" label with just three items: `connection`, Runtime Configuration and Local Development.
- Added a `Usage` section (Run the Generator and Options) to the `connection` generator guide, matching the start of the individual connection pages, across all locales (en, jp, ko, fr, it, es, pt, zh, vi).

### Description of how you validated changes

Ran the docs build (`nx run docs:build`) which completed successfully with all internal links validated, and previewed the rendered site locally.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

🤖 Generated with [Claude Code](https://claude.com/claude-code)