### PR TITLE
feat(ts#website#auth): use L2 UserPoolDomain construct

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -101,13 +101,14 @@ import {
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
-  CfnUserPoolDomain,
   FeaturePlan,
+  ManagedLoginVersion,
   Mfa,
   OAuthScope,
   StandardThreatProtectionMode,
   UserPool,
   UserPoolClient,
+  UserPoolDomain,
 } from 'aws-cdk-lib/aws-cognito';
 import {
   CfnLoggingConfiguration,
@@ -141,7 +142,7 @@ export class UserIdentity extends Construct {
   public readonly identityPool: IdentityPool;
   public readonly userPool: UserPool;
   public readonly userPoolClient: UserPoolClient;
-  public readonly userPoolDomain: CfnUserPoolDomain;
+  public readonly userPoolDomain: UserPoolDomain;
 
   /** The WAFv2 Web ACL associated with the user pool, if WAF is enabled */
   public readonly webAcl?: CfnWebACL;
@@ -321,10 +322,12 @@ export class UserIdentity extends Construct {
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>
-    new CfnUserPoolDomain(this, 'UserPoolDomain', {
-      domain: \`test-\${Stack.of(this).account}\`,
-      userPoolId: userPool.userPoolId,
-      managedLoginVersion: 2,
+    new UserPoolDomain(this, 'UserPoolDomain', {
+      userPool,
+      cognitoDomain: {
+        domainPrefix: \`test-\${Stack.of(this).account}\`,
+      },
+      managedLoginVersion: ManagedLoginVersion.NEWER_MANAGED_LOGIN,
     });
 
   private createUserPoolClient = (userPool: UserPool) => {
@@ -374,7 +377,7 @@ export class UserIdentity extends Construct {
   private createManagedLoginBranding = (
     userPool: UserPool,
     userPoolClient: UserPoolClient,
-    userPoolDomain: CfnUserPoolDomain,
+    userPoolDomain: UserPoolDomain,
   ) => {
     new CfnManagedLoginBranding(this, 'ManagedLoginBranding', {
       userPoolId: userPool.userPoolId,

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
@@ -533,11 +533,11 @@ describe('cognito-auth generator', () => {
       .read('packages/common/constructs/src/core/user-identity.ts', 'utf-8')
       ?.toString();
     // Reserved words "cognito" and "aws" should be stripped, leaving collapsed hyphens
-    expect(userIdentity).not.toMatch(/domain: `[^`]*cognito[^`]*`/i);
-    expect(userIdentity).not.toMatch(/domain: `[^`]*aws[^`]*`/i);
-    expect(userIdentity).not.toMatch(/domain: `[^`]*amazon[^`]*`/i);
+    expect(userIdentity).not.toMatch(/domainPrefix: `[^`]*cognito[^`]*`/i);
+    expect(userIdentity).not.toMatch(/domainPrefix: `[^`]*aws[^`]*`/i);
+    expect(userIdentity).not.toMatch(/domainPrefix: `[^`]*amazon[^`]*`/i);
     // The remaining derived prefix should still match the Cognito pattern.
-    const match = userIdentity?.match(/domain: `([^`$]+?)-\$\{/);
+    const match = userIdentity?.match(/domainPrefix: `([^`$]+?)-\$\{/);
     expect(match).toBeTruthy();
     expect(match![1]).toMatch(/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/);
   });

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -13,13 +13,14 @@ import {
 import {
   AccountRecovery,
   CfnManagedLoginBranding,
-  CfnUserPoolDomain,
   FeaturePlan,
+  ManagedLoginVersion,
   Mfa,
   OAuthScope,
   StandardThreatProtectionMode,
   UserPool,
   UserPoolClient,
+  UserPoolDomain,
 } from 'aws-cdk-lib/aws-cognito';
 import {
   CfnLoggingConfiguration,
@@ -53,7 +54,7 @@ export class UserIdentity extends Construct {
   public readonly identityPool: IdentityPool;
   public readonly userPool: UserPool;
   public readonly userPoolClient: UserPoolClient;
-  public readonly userPoolDomain: CfnUserPoolDomain;
+  public readonly userPoolDomain: UserPoolDomain;
 
   /** The WAFv2 Web ACL associated with the user pool, if WAF is enabled */
   public readonly webAcl?: CfnWebACL;
@@ -229,10 +230,12 @@ export class UserIdentity extends Construct {
   };
 
   private createUserPoolDomain = (userPool: UserPool) =>
-    new CfnUserPoolDomain(this, 'UserPoolDomain', {
-      domain: `<%= cognitoDomain %>-${Stack.of(this).account}`,
-      userPoolId: userPool.userPoolId,
-      managedLoginVersion: 2,
+    new UserPoolDomain(this, 'UserPoolDomain', {
+      userPool,
+      cognitoDomain: {
+        domainPrefix: `<%= cognitoDomain %>-${Stack.of(this).account}`,
+      },
+      managedLoginVersion: ManagedLoginVersion.NEWER_MANAGED_LOGIN,
     });
 
   private createUserPoolClient = (userPool: UserPool) => {
@@ -282,7 +285,7 @@ export class UserIdentity extends Construct {
   private createManagedLoginBranding = (
     userPool: UserPool,
     userPoolClient: UserPoolClient,
-    userPoolDomain: CfnUserPoolDomain
+    userPoolDomain: UserPoolDomain
   ) => {
     new CfnManagedLoginBranding(this, 'ManagedLoginBranding', {
       userPoolId: userPool.userPoolId,


### PR DESCRIPTION
### Reason for this change

The L1 `CfnUserPoolDomain` only exposes raw CloudFormation attributes.
Switching to the L2 `UserPoolDomain` gives us helpers like `baseUrl()` and lets us configure the various options for new app clients in a more type-friendly way going forward. This is also groundwork for dcr-proxy.

### Description of changes

Upgraded the user pool domain in the generated `user-identity.ts` template from the L1 `CfnUserPoolDomain` to the L2 `UserPoolDomain` construct:

- `userPoolDomain` field is now typed as `UserPoolDomain` (was `CfnUserPoolDomain`); `createManagedLoginBranding` accepts the L2 type accordingly.
- `createUserPoolDomain` now builds a `UserPoolDomain` with  `cognitoDomain.domainPrefix` set to the derived prefix, and `managedLoginVersion` set to the `ManagedLoginVersion.NEWER_MANAGED_LOGIN` enum (replacing the raw `2`).
- Since the L2 `UserPoolDomain` wraps the same underlying `CfnUserPoolDomain`, the synthesized resource is identical — this is a construct-level change only, with no CloudFormation output diff.
- The L2 construct additionally exposes `baseUrl()` for downstream consumers.

No impact on the connection flow: `cognitoProps` still carries only `region` / `identityPoolId` / `userPoolId` / `userPoolWebClientId` and never referenced the domain.

### Description of how you validated changes

Updated the `cognito-auth` generator unit tests: the derived-domain spec regex now matches the new `domainPrefix` field (previously `domain`), and the generator snapshot was regenerated to reflect the L2 construct usage. Ran the test suite with snapshot updates and verified the build passes.

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----