### PR TITLE
ci: enable git long paths on Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,10 @@ jobs:
           - dungeon-adventure
           - git-secrets
     steps:
+      # Allow paths beyond the Windows 260-char MAX_PATH limit during checkout.
+      - name: Enable git long paths
+        shell: pwsh
+        run: git config --system core.longpaths true
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -218,6 +222,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
+      # Allow paths beyond the Windows 260-char MAX_PATH limit during checkout.
+      - name: Enable git long paths
+        shell: pwsh
+        run: git config --system core.longpaths true
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,6 +173,10 @@ jobs:
           - dungeon-adventure
           - git-secrets
     steps:
+      # Allow paths beyond the Windows 260-char MAX_PATH limit during checkout.
+      - name: Enable git long paths
+        shell: pwsh
+        run: git config --system core.longpaths true
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -198,6 +202,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
+      # Allow paths beyond the Windows 260-char MAX_PATH limit during checkout.
+      - name: Enable git long paths
+        shell: pwsh
+        run: git config --system core.longpaths true
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0


### PR DESCRIPTION
### Reason for this change

The latest CI runs on `main` are **failing deterministically** — all 6 shards of the `Windows Smoke Tests - standalone` job fail at the `actions/checkout@v7` step, **before any test runs**:

```
error: unable to create file packages/nx-plugin/src/py/agent/a2a-connection/files/langchain/agent-connection/app/__targetAgentSnakeCase___client_langchain.py.template: Filename too long
...
The process 'C:\Program Files\Git\cmd\git.exe' failed with exit code 1
```

**Root cause — Windows `MAX_PATH` (260 chars):** The standalone Windows legs run on CodeBuild runners whose working-directory prefix is very long (`C:\codebuild\tmp\output\src...\actions-runner\_work\nx-plugin-for-aws\nx-plugin-for-aws\`, ~120 chars). Combined with template file paths that reach ~145 chars (e.g. the newly added agent-connection templates), the total path exceeds the Windows 260-char limit and `git checkout` cannot create the files.

This is **not transient** — reruns fail identically. It first appeared on the run that introduced the CodeBuild Windows-standalone leg. The GitHub-hosted `windows-latest` legs (short `D:\a\...` prefix) are unaffected and stay green.

### Description of changes

Add a pre-checkout `git config --system core.longpaths true` step to the Windows smoke test legs (both standalone CodeBuild and `windows-latest`) in `ci.yml` and `pr.yml`, so git can create paths longer than 260 characters.

### Description of how you validated changes

- Confirmed the failure across the two most recent runs that include the CodeBuild Windows-standalone leg — identical `Filename too long` checkout errors on all 6 shards.
- Confirmed the `windows-latest` legs pass in the same runs (shorter path prefix), isolating the cause to path length on the CodeBuild runners.
- Validated both workflow YAML files parse correctly.
- CI on this PR (`pr.yml`, which contains the same legs) exercises the fix directly.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*