### PR TITLE
feat(connection): more complete, correct OpenAPI client generation with lighter installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@commitlint/cli": "20.5.3",
     "@commitlint/config-conventional": "20.5.3",
     "@getgrit/gritql": "0.0.3",
-    "@hey-api/openapi-ts": "0.64.13",
     "@iarna/toml": "2.2.5",
     "@middy/core": "7.7.0",
     "@modelcontextprotocol/inspector": "0.19.0",

--- a/packages/nx-plugin/LICENSE-THIRD-PARTY
+++ b/packages/nx-plugin/LICENSE-THIRD-PARTY
@@ -3659,60 +3659,6 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: @hey-api/json-schema-ref-parser (1.0.3)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Hey API
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-The following software may be included in this product: @hey-api/openapi-ts (0.64.13)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Hey API
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: @hono/node-server (1.19.9)
 This software contains the following license and notice below:
 
@@ -3912,35 +3858,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-The following software may be included in this product: @jsdevtools/ono (7.1.3)
-This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2015 James Messinger
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-.
 
 ---
 
@@ -10439,33 +10356,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: c12 (2.0.1)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: cacheable-lookup (6.1.0)
 This software contains the following license and notice below:
 
@@ -10880,33 +10770,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: chokidar (4.0.3)
-This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2012 Paul Miller (https://paulmillr.com), Elan Shanker
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----
-
 The following software may be included in this product: chokidar (5.0.0)
 This software contains the following license and notice below:
 
@@ -10959,47 +10822,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-The following software may be included in this product: citty (0.1.6)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-Parser is based on https://github.com/lukeed/mri
-
-The MIT License (MIT)
-
-Copyright (c) Luke Edwards luke.edwards05@gmail.com (lukeed.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
@@ -11383,34 +11205,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: commander (13.0.0)
-This software contains the following license and notice below:
-
-(The MIT License)
-
-Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
 The following software may be included in this product: commondir (1.0.1)
 This software contains the following license and notice below:
 
@@ -11549,183 +11343,6 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-The following software may be included in this product: confbox (0.1.8)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-js-yaml: https://github.com/nodeca/js-yaml/tree/master
-
-(The MIT License)
-
-Copyright (C) 2011-2015 by Vitaly Puzrin
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----
-
-smol-toml: https://github.com/squirrelchat/smol-toml/blob/mistress/LICENSE
-
-Copyright (c) Squirrel Chat et al., All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software without
-   specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----
-
-jsonc-parser: https://github.com/microsoft/node-jsonc-parser/blob/main/LICENSE.md
-
-The MIT License (MIT)
-
-Copyright (c) Microsoft
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-json5: https://github.com/json5/json5/blob/main/LICENSE.md
-
-MIT License
-
-Copyright (c) 2012-2018 Aseem Kishore, and others (https://github.com/json5/json5/graphs/contributors)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-detect-indent: https://github.com/sindresorhus/detect-indent/blob/main/license
-
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-The following software may be included in this product: consola (3.4.2)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-Prompt support is based on https://github.com/bombshell-dev/clack
-
-MIT License
-
-Copyright (c) Nate Moore
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-Color support is based on https://github.com/jorgebucaran/colorette
-
-Copyright © Jorge Bucaran <https://jorgebucaran.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
@@ -12793,33 +12410,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
-The following software may be included in this product: defu (6.1.4)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: delayed-stream (1.0.0)
 This software contains the following license and notice below:
 
@@ -12951,33 +12541,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
----
-
-The following software may be included in this product: destr (2.0.5)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ---
 
@@ -15520,33 +15083,6 @@ IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: giget (1.2.5)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: global-modules (1.0.0)
 This software contains the following license and notice below:
 
@@ -15694,31 +15230,6 @@ This software contains the following license and notice below:
 The MIT License (MIT)
 
 Copyright (c) 2016 Mathias Buus
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----
-
-The following software may be included in this product: handlebars (4.7.8)
-This software contains the following license and notice below:
-
-Copyright (C) 2011-2019 by Yehuda Katz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20988,38 +20499,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: minizlib (2.1.2)
-This software contains the following license and notice below:
-
-Minizlib was created by Isaac Z. Schlueter.
-It is a derivative work of the Node.js project.
-
-"""
-Copyright Isaac Z. Schlueter and Contributors
-Copyright Node.js contributors. All rights reserved.
-Copyright Joyent, Inc. and other Node contributors. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-"""
-
----
-
 The following software may be included in this product: mkdirp (1.0.4)
 This software contains the following license and notice below:
 
@@ -21044,33 +20523,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
----
-
-The following software may be included in this product: mlly (1.8.0)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ---
 
@@ -21458,126 +20910,6 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: node-fetch-native (1.6.7)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-https://github.com/node-fetch/node-fetch
-
-The MIT License (MIT)
-
-Copyright (c) 2016 - 2020 Node Fetch Team
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-https://github.com/mysticatea/abort-controller
-
-MIT License
-
-Copyright (c) 2017 Toru Nagashima
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-https://github.com/TooTallNate/proxy-agents
-
-(The MIT License)
-
-Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-https://github.com/nodejs/undici
-
-MIT License
-
-Copyright (c) Matteo Collina and Undici contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: node-releases (2.0.50)
 This software contains the following license and notice below:
 
@@ -21787,33 +21119,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: nypm (0.5.4)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: object-assign (4.1.1)
 This software contains the following license and notice below:
 
@@ -21876,33 +21181,6 @@ The MIT License (MIT)
 Copyright © 2025-PRESENT Kevin Deng (https://github.com/sxzz)
 Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
 Copyright (c) 2018-2021 Josh Junon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-The following software may be included in this product: ohash (1.1.6)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22586,56 +21864,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
-The following software may be included in this product: pathe (1.1.2)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io> - Daniel Roe <daniel@roe.dev>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Copyright Joyent, Inc. and other Node contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
 The following software may be included in this product: pathe (2.0.3)
 This software contains the following license and notice below:
 
@@ -22764,33 +21992,6 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
 BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
 ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-The following software may be included in this product: perfect-debounce (1.0.0)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ---
@@ -23052,56 +22253,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-The following software may be included in this product: pkg-types (1.3.1)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io> - Daniel Roe <daniel@roe.dev>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Copyright Joyent, Inc. and other Node contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
@@ -23786,51 +22937,6 @@ THE SOFTWARE.
 
 ---
 
-The following software may be included in this product: rc9 (2.1.2)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
------
-
-Bundled with https://github.com/hughsk/flat
-
-Copyright (c) 2014, Hugh Kennedy
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the  nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----
-
 The following software may be included in this product: react (19.2.7)
 This software contains the following license and notice below:
 
@@ -24041,33 +23147,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
-
----
-
-The following software may be included in this product: readdirp (4.1.2)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2012-2019 Thorsten Lorenz, Paul Miller (https://paulmillr.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ---
 
@@ -27345,33 +26424,6 @@ SOFTWARE.
 
 ---
 
-The following software may be included in this product: tinyexec (0.3.2)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2024 Tinylibs
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
 The following software may be included in this product: tinyexec (1.0.4)
 This software contains the following license and notice below:
 
@@ -27933,33 +26985,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-The following software may be included in this product: ufo (1.6.3)
-This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Pooya Parsa <pooya@pi0.io>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ---
 
@@ -40504,27 +39529,6 @@ THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO
 
 ---
 
-The following software may be included in this product: chownr (2.0.0)
-This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-
 The following software may be included in this product: cliui (8.0.1)
 This software contains the following license and notice below:
 
@@ -40623,27 +39627,6 @@ This software contains the following license and notice below:
 The ISC License
 
 Copyright (c) 2015-2023 Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-
-The following software may be included in this product: fs-minipass (2.1.0)
-This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -41141,48 +40124,6 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-The following software may be included in this product: minipass (3.3.6)
-This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) 2017-2022 npm, Inc., Isaac Z. Schlueter, and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-
-The following software may be included in this product: minipass (5.0.0)
-This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) 2017-2023 npm, Inc., Isaac Z. Schlueter, and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-
 The following software may be included in this product: minipass (7.1.2)
 This software contains the following license and notice below:
 
@@ -41622,27 +40563,6 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ---
 
-The following software may be included in this product: tar (6.2.1)
-This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-
 The following software may be included in this product: which (1.3.1)
 This software contains the following license and notice below:
 
@@ -41747,27 +40667,6 @@ THIS SOFTWARE.
 ---
 
 The following software may be included in this product: yallist (3.1.1)
-This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-
-The following software may be included in this product: yallist (4.0.0)
 This software contains the following license and notice below:
 
 The ISC License

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -43,7 +43,6 @@
     "@biomejs/js-api": "4.0.0",
     "@biomejs/wasm-nodejs": "2.5.1",
     "@getgrit/gritql": "0.0.3",
-    "@hey-api/openapi-ts": "0.64.13",
     "@iarna/toml": "2.2.5",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@nx/devkit": "23.0.1",

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -457,16 +457,12 @@ export class TestApi {
     this.getDynamicPropertyValues = this.getDynamicPropertyValues.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1914,16 +1910,12 @@ export class TestApi {
       this.getPatternPropertiesSingle.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2410,16 +2402,12 @@ export class TestApi {
     this.getBareObject = this.getBareObject.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -468,7 +468,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -479,17 +481,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1901,7 +1917,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1912,17 +1930,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2373,7 +2405,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2384,17 +2418,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -464,6 +464,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -487,19 +502,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1913,6 +1923,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1936,19 +1961,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2401,6 +2421,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2424,19 +2459,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`openApiTsClientGenerator - complex types > should handle response objec
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetDynamicPropertiesAny200Response = {
@@ -765,7 +765,7 @@ exports[`openApiTsClientGenerator - complex types > should handle response objec
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetPatternPropertiesArrayArrays200Response = {
@@ -2245,7 +2245,7 @@ exports[`openApiTsClientGenerator - complex types > should render \`unknown\` va
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetAdditionalPropsTrue200Response = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -457,11 +457,18 @@ export class TestApi {
     this.getDynamicPropertyValues = this.getDynamicPropertyValues.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -480,7 +487,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -490,13 +499,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1872,11 +1890,18 @@ export class TestApi {
       this.getPatternPropertiesSingle.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1895,7 +1920,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1905,13 +1932,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -2326,11 +2362,18 @@ export class TestApi {
     this.getBareObject = this.getBareObject.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2349,7 +2392,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2359,13 +2404,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.additional-properties.spec.ts.snap
@@ -502,8 +502,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1961,8 +1959,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2459,8 +2455,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -155,16 +155,12 @@ export class TestApi {
     this.processUsers = this.processUsers.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -497,16 +493,12 @@ export class TestApi {
     this.batchCreateCustomers = this.batchCreateCustomers.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -713,16 +705,12 @@ export class TestApi {
     this.processTags = this.processTags.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1069,16 +1057,12 @@ export class TestApi {
     this.getProducts = this.getProducts.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1484,16 +1468,12 @@ export class TestApi {
     this.getOrders = this.getOrders.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1705,16 +1685,12 @@ export class TestApi {
     this.getCategories = this.getCategories.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which accep
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static ProcessUsers200Response = {
@@ -274,7 +274,7 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which accep
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static BatchCreateCustomers201Response = {
@@ -558,7 +558,7 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which accep
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static ProcessTags200Response = {
@@ -748,7 +748,7 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which retur
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetProducts200ResponseItem = {
@@ -1086,7 +1086,7 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which retur
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetOrdersRequestQueryParameters = {
@@ -1421,7 +1421,7 @@ exports[`openApiTsClientGenerator - arrays > should handle operation which retur
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetCategoriesRequestQueryParameters = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -166,7 +166,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -177,17 +179,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -484,7 +500,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -495,17 +513,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -676,7 +708,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -687,17 +721,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1008,7 +1056,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1019,17 +1069,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1399,7 +1463,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1410,17 +1476,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1596,7 +1676,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1607,17 +1689,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -155,11 +155,18 @@ export class TestApi {
     this.processUsers = this.processUsers.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -178,7 +185,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -188,13 +197,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -455,11 +473,18 @@ export class TestApi {
     this.batchCreateCustomers = this.batchCreateCustomers.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -478,7 +503,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -488,13 +515,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -629,11 +665,18 @@ export class TestApi {
     this.processTags = this.processTags.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -652,7 +695,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -662,13 +707,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -943,11 +997,18 @@ export class TestApi {
     this.getProducts = this.getProducts.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -966,7 +1027,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -976,13 +1039,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -999,7 +1071,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.GetProductsRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       category: 'multi',
       limit: 'multi',
     } as const;
@@ -1011,10 +1083,10 @@ export class TestApi {
         '/get-products',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },
@@ -1316,11 +1388,18 @@ export class TestApi {
     this.getOrders = this.getOrders.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1339,7 +1418,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1349,13 +1430,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1370,7 +1460,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.GetOrdersRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       customerId: 'multi',
       status: 'multi',
       limit: 'multi',
@@ -1379,9 +1469,14 @@ export class TestApi {
     const body = undefined;
 
     const response = await this.$fetch(
-      this.$url('/orders', pathParameters, queryParameters, collectionFormats),
+      this.$url(
+        '/orders',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },
@@ -1490,11 +1585,18 @@ export class TestApi {
     this.getCategories = this.getCategories.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1513,7 +1615,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1523,13 +1627,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1546,7 +1659,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.GetCategoriesRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       filter: 'multi',
     } as const;
 
@@ -1557,10 +1670,10 @@ export class TestApi {
         '/get-categories',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -162,6 +162,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -185,19 +200,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -496,6 +506,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -519,19 +544,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -704,6 +724,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -727,19 +762,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1052,6 +1082,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1075,19 +1120,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1459,6 +1499,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1482,19 +1537,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1672,6 +1722,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1695,19 +1760,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.arrays.spec.ts.snap
@@ -200,8 +200,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -544,8 +542,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -762,8 +758,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1120,8 +1114,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1537,8 +1529,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1760,8 +1750,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -200,11 +200,18 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -223,7 +230,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -233,13 +242,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -944,11 +962,18 @@ export class TestApi {
     this.testNullable = this.testNullable.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -967,7 +992,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -977,13 +1004,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1151,7 +1187,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       queryString: 'multi',
       queryNumber: 'multi',
       queryInteger: 'multi',
@@ -1171,10 +1207,10 @@ export class TestApi {
         '/test/{pathParam}',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },
@@ -1490,11 +1526,18 @@ export class TestApi {
     this.postMapOfObjects = this.postMapOfObjects.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1513,7 +1556,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1523,13 +1568,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1880,11 +1934,18 @@ export class TestApi {
     this.getTree = this.getTree.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1903,7 +1964,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1913,13 +1976,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -2210,11 +2282,18 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2233,7 +2312,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2243,13 +2324,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -245,8 +245,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1067,8 +1065,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1657,8 +1653,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2091,8 +2085,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2465,8 +2457,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`openApiTsClientGenerator - complex types > should generate valid TypeSc
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200ResponseItem = {
@@ -382,7 +382,7 @@ exports[`openApiTsClientGenerator - complex types > should handle nullable schem
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostSingleNullableObjectRequestContent = {
@@ -1275,7 +1275,7 @@ exports[`openApiTsClientGenerator - complex types > should handle operations wit
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostMapOfArraysOfObjectsRequestContent = {
@@ -1796,7 +1796,7 @@ exports[`openApiTsClientGenerator - complex types > should handle recursive sche
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TreeNode = {
@@ -2024,7 +2024,7 @@ exports[`openApiTsClientGenerator - complex types > should handle refs and hoist
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static _Error = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -200,16 +200,12 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1020,16 +1016,12 @@ export class TestApi {
     this.testNullable = this.testNullable.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1608,16 +1600,12 @@ export class TestApi {
     this.postMapOfObjects = this.postMapOfObjects.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2040,16 +2028,12 @@ export class TestApi {
     this.getTree = this.getTree.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2412,16 +2396,12 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -207,6 +207,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -230,19 +245,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -366,7 +376,10 @@ export type TestNullableRequestQueryParameters = {
   queryInteger?: number | null;
   queryBoolean?: boolean | null;
   queryArray?: Array<string> | null;
-  queryObject?: unknown | null;
+  queryObject?: TestNullableRequestQueryQueryObject;
+};
+export type TestNullableRequestQueryQueryObject = null | {
+  key?: string;
 };
 
 export type PostSingleNullableArrayRequest = Array<string> | undefined;
@@ -404,6 +417,7 @@ exports[`openApiTsClientGenerator - complex types > should handle nullable schem
   TestNullableRequestContentObjectWithNullablePropsNullableObject,
   TestNullableRequestPathParameters,
   TestNullableRequestQueryParameters,
+  TestNullableRequestQueryQueryObject,
   PostSingleNullableArrayRequest,
   PostSingleNullableBooleanRequest,
   PostSingleNullableNumberRequest,
@@ -885,7 +899,9 @@ export class $IO {
         ...(model.queryObject === undefined
           ? {}
           : {
-              queryObject: model.queryObject,
+              queryObject: $IO.TestNullableRequestQueryQueryObject.toJson(
+                model.queryObject,
+              ),
             }),
       };
     },
@@ -927,8 +943,36 @@ export class $IO {
         ...(json['queryObject'] === undefined
           ? {}
           : {
-              queryObject:
-                json['queryObject'] === null ? null : json['queryObject'],
+              queryObject: $IO.TestNullableRequestQueryQueryObject.fromJson(
+                json['queryObject'],
+              ),
+            }),
+      };
+    },
+  };
+
+  public static TestNullableRequestQueryQueryObject = {
+    toJson: (model: TestNullableRequestQueryQueryObject): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.key === undefined
+          ? {}
+          : {
+              key: model.key,
+            }),
+      };
+    },
+    fromJson: (json: any): TestNullableRequestQueryQueryObject => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['key'] === undefined
+          ? {}
+          : {
+              key: json['key'],
             }),
       };
     },
@@ -985,6 +1029,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1008,19 +1067,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1565,6 +1619,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1588,19 +1657,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1989,6 +2053,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2012,19 +2091,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2353,6 +2427,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2376,19 +2465,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -211,7 +211,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -222,17 +224,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -973,7 +989,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -984,17 +1002,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1537,7 +1569,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1548,17 +1582,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1945,7 +1993,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1956,17 +2006,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2293,7 +2357,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2304,17 +2370,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -463,6 +463,12 @@ export class $IO {
       if (model === undefined || model === null) {
         return model;
       }
+      switch ((model as any).kind) {
+        case 'circle':
+          return $IO.Circle.toJson(model as Circle);
+        case 'square':
+          return $IO.Square.toJson(model as Square);
+      }
       return {
         ...$IO.Circle.toJson(model as Circle),
         ...$IO.Square.toJson(model as Square),
@@ -471,6 +477,12 @@ export class $IO {
     fromJson: (json: any): ShapesOutCanonical => {
       if (json === undefined || json === null) {
         return json;
+      }
+      switch (json?.['kind']) {
+        case 'circle':
+          return $IO.Circle.fromJson(json);
+        case 'square':
+          return $IO.Square.fromJson(json);
       }
       return {
         ...$IO.Circle.fromJson(json),

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -281,6 +281,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -304,19 +319,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -582,6 +592,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -605,19 +630,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -830,6 +850,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -853,19 +888,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1089,6 +1119,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1112,19 +1157,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1449,6 +1489,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1472,19 +1527,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1881,6 +1931,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1904,19 +1969,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2312,6 +2372,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2335,19 +2410,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2538,6 +2608,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2561,19 +2646,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -319,8 +319,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -630,8 +628,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -888,8 +884,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1157,8 +1151,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1527,8 +1519,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1969,8 +1959,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2410,8 +2398,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2646,8 +2632,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -285,7 +285,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -296,17 +298,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -570,7 +586,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -581,17 +599,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -802,7 +834,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -813,17 +847,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1045,7 +1093,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1056,17 +1106,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1389,7 +1453,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1400,17 +1466,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1805,7 +1885,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1816,17 +1898,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2220,7 +2316,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2231,17 +2329,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2430,7 +2542,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2441,17 +2555,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -274,11 +274,18 @@ export class TestApi {
     this.putTest = this.putTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -297,7 +304,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -307,13 +316,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -529,11 +547,18 @@ export class TestApi {
     this.getShapes = this.getShapes.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -552,7 +577,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -562,13 +589,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -743,11 +779,18 @@ export class TestApi {
     this.testAnyOfAny = this.testAnyOfAny.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -766,7 +809,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -776,13 +821,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -968,11 +1022,18 @@ export class TestApi {
     this.testAnyOfEnum = this.testAnyOfEnum.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -991,7 +1052,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1001,13 +1064,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1294,11 +1366,18 @@ export class TestApi {
     this.composite = this.composite.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1317,7 +1396,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1327,13 +1408,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1692,11 +1782,18 @@ export class TestApi {
     this.testPrimitiveText = this.testPrimitiveText.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1715,7 +1812,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1725,13 +1824,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1776,7 +1884,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       someParameter: 'multi',
     } as const;
     const body =
@@ -1792,10 +1900,10 @@ export class TestApi {
         '/arrays-with-other-parameters',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },
@@ -2089,11 +2197,18 @@ export class TestApi {
     this.testNot = this.testNot.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2112,7 +2227,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2122,13 +2239,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -2281,11 +2407,18 @@ export class TestApi {
     this.postMaybeDate = this.postMaybeDate.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2304,7 +2437,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2314,13 +2449,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -274,16 +274,12 @@ export class TestApi {
     this.putTest = this.putTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -583,16 +579,12 @@ export class TestApi {
     this.getShapes = this.getShapes.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -839,16 +831,12 @@ export class TestApi {
     this.testAnyOfAny = this.testAnyOfAny.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1106,16 +1094,12 @@ export class TestApi {
     this.testAnyOfEnum = this.testAnyOfEnum.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1474,16 +1458,12 @@ export class TestApi {
     this.composite = this.composite.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1914,16 +1894,12 @@ export class TestApi {
     this.testPrimitiveText = this.testPrimitiveText.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2353,16 +2329,12 @@ export class TestApi {
     this.testNot = this.testNot.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2587,16 +2559,12 @@ export class TestApi {
     this.postMaybeDate = this.postMaybeDate.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`openApiTsClientGenerator - composite schemas > should generate valid Ty
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PutTest200Response = {
@@ -385,7 +385,7 @@ exports[`openApiTsClientGenerator - composite schemas > should handle FastAPI-st
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static Circle = {
@@ -628,7 +628,7 @@ exports[`openApiTsClientGenerator - composite schemas > should handle anyOf with
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestAnyOfAny200Response = {
@@ -853,7 +853,7 @@ exports[`openApiTsClientGenerator - composite schemas > should handle anyOf with
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestAnyOfEnum200Response = {
@@ -1088,7 +1088,7 @@ exports[`openApiTsClientGenerator - composite schemas > should handle composite 
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static CompositeRequestContent = {
@@ -1444,7 +1444,7 @@ exports[`openApiTsClientGenerator - composite schemas > should handle inline pri
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestArrays200Response = {
@@ -1956,7 +1956,7 @@ exports[`openApiTsClientGenerator - composite schemas > should handle not schema
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestNot200Response = {
@@ -2191,7 +2191,7 @@ exports[`openApiTsClientGenerator - composite schemas > should round-trip Date t
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static MaybeDate = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -49,16 +49,12 @@ export class TestApi {
     this.postUpload = this.postUpload.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -245,16 +241,12 @@ export class TestApi {
     this.postMulti = this.postMulti.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -464,16 +456,12 @@ export class TestApi {
     this.getSecret = this.getSecret.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -60,7 +60,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -71,17 +73,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -232,7 +248,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -243,17 +261,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -427,7 +459,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -438,17 +472,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -94,8 +94,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -292,8 +290,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -513,8 +509,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -49,11 +49,18 @@ export class TestApi {
     this.postUpload = this.postUpload.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -72,7 +79,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -82,13 +91,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -203,11 +221,18 @@ export class TestApi {
     this.postMulti = this.postMulti.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -226,7 +251,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -236,13 +263,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -380,11 +416,18 @@ export class TestApi {
     this.getSecret = this.getSecret.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -403,7 +446,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -413,13 +458,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`openApiTsClientGenerator - content type header > should not force Conte
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -134,7 +134,7 @@ exports[`openApiTsClientGenerator - content type header > should pick a single w
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostMultiRequestContent = {
@@ -301,7 +301,7 @@ exports[`openApiTsClientGenerator - content type header > should serialise cooki
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetSecretRequestCookieParameters = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -56,6 +56,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -79,19 +94,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -244,6 +254,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -267,19 +292,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -455,6 +475,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -478,19 +513,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -134,16 +134,12 @@ export class TestApi {
     this.operation = this.operation.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -493,16 +489,12 @@ export class TestApi {
     this.operation = this.operation.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -730,16 +722,12 @@ export class TestApi {
     this.user = this.user.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -961,16 +949,12 @@ export class TestApi {
     this.chat = this.chat.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -145,7 +145,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -156,17 +158,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -480,7 +496,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -491,17 +509,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -693,7 +725,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -704,17 +738,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -900,7 +948,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -911,17 +961,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`openApiTsClientGenerator - duplicate types > should handle duplicated m
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static Clash = {
@@ -252,7 +252,7 @@ exports[`openApiTsClientGenerator - duplicate types > should handle many duplica
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static AnotherModel = {
@@ -557,7 +557,7 @@ exports[`openApiTsClientGenerator - duplicate types > should handle multiple ope
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static OrderRequest = {
@@ -770,7 +770,7 @@ exports[`openApiTsClientGenerator - duplicate types > should handle operation ID
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static ChatRequest = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -179,8 +179,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -540,8 +538,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -779,8 +775,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1012,8 +1006,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -141,6 +141,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -164,19 +179,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -492,6 +502,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -515,19 +540,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -721,6 +741,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -744,19 +779,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -944,6 +974,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -967,19 +1012,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -134,11 +134,18 @@ export class TestApi {
     this.operation = this.operation.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -157,7 +164,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -167,13 +176,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -451,11 +469,18 @@ export class TestApi {
     this.operation = this.operation.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -474,7 +499,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -484,13 +511,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -646,11 +682,18 @@ export class TestApi {
     this.user = this.user.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -669,7 +712,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -679,13 +724,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -835,11 +889,18 @@ export class TestApi {
     this.chat = this.chat.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -858,7 +919,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -868,13 +931,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -147,6 +147,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -170,19 +185,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -403,6 +413,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -426,19 +451,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -573,6 +593,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -596,19 +631,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -758,6 +788,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -781,19 +826,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -943,6 +983,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -966,19 +1021,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1177,6 +1227,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1200,19 +1265,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1405,6 +1465,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1428,19 +1503,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1643,6 +1713,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1666,19 +1751,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1897,6 +1977,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1920,19 +2015,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2163,6 +2253,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2186,19 +2291,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2431,6 +2531,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2454,19 +2569,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2708,6 +2818,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2731,19 +2856,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2875,6 +2995,7 @@ export type PutThingsError = never;
 
 exports[`openApiTsClientGenerator - edge cases > omits undefined and null members of a deepObject query parameter > client.gen.ts 1`] = `
 "import type {
+  SearchRequestQueryFilter,
   SearchRequestQueryParameters,
   SearchRequest,
 } from './types.gen.js';
@@ -2886,6 +3007,43 @@ export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
+  public static SearchRequestQueryFilter = {
+    toJson: (model: SearchRequestQueryFilter): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.tag === undefined
+          ? {}
+          : {
+              tag: model.tag,
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryFilter => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['name'] === undefined
+          ? {}
+          : {
+              name: json['name'],
+            }),
+        ...(json['tag'] === undefined
+          ? {}
+          : {
+              tag: json['tag'] === null ? null : json['tag'],
+            }),
+      };
+    },
+  };
+
   public static SearchRequestQueryParameters = {
     toJson: (model: SearchRequestQueryParameters): any => {
       if (model === undefined || model === null) {
@@ -2895,7 +3053,7 @@ export class $IO {
         ...(model.filter === undefined
           ? {}
           : {
-              filter: model.filter,
+              filter: $IO.SearchRequestQueryFilter.toJson(model.filter),
             }),
       };
     },
@@ -2907,7 +3065,7 @@ export class $IO {
         ...(json['filter'] === undefined
           ? {}
           : {
-              filter: json['filter'],
+              filter: $IO.SearchRequestQueryFilter.fromJson(json['filter']),
             }),
       };
     },
@@ -2959,6 +3117,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2982,19 +3155,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -3069,8 +3237,300 @@ export class TestApi {
 `;
 
 exports[`openApiTsClientGenerator - edge cases > omits undefined and null members of a deepObject query parameter > types.gen.ts 1`] = `
-"export type SearchRequestQueryParameters = {
-  filter?: unknown;
+"export type SearchRequestQueryFilter = {
+  name?: string;
+  tag?: string | null;
+};
+export type SearchRequestQueryParameters = {
+  filter?: SearchRequestQueryFilter;
+};
+
+export type SearchRequest = SearchRequestQueryParameters;
+export type SearchError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > recurses into a nested deepObject query parameter > client.gen.ts 1`] = `
+"import type {
+  SearchRequestQueryFilter,
+  SearchRequestQueryFilterPage,
+  SearchRequestQueryParameters,
+  SearchRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static SearchRequestQueryFilter = {
+    toJson: (model: SearchRequestQueryFilter): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.page === undefined
+          ? {}
+          : {
+              page: $IO.SearchRequestQueryFilterPage.toJson(model.page),
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryFilter => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['page'] === undefined
+          ? {}
+          : {
+              page: $IO.SearchRequestQueryFilterPage.fromJson(json['page']),
+            }),
+      };
+    },
+  };
+
+  public static SearchRequestQueryFilterPage = {
+    toJson: (model: SearchRequestQueryFilterPage): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.size === undefined
+          ? {}
+          : {
+              size: model.size,
+            }),
+        ...(model.sort === undefined
+          ? {}
+          : {
+              sort: model.sort,
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryFilterPage => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['size'] === undefined
+          ? {}
+          : {
+              size: json['size'],
+            }),
+        ...(json['sort'] === undefined
+          ? {}
+          : {
+              sort: json['sort'],
+            }),
+      };
+    },
+  };
+
+  public static SearchRequestQueryParameters = {
+    toJson: (model: SearchRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.filter === undefined
+          ? {}
+          : {
+              filter: $IO.SearchRequestQueryFilter.toJson(model.filter),
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['filter'] === undefined
+          ? {}
+          : {
+              filter: $IO.SearchRequestQueryFilter.fromJson(json['filter']),
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.search = this.search.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async search(input: SearchRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.SearchRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const queryCollectionFormats = {
+      filter: 'deepObject',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/search',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > recurses into a nested deepObject query parameter > types.gen.ts 1`] = `
+"export type SearchRequestQueryFilter = {
+  page?: SearchRequestQueryFilterPage;
+};
+export type SearchRequestQueryFilterPage = {
+  size?: number;
+  sort?: string;
+};
+export type SearchRequestQueryParameters = {
+  filter?: SearchRequestQueryFilter;
 };
 
 export type SearchRequest = SearchRequestQueryParameters;
@@ -3192,6 +3652,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -3215,19 +3690,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -3407,6 +3877,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -3430,19 +3915,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -3653,6 +4133,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -3676,19 +4171,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -3767,6 +4257,7 @@ export type GetThingError = never;
 
 exports[`openApiTsClientGenerator - edge cases > serialises a deepObject query parameter as key[prop]=value pairs > client.gen.ts 1`] = `
 "import type {
+  SearchRequestQueryFilter,
   SearchRequestQueryParameters,
   SearchRequest,
 } from './types.gen.js';
@@ -3778,6 +4269,53 @@ export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
+  public static SearchRequestQueryFilter = {
+    toJson: (model: SearchRequestQueryFilter): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.name === undefined
+          ? {}
+          : {
+              name: model.name,
+            }),
+        ...(model.min === undefined
+          ? {}
+          : {
+              min: model.min,
+            }),
+        ...(model.since === undefined
+          ? {}
+          : {
+              since: model.since.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryFilter => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['name'] === undefined
+          ? {}
+          : {
+              name: json['name'],
+            }),
+        ...(json['min'] === undefined
+          ? {}
+          : {
+              min: json['min'],
+            }),
+        ...(json['since'] === undefined
+          ? {}
+          : {
+              since: new Date(json['since']),
+            }),
+      };
+    },
+  };
+
   public static SearchRequestQueryParameters = {
     toJson: (model: SearchRequestQueryParameters): any => {
       if (model === undefined || model === null) {
@@ -3787,7 +4325,7 @@ export class $IO {
         ...(model.filter === undefined
           ? {}
           : {
-              filter: model.filter,
+              filter: $IO.SearchRequestQueryFilter.toJson(model.filter),
             }),
       };
     },
@@ -3799,7 +4337,7 @@ export class $IO {
         ...(json['filter'] === undefined
           ? {}
           : {
-              filter: json['filter'],
+              filter: $IO.SearchRequestQueryFilter.fromJson(json['filter']),
             }),
       };
     },
@@ -3851,6 +4389,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -3874,19 +4427,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -3961,8 +4509,13 @@ export class TestApi {
 `;
 
 exports[`openApiTsClientGenerator - edge cases > serialises a deepObject query parameter as key[prop]=value pairs > types.gen.ts 1`] = `
-"export type SearchRequestQueryParameters = {
-  filter?: unknown;
+"export type SearchRequestQueryFilter = {
+  name?: string;
+  min?: number;
+  since?: Date;
+};
+export type SearchRequestQueryParameters = {
+  filter?: SearchRequestQueryFilter;
 };
 
 export type SearchRequest = SearchRequestQueryParameters;
@@ -4066,6 +4619,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -4089,19 +4657,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -4243,6 +4806,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -4266,19 +4844,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -4403,6 +4976,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -4426,19 +5014,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -185,8 +185,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -451,8 +449,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -631,8 +627,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -826,8 +820,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1021,8 +1013,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1265,8 +1255,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1503,8 +1491,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1751,8 +1737,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2015,8 +1999,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2291,8 +2273,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2569,8 +2549,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2856,8 +2834,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -3155,8 +3131,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -3440,8 +3414,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -3690,8 +3662,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -3915,8 +3885,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -4171,8 +4139,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -4427,8 +4393,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -4657,8 +4621,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -4844,8 +4806,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -5014,8 +4974,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -1387,6 +1387,510 @@ export type CreateDogError = never;
 "
 `;
 
+exports[`openApiTsClientGenerator - edge cases > marshals a discriminated oneOf to the matching branch (explicit mapping) > client.gen.ts 1`] = `
+"import type { Cat, Dog, Shape, PostShapeRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Cat = {
+    toJson: (model: Cat): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Cat => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static Dog = {
+    toJson: (model: Dog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Dog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+
+  public static Shape = {
+    toJson: (model: Shape): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).kind) {
+        case 'cat':
+          return $IO.Cat.toJson(model as Cat);
+        case 'dog':
+          return $IO.Dog.toJson(model as Dog);
+      }
+      return {
+        ...$IO.Cat.toJson(model as Cat),
+        ...$IO.Dog.toJson(model as Dog),
+      };
+    },
+    fromJson: (json: any): Shape => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.['kind']) {
+        case 'cat':
+          return $IO.Cat.fromJson(json);
+        case 'dog':
+          return $IO.Dog.fromJson(json);
+      }
+      return {
+        ...$IO.Cat.fromJson(json),
+        ...$IO.Dog.fromJson(json),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postShape = this.postShape.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postShape(input: PostShapeRequest): Promise<Shape> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.Shape.toJson(input))
+        : String($IO.Shape.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/shapes', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Shape.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > marshals a discriminated oneOf to the matching branch (explicit mapping) > types.gen.ts 1`] = `
+"export type Cat = {
+  kind: string;
+  napAt: Date;
+};
+export type Dog = {
+  kind: string;
+  walkAt: Date;
+};
+export type Shape = Cat | Dog;
+
+export type PostShapeRequest = Shape;
+export type PostShapeError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > marshals a discriminated oneOf using implicit (schema-name) mapping > client.gen.ts 1`] = `
+"import type { Cat, Dog, Shape, PostShapeRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Cat = {
+    toJson: (model: Cat): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Cat => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static Dog = {
+    toJson: (model: Dog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Dog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+
+  public static Shape = {
+    toJson: (model: Shape): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).kind) {
+        case 'Cat':
+          return $IO.Cat.toJson(model as Cat);
+        case 'Dog':
+          return $IO.Dog.toJson(model as Dog);
+      }
+      return {
+        ...$IO.Cat.toJson(model as Cat),
+        ...$IO.Dog.toJson(model as Dog),
+      };
+    },
+    fromJson: (json: any): Shape => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.['kind']) {
+        case 'Cat':
+          return $IO.Cat.fromJson(json);
+        case 'Dog':
+          return $IO.Dog.fromJson(json);
+      }
+      return {
+        ...$IO.Cat.fromJson(json),
+        ...$IO.Dog.fromJson(json),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postShape = this.postShape.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postShape(input: PostShapeRequest): Promise<Shape> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.Shape.toJson(input))
+        : String($IO.Shape.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/shapes', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Shape.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > marshals a discriminated oneOf using implicit (schema-name) mapping > types.gen.ts 1`] = `
+"export type Cat = {
+  kind: string;
+  napAt: Date;
+};
+export type Dog = {
+  kind: string;
+  walkAt: Date;
+};
+export type Shape = Cat | Dog;
+
+export type PostShapeRequest = Shape;
+export type PostShapeError = never;
+"
+`;
+
 exports[`openApiTsClientGenerator - edge cases > marshals shared path-level array parameters (dates and refs) > client.gen.ts 1`] = `
 "import type {
   GetThingsRequestQueryParameters,

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -1,0 +1,1270 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - edge cases > escapes quotes, backslashes and newlines in enum values > client.gen.ts 1`] = `
+"import type { Tricky } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getTricky = this.getTricky.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getTricky(): Promise<Tricky> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/tricky', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return (await response.text()) as Tricky;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > escapes quotes, backslashes and newlines in enum values > types.gen.ts 1`] = `
+"export type Tricky = "don't" | 'back\\\\slash' | 'new\\nline';
+export type GetTrickyError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > handles an inline object itemSchema on a streaming response > client.gen.ts 1`] = `
+"import type { StreamThings200ResponseItem } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static StreamThings200ResponseItem = {
+    toJson: (model: StreamThings200ResponseItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.line === undefined
+          ? {}
+          : {
+              line: model.line,
+            }),
+      };
+    },
+    fromJson: (json: any): StreamThings200ResponseItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        line: json['line'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.streamThings = this.streamThings.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *streamThings(): AsyncIterableIterator<StreamThings200ResponseItem> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/stream', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      let buffer = '';
+      while (reader) {
+        const { value: chunk, done } = await reader.read();
+        if (done) {
+          if (buffer.trim()) {
+            yield $IO.StreamThings200ResponseItem.fromJson(JSON.parse(buffer));
+          }
+          return;
+        }
+        if (chunk) {
+          buffer += chunk;
+        }
+        const lines = buffer.split('\\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (line.trim()) {
+            yield $IO.StreamThings200ResponseItem.fromJson(JSON.parse(line));
+          }
+        }
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > handles an inline object itemSchema on a streaming response > types.gen.ts 1`] = `
+"export type StreamThings200ResponseItem = {
+  line: string;
+};
+export type StreamThingsError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > handles an inline primitive itemSchema on a streaming response > client.gen.ts 1`] = `
+"/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.streamNumbers = this.streamNumbers.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async *streamNumbers(): AsyncIterableIterator<number> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/stream', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      const reader = response.body
+        ?.pipeThrough(new TextDecoderStream())
+        .getReader();
+      let buffer = '';
+      while (reader) {
+        const { value: chunk, done } = await reader.read();
+        if (done) {
+          if (buffer.trim()) {
+            yield Number(buffer);
+          }
+          return;
+        }
+        if (chunk) {
+          buffer += chunk;
+        }
+        const lines = buffer.split('\\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (line.trim()) {
+            yield Number(line);
+          }
+        }
+      }
+      return;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > handles an inline primitive itemSchema on a streaming response > types.gen.ts 1`] = `
+"export type StreamNumbersError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > keeps parameters with the same name in path and query distinct > client.gen.ts 1`] = `
+"import type {
+  GetItemRequestPathParameters,
+  GetItemRequestQueryParameters,
+  GetItemRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetItemRequestPathParameters = {
+    toJson: (model: GetItemRequestPathParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+      };
+    },
+    fromJson: (json: any): GetItemRequestPathParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+      };
+    },
+  };
+
+  public static GetItemRequestQueryParameters = {
+    toJson: (model: GetItemRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): GetItemRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['id'] === undefined
+          ? {}
+          : {
+              id: new Date(json['id']),
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getItem = this.getItem.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getItem(input: GetItemRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } =
+      $IO.GetItemRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } =
+      $IO.GetItemRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const collectionFormats = {
+      id: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/items/{id}',
+        pathParameters,
+        queryParameters,
+        collectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > keeps parameters with the same name in path and query distinct > types.gen.ts 1`] = `
+"export type GetItemRequestPathParameters = {
+  id: string;
+};
+export type GetItemRequestQueryParameters = {
+  id?: Date;
+};
+
+export type GetItemRequest = GetItemRequestPathParameters &
+  GetItemRequestQueryParameters;
+export type GetItemError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > keeps sibling properties declared alongside allOf > client.gen.ts 1`] = `
+"import type { Base, Dog, DogAllOf, CreateDogRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Base = {
+    toJson: (model: Base): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+      };
+    },
+    fromJson: (json: any): Base => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['id'] === undefined
+          ? {}
+          : {
+              id: json['id'],
+            }),
+      };
+    },
+  };
+
+  public static Dog = {
+    toJson: (model: Dog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.Base.toJson(model),
+        ...$IO.DogAllOf.toJson(model),
+      };
+    },
+    fromJson: (json: any): Dog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.Base.fromJson(json),
+        ...$IO.DogAllOf.fromJson(json),
+      };
+    },
+  };
+
+  public static DogAllOf = {
+    toJson: (model: DogAllOf): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.bark === undefined
+          ? {}
+          : {
+              bark: model.bark,
+            }),
+      };
+    },
+    fromJson: (json: any): DogAllOf => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        bark: json['bark'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.createDog = this.createDog.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async createDog(input: CreateDogRequest): Promise<Dog> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.Dog.toJson(input))
+        : String($IO.Dog.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/dogs', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Dog.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > keeps sibling properties declared alongside allOf > types.gen.ts 1`] = `
+"export type Base = {
+  id?: string;
+};
+export type Dog = Base & DogAllOf;
+export type DogAllOf = {
+  bark: boolean;
+};
+
+export type CreateDogRequest = Dog;
+export type CreateDogError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > marshals shared path-level array parameters (dates and refs) > client.gen.ts 1`] = `
+"import type {
+  GetThingsRequestQueryParameters,
+  PutThingsRequestQueryParameters,
+  Thing,
+  GetThingsRequest,
+  PutThingsRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetThingsRequestQueryParameters = {
+    toJson: (model: GetThingsRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.whens === undefined
+          ? {}
+          : {
+              whens: model.whens.map((item0) => item0.toISOString()),
+            }),
+        ...(model.things === undefined
+          ? {}
+          : {
+              things: model.things.map($IO.Thing.toJson),
+            }),
+      };
+    },
+    fromJson: (json: any): GetThingsRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        whens: (json['whens'] as Array<any>).map((item0) => new Date(item0)),
+        ...(json['things'] === undefined
+          ? {}
+          : {
+              things: (json['things'] as Array<any>).map($IO.Thing.fromJson),
+            }),
+      };
+    },
+  };
+
+  public static PutThingsRequestQueryParameters = {
+    toJson: (model: PutThingsRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.whens === undefined
+          ? {}
+          : {
+              whens: model.whens.map((item0) => item0.toISOString()),
+            }),
+        ...(model.things === undefined
+          ? {}
+          : {
+              things: model.things.map($IO.Thing.toJson),
+            }),
+      };
+    },
+    fromJson: (json: any): PutThingsRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        whens: (json['whens'] as Array<any>).map((item0) => new Date(item0)),
+        ...(json['things'] === undefined
+          ? {}
+          : {
+              things: (json['things'] as Array<any>).map($IO.Thing.fromJson),
+            }),
+      };
+    },
+  };
+
+  public static Thing = {
+    toJson: (model: Thing): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.at === undefined
+          ? {}
+          : {
+              at: model.at.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Thing => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['at'] === undefined
+          ? {}
+          : {
+              at: new Date(json['at']),
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getThings = this.getThings.bind(this);
+    this.putThings = this.putThings.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getThings(input: GetThingsRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.GetThingsRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const collectionFormats = {
+      whens: 'multi',
+      things: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/things', pathParameters, queryParameters, collectionFormats),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async putThings(input: PutThingsRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.PutThingsRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const collectionFormats = {
+      whens: 'multi',
+      things: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/things', pathParameters, queryParameters, collectionFormats),
+      {
+        headers: this.$headers(headerParameters, collectionFormats),
+        method: 'PUT',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > marshals shared path-level array parameters (dates and refs) > types.gen.ts 1`] = `
+"export type GetThingsRequestQueryParameters = {
+  whens: Array<Date>;
+  things?: Array<Thing>;
+};
+export type PutThingsRequestQueryParameters = {
+  whens: Array<Date>;
+  things?: Array<Thing>;
+};
+export type Thing = {
+  at?: Date;
+};
+
+export type GetThingsRequest = GetThingsRequestQueryParameters;
+export type GetThingsError = never;
+
+export type PutThingsRequest = PutThingsRequestQueryParameters;
+export type PutThingsError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > treats a null enum member as nullable, not an empty literal > client.gen.ts 1`] = `
+"import type { Status } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getStatus = this.getStatus.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getStatus(): Promise<Status> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/status', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return (await response.text()) as Status;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > treats a null enum member as nullable, not an empty literal > types.gen.ts 1`] = `
+"export type Status = 'active' | 'inactive';
+export type GetStatusError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -140,16 +140,12 @@ export class TestApi {
     this.postShape = this.postShape.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -404,16 +400,12 @@ export class TestApi {
     this.getShape = this.getShape.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -582,16 +574,12 @@ export class TestApi {
     this.getTricky = this.getTricky.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -775,16 +763,12 @@ export class TestApi {
     this.streamThings = this.streamThings.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -968,16 +952,12 @@ export class TestApi {
     this.streamNumbers = this.streamNumbers.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1210,16 +1190,12 @@ export class TestApi {
     this.postV = this.postV.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1446,16 +1422,12 @@ export class TestApi {
     this.getItem = this.getItem.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1692,16 +1664,12 @@ export class TestApi {
     this.listItems = this.listItems.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1954,16 +1922,12 @@ export class TestApi {
     this.createDog = this.createDog.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2228,16 +2192,12 @@ export class TestApi {
     this.postShape = this.postShape.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2504,16 +2464,12 @@ export class TestApi {
     this.postShape = this.postShape.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2789,16 +2745,12 @@ export class TestApi {
     this.putThings = this.putThings.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -3086,16 +3038,12 @@ export class TestApi {
     this.search = this.search.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -3369,16 +3317,12 @@ export class TestApi {
     this.search = this.search.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -3617,16 +3561,12 @@ export class TestApi {
     this.getThing = this.getThing.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -3840,16 +3780,12 @@ export class TestApi {
     this.getThings = this.getThings.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -4094,16 +4030,12 @@ export class TestApi {
     this.getThing = this.getThing.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -4348,16 +4280,12 @@ export class TestApi {
     this.search = this.search.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -4576,16 +4504,12 @@ export class TestApi {
     this.search = this.search.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -4761,16 +4685,12 @@ export class TestApi {
     this.getStatus = this.getStatus.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -4929,16 +4849,12 @@ export class TestApi {
     this.doNoop = this.doNoop.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -151,7 +151,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -162,17 +164,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -391,7 +407,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -402,17 +420,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -545,7 +577,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -556,17 +590,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -714,7 +762,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -725,17 +775,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -883,7 +947,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -894,17 +960,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1101,7 +1181,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1112,17 +1194,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1313,7 +1409,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1324,17 +1422,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1535,7 +1647,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1546,17 +1660,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1773,7 +1901,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1784,17 +1914,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2023,7 +2167,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2034,17 +2180,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2275,7 +2435,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2286,17 +2448,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2536,7 +2712,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2547,17 +2725,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2681,6 +2873,211 @@ export type PutThingsError = never;
 "
 `;
 
+exports[`openApiTsClientGenerator - edge cases > omits undefined and null members of a deepObject query parameter > client.gen.ts 1`] = `
+"import type {
+  SearchRequestQueryParameters,
+  SearchRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static SearchRequestQueryParameters = {
+    toJson: (model: SearchRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.filter === undefined
+          ? {}
+          : {
+              filter: model.filter,
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['filter'] === undefined
+          ? {}
+          : {
+              filter: json['filter'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.search = this.search.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
+            .map(
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async search(input: SearchRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.SearchRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const queryCollectionFormats = {
+      filter: 'deepObject',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/search',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > omits undefined and null members of a deepObject query parameter > types.gen.ts 1`] = `
+"export type SearchRequestQueryParameters = {
+  filter?: unknown;
+};
+
+export type SearchRequest = SearchRequestQueryParameters;
+export type SearchError = never;
+"
+`;
+
 exports[`openApiTsClientGenerator - edge cases > renders a multi-type union for items of a nullable (multi-type) array > client.gen.ts 1`] = `
 "import type { Thing, ThingDataItem } from './types.gen.js';
 
@@ -2799,7 +3196,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2810,17 +3209,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2998,7 +3411,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -3009,17 +3424,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -3228,7 +3657,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -3239,17 +3670,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -3317,6 +3762,211 @@ export type ThingWrapper = null | {
 };
 export type ThingWrapperKind = 'fixed';
 export type GetThingError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > serialises a deepObject query parameter as key[prop]=value pairs > client.gen.ts 1`] = `
+"import type {
+  SearchRequestQueryParameters,
+  SearchRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static SearchRequestQueryParameters = {
+    toJson: (model: SearchRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.filter === undefined
+          ? {}
+          : {
+              filter: model.filter,
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['filter'] === undefined
+          ? {}
+          : {
+              filter: json['filter'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.search = this.search.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
+            .map(
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async search(input: SearchRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.SearchRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const queryCollectionFormats = {
+      filter: 'deepObject',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/search',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > serialises a deepObject query parameter as key[prop]=value pairs > types.gen.ts 1`] = `
+"export type SearchRequestQueryParameters = {
+  filter?: unknown;
+};
+
+export type SearchRequest = SearchRequestQueryParameters;
+export type SearchError = never;
 "
 `;
 
@@ -3420,7 +4070,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -3431,17 +4083,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -3581,7 +4247,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -3592,17 +4260,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -3725,7 +4407,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -3736,17 +4420,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -1,5 +1,490 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`openApiTsClientGenerator - edge cases > dispatches a discriminator whose wire name differs from its TS name > client.gen.ts 1`] = `
+"import type { Cat, Dog, Shape, PostShapeRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Cat = {
+    toJson: (model: Cat): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.petType === undefined
+          ? {}
+          : {
+              'pet-type': model.petType,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Cat => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        petType: json['pet-type'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static Dog = {
+    toJson: (model: Dog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.petType === undefined
+          ? {}
+          : {
+              'pet-type': model.petType,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Dog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        petType: json['pet-type'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+
+  public static Shape = {
+    toJson: (model: Shape): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).petType) {
+        case 'cat':
+          return $IO.Cat.toJson(model as Cat);
+        case 'dog':
+          return $IO.Dog.toJson(model as Dog);
+      }
+      return {
+        ...$IO.Cat.toJson(model as Cat),
+        ...$IO.Dog.toJson(model as Dog),
+      };
+    },
+    fromJson: (json: any): Shape => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.['pet-type']) {
+        case 'cat':
+          return $IO.Cat.fromJson(json);
+        case 'dog':
+          return $IO.Dog.fromJson(json);
+      }
+      return {
+        ...$IO.Cat.fromJson(json),
+        ...$IO.Dog.fromJson(json),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postShape = this.postShape.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postShape(input: PostShapeRequest): Promise<Shape> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.Shape.toJson(input))
+        : String($IO.Shape.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/shapes', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Shape.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > dispatches a discriminator whose wire name differs from its TS name > types.gen.ts 1`] = `
+"export type Cat = {
+  petType: string;
+  napAt: Date;
+};
+export type Dog = {
+  petType: string;
+  walkAt: Date;
+};
+export type Shape = Cat | Dog;
+
+export type PostShapeRequest = Shape;
+export type PostShapeError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > does not build a discriminator switch for inline (hoisted) union members > client.gen.ts 1`] = `
+"import type { Shape, ShapeOneOf, ShapeOneOf1 } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Shape = {
+    toJson: (model: Shape): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...$IO.ShapeOneOf.toJson(model as ShapeOneOf),
+        ...$IO.ShapeOneOf1.toJson(model as ShapeOneOf1),
+      };
+    },
+    fromJson: (json: any): Shape => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...$IO.ShapeOneOf.fromJson(json),
+        ...$IO.ShapeOneOf1.fromJson(json),
+      };
+    },
+  };
+
+  public static ShapeOneOf = {
+    toJson: (model: ShapeOneOf): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): ShapeOneOf => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static ShapeOneOf1 = {
+    toJson: (model: ShapeOneOf1): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): ShapeOneOf1 => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getShape = this.getShape.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getShape(): Promise<Shape> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/shapes', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Shape.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > does not build a discriminator switch for inline (hoisted) union members > types.gen.ts 1`] = `
+"export type Shape = ShapeOneOf | ShapeOneOf1;
+export type ShapeOneOf = {
+  kind: string;
+  napAt: Date;
+};
+export type ShapeOneOf1 = {
+  kind: string;
+  walkAt: Date;
+};
+export type GetShapeError = never;
+"
+`;
+
 exports[`openApiTsClientGenerator - edge cases > escapes quotes, backslashes and newlines in enum values > client.gen.ts 1`] = `
 "import type { Tricky } from './types.gen.js';
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -452,6 +452,196 @@ exports[`openApiTsClientGenerator - edge cases > handles an inline primitive ite
 "
 `;
 
+exports[`openApiTsClientGenerator - edge cases > hoists and marshals vendored +json request/response schemas > client.gen.ts 1`] = `
+"import type {
+  PostV200Response,
+  PostVRequestContent,
+  PostVRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static PostV200Response = {
+    toJson: (model: PostV200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.at === undefined
+          ? {}
+          : {
+              at: model.at.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): PostV200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        at: new Date(json['at']),
+      };
+    },
+  };
+
+  public static PostVRequestContent = {
+    toJson: (model: PostVRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.at === undefined
+          ? {}
+          : {
+              at: model.at.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): PostVRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        at: new Date(json['at']),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postV = this.postV.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postV(input: PostVRequest): Promise<PostV200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/vnd.api+json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.PostVRequestContent.toJson(input))
+        : String($IO.PostVRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/v', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.PostV200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > hoists and marshals vendored +json request/response schemas > types.gen.ts 1`] = `
+"export type PostV200Response = {
+  at: Date;
+};
+export type PostVRequestContent = {
+  at: Date;
+};
+
+export type PostVRequest = PostVRequestContent;
+export type PostVError = never;
+"
+`;
+
 exports[`openApiTsClientGenerator - edge cases > keeps parameters with the same name in path and query distinct > client.gen.ts 1`] = `
 "import type {
   GetItemRequestPathParameters,
@@ -1141,6 +1331,591 @@ export type PutThingsError = never;
 "
 `;
 
+exports[`openApiTsClientGenerator - edge cases > renders a multi-type union for items of a nullable (multi-type) array > client.gen.ts 1`] = `
+"import type { Thing, ThingDataItem } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Thing = {
+    toJson: (model: Thing): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.data === undefined
+          ? {}
+          : {
+              data:
+                model.data === null ? null : model.data.map((item0) => item0),
+            }),
+      };
+    },
+    fromJson: (json: any): Thing => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['data'] === undefined
+          ? {}
+          : {
+              data:
+                json['data'] === null
+                  ? null
+                  : (json['data'] as Array<any>).map((item0) => item0),
+            }),
+      };
+    },
+  };
+
+  public static ThingDataItem = {
+    toJson: (model: ThingDataItem): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      if (typeof model === 'number') {
+        return model;
+      }
+      if (typeof model === 'string') {
+        return model;
+      }
+      return model;
+    },
+    fromJson: (json: any): ThingDataItem => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      if (typeof json === 'number') {
+        return json;
+      }
+      if (typeof json === 'string') {
+        return json;
+      }
+      return json;
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getThing = this.getThing.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getThing(): Promise<Thing> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/r', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Thing.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > renders a multi-type union for items of a nullable (multi-type) array > types.gen.ts 1`] = `
+"export type Thing = {
+  data?: Array<ThingDataItem> | null;
+};
+export type ThingDataItem = number | string;
+export type GetThingError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > resolves $ref path items, sharing one path item across paths > client.gen.ts 1`] = `
+"import type {
+  GetOtherThings200Response,
+  GetThings200Response,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetOtherThings200Response = {
+    toJson: (model: GetOtherThings200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.at === undefined
+          ? {}
+          : {
+              at: model.at.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): GetOtherThings200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        at: new Date(json['at']),
+      };
+    },
+  };
+
+  public static GetThings200Response = {
+    toJson: (model: GetThings200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.at === undefined
+          ? {}
+          : {
+              at: model.at.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): GetThings200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        at: new Date(json['at']),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getOtherThings = this.getOtherThings.bind(this);
+    this.getThings = this.getThings.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getOtherThings(): Promise<GetOtherThings200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/other-things', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetOtherThings200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+
+  public async getThings(): Promise<GetThings200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/things', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.GetThings200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > resolves $ref path items, sharing one path item across paths > types.gen.ts 1`] = `
+"export type GetOtherThings200Response = {
+  at: Date;
+};
+export type GetThings200Response = {
+  at: Date;
+};
+export type GetOtherThingsError = never;
+export type GetThingsError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > rewrites a const declared inside a nullable (multi-type) object > client.gen.ts 1`] = `
+"import type { Thing, ThingWrapper } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Thing = {
+    toJson: (model: Thing): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.wrapper === undefined
+          ? {}
+          : {
+              wrapper: $IO.ThingWrapper.toJson(model.wrapper),
+            }),
+      };
+    },
+    fromJson: (json: any): Thing => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['wrapper'] === undefined
+          ? {}
+          : {
+              wrapper: $IO.ThingWrapper.fromJson(json['wrapper']),
+            }),
+      };
+    },
+  };
+
+  public static ThingWrapper = {
+    toJson: (model: ThingWrapper): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+      };
+    },
+    fromJson: (json: any): ThingWrapper => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['kind'] === undefined
+          ? {}
+          : {
+              kind: json['kind'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getThing = this.getThing.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getThing(): Promise<Thing> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/r', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Thing.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > rewrites a const declared inside a nullable (multi-type) object > types.gen.ts 1`] = `
+"export type Thing = {
+  wrapper?: ThingWrapper;
+};
+export type ThingWrapper = null | {
+  kind?: ThingWrapperKind;
+};
+export type ThingWrapperKind = 'fixed';
+export type GetThingError = never;
+"
+`;
+
 exports[`openApiTsClientGenerator - edge cases > treats a null enum member as nullable, not an empty literal > client.gen.ts 1`] = `
 "import type { Status } from './types.gen.js';
 
@@ -1266,5 +2041,130 @@ export class TestApi {
 exports[`openApiTsClientGenerator - edge cases > treats a null enum member as nullable, not an empty literal > types.gen.ts 1`] = `
 "export type Status = 'active' | 'inactive';
 export type GetStatusError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > treats a requestBody with an empty content map as no body > client.gen.ts 1`] = `
+"/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.doNoop = this.doNoop.bind(this);
+  }
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      return [[key, String(value)]];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async doNoop(): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/noop', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > treats a requestBody with an empty content map as no body > types.gen.ts 1`] = `
+"export type DoNoopError = never;
 "
 `;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -49,11 +49,18 @@ export class TestApi {
     this.getTricky = this.getTricky.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -72,7 +79,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -82,13 +91,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -200,11 +218,18 @@ export class TestApi {
     this.streamThings = this.streamThings.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -223,7 +248,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -233,13 +260,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -351,11 +387,18 @@ export class TestApi {
     this.streamNumbers = this.streamNumbers.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -374,7 +417,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -384,13 +429,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -551,11 +605,18 @@ export class TestApi {
     this.postV = this.postV.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -574,7 +635,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -584,13 +647,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -745,11 +817,18 @@ export class TestApi {
     this.getItem = this.getItem.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -768,7 +847,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -778,13 +859,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -797,7 +887,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.GetItemRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       id: 'multi',
     } as const;
 
@@ -808,10 +898,10 @@ export class TestApi {
         '/items/{id}',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },
@@ -839,6 +929,231 @@ export type GetItemRequestQueryParameters = {
 export type GetItemRequest = GetItemRequestPathParameters &
   GetItemRequestQueryParameters;
 export type GetItemError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > keeps separate collection-format maps for same-named query and header arrays > client.gen.ts 1`] = `
+"import type {
+  ListItemsRequestHeaderParameters,
+  ListItemsRequestQueryParameters,
+  ListItemsRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static ListItemsRequestHeaderParameters = {
+    toJson: (model: ListItemsRequestHeaderParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.ids === undefined
+          ? {}
+          : {
+              ids: model.ids,
+            }),
+      };
+    },
+    fromJson: (json: any): ListItemsRequestHeaderParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['ids'] === undefined
+          ? {}
+          : {
+              ids: json['ids'],
+            }),
+      };
+    },
+  };
+
+  public static ListItemsRequestQueryParameters = {
+    toJson: (model: ListItemsRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.ids === undefined
+          ? {}
+          : {
+              ids: model.ids,
+            }),
+      };
+    },
+    fromJson: (json: any): ListItemsRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['ids'] === undefined
+          ? {}
+          : {
+              ids: json['ids'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.listItems = this.listItems.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async listItems(input: ListItemsRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.ListItemsRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } =
+      $IO.ListItemsRequestHeaderParameters.toJson(input);
+    const queryCollectionFormats = {
+      ids: 'csv',
+    } as const;
+    const headerCollectionFormats = {
+      ids: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/items',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters, headerCollectionFormats),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > keeps separate collection-format maps for same-named query and header arrays > types.gen.ts 1`] = `
+"export type ListItemsRequestHeaderParameters = {
+  ids?: Array<string>;
+};
+export type ListItemsRequestQueryParameters = {
+  ids?: Array<string>;
+};
+
+export type ListItemsRequest = ListItemsRequestQueryParameters &
+  ListItemsRequestHeaderParameters;
+export type ListItemsError = never;
 "
 `;
 
@@ -962,11 +1277,18 @@ export class TestApi {
     this.createDog = this.createDog.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -985,7 +1307,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -995,13 +1319,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1203,11 +1536,18 @@ export class TestApi {
     this.putThings = this.putThings.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1226,7 +1566,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1236,13 +1578,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1254,7 +1605,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.GetThingsRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       whens: 'multi',
       things: 'multi',
     } as const;
@@ -1262,9 +1613,14 @@ export class TestApi {
     const body = undefined;
 
     const response = await this.$fetch(
-      this.$url('/things', pathParameters, queryParameters, collectionFormats),
+      this.$url(
+        '/things',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },
@@ -1283,7 +1639,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.PutThingsRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       whens: 'multi',
       things: 'multi',
     } as const;
@@ -1291,9 +1647,14 @@ export class TestApi {
     const body = undefined;
 
     const response = await this.$fetch(
-      this.$url('/things', pathParameters, queryParameters, collectionFormats),
+      this.$url(
+        '/things',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'PUT',
         body,
       },
@@ -1438,11 +1799,18 @@ export class TestApi {
     this.getThing = this.getThing.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1461,7 +1829,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1471,13 +1841,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1619,11 +1998,18 @@ export class TestApi {
     this.getThings = this.getThings.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1642,7 +2028,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1652,13 +2040,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1831,11 +2228,18 @@ export class TestApi {
     this.getThing = this.getThing.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1854,7 +2258,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1864,13 +2270,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1913,6 +2328,207 @@ export type ThingWrapper = null | {
 };
 export type ThingWrapperKind = 'fixed';
 export type GetThingError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > serialises spaceDelimited and pipeDelimited query arrays with the right delimiter > client.gen.ts 1`] = `
+"import type {
+  SearchRequestQueryParameters,
+  SearchRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static SearchRequestQueryParameters = {
+    toJson: (model: SearchRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.spaced === undefined
+          ? {}
+          : {
+              spaced: model.spaced,
+            }),
+        ...(model.piped === undefined
+          ? {}
+          : {
+              piped: model.piped,
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['spaced'] === undefined
+          ? {}
+          : {
+              spaced: json['spaced'],
+            }),
+        ...(json['piped'] === undefined
+          ? {}
+          : {
+              piped: json['piped'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.search = this.search.bind(this);
+  }
+
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .map(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value
+            .map(
+              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+            )
+            .join('&');
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async search(input: SearchRequest): Promise<void> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.SearchRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const queryCollectionFormats = {
+      spaced: 'ssv',
+      piped: 'pipes',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/search',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return undefined;
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > serialises spaceDelimited and pipeDelimited query arrays with the right delimiter > types.gen.ts 1`] = `
+"export type SearchRequestQueryParameters = {
+  spaced?: Array<string>;
+  piped?: Array<string>;
+};
+
+export type SearchRequest = SearchRequestQueryParameters;
+export type SearchError = never;
 "
 `;
 
@@ -1965,11 +2581,18 @@ export class TestApi {
     this.getStatus = this.getStatus.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1988,7 +2611,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1998,13 +2623,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -2091,11 +2725,18 @@ export class TestApi {
     this.doNoop = this.doNoop.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2114,7 +2755,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2124,13 +2767,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -48,7 +48,7 @@ exports[`openApiTsClientGenerator - FastAPI > should generate valid TypeScript f
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static EchoOutput = {
@@ -375,7 +375,7 @@ exports[`openApiTsClientGenerator - FastAPI > should handle FastAPI validation e
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static LocationItem = {
@@ -801,7 +801,7 @@ exports[`openApiTsClientGenerator - FastAPI > should handle schemas with hyphens
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static ContentBlockInput = {
@@ -1935,7 +1935,7 @@ exports[`openApiTsClientGenerator - FastAPI > should hoist inline composite para
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetPetRequestCookieParameters = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -250,16 +250,12 @@ export class TestApi {
     this.echo = this.echo.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -578,16 +574,12 @@ export class TestApi {
     this.testValidation = this.testValidation.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1830,16 +1822,12 @@ export class TestApi {
     this.ping = this.ping.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2283,16 +2271,12 @@ export class TestApi {
     this.getPet = this.getPet.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -250,11 +250,18 @@ export class TestApi {
     this.echo = this.echo.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -273,7 +280,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -283,13 +292,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -301,16 +319,21 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.EchoRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       message: 'multi',
     } as const;
 
     const body = undefined;
 
     const response = await this.$fetch(
-      this.$url('/echo', pathParameters, queryParameters, collectionFormats),
+      this.$url(
+        '/echo',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },
@@ -531,11 +554,18 @@ export class TestApi {
     this.testValidation = this.testValidation.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -554,7 +584,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -564,13 +596,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1741,11 +1782,18 @@ export class TestApi {
     this.ping = this.ping.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1764,7 +1812,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1774,13 +1824,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1846,7 +1905,7 @@ export class TestApi {
     const queryParameters: { [key: string]: any } =
       $IO.ListMessagesRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } = {};
-    const collectionFormats = {
+    const queryCollectionFormats = {
       session_id: 'multi',
     } as const;
 
@@ -1857,10 +1916,10 @@ export class TestApi {
         '/messages',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'GET',
         body,
       },
@@ -2152,11 +2211,18 @@ export class TestApi {
     this.getPet = this.getPet.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2175,7 +2241,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2185,13 +2253,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -2215,9 +2292,11 @@ export class TestApi {
     if (cookiePairs.length > 0) {
       headerParameters['Cookie'] = cookiePairs.join('; ');
     }
-    const collectionFormats = {
-      'X-Client': 'csv',
+    const queryCollectionFormats = {
       tag: 'multi',
+    } as const;
+    const headerCollectionFormats = {
+      'X-Client': 'csv',
     } as const;
 
     const body = undefined;
@@ -2227,10 +2306,10 @@ export class TestApi {
         '/pets/{petId}',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters, headerCollectionFormats),
         method: 'GET',
         body,
       },

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -257,6 +257,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -280,19 +295,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -577,6 +587,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -600,19 +625,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1821,6 +1841,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1844,19 +1879,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2266,6 +2296,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2289,19 +2334,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -295,8 +295,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -625,8 +623,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1879,8 +1875,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2334,8 +2328,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -261,7 +261,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -272,17 +274,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -565,7 +581,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -576,17 +594,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1793,7 +1825,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1804,17 +1838,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2222,7 +2270,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2233,17 +2283,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -126,16 +126,12 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -439,16 +435,12 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -728,16 +720,12 @@ export class TestApi {
     this.postSingleDate = this.postSingleDate.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -999,16 +987,12 @@ export class TestApi {
     this.updateStatus = this.updateStatus.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1186,16 +1170,12 @@ export class TestApi {
     this.updateStatus = this.updateStatus.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1472,16 +1452,12 @@ export class TestApi {
     this.testConstraints = this.testConstraints.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1836,16 +1812,12 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -126,11 +126,18 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -149,7 +156,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -159,13 +168,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -397,11 +415,18 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -420,7 +445,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -430,13 +457,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -644,11 +680,18 @@ export class TestApi {
     this.postSingleDate = this.postSingleDate.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -667,7 +710,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -677,13 +722,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -873,11 +927,18 @@ export class TestApi {
     this.updateStatus = this.updateStatus.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -896,7 +957,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -906,13 +969,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1018,11 +1090,18 @@ export class TestApi {
     this.updateStatus = this.updateStatus.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1041,7 +1120,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1051,13 +1132,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1262,11 +1352,18 @@ export class TestApi {
     this.testConstraints = this.testConstraints.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1285,7 +1382,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1295,13 +1394,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1584,11 +1692,18 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1607,7 +1722,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1617,13 +1734,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1638,7 +1764,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       date: 'multi',
       timestamp: 'multi',
     } as const;
@@ -1650,9 +1776,14 @@ export class TestApi {
           : String($IO.PostTestRequestContent.toJson(input));
 
     const response = await this.$fetch(
-      this.$url('/test', pathParameters, queryParameters, collectionFormats),
+      this.$url(
+        '/test',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -137,7 +137,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -148,17 +150,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -426,7 +442,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -437,17 +455,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -691,7 +723,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -702,17 +736,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -938,7 +986,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -949,17 +999,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1101,7 +1165,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1112,17 +1178,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1363,7 +1443,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1374,17 +1456,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1703,7 +1799,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1714,17 +1812,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`openApiTsClientGenerator - primitive types > should generate valid Type
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -231,7 +231,7 @@ exports[`openApiTsClientGenerator - primitive types > should generate valid type
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200Response = {
@@ -507,7 +507,7 @@ exports[`openApiTsClientGenerator - primitive types > should handle date and dat
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostDates200Response = {
@@ -777,7 +777,7 @@ exports[`openApiTsClientGenerator - primitive types > should handle enum referen
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static UpdateStatus200Response = {
@@ -976,7 +976,7 @@ exports[`openApiTsClientGenerator - primitive types > should handle enum request
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -1124,7 +1124,7 @@ exports[`openApiTsClientGenerator - primitive types > should handle number and s
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestConstraints200Response = {
@@ -1381,7 +1381,7 @@ exports[`openApiTsClientGenerator - primitive types > should handle special form
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200Response = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -171,8 +171,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -486,8 +484,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -777,8 +773,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1050,8 +1044,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1239,8 +1231,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1527,8 +1517,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1893,8 +1881,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.primitive-types.spec.ts.snap
@@ -133,6 +133,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -156,19 +171,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -438,6 +448,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -461,19 +486,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -719,6 +739,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -742,19 +777,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -982,6 +1012,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1005,19 +1050,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1161,6 +1201,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1184,19 +1239,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1439,6 +1489,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1462,19 +1527,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1795,6 +1855,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1818,19 +1893,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
@@ -237,7 +237,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -248,17 +250,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -629,7 +645,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -640,17 +658,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1102,7 +1134,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1113,17 +1147,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`openApiTsClientGenerator - requests > should generate valid TypeScript 
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -389,7 +389,7 @@ exports[`openApiTsClientGenerator - requests > should handle operations with sim
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostBooleanWithQueryRequestBodyParameters = {
@@ -874,7 +874,7 @@ exports[`openApiTsClientGenerator - requests > should handle request body proper
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static PostTest200Response = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
@@ -226,11 +226,18 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -249,7 +256,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -259,13 +268,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -279,10 +297,12 @@ export class TestApi {
       $IO.GetTestRequestQueryParameters.toJson(input);
     const headerParameters: { [key: string]: any } =
       $IO.GetTestRequestHeaderParameters.toJson(input);
-    const collectionFormats = {
-      'x-api-key': 'csv',
+    const queryCollectionFormats = {
       filter: 'multi',
       tags: 'multi',
+    } as const;
+    const headerCollectionFormats = {
+      'x-api-key': 'csv',
     } as const;
 
     const body = undefined;
@@ -292,10 +312,10 @@ export class TestApi {
         '/test/{id}',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters, headerCollectionFormats),
         method: 'GET',
         body,
       },
@@ -598,11 +618,18 @@ export class TestApi {
     this.postStringWithQuery = this.postStringWithQuery.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -621,7 +648,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -631,13 +660,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -680,7 +718,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       filter: 'multi',
     } as const;
     const body = input === undefined ? undefined : String(input.body);
@@ -690,10 +728,10 @@ export class TestApi {
         '/boolean-with-query',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },
@@ -743,7 +781,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       filter: 'multi',
     } as const;
     const body = input === undefined ? undefined : String(input.body);
@@ -753,10 +791,10 @@ export class TestApi {
         '/number-with-query',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },
@@ -806,7 +844,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       filter: 'multi',
     } as const;
     const body = input === undefined ? undefined : String(input.body);
@@ -816,10 +854,10 @@ export class TestApi {
         '/string-with-query',
         pathParameters,
         queryParameters,
-        collectionFormats,
+        queryCollectionFormats,
       ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },
@@ -1053,11 +1091,18 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1076,7 +1121,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1086,13 +1133,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1107,7 +1163,7 @@ export class TestApi {
     if (!this.$config.options?.omitContentTypeHeader) {
       headerParameters['Content-Type'] = 'application/json';
     }
-    const collectionFormats = {
+    const queryCollectionFormats = {
       filter: 'multi',
     } as const;
     const body =
@@ -1118,9 +1174,14 @@ export class TestApi {
           : String($IO.PostTestRequestBodyParameters.toJson(input).body);
 
     const response = await this.$fetch(
-      this.$url('/test', pathParameters, queryParameters, collectionFormats),
+      this.$url(
+        '/test',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
       {
-        headers: this.$headers(headerParameters, collectionFormats),
+        headers: this.$headers(headerParameters),
         method: 'POST',
         body,
       },

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
@@ -233,6 +233,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -256,19 +271,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -641,6 +651,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -664,19 +689,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1130,6 +1150,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1153,19 +1188,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
@@ -226,16 +226,12 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -642,16 +638,12 @@ export class TestApi {
     this.postStringWithQuery = this.postStringWithQuery.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1139,16 +1131,12 @@ export class TestApi {
     this.postTest = this.postTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.request.spec.ts.snap
@@ -271,8 +271,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -689,8 +687,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1188,8 +1184,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
@@ -655,6 +655,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -678,19 +693,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2119,6 +2129,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2142,19 +2167,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
@@ -648,11 +648,18 @@ export class TestApi {
     this.testReservedModels = this.testReservedModels.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -671,7 +678,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -681,13 +690,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -2078,11 +2096,18 @@ export class TestApi {
     this.op = this.op.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2101,7 +2126,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2111,13 +2138,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
@@ -693,8 +693,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2167,8 +2165,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
@@ -659,7 +659,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -670,17 +672,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2107,7 +2123,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2118,17 +2136,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
@@ -648,16 +648,12 @@ export class TestApi {
     this.testReservedModels = this.testReservedModels.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2120,16 +2116,12 @@ export class TestApi {
     this.op = this.op.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.reserved-keywords.spec.ts.snap
@@ -94,7 +94,7 @@ exports[`openApiTsClientGenerator - reserved keywords > should handle reserved T
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static _Array = {
@@ -885,7 +885,7 @@ exports[`openApiTsClientGenerator - reserved keywords > should handle reserved l
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static As = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
@@ -158,8 +158,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -578,8 +576,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -796,8 +792,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`openApiTsClientGenerator - responses > should handle default responses 
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -329,7 +329,7 @@ exports[`openApiTsClientGenerator - responses > should handle multiple response 
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static TestResponses2XXResponse = {
@@ -598,7 +598,7 @@ exports[`openApiTsClientGenerator - responses > should handle only default respo
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTestdefaultResponse = {

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
@@ -120,6 +120,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -143,19 +158,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -530,6 +540,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -553,19 +578,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -738,6 +758,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -761,19 +796,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
@@ -113,16 +113,12 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -531,16 +527,12 @@ export class TestApi {
     this.testResponses = this.testResponses.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -747,16 +739,12 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
@@ -113,11 +113,18 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -136,7 +143,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -146,13 +155,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -489,11 +507,18 @@ export class TestApi {
     this.testResponses = this.testResponses.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -512,7 +537,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -522,13 +549,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -663,11 +699,18 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -686,7 +729,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -696,13 +741,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.response.spec.ts.snap
@@ -124,7 +124,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -135,17 +137,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -518,7 +534,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -529,17 +547,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -710,7 +742,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -721,17 +755,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -123,7 +123,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -134,17 +136,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -334,7 +350,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -345,17 +363,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -583,7 +615,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -594,17 +628,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -789,7 +837,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -800,17 +850,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1353,7 +1417,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1364,17 +1430,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1732,7 +1812,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1743,17 +1825,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -1982,7 +2078,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1993,17 +2091,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -2133,7 +2245,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2144,17 +2258,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -157,8 +157,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -394,8 +392,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -669,8 +665,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -901,8 +895,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1491,8 +1483,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -1896,8 +1886,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2172,8 +2160,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -2349,8 +2335,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -112,16 +112,12 @@ export class TestApi {
     this.streamData = this.streamData.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -347,16 +343,12 @@ export class TestApi {
     this.getEvents = this.getEvents.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -620,16 +612,12 @@ export class TestApi {
     this.getStream = this.getStream.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -850,16 +838,12 @@ export class TestApi {
     this.getStringArrays = this.getStringArrays.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1438,16 +1422,12 @@ export class TestApi {
     this.getStringDict = this.getStringDict.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -1841,16 +1821,12 @@ export class TestApi {
     this.getNumbers = this.getNumbers.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2115,16 +2091,12 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -2290,16 +2262,12 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`openApiTsClientGenerator - streaming > OpenAPI 3.2 JSONL streaming (app
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static StreamChunk = {
@@ -224,7 +224,7 @@ exports[`openApiTsClientGenerator - streaming > OpenAPI 3.2 JSONL streaming (app
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static Event = {
@@ -432,7 +432,7 @@ exports[`openApiTsClientGenerator - streaming > should handle error responses fo
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetStream400Response = {
@@ -649,7 +649,7 @@ exports[`openApiTsClientGenerator - streaming > should return an iterator over a
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetObjectArrays200ResponseItem = {
@@ -1000,7 +1000,7 @@ exports[`openApiTsClientGenerator - streaming > should return an iterator over a
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetArrayDict200Response = {
@@ -1587,7 +1587,7 @@ exports[`openApiTsClientGenerator - streaming > should return an iterator over a
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -1792,7 +1792,7 @@ exports[`openApiTsClientGenerator - streaming > should return an iterator over a
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 
   public static GetTest200Response = {
@@ -1954,7 +1954,7 @@ exports[`openApiTsClientGenerator - streaming > should return an iterator over a
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -112,11 +112,18 @@ export class TestApi {
     this.streamData = this.streamData.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -135,7 +142,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -145,13 +154,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -305,11 +323,18 @@ export class TestApi {
     this.getEvents = this.getEvents.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -328,7 +353,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -338,13 +365,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -536,11 +572,18 @@ export class TestApi {
     this.getStream = this.getStream.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -559,7 +602,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -569,13 +614,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -724,11 +778,18 @@ export class TestApi {
     this.getStringArrays = this.getStringArrays.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -747,7 +808,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -757,13 +820,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1270,11 +1342,18 @@ export class TestApi {
     this.getStringDict = this.getStringDict.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1293,7 +1372,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1303,13 +1384,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1631,11 +1721,18 @@ export class TestApi {
     this.getNumbers = this.getNumbers.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1654,7 +1751,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1664,13 +1763,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1863,11 +1971,18 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -1886,7 +2001,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -1896,13 +2013,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -1996,11 +2122,18 @@ export class TestApi {
     this.getTest = this.getTest.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -2019,7 +2152,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -2029,13 +2164,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.streaming.spec.ts.snap
@@ -119,6 +119,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -142,19 +157,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -346,6 +356,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -369,19 +394,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -611,6 +631,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -634,19 +669,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -833,6 +863,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -856,19 +901,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1413,6 +1453,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1436,19 +1491,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -1808,6 +1858,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -1831,19 +1896,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2074,6 +2134,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2097,19 +2172,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -2241,6 +2311,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -2264,19 +2349,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
@@ -65,7 +65,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -76,17 +78,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -262,7 +278,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -273,17 +291,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -449,7 +481,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -460,17 +494,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (
@@ -687,7 +735,9 @@ export class TestApi {
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -698,17 +748,31 @@ export class TestApi {
       path,
     );
     const queryString = Object.entries(queryParameters)
-      .map(([key, value]) => {
+      .flatMap(([key, value]) => {
         if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-          return value
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value)
+        ) {
+          return Object.entries(value)
+            .filter(([, v]) => v !== undefined && v !== null)
             .map(
-              (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
-            )
-            .join('&');
+              ([prop, v]) =>
+                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
+            );
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
       })
       .join('&');
     return (

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
@@ -54,16 +54,12 @@ export class TestApi {
     this._usersPeopleList = this._usersPeopleList.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -275,16 +271,12 @@ export class TestApi {
     this._usersList = this._usersList.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -486,16 +478,12 @@ export class TestApi {
     this._getUsers = this._getUsers.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];
@@ -748,16 +736,12 @@ export class TestApi {
     this._postMultiTagged = this._postMultiTagged.bind(this);
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = {
     csv: ',',
     ssv: ' ',
     pipes: '|',
   };
 
-  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
@@ -99,8 +99,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -322,8 +320,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -535,8 +531,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
@@ -799,8 +793,6 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
-        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`openApiTsClientGenerator - tags > should allow duplicate operation ids 
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -190,7 +190,7 @@ exports[`openApiTsClientGenerator - tags > should allow duplicate operation ids 
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -357,7 +357,7 @@ exports[`openApiTsClientGenerator - tags > should handle operation tags and mult
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 
@@ -579,7 +579,7 @@ exports[`openApiTsClientGenerator - tags > should handle operations with multipl
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 }
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
@@ -54,11 +54,18 @@ export class TestApi {
     this._usersPeopleList = this._usersPeopleList.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -77,7 +84,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -87,13 +96,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -233,11 +251,18 @@ export class TestApi {
     this._usersList = this._usersList.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -256,7 +281,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -266,13 +293,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -402,11 +438,18 @@ export class TestApi {
     this._getUsers = this._getUsers.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -425,7 +468,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -435,13 +480,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 
@@ -622,11 +676,18 @@ export class TestApi {
     this._postMultiTagged = this._postMultiTagged.bind(this);
   }
 
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
     queryParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): string => {
     const baseUrl = this.$config.url.endsWith('/')
       ? this.$config.url.slice(0, -1)
@@ -645,7 +706,9 @@ export class TestApi {
             )
             .join('&');
         }
-        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}\`;
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`;
       })
       .join('&');
     return (
@@ -655,13 +718,22 @@ export class TestApi {
 
   private $headers = (
     headerParameters: { [key: string]: any },
-    collectionFormats?: { [key: string]: 'multi' | 'csv' },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
   ): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map((v) => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
     });
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.tags.spec.ts.snap
@@ -61,6 +61,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -84,19 +99,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -274,6 +284,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -297,19 +322,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -477,6 +497,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -500,19 +535,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
@@ -731,6 +761,21 @@ export class TestApi {
     pipes: '|',
   };
 
+  // Serialise a \`deepObject\` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. \`filter[page][size]=10\`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
   private $url = (
     path: string,
     pathParameters: { [key: string]: any },
@@ -754,19 +799,14 @@ export class TestApi {
             (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
           );
         }
-        // deepObject: serialise an object as \`key[prop]=value\` pairs.
+        // deepObject: serialise an object as \`key[prop]=value\` pairs (recursing
+        // into nested objects/arrays).
         if (
           collectionFormats?.[key] === 'deepObject' &&
           value !== null &&
-          typeof value === 'object' &&
-          !Array.isArray(value)
+          typeof value === 'object'
         ) {
-          return Object.entries(value)
-            .filter(([, v]) => v !== undefined && v !== null)
-            .map(
-              ([prop, v]) =>
-                \`\${encodeURIComponent(key)}[\${encodeURIComponent(prop)}]=\${encodeURIComponent(String(v))}\`,
-            );
+          return this.$deepObject(encodeURIComponent(key), value);
         }
         const delimiter =
           this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -435,17 +435,23 @@ export class <%- className %> {
   // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = { csv: ',', ssv: ' ', pipes: '|' };
 
-  private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' }): string => {
+  private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject' }): string => {
     const baseUrl = this.$config.url.endsWith('/') ? this.$config.url.slice(0, -1) : this.$config.url;
     const pathWithParameters = Object.entries(pathParameters).reduce((withParams, [key, value]) =>
       withParams.replace(`{${key}}`, encodeURIComponent(`${value}`))
     , path);
-    const queryString = Object.entries(queryParameters).map(([key, value]) => {
+    const queryString = Object.entries(queryParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-        return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(`${v}`)}`).join('&');
+        return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(`${v}`)}`);
+      }
+      // deepObject: serialise an object as `key[prop]=value` pairs.
+      if (collectionFormats?.[key] === 'deepObject' && value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        return Object.entries(value)
+          .filter(([, v]) => v !== undefined && v !== null)
+          .map(([prop, v]) => `${encodeURIComponent(key)}[${encodeURIComponent(prop)}]=${encodeURIComponent(String(v))}`);
       }
       const delimiter = this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-      return `${encodeURIComponent(key)}=${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}`;
+      return [`${encodeURIComponent(key)}=${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}`];
     }).join('&');
     return baseUrl + pathWithParameters + (queryString ? `?${queryString}` : '');
   };

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -435,6 +435,21 @@ export class <%- className %> {
   // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = { csv: ',', ssv: ' ', pipes: '|' };
 
+  // Serialise a `deepObject` value into bracketed query pairs, recursing into
+  // nested objects/arrays (e.g. `filter[page][size]=10`). undefined/null members
+  // are omitted.
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [`${key}=${encodeURIComponent(String(value))}`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(`${key}[${encodeURIComponent(prop)}]`, v),
+    );
+  };
+
   private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject' }): string => {
     const baseUrl = this.$config.url.endsWith('/') ? this.$config.url.slice(0, -1) : this.$config.url;
     const pathWithParameters = Object.entries(pathParameters).reduce((withParams, [key, value]) =>
@@ -444,11 +459,10 @@ export class <%- className %> {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(`${v}`)}`);
       }
-      // deepObject: serialise an object as `key[prop]=value` pairs.
-      if (collectionFormats?.[key] === 'deepObject' && value !== null && typeof value === 'object' && !Array.isArray(value)) {
-        return Object.entries(value)
-          .filter(([, v]) => v !== undefined && v !== null)
-          .map(([prop, v]) => `${encodeURIComponent(key)}[${encodeURIComponent(prop)}]=${encodeURIComponent(String(v))}`);
+      // deepObject: serialise an object as `key[prop]=value` pairs (recursing
+      // into nested objects/arrays).
+      if (collectionFormats?.[key] === 'deepObject' && value !== null && typeof value === 'object') {
+        return this.$deepObject(encodeURIComponent(key), value);
       }
       const delimiter = this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
       return [`${encodeURIComponent(key)}=${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}`];

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -16,7 +16,7 @@ const uniqStrings = (strings) => {
     return true;
   });
 };
-const returnTypeSet = new Set(allOperations.map(op => op.result.typescriptType));
+const returnTypeSet = new Set(allOperations.flatMap(op => op.result ? [op.result.typescriptType] : []));
 _%>
 <%_ if ((models.length + allOperations.filter(p => p.parameters.length > 0).length) > 0) { _%>
 import type {
@@ -167,7 +167,7 @@ _%>
  * Utility for serialisation and deserialisation of API types.
  */
 export class $IO {
-  protected static $mapValues = (data: any, fn: (item: any) => any) =>
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 <%_ models.filter(m => m.export !== 'enum').forEach((model) => { _%>
 <%_ const isComposite = model.export === "one-of" || model.export === "any-of" || model.export === "all-of"; _%>

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -17,6 +17,18 @@ const uniqStrings = (strings) => {
   });
 };
 const returnTypeSet = new Set(allOperations.flatMap(op => op.result ? [op.result.typescriptType] : []));
+// Names of discriminator "base" models (an object schema whose subtypes allOf-
+// compose it). A subtype composes its base's non-dispatching `$toJsonBase`/
+// `$fromJsonBase` body, so composing the dispatching `toJson`/`fromJson` would
+// recurse infinitely (base -> subtype -> base).
+const discriminatorBaseNames = new Set(models.filter(m => m.discriminator && m.discriminator.isBase).map(m => m.name));
+const modelByName = Object.fromEntries(models.map(m => [m.name, m]));
+// The $IO marshaller call for a composed member: a subtype composes its base's
+// non-dispatching body to avoid recursing back through the base's dispatch.
+const composedMarshaller = (property, method) =>
+  property.export === 'reference' && discriminatorBaseNames.has(property.type)
+    ? `$IO.${property.typescriptType}.$${method}Base`
+    : `$IO.${property.typescriptType}.${method}`;
 _%>
 <%_ if ((models.length + allOperations.filter(p => p.parameters.length > 0).length) > 0) { _%>
 import type {
@@ -171,9 +183,40 @@ export class $IO {
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
 <%_ models.filter(m => m.export !== 'enum').forEach((model) => { _%>
 <%_ const isComposite = model.export === "one-of" || model.export === "any-of" || model.export === "all-of"; _%>
+<%_ /* A discriminator base emits its plain (own-fields) body under a $-prefixed
+      name that its subtypes compose, while its public toJson/fromJson dispatch
+      to the matching subtype — so composing a subtype never recurses back into
+      the dispatch. */ _%>
+<%_ const isBase = model.discriminator && model.discriminator.isBase; _%>
+<%_ const toJsonName = isBase ? '$toJsonBase' : 'toJson'; _%>
+<%_ const fromJsonName = isBase ? '$fromJsonBase' : 'fromJson'; _%>
 
   public static <%- model.typescriptName %> = {
+    <%_ if (isBase) { _%>
     toJson: (model: <%- model.typescriptName %>): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).<%- model.discriminator.typescriptPropertyName %>) {
+        <%_ model.discriminator.mapping.filter(m => modelByName[m.modelName]).forEach(({ value, modelName }) => { _%>
+        case <%- JSON.stringify(value) %>: return $IO.<%- modelByName[modelName].typescriptName %>.toJson(model as <%- modelByName[modelName].typescriptName %>);
+        <%_ }); _%>
+      }
+      return $IO.<%- model.typescriptName %>.$toJsonBase(model);
+    },
+    fromJson: (json: any): <%- model.typescriptName %> => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.[<%- JSON.stringify(model.discriminator.propertyName) %>]) {
+        <%_ model.discriminator.mapping.filter(m => modelByName[m.modelName]).forEach(({ value, modelName }) => { _%>
+        case <%- JSON.stringify(value) %>: return $IO.<%- modelByName[modelName].typescriptName %>.fromJson(json);
+        <%_ }); _%>
+      }
+      return $IO.<%- model.typescriptName %>.$fromJsonBase(json);
+    },
+    <%_ } _%>
+    <%- toJsonName %>: (model: <%- model.typescriptName %>): any => {
       if (model === undefined || model === null) {
         return model;
       }
@@ -220,7 +263,11 @@ export class $IO {
       <%_ if (model.composedModels.length > 0) { _%>
       return {
         <%_ model.properties.filter(p => !p.isPrimitive && p.export !== 'array').forEach((property, i) => { _%>
+        <%_ if (property.export === 'reference' && discriminatorBaseNames.has(property.type)) { _%>
+        ...<%- composedMarshaller(property, 'toJson') %>(model),
+        <%_ } else { _%>
         ...<%- renderToJsonValue(property, `model${(model.export !== 'all-of' && property.export !== 'dictionary') ? ` as ${property.typescriptType}` : ''}`) %>,
+        <%_ } _%>
         <%_ }); _%>
       };
       <%_ } else { _%>
@@ -253,7 +300,7 @@ export class $IO {
       };
       <%_ } _%>
     },
-    fromJson: (json: any): <%- model.typescriptName %> => {
+    <%- fromJsonName %>: (json: any): <%- model.typescriptName %> => {
       if (json === undefined || json === null) {
         return json;
       }
@@ -299,7 +346,11 @@ export class $IO {
       <%_ if (model.composedModels.length > 0) { _%>
       return {
         <%_ model.properties.filter(p => !p.isPrimitive && p.export !== 'array').forEach((composedType) => { _%>
+        <%_ if (composedType.export === 'reference' && discriminatorBaseNames.has(composedType.type)) { _%>
+        ...<%- composedMarshaller(composedType, 'fromJson') %>(json),
+        <%_ } else { _%>
         ...<%- renderFromJsonValue(composedType, 'json') %>,
+        <%_ } _%>
         <%_ }); _%>
       };
       <%_ } else { _%>

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -459,8 +459,6 @@ export class <%- className %> {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(`${v}`)}`);
       }
-      // deepObject: serialise an object as `key[prop]=value` pairs (recursing
-      // into nested objects/arrays).
       if (collectionFormats?.[key] === 'deepObject' && value !== null && typeof value === 'object') {
         return this.$deepObject(encodeURIComponent(key), value);
       }

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -432,12 +432,8 @@ export class <%- className %> {
     <%_ }); _%>
   }
 
-  // Delimiters for non-'multi' array serialisation formats.
   private $collectionDelimiters: { [format: string]: string } = { csv: ',', ssv: ' ', pipes: '|' };
 
-  // Serialise a `deepObject` value into bracketed query pairs, recursing into
-  // nested objects/arrays (e.g. `filter[page][size]=10`). undefined/null members
-  // are omitted.
   private $deepObject = (key: string, value: any): string[] => {
     if (value === undefined || value === null) {
       return [];

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -44,7 +44,9 @@ const renderToJsonDateValue = (identifier, format) => {
 // Renders the appropriate nested function for .map() or $mapValues() for arrays and dictionaries for the given type
 const renderNestedToJsonValue = (type, argumentType = undefined, depth = 0) => {
   const itemIdentifier = `item${depth}`;
-  const argType = `${argumentType ? `: ${argumentType}` : ''}`;
+  // Nested items (depth > 0) come from mapping over an `any`, so annotate them
+  // to satisfy noImplicitAny.
+  const argType = `${argumentType ? `: ${argumentType}` : (depth > 0 ? ': any' : '')}`;
   if (type.isPrimitive || type.typescriptType === 'unknown' || type.export === 'enum' || type.isEnum) {
     return `(${itemIdentifier}${argType}) => ${["date", "date-time"].includes(type.format) ? renderToJsonDateValue(itemIdentifier, type.format) : itemIdentifier}`;
   } else if (type.export === "array") {
@@ -83,7 +85,9 @@ const renderToJsonValue = (property, value, argumentType = undefined) => {
 // Renders the appropriate nested function for .map() or $mapValues() for arrays and dictionaries for the given type
 const renderNestedFromJsonValue = (type, argumentType = undefined, depth = 0) => {
     const itemIdentifier = `item${depth}`;
-    const argType = `${argumentType ? `: ${argumentType}` : ''}`;
+    // Nested items (depth > 0) come from mapping over an `any`, so annotate them
+    // to satisfy noImplicitAny.
+    const argType = `${argumentType ? `: ${argumentType}` : (depth > 0 ? ': any' : '')}`;
     if (type.isPrimitive || type.typescriptType === 'unknown' || type.export === 'enum' || type.isEnum) {
         return `(${itemIdentifier}${argType}) => ${["date", "date-time"].includes(type.format) ? `new Date(${itemIdentifier})` : itemIdentifier}`;
     } else if (type.export === "array") {

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -206,6 +206,17 @@ export class $IO {
           return <%- renderToJsonValue(arrayOfNonPrimitives, 'model') %>;
       }
       <%_ } _%>
+      <%_ /* A discriminated composite marshals directly to the matching branch,
+            rather than merging every branch (which would leak fields from the
+            non-matching branches). Unknown values fall through to the merge. */ _%>
+      <%_ if (model.discriminator) { _%>
+      <%_ const discToJsonByName = Object.fromEntries(model.composedModels.map(m => [m.name, m.typescriptName])); _%>
+      switch ((model as any).<%- model.discriminator.typescriptPropertyName %>) {
+        <%_ model.discriminator.mapping.filter(m => discToJsonByName[m.modelName]).forEach(({ value, modelName }) => { _%>
+        case <%- JSON.stringify(value) %>: return $IO.<%- discToJsonByName[modelName] %>.toJson(model as <%- discToJsonByName[modelName] %>);
+        <%_ }); _%>
+      }
+      <%_ } _%>
       <%_ if (model.composedModels.length > 0) { _%>
       return {
         <%_ model.properties.filter(p => !p.isPrimitive && p.export !== 'array').forEach((property, i) => { _%>
@@ -272,6 +283,17 @@ export class $IO {
       <%_ if (arrayOfNonPrimitives) { _%>
       if (Array.isArray(json) && (json.length === 0 || typeof json[0] === 'object')) {
           return <%- renderFromJsonValue(arrayOfNonPrimitives, 'json') %>;
+      }
+      <%_ } _%>
+      <%_ /* A discriminated composite marshals directly to the matching branch;
+            the discriminator value comes off the raw json by its wire name.
+            Unknown values fall through to the merge. */ _%>
+      <%_ if (model.discriminator) { _%>
+      <%_ const discFromJsonByName = Object.fromEntries(model.composedModels.map(m => [m.name, m.typescriptName])); _%>
+      switch (json?.[<%- JSON.stringify(model.discriminator.propertyName) %>]) {
+        <%_ model.discriminator.mapping.filter(m => discFromJsonByName[m.modelName]).forEach(({ value, modelName }) => { _%>
+        case <%- JSON.stringify(value) %>: return $IO.<%- discFromJsonByName[modelName] %>.fromJson(json);
+        <%_ }); _%>
       }
       <%_ } _%>
       <%_ if (model.composedModels.length > 0) { _%>

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -359,7 +359,10 @@ export class <%- className %> {
     <%_ }); _%>
   }
 
-  private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' }): string => {
+  // Delimiters for non-'multi' array serialisation formats.
+  private $collectionDelimiters: { [format: string]: string } = { csv: ',', ssv: ' ', pipes: '|' };
+
+  private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' }): string => {
     const baseUrl = this.$config.url.endsWith('/') ? this.$config.url.slice(0, -1) : this.$config.url;
     const pathWithParameters = Object.entries(pathParameters).reduce((withParams, [key, value]) =>
       withParams.replace(`{${key}}`, encodeURIComponent(`${value}`))
@@ -368,17 +371,19 @@ export class <%- className %> {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(`${v}`)}`).join('&');
       }
-      return `${encodeURIComponent(key)}=${encodeURIComponent(Array.isArray(value) ? value.map(String).join(',') : String(value))}`;
+      const delimiter = this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return `${encodeURIComponent(key)}=${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}`;
     }).join('&');
     return baseUrl + pathWithParameters + (queryString ? `?${queryString}` : '');
   };
 
-  private $headers = (headerParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' }): [string, string][] => {
+  private $headers = (headerParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' }): [string, string][] => {
     return Object.entries(headerParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
         return value.map(v => [key, String(v)]) as [string, string][];
       }
-      return [[key, String(value)]];
+      const delimiter = this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [[key, Array.isArray(value) ? value.map(String).join(delimiter) : String(value)]];
     });
   };
 
@@ -422,9 +427,21 @@ export class <%- className %> {
     }
     <%_ } _%>
     <%_ } _%>
-    <%_ if (op.parameters.filter(p => p.collectionFormat).length > 0) { _%>
-    const collectionFormats = {
-      <%_ op.parameters.filter(p => p.collectionFormat).forEach((parameter) => { _%>
+    <%_ /* Query and header collection formats are kept in separate maps: a
+           query and a header parameter may share a name, which would collide
+           in a single object literal. */ _%>
+    <%_ const queryCollectionParams = op.parameters.filter(p => p.collectionFormat && p.in === 'query'); _%>
+    <%_ const headerCollectionParams = op.parameters.filter(p => p.collectionFormat && p.in === 'header'); _%>
+    <%_ if (queryCollectionParams.length > 0) { _%>
+    const queryCollectionFormats = {
+      <%_ queryCollectionParams.forEach((parameter) => { _%>
+      '<%- parameter.prop %>': '<%- parameter.collectionFormat %>',
+      <%_ }); _%>
+    } as const;
+    <%_ } _%>
+    <%_ if (headerCollectionParams.length > 0) { _%>
+    const headerCollectionFormats = {
+      <%_ headerCollectionParams.forEach((parameter) => { _%>
       '<%- parameter.prop %>': '<%- parameter.collectionFormat %>',
       <%_ }); _%>
     } as const;
@@ -461,8 +478,8 @@ export class <%- className %> {
     const body = undefined;
     <%_ } _%>
 
-    const response = await this.$fetch(this.$url('<%- op.path %>', pathParameters, queryParameters<% if (op.parameters.filter(p => p.collectionFormat).length > 0) { %>, collectionFormats<% } %>), {
-      headers: this.$headers(headerParameters<% if (op.parameters.filter(p => p.collectionFormat).length > 0) { %>, collectionFormats<% } %>),
+    const response = await this.$fetch(this.$url('<%- op.path %>', pathParameters, queryParameters<% if (queryCollectionParams.length > 0) { %>, queryCollectionFormats<% } %>), {
+      headers: this.$headers(headerParameters<% if (headerCollectionParams.length > 0) { %>, headerCollectionFormats<% } %>),
       method: '<%- op.method %>',
       body,
     });

--- a/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
@@ -30,9 +30,8 @@ _%>
 <%- docString(model, '') %>export type <%= model.typescriptName %> = <% if (model.isNullable && model.type !== 'null') { %>null | <% } %>{
 <%_ if (model.export === "dictionary" && model.link) { _%>
 <%_ /* When the spec says `type: object` with `additionalProperties: true`
-      (or omits additionalProperties), hey-api sets `model.link` but the
-      link's typescriptType is empty — fall back to `unknown` to keep the
-      emitted code valid. */ _%>
+      (or omits additionalProperties), the value model has an unknown type —
+      fall back to `unknown` to keep the emitted code valid. */ _%>
 <%- docString(model.link, '  ') %>  [key: string]: <%- model.link.typescriptType || 'unknown' %>;
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>

--- a/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/types.gen.ts.template
@@ -22,7 +22,8 @@ _%>
 <%_ if (model.export === "enum") { _%>
 <%- docString(model, '') %>export type <%= model.typescriptName %> =
 <%_ model.enum.forEach((enumMember, i) => { _%>
-  | '<%- enumMember.value %>'
+<%_ /* JSON.stringify escapes quotes, newlines and backslashes in values */ _%>
+  | <%- JSON.stringify(`${enumMember.value}`) %>
 <%_ }); _%>
 <%_ } else if (isComposite) { _%>
 <%- docString(model, '') %>export type <%- model.typescriptName %> =<% model.properties.forEach((composedType, i) => { %><% if (i > 0) { %><% if (model.export === "all-of") { %> &<% } else { %> |<% } %><% } %> <%- composedType.typescriptType %><% }); %>;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -1295,4 +1295,152 @@ describe('openApiTsClientGenerator - composite schemas', () => {
     expect(types).toMatchSnapshot();
     expect(client).toMatchSnapshot();
   });
+
+  it('should marshal an inheritance-style discriminator base to its subtype', async () => {
+    // A base object schema carries the discriminator; subtypes allOf-compose
+    // it. A response typed as the base must still round-trip subtype-only
+    // fields (here a date) rather than dropping them.
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/pets/{id}': {
+          get: {
+            operationId: 'getPet',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Pet' },
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            operationId: 'putPet',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Pet: {
+            type: 'object',
+            required: ['petType', 'name'],
+            properties: {
+              petType: { type: 'string' },
+              name: { type: 'string' },
+              bornAt: { type: 'string', format: 'date-time' },
+            },
+            discriminator: {
+              propertyName: 'petType',
+              mapping: {
+                cat: '#/components/schemas/Cat',
+                dog: '#/components/schemas/Dog',
+              },
+            },
+          } as never,
+          Cat: {
+            allOf: [
+              { $ref: '#/components/schemas/Pet' },
+              {
+                type: 'object',
+                required: ['lastNapAt'],
+                properties: {
+                  lastNapAt: { type: 'string', format: 'date-time' },
+                },
+              },
+            ],
+          },
+          Dog: {
+            allOf: [
+              { $ref: '#/components/schemas/Pet' },
+              {
+                type: 'object',
+                properties: { packSize: { type: 'integer' } },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+
+    // The base dispatches to subtypes; subtypes compose the base's
+    // non-dispatching body (no infinite recursion).
+    expect(client).toContain('$toJsonBase');
+    expect(client).toContain('$IO.Pet.$toJsonBase(model)');
+    expect(client).toMatch(/case 'cat':\s*return \$IO\.Cat\.toJson/);
+
+    // GET: a Cat payload through the Pet-typed response revives lastNapAt.
+    const getFetch = vi.fn();
+    getFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        petType: 'cat',
+        name: 'felix',
+        bornAt: '2020-01-02T03:04:05.000Z',
+        lastNapAt: '2024-01-02T03:04:05.000Z',
+      }),
+    });
+    const getRes = await callGeneratedClient(client, getFetch, 'getPet', {
+      id: 'felix',
+    });
+    expect(getRes.lastNapAt).toEqual(new Date('2024-01-02T03:04:05.000Z'));
+    expect(getRes.bornAt).toEqual(new Date('2020-01-02T03:04:05.000Z'));
+
+    // PUT: a Cat through the Pet-typed body serialises lastNapAt.
+    const putFetch = vi.fn();
+    putFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, putFetch, 'putPet', {
+      id: 'felix',
+      petType: 'cat',
+      name: 'felix',
+      bornAt: new Date('2020-01-02T03:04:05.000Z'),
+      lastNapAt: new Date('2024-01-02T03:04:05.000Z'),
+    } as never);
+    const [, putRequest] = putFetch.mock.calls[0];
+    expect(JSON.parse(putRequest.body)).toEqual({
+      petType: 'cat',
+      name: 'felix',
+      bornAt: '2020-01-02T03:04:05.000Z',
+      lastNapAt: '2024-01-02T03:04:05.000Z',
+    });
+  });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -1279,6 +1279,19 @@ describe('openApiTsClientGenerator - composite schemas', () => {
     expect(types).toMatch(/kind:\s*string\b/);
     expect(types).not.toMatch(/kind:\s*'circle'/);
 
+    // The discriminator must marshal directly to the matching branch, so a
+    // Square must not gain a spurious `radius` from the Circle branch.
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ canonical: { kind: 'square', side: 3 } }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'getShapes');
+    expect(response.canonical).toEqual({ kind: 'square', side: 3 });
+    expect('radius' in response.canonical).toBe(false);
+
     expect(types).toMatchSnapshot();
     expect(client).toMatchSnapshot();
   });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -39,6 +39,7 @@ import {
  *     branch (which leaks fields from the non-matching branches)
  *  N. a discriminator whose wire name differs from its TS name (e.g. `pet-type`)
  *     must dispatch on the TS name in toJson and the wire name in fromJson
+ *  O. a `deepObject` query parameter must serialise as `key[prop]=value` pairs
  */
 describe('openApiTsClientGenerator - edge cases', () => {
   let tree: Tree;
@@ -1021,5 +1022,89 @@ describe('openApiTsClientGenerator - edge cases', () => {
       'pet-type': 'dog',
       walkAt: '2024-01-02T03:04:05.000Z',
     });
+  });
+
+  // ---- O. deepObject query parameters ---------------------------------------
+
+  it('serialises a deepObject query parameter as key[prop]=value pairs', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                style: 'deepObject',
+                explode: true,
+                schema: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string' },
+                    min: { type: 'integer' },
+                  },
+                },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'search', {
+      filter: { name: 'bob', min: 3 },
+    });
+    const [url] = mockFetch.mock.calls[0];
+    // Each property becomes its own bracketed query pair. Brackets are not
+    // percent-encoded (matches the deepObject convention servers expect).
+    expect(url).toBe(`${baseUrl}/search?filter[name]=bob&filter[min]=3`);
+  });
+
+  it('omits undefined and null members of a deepObject query parameter', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                style: 'deepObject',
+                explode: true,
+                schema: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string' },
+                    tag: { type: 'string', nullable: true },
+                  },
+                },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'search', {
+      filter: { name: 'bob', tag: null },
+    });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(`${baseUrl}/search?filter[name]=bob`);
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -26,6 +26,11 @@ import {
  *     the type and the runtime marshalling
  *  E. inline (non-$ref) streaming `itemSchema` must produce a valid item type
  *  F. enum literal values containing quotes/newlines/backslashes must escape
+ *  G. `$ref` path items must be resolved (including when shared by paths)
+ *  H. a requestBody with an empty `content` map declares no body
+ *  I. vendored `+json` media types must hoist/marshal like application/json
+ *  J. schemas nested inside a rewritten schema (multi-type array items,
+ *     `const` in a nullable object, allOf siblings) must also be rewritten
  */
 describe('openApiTsClientGenerator - edge cases', () => {
   let tree: Tree;
@@ -397,5 +402,244 @@ describe('openApiTsClientGenerator - edge cases', () => {
     });
     const response = await callGeneratedClient(client, mockFetch, 'getTricky');
     expect(response).toEqual("don't");
+  });
+
+  // ---- G. $ref path items ---------------------------------------------------
+
+  it('resolves $ref path items, sharing one path item across paths', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things': { $ref: '#/components/pathItems/ThingPath' },
+        '/other-things': { $ref: '#/components/pathItems/ThingPath' },
+      },
+      components: {
+        pathItems: {
+          ThingPath: {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          at: { type: 'string', format: 'date-time' },
+                        },
+                        required: ['at'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        schemas: {},
+      },
+    } as unknown as Spec;
+    const { types, client } = await generate(spec);
+
+    // Both paths get an operation, distinctly named, with the date revived.
+    expect(client).toContain("this.$url('/things'");
+    expect(client).toContain("this.$url('/other-things'");
+    expect(types).toContain('GetThings200Response');
+    expect(types).toContain('GetOtherThings200Response');
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({ at: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'getThings');
+    expect(response).toEqual({ at: new Date('2024-01-02T03:04:05.000Z') });
+  });
+
+  // ---- H. empty request body content ---------------------------------------
+
+  it('treats a requestBody with an empty content map as no body', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/noop': {
+          post: {
+            operationId: 'doNoop',
+            requestBody: { content: {} },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    // No body parameter means no Content-Type header and an undefined body.
+    expect(client).not.toContain("headerParameters['Content-Type']");
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'doNoop');
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/noop`,
+      expect.objectContaining({ method: 'POST', body: undefined }),
+    );
+  });
+
+  // ---- I. vendored +json media types ----------------------------------------
+
+  it('hoists and marshals vendored +json request/response schemas', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/v': {
+          post: {
+            operationId: 'postV',
+            requestBody: {
+              required: true,
+              content: {
+                'application/vnd.api+json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      at: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['at'],
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/vnd.api+json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        at: { type: 'string', format: 'date-time' },
+                      },
+                      required: ['at'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { types, client } = await generate(spec);
+
+    // The inline schemas are hoisted to named models with Date properties.
+    expect(types).toContain('PostVRequestContent');
+    expect(types).toContain('PostV200Response');
+    expect(types).toMatch(/at: Date;/);
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({ at: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'postV', {
+      at: new Date('2024-01-02T03:04:05.000Z'),
+    });
+    expect(response).toEqual({ at: new Date('2024-01-02T03:04:05.000Z') });
+    const [, request] = mockFetch.mock.calls[0];
+    expect(JSON.parse(request.body)).toEqual({
+      at: '2024-01-02T03:04:05.000Z',
+    });
+    expect(request.headers).toContainEqual([
+      'Content-Type',
+      'application/vnd.api+json',
+    ]);
+  });
+
+  // ---- J. rewrites nested inside rewritten schemas ---------------------------
+
+  it('renders a multi-type union for items of a nullable (multi-type) array', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/r': {
+          get: {
+            operationId: 'getThing',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Thing' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Thing: {
+            type: 'object',
+            properties: {
+              data: {
+                type: ['array', 'null'],
+                items: { type: ['integer', 'string'] },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Spec;
+    const { types } = await generate(spec);
+
+    expect(types).toMatch(/number \| string/);
+  });
+
+  it('rewrites a const declared inside a nullable (multi-type) object', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/r': {
+          get: {
+            operationId: 'getThing',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Thing' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Thing: {
+            type: 'object',
+            properties: {
+              wrapper: {
+                type: ['object', 'null'],
+                properties: {
+                  kind: { type: 'string', const: 'fixed' },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Spec;
+    const { types } = await generate(spec);
+
+    expect(types).toContain("'fixed'");
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -35,6 +35,8 @@ import {
  *     collection-format maps (no duplicate object key)
  *  L. spaceDelimited / pipeDelimited query arrays must serialise with the
  *     correct delimiter (and compile)
+ *  M. discriminated oneOf must marshal to the matching branch, not merge every
+ *     branch (which leaks fields from the non-matching branches)
  */
 describe('openApiTsClientGenerator - edge cases', () => {
   let tree: Tree;
@@ -740,5 +742,125 @@ describe('openApiTsClientGenerator - edge cases', () => {
     const [url] = mockFetch.mock.calls[0];
     // %20 = space, %7C = pipe
     expect(url).toBe(`${baseUrl}/search?spaced=a%20b%20c&piped=x%7Cy`);
+  });
+
+  // ---- M. discriminated oneOf marshalling -----------------------------------
+
+  const discriminatedShapeSpec = (withMapping: boolean): Spec =>
+    ({
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/shapes': {
+          post: {
+            operationId: 'postShape',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Shape' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Shape' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Cat: {
+            type: 'object',
+            required: ['kind', 'napAt'],
+            properties: {
+              kind: { type: 'string' },
+              napAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Dog: {
+            type: 'object',
+            required: ['kind', 'walkAt'],
+            properties: {
+              kind: { type: 'string' },
+              walkAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Shape: {
+            oneOf: [
+              { $ref: '#/components/schemas/Cat' },
+              { $ref: '#/components/schemas/Dog' },
+            ],
+            discriminator: {
+              propertyName: 'kind',
+              ...(withMapping
+                ? {
+                    mapping: {
+                      cat: '#/components/schemas/Cat',
+                      dog: '#/components/schemas/Dog',
+                    },
+                  }
+                : {}),
+            },
+          },
+        },
+      },
+    }) as unknown as Spec;
+
+  it('marshals a discriminated oneOf to the matching branch (explicit mapping)', async () => {
+    const { client } = await generate(discriminatedShapeSpec(true));
+
+    // fromJson dispatches on the wire discriminator and picks a single branch.
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ kind: 'dog', walkAt: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'postShape', {
+      kind: 'dog',
+      walkAt: new Date('2024-01-02T03:04:05.000Z'),
+    });
+    // The Cat branch's napAt must not leak onto the Dog result.
+    expect(response).toEqual({
+      kind: 'dog',
+      walkAt: new Date('2024-01-02T03:04:05.000Z'),
+    });
+    expect('napAt' in response).toBe(false);
+    // The request body is marshalled via the Dog branch only.
+    const [, request] = mockFetch.mock.calls[0];
+    expect(JSON.parse(request.body)).toEqual({
+      kind: 'dog',
+      walkAt: '2024-01-02T03:04:05.000Z',
+    });
+  });
+
+  it('marshals a discriminated oneOf using implicit (schema-name) mapping', async () => {
+    const { client } = await generate(discriminatedShapeSpec(false));
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ kind: 'Dog', walkAt: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'postShape', {
+      kind: 'Dog',
+      walkAt: new Date('2024-01-02T03:04:05.000Z'),
+    });
+    expect(response).toEqual({
+      kind: 'Dog',
+      walkAt: new Date('2024-01-02T03:04:05.000Z'),
+    });
+    expect('napAt' in response).toBe(false);
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -31,6 +31,10 @@ import {
  *  I. vendored `+json` media types must hoist/marshal like application/json
  *  J. schemas nested inside a rewritten schema (multi-type array items,
  *     `const` in a nullable object, allOf siblings) must also be rewritten
+ *  K. a query and a header array parameter sharing a name must keep separate
+ *     collection-format maps (no duplicate object key)
+ *  L. spaceDelimited / pipeDelimited query arrays must serialise with the
+ *     correct delimiter (and compile)
  */
 describe('openApiTsClientGenerator - edge cases', () => {
   let tree: Tree;
@@ -641,5 +645,100 @@ describe('openApiTsClientGenerator - edge cases', () => {
     const { types } = await generate(spec);
 
     expect(types).toContain("'fixed'");
+  });
+
+  // ---- K. query + header array params sharing a name ------------------------
+
+  it('keeps separate collection-format maps for same-named query and header arrays', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'listItems',
+            parameters: [
+              {
+                name: 'ids',
+                in: 'query',
+                schema: { type: 'array', items: { type: 'string' } },
+                explode: false,
+              },
+              {
+                name: 'ids',
+                in: 'header',
+                schema: { type: 'array', items: { type: 'string' } },
+                explode: true,
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    // The two 'ids' params live in separate collection-format maps.
+    expect(client).toContain('queryCollectionFormats');
+    expect(client).toContain('headerCollectionFormats');
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'listItems', {
+      ids: ['a', 'b'],
+    });
+    const [url, request] = mockFetch.mock.calls[0];
+    // Query: csv (explode false); header: multi (explode true, repeated).
+    expect(url).toBe(`${baseUrl}/items?ids=a%2Cb`);
+    expect(request.headers).toEqual([
+      ['ids', 'a'],
+      ['ids', 'b'],
+    ]);
+  });
+
+  // ---- L. spaceDelimited / pipeDelimited query arrays -----------------------
+
+  it('serialises spaceDelimited and pipeDelimited query arrays with the right delimiter', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            parameters: [
+              {
+                name: 'spaced',
+                in: 'query',
+                style: 'spaceDelimited',
+                explode: false,
+                schema: { type: 'array', items: { type: 'string' } },
+              },
+              {
+                name: 'piped',
+                in: 'query',
+                style: 'pipeDelimited',
+                explode: false,
+                schema: { type: 'array', items: { type: 'string' } },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'search', {
+      spaced: ['a', 'b', 'c'],
+      piped: ['x', 'y'],
+    });
+    const [url] = mockFetch.mock.calls[0];
+    // %20 = space, %7C = pipe
+    expect(url).toBe(`${baseUrl}/search?spaced=a%20b%20c&piped=x%7Cy`);
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -1045,6 +1045,7 @@ describe('openApiTsClientGenerator - edge cases', () => {
                   properties: {
                     name: { type: 'string' },
                     min: { type: 'integer' },
+                    since: { type: 'string', format: 'date-time' },
                   },
                 },
               },
@@ -1055,17 +1056,28 @@ describe('openApiTsClientGenerator - edge cases', () => {
       },
       components: { schemas: {} },
     } as unknown as Spec;
-    const { client } = await generate(spec);
+    const { types, client } = await generate(spec);
+
+    // The inline object param is hoisted to a named model, so its members
+    // (including the Date) are fully typed and marshalled.
+    expect(types).toContain('SearchRequestQueryFilter');
 
     const mockFetch = vi.fn();
     mockFetch.mockResolvedValue({ status: 200 });
     await callGeneratedClient(client, mockFetch, 'search', {
-      filter: { name: 'bob', min: 3 },
+      filter: {
+        name: 'bob',
+        min: 3,
+        since: new Date('2024-01-02T03:04:05.000Z'),
+      },
     });
     const [url] = mockFetch.mock.calls[0];
-    // Each property becomes its own bracketed query pair. Brackets are not
-    // percent-encoded (matches the deepObject convention servers expect).
-    expect(url).toBe(`${baseUrl}/search?filter[name]=bob&filter[min]=3`);
+    // Each property becomes its own bracketed query pair; the nested Date is
+    // marshalled to an ISO string. Brackets are not percent-encoded (matches
+    // the deepObject convention servers expect).
+    expect(url).toBe(
+      `${baseUrl}/search?filter[name]=bob&filter[min]=3&filter[since]=2024-01-02T03%3A04%3A05.000Z`,
+    );
   });
 
   it('omits undefined and null members of a deepObject query parameter', async () => {
@@ -1106,5 +1118,53 @@ describe('openApiTsClientGenerator - edge cases', () => {
     });
     const [url] = mockFetch.mock.calls[0];
     expect(url).toBe(`${baseUrl}/search?filter[name]=bob`);
+  });
+
+  it('recurses into a nested deepObject query parameter', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                style: 'deepObject',
+                explode: true,
+                schema: {
+                  type: 'object',
+                  properties: {
+                    page: {
+                      type: 'object',
+                      properties: {
+                        size: { type: 'integer' },
+                        sort: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'search', {
+      filter: { page: { size: 10, sort: 'asc' } },
+    });
+    const [url] = mockFetch.mock.calls[0];
+    // Nested objects recurse to `filter[page][size]=…`, not `[object Object]`.
+    expect(url).toBe(
+      `${baseUrl}/search?filter[page][size]=10&filter[page][sort]=asc`,
+    );
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -37,6 +37,8 @@ import {
  *     correct delimiter (and compile)
  *  M. discriminated oneOf must marshal to the matching branch, not merge every
  *     branch (which leaks fields from the non-matching branches)
+ *  N. a discriminator whose wire name differs from its TS name (e.g. `pet-type`)
+ *     must dispatch on the TS name in toJson and the wire name in fromJson
  */
 describe('openApiTsClientGenerator - edge cases', () => {
   let tree: Tree;
@@ -862,5 +864,162 @@ describe('openApiTsClientGenerator - edge cases', () => {
       walkAt: new Date('2024-01-02T03:04:05.000Z'),
     });
     expect('napAt' in response).toBe(false);
+  });
+
+  it('does not build a discriminator switch for inline (hoisted) union members', async () => {
+    // Inline oneOf members are hoisted to synthetic names (ShapeOneOf, …) that
+    // can never appear on the wire, so an implicit discriminator must not emit
+    // dispatch cases on them; marshalling falls through to the merge.
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/shapes': {
+          get: {
+            operationId: 'getShape',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Shape' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Shape: {
+            oneOf: [
+              {
+                type: 'object',
+                required: ['kind', 'napAt'],
+                properties: {
+                  kind: { type: 'string' },
+                  napAt: { type: 'string', format: 'date-time' },
+                },
+              },
+              {
+                type: 'object',
+                required: ['kind', 'walkAt'],
+                properties: {
+                  kind: { type: 'string' },
+                  walkAt: { type: 'string', format: 'date-time' },
+                },
+              },
+            ],
+            discriminator: { propertyName: 'kind' },
+          },
+        },
+      },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    // No dispatch on synthetic hoisted names.
+    expect(client).not.toContain("case 'ShapeOneOf'");
+    expect(client).not.toMatch(/switch \(json\?\.\['kind'\]\)/);
+
+    // Still deserialises without crashing (merge fallthrough).
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ kind: 'dog', walkAt: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'getShape');
+    expect(response.walkAt).toEqual(new Date('2024-01-02T03:04:05.000Z'));
+  });
+
+  it('dispatches a discriminator whose wire name differs from its TS name', async () => {
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/shapes': {
+          post: {
+            operationId: 'postShape',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Shape' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Shape' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Cat: {
+            type: 'object',
+            required: ['pet-type', 'napAt'],
+            properties: {
+              'pet-type': { type: 'string' },
+              napAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Dog: {
+            type: 'object',
+            required: ['pet-type', 'walkAt'],
+            properties: {
+              'pet-type': { type: 'string' },
+              walkAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Shape: {
+            oneOf: [
+              { $ref: '#/components/schemas/Cat' },
+              { $ref: '#/components/schemas/Dog' },
+            ],
+            discriminator: {
+              propertyName: 'pet-type',
+              mapping: {
+                cat: '#/components/schemas/Cat',
+                dog: '#/components/schemas/Dog',
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Spec;
+    const { client } = await generate(spec);
+
+    // toJson dispatches on the TS name, fromJson on the wire name.
+    expect(client).toContain('switch ((model as any).petType)');
+    expect(client).toContain("switch (json?.['pet-type'])");
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ 'pet-type': 'dog', walkAt: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'postShape', {
+      petType: 'dog',
+      walkAt: new Date('2024-01-02T03:04:05.000Z'),
+    } as never);
+    expect('napAt' in response).toBe(false);
+    // The request body carries the wire discriminator name.
+    const [, request] = mockFetch.mock.calls[0];
+    expect(JSON.parse(request.body)).toEqual({
+      'pet-type': 'dog',
+      walkAt: '2024-01-02T03:04:05.000Z',
+    });
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -1,0 +1,401 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
+import type { Spec } from '../utils/types';
+import { openApiTsClientGenerator } from './generator';
+import {
+  baseUrl,
+  callGeneratedClient,
+  callGeneratedClientStreaming,
+  mockJsonlStreamingFetch,
+} from './generator.utils.spec';
+
+/**
+ * Regression coverage for edge cases surfaced by differentially testing a
+ * corner-case spec corpus against the hey-api-based generator:
+ *  A. path-level (shared) parameters with collection schemas (arrays of
+ *     dates/refs) must be marshalled, not passed through raw
+ *  B. parameters sharing a name across `in` positions must not collide
+ *  C. a `null` enum member must mark the enum nullable, not render `| ''`
+ *  D. allOf with sibling `properties` must keep the sibling fields in both
+ *     the type and the runtime marshalling
+ *  E. inline (non-$ref) streaming `itemSchema` must produce a valid item type
+ *  F. enum literal values containing quotes/newlines/backslashes must escape
+ */
+describe('openApiTsClientGenerator - edge cases', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const generate = async (spec: Spec) => {
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    expectTypeScriptToCompile(tree, [
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
+    return { types, client };
+  };
+
+  // ---- A. shared path-level collection parameters -------------------------
+
+  it('marshals shared path-level array parameters (dates and refs)', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things': {
+          parameters: [
+            {
+              name: 'whens',
+              in: 'query',
+              required: true,
+              schema: {
+                type: 'array',
+                items: { type: 'string', format: 'date-time' },
+              },
+            },
+            {
+              name: 'things',
+              in: 'query',
+              schema: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/Thing' },
+              },
+            },
+          ],
+          get: {
+            operationId: 'getThings',
+            responses: { '200': { description: 'ok' } },
+          },
+          put: {
+            operationId: 'putThings',
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Thing: {
+            type: 'object',
+            properties: { at: { type: 'string', format: 'date-time' } },
+          },
+        },
+      },
+    };
+    const { client } = await generate(spec);
+
+    // Dates must be serialised, and refs marshalled via their model.
+    expect(client).toContain('item0.toISOString()');
+    expect(client).toContain('$IO.Thing.toJson');
+    expect(client).not.toContain('$IO.undefined');
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+    await callGeneratedClient(client, mockFetch, 'getThings', {
+      whens: [new Date('2024-01-02T03:04:05.000Z')],
+      things: [{ at: new Date('2024-06-07T08:09:10.000Z') }],
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/things?whens=2024-01-02T03%3A04%3A05.000Z&things=%5Bobject%20Object%5D`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  // ---- B. same parameter name in different positions ----------------------
+
+  it('keeps parameters with the same name in path and query distinct', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/items/{id}': {
+          get: {
+            operationId: 'getItem',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+              {
+                name: 'id',
+                in: 'query',
+                schema: { type: 'string', format: 'date-time' },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    };
+    const { types } = await generate(spec);
+
+    // The path `id` is a plain string; only the query `id` is a Date.
+    expect(types).toMatch(/GetItemRequestPathParameters = \{\s*id: string;/);
+    expect(types).toMatch(/GetItemRequestQueryParameters = \{\s*id\?: Date;/);
+  });
+
+  // ---- C. null enum members ------------------------------------------------
+
+  it('treats a null enum member as nullable, not an empty literal', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/status': {
+          get: {
+            operationId: 'getStatus',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Status' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Status: {
+            type: 'string',
+            nullable: true,
+            enum: ['active', 'inactive', null],
+          } as never,
+        },
+      },
+    };
+    const { types } = await generate(spec);
+
+    expect(types).toContain("'active'");
+    expect(types).toContain("'inactive'");
+    expect(types).not.toMatch(/\|\s*''/);
+  });
+
+  // ---- D. allOf with sibling properties ------------------------------------
+
+  it('keeps sibling properties declared alongside allOf', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/dogs': {
+          post: {
+            operationId: 'createDog',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Dog' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Dog' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Base: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+          },
+          Dog: {
+            type: 'object',
+            allOf: [{ $ref: '#/components/schemas/Base' }],
+            properties: { bark: { type: 'boolean' } },
+            required: ['bark'],
+          },
+        },
+      },
+    };
+    const { types, client } = await generate(spec);
+
+    // The sibling property is part of the type...
+    expect(types).toMatch(/bark: boolean/);
+
+    // ...and survives a request/response round trip.
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({ id: 'rex', bark: true }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'createDog', {
+      id: 'rex',
+      bark: true,
+    });
+    expect(response).toEqual({ id: 'rex', bark: true });
+    const [, request] = mockFetch.mock.calls[0];
+    expect(JSON.parse(request.body)).toEqual({ id: 'rex', bark: true });
+  });
+
+  // ---- E. inline streaming itemSchema ---------------------------------------
+
+  it('handles an inline object itemSchema on a streaming response', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/stream': {
+          get: {
+            operationId: 'streamThings',
+            responses: {
+              '200': {
+                description: 'stream',
+                content: {
+                  'application/x-ndjson': {
+                    itemSchema: {
+                      type: 'object',
+                      properties: { line: { type: 'string' } },
+                      required: ['line'],
+                    },
+                  },
+                } as never,
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: {} },
+    };
+    const { types, client } = await generate(spec);
+
+    // The inline item schema is hoisted to a named model.
+    expect(types).toContain('StreamThings200ResponseItem');
+    expect(client).toContain(
+      'AsyncIterableIterator<StreamThings200ResponseItem>',
+    );
+
+    const mockFetch = mockJsonlStreamingFetch(200, [
+      '{"line":"first"}',
+      '{"line":"second"}',
+    ]);
+    const chunks: unknown[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetch,
+      'streamThings',
+    )) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ line: 'first' }, { line: 'second' }]);
+  });
+
+  it('handles an inline primitive itemSchema on a streaming response', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/stream': {
+          get: {
+            operationId: 'streamNumbers',
+            responses: {
+              '200': {
+                description: 'stream',
+                content: {
+                  'application/x-ndjson': {
+                    itemSchema: { type: 'number' },
+                  },
+                } as never,
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: {} },
+    };
+    const { client } = await generate(spec);
+
+    expect(client).toContain('AsyncIterableIterator<number>');
+
+    const mockFetch = mockJsonlStreamingFetch(200, ['1', '2', '3']);
+    const chunks: unknown[] = [];
+    for await (const chunk of await callGeneratedClientStreaming(
+      client,
+      mockFetch,
+      'streamNumbers',
+    )) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([1, 2, 3]);
+  });
+
+  // ---- F. enum literal escaping ---------------------------------------------
+
+  it('escapes quotes, backslashes and newlines in enum values', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/tricky': {
+          get: {
+            operationId: 'getTricky',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Tricky' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Tricky: {
+            type: 'string',
+            enum: ["don't", 'back\\slash', 'new\nline'],
+          },
+        },
+      },
+    };
+    const { types, client } = await generate(spec);
+
+    // The formatter may render either quote style; the values must be escaped
+    // so the emitted literals parse (compilation is asserted above).
+    expect(types).toContain(String.raw`"don't"`);
+    expect(types).toContain(String.raw`'back\\slash'`);
+    expect(types).toContain(String.raw`'new\nline'`);
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue("don't"),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'getTricky');
+    expect(response).toEqual("don't");
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
@@ -494,4 +494,70 @@ describe('openApiTsClientGenerator - regressions', () => {
     // Must compile — the hoisted schema name and its reference must agree.
     await generate(spec);
   });
+
+  // ---- J. path-level param shared across several methods -----------------
+
+  it('inherits a path-level parameter into every method on the path', async () => {
+    // The `common-parameters` shape: one path-level `petId` shared by GET, PUT
+    // and DELETE on the same path.
+    const pathParam = {
+      name: 'petId',
+      in: 'path',
+      required: true,
+      schema: { type: 'integer' },
+    };
+    const okResponse = {
+      '200': {
+        description: 'ok',
+        content: { 'application/json': { schema: { type: 'string' } } },
+      },
+    };
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/pets/{petId}': {
+          parameters: [pathParam as never],
+          get: { operationId: 'getPet', responses: okResponse as never },
+          delete: {
+            operationId: 'deletePet',
+            responses: { '204': { description: 'gone' } } as never,
+          },
+          put: {
+            operationId: 'updatePet',
+            requestBody: {
+              content: {
+                'application/json': { schema: { type: 'string' } },
+              },
+            },
+            responses: okResponse as never,
+          },
+        },
+      },
+    };
+    const types = await generate(spec);
+    expect(types).toMatch(/GetPetRequest[\s\S]*petId: number/);
+    expect(types).toMatch(/DeletePetRequest[\s\S]*petId: number/);
+    expect(types).toMatch(/UpdatePetRequest[\s\S]*petId: number/);
+  });
+
+  // ---- K. 3.1 `type: [array, null]` with object items --------------------
+
+  it('renders a nullable array of objects (`type: [array, null]`)', async () => {
+    // The `null-types-with-type-array` shape: a nullable array whose items are
+    // an inline object; the item type must be hoisted, not `unknown`.
+    const types = await generate(
+      responseSchema({
+        nullableSkills: {
+          type: ['array', 'null'],
+          items: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      }),
+    );
+    expect(types).toMatch(/nullableSkills\?: Array<\w+> \| null/);
+    expect(types).not.toMatch(/nullableSkills\?: Array<unknown>/);
+  });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
@@ -340,4 +340,158 @@ describe('openApiTsClientGenerator - regressions', () => {
     const types = await generate(spec);
     expect(types).toContain('The thing to update');
   });
+
+  // ---- F. operations whose only responses are errors (no result) ---------
+
+  it('compiles an operation whose only response is an error code', async () => {
+    // `op.result` is undefined when no 2XX/default response exists; the client
+    // template used to read `op.result.typescriptType` unconditionally and crash.
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/thing': {
+          post: {
+            operationId: 'createThing',
+            responses: {
+              '403': {
+                description: 'forbidden',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { message: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    // Generation must not throw and must compile (result type is `void`).
+    const types = await generate(spec);
+    expect(types).toContain('CreateThingError');
+  });
+
+  // ---- G. identifiers from non-identifier characters ---------------------
+
+  it('sanitizes non-ASCII operationIds into valid identifiers', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/thing': {
+          get: {
+            // The `≠` (and accented chars) must not leak into TS identifiers.
+            operationId: 'getThing≠Café',
+            parameters: [
+              { name: 'q', in: 'query', schema: { type: 'string' } },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const types = await generate(spec);
+    expect(types).not.toMatch(/[^\x00-\x7F]/); // no non-ASCII in output
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(client).not.toMatch(/[^\x00-\x7F]/);
+  });
+
+  it('handles a property named entirely of non-identifier characters', async () => {
+    // A property named "_" camelCases to an empty string; it must still emit a
+    // valid identifier rather than `model.` / an empty key.
+    const types = await generate(
+      responseSchema({
+        _: { type: 'object', additionalProperties: { type: 'string' } },
+      }),
+    );
+    expect(types).toBeDefined();
+  });
+
+  // ---- H. dictionary (map) response body ---------------------------------
+
+  it('compiles an operation returning a bare dictionary', async () => {
+    // A map response emits `$IO.$mapValues(...)` inside the client class, which
+    // requires `$mapValues` to be accessible (not `protected`).
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things': {
+          get: {
+            operationId: 'getThings',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'object',
+                        properties: { name: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    // Must compile — cross-class `$IO.$mapValues` access.
+    await generate(spec);
+  });
+
+  // ---- I. hoisted inline schema names with `_`-separated property names ---
+
+  it('resolves hoisted inline schema names for snake_case properties', async () => {
+    // `store_photos` hoists to a schema whose name must match its references
+    // (both normalised, so `StorePhotos` not `Store_photos`).
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        store_photos: {
+                          type: 'object',
+                          additionalProperties: {
+                            type: 'object',
+                            properties: { url: { type: 'string' } },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    // Must compile — the hoisted schema name and its reference must agree.
+    await generate(spec);
+  });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
@@ -214,6 +214,78 @@ describe('openApiTsClientGenerator - regressions', () => {
     expect(types).not.toMatch(/limit\??: string;/);
   });
 
+  // ---- E. nested-array marshalling (noImplicitAny) -----------------------
+
+  it('compiles nested arrays of dates/models (annotates inner map params)', async () => {
+    // The nested `.map()` marshalling helpers used to leave the inner lambda
+    // parameter untyped, tripping noImplicitAny for arrays-of-arrays whose leaf
+    // needs conversion (dates, models, primitive unions).
+    const spec: Spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/r': {
+          post: {
+            operationId: 'postNested',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Nested' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Nested' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Leaf: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+          },
+          Nested: {
+            type: 'object',
+            properties: {
+              dates2d: {
+                type: 'array',
+                items: {
+                  type: 'array',
+                  items: { type: 'string', format: 'date-time' },
+                },
+              },
+              models2d: {
+                type: 'array',
+                items: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Leaf' },
+                },
+              },
+              unions2d: {
+                type: 'array',
+                items: {
+                  type: 'array',
+                  items: { type: ['integer', 'string'] },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    // Must compile under strict/noImplicitAny (the assertion is in generate()).
+    await generate(spec);
+  });
+
   // ---- D. requestBody description ----------------------------------------
 
   it('renders requestBody.description as the body parameter doc comment', async () => {

--- a/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
+import type { Spec } from '../utils/types';
+import { openApiTsClientGenerator } from './generator';
+
+/**
+ * Regression coverage for parser defects surfaced by differentially testing a
+ * wide corpus of real-world specs (FastAPI / Smithy / raw OpenAPI) against the
+ * generator output:
+ *  A. boolean/number enums must render as their bare primitive, not `string`
+ *  B. multi-type schemas (`type: ['integer', 'string']`) must render a union
+ *  C. path-level (shared) parameters must be inherited by every operation
+ *  D. `requestBody.description` must render as the body param's doc comment
+ */
+describe('openApiTsClientGenerator - regressions', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const generate = async (spec: Spec) => {
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    expectTypeScriptToCompile(tree, [
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    return tree.read('src/generated/types.gen.ts', 'utf-8')!;
+  };
+
+  const responseSchema = (schema: unknown): Spec => ({
+    openapi: '3.0.3',
+    info: { title, version: '1.0.0' },
+    paths: {
+      '/r': {
+        get: {
+          operationId: 'getThing',
+          responses: {
+            '200': {
+              description: 'ok',
+              content: { 'application/json': { schema: schema as never } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Thing: {
+          type: 'object',
+          properties: schema as never,
+        },
+      },
+    },
+  });
+
+  // ---- A. boolean & numeric enums ----------------------------------------
+
+  it('renders a boolean enum as `boolean`, not `string`', async () => {
+    const types = await generate(
+      responseSchema({
+        flagTrue: { type: 'boolean', enum: [true] },
+        flagFalse: { type: 'boolean', enum: [false] },
+        flagBoth: { type: 'boolean', enum: [true, false] },
+      }),
+    );
+    expect(types).toMatch(/flagTrue\?: boolean;/);
+    expect(types).toMatch(/flagFalse\?: boolean;/);
+    expect(types).toMatch(/flagBoth\?: boolean;/);
+    expect(types).not.toMatch(/flag\w+\?: string;/);
+  });
+
+  it('renders an integer enum as `number`, not `string`', async () => {
+    const types = await generate(
+      responseSchema({
+        code: { type: 'integer', enum: [1, 2, 3] },
+        ratio: { type: 'number', enum: [1.5, 2.5] },
+      }),
+    );
+    expect(types).toMatch(/code\?: number;/);
+    expect(types).toMatch(/ratio\?: number;/);
+  });
+
+  it('still renders a string enum as a literal union', async () => {
+    const types = await generate(
+      responseSchema({
+        status: { type: 'string', enum: ['a', 'b'] },
+      }),
+    );
+    expect(types).toMatch(/'a'/);
+    expect(types).toMatch(/'b'/);
+  });
+
+  // ---- B. multi-type schemas ---------------------------------------------
+
+  it('renders a multi-type schema as a union of all its types', async () => {
+    const types = await generate(
+      responseSchema({
+        both: { type: ['integer', 'string'] },
+        three: { type: ['integer', 'string', 'boolean'] },
+      }),
+    );
+    expect(types).toMatch(/number \| string/);
+    expect(types).toMatch(/number \| string \| boolean/);
+  });
+
+  it('renders a multi-type array item as a union', async () => {
+    const types = await generate(
+      responseSchema({
+        items: { type: 'array', items: { type: ['number', 'string'] } },
+      }),
+    );
+    expect(types).toMatch(/number \| string/);
+    expect(types).toMatch(/Array<\w+>/);
+  });
+
+  it('treats `[T, null]` as nullable `T`, not a union', async () => {
+    const types = await generate(
+      responseSchema({
+        maybe: { type: ['string', 'null'] },
+      }),
+    );
+    expect(types).toMatch(/maybe\?: string \| null;/);
+  });
+
+  // ---- C. path-level (shared) parameters ---------------------------------
+
+  it('inherits path-level parameters into each operation', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things': {
+          parameters: [
+            {
+              name: 'X-Tenant-Id',
+              in: 'header',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+          get: {
+            operationId: 'listThings',
+            parameters: [
+              { name: 'limit', in: 'query', schema: { type: 'integer' } },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const types = await generate(spec);
+    // The required path-level header must appear on the request type.
+    expect(types).toMatch(/xTenantId: string;/);
+    expect(types).toMatch(/limit\?: number;/);
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(client).toContain("'X-Tenant-Id'");
+  });
+
+  it('lets an operation-level parameter override a path-level one', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things': {
+          parameters: [
+            { name: 'limit', in: 'query', schema: { type: 'string' } },
+          ],
+          get: {
+            operationId: 'listThings',
+            parameters: [
+              {
+                name: 'limit',
+                in: 'query',
+                required: true,
+                schema: { type: 'integer' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const types = await generate(spec);
+    // Operation-level `limit: integer` (required) wins over path-level string.
+    expect(types).toMatch(/limit: number;/);
+    expect(types).not.toMatch(/limit\??: string;/);
+  });
+
+  // ---- D. requestBody description ----------------------------------------
+
+  it('renders requestBody.description as the body parameter doc comment', async () => {
+    // When the body cannot be inlined (here its `id` property clashes with the
+    // path param `id`), it gets a dedicated `...RequestBodyParameters` wrapper
+    // whose doc comment must carry the requestBody description — the petstore
+    // `updateUser` shape (its `User` body has a `username` clashing with the
+    // `username` path param).
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things/{id}': {
+          put: {
+            operationId: 'updateThing',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            requestBody: {
+              description: 'The thing to update',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Thing' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Thing: {
+            type: 'object',
+            properties: { id: { type: 'string' }, name: { type: 'string' } },
+          },
+        },
+      },
+    };
+    const types = await generate(spec);
+    expect(types).toContain('The thing to update');
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-client/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.ts
@@ -35,7 +35,7 @@ export const buildOpenApiCodeGenerationData = async (
   specPath: string,
 ) => {
   const spec = await parseOpenApiSpec(tree, specPath);
-  return await buildOpenApiCodeGenData(spec);
+  return buildOpenApiCodeGenData(spec);
 };
 
 /**

--- a/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-hooks/files/options-proxy.gen.ts.template
@@ -36,6 +36,11 @@ import type {
 <%_ uniq(allOperations.flatMap((op) => op.result && modelsByName[op.result.type] ? [modelsByName[op.result.type].typescriptType] : [])).forEach((returnTypeModel) => { _%>
   <%- returnTypeModel %>,
 <%_ }); _%>
+<%_ /* Infinite-query cursor types may reference a named model (e.g. an enum),
+      which the cursorType uses but is otherwise not imported. */ _%>
+<%_ uniq(allOperations.flatMap((op) => op.isInfiniteQuery && op.infiniteQueryCursorProperty && modelsByName[op.infiniteQueryCursorProperty.type] ? [modelsByName[op.infiniteQueryCursorProperty.type].typescriptType] : [])).forEach((cursorTypeModel) => { _%>
+  <%- cursorTypeModel %>,
+<%_ }); _%>
 } from './types.gen.js';
 <%_ } _%>
 import { <%- className %> } from './client.gen.js';

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
@@ -1226,6 +1226,76 @@ describe('openApiTsHooksGenerator', () => {
     );
   });
 
+  it('should import the cursor model when the cursor parameter is a $ref', async () => {
+    // Regression: when the infinite-query cursor parameter is a $ref to a named
+    // schema (e.g. an enum), the options proxy references that model in the
+    // cursor type but must also import it, or the proxy fails to compile.
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/records': {
+          get: {
+            ...{ 'x-cursor': 'token' },
+            operationId: 'listRecords',
+            parameters: [
+              {
+                name: 'token',
+                in: 'query',
+                required: false,
+                schema: { $ref: '#/components/schemas/PageToken' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['records'],
+                      properties: {
+                        records: { type: 'array', items: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          PageToken: { type: 'string', enum: ['a', 'b', 'c'] },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsHooksGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    const optionsProxy = tree.read(
+      'src/generated/options-proxy.gen.ts',
+      'utf-8',
+    )!;
+    // The cursor model is used in the cursor type and imported from types.gen.
+    expect(optionsProxy).toContain('PageToken | undefined | null');
+    expect(optionsProxy).toMatch(
+      /import type \{[\s\S]*PageToken,[\s\S]*\} from '\.\/types\.gen\.js'/,
+    );
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+      'src/generated/options-proxy.gen.ts',
+    ]);
+  });
+
   it('should handle infinite query with custom cursor parameter via object vendor extension', async () => {
     const spec: Spec = {
       openapi: '3.0.0',

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -323,5 +323,174 @@ describe('openapi codegen data utils', () => {
         'operation-value',
       );
     });
+
+    it('should throw for allOf composing non-object types', () => {
+      const specWithInvalidAllOf: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            StringAndPet: {
+              allOf: [{ type: 'string' }, { $ref: '#/components/schemas/Pet' }],
+            },
+          },
+        },
+      };
+
+      expect(() => buildOpenApiCodeGenData(specWithInvalidAllOf)).toThrow(
+        /allOf with non-object types/,
+      );
+    });
+
+    it('should classify operations as query or mutation by method', async () => {
+      const data = await buildOpenApiCodeGenData(sampleSpec);
+
+      const listPetsOp = data.allOperations.find(
+        (op) => op.name === 'listPets',
+      );
+      expect(listPetsOp).toMatchObject({ isQuery: true, isMutation: false });
+
+      const createPetOp = data.allOperations.find(
+        (op) => op.name === 'createPet',
+      );
+      expect(createPetOp).toMatchObject({ isQuery: false, isMutation: true });
+    });
+
+    it('should let x-query and x-mutation override the method default', async () => {
+      const specWithOverrides: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/pets': {
+            get: {
+              operationId: 'listPets',
+              ...{ 'x-mutation': true },
+              responses: {
+                '200': {
+                  description: 'List of pets',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/Pet' },
+                    },
+                  },
+                },
+              },
+            },
+            post: {
+              operationId: 'queryPets',
+              ...{ 'x-query': true },
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/NewPet' },
+                  },
+                },
+              },
+              responses: {
+                '200': {
+                  description: 'Queried pets',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/Pet' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const data = await buildOpenApiCodeGenData(specWithOverrides);
+
+      const getOp = data.allOperations.find((op) => op.name === 'listPets');
+      expect(getOp).toMatchObject({ isMutation: true, isQuery: false });
+
+      const postOp = data.allOperations.find((op) => op.name === 'queryPets');
+      expect(postOp).toMatchObject({ isMutation: false, isQuery: true });
+    });
+
+    const paginatedSpec = (
+      cursorExtension: Record<string, unknown>,
+      cursorParamName = 'cursor',
+    ): Spec => ({
+      ...sampleSpec,
+      paths: {
+        '/pets': {
+          get: {
+            operationId: 'listPets',
+            ...cursorExtension,
+            parameters: [
+              {
+                name: cursorParamName,
+                in: 'query',
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'List of pets',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    it('should treat a query with a cursor parameter as an infinite query', async () => {
+      const data = await buildOpenApiCodeGenData(paginatedSpec({}));
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isInfiniteQuery).toBe(true);
+      expect(op.infiniteQueryCursorProperty).toMatchObject({ name: 'cursor' });
+    });
+
+    it('should page on the property named by a string x-cursor', async () => {
+      const data = await buildOpenApiCodeGenData(
+        paginatedSpec({ 'x-cursor': 'nextToken' }, 'nextToken'),
+      );
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isInfiniteQuery).toBe(true);
+      expect(op.infiniteQueryCursorProperty).toMatchObject({
+        name: 'nextToken',
+      });
+    });
+
+    it('should page on the property named by x-cursor inputToken', async () => {
+      const data = await buildOpenApiCodeGenData(
+        paginatedSpec({ 'x-cursor': { inputToken: 'nextToken' } }, 'nextToken'),
+      );
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isInfiniteQuery).toBe(true);
+      expect(op.infiniteQueryCursorProperty).toMatchObject({
+        name: 'nextToken',
+      });
+    });
+
+    it('should disable pagination when x-cursor is false', async () => {
+      const data = await buildOpenApiCodeGenData(
+        paginatedSpec({ 'x-cursor': false }),
+      );
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isInfiniteQuery).toBe(false);
+      expect(op.infiniteQueryCursorProperty).toBeUndefined();
+    });
+
+    it('should disable pagination when x-cursor sets enabled to false', async () => {
+      const data = await buildOpenApiCodeGenData(
+        paginatedSpec({ 'x-cursor': { enabled: false } }),
+      );
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isInfiniteQuery).toBe(false);
+      expect(op.infiniteQueryCursorProperty).toBeUndefined();
+    });
   });
 });

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -858,6 +858,110 @@ describe('openapi codegen data utils', () => {
       ]);
     });
 
+    it('should exclude hoisted inline members from implicit discriminator mapping', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Dog: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' } },
+            },
+            Animal: {
+              oneOf: [
+                { $ref: '#/components/schemas/Dog' },
+                {
+                  type: 'object',
+                  required: ['kind'],
+                  properties: { kind: { type: 'string' } },
+                } as never,
+              ],
+              discriminator: { propertyName: 'kind' },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const animal = data.models.find((m) => m.name === 'Animal')!;
+      // The hoisted inline member's synthetic name (AnimalOneOf1) can never
+      // appear on the wire, so only the named member is mapped.
+      expect(animal.discriminator?.mapping).toEqual([
+        { value: 'Dog', modelName: 'Dog' },
+      ]);
+    });
+
+    it('should build base discriminator metadata for inheritance-style schemas', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Base: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' } },
+              discriminator: {
+                propertyName: 'kind',
+                mapping: {
+                  cat: '#/components/schemas/Cat',
+                  dog: '#/components/schemas/Dog',
+                },
+              },
+            },
+            Cat: {
+              allOf: [
+                { $ref: '#/components/schemas/Base' },
+                { type: 'object', properties: { meow: { type: 'boolean' } } },
+              ],
+            },
+            Dog: {
+              allOf: [
+                { $ref: '#/components/schemas/Base' },
+                { type: 'object', properties: { bark: { type: 'boolean' } } },
+              ],
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const base = data.models.find((m) => m.name === 'Base')!;
+      expect(base.export).toBe('interface');
+      expect(base.discriminator).toEqual({
+        propertyName: 'kind',
+        typescriptPropertyName: 'kind',
+        isBase: true,
+        mapping: [
+          { value: 'cat', modelName: 'Cat' },
+          { value: 'dog', modelName: 'Dog' },
+        ],
+      });
+    });
+
+    it('should not build a base discriminator when no subtypes compose it', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Lonely: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' } },
+              discriminator: { propertyName: 'kind' },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const lonely = data.models.find((m) => m.name === 'Lonely')!;
+      expect(lonely.discriminator).toBeUndefined();
+    });
+
     it('should not build discriminator metadata for a non-discriminated oneOf', () => {
       const spec: Spec = {
         ...sampleSpec,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -210,8 +210,8 @@ describe('openapi codegen data utils', () => {
       const compositeModel = data.models.find((m) => m.name === 'CompositePet');
       expect(compositeModel).toBeDefined();
       expect(compositeModel.export).toBe('all-of');
-      expect(compositeModel).toHaveProperty('composedModels');
-      expect(compositeModel).toHaveProperty('composedPrimitives');
+      expect(compositeModel.composedModels.map((m) => m.name)).toContain('Pet');
+      expect(compositeModel.composedPrimitives).toHaveLength(0);
     });
 
     it('should handle array and dictionary types', () => {
@@ -249,6 +249,87 @@ describe('openapi codegen data utils', () => {
       expect(dictModel).toBeDefined();
       expect(dictModel.export).toBe('dictionary');
       expect(dictModel.link).toBeDefined();
+    });
+
+    it('should build a value model for inline additionalProperties', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Counts: {
+              type: 'object',
+              additionalProperties: { type: 'integer' },
+            },
+          },
+        },
+      };
+
+      const model = buildOpenApiCodeGenData(spec).models.find(
+        (m) => m.name === 'Counts',
+      );
+      expect(model.export).toBe('dictionary');
+      expect(model.link).toMatchObject({ type: 'number' });
+    });
+
+    it('should build value models for patternProperties as an interface', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Patterned: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              ...{ patternProperties: { '^x-': { type: 'string' } } },
+            },
+          },
+        },
+      };
+
+      const model = buildOpenApiCodeGenData(spec).models.find(
+        (m) => m.name === 'Patterned',
+      );
+      // Mixing explicit + pattern properties makes it an interface.
+      expect(model.export).toBe('interface');
+      expect(model.hasPatternProperties).toBe(true);
+      expect(model.patternPropertiesModels).toEqual([
+        expect.objectContaining({
+          pattern: '^x-',
+          model: expect.objectContaining({ type: 'string' }),
+        }),
+      ]);
+    });
+
+    it('should build an item model for an inline jsonl streaming itemSchema', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/pets': {
+            get: {
+              operationId: 'streamPets',
+              responses: {
+                '200': {
+                  description: 'stream',
+                  content: {
+                    'application/jsonl': {
+                      schema: { type: 'string' },
+                      ...{ itemSchema: { $ref: '#/components/schemas/Pet' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const op = buildOpenApiCodeGenData(spec).allOperations.find(
+        (o) => o.name === 'streamPets',
+      );
+      const response = op.responses[0];
+      expect(response.isJsonlStreaming).toBe(true);
+      expect(response.itemSchemaModel).toMatchObject({ name: 'Pet' });
     });
 
     it('should handle operations without operationId', () => {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -710,6 +710,74 @@ describe('openapi codegen data utils', () => {
       );
     });
 
+    it('should throw when two properties map to the same TypeScript name', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Clashing: {
+              type: 'object',
+              properties: {
+                'foo-bar': { type: 'string' },
+                foo_bar: { type: 'number' },
+              },
+            },
+          },
+        },
+      };
+
+      expect(() => buildOpenApiCodeGenData(spec)).toThrow(
+        /both map to the TypeScript name "fooBar"/,
+      );
+    });
+
+    it('should throw when two parameters in one position map to the same name', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/x': {
+            get: {
+              operationId: 'getX',
+              parameters: [
+                { name: 'user-id', in: 'query', schema: { type: 'string' } },
+                { name: 'user_id', in: 'query', schema: { type: 'number' } },
+              ],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      };
+
+      expect(() => buildOpenApiCodeGenData(spec)).toThrow(
+        /both map to the TypeScript name "userId"/,
+      );
+    });
+
+    it('should allow a query and header parameter to share a name', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/x': {
+            get: {
+              operationId: 'getX',
+              parameters: [
+                { name: 'token', in: 'query', schema: { type: 'string' } },
+                { name: 'token', in: 'header', schema: { type: 'string' } },
+              ],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const op = data.allOperations.find((o) => o.name === 'getX')!;
+      // The two parameters live in separate request-position models, so they
+      // do not clash.
+      expect(op.parameters.filter((p) => p.name === 'token')).toHaveLength(2);
+    });
+
     it('should throw when a response is a composite of primitives', () => {
       const spec: Spec = {
         ...sampleSpec,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -363,6 +363,29 @@ describe('openapi codegen data utils', () => {
       expect(operation.name).toBe('getPets');
     });
 
+    it('should treat a requestBody with an empty content map as no body', () => {
+      const specWithEmptyContent: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/noop': {
+            post: {
+              operationId: 'doNoop',
+              requestBody: { content: {} },
+              responses: {
+                '200': { description: 'ok' },
+              },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(specWithEmptyContent);
+
+      const operation = data.allOperations[0];
+      expect(operation.parametersBody).toBeNull();
+      expect(operation.parameters).toHaveLength(0);
+    });
+
     it('should handle vendor extensions', () => {
       const specWithExtensions: Spec = {
         ...sampleSpec,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -317,7 +317,7 @@ describe('openapi codegen data utils', () => {
       );
 
       // Check operation level extensions
-      const operation = data.allOperations[0] as any;
+      const operation = data.allOperations[0];
       expect(operation.vendorExtensions).toHaveProperty(
         'x-custom-operation',
         'operation-value',

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -94,8 +94,8 @@ describe('openapi codegen data utils', () => {
       },
     };
 
-    it('should generate code gen data with correct structure', async () => {
-      const data = await buildOpenApiCodeGenData(sampleSpec);
+    it('should generate code gen data with correct structure', () => {
+      const data = buildOpenApiCodeGenData(sampleSpec);
 
       // Verify basic structure
       expect(data).toHaveProperty('info', sampleSpec.info);
@@ -105,8 +105,8 @@ describe('openapi codegen data utils', () => {
       expect(data).toHaveProperty('vendorExtensions');
     });
 
-    it('should process models correctly', async () => {
-      const data = await buildOpenApiCodeGenData(sampleSpec);
+    it('should process models correctly', () => {
+      const data = buildOpenApiCodeGenData(sampleSpec);
 
       // Find the Pet model
       const petModel = data.models.find((m) => m.name === 'Pet');
@@ -142,8 +142,8 @@ describe('openapi codegen data utils', () => {
       });
     });
 
-    it('should process operations correctly', async () => {
-      const data = await buildOpenApiCodeGenData(sampleSpec);
+    it('should process operations correctly', () => {
+      const data = buildOpenApiCodeGenData(sampleSpec);
 
       // Verify operations were processed
       expect(data.allOperations).toHaveLength(2);
@@ -183,7 +183,7 @@ describe('openapi codegen data utils', () => {
       });
     });
 
-    it('should handle composite models', async () => {
+    it('should handle composite models', () => {
       const specWithComposite: Spec = {
         ...sampleSpec,
         components: {
@@ -204,7 +204,7 @@ describe('openapi codegen data utils', () => {
         },
       };
 
-      const data = await buildOpenApiCodeGenData(specWithComposite);
+      const data = buildOpenApiCodeGenData(specWithComposite);
 
       // Find the composite model
       const compositeModel = data.models.find((m) => m.name === 'CompositePet');
@@ -214,7 +214,7 @@ describe('openapi codegen data utils', () => {
       expect(compositeModel).toHaveProperty('composedPrimitives');
     });
 
-    it('should handle array and dictionary types', async () => {
+    it('should handle array and dictionary types', () => {
       const specWithCollections: Spec = {
         ...sampleSpec,
         components: {
@@ -236,7 +236,7 @@ describe('openapi codegen data utils', () => {
         },
       };
 
-      const data = await buildOpenApiCodeGenData(specWithCollections);
+      const data = buildOpenApiCodeGenData(specWithCollections);
 
       // Check array type
       const arrayModel = data.models.find((m) => m.name === 'PetArray');
@@ -251,7 +251,7 @@ describe('openapi codegen data utils', () => {
       expect(dictModel.link).toBeDefined();
     });
 
-    it('should handle operations without operationId', async () => {
+    it('should handle operations without operationId', () => {
       const specWithoutOperationId: Spec = {
         ...sampleSpec,
         paths: {
@@ -275,14 +275,14 @@ describe('openapi codegen data utils', () => {
         },
       };
 
-      const data = await buildOpenApiCodeGenData(specWithoutOperationId);
+      const data = buildOpenApiCodeGenData(specWithoutOperationId);
 
       // Should generate an operation name based on path and method
       const operation = data.allOperations[0];
       expect(operation.name).toBe('getPets');
     });
 
-    it('should handle vendor extensions', async () => {
+    it('should handle vendor extensions', () => {
       const specWithExtensions: Spec = {
         ...sampleSpec,
         ...{ 'x-custom-root': 'root-value' },
@@ -308,7 +308,7 @@ describe('openapi codegen data utils', () => {
         },
       };
 
-      const data = await buildOpenApiCodeGenData(specWithExtensions);
+      const data = buildOpenApiCodeGenData(specWithExtensions);
 
       // Check root level extensions
       expect(data.vendorExtensions).toHaveProperty(
@@ -342,8 +342,8 @@ describe('openapi codegen data utils', () => {
       );
     });
 
-    it('should classify operations as query or mutation by method', async () => {
-      const data = await buildOpenApiCodeGenData(sampleSpec);
+    it('should classify operations as query or mutation by method', () => {
+      const data = buildOpenApiCodeGenData(sampleSpec);
 
       const listPetsOp = data.allOperations.find(
         (op) => op.name === 'listPets',
@@ -356,7 +356,7 @@ describe('openapi codegen data utils', () => {
       expect(createPetOp).toMatchObject({ isQuery: false, isMutation: true });
     });
 
-    it('should let x-query and x-mutation override the method default', async () => {
+    it('should let x-query and x-mutation override the method default', () => {
       const specWithOverrides: Spec = {
         ...sampleSpec,
         paths: {
@@ -400,7 +400,7 @@ describe('openapi codegen data utils', () => {
         },
       };
 
-      const data = await buildOpenApiCodeGenData(specWithOverrides);
+      const data = buildOpenApiCodeGenData(specWithOverrides);
 
       const getOp = data.allOperations.find((op) => op.name === 'listPets');
       expect(getOp).toMatchObject({ isMutation: true, isQuery: false });
@@ -441,16 +441,16 @@ describe('openapi codegen data utils', () => {
       },
     });
 
-    it('should treat a query with a cursor parameter as an infinite query', async () => {
-      const data = await buildOpenApiCodeGenData(paginatedSpec({}));
+    it('should treat a query with a cursor parameter as an infinite query', () => {
+      const data = buildOpenApiCodeGenData(paginatedSpec({}));
 
       const op = data.allOperations.find((o) => o.name === 'listPets');
       expect(op.isInfiniteQuery).toBe(true);
       expect(op.infiniteQueryCursorProperty).toMatchObject({ name: 'cursor' });
     });
 
-    it('should page on the property named by a string x-cursor', async () => {
-      const data = await buildOpenApiCodeGenData(
+    it('should page on the property named by a string x-cursor', () => {
+      const data = buildOpenApiCodeGenData(
         paginatedSpec({ 'x-cursor': 'nextToken' }, 'nextToken'),
       );
 
@@ -461,8 +461,8 @@ describe('openapi codegen data utils', () => {
       });
     });
 
-    it('should page on the property named by x-cursor inputToken', async () => {
-      const data = await buildOpenApiCodeGenData(
+    it('should page on the property named by x-cursor inputToken', () => {
+      const data = buildOpenApiCodeGenData(
         paginatedSpec({ 'x-cursor': { inputToken: 'nextToken' } }, 'nextToken'),
       );
 
@@ -473,8 +473,8 @@ describe('openapi codegen data utils', () => {
       });
     });
 
-    it('should disable pagination when x-cursor is false', async () => {
-      const data = await buildOpenApiCodeGenData(
+    it('should disable pagination when x-cursor is false', () => {
+      const data = buildOpenApiCodeGenData(
         paginatedSpec({ 'x-cursor': false }),
       );
 
@@ -483,14 +483,162 @@ describe('openapi codegen data utils', () => {
       expect(op.infiniteQueryCursorProperty).toBeUndefined();
     });
 
-    it('should disable pagination when x-cursor sets enabled to false', async () => {
-      const data = await buildOpenApiCodeGenData(
+    it('should disable pagination when x-cursor sets enabled to false', () => {
+      const data = buildOpenApiCodeGenData(
         paginatedSpec({ 'x-cursor': { enabled: false } }),
       );
 
       const op = data.allOperations.find((o) => o.name === 'listPets');
       expect(op.isInfiniteQuery).toBe(false);
       expect(op.infiniteQueryCursorProperty).toBeUndefined();
+    });
+
+    it('should not be an infinite query when the named cursor param is absent', () => {
+      const data = buildOpenApiCodeGenData(
+        paginatedSpec({ 'x-cursor': 'missing' }, 'cursor'),
+      );
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isInfiniteQuery).toBe(false);
+    });
+
+    it('should not treat a mutation with a cursor parameter as an infinite query', () => {
+      const data = buildOpenApiCodeGenData(
+        paginatedSpec({ 'x-mutation': true }),
+      );
+
+      const op = data.allOperations.find((o) => o.name === 'listPets');
+      expect(op.isMutation).toBe(true);
+      expect(op.isInfiniteQuery).toBeFalsy();
+    });
+
+    it('should treat a 3.1 [T, "null"] type array as a nullable primary type T', () => {
+      const spec: Spec = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            Nullable: {
+              type: 'object',
+              properties: { bar: { type: ['string', 'null'] } },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const bar = data.models
+        .find((m) => m.name === 'Nullable')
+        .properties.find((p) => p.name === 'bar');
+      expect(bar).toMatchObject({ type: 'string', isNullable: true });
+    });
+
+    const specWithParameterisedOperation = (): Spec => ({
+      ...sampleSpec,
+      paths: {
+        '/pets': {
+          post: {
+            operationId: 'createPet',
+            parameters: [
+              { name: 'limit', in: 'query', schema: { type: 'integer' } },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    it('should use the standard Request suffix when the name is free', () => {
+      const data = buildOpenApiCodeGenData(specWithParameterisedOperation());
+
+      const op = data.allOperations.find((o) => o.name === 'createPet');
+      expect(op.requestTypeName).toBe('CreatePetRequest');
+    });
+
+    it('should use the OperationRequest suffix when Request clashes with a schema', () => {
+      const spec: Spec = {
+        ...specWithParameterisedOperation(),
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            CreatePetRequest: { type: 'object', properties: {} },
+          },
+        },
+      };
+
+      const op = buildOpenApiCodeGenData(spec).allOperations.find(
+        (o) => o.name === 'createPet',
+      );
+      expect(op.requestTypeName).toBe('CreatePetOperationRequest');
+    });
+
+    it('should throw for anyOf composing multiple non-primitive arrays', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            TwoArrays: {
+              anyOf: [
+                { type: 'array', items: { $ref: '#/components/schemas/Pet' } },
+                {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/NewPet' },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      expect(() => buildOpenApiCodeGenData(spec)).toThrow(
+        /multiple array types/,
+      );
+    });
+
+    it('should throw when a response is a composite of primitives', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/pets': {
+            get: {
+              operationId: 'listPets',
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/StringOrNumber' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            StringOrNumber: {
+              oneOf: [{ type: 'string' }, { type: 'number' }],
+            },
+          },
+        },
+      };
+
+      expect(() => buildOpenApiCodeGenData(spec)).toThrow(
+        /composite schema of primitives/,
+      );
     });
   });
 });

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -778,6 +778,115 @@ describe('openapi codegen data utils', () => {
       expect(op.parameters.filter((p) => p.name === 'token')).toHaveLength(2);
     });
 
+    it('should build discriminator metadata for a discriminated oneOf', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Cat: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' }, meow: { type: 'boolean' } },
+            },
+            Dog: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' }, bark: { type: 'boolean' } },
+            },
+            Animal: {
+              oneOf: [
+                { $ref: '#/components/schemas/Cat' },
+                { $ref: '#/components/schemas/Dog' },
+              ],
+              discriminator: {
+                propertyName: 'kind',
+                mapping: {
+                  cat: '#/components/schemas/Cat',
+                  dog: '#/components/schemas/Dog',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const animal = data.models.find((m) => m.name === 'Animal')!;
+      expect(animal.discriminator).toEqual({
+        propertyName: 'kind',
+        typescriptPropertyName: 'kind',
+        mapping: [
+          { value: 'cat', modelName: 'Cat' },
+          { value: 'dog', modelName: 'Dog' },
+        ],
+      });
+    });
+
+    it('should build implicit discriminator mapping from member names', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Cat: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' } },
+            },
+            Dog: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' } },
+            },
+            Animal: {
+              oneOf: [
+                { $ref: '#/components/schemas/Cat' },
+                { $ref: '#/components/schemas/Dog' },
+              ],
+              discriminator: { propertyName: 'kind' },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const animal = data.models.find((m) => m.name === 'Animal')!;
+      expect(animal.discriminator?.mapping).toEqual([
+        { value: 'Cat', modelName: 'Cat' },
+        { value: 'Dog', modelName: 'Dog' },
+      ]);
+    });
+
+    it('should not build discriminator metadata for a non-discriminated oneOf', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Cat: {
+              type: 'object',
+              properties: { meow: { type: 'boolean' } },
+            },
+            Dog: {
+              type: 'object',
+              properties: { bark: { type: 'boolean' } },
+            },
+            Animal: {
+              oneOf: [
+                { $ref: '#/components/schemas/Cat' },
+                { $ref: '#/components/schemas/Dog' },
+              ],
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const animal = data.models.find((m) => m.name === 'Animal')!;
+      expect(animal.discriminator).toBeUndefined();
+    });
+
     it('should throw when a response is a composite of primitives', () => {
       const spec: Spec = {
         ...sampleSpec,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -61,33 +61,26 @@ const compositeMemberSchemas = (
 export const buildOpenApiCodeGenData = (
   inSpec: Spec,
 ): CodeGenData => {
-  // Ensure spec is ready for codegen
   const spec = normaliseOpenApiSpecForCodeGen(inSpec);
-
-  // Build the initial data, which we will augment with additional information
   const data = buildClientData(spec);
 
-  // Ensure the models have their links set when they are arrays/dictionaries
+  // Set array/dictionary links and composite members before augmentation reads
+  // them.
   ensureModelLinks(spec, data);
-
-  // Resolve the composed models/primitives for composite schemas so the
-  // templates can render them
   resolveComposedModels(data);
 
   const modelsByName = Object.fromEntries(data.models.map((m) => [m.name, m]));
 
-  // Augment each service's operations with additional data
   for (const service of data.services) {
     augmentService(spec, service, modelsByName);
   }
 
-  // All operations across all services
   const allOperations = uniqBy(
     data.services.flatMap((s) => s.operations),
     (o) => o.uniqueName,
   );
 
-  // Add additional models for each operation's request parameters
+  // A model per operation request parameter position (query/path/body/...).
   data.models = [
     ...data.models,
     ...allOperations.flatMap((op) =>
@@ -95,8 +88,6 @@ export const buildOpenApiCodeGenData = (
     ),
   ];
 
-  // Augment every model (including the request parameter models just added)
-  // with schema-derived and language-specific data
   for (const model of data.models) {
     augmentModel(spec, model, modelsByName);
   }
@@ -105,10 +96,8 @@ export const buildOpenApiCodeGenData = (
     model.typescriptType = model.typescriptName;
   }
 
-  // Order models lexicographically by name
   data.models = orderBy(data.models, (d) => d.name);
-
-  // Order services so default appears first, then otherwise by name
+  // Default service first, then by name.
   data.services = orderBy(data.services, (s) =>
     s.name === 'Default' ? '' : s.name,
   );
@@ -122,7 +111,7 @@ export const buildOpenApiCodeGenData = (
     untaggedOperations,
     info: spec.info,
     allOperations,
-    vendorExtensions: extractVendorExtensions(spec),
+    vendorExtensions: vendorExtensionsOf(spec ?? {}),
     className: toClassName(spec.info.title),
   };
 };
@@ -137,20 +126,14 @@ const augmentService = (
   service: Service,
   modelsByName: { [name: string]: Model },
 ): void => {
-  // Model names each operation needs to import, accumulated across operations
-  const modelImports: string[] = [];
+  const modelImports = service.operations.flatMap((op) =>
+    augmentOperation(spec, op, modelsByName),
+  );
 
-  for (const op of service.operations) {
-    modelImports.push(...augmentOperation(spec, op, modelsByName));
-  }
-
-  // Lexicographical ordering of operations
   service.operations = orderBy(service.operations, (op) => op.uniqueName);
-
   service.modelImports = orderBy(
     uniqBy([...service.imports, ...modelImports], (x) => x),
   );
-
   service.className = `${service.name}Api`;
   service.nameSnakeCase = snakeCase(service.name);
 };
@@ -168,40 +151,30 @@ const augmentOperation = (
 
   assignOperationNames(op, specOp);
 
-  // Add vendor extensions
-  op.vendorExtensions = op.vendorExtensions ?? {};
-  copyVendorExtensions(specOp ?? {}, op.vendorExtensions);
+  op.vendorExtensions = vendorExtensionsOf(specOp ?? {});
 
-  const modelImports: string[] = [];
-  if (specOp) {
-    modelImports.push(...augmentResponses(spec, op, specOp, modelsByName));
-  }
-  modelImports.push(...augmentParameters(spec, op, specOp, modelsByName));
+  const modelImports = [
+    ...(specOp ? augmentResponses(spec, op, specOp, modelsByName) : []),
+    ...augmentParameters(spec, op, specOp, modelsByName),
+  ];
 
-  // Add language types to response models
   op.responses.forEach(addLanguageTypes);
-
-  // Sort responses by code
   op.responses = orderBy(op.responses, (r) => r.code);
-  // Result is the lowest successful response, otherwise the 2XX or default response
-  const result = op.responses.find(
-    (r) => typeof r.code === 'number' && r.code >= 200 && r.code < 300,
-  );
-  op.result =
-    result ??
-    op.responses.find((r) => r.code === '2XX' || r.code === 'default');
 
-  // Add variants of operation name (after uniqueName is set)
+  // Result is the lowest successful response, otherwise the 2XX or default.
+  op.result =
+    op.responses.find(
+      (r) => typeof r.code === 'number' && r.code >= 200 && r.code < 300,
+    ) ?? op.responses.find((r) => r.code === '2XX' || r.code === 'default');
+
   op.operationIdPascalCase = pascalCase(op.uniqueName);
   op.operationIdSnakeCase = toPythonName('operation', op.uniqueName);
 
-  // Add request type name (after operationIdPascalCase is set)
-  if (op.parameters && op.parameters.length > 0) {
+  if (op.parameters.length > 0) {
     const baseRequestTypeName = `${op.operationIdPascalCase}Request`;
-    const hasConflict = !!spec.components?.schemas?.[baseRequestTypeName];
     // Use the OperationRequest suffix when the standard Request name clashes
-    // with an existing schema, otherwise the standard Request suffix.
-    op.requestTypeName = hasConflict
+    // with an existing schema.
+    op.requestTypeName = spec.components?.schemas?.[baseRequestTypeName]
       ? `${op.operationIdPascalCase}OperationRequest`
       : baseRequestTypeName;
   }
@@ -219,19 +192,15 @@ const assignOperationNames = (
   op: Operation,
   specOp: OpenAPIV3.OperationObject | undefined,
 ): void => {
-  op.name = op.id ?? op.name;
-  op.uniqueName = op.name;
-
   const deduplicatedOpId = specOp?.['x-aws-nx-deduplicated-op-id'] as
     | string
     | undefined;
-  if (deduplicatedOpId) {
-    op.uniqueName = deduplicatedOpId;
-  }
-
   const dotNotationOpId = specOp?.['x-aws-nx-deduplicated-dot-op-id'] as
     | string
     | undefined;
+
+  op.name = op.id ?? op.name;
+  op.uniqueName = deduplicatedOpId ?? op.name;
   if (dotNotationOpId) {
     op.dotNotationName = dotNotationOpId;
   }
@@ -461,20 +430,16 @@ const buildRequestParameterModels = (
     );
   };
 
-  // Group the parameters we will create models for by their position (ie 'in'
-  // in the openapi spec, eg body, query, path, header, etc)
-  const parametersByPosition: { [position: string]: Model[] } = {};
-  for (const parameter of op.parameters) {
-    if (parameter.in === 'body' && canInlineBody(parameter)) {
-      continue;
-    }
-    parametersByPosition[parameter.in] = [
-      ...(parametersByPosition[parameter.in] ?? []),
-      parameter,
-    ];
-  }
+  // Group parameters by their position (`in`: query/path/header/cookie/body),
+  // dropping any body that can be inlined.
+  const parametersByPosition = op.parameters
+    .filter((p) => !(p.in === 'body' && canInlineBody(p)))
+    .reduce<{ [position: string]: Model[] }>(
+      (acc, p) => ({ ...acc, [p.in]: [...(acc[p.in] ?? []), p] }),
+      {},
+    );
 
-  // Ensure that if we have an explicit (non-inlined) body parameter, it's called "body"
+  // An explicit (non-inlined) body parameter is named "body".
   const requestBodyParameter = parametersByPosition['body']?.[0];
   if (requestBodyParameter) {
     requestBodyParameter.name = 'body';
@@ -504,7 +469,6 @@ const augmentModel = (
   model: Model,
   modelsByName: { [name: string]: Model },
 ): void => {
-  // Add a snake_case name
   model.nameSnakeCase = toPythonName('model', model.name);
 
   const matchingSpecModel = spec?.components?.schemas?.[model.name];
@@ -512,25 +476,17 @@ const augmentModel = (
     const specModel = resolveIfRef(spec, matchingSpecModel);
 
     augmentModelFromSchema(spec, model, specModel, modelsByName);
-
     model.deprecated = specModel.deprecated || false;
 
-    // Augment properties with schema-derived data
     for (const property of model.properties) {
       const matchingSpecProperty = specModel.properties?.[property.name];
       if (matchingSpecProperty) {
         const specProperty = resolveIfRef(spec, matchingSpecProperty);
-        augmentModelFromSchema(
-          spec,
-          property,
-          specProperty,
-          modelsByName,
-        );
+        augmentModelFromSchema(spec, property, specProperty, modelsByName);
       }
     }
   }
 
-  // Add language-specific names/types to properties
   model.properties.forEach(addLanguageTypes);
 };
 
@@ -544,28 +500,20 @@ const groupOperationsByTag = (
   operationsByTag: { [tag: string]: Operation[] };
   untaggedOperations: Operation[];
 } => {
-  const operationsByTag: { [tag: string]: Operation[] } = {};
-  const untaggedOperations: Operation[] = [];
-  allOperations.forEach((op) => {
-    const tags = op.tags;
-    if (tags && tags.length > 0) {
-      tags.map(camelCase).forEach((tag) => {
-        operationsByTag[tag] = [...(operationsByTag[tag] ?? []), op];
-      });
-    } else {
-      untaggedOperations.push(op);
-    }
-  });
-  return { operationsByTag, untaggedOperations };
-};
+  const isTagged = (op: Operation): boolean => !!op.tags && op.tags.length > 0;
 
-/**
- * Collect the top-level vendor extensions (`x-*`) declared on the spec.
- */
-const extractVendorExtensions = (spec: Spec): VendorExtensions => {
-  const vendorExtensions: VendorExtensions = {};
-  copyVendorExtensions(spec ?? {}, vendorExtensions);
-  return vendorExtensions;
+  const operationsByTag = allOperations
+    .filter(isTagged)
+    .flatMap((op) => op.tags!.map((tag) => [camelCase(tag), op] as const))
+    .reduce<{ [tag: string]: Operation[] }>(
+      (acc, [tag, op]) => ({ ...acc, [tag]: [...(acc[tag] ?? []), op] }),
+      {},
+    );
+
+  return {
+    operationsByTag,
+    untaggedOperations: allOperations.filter((op) => !isTagged(op)),
+  };
 };
 
 /**
@@ -636,18 +584,12 @@ const getSpecOperation = (
   ];
 
 /**
- * Copy vendor extensions from the first parameter to the second
+ * The `x-*` vendor extensions declared on an object.
  */
-const copyVendorExtensions = (
-  object: object,
-  vendorExtensions: VendorExtensions,
-) => {
-  Object.entries(object ?? {}).forEach(([key, value]) => {
-    if (key.startsWith('x-')) {
-      vendorExtensions[key] = value;
-    }
-  });
-};
+const vendorExtensionsOf = (object: object): VendorExtensions =>
+  Object.fromEntries(
+    Object.entries(object ?? {}).filter(([key]) => key.startsWith('x-')),
+  );
 
 const augmentModelFromSchema = (
   spec: Spec,
@@ -660,10 +602,7 @@ const augmentModelFromSchema = (
   model.deprecated = !!schema.deprecated;
   model.openapiType = schema.type;
   model.isEnum = !!schema.enum && schema.enum.length > 0;
-
-  // Copy any schema vendor extensions
-  model.vendorExtensions = {};
-  copyVendorExtensions(schema, model.vendorExtensions);
+  model.vendorExtensions = vendorExtensionsOf(schema);
 
   // A "dictionary" has only additional properties; an "interface" may mix
   // explicit and additional properties.
@@ -694,41 +633,31 @@ const augmentModelFromSchema = (
   }
 
   // Pattern properties can have different value types per pattern, so the model
-  // is an interface rather than a dictionary
+  // is an interface rather than a dictionary.
   if (schema.patternProperties) {
     const patternProperties = resolveIfRef(spec, schema.patternProperties);
-
-    const patternPropertiesModels: PatternPropertyModel[] = [];
 
     if (model.export === 'dictionary') {
       model.export = 'interface';
     }
 
-    for (const [pattern, patternProperty] of Object.entries(
-      patternProperties,
-    )) {
-      const patternPropertyModel = buildOrReferenceModel(
-        spec,
-        modelsByName,
-        patternProperty,
-      );
-      if (patternPropertyModel) {
-        patternPropertiesModels.push({
-          pattern,
-          model: patternPropertyModel,
-        });
-      }
-    }
-
     model.hasPatternProperties = true;
-    model.patternPropertiesModels = patternPropertiesModels;
+    model.patternPropertiesModels = Object.entries(patternProperties)
+      .map(([pattern, patternProperty]) => ({
+        pattern,
+        model: buildOrReferenceModel(spec, modelsByName, patternProperty),
+      }))
+      .filter((entry): entry is PatternPropertyModel => !!entry.model);
   }
 
   addLanguageTypes(model);
 
   visited.add(model);
 
-  // Also apply to array items recursively
+  const recurse = (target: Model, subSchema: OpenApiSchema): void =>
+    augmentModelFromSchema(spec, target, subSchema, modelsByName, visited);
+
+  // Array element type.
   if (
     model.export === 'array' &&
     model.link &&
@@ -736,17 +665,11 @@ const augmentModelFromSchema = (
     schema.items &&
     !visited.has(model.link)
   ) {
-    const subSchema = resolveIfRef(spec, schema.items);
-    augmentModelFromSchema(
-      spec,
-      model.link,
-      subSchema,
-      modelsByName,
-      visited,
-    );
+    recurse(model.link, resolveIfRef(spec, schema.items));
   }
 
-  // Also apply to object properties recursively
+  // Dictionary value type (additionalProperties may be `true` rather than a
+  // schema).
   if (
     model.export === 'dictionary' &&
     model.link &&
@@ -755,48 +678,28 @@ const augmentModelFromSchema = (
     !visited.has(model.link)
   ) {
     const subSchema = resolveIfRef(spec, schema.additionalProperties);
-    // Additional properties can be "true" rather than a type
     if (subSchema !== true) {
-      augmentModelFromSchema(
-        spec,
-        model.link,
-        subSchema,
-        modelsByName,
-        visited,
-      );
+      recurse(model.link, subSchema);
     }
   }
 
-  for (const property of model.properties.filter(
-    (p) => !visited.has(p) && schema.properties?.[trim(p.name, `"'`)],
-  )) {
-    const subSchema = resolveIfRef(
-      spec,
-      schema.properties![trim(property.name, `"'`)],
+  model.properties
+    .filter((p) => !visited.has(p) && schema.properties?.[trim(p.name, `"'`)])
+    .forEach((property) =>
+      recurse(
+        property,
+        resolveIfRef(spec, schema.properties![trim(property.name, `"'`)]),
+      ),
     );
-    augmentModelFromSchema(
-      spec,
-      property,
-      subSchema,
-      modelsByName,
-      visited,
-    );
-  }
 
   if (COMPOSED_SCHEMA_TYPES.has(model.export)) {
     const memberSchemas = compositeMemberSchemas(schema, model.export);
-    for (let i = 0; i < model.properties.length; i++) {
+    model.properties.forEach((property, i) => {
       const subSchema = resolveIfRef(spec, memberSchemas[i]);
       if (subSchema) {
-        augmentModelFromSchema(
-          spec,
-          model.properties[i],
-          subSchema,
-          modelsByName,
-          visited,
-        );
+        recurse(property, subSchema);
       }
-    }
+    });
   }
 };
 
@@ -960,9 +863,8 @@ const ensureModelLink = (
 };
 
 /**
- * Mutates the given data to ensure composite models (ie allOf, oneOf, anyOf) have the necessary
- * properties for representing them in generated code. Adds `composedModels` and `composedPrimitives`
- * which contain the models and primitive types that each model is composed of.
+ * Populate `composedModels` and `composedPrimitives` on each composite model
+ * (allOf/anyOf/oneOf) with the models and primitive types it is composed of.
  */
 const resolveComposedModels = (data: ClientData) => {
   const visited = new Set<Model>();
@@ -974,74 +876,59 @@ const resolveComposedModel = (
   model: Model,
   visited: Set<Model>,
 ) => {
-  if (COMPOSED_SCHEMA_TYPES.has(model.export) && !visited.has(model)) {
-    visited.add(model);
-
-    // Find the models/primitives which this is composed from
-    const composedModelReferences = model.properties.filter(
-      (p) => !p.name && p.export === 'reference',
-    );
-    const composedPrimitives = model.properties.filter(
-      (p) => !p.name && p.export !== 'reference',
-    );
-
-    const modelsByName = Object.fromEntries(
-      data.models.map((m) => [m.name, m]),
-    );
-    let composedModels = composedModelReferences.flatMap((r) =>
-      modelsByName[r.type] ? [modelsByName[r.type]] : [],
-    );
-    // Resolve recursively so all-of mixins include nested all-of properties
-    composedModels.forEach((m) => resolveComposedModel(data, m, visited));
-
-    // Enums serialise as primitives, so group them with the primitives
-    composedPrimitives.push(
-      ...composedModels.filter((m) => m.export === 'enum'),
-    );
-    composedModels = composedModels.filter((m) => m.export !== 'enum');
-
-    // Composing multiple arrays of non-primitives is not distinguishable at
-    // runtime, so it's validated away below.
-    // TODO: honour `discriminator` to support this case.
-    const isPrimitiveArray = (m: Model) => {
-      if (m.link && ['array', 'dictionary'].includes(m.export)) {
-        return isPrimitiveArray(m.link);
-      }
-      return (
-        PRIMITIVE_TYPES.has(m.type) &&
-        !['date', 'date-time'].includes(m.format ?? '')
-      );
-    };
-    const arrayComposedModels = composedPrimitives.filter(
-      (m) => m.export === 'array' && !isPrimitiveArray(m),
-    );
-    if (arrayComposedModels.length > 1) {
-      throw new Error(
-        `Schema "${model.name}" defines ${camelCase(model.export)} with multiple array types which cannot be distinguished at runtime.`,
-      );
-    }
-
-    // For all-of models, we include all composed model properties.
-    if (model.export === 'all-of') {
-      if (composedPrimitives.length > 0) {
-        throw new Error(
-          `Schema "${model.name}" defines allOf with non-object types. allOf may only compose object types in the OpenAPI specification.`,
-        );
-      }
-    }
-
-    model.composedModels = composedModels;
-    model.composedPrimitives = composedPrimitives;
+  if (!COMPOSED_SCHEMA_TYPES.has(model.export) || visited.has(model)) {
+    return;
   }
+  visited.add(model);
+
+  const members = model.properties.filter((p) => !p.name);
+  const modelsByName = Object.fromEntries(data.models.map((m) => [m.name, m]));
+  const referenced = members
+    .filter((p) => p.export === 'reference')
+    .flatMap((r) => (modelsByName[r.type] ? [modelsByName[r.type]] : []));
+
+  // Resolve recursively so all-of mixins include nested all-of properties
+  referenced.forEach((m) => resolveComposedModel(data, m, visited));
+
+  // Enums serialise as primitives, so group them with the primitives
+  const composedModels = referenced.filter((m) => m.export !== 'enum');
+  const composedPrimitives = [
+    ...members.filter((p) => p.export !== 'reference'),
+    ...referenced.filter((m) => m.export === 'enum'),
+  ];
+
+  // Composing multiple arrays of non-primitives is not distinguishable at
+  // runtime, so it's validated away.
+  // TODO: honour `discriminator` to support this case.
+  const isPrimitiveArray = (m: Model): boolean =>
+    m.link && ['array', 'dictionary'].includes(m.export)
+      ? isPrimitiveArray(m.link)
+      : PRIMITIVE_TYPES.has(m.type) &&
+        !['date', 'date-time'].includes(m.format ?? '');
+  const arrayComposedModels = composedPrimitives.filter(
+    (m) => m.export === 'array' && !isPrimitiveArray(m),
+  );
+  if (arrayComposedModels.length > 1) {
+    throw new Error(
+      `Schema "${model.name}" defines ${camelCase(model.export)} with multiple array types which cannot be distinguished at runtime.`,
+    );
+  }
+
+  if (model.export === 'all-of' && composedPrimitives.length > 0) {
+    throw new Error(
+      `Schema "${model.name}" defines allOf with non-object types. allOf may only compose object types in the OpenAPI specification.`,
+    );
+  }
+
+  model.composedModels = composedModels;
+  model.composedPrimitives = composedPrimitives;
 };
 
 /**
- * Mutates the given model to add language specific types and names
+ * Add language-specific names and types to a model.
  */
 const addLanguageTypes = (model: Model) => {
-  // Trim any surrounding quotes from name
   model.name = trim(model.name, `"'`);
-
   model.typescriptName = toTypeScriptName(model.name);
   model.typescriptType = toTypeScriptType(model);
   model.pythonName = toPythonName('property', model.name);
@@ -1092,33 +979,23 @@ const augmentInfiniteQuery = (op: Operation) => {
  * - `'property'` / `{ inputToken: 'property' }` — the input property to page on
  * - `false` / `{ enabled: false }` — disable pagination
  */
-const getCursorOptions = (op: Operation) => {
-  const cursorExtension = op.vendorExtensions?.[VENDOR_EXTENSIONS.CURSOR];
+const getCursorOptions = (
+  op: Operation,
+): { paginationDisabled: boolean; cursorPropertyName: string } => {
+  const cursor = op.vendorExtensions?.[VENDOR_EXTENSIONS.CURSOR];
 
-  // Defaults: pagination enabled, paging on a property named 'cursor'
-  let paginationDisabled = false;
-  let cursorPropertyName = 'cursor';
-
-  if (cursorExtension === false) {
-    paginationDisabled = true;
-  } else if (typeof cursorExtension === 'string') {
-    cursorPropertyName = cursorExtension;
-  } else if (cursorExtension && typeof cursorExtension === 'object') {
-    const cursorOptions = cursorExtension as {
-      enabled?: boolean;
-      inputToken?: unknown;
-    };
-    if (cursorOptions.enabled === false) {
-      paginationDisabled = true;
-    }
-    if (typeof cursorOptions.inputToken === 'string') {
-      cursorPropertyName = cursorOptions.inputToken;
-    }
+  // Defaults: pagination enabled, paging on a property named 'cursor'.
+  if (cursor === false) {
+    return { paginationDisabled: true, cursorPropertyName: 'cursor' };
   }
-
+  if (typeof cursor === 'string') {
+    return { paginationDisabled: false, cursorPropertyName: cursor };
+  }
+  const options = (cursor ?? {}) as { enabled?: boolean; inputToken?: unknown };
   return {
-    paginationDisabled,
-    cursorPropertyName,
+    paginationDisabled: options.enabled === false,
+    cursorPropertyName:
+      typeof options.inputToken === 'string' ? options.inputToken : 'cursor',
   };
 };
 

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -22,7 +22,6 @@ import {
   toTypeScriptType,
 } from './codegen-data/languages';
 import {
-  type ClientData,
   COLLECTION_TYPES,
   COMPOSED_SCHEMA_TYPES,
   type CodeGenData,
@@ -31,7 +30,6 @@ import {
   DEFAULT_SERVICE_NAME,
   indexModelsByName,
   type Model,
-  type ModelExport,
   type ModelsByName,
   type Operation,
   type PatternPropertyModel,
@@ -42,35 +40,23 @@ import {
   type VendorExtensions,
 } from './codegen-data/types';
 import { normaliseOpenApiSpecForCodeGen } from './normalise';
-import { buildClientData } from './parser';
+import {
+  buildClientData,
+  buildInlineModel,
+  compositeMemberSchemas,
+  getSpecOperation,
+  getSpecParametersByName,
+  linkModel,
+} from './parser';
 import { isRef, resolveIfRef, splitRef } from './refs';
 import type { OpenApiSchema, OpenApiSchemaOrRef, Spec } from './types';
 
 /**
- * Return the member sub-schemas of a composite (allOf/anyOf/oneOf) schema, in
- * order, for the given composite `export` kind.
- */
-const compositeMemberSchemas = (
-  schema: OpenApiSchema,
-  compositeExport: ModelExport,
-): OpenApiSchemaOrRef[] => {
-  const keyword = camelCase(compositeExport) as 'allOf' | 'anyOf' | 'oneOf';
-  return (schema[keyword] as OpenApiSchemaOrRef[] | undefined) ?? [];
-};
-
-/**
  * Build the data structure used to generate code from an OpenAPI spec.
  */
-export const buildOpenApiCodeGenData = (
-  inSpec: Spec,
-): CodeGenData => {
+export const buildOpenApiCodeGenData = (inSpec: Spec): CodeGenData => {
   const spec = normaliseOpenApiSpecForCodeGen(inSpec);
   const data = buildClientData(spec);
-
-  // Set array/dictionary links and composite members before augmentation reads
-  // them.
-  ensureModelLinks(spec, data);
-  resolveComposedModels(data);
 
   const modelsByName = indexModelsByName(data.models);
 
@@ -303,7 +289,12 @@ const augmentParameters = (
     const specParameter = specParametersByName[parameter.prop];
     const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
     if (specParameterSchema) {
-      augmentModelFromSchema(spec, parameter, specParameterSchema, modelsByName);
+      augmentModelFromSchema(
+        spec,
+        parameter,
+        specParameterSchema,
+        modelsByName,
+      );
     }
 
     if (parameter.in === 'body') {
@@ -504,42 +495,9 @@ const groupOperationsByTag = (
 };
 
 /**
- * Build a model for a particular primitive schema.
- * Only primitives are supported since we only return one model.
- * For non-primitives, it assumes all referenced subschemas are already models
+ * Resolve a schema to its model: an existing named model for a `$ref`, or a
+ * freshly built-and-augmented model for an inline (nested value) schema.
  */
-const buildModelForPrimitive = (
-  originalSpec: Spec,
-  schema: OpenApiSchema,
-): Model => {
-  const targetSchemaName = '___aws_nx_plugin_openapi_tmp_schema___';
-
-  const spec: Spec = {
-    openapi: '3.1.0',
-    info: { title: 'tmp', version: '1.0.0' },
-    paths: {},
-    components: {
-      schemas: {
-        ...originalSpec.components?.schemas,
-        [targetSchemaName]: schema,
-      },
-    },
-  };
-  const data = buildClientData(spec);
-
-  const model = data.models.find((m) => m.name === targetSchemaName);
-  if (!model) {
-    throw new Error(
-      `Failed to construct model for schema ${JSON.stringify(schema)}`,
-    );
-  }
-
-  ensureModelLinks(spec, data);
-  augmentModelFromSchema(spec, model, schema, indexModelsByName(data.models));
-
-  return model;
-};
-
 const buildOrReferenceModel = (
   spec: Spec,
   modelsByName: ModelsByName,
@@ -549,35 +507,11 @@ const buildOrReferenceModel = (
     const name = splitRef(schema.$ref)[2];
     return modelsByName[name];
   }
-  // Non referenced schemas won't have a top-level model created as they are
-  // primitives, so we build the model here
-  return buildModelForPrimitive(spec, schema);
+  const model = buildInlineModel(spec, schema);
+  linkModel(spec, modelsByName, model, schema);
+  augmentModelFromSchema(spec, model, schema, modelsByName);
+  return model;
 };
-
-/**
- * Look up the spec operation object for a parsed operation.
- */
-const getSpecOperation = (
-  spec: Spec,
-  op: Operation,
-): OpenAPIV3.OperationObject | undefined =>
-  (spec.paths?.[op.path] as OpenAPIV3.PathItemObject | undefined)?.[
-    op.method.toLowerCase() as OpenAPIV3.HttpMethods
-  ];
-
-/**
- * An operation's resolved parameters indexed by name.
- */
-const getSpecParametersByName = (
-  spec: Spec,
-  specOp: OpenAPIV3.OperationObject | undefined,
-): { [name: string]: OpenAPIV3.ParameterObject } =>
-  Object.fromEntries(
-    (specOp?.parameters ?? []).map((p) => {
-      const param = resolveIfRef(spec, p);
-      return [param.name, param];
-    }),
-  );
 
 /**
  * The `x-*` vendor extensions declared on an object.
@@ -697,223 +631,6 @@ const augmentModelFromSchema = (
       }
     });
   }
-};
-
-/**
- * Ensure that the "link" property of all dictionary/array models and properties are set recursively
- */
-const ensureModelLinks = (spec: Spec, data: ClientData) => {
-  const modelsByName = indexModelsByName(data.models);
-  const visited = new Set<Model>();
-
-  // Ensure set for all models
-  data.models.forEach((model) => {
-    const schema = resolveIfRef<OpenApiSchema | undefined>(
-      spec,
-      spec?.components?.schemas?.[model.name],
-    );
-    if (schema) {
-      // Object schemas should be typed as the model we will create
-      if (
-        schema.type === 'object' &&
-        (schema.properties || schema.patternProperties)
-      ) {
-        model.type = model.name;
-      }
-      ensureModelLink(spec, modelsByName, model, schema, visited);
-    }
-  });
-
-  // Ensure set for all parameters and responses
-  data.services.forEach((service) => {
-    service.operations.forEach((op) => {
-      const specOp = getSpecOperation(spec, op);
-      const specParametersByName = getSpecParametersByName(spec, specOp);
-
-      op.parameters.forEach((parameter) => {
-        const specParameter = specParametersByName[parameter.prop];
-        const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
-
-        if (specParameterSchema) {
-          ensureModelLink(
-            spec,
-            modelsByName,
-            parameter,
-            specParameterSchema,
-            visited,
-          );
-        } else if (parameter.in === 'body') {
-          // Body is not in the "parameters" section of the OpenAPI spec so we handle it in an explicit case here
-          const specBody = resolveIfRef(spec, specOp?.requestBody);
-          const specBodySchema = resolveIfRef(
-            spec,
-            specBody?.content?.[parameter.mediaType]?.schema,
-          );
-
-          if (specBodySchema) {
-            ensureModelLink(
-              spec,
-              modelsByName,
-              parameter,
-              specBodySchema,
-              visited,
-            );
-          }
-        }
-      });
-
-      op.responses.forEach((response) => {
-        const specResponse = resolveIfRef(
-          spec,
-          specOp?.responses?.[response.code],
-        );
-        const mediaTypes = Object.keys(specResponse?.content ?? {});
-        mediaTypes.forEach((mediaType) => {
-          const responseSchema = resolveIfRef(
-            spec,
-            specResponse?.content?.[mediaType]?.schema,
-          );
-          if (responseSchema) {
-            ensureModelLink(
-              spec,
-              modelsByName,
-              response,
-              responseSchema,
-              visited,
-            );
-          }
-        });
-      });
-    });
-  });
-};
-
-const ensureModelLink = (
-  spec: Spec,
-  modelsByName: ModelsByName,
-  model: Model,
-  schema: OpenApiSchema,
-  visited: Set<Model>,
-) => {
-  if (visited.has(model)) {
-    return;
-  }
-
-  visited.add(model);
-
-  if (
-    model.export === 'dictionary' &&
-    'additionalProperties' in schema &&
-    schema.additionalProperties
-  ) {
-    if (isRef(schema.additionalProperties)) {
-      const name = splitRef(schema.additionalProperties.$ref)[2];
-      if (modelsByName[name] && !model.link) {
-        model.link = modelsByName[name];
-      }
-    } else if (model.link && typeof schema.additionalProperties !== 'boolean') {
-      ensureModelLink(
-        spec,
-        modelsByName,
-        model.link,
-        schema.additionalProperties,
-        visited,
-      );
-    }
-  } else if (model.export === 'array' && 'items' in schema && schema.items) {
-    if (isRef(schema.items)) {
-      const name = splitRef(schema.items.$ref)[2];
-      if (modelsByName[name] && !model.link) {
-        model.link = modelsByName[name];
-      }
-    } else if (model.link) {
-      ensureModelLink(spec, modelsByName, model.link, schema.items, visited);
-    }
-  }
-
-  model.properties
-    .filter((p) => !visited.has(p) && schema.properties?.[trim(p.name, `"'`)])
-    .forEach((property) => {
-      const subSchema = resolveIfRef(
-        spec,
-        schema.properties![trim(property.name, `"'`)],
-      );
-      ensureModelLink(spec, modelsByName, property, subSchema, visited);
-    });
-
-  if (COMPOSED_SCHEMA_TYPES.has(model.export)) {
-    const memberSchemas = compositeMemberSchemas(schema, model.export);
-    model.properties.forEach((property, i) => {
-      const subSchema = resolveIfRef(spec, memberSchemas[i]);
-      if (subSchema) {
-        ensureModelLink(spec, modelsByName, property, subSchema, visited);
-      }
-    });
-  }
-};
-
-/**
- * Populate `composedModels` and `composedPrimitives` on each composite model
- * (allOf/anyOf/oneOf) with the models and primitive types it is composed of.
- */
-const resolveComposedModels = (data: ClientData) => {
-  const modelsByName = indexModelsByName(data.models);
-  const visited = new Set<Model>();
-  data.models.forEach((model) =>
-    resolveComposedModel(modelsByName, model, visited),
-  );
-};
-
-const resolveComposedModel = (
-  modelsByName: ModelsByName,
-  model: Model,
-  visited: Set<Model>,
-) => {
-  if (!COMPOSED_SCHEMA_TYPES.has(model.export) || visited.has(model)) {
-    return;
-  }
-  visited.add(model);
-
-  const members = model.properties.filter((p) => !p.name);
-  const referenced = members
-    .filter((p) => p.export === 'reference')
-    .flatMap((r) => (modelsByName[r.type] ? [modelsByName[r.type]] : []));
-
-  // Resolve recursively so all-of mixins include nested all-of properties
-  referenced.forEach((m) => resolveComposedModel(modelsByName, m, visited));
-
-  // Enums serialise as primitives, so group them with the primitives
-  const composedModels = referenced.filter((m) => m.export !== 'enum');
-  const composedPrimitives = [
-    ...members.filter((p) => p.export !== 'reference'),
-    ...referenced.filter((m) => m.export === 'enum'),
-  ];
-
-  // Composing multiple arrays of non-primitives is not distinguishable at
-  // runtime, so it's validated away.
-  // TODO: honour `discriminator` to support this case.
-  const isPrimitiveArray = (m: Model): boolean =>
-    m.link && COLLECTION_TYPES.has(m.export)
-      ? isPrimitiveArray(m.link)
-      : PRIMITIVE_TYPES.has(m.type) &&
-        !['date', 'date-time'].includes(m.format ?? '');
-  const arrayComposedModels = composedPrimitives.filter(
-    (m) => m.export === 'array' && !isPrimitiveArray(m),
-  );
-  if (arrayComposedModels.length > 1) {
-    throw new Error(
-      `Schema "${model.name}" defines ${camelCase(model.export)} with multiple array types which cannot be distinguished at runtime.`,
-    );
-  }
-
-  if (model.export === 'all-of' && composedPrimitives.length > 0) {
-    throw new Error(
-      `Schema "${model.name}" defines allOf with non-object types. allOf may only compose object types in the OpenAPI specification.`,
-    );
-  }
-
-  model.composedModels = composedModels;
-  model.composedPrimitives = composedPrimitives;
 };
 
 const addLanguageTypes = (model: Model) => {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import camelCase from 'lodash.camelcase';
 import orderBy from 'lodash.orderby';
 import trim from 'lodash.trim';
 import uniqBy from 'lodash.uniqby';
 import type { OpenAPIV3 } from 'openapi-types';
 import {
+  camelCase,
   pascalCase,
   snakeCase,
   toClassName,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -9,7 +9,6 @@ import trim from 'lodash.trim';
 import uniqBy from 'lodash.uniqby';
 import type { OpenAPIV3 } from 'openapi-types';
 import {
-  kebabCase,
   pascalCase,
   snakeCase,
   toClassName,
@@ -29,7 +28,6 @@ import {
   type CodeGenData,
   type CollectionFormat,
   createModel,
-  flattenModelLink,
   type Model,
   type ModelExport,
   type Operation,
@@ -60,9 +58,9 @@ const compositeMemberSchemas = (
 /**
  * Build the data structure used to generate code from an OpenAPI spec.
  */
-export const buildOpenApiCodeGenData = async (
+export const buildOpenApiCodeGenData = (
   inSpec: Spec,
-): Promise<CodeGenData> => {
+): CodeGenData => {
   // Ensure spec is ready for codegen
   const spec = normaliseOpenApiSpecForCodeGen(inSpec);
 
@@ -80,7 +78,7 @@ export const buildOpenApiCodeGenData = async (
 
   // Augment each service's operations with additional data
   for (const service of data.services) {
-    await augmentService(spec, service, modelsByName);
+    augmentService(spec, service, modelsByName);
   }
 
   // All operations across all services
@@ -100,7 +98,7 @@ export const buildOpenApiCodeGenData = async (
   // Augment every model (including the request parameter models just added)
   // with schema-derived and language-specific data
   for (const model of data.models) {
-    await augmentModel(spec, model, modelsByName);
+    augmentModel(spec, model, modelsByName);
   }
   for (const model of data.models) {
     model.typescriptName = toTypeScriptModelName(model.name);
@@ -134,16 +132,16 @@ export const buildOpenApiCodeGenData = async (
  * generation (names, imports, result/request types, behavioural flags), and
  * compute the set of models the service (ie API client) needs to import.
  */
-const augmentService = async (
+const augmentService = (
   spec: Spec,
   service: Service,
   modelsByName: { [name: string]: Model },
-): Promise<void> => {
+): void => {
   // Model names each operation needs to import, accumulated across operations
   const modelImports: string[] = [];
 
   for (const op of service.operations) {
-    modelImports.push(...(await augmentOperation(spec, op, modelsByName)));
+    modelImports.push(...augmentOperation(spec, op, modelsByName));
   }
 
   // Lexicographical ordering of operations
@@ -154,7 +152,6 @@ const augmentService = async (
   );
 
   service.className = `${service.name}Api`;
-  service.classNameSnakeCase = snakeCase(service.className);
   service.nameSnakeCase = snakeCase(service.name);
 };
 
@@ -162,11 +159,11 @@ const augmentService = async (
  * Augment a single operation with all the data the templates need, returning
  * the names of the models it references (for the service's import list).
  */
-const augmentOperation = async (
+const augmentOperation = (
   spec: Spec,
   op: Operation,
   modelsByName: { [name: string]: Model },
-): Promise<string[]> => {
+): string[] => {
   const specOp = getSpecOperation(spec, op);
 
   assignOperationNames(op, specOp);
@@ -177,13 +174,9 @@ const augmentOperation = async (
 
   const modelImports: string[] = [];
   if (specOp) {
-    modelImports.push(
-      ...(await augmentResponses(spec, op, specOp, modelsByName)),
-    );
+    modelImports.push(...augmentResponses(spec, op, specOp, modelsByName));
   }
-  modelImports.push(
-    ...(await augmentParameters(spec, op, specOp, modelsByName)),
-  );
+  modelImports.push(...augmentParameters(spec, op, specOp, modelsByName));
 
   // Add language types to response models
   op.responses.forEach(addLanguageTypes);
@@ -200,7 +193,6 @@ const augmentOperation = async (
 
   // Add variants of operation name (after uniqueName is set)
   op.operationIdPascalCase = pascalCase(op.uniqueName);
-  op.operationIdKebabCase = kebabCase(op.uniqueName);
   op.operationIdSnakeCase = toPythonName('operation', op.uniqueName);
 
   // Add request type name (after operationIdPascalCase is set)
@@ -250,12 +242,12 @@ const assignOperationNames = (
  * void responses and streaming item schemas. Returns the response model names
  * to import.
  */
-const augmentResponses = async (
+const augmentResponses = (
   spec: Spec,
   op: Operation,
   specOp: OpenAPIV3.OperationObject,
   modelsByName: { [name: string]: Model },
-): Promise<string[]> => {
+): string[] => {
   const modelImports = op.responses
     .filter((r) => r.export === 'reference')
     .map((r) => r.type);
@@ -297,7 +289,7 @@ const augmentResponses = async (
         Object.values(specResponse.content)[0];
       const responseSchema = resolveIfRef(spec, responseContent.schema);
       if (responseSchema) {
-        await augmentModelFromSchema(
+        augmentModelFromSchema(
           spec,
           response,
           responseSchema,
@@ -309,7 +301,7 @@ const augmentResponses = async (
         'itemSchema' in responseContent
       ) {
         response.isJsonlStreaming = true;
-        response.itemSchemaModel = await buildOrReferenceModel(
+        response.itemSchemaModel = buildOrReferenceModel(
           spec,
           modelsByName,
           responseContent.itemSchema as OpenApiSchemaOrRef,
@@ -326,12 +318,12 @@ const augmentResponses = async (
  * request bodies and query/header collection formats. Returns the parameter
  * model names to import.
  */
-const augmentParameters = async (
+const augmentParameters = (
   spec: Spec,
   op: Operation,
   specOp: OpenAPIV3.OperationObject | undefined,
   modelsByName: { [name: string]: Model },
-): Promise<string[]> => {
+): string[] => {
   const specParametersByName = Object.fromEntries(
     (specOp?.parameters ?? []).map((p) => {
       const param = resolveIfRef(spec, p);
@@ -349,7 +341,7 @@ const augmentParameters = async (
     const specParameter = specParametersByName[parameter.prop];
     const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
     if (specParameterSchema) {
-      await augmentModelFromSchema(
+      augmentModelFromSchema(
         spec,
         parameter,
         specParameterSchema,
@@ -358,7 +350,7 @@ const augmentParameters = async (
     }
 
     if (parameter.in === 'body') {
-      await augmentBodyParameter(spec, parameter, specOp, modelsByName);
+      augmentBodyParameter(spec, parameter, specOp, modelsByName);
     } else if (
       (parameter.in === 'query' || parameter.in === 'header') &&
       specParameter
@@ -380,12 +372,12 @@ const augmentParameters = async (
  * spec's `parameters`, so it is resolved from `requestBody` here) and record
  * its acceptable media types.
  */
-const augmentBodyParameter = async (
+const augmentBodyParameter = (
   spec: Spec,
   parameter: Model,
   specOp: OpenAPIV3.OperationObject | undefined,
   modelsByName: { [name: string]: Model },
-): Promise<void> => {
+): void => {
   // The request body parameter is named 'body' downstream.
   parameter.name = 'body';
   parameter.prop = 'body';
@@ -399,7 +391,7 @@ const augmentBodyParameter = async (
       specBody.content?.[parameter.mediaType]?.schema,
     );
     if (bodySchema) {
-      await augmentModelFromSchema(spec, parameter, bodySchema, modelsByName);
+      augmentModelFromSchema(spec, parameter, bodySchema, modelsByName);
     }
   }
   // Track all the media types that can be accepted in the request body
@@ -507,11 +499,11 @@ const buildRequestParameterModels = (
  * Augment a single model with schema-derived data (from its matching spec
  * schema, if any) and language-specific names and types.
  */
-const augmentModel = async (
+const augmentModel = (
   spec: Spec,
   model: Model,
   modelsByName: { [name: string]: Model },
-): Promise<void> => {
+): void => {
   // Add a snake_case name
   model.nameSnakeCase = toPythonName('model', model.name);
 
@@ -519,20 +511,7 @@ const augmentModel = async (
   if (matchingSpecModel) {
     const specModel = resolveIfRef(spec, matchingSpecModel);
 
-    await augmentModelFromSchema(spec, model, specModel, modelsByName);
-
-    // Add unique imports (property references, excluding self for recursive models)
-    model.uniqueImports = orderBy(
-      uniqBy(
-        [
-          ...model.imports,
-          ...model.properties
-            .filter((p) => p.export === 'reference')
-            .map((p) => p.type),
-        ],
-        (x) => x,
-      ),
-    ).filter((modelImport) => modelImport !== model.name);
+    augmentModelFromSchema(spec, model, specModel, modelsByName);
 
     model.deprecated = specModel.deprecated || false;
 
@@ -541,7 +520,7 @@ const augmentModel = async (
       const matchingSpecProperty = specModel.properties?.[property.name];
       if (matchingSpecProperty) {
         const specProperty = resolveIfRef(spec, matchingSpecProperty);
-        await augmentModelFromSchema(
+        augmentModelFromSchema(
           spec,
           property,
           specProperty,
@@ -594,10 +573,10 @@ const extractVendorExtensions = (spec: Spec): VendorExtensions => {
  * Only primitives are supported since we only return one model.
  * For non-primitives, it assumes all referenced subschemas are already models
  */
-const buildModelForPrimitive = async (
+const buildModelForPrimitive = (
   originalSpec: Spec,
   schema: OpenApiSchema,
-): Promise<Model> => {
+): Model => {
   const targetSchemaName = '___aws_nx_plugin_openapi_tmp_schema___';
 
   const spec: Spec = {
@@ -621,7 +600,7 @@ const buildModelForPrimitive = async (
   }
 
   ensureModelLinks(spec, data);
-  await augmentModelFromSchema(
+  augmentModelFromSchema(
     spec,
     model,
     schema,
@@ -631,18 +610,18 @@ const buildModelForPrimitive = async (
   return model;
 };
 
-const buildOrReferenceModel = async (
+const buildOrReferenceModel = (
   spec: Spec,
   modelsByName: { [name: string]: Model },
   schema: OpenApiSchemaOrRef,
-): Promise<Model> => {
+): Model => {
   if (isRef(schema)) {
     const name = splitRef(schema.$ref)[2];
     return modelsByName[name];
   }
   // Non referenced schemas won't have a top-level model created as they are
   // primitives, so we build the model here
-  return await buildModelForPrimitive(spec, schema);
+  return buildModelForPrimitive(spec, schema);
 };
 
 /**
@@ -670,7 +649,7 @@ const copyVendorExtensions = (
   });
 };
 
-const augmentModelFromSchema = async (
+const augmentModelFromSchema = (
   spec: Spec,
   model: Model,
   schema: OpenApiSchema,
@@ -689,7 +668,7 @@ const augmentModelFromSchema = async (
   // A "dictionary" has only additional properties; an "interface" may mix
   // explicit and additional properties.
   if (schema.additionalProperties) {
-    const additionalPropertiesModel = await buildOrReferenceModel(
+    const additionalPropertiesModel = buildOrReferenceModel(
       spec,
       modelsByName,
       schema.additionalProperties === true ? {} : schema.additionalProperties,
@@ -728,7 +707,7 @@ const augmentModelFromSchema = async (
     for (const [pattern, patternProperty] of Object.entries(
       patternProperties,
     )) {
-      const patternPropertyModel = await buildOrReferenceModel(
+      const patternPropertyModel = buildOrReferenceModel(
         spec,
         modelsByName,
         patternProperty,
@@ -749,20 +728,18 @@ const augmentModelFromSchema = async (
 
   visited.add(model);
 
-  const modelLink = flattenModelLink(model.link);
-
   // Also apply to array items recursively
   if (
     model.export === 'array' &&
-    modelLink &&
+    model.link &&
     'items' in schema &&
     schema.items &&
-    !visited.has(modelLink)
+    !visited.has(model.link)
   ) {
     const subSchema = resolveIfRef(spec, schema.items);
-    await augmentModelFromSchema(
+    augmentModelFromSchema(
       spec,
-      modelLink,
+      model.link,
       subSchema,
       modelsByName,
       visited,
@@ -775,14 +752,14 @@ const augmentModelFromSchema = async (
     model.link &&
     'additionalProperties' in schema &&
     schema.additionalProperties &&
-    !visited.has(modelLink)
+    !visited.has(model.link)
   ) {
     const subSchema = resolveIfRef(spec, schema.additionalProperties);
     // Additional properties can be "true" rather than a type
     if (subSchema !== true) {
-      await augmentModelFromSchema(
+      augmentModelFromSchema(
         spec,
-        modelLink,
+        model.link,
         subSchema,
         modelsByName,
         visited,
@@ -797,7 +774,7 @@ const augmentModelFromSchema = async (
       spec,
       schema.properties![trim(property.name, `"'`)],
     );
-    await augmentModelFromSchema(
+    augmentModelFromSchema(
       spec,
       property,
       subSchema,
@@ -811,7 +788,7 @@ const augmentModelFromSchema = async (
     for (let i = 0; i < model.properties.length; i++) {
       const subSchema = resolveIfRef(spec, memberSchemas[i]);
       if (subSchema) {
-        await augmentModelFromSchema(
+        augmentModelFromSchema(
           spec,
           model.properties[i],
           subSchema,
@@ -945,7 +922,7 @@ const ensureModelLink = (
       ensureModelLink(
         spec,
         modelsByName,
-        flattenModelLink(model.link),
+        model.link,
         schema.additionalProperties,
         visited,
       );
@@ -957,13 +934,7 @@ const ensureModelLink = (
         model.link = modelsByName[name];
       }
     } else if (model.link) {
-      ensureModelLink(
-        spec,
-        modelsByName,
-        flattenModelLink(model.link),
-        schema.items,
-        visited,
-      );
+      ensureModelLink(spec, modelsByName, model.link, schema.items, visited);
     }
   }
 
@@ -1034,7 +1005,7 @@ const resolveComposedModel = (
     // TODO: honour `discriminator` to support this case.
     const isPrimitiveArray = (m: Model) => {
       if (m.link && ['array', 'dictionary'].includes(m.export)) {
-        return isPrimitiveArray(flattenModelLink(m.link));
+        return isPrimitiveArray(m.link);
       }
       return (
         PRIMITIVE_TYPES.has(m.type) &&

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -46,6 +46,7 @@ import {
   compositeMemberSchemas,
   getSpecOperation,
   getSpecParametersByName,
+  getSpecPathParameters,
   linkModel,
 } from './parser';
 import { isRef, resolveIfRef, splitRef } from './refs';
@@ -277,7 +278,11 @@ const augmentParameters = (
   specOp: OpenAPIV3.OperationObject | undefined,
   modelsByName: ModelsByName,
 ): string[] => {
-  const specParametersByName = getSpecParametersByName(spec, specOp);
+  const specParametersByName = getSpecParametersByName(
+    spec,
+    specOp,
+    getSpecPathParameters(spec, op),
+  );
 
   const modelImports: string[] = [];
 

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -28,8 +28,10 @@ import {
   type CodeGenData,
   type CollectionFormat,
   createModel,
+  indexModelsByName,
   type Model,
   type ModelExport,
+  type ModelsByName,
   type Operation,
   type PatternPropertyModel,
   PRIMITIVE_TYPES,
@@ -69,7 +71,7 @@ export const buildOpenApiCodeGenData = (
   ensureModelLinks(spec, data);
   resolveComposedModels(data);
 
-  const modelsByName = Object.fromEntries(data.models.map((m) => [m.name, m]));
+  const modelsByName = indexModelsByName(data.models);
 
   for (const service of data.services) {
     augmentService(spec, service, modelsByName);
@@ -111,7 +113,7 @@ export const buildOpenApiCodeGenData = (
     untaggedOperations,
     info: spec.info,
     allOperations,
-    vendorExtensions: vendorExtensionsOf(spec ?? {}),
+    vendorExtensions: vendorExtensionsOf(spec),
     className: toClassName(spec.info.title),
   };
 };
@@ -124,7 +126,7 @@ export const buildOpenApiCodeGenData = (
 const augmentService = (
   spec: Spec,
   service: Service,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): void => {
   const modelImports = service.operations.flatMap((op) =>
     augmentOperation(spec, op, modelsByName),
@@ -145,13 +147,13 @@ const augmentService = (
 const augmentOperation = (
   spec: Spec,
   op: Operation,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): string[] => {
   const specOp = getSpecOperation(spec, op);
 
   assignOperationNames(op, specOp);
 
-  op.vendorExtensions = vendorExtensionsOf(specOp ?? {});
+  op.vendorExtensions = vendorExtensionsOf(specOp);
 
   const modelImports = [
     ...(specOp ? augmentResponses(spec, op, specOp, modelsByName) : []),
@@ -215,7 +217,7 @@ const augmentResponses = (
   spec: Spec,
   op: Operation,
   specOp: OpenAPIV3.OperationObject,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): string[] => {
   const modelImports = op.responses
     .filter((r) => r.export === 'reference')
@@ -258,12 +260,7 @@ const augmentResponses = (
         Object.values(specResponse.content)[0];
       const responseSchema = resolveIfRef(spec, responseContent.schema);
       if (responseSchema) {
-        augmentModelFromSchema(
-          spec,
-          response,
-          responseSchema,
-          modelsByName,
-        );
+        augmentModelFromSchema(spec, response, responseSchema, modelsByName);
       }
       if (
         STREAMING_CONTENT_TYPES.has(mediaType) &&
@@ -291,14 +288,9 @@ const augmentParameters = (
   spec: Spec,
   op: Operation,
   specOp: OpenAPIV3.OperationObject | undefined,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): string[] => {
-  const specParametersByName = Object.fromEntries(
-    (specOp?.parameters ?? []).map((p) => {
-      const param = resolveIfRef(spec, p);
-      return [param.name, param];
-    }),
-  );
+  const specParametersByName = getSpecParametersByName(spec, specOp);
 
   const modelImports: string[] = [];
 
@@ -310,12 +302,7 @@ const augmentParameters = (
     const specParameter = specParametersByName[parameter.prop];
     const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
     if (specParameterSchema) {
-      augmentModelFromSchema(
-        spec,
-        parameter,
-        specParameterSchema,
-        modelsByName,
-      );
+      augmentModelFromSchema(spec, parameter, specParameterSchema, modelsByName);
     }
 
     if (parameter.in === 'body') {
@@ -345,7 +332,7 @@ const augmentBodyParameter = (
   spec: Spec,
   parameter: Model,
   specOp: OpenAPIV3.OperationObject | undefined,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): void => {
   // The request body parameter is named 'body' downstream.
   parameter.name = 'body';
@@ -404,7 +391,7 @@ const getCollectionFormat = (
  */
 const buildRequestParameterModels = (
   op: Operation,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): Model[] => {
   if (!op.parameters || op.parameters.length === 0) {
     return [];
@@ -467,7 +454,7 @@ const buildRequestParameterModels = (
 const augmentModel = (
   spec: Spec,
   model: Model,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
 ): void => {
   model.nameSnakeCase = toPythonName('model', model.name);
 
@@ -476,7 +463,6 @@ const augmentModel = (
     const specModel = resolveIfRef(spec, matchingSpecModel);
 
     augmentModelFromSchema(spec, model, specModel, modelsByName);
-    model.deprecated = specModel.deprecated || false;
 
     for (const property of model.properties) {
       const matchingSpecProperty = specModel.properties?.[property.name];
@@ -548,19 +534,14 @@ const buildModelForPrimitive = (
   }
 
   ensureModelLinks(spec, data);
-  augmentModelFromSchema(
-    spec,
-    model,
-    schema,
-    Object.fromEntries(data.models.map((m) => [m.name, m])),
-  );
+  augmentModelFromSchema(spec, model, schema, indexModelsByName(data.models));
 
   return model;
 };
 
 const buildOrReferenceModel = (
   spec: Spec,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
   schema: OpenApiSchemaOrRef,
 ): Model => {
   if (isRef(schema)) {
@@ -584,9 +565,23 @@ const getSpecOperation = (
   ];
 
 /**
+ * An operation's resolved parameters indexed by name.
+ */
+const getSpecParametersByName = (
+  spec: Spec,
+  specOp: OpenAPIV3.OperationObject | undefined,
+): { [name: string]: OpenAPIV3.ParameterObject } =>
+  Object.fromEntries(
+    (specOp?.parameters ?? []).map((p) => {
+      const param = resolveIfRef(spec, p);
+      return [param.name, param];
+    }),
+  );
+
+/**
  * The `x-*` vendor extensions declared on an object.
  */
-const vendorExtensionsOf = (object: object): VendorExtensions =>
+const vendorExtensionsOf = (object: object | undefined): VendorExtensions =>
   Object.fromEntries(
     Object.entries(object ?? {}).filter(([key]) => key.startsWith('x-')),
   );
@@ -595,7 +590,7 @@ const augmentModelFromSchema = (
   spec: Spec,
   model: Model,
   schema: OpenApiSchema,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
   visited: Set<Model> = new Set(),
 ) => {
   model.format = schema.format;
@@ -707,15 +702,15 @@ const augmentModelFromSchema = (
  * Ensure that the "link" property of all dictionary/array models and properties are set recursively
  */
 const ensureModelLinks = (spec: Spec, data: ClientData) => {
-  const modelsByName = Object.fromEntries(data.models.map((m) => [m.name, m]));
+  const modelsByName = indexModelsByName(data.models);
   const visited = new Set<Model>();
 
   // Ensure set for all models
   data.models.forEach((model) => {
-    const schema = resolveIfRef(
+    const schema = resolveIfRef<OpenApiSchema | undefined>(
       spec,
       spec?.components?.schemas?.[model.name],
-    ) as OpenApiSchema | undefined;
+    );
     if (schema) {
       // Object schemas should be typed as the model we will create
       if (
@@ -732,13 +727,7 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
   data.services.forEach((service) => {
     service.operations.forEach((op) => {
       const specOp = getSpecOperation(spec, op);
-
-      const specParametersByName = Object.fromEntries(
-        (specOp?.parameters ?? []).map((p) => {
-          const param = resolveIfRef(spec, p);
-          return [param.name, param];
-        }),
-      );
+      const specParametersByName = getSpecParametersByName(spec, specOp);
 
       op.parameters.forEach((parameter) => {
         const specParameter = specParametersByName[parameter.prop];
@@ -800,7 +789,7 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
 
 const ensureModelLink = (
   spec: Spec,
-  modelsByName: { [name: string]: Model },
+  modelsByName: ModelsByName,
   model: Model,
   schema: OpenApiSchema,
   visited: Set<Model>,
@@ -867,12 +856,15 @@ const ensureModelLink = (
  * (allOf/anyOf/oneOf) with the models and primitive types it is composed of.
  */
 const resolveComposedModels = (data: ClientData) => {
+  const modelsByName = indexModelsByName(data.models);
   const visited = new Set<Model>();
-  data.models.forEach((model) => resolveComposedModel(data, model, visited));
+  data.models.forEach((model) =>
+    resolveComposedModel(modelsByName, model, visited),
+  );
 };
 
 const resolveComposedModel = (
-  data: ClientData,
+  modelsByName: ModelsByName,
   model: Model,
   visited: Set<Model>,
 ) => {
@@ -882,13 +874,12 @@ const resolveComposedModel = (
   visited.add(model);
 
   const members = model.properties.filter((p) => !p.name);
-  const modelsByName = Object.fromEntries(data.models.map((m) => [m.name, m]));
   const referenced = members
     .filter((p) => p.export === 'reference')
     .flatMap((r) => (modelsByName[r.type] ? [modelsByName[r.type]] : []));
 
   // Resolve recursively so all-of mixins include nested all-of properties
-  referenced.forEach((m) => resolveComposedModel(data, m, visited));
+  referenced.forEach((m) => resolveComposedModel(modelsByName, m, visited));
 
   // Enums serialise as primitives, so group them with the primitives
   const composedModels = referenced.filter((m) => m.export !== 'enum');

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -472,6 +472,13 @@ const augmentModel = (
   }
 
   model.properties.forEach(addLanguageTypes);
+
+  // Resolve the discriminator's TypeScript property name for marshalling.
+  if (model.discriminator) {
+    model.discriminator.typescriptPropertyName = toTypeScriptName(
+      model.discriminator.propertyName,
+    );
+  }
 };
 
 /**

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -87,6 +87,10 @@ export const buildOpenApiCodeGenData = (inSpec: Spec): CodeGenData => {
     model.typescriptType = model.typescriptName;
   }
 
+  for (const model of data.models) {
+    assertNoClashingPropertyNames(model);
+  }
+
   data.models = orderBy(data.models, (d) => d.name);
   // Default service first, then by name.
   data.services = orderBy(data.services, (s) =>
@@ -374,7 +378,7 @@ const getCollectionFormat = (
     : ((
         {
           spaceDelimited: 'ssv',
-          pipeDelimited: 'tsv',
+          pipeDelimited: 'pipes',
           simple: 'csv',
           form: 'csv',
         } as const
@@ -468,6 +472,28 @@ const augmentModel = (
   }
 
   model.properties.forEach(addLanguageTypes);
+};
+
+/**
+ * Ensure no two properties/parameters of an object model collapse onto the same
+ * TypeScript identifier (e.g. `foo-bar` and `foo_bar` both camelCase to
+ * `fooBar`, or a query and header parameter sharing a name within one request
+ * position). Such a clash would emit a type with duplicate members that does
+ * not compile, so fail fast with an actionable error instead.
+ */
+const assertNoClashingPropertyNames = (model: Model): void => {
+  const seen = new Map<string, string>();
+  for (const property of model.properties) {
+    // Composite members are unnamed (their names are empty); skip them.
+    if (!property.name) continue;
+    const existing = seen.get(property.typescriptName!);
+    if (existing !== undefined && existing !== property.name) {
+      throw new Error(
+        `Property name conflict in "${model.name}": "${existing}" and "${property.name}" both map to the TypeScript name "${property.typescriptName}". Please rename one of these in your OpenAPI specification.`,
+      );
+    }
+    seen.set(property.typescriptName!, property.name);
+  }
 };
 
 /**

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -28,6 +28,7 @@ import {
   type CodeGenData,
   type CollectionFormat,
   createModel,
+  DEFAULT_SERVICE_NAME,
   indexModelsByName,
   type Model,
   type ModelExport,
@@ -101,7 +102,7 @@ export const buildOpenApiCodeGenData = (
   data.models = orderBy(data.models, (d) => d.name);
   // Default service first, then by name.
   data.services = orderBy(data.services, (s) =>
-    s.name === 'Default' ? '' : s.name,
+    s.name === DEFAULT_SERVICE_NAME ? '' : s.name,
   );
 
   const { operationsByTag, untaggedOperations } =
@@ -232,7 +233,7 @@ const augmentResponses = (
     ) {
       const composedPrimitives = (
         modelsByName[response.type].composedPrimitives ?? []
-      ).filter((p) => !['array', 'dictionary'].includes(p.export));
+      ).filter((p) => !COLLECTION_TYPES.has(p.export));
       if (composedPrimitives.length > 0) {
         throw new Error(
           `Operation "${op.method} ${op.path}" returns a composite schema of primitives with ${camelCase(modelsByName[response.type].export)}, which cannot be distinguished at runtime`,
@@ -892,7 +893,7 @@ const resolveComposedModel = (
   // runtime, so it's validated away.
   // TODO: honour `discriminator` to support this case.
   const isPrimitiveArray = (m: Model): boolean =>
-    m.link && ['array', 'dictionary'].includes(m.export)
+    m.link && COLLECTION_TYPES.has(m.export)
       ? isPrimitiveArray(m.link)
       : PRIMITIVE_TYPES.has(m.type) &&
         !['date', 'date-time'].includes(m.format ?? '');
@@ -915,9 +916,6 @@ const resolveComposedModel = (
   model.composedPrimitives = composedPrimitives;
 };
 
-/**
- * Add language-specific names and types to a model.
- */
 const addLanguageTypes = (model: Model) => {
   model.name = trim(model.name, `"'`);
   model.typescriptName = toTypeScriptName(model.name);
@@ -930,24 +928,17 @@ const addLanguageTypes = (model: Model) => {
     !COLLECTION_TYPES.has(model.export);
 };
 
-/**
- * Determine whether or not an operation is a mutation
- */
 const isOperationMutation = (op: Operation): boolean => {
-  // Let the user override whether an operation is a query or mutation using x-mutation/x-query
+  // x-mutation/x-query override the HTTP-method default.
   const { vendorExtensions } = op;
   if (vendorExtensions?.[VENDOR_EXTENSIONS.MUTATION]) {
     return true;
   } else if (vendorExtensions?.[VENDOR_EXTENSIONS.QUERY]) {
     return false;
   }
-  // Assume a restful API and treat mutative HTTP methods as mutations
   return ['PATCH', 'POST', 'PUT', 'DELETE'].includes(op.method);
 };
 
-/**
- * Add infinite query details to the operation
- */
 const augmentInfiniteQuery = (op: Operation) => {
   const { paginationDisabled, cursorPropertyName } = getCursorOptions(op);
 

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Plugin } from '@hey-api/openapi-ts';
-import * as gen from '@hey-api/openapi-ts';
 import camelCase from 'lodash.camelcase';
 import orderBy from 'lodash.orderby';
 import trim from 'lodash.trim';
 import uniqBy from 'lodash.uniqby';
-import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import type { OpenAPIV3 } from 'openapi-types';
 import {
   kebabCase,
   pascalCase,
@@ -29,19 +27,38 @@ import {
   COLLECTION_TYPES,
   COMPOSED_SCHEMA_TYPES,
   type CodeGenData,
+  type CollectionFormat,
+  createModel,
   flattenModelLink,
   type Model,
+  type ModelExport,
   type Operation,
+  type PatternPropertyModel,
   PRIMITIVE_TYPES,
+  type Service,
   STREAMING_CONTENT_TYPES,
   VENDOR_EXTENSIONS,
+  type VendorExtensions,
 } from './codegen-data/types';
 import { normaliseOpenApiSpecForCodeGen } from './normalise';
+import { buildClientData } from './parser';
 import { isRef, resolveIfRef, splitRef } from './refs';
-import type { Spec } from './types';
+import type { OpenApiSchema, OpenApiSchemaOrRef, Spec } from './types';
 
 /**
- * Builds a data structure from an OpenAPI spec which can be used to generate code
+ * Return the member sub-schemas of a composite (allOf/anyOf/oneOf) schema, in
+ * order, for the given composite `export` kind.
+ */
+const compositeMemberSchemas = (
+  schema: OpenApiSchema,
+  compositeExport: ModelExport,
+): OpenApiSchemaOrRef[] => {
+  const keyword = camelCase(compositeExport) as 'allOf' | 'anyOf' | 'oneOf';
+  return (schema[keyword] as OpenApiSchemaOrRef[] | undefined) ?? [];
+};
+
+/**
+ * Build the data structure used to generate code from an OpenAPI spec.
  */
 export const buildOpenApiCodeGenData = async (
   inSpec: Spec,
@@ -50,416 +67,44 @@ export const buildOpenApiCodeGenData = async (
   const spec = normaliseOpenApiSpecForCodeGen(inSpec);
 
   // Build the initial data, which we will augment with additional information
-  const data = await buildInitialCodeGenData(spec);
+  const data = buildClientData(spec);
 
   // Ensure the models have their links set when they are arrays/dictionaries
   ensureModelLinks(spec, data);
 
-  // Mutate the models with enough data to render composite models in the templates
-  ensureCompositeModels(data);
+  // Resolve the composed models/primitives for composite schemas so the
+  // templates can render them
+  resolveComposedModels(data);
 
   const modelsByName = Object.fromEntries(data.models.map((m) => [m.name, m]));
 
-  // Augment operations with additional data
+  // Augment each service's operations with additional data
   for (const service of data.services) {
-    // Keep track of the request and response models we need the service (ie api client) to import
-    const requestModelImports: string[] = [];
-    const responseModelImports: string[] = [];
-
-    for (const op of service.operations) {
-      // Extract the operation back from the openapi spec
-      const specOp = (spec as any)?.paths?.[op.path]?.[
-        op.method.toLowerCase()
-      ] as OpenAPIV3.OperationObject | undefined;
-
-      op.name = op.id ?? op.name;
-      (op as any).uniqueName = op.name;
-      if (specOp['x-aws-nx-deduplicated-op-id']) {
-        (op as any).uniqueName = specOp['x-aws-nx-deduplicated-op-id'];
-      }
-      if (specOp['x-aws-nx-deduplicated-dot-op-id']) {
-        (op as any).dotNotationName = specOp['x-aws-nx-deduplicated-dot-op-id'];
-      }
-
-      // Add vendor extensions
-      (op as any).vendorExtensions = (op as any).vendorExtensions ?? {};
-      copyVendorExtensions(specOp ?? {}, (op as any).vendorExtensions);
-
-      if (specOp) {
-        // Add all response models to the response model imports
-        responseModelImports.push(
-          ...op.responses
-            .filter((r) => r.export === 'reference')
-            .map((r) => r.type),
-        );
-
-        for (const response of op.responses) {
-          // Validate that the response is not a composite schema of primitives since we cannot determine what
-          // the type of the response is (it all comes back as text!)
-          if (
-            response.export === 'reference' &&
-            COMPOSED_SCHEMA_TYPES.has(modelsByName[response.type]?.export)
-          ) {
-            const composedPrimitives = (
-              modelsByName[response.type] as any
-            ).composedPrimitives.filter(
-              (p) => !['array', 'dictionary'].includes(p.export),
-            );
-            if (composedPrimitives.length > 0) {
-              throw new Error(
-                `Operation "${op.method} ${op.path}" returns a composite schema of primitives with ${camelCase(modelsByName[response.type].export)}, which cannot be distinguished at runtime`,
-              );
-            }
-          }
-
-          const matchingSpecResponse = specOp.responses[`${response.code}`];
-
-          // @hey-api/openapi-ts does not distinguish between returning an "any" or returning "void"
-          // We distinguish this by looking back at each response in the spec, and checking whether it
-          // has content
-          if (matchingSpecResponse) {
-            // Resolve the ref if necessary
-            const specResponse = resolveIfRef(spec, matchingSpecResponse);
-
-            // When there's no content, we set the type to 'void'
-            if (!specResponse.content) {
-              response.type = 'void';
-            } else {
-              // Add the response media types
-              const mediaTypes = Object.keys(specResponse.content);
-              (response as any).mediaTypes = mediaTypes;
-
-              for (const mediaType of mediaTypes) {
-                const responseContent =
-                  specResponse.content?.[mediaType] ??
-                  Object.values(specResponse.content)[0];
-                const responseSchema = resolveIfRef(
-                  spec,
-                  responseContent.schema,
-                );
-                if (responseSchema) {
-                  await mutateWithOpenapiSchemaProperties(
-                    spec,
-                    response,
-                    responseSchema,
-                    modelsByName,
-                  );
-                }
-                if (
-                  STREAMING_CONTENT_TYPES.has(mediaType) &&
-                  'itemSchema' in responseContent
-                ) {
-                  (response as any).isJsonlStreaming = true;
-                  (response as any).itemSchemaModel =
-                    await buildOrReferenceModel(
-                      spec,
-                      modelsByName,
-                      responseContent.itemSchema,
-                    );
-                }
-              }
-            }
-          }
-        }
-      }
-
-      const specParametersByName = Object.fromEntries(
-        (specOp?.parameters ?? []).map((p) => {
-          const param = resolveIfRef(spec, p);
-          return [param.name, param];
-        }),
-      );
-
-      // Loop through the parameters
-      for (const parameter of op.parameters) {
-        // Add the request model import
-        if (parameter.export === 'reference') {
-          requestModelImports.push(parameter.type);
-        }
-
-        const specParameter = specParametersByName[parameter.prop];
-        const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
-
-        if (specParameterSchema) {
-          await mutateWithOpenapiSchemaProperties(
-            spec,
-            parameter,
-            specParameterSchema,
-            modelsByName,
-          );
-        }
-
-        if (parameter.in === 'body' || parameter.in === 'formData') {
-          // Parameter name for the body is 'body'.  `formData` bodies arrive
-          // under a synthetic `formData` param (hey-api convention) that's
-          // logically the body — normalise both shapes to `in === 'body'`
-          // so every downstream consumer (including ts-client's request-
-          // type composition) sees a single body kind.
-          parameter.name = 'body';
-          parameter.prop = 'body';
-          parameter.in = 'body';
-
-          // The request body is not in the "parameters" section of the openapi spec so we won't have added the schema
-          // properties above. Find it here.
-          const specBody = resolveIfRef(spec, specOp?.requestBody);
-          if (specBody) {
-            if (parameter.mediaType) {
-              const bodySchema = resolveIfRef(
-                spec,
-                specBody.content?.[parameter.mediaType]?.schema,
-              );
-              if (bodySchema) {
-                await mutateWithOpenapiSchemaProperties(
-                  spec,
-                  parameter,
-                  bodySchema,
-                  modelsByName,
-                );
-              }
-            }
-            // Track all the media types that can be accepted in the request body
-            (parameter as any).mediaTypes = Object.keys(specBody.content);
-          }
-        } else if (
-          ['query', 'header'].includes(parameter.in) &&
-          specParameter
-        ) {
-          // Translate style/explode to OpenAPI v2 style collectionFormat
-          // https://spec.openapis.org/oas/v3.0.3.html#style-values
-          const style =
-            specParameter.style ??
-            (parameter.in === 'query' ? 'form' : 'simple');
-          const explode = specParameter.explode ?? style === 'form';
-
-          if (parameter.in === 'query') {
-            (parameter as any).collectionFormat = explode
-              ? 'multi'
-              : ({
-                  spaceDelimited: 'ssv',
-                  pipeDelimited: 'tsv',
-                  simple: 'csv',
-                  form: 'csv',
-                }[style] ?? 'multi');
-          } else {
-            // parameter.in === "header"
-            (parameter as any).collectionFormat = explode ? 'multi' : 'csv';
-          }
-        }
-
-        mutateModelWithAdditionalTypes(parameter);
-      }
-
-      // Add language types to response models
-      (op.responses ?? []).forEach(mutateModelWithAdditionalTypes);
-
-      // Sort responses by code
-      op.responses = orderBy(op.responses, (r) => r.code);
-      // Result is the lowest successful response, otherwise is the 2XX or default response
-      const result = op.responses.find(
-        (r) => typeof r.code === 'number' && r.code >= 200 && r.code < 300,
-      );
-      (op as any).result =
-        result ??
-        op.responses.find((r) => r.code === '2XX' || r.code === 'default');
-
-      // Add variants of operation name
-      (op as any).operationIdPascalCase = pascalCase((op as any).uniqueName);
-      (op as any).operationIdKebabCase = kebabCase((op as any).uniqueName);
-      (op as any).operationIdSnakeCase = toPythonName(
-        'operation',
-        (op as any).uniqueName,
-      );
-
-      // Add request type name (after operationIdPascalCase is set)
-      if (op.parameters && op.parameters.length > 0) {
-        const baseRequestTypeName = `${(op as any).operationIdPascalCase}Request`;
-        const hasConflict = !!spec.components?.schemas?.[baseRequestTypeName];
-        if (hasConflict) {
-          // Use OperationRequest suffix when there's a conflict
-          (op as any).requestTypeName =
-            `${(op as any).operationIdPascalCase}OperationRequest`;
-        } else {
-          // Use standard Request suffix when no conflict
-          (op as any).requestTypeName = baseRequestTypeName;
-        }
-      }
-
-      mutateOperationWithAdditionalData(op);
-    }
-
-    // Lexicographical ordering of operations
-    service.operations = orderBy(
-      service.operations,
-      (op) => (op as any).uniqueName,
-    );
-
-    // Add the models to import
-    (service as any).modelImports = orderBy(
-      uniqBy(
-        [...service.imports, ...requestModelImports, ...responseModelImports],
-        (x) => x,
-      ),
-    );
-
-    // Add the service class name
-    (service as any).className = `${service.name}Api`;
-    (service as any).classNameSnakeCase = snakeCase((service as any).className);
-    (service as any).nameSnakeCase = snakeCase(service.name);
+    await augmentService(spec, service, modelsByName);
   }
 
   // All operations across all services
   const allOperations = uniqBy(
     data.services.flatMap((s) => s.operations),
-    (o) => (o as any).uniqueName,
+    (o) => o.uniqueName,
   );
 
-  // Add additional models for operation parameters
+  // Add additional models for each operation's request parameters
   data.models = [
     ...data.models,
-    ...allOperations.flatMap((op: Operation): Model[] => {
-      if (op.parameters && op.parameters.length > 0) {
-        // Build a collection of request parameter models to create based on their position (ie 'in' in the openapi spec, eg body, query, path, header, etc)
-        const parametersByPosition: { [position: string]: Model[] } = {};
-
-        op.parameters
-          .filter(
-            // We filter out (return false for) request bodies which we "inline" - ie we don't create a property which points to the body, the request will only be the body itself
-            (p) => {
-              // Always create models for non-body parameters
-              if (p.in !== 'body') {
-                return true;
-              }
-
-              // If the body is the only parameter, we can inline it no matter the type
-              if (op.parameters.length === 1) {
-                return false;
-              }
-
-              // We inline object bodies, so long as they aren't dictionaries (as dictionary keys could clash with other parameters),
-              // and so long as they don't have a property name that clashes with another parameter
-              const hasClashingPropertyName = (
-                modelsByName?.[p.type]?.properties ?? []
-              ).some((prop) =>
-                op.parameters.some((param) => param.name === prop.name),
-              );
-              if (
-                p.export === 'reference' &&
-                modelsByName?.[p.type]?.export !== 'dictionary' &&
-                !hasClashingPropertyName
-              ) {
-                return false;
-              }
-
-              // Don't inline anything else
-              return true;
-            },
-          )
-          .forEach((parameter) => {
-            parametersByPosition[parameter.in] = [
-              ...(parametersByPosition[parameter.in] ?? []),
-              parameter,
-            ];
-          });
-
-        // Ensure that if we have an explicit body parameter, it's called "body"
-        const requestBodyParameter = parametersByPosition['body']?.[0];
-        if (requestBodyParameter) {
-          requestBodyParameter.name = 'body';
-          (requestBodyParameter as any).prop = 'body';
-        }
-
-        (op as any).explicitRequestBodyParameter = requestBodyParameter;
-
-        return Object.entries(parametersByPosition).map(
-          ([position, parameters]) => {
-            const name = `${(op as any).operationIdPascalCase}Request${upperFirst(position)}Parameters`;
-            return {
-              $refs: [],
-              base: name,
-              description: op.description,
-              enum: null,
-              enums: null,
-              export: 'interface',
-              imports: [],
-              in: '',
-              link: undefined,
-              name,
-              properties: parameters,
-              template: '',
-              type: name,
-              isDefinition: false,
-              isNullable: false,
-              isReadOnly: false,
-              isRequired: true,
-            };
-          },
-        );
-      }
-      return [] as Model[];
-    }),
+    ...allOperations.flatMap((op) =>
+      buildRequestParameterModels(op, modelsByName),
+    ),
   ];
 
-  // Augment models with additional data
+  // Augment every model (including the request parameter models just added)
+  // with schema-derived and language-specific data
   for (const model of data.models) {
-    // Add a snake_case name
-    (model as any).nameSnakeCase = toPythonName('model', model.name);
-
-    const matchingSpecModel = spec?.components?.schemas?.[model.name];
-
-    if (matchingSpecModel) {
-      const specModel = resolveIfRef(spec, matchingSpecModel);
-
-      await mutateWithOpenapiSchemaProperties(
-        spec,
-        model,
-        specModel,
-        modelsByName,
-      );
-
-      // Add unique imports
-      (model as any).uniqueImports = orderBy(
-        uniqBy(
-          [
-            ...model.imports,
-            // Include property imports, if any
-            ...model.properties
-              .filter((p) => p.export === 'reference')
-              .map((p) => p.type),
-          ],
-          (x) => x,
-        ),
-      ).filter((modelImport) => modelImport !== model.name); // Filter out self for recursive model references
-
-      // Add deprecated flag if present
-      (model as any).deprecated = specModel.deprecated || false;
-
-      // Augment properties with additional data
-      for (const property of model.properties) {
-        const matchingSpecProperty = specModel.properties?.[property.name];
-
-        if (matchingSpecProperty) {
-          const specProperty = resolveIfRef(spec, matchingSpecProperty);
-          await mutateWithOpenapiSchemaProperties(
-            spec,
-            property,
-            specProperty,
-            modelsByName,
-          );
-        }
-      }
-    }
-
-    // Augment properties with additional data
-    model.properties.forEach((property) => {
-      // Add language-specific names/types
-      mutateModelWithAdditionalTypes(property);
-    });
+    await augmentModel(spec, model, modelsByName);
   }
-
   for (const model of data.models) {
-    // Set the model's typescript name and type
-    (model as any).typescriptName = toTypeScriptModelName(model.name);
-    (model as any).typescriptType = (model as any).typescriptName;
+    model.typescriptName = toTypeScriptModelName(model.name);
+    model.typescriptType = model.typescriptName;
   }
 
   // Order models lexicographically by name
@@ -470,23 +115,8 @@ export const buildOpenApiCodeGenData = async (
     s.name === 'Default' ? '' : s.name,
   );
 
-  // All operations by tags
-  const operationsByTag: { [tag: string]: Operation[] } = {};
-  const untaggedOperations: Operation[] = [];
-  allOperations.forEach((op) => {
-    const tags = (op as any).tags;
-    if (tags && tags.length > 0) {
-      tags.map(camelCase).forEach((tag: string) => {
-        operationsByTag[tag] = [...(operationsByTag[tag] ?? []), op];
-      });
-    } else {
-      untaggedOperations.push(op);
-    }
-  });
-
-  // Add top level vendor extensions
-  const vendorExtensions: { [key: string]: any } = {};
-  copyVendorExtensions(spec ?? {}, vendorExtensions);
+  const { operationsByTag, untaggedOperations } =
+    groupOperationsByTag(allOperations);
 
   return {
     ...data,
@@ -494,42 +124,469 @@ export const buildOpenApiCodeGenData = async (
     untaggedOperations,
     info: spec.info,
     allOperations,
-    vendorExtensions,
+    vendorExtensions: extractVendorExtensions(spec),
     className: toClassName(spec.info.title),
   };
 };
 
-const buildInitialCodeGenData = async (spec: Spec): Promise<ClientData> => {
-  let data: ClientData;
+/**
+ * Augment a service and each of its operations with the data needed for code
+ * generation (names, imports, result/request types, behavioural flags), and
+ * compute the set of models the service (ie API client) needs to import.
+ */
+const augmentService = async (
+  spec: Spec,
+  service: Service,
+  modelsByName: { [name: string]: Model },
+): Promise<void> => {
+  // Model names each operation needs to import, accumulated across operations
+  const modelImports: string[] = [];
 
-  // We create a plugin which will capture the client data
-  const plugin: Plugin.DefineConfig<{ name: string }> = () => ({
-    name: 'plugin',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    _handler: () => {},
-    _handlerLegacy: ({ client }) => {
-      data = client;
-    },
-  });
-
-  // Use @hey-api/openapi-ts to build the initial data structure that we'll generate clients from
-  await gen.createClient({
-    experimentalParser: false,
-    input: {
-      path: spec,
-    },
-    output: 'unused',
-    plugins: [plugin()],
-    dryRun: true,
-    logs: { level: 'silent' },
-  });
-
-  if (!data) {
-    // If this happens it indicates an update to @hey-api/openapi-ts which has removed the legacy parser
-    throw new Error('Failed to build code generation data');
+  for (const op of service.operations) {
+    modelImports.push(...(await augmentOperation(spec, op, modelsByName)));
   }
 
-  return data;
+  // Lexicographical ordering of operations
+  service.operations = orderBy(service.operations, (op) => op.uniqueName);
+
+  service.modelImports = orderBy(
+    uniqBy([...service.imports, ...modelImports], (x) => x),
+  );
+
+  service.className = `${service.name}Api`;
+  service.classNameSnakeCase = snakeCase(service.className);
+  service.nameSnakeCase = snakeCase(service.name);
+};
+
+/**
+ * Augment a single operation with all the data the templates need, returning
+ * the names of the models it references (for the service's import list).
+ */
+const augmentOperation = async (
+  spec: Spec,
+  op: Operation,
+  modelsByName: { [name: string]: Model },
+): Promise<string[]> => {
+  const specOp = getSpecOperation(spec, op);
+
+  assignOperationNames(op, specOp);
+
+  // Add vendor extensions
+  op.vendorExtensions = op.vendorExtensions ?? {};
+  copyVendorExtensions(specOp ?? {}, op.vendorExtensions);
+
+  const modelImports: string[] = [];
+  if (specOp) {
+    modelImports.push(
+      ...(await augmentResponses(spec, op, specOp, modelsByName)),
+    );
+  }
+  modelImports.push(
+    ...(await augmentParameters(spec, op, specOp, modelsByName)),
+  );
+
+  // Add language types to response models
+  op.responses.forEach(addLanguageTypes);
+
+  // Sort responses by code
+  op.responses = orderBy(op.responses, (r) => r.code);
+  // Result is the lowest successful response, otherwise the 2XX or default response
+  const result = op.responses.find(
+    (r) => typeof r.code === 'number' && r.code >= 200 && r.code < 300,
+  );
+  op.result =
+    result ??
+    op.responses.find((r) => r.code === '2XX' || r.code === 'default');
+
+  // Add variants of operation name (after uniqueName is set)
+  op.operationIdPascalCase = pascalCase(op.uniqueName);
+  op.operationIdKebabCase = kebabCase(op.uniqueName);
+  op.operationIdSnakeCase = toPythonName('operation', op.uniqueName);
+
+  // Add request type name (after operationIdPascalCase is set)
+  if (op.parameters && op.parameters.length > 0) {
+    const baseRequestTypeName = `${op.operationIdPascalCase}Request`;
+    const hasConflict = !!spec.components?.schemas?.[baseRequestTypeName];
+    // Use the OperationRequest suffix when the standard Request name clashes
+    // with an existing schema, otherwise the standard Request suffix.
+    op.requestTypeName = hasConflict
+      ? `${op.operationIdPascalCase}OperationRequest`
+      : baseRequestTypeName;
+  }
+
+  augmentOperationBehaviour(op);
+
+  return modelImports;
+};
+
+/**
+ * Set an operation's name and its deduplicated variants from the vendor
+ * extensions the normaliser added.
+ */
+const assignOperationNames = (
+  op: Operation,
+  specOp: OpenAPIV3.OperationObject | undefined,
+): void => {
+  op.name = op.id ?? op.name;
+  op.uniqueName = op.name;
+
+  const deduplicatedOpId = specOp?.['x-aws-nx-deduplicated-op-id'] as
+    | string
+    | undefined;
+  if (deduplicatedOpId) {
+    op.uniqueName = deduplicatedOpId;
+  }
+
+  const dotNotationOpId = specOp?.['x-aws-nx-deduplicated-dot-op-id'] as
+    | string
+    | undefined;
+  if (dotNotationOpId) {
+    op.dotNotationName = dotNotationOpId;
+  }
+};
+
+/**
+ * Augment an operation's response models with schema-derived data, resolving
+ * void responses and streaming item schemas. Returns the response model names
+ * to import.
+ */
+const augmentResponses = async (
+  spec: Spec,
+  op: Operation,
+  specOp: OpenAPIV3.OperationObject,
+  modelsByName: { [name: string]: Model },
+): Promise<string[]> => {
+  const modelImports = op.responses
+    .filter((r) => r.export === 'reference')
+    .map((r) => r.type);
+
+  for (const response of op.responses) {
+    // We cannot distinguish a composite of primitives at runtime (it all comes
+    // back as text), so validate this away.
+    if (
+      response.export === 'reference' &&
+      COMPOSED_SCHEMA_TYPES.has(modelsByName[response.type]?.export)
+    ) {
+      const composedPrimitives = (
+        modelsByName[response.type].composedPrimitives ?? []
+      ).filter((p) => !['array', 'dictionary'].includes(p.export));
+      if (composedPrimitives.length > 0) {
+        throw new Error(
+          `Operation "${op.method} ${op.path}" returns a composite schema of primitives with ${camelCase(modelsByName[response.type].export)}, which cannot be distinguished at runtime`,
+        );
+      }
+    }
+
+    const matchingSpecResponse = specOp.responses[`${response.code}`];
+    if (!matchingSpecResponse) continue;
+
+    const specResponse = resolveIfRef(spec, matchingSpecResponse);
+
+    // When there's no content, the response type is 'void'
+    if (!specResponse.content) {
+      response.type = 'void';
+      continue;
+    }
+
+    const mediaTypes = Object.keys(specResponse.content);
+    response.mediaTypes = mediaTypes;
+
+    for (const mediaType of mediaTypes) {
+      const responseContent =
+        specResponse.content?.[mediaType] ??
+        Object.values(specResponse.content)[0];
+      const responseSchema = resolveIfRef(spec, responseContent.schema);
+      if (responseSchema) {
+        await augmentModelFromSchema(
+          spec,
+          response,
+          responseSchema,
+          modelsByName,
+        );
+      }
+      if (
+        STREAMING_CONTENT_TYPES.has(mediaType) &&
+        'itemSchema' in responseContent
+      ) {
+        response.isJsonlStreaming = true;
+        response.itemSchemaModel = await buildOrReferenceModel(
+          spec,
+          modelsByName,
+          responseContent.itemSchema as OpenApiSchemaOrRef,
+        );
+      }
+    }
+  }
+
+  return modelImports;
+};
+
+/**
+ * Augment an operation's parameter models with schema-derived data, resolving
+ * request bodies and query/header collection formats. Returns the parameter
+ * model names to import.
+ */
+const augmentParameters = async (
+  spec: Spec,
+  op: Operation,
+  specOp: OpenAPIV3.OperationObject | undefined,
+  modelsByName: { [name: string]: Model },
+): Promise<string[]> => {
+  const specParametersByName = Object.fromEntries(
+    (specOp?.parameters ?? []).map((p) => {
+      const param = resolveIfRef(spec, p);
+      return [param.name, param];
+    }),
+  );
+
+  const modelImports: string[] = [];
+
+  for (const parameter of op.parameters) {
+    if (parameter.export === 'reference') {
+      modelImports.push(parameter.type);
+    }
+
+    const specParameter = specParametersByName[parameter.prop];
+    const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
+    if (specParameterSchema) {
+      await augmentModelFromSchema(
+        spec,
+        parameter,
+        specParameterSchema,
+        modelsByName,
+      );
+    }
+
+    if (parameter.in === 'body') {
+      await augmentBodyParameter(spec, parameter, specOp, modelsByName);
+    } else if (
+      (parameter.in === 'query' || parameter.in === 'header') &&
+      specParameter
+    ) {
+      parameter.collectionFormat = getCollectionFormat(
+        parameter.in,
+        specParameter,
+      );
+    }
+
+    addLanguageTypes(parameter);
+  }
+
+  return modelImports;
+};
+
+/**
+ * Augment a request body parameter with its schema (the body is not in the
+ * spec's `parameters`, so it is resolved from `requestBody` here) and record
+ * its acceptable media types.
+ */
+const augmentBodyParameter = async (
+  spec: Spec,
+  parameter: Model,
+  specOp: OpenAPIV3.OperationObject | undefined,
+  modelsByName: { [name: string]: Model },
+): Promise<void> => {
+  // The request body parameter is named 'body' downstream.
+  parameter.name = 'body';
+  parameter.prop = 'body';
+
+  const specBody = resolveIfRef(spec, specOp?.requestBody);
+  if (!specBody) return;
+
+  if (parameter.mediaType) {
+    const bodySchema = resolveIfRef(
+      spec,
+      specBody.content?.[parameter.mediaType]?.schema,
+    );
+    if (bodySchema) {
+      await augmentModelFromSchema(spec, parameter, bodySchema, modelsByName);
+    }
+  }
+  // Track all the media types that can be accepted in the request body
+  parameter.mediaTypes = Object.keys(specBody.content);
+};
+
+/**
+ * Translate an OpenAPI v3 parameter's style/explode into a v2-style
+ * collectionFormat used when serialising array parameters.
+ * @see https://spec.openapis.org/oas/v3.0.3.html#style-values
+ */
+const getCollectionFormat = (
+  position: 'query' | 'header',
+  specParameter: OpenAPIV3.ParameterObject,
+): CollectionFormat => {
+  const style =
+    specParameter.style ?? (position === 'query' ? 'form' : 'simple');
+  const explode = specParameter.explode ?? style === 'form';
+
+  if (position === 'header') {
+    return explode ? 'multi' : 'csv';
+  }
+  return explode
+    ? 'multi'
+    : ((
+        {
+          spaceDelimited: 'ssv',
+          pipeDelimited: 'tsv',
+          simple: 'csv',
+          form: 'csv',
+        } as const
+      )[style] ?? 'multi');
+};
+
+/**
+ * Build the request parameter models for an operation — one model per parameter
+ * position (query/path/header/cookie/body), named e.g.
+ * `FooRequestQueryParameters`. Request bodies that can be represented directly
+ * (the sole parameter, or a non-clashing object reference) are inlined rather
+ * than given a wrapper model, and recorded on `op.explicitRequestBodyParameter`.
+ */
+const buildRequestParameterModels = (
+  op: Operation,
+  modelsByName: { [name: string]: Model },
+): Model[] => {
+  if (!op.parameters || op.parameters.length === 0) {
+    return [];
+  }
+
+  // Whether the request body can be represented directly, without a wrapper
+  // model (ie the request will be the body itself).
+  const canInlineBody = (body: Model): boolean => {
+    // If the body is the only parameter, we can inline it no matter the type
+    if (op.parameters.length === 1) {
+      return true;
+    }
+    // We inline object bodies, so long as they aren't dictionaries (as
+    // dictionary keys could clash with other parameters), and so long as they
+    // don't have a property name that clashes with another parameter
+    const hasClashingPropertyName = (
+      modelsByName?.[body.type]?.properties ?? []
+    ).some((prop) => op.parameters.some((param) => param.name === prop.name));
+    return (
+      body.export === 'reference' &&
+      modelsByName?.[body.type]?.export !== 'dictionary' &&
+      !hasClashingPropertyName
+    );
+  };
+
+  // Group the parameters we will create models for by their position (ie 'in'
+  // in the openapi spec, eg body, query, path, header, etc)
+  const parametersByPosition: { [position: string]: Model[] } = {};
+  for (const parameter of op.parameters) {
+    if (parameter.in === 'body' && canInlineBody(parameter)) {
+      continue;
+    }
+    parametersByPosition[parameter.in] = [
+      ...(parametersByPosition[parameter.in] ?? []),
+      parameter,
+    ];
+  }
+
+  // Ensure that if we have an explicit (non-inlined) body parameter, it's called "body"
+  const requestBodyParameter = parametersByPosition['body']?.[0];
+  if (requestBodyParameter) {
+    requestBodyParameter.name = 'body';
+    requestBodyParameter.prop = 'body';
+  }
+  op.explicitRequestBodyParameter = requestBodyParameter;
+
+  return Object.entries(parametersByPosition).map(([position, parameters]) => {
+    const name = `${op.operationIdPascalCase}Request${upperFirst(position)}Parameters`;
+    return createModel({
+      description: op.description,
+      export: 'interface',
+      name,
+      properties: parameters,
+      type: name,
+      isRequired: true,
+    });
+  });
+};
+
+/**
+ * Augment a single model with schema-derived data (from its matching spec
+ * schema, if any) and language-specific names and types.
+ */
+const augmentModel = async (
+  spec: Spec,
+  model: Model,
+  modelsByName: { [name: string]: Model },
+): Promise<void> => {
+  // Add a snake_case name
+  model.nameSnakeCase = toPythonName('model', model.name);
+
+  const matchingSpecModel = spec?.components?.schemas?.[model.name];
+  if (matchingSpecModel) {
+    const specModel = resolveIfRef(spec, matchingSpecModel);
+
+    await augmentModelFromSchema(spec, model, specModel, modelsByName);
+
+    // Add unique imports (property references, excluding self for recursive models)
+    model.uniqueImports = orderBy(
+      uniqBy(
+        [
+          ...model.imports,
+          ...model.properties
+            .filter((p) => p.export === 'reference')
+            .map((p) => p.type),
+        ],
+        (x) => x,
+      ),
+    ).filter((modelImport) => modelImport !== model.name);
+
+    model.deprecated = specModel.deprecated || false;
+
+    // Augment properties with schema-derived data
+    for (const property of model.properties) {
+      const matchingSpecProperty = specModel.properties?.[property.name];
+      if (matchingSpecProperty) {
+        const specProperty = resolveIfRef(spec, matchingSpecProperty);
+        await augmentModelFromSchema(
+          spec,
+          property,
+          specProperty,
+          modelsByName,
+        );
+      }
+    }
+  }
+
+  // Add language-specific names/types to properties
+  model.properties.forEach(addLanguageTypes);
+};
+
+/**
+ * Group operations by their (camelCased) tags, collecting any untagged
+ * operations separately.
+ */
+const groupOperationsByTag = (
+  allOperations: Operation[],
+): {
+  operationsByTag: { [tag: string]: Operation[] };
+  untaggedOperations: Operation[];
+} => {
+  const operationsByTag: { [tag: string]: Operation[] } = {};
+  const untaggedOperations: Operation[] = [];
+  allOperations.forEach((op) => {
+    const tags = op.tags;
+    if (tags && tags.length > 0) {
+      tags.map(camelCase).forEach((tag) => {
+        operationsByTag[tag] = [...(operationsByTag[tag] ?? []), op];
+      });
+    } else {
+      untaggedOperations.push(op);
+    }
+  });
+  return { operationsByTag, untaggedOperations };
+};
+
+/**
+ * Collect the top-level vendor extensions (`x-*`) declared on the spec.
+ */
+const extractVendorExtensions = (spec: Spec): VendorExtensions => {
+  const vendorExtensions: VendorExtensions = {};
+  copyVendorExtensions(spec ?? {}, vendorExtensions);
+  return vendorExtensions;
 };
 
 /**
@@ -539,7 +596,7 @@ const buildInitialCodeGenData = async (spec: Spec): Promise<ClientData> => {
  */
 const buildModelForPrimitive = async (
   originalSpec: Spec,
-  schema: OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject,
+  schema: OpenApiSchema,
 ): Promise<Model> => {
   const targetSchemaName = '___aws_nx_plugin_openapi_tmp_schema___';
 
@@ -554,7 +611,7 @@ const buildModelForPrimitive = async (
       },
     },
   };
-  const data = await buildInitialCodeGenData(spec);
+  const data = buildClientData(spec);
 
   const model = data.models.find((m) => m.name === targetSchemaName);
   if (!model) {
@@ -564,7 +621,7 @@ const buildModelForPrimitive = async (
   }
 
   ensureModelLinks(spec, data);
-  await mutateWithOpenapiSchemaProperties(
+  await augmentModelFromSchema(
     spec,
     model,
     schema,
@@ -577,26 +634,34 @@ const buildModelForPrimitive = async (
 const buildOrReferenceModel = async (
   spec: Spec,
   modelsByName: { [name: string]: Model },
-  schema:
-    | OpenAPIV3.SchemaObject
-    | OpenAPIV3_1.SchemaObject
-    | OpenAPIV3.ReferenceObject,
+  schema: OpenApiSchemaOrRef,
 ): Promise<Model> => {
   if (isRef(schema)) {
     const name = splitRef(schema.$ref)[2];
     return modelsByName[name];
   }
-  // Non referenced schemas won't have a model created as they are primitives and aren't covered by @heyapi
-  // So we build the model here
+  // Non referenced schemas won't have a top-level model created as they are
+  // primitives, so we build the model here
   return await buildModelForPrimitive(spec, schema);
 };
+
+/**
+ * Look up the spec operation object for a parsed operation.
+ */
+const getSpecOperation = (
+  spec: Spec,
+  op: Operation,
+): OpenAPIV3.OperationObject | undefined =>
+  (spec.paths?.[op.path] as OpenAPIV3.PathItemObject | undefined)?.[
+    op.method.toLowerCase() as OpenAPIV3.HttpMethods
+  ];
 
 /**
  * Copy vendor extensions from the first parameter to the second
  */
 const copyVendorExtensions = (
   object: object,
-  vendorExtensions: { [key: string]: any },
+  vendorExtensions: VendorExtensions,
 ) => {
   Object.entries(object ?? {}).forEach(([key, value]) => {
     if (key.startsWith('x-')) {
@@ -605,32 +670,24 @@ const copyVendorExtensions = (
   });
 };
 
-const mutateWithOpenapiSchemaProperties = async (
+const augmentModelFromSchema = async (
   spec: Spec,
   model: Model,
-  schema: OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject,
+  schema: OpenApiSchema,
   modelsByName: { [name: string]: Model },
   visited: Set<Model> = new Set(),
 ) => {
-  (model as any).format = schema.format;
-  (model as any).isInteger = schema.type === 'integer';
-  (model as any).isShort = schema.format === 'int32';
-  (model as any).isLong = schema.format === 'int64';
-  (model as any).deprecated = !!schema.deprecated;
-  (model as any).openapiType = schema.type;
-  (model as any).isNotSchema = !!schema.not;
-  (model as any).isEnum = !!schema.enum && schema.enum.length > 0;
+  model.format = schema.format;
+  model.deprecated = !!schema.deprecated;
+  model.openapiType = schema.type;
+  model.isEnum = !!schema.enum && schema.enum.length > 0;
 
   // Copy any schema vendor extensions
-  (model as any).vendorExtensions = {};
-  copyVendorExtensions(schema, (model as any).vendorExtensions);
+  model.vendorExtensions = {};
+  copyVendorExtensions(schema, model.vendorExtensions);
 
-  // Use our added vendor extension
-  (model as any).isHoisted = !!(model as any).vendorExtensions?.[
-    'x-aws-nx-hoisted'
-  ];
-
-  // Ensure models with additional properties are handled correctly
+  // A "dictionary" has only additional properties; an "interface" may mix
+  // explicit and additional properties.
   if (schema.additionalProperties) {
     const additionalPropertiesModel = await buildOrReferenceModel(
       spec,
@@ -638,52 +695,32 @@ const mutateWithOpenapiSchemaProperties = async (
       schema.additionalProperties === true ? {} : schema.additionalProperties,
     );
 
-    // The original models treat _some_ objects with additional properties as a "dictionary", and others as an "interface"
-    // For the purposes of our code generation, we define a "dictionary" to be a model with no explicit properties, only
-    // additional properties. Interfaces can have a mixture of explicit properties and additional properties.
     if (model.export === 'dictionary') {
-      // Dictionaries contain a special property which is the model itself. Other properties are explicit properties.
+      // A dictionary carries a self-referential property; the rest are explicit
       const explicitProperties = model.properties.filter(
         (p) => !(p.export === 'dictionary' && p.name === model.name),
       );
 
-      if (explicitProperties.length > 0 || (schema as any).patternProperties) {
-        // Treat this model as an interface instead of a dictionary, since this has
-        // explicit properties
+      // Explicit properties make this an interface rather than a dictionary
+      if (explicitProperties.length > 0 || schema.patternProperties) {
         model.export = 'interface';
-        (model as any).hasAdditionalProperties = true;
-        (model as any).additionalPropertiesModel = additionalPropertiesModel;
+        model.hasAdditionalProperties = true;
+        model.additionalPropertiesModel = additionalPropertiesModel;
         model.properties = explicitProperties;
       }
     } else {
-      (model as any).hasAdditionalProperties = true;
-      (model as any).additionalPropertiesModel = additionalPropertiesModel;
-      // There's a special property named [key: string] which is the definition of the additional properties
-      // We remove this so we don't render it as a regular property.
-      model.properties = (model.properties ?? []).filter(
-        (p) => p.name !== '[key: string]',
-      );
+      model.hasAdditionalProperties = true;
+      model.additionalPropertiesModel = additionalPropertiesModel;
     }
   }
 
-  // Ensure models with pattern properties are handled correctly
-  if ((schema as any).patternProperties) {
-    const patternProperties = resolveIfRef(
-      spec,
-      (schema as any).patternProperties as
-        | OpenAPIV3.ReferenceObject
-        | {
-            [pattern: string]:
-              | OpenAPIV3.ReferenceObject
-              | OpenAPIV3.SchemaObject
-              | OpenAPIV3_1.SchemaObject;
-          },
-    );
+  // Pattern properties can have different value types per pattern, so the model
+  // is an interface rather than a dictionary
+  if (schema.patternProperties) {
+    const patternProperties = resolveIfRef(spec, schema.patternProperties);
 
-    const patternPropertiesModels: { pattern: string; model: Model }[] = [];
+    const patternPropertiesModels: PatternPropertyModel[] = [];
 
-    // When there are pattern properties, we don't want to treat models as dictionaries since there can be more than one type of "value"
-    // depending on what pattern the key matches
     if (model.export === 'dictionary') {
       model.export = 'interface';
     }
@@ -704,11 +741,11 @@ const mutateWithOpenapiSchemaProperties = async (
       }
     }
 
-    (model as any).hasPatternProperties = true;
-    (model as any).patternPropertiesModels = patternPropertiesModels;
+    model.hasPatternProperties = true;
+    model.patternPropertiesModels = patternPropertiesModels;
   }
 
-  mutateModelWithAdditionalTypes(model);
+  addLanguageTypes(model);
 
   visited.add(model);
 
@@ -723,7 +760,7 @@ const mutateWithOpenapiSchemaProperties = async (
     !visited.has(modelLink)
   ) {
     const subSchema = resolveIfRef(spec, schema.items);
-    await mutateWithOpenapiSchemaProperties(
+    await augmentModelFromSchema(
       spec,
       modelLink,
       subSchema,
@@ -743,7 +780,7 @@ const mutateWithOpenapiSchemaProperties = async (
     const subSchema = resolveIfRef(spec, schema.additionalProperties);
     // Additional properties can be "true" rather than a type
     if (subSchema !== true) {
-      await mutateWithOpenapiSchemaProperties(
+      await augmentModelFromSchema(
         spec,
         modelLink,
         subSchema,
@@ -760,7 +797,7 @@ const mutateWithOpenapiSchemaProperties = async (
       spec,
       schema.properties![trim(property.name, `"'`)],
     );
-    await mutateWithOpenapiSchemaProperties(
+    await augmentModelFromSchema(
       spec,
       property,
       subSchema,
@@ -770,13 +807,11 @@ const mutateWithOpenapiSchemaProperties = async (
   }
 
   if (COMPOSED_SCHEMA_TYPES.has(model.export)) {
+    const memberSchemas = compositeMemberSchemas(schema, model.export);
     for (let i = 0; i < model.properties.length; i++) {
-      const subSchema = resolveIfRef(
-        spec,
-        (schema as any)[camelCase(model.export)]?.[i],
-      );
+      const subSchema = resolveIfRef(spec, memberSchemas[i]);
       if (subSchema) {
-        await mutateWithOpenapiSchemaProperties(
+        await augmentModelFromSchema(
           spec,
           model.properties[i],
           subSchema,
@@ -797,25 +832,26 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
 
   // Ensure set for all models
   data.models.forEach((model) => {
-    const schema = resolveIfRef(spec, spec?.components?.schemas?.[model.name]);
+    const schema = resolveIfRef(
+      spec,
+      spec?.components?.schemas?.[model.name],
+    ) as OpenApiSchema | undefined;
     if (schema) {
       // Object schemas should be typed as the model we will create
       if (
         schema.type === 'object' &&
-        (schema.properties || (schema as any).patternProperties)
+        (schema.properties || schema.patternProperties)
       ) {
         model.type = model.name;
       }
-      _ensureModelLinks(spec, modelsByName, model, schema, visited);
+      ensureModelLink(spec, modelsByName, model, schema, visited);
     }
   });
 
   // Ensure set for all parameters and responses
   data.services.forEach((service) => {
     service.operations.forEach((op) => {
-      const specOp = (spec as any)?.paths?.[op.path]?.[
-        op.method.toLowerCase()
-      ] as OpenAPIV3.OperationObject | undefined;
+      const specOp = getSpecOperation(spec, op);
 
       const specParametersByName = Object.fromEntries(
         (specOp?.parameters ?? []).map((p) => {
@@ -829,7 +865,7 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
         const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
 
         if (specParameterSchema) {
-          _ensureModelLinks(
+          ensureModelLink(
             spec,
             modelsByName,
             parameter,
@@ -845,7 +881,7 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
           );
 
           if (specBodySchema) {
-            _ensureModelLinks(
+            ensureModelLink(
               spec,
               modelsByName,
               parameter,
@@ -868,7 +904,7 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
             specResponse?.content?.[mediaType]?.schema,
           );
           if (responseSchema) {
-            _ensureModelLinks(
+            ensureModelLink(
               spec,
               modelsByName,
               response,
@@ -882,11 +918,11 @@ const ensureModelLinks = (spec: Spec, data: ClientData) => {
   });
 };
 
-const _ensureModelLinks = (
+const ensureModelLink = (
   spec: Spec,
   modelsByName: { [name: string]: Model },
   model: Model,
-  schema: OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject,
+  schema: OpenApiSchema,
   visited: Set<Model>,
 ) => {
   if (visited.has(model)) {
@@ -906,7 +942,7 @@ const _ensureModelLinks = (
         model.link = modelsByName[name];
       }
     } else if (model.link && typeof schema.additionalProperties !== 'boolean') {
-      _ensureModelLinks(
+      ensureModelLink(
         spec,
         modelsByName,
         flattenModelLink(model.link),
@@ -921,7 +957,7 @@ const _ensureModelLinks = (
         model.link = modelsByName[name];
       }
     } else if (model.link) {
-      _ensureModelLinks(
+      ensureModelLink(
         spec,
         modelsByName,
         flattenModelLink(model.link),
@@ -938,17 +974,15 @@ const _ensureModelLinks = (
         spec,
         schema.properties![trim(property.name, `"'`)],
       );
-      _ensureModelLinks(spec, modelsByName, property, subSchema, visited);
+      ensureModelLink(spec, modelsByName, property, subSchema, visited);
     });
 
   if (COMPOSED_SCHEMA_TYPES.has(model.export)) {
+    const memberSchemas = compositeMemberSchemas(schema, model.export);
     model.properties.forEach((property, i) => {
-      const subSchema = resolveIfRef(
-        spec,
-        (schema as any)[camelCase(model.export)]?.[i],
-      );
+      const subSchema = resolveIfRef(spec, memberSchemas[i]);
       if (subSchema) {
-        _ensureModelLinks(spec, modelsByName, property, subSchema, visited);
+        ensureModelLink(spec, modelsByName, property, subSchema, visited);
       }
     });
   }
@@ -959,14 +993,12 @@ const _ensureModelLinks = (
  * properties for representing them in generated code. Adds `composedModels` and `composedPrimitives`
  * which contain the models and primitive types that each model is composed of.
  */
-const ensureCompositeModels = (data: ClientData) => {
+const resolveComposedModels = (data: ClientData) => {
   const visited = new Set<Model>();
-  data.models.forEach((model) =>
-    mutateModelWithCompositeProperties(data, model, visited),
-  );
+  data.models.forEach((model) => resolveComposedModel(data, model, visited));
 };
 
-const mutateModelWithCompositeProperties = (
+const resolveComposedModel = (
   data: ClientData,
   model: Model,
   visited: Set<Model>,
@@ -988,27 +1020,25 @@ const mutateModelWithCompositeProperties = (
     let composedModels = composedModelReferences.flatMap((r) =>
       modelsByName[r.type] ? [modelsByName[r.type]] : [],
     );
-    // Recursively resolve composed properties of properties, to ensure mixins for all-of include all recursive all-of properties
-    composedModels.forEach((m) =>
-      mutateModelWithCompositeProperties(data, m, visited),
-    );
+    // Resolve recursively so all-of mixins include nested all-of properties
+    composedModels.forEach((m) => resolveComposedModel(data, m, visited));
 
-    // Enums are models, however they are serialised as primitives and so should be moved to the primitives list
+    // Enums serialise as primitives, so group them with the primitives
     composedPrimitives.push(
       ...composedModels.filter((m) => m.export === 'enum'),
     );
     composedModels = composedModels.filter((m) => m.export !== 'enum');
 
-    // When multiple arrays of non-primitives are composed using allOf/oneOf/anyOf, it's not possible to distinguish at runtime which
-    // type it is, and so we validate this away.
-    // TODO: consider honouring more advanced OpenAPI spec features like "discriminators" which can help for this case, but in practice
-    // users are unlikely to model their API this way
+    // Composing multiple arrays of non-primitives is not distinguishable at
+    // runtime, so it's validated away below.
+    // TODO: honour `discriminator` to support this case.
     const isPrimitiveArray = (m: Model) => {
       if (m.link && ['array', 'dictionary'].includes(m.export)) {
         return isPrimitiveArray(flattenModelLink(m.link));
       }
       return (
-        PRIMITIVE_TYPES.has(m.type) && !['date', 'date-time'].includes(m.format)
+        PRIMITIVE_TYPES.has(m.type) &&
+        !['date', 'date-time'].includes(m.format ?? '')
       );
     };
     const arrayComposedModels = composedPrimitives.filter(
@@ -1029,23 +1059,23 @@ const mutateModelWithCompositeProperties = (
       }
     }
 
-    (model as any).composedModels = composedModels;
-    (model as any).composedPrimitives = composedPrimitives;
+    model.composedModels = composedModels;
+    model.composedPrimitives = composedPrimitives;
   }
 };
 
 /**
  * Mutates the given model to add language specific types and names
  */
-const mutateModelWithAdditionalTypes = (model: Model) => {
+const addLanguageTypes = (model: Model) => {
   // Trim any surrounding quotes from name
   model.name = trim(model.name, `"'`);
 
-  (model as any).typescriptName = toTypeScriptName(model.name);
-  (model as any).typescriptType = toTypeScriptType(model);
-  (model as any).pythonName = toPythonName('property', model.name);
-  (model as any).pythonType = toPythonType(model);
-  (model as any).isPrimitive =
+  model.typescriptName = toTypeScriptName(model.name);
+  model.typescriptType = toTypeScriptType(model);
+  model.pythonName = toPythonName('property', model.name);
+  model.pythonType = toPythonType(model);
+  model.isPrimitive =
     PRIMITIVE_TYPES.has(model.type) &&
     !COMPOSED_SCHEMA_TYPES.has(model.export) &&
     !COLLECTION_TYPES.has(model.export);
@@ -1056,7 +1086,7 @@ const mutateModelWithAdditionalTypes = (model: Model) => {
  */
 const isOperationMutation = (op: Operation): boolean => {
   // Let the user override whether an operation is a query or mutation using x-mutation/x-query
-  const { vendorExtensions } = op as any;
+  const { vendorExtensions } = op;
   if (vendorExtensions?.[VENDOR_EXTENSIONS.MUTATION]) {
     return true;
   } else if (vendorExtensions?.[VENDOR_EXTENSIONS.QUERY]) {
@@ -1069,62 +1099,51 @@ const isOperationMutation = (op: Operation): boolean => {
 /**
  * Add infinite query details to the operation
  */
-const mutateOperationWithInfiniteQueryDetails = (op: Operation) => {
+const augmentInfiniteQuery = (op: Operation) => {
   const { paginationDisabled, cursorPropertyName } = getCursorOptions(op);
 
-  // Allow users to customise the "cursor" property used for paginated requests
   const cursorProperty = op.parameters.find(
     (p) => p.name === cursorPropertyName,
   );
 
-  // The operation is an infinite query if:
-  // - x-cursor is not set to 'false' (this allows users to disable infinite queries for operations that accept a 'cursor')
-  // - the operation accepts a parameter named 'cursor', or a parameter named as the user specified with x-cursor
-  (op as any).isInfiniteQuery = !paginationDisabled && !!cursorProperty;
-  if ((op as any).isInfiniteQuery) {
-    (op as any).infiniteQueryCursorProperty = cursorProperty;
+  // An infinite query is a paginated operation that accepts the cursor parameter
+  op.isInfiniteQuery = !paginationDisabled && !!cursorProperty;
+  if (op.isInfiniteQuery) {
+    op.infiniteQueryCursorProperty = cursorProperty;
   }
 };
 
 /**
- * Extracts the cursor options for this operation based on the vendor extensions
+ * Resolve the pagination cursor options from an operation's `x-cursor` vendor
+ * extension. Accepted forms (object variants exist because Smithy vendor
+ * extensions must be objects):
  *
- * Valid usage of x-cursor:
- *
- * x-cursor: 'property' - customises the input property used for pagination
- * x-cursor: false - disables pagination for the operation (ie the operation would have pagination by default as an input 'cursor' property exists)
- *
- * We also support object equivalents of the above, since Smithy vendor extensions can only be objects
- *
- * x-cursor: { inputToken: 'property' }
- * x-cursor: { enabled: false }
+ * - `'property'` / `{ inputToken: 'property' }` — the input property to page on
+ * - `false` / `{ enabled: false }` — disable pagination
  */
 const getCursorOptions = (op: Operation) => {
-  const { vendorExtensions } = op as any;
+  const cursorExtension = op.vendorExtensions?.[VENDOR_EXTENSIONS.CURSOR];
 
-  const cursorExtension = vendorExtensions?.[VENDOR_EXTENSIONS.CURSOR];
-
-  // By default pagination isn't explicitly disabled and the cursor property to look for is 'cursor'
+  // Defaults: pagination enabled, paging on a property named 'cursor'
   let paginationDisabled = false;
   let cursorPropertyName = 'cursor';
 
-  if (typeof cursorExtension === 'boolean' && cursorExtension === false) {
+  if (cursorExtension === false) {
     paginationDisabled = true;
   } else if (typeof cursorExtension === 'string') {
     cursorPropertyName = cursorExtension;
-  } else if (typeof cursorExtension === 'object') {
-    if (cursorExtension?.enabled === false) {
+  } else if (cursorExtension && typeof cursorExtension === 'object') {
+    const cursorOptions = cursorExtension as {
+      enabled?: boolean;
+      inputToken?: unknown;
+    };
+    if (cursorOptions.enabled === false) {
       paginationDisabled = true;
     }
-    if (
-      cursorExtension?.inputToken &&
-      typeof cursorExtension.inputToken === 'string'
-    ) {
-      cursorPropertyName = cursorExtension.inputToken;
+    if (typeof cursorOptions.inputToken === 'string') {
+      cursorPropertyName = cursorOptions.inputToken;
     }
   }
-
-  // x-cursor can be: a string (indicating pagination is enabled and the property name to use)
 
   return {
     paginationDisabled,
@@ -1133,27 +1152,23 @@ const getCursorOptions = (op: Operation) => {
 };
 
 /**
- * Add additional data to an operation for code generation decisions
+ * Add query/mutation, streaming and infinite-query flags to an operation.
  */
-const mutateOperationWithAdditionalData = (op: Operation) => {
-  // Add mutation/query details
+const augmentOperationBehaviour = (op: Operation) => {
   const isMutation = isOperationMutation(op);
-  (op as any).isMutation = isMutation;
-  (op as any).isQuery = !isMutation;
+  op.isMutation = isMutation;
+  op.isQuery = !isMutation;
 
-  // Streaming responses
-  (op as any).isStreaming =
-    !!(op as any).vendorExtensions?.[VENDOR_EXTENSIONS.STREAMING] ||
-    op.responses.some((res) => (res as any).isJsonlStreaming);
+  op.isStreaming =
+    !!op.vendorExtensions?.[VENDOR_EXTENSIONS.STREAMING] ||
+    op.responses.some((res) => res.isJsonlStreaming);
 
-  // Set the result type for the client method to the item schema so that
-  // it will resolve to AsyncIterableIterator<{itemSchemaModel.name}>
-  const jsonlResponse = op.responses.find(
-    (res) => (res as any).isJsonlStreaming,
-  );
+  // For JSON-lines streaming, the result is each streamed item, so the client
+  // method returns AsyncIterableIterator<itemSchemaModel>
+  const jsonlResponse = op.responses.find((res) => res.isJsonlStreaming);
   if (jsonlResponse) {
-    const itemSchemaModel = (jsonlResponse as any).itemSchemaModel;
-    const result = (op as any).result;
+    const itemSchemaModel = jsonlResponse.itemSchemaModel;
+    const result = op.result;
     if (result && itemSchemaModel) {
       result.type = itemSchemaModel.name;
       result.typescriptType = itemSchemaModel.name;
@@ -1163,6 +1178,6 @@ const mutateOperationWithAdditionalData = (op: Operation) => {
 
   // Add infinite query details if applicable
   if (!isMutation) {
-    mutateOperationWithInfiniteQueryDetails(op);
+    augmentInfiniteQuery(op);
   }
 };

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -373,6 +373,11 @@ const getCollectionFormat = (
   if (position === 'header') {
     return explode ? 'multi' : 'csv';
   }
+  // `deepObject` serialises an object as `key[prop]=value` pairs regardless of
+  // explode; the object shape (not array collection) drives its serialisation.
+  if (style === 'deepObject') {
+    return 'deepObject';
+  }
   return explode
     ? 'multi'
     : ((

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -45,9 +45,10 @@ import {
   buildInlineModel,
   compositeMemberSchemas,
   getSpecOperation,
-  getSpecParametersByName,
+  getSpecParametersByKey,
   getSpecPathParameters,
   linkModel,
+  specParameterKey,
 } from './parser';
 import { isRef, resolveIfRef, splitRef } from './refs';
 import type { OpenApiSchema, OpenApiSchemaOrRef, Spec } from './types';
@@ -243,9 +244,7 @@ const augmentResponses = (
     response.mediaTypes = mediaTypes;
 
     for (const mediaType of mediaTypes) {
-      const responseContent =
-        specResponse.content?.[mediaType] ??
-        Object.values(specResponse.content)[0];
+      const responseContent = specResponse.content[mediaType];
       const responseSchema = resolveIfRef(spec, responseContent.schema);
       if (responseSchema) {
         augmentModelFromSchema(spec, response, responseSchema, modelsByName);
@@ -278,7 +277,7 @@ const augmentParameters = (
   specOp: OpenAPIV3.OperationObject | undefined,
   modelsByName: ModelsByName,
 ): string[] => {
-  const specParametersByName = getSpecParametersByName(
+  const specParametersByKey = getSpecParametersByKey(
     spec,
     specOp,
     getSpecPathParameters(spec, op),
@@ -291,7 +290,10 @@ const augmentParameters = (
       modelImports.push(parameter.type);
     }
 
-    const specParameter = specParametersByName[parameter.prop];
+    const specParameter =
+      specParametersByKey[
+        specParameterKey({ in: parameter.in, name: parameter.prop })
+      ];
     const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
     if (specParameterSchema) {
       augmentModelFromSchema(
@@ -423,13 +425,8 @@ const buildRequestParameterModels = (
       {},
     );
 
-  // An explicit (non-inlined) body parameter is named "body".
-  const requestBodyParameter = parametersByPosition['body']?.[0];
-  if (requestBodyParameter) {
-    requestBodyParameter.name = 'body';
-    requestBodyParameter.prop = 'body';
-  }
-  op.explicitRequestBodyParameter = requestBodyParameter;
+  // The body parameter was already renamed to "body" by augmentBodyParameter.
+  op.explicitRequestBodyParameter = parametersByPosition['body']?.[0];
 
   return Object.entries(parametersByPosition).map(([position, parameters]) => {
     const name = `${op.operationIdPascalCase}Request${upperFirst(position)}Parameters`;
@@ -716,15 +713,25 @@ const augmentOperationBehaviour = (op: Operation) => {
     op.responses.some((res) => res.isJsonlStreaming);
 
   // For JSON-lines streaming, the result is each streamed item, so the client
-  // method returns AsyncIterableIterator<itemSchemaModel>
+  // method returns AsyncIterableIterator<itemSchemaModel>. Named (hoisted)
+  // item schemas become references; inline primitives keep their own type.
   const jsonlResponse = op.responses.find((res) => res.isJsonlStreaming);
   if (jsonlResponse) {
     const itemSchemaModel = jsonlResponse.itemSchemaModel;
     const result = op.result;
     if (result && itemSchemaModel) {
-      result.type = itemSchemaModel.name;
-      result.typescriptType = itemSchemaModel.name;
-      result.export = 'reference';
+      if (itemSchemaModel.name) {
+        result.type = itemSchemaModel.name;
+        result.typescriptType = itemSchemaModel.name;
+        result.export = 'reference';
+      } else {
+        result.type = itemSchemaModel.type;
+        result.typescriptType = itemSchemaModel.typescriptType;
+        result.export = itemSchemaModel.export;
+        result.format = itemSchemaModel.format;
+        result.link = itemSchemaModel.link;
+        result.isPrimitive = itemSchemaModel.isPrimitive;
+      }
     }
   }
 

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import camelCase from 'lodash.camelcase';
-import { snakeCase, toClassName } from '../../../utils/names';
+import { camelCase, snakeCase, toClassName } from '../../../utils/names';
 import { type Model, PRIMITIVE_TYPES } from './types';
 
 const toTypescriptPrimitive = (property: Model): string => {
@@ -49,7 +48,15 @@ export const toTypeScriptType = (property: Model): string => {
 };
 
 export const toTypeScriptName = (name: string): string => {
-  return camelCase(name);
+  const camel = camelCase(name);
+  if (camel) {
+    return camel;
+  }
+  // Names made up entirely of non-identifier characters (e.g. "_") camelCase to
+  // an empty string; fall back to an underscore-escaped form so the emitted
+  // property is still a valid identifier.
+  const escaped = (name ?? '').replace(/[^a-zA-Z0-9]/g, '_');
+  return /^[0-9]/.test(escaped) ? `_${escaped}` : escaped || '_';
 };
 
 const TYPESCRIPT_RESERVED_MODEL_NAMES = new Set([

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -95,7 +95,7 @@ const toPythonPrimitive = (property: Model): string => {
   } else if (property.type === 'binary') {
     return 'bytearray';
   } else if (property.type === 'number') {
-    if ((property as any).openapiType === 'integer') {
+    if (property.openapiType === 'integer') {
       return 'int';
     }
 

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -48,15 +48,9 @@ export const toTypeScriptType = (property: Model): string => {
 };
 
 export const toTypeScriptName = (name: string): string => {
-  const camel = camelCase(name);
-  if (camel) {
-    return camel;
-  }
-  // Names made up entirely of non-identifier characters (e.g. "_") camelCase to
-  // an empty string; fall back to an underscore-escaped form so the emitted
-  // property is still a valid identifier.
-  const escaped = (name ?? '').replace(/[^a-zA-Z0-9]/g, '_');
-  return /^[0-9]/.test(escaped) ? `_${escaped}` : escaped || '_';
+  // A name of only non-identifier characters (e.g. "_") camelCases to an empty
+  // string; fall back to an underscore so the emitted property stays valid.
+  return camelCase(name) || (name ?? '').replace(/[^a-zA-Z0-9]/g, '_') || '_';
 };
 
 const TYPESCRIPT_RESERVED_MODEL_NAMES = new Set([

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -23,15 +23,18 @@ const toTypescriptPrimitive = (property: Model): string => {
  * Return the typescript type for the given model
  */
 export const toTypeScriptType = (property: Model): string => {
-  const propertyLink = property.link;
+  const link = property.link;
+  // Enum links serialise as their primitive; use the model's own type instead.
+  const valueType =
+    link && link.export !== 'enum' ? toTypeScriptType(link) : property.type;
   switch (property.export) {
     case 'enum':
     case 'generic':
       return toTypescriptPrimitive(property);
     case 'array':
-      return `Array<${propertyLink && propertyLink.export !== 'enum' ? toTypeScriptType(propertyLink) : property.type}>`;
+      return `Array<${valueType}>`;
     case 'dictionary':
-      return `{ [key: string]: ${propertyLink && propertyLink.export !== 'enum' ? toTypeScriptType(propertyLink) : property.type}; }`;
+      return `{ [key: string]: ${valueType}; }`;
     case 'one-of':
     case 'any-of':
     case 'all-of':
@@ -120,15 +123,17 @@ const toPythonPrimitive = (property: Model): string => {
  * Return the python type for a given property
  */
 export const toPythonType = (property: Model): string => {
-  const propertyLink = property.link;
+  const link = property.link;
+  const valueType =
+    link && link.export !== 'enum' ? toPythonType(link) : property.type;
   switch (property.export) {
     case 'generic':
     case 'reference':
       return toPythonPrimitive(property);
     case 'array':
-      return `List[${propertyLink && propertyLink.export !== 'enum' ? toPythonType(propertyLink) : property.type}]`;
+      return `List[${valueType}]`;
     case 'dictionary':
-      return `Dict[str, ${propertyLink && propertyLink.export !== 'enum' ? toPythonType(propertyLink) : property.type}]`;
+      return `Dict[str, ${valueType}]`;
     case 'one-of':
     case 'any-of':
     case 'all-of':

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -19,22 +19,19 @@ const toTypescriptPrimitive = (property: Model): string => {
   return property.type;
 };
 
-/**
- * Return the typescript type for the given model
- */
 export const toTypeScriptType = (property: Model): string => {
   const link = property.link;
   // Enum links serialise as their primitive; use the model's own type instead.
-  const valueType =
+  const valueType = () =>
     link && link.export !== 'enum' ? toTypeScriptType(link) : property.type;
   switch (property.export) {
     case 'enum':
     case 'generic':
       return toTypescriptPrimitive(property);
     case 'array':
-      return `Array<${valueType}>`;
+      return `Array<${valueType()}>`;
     case 'dictionary':
-      return `{ [key: string]: ${valueType}; }`;
+      return `{ [key: string]: ${valueType()}; }`;
     case 'one-of':
     case 'any-of':
     case 'all-of':
@@ -119,21 +116,18 @@ const toPythonPrimitive = (property: Model): string => {
   return property.type;
 };
 
-/**
- * Return the python type for a given property
- */
 export const toPythonType = (property: Model): string => {
   const link = property.link;
-  const valueType =
+  const valueType = () =>
     link && link.export !== 'enum' ? toPythonType(link) : property.type;
   switch (property.export) {
     case 'generic':
     case 'reference':
       return toPythonPrimitive(property);
     case 'array':
-      return `List[${valueType}]`;
+      return `List[${valueType()}]`;
     case 'dictionary':
-      return `Dict[str, ${valueType}]`;
+      return `Dict[str, ${valueType()}]`;
     case 'one-of':
     case 'any-of':
     case 'all-of':

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -199,8 +199,8 @@ export const toPythonName = (
 ) => {
   const nameSnakeCase = snakeCase(name);
 
-  // Check if the name is a reserved word. Reserved words that overlap with TypeScript will already be escaped
-  // with a leading _ by @hey-api/openapi-ts, so we remove this to test
+  // Names overlapping a TypeScript reserved word carry a leading `_`; strip it
+  // before testing against the Python keyword set.
   if (PYTHON_KEYWORDS.has(name.startsWith('_') ? name.slice(1) : name)) {
     const nameSuffix = `_${nameSnakeCase}`;
     switch (namedEntity) {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -5,7 +5,7 @@
 
 import camelCase from 'lodash.camelcase';
 import { snakeCase, toClassName } from '../../../utils/names';
-import { flattenModelLink, type Model, PRIMITIVE_TYPES } from './types';
+import { type Model, PRIMITIVE_TYPES } from './types';
 
 const toTypescriptPrimitive = (property: Model): string => {
   if (
@@ -23,7 +23,7 @@ const toTypescriptPrimitive = (property: Model): string => {
  * Return the typescript type for the given model
  */
 export const toTypeScriptType = (property: Model): string => {
-  const propertyLink = flattenModelLink(property.link);
+  const propertyLink = property.link;
   switch (property.export) {
     case 'enum':
     case 'generic':
@@ -120,7 +120,7 @@ const toPythonPrimitive = (property: Model): string => {
  * Return the python type for a given property
  */
 export const toPythonType = (property: Model): string => {
-  const propertyLink = flattenModelLink(property.link);
+  const propertyLink = property.link;
   switch (property.export) {
     case 'generic':
     case 'reference':

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -39,8 +39,11 @@ export type ModelIn =
   | 'body'
   | 'response';
 
-/** How array/dictionary query & header parameters are serialised on the wire. */
-export type CollectionFormat = 'multi' | 'csv' | 'ssv' | 'pipes';
+/**
+ * How array/object query & header parameters are serialised on the wire.
+ * `deepObject` explodes an object into `key[prop]=value` query pairs.
+ */
+export type CollectionFormat = 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
 
 /** A single enum member value. */
 export interface EnumMember {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -215,6 +215,13 @@ export interface ClientData {
   services: Service[];
 }
 
+/** Models indexed by name, for reference resolution during augmentation. */
+export type ModelsByName = { [name: string]: Model };
+
+/** Index a list of models by name. */
+export const indexModelsByName = (models: Model[]): ModelsByName =>
+  Object.fromEntries(models.map((m) => [m.name, m]));
+
 /**
  * The full data structure handed to the code generation templates.
  */

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -47,6 +47,30 @@ export interface EnumMember {
   value: string | number | boolean;
 }
 
+/**
+ * A discriminated-composite mapping entry: a discriminator value and the name
+ * of the composed model it selects.
+ */
+export interface DiscriminatorMapping {
+  /** The discriminator property value (e.g. `"cat"`). */
+  value: string;
+  /** The name of the composed model this value selects (e.g. `"Cat"`). */
+  modelName: string;
+}
+
+/**
+ * The discriminator of a `oneOf`/`anyOf` composite, used to marshal directly to
+ * the matching branch rather than merging every branch.
+ */
+export interface Discriminator {
+  /** The wire property name carrying the discriminator value. */
+  propertyName: string;
+  /** The TypeScript property name (resolved during augmentation). */
+  typescriptPropertyName?: string;
+  /** The value → composed-model mapping. */
+  mapping: DiscriminatorMapping[];
+}
+
 /** A pattern-property entry: a regex pattern and the model for its values. */
 export interface PatternPropertyModel {
   pattern: string;
@@ -122,6 +146,8 @@ export interface Model {
   composedModels?: Model[];
   /** For composites: the primitive/enum/array members composed together. */
   composedPrimitives?: Model[];
+  /** For discriminated one-of/any-of composites: the discriminator metadata. */
+  discriminator?: Discriminator;
 
   /** The TypeScript identifier for this model/property. */
   typescriptName?: string;

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -222,6 +222,9 @@ export type ModelsByName = { [name: string]: Model };
 export const indexModelsByName = (models: Model[]): ModelsByName =>
   Object.fromEntries(models.map((m) => [m.name, m]));
 
+/** The single service the parser emits; operations are re-grouped by tag. */
+export const DEFAULT_SERVICE_NAME = 'Default';
+
 /**
  * The full data structure handed to the code generation templates.
  */

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -2,28 +2,286 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { Plugin } from '@hey-api/openapi-ts';
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
-export type ClientData = Parameters<Plugin.LegacyHandler<any>>[0]['client'];
-export type Operation = ClientData['services'][number]['operations'][number];
-export type Model = ClientData['models'][number];
+/**
+ * The kind of a {@link Model}, describing how it should be rendered.
+ *
+ * - `interface` — an object type with named properties
+ * - `enum` — a set of string/number literal values
+ * - `array` — a list whose element type is described by `link`
+ * - `dictionary` — a map whose value type is described by `link`
+ * - `reference` — a reference to another named model (`type` is its name)
+ * - `generic` — a primitive (string/number/boolean/null/void/binary/any)
+ * - `one-of` / `any-of` / `all-of` — a composite of other schemas
+ */
+export type ModelExport =
+  | 'interface'
+  | 'enum'
+  | 'array'
+  | 'dictionary'
+  | 'reference'
+  | 'generic'
+  | 'one-of'
+  | 'any-of'
+  | 'all-of';
 
+/**
+ * Where a parameter-like {@link Model} appears in a request/response.
+ * Empty string is used for models that are not parameters (schemas/properties).
+ */
+export type ModelIn =
+  | ''
+  | 'query'
+  | 'path'
+  | 'header'
+  | 'cookie'
+  | 'body'
+  | 'response';
+
+/** How array/dictionary query & header parameters are serialised on the wire. */
+export type CollectionFormat = 'multi' | 'csv' | 'ssv' | 'tsv';
+
+/** A single enum member value. */
+export interface EnumMember {
+  value: string | number | boolean;
+}
+
+/** A pattern-property entry: a regex pattern and the model for its values. */
+export interface PatternPropertyModel {
+  pattern: string;
+  model: Model;
+}
+
+/**
+ * A model represents an OpenAPI schema, or something derived from one (a
+ * property, parameter, or response). It is produced by the parser
+ * (`../parser.ts`) and progressively augmented by `../codegen-data.ts` with
+ * language-specific and code-generation fields before being handed to the
+ * templates.
+ *
+ * Fields are grouped by the stage that populates them. All augmentation fields
+ * are optional because they are absent on the raw parser output and only
+ * present once the relevant augmentation pass has run.
+ */
+export interface Model {
+  // ---- Core structural fields (populated by the parser) --------------------
+  /** The schema, property, or parameter name. */
+  name: string;
+  /** How this model should be rendered. */
+  export: ModelExport;
+  /**
+   * The model's type: a primitive name (`string`, `number`, `boolean`, `null`,
+   * `void`, `binary`, `any`), `unknown`, or the name of a referenced model.
+   */
+  type: string;
+  /** The OpenAPI `format` (e.g. `int32`, `date-time`, `binary`), if any. */
+  format?: string;
+  /** Description, used to render doc comments. */
+  description: string | null;
+  /** Whether the schema is marked deprecated. */
+  deprecated: boolean;
+  /** Whether the value may be null. */
+  isNullable: boolean;
+  /** Whether the property is read-only. */
+  isReadOnly: boolean;
+  /** Whether the property/parameter is required. */
+  isRequired: boolean;
+  /** Whether an array enforces uniqueness (rendered as a `Set`). */
+  uniqueItems?: boolean;
+  /** For arrays/dictionaries, the model describing the element/value type. */
+  link?: Model | Model[] | null;
+  /** Child properties (for interfaces) or members (for composites). */
+  properties: Model[];
+  /** Enum members, when `export === 'enum'`. */
+  enum: EnumMember[];
+  /** Names of other models this model references (for import generation). */
+  imports: string[];
+
+  // ---- Parameter / response fields (populated by the parser) ---------------
+  /** Where a parameter appears; `''` for non-parameter models. */
+  in: ModelIn;
+  /** The source property name for a parameter (body parameters use `body`). */
+  prop?: string;
+  /** The chosen request/response media type, for body params and responses. */
+  mediaType?: string | null;
+  /** All acceptable media types (request body / response). */
+  mediaTypes?: string[];
+  /** The response status code, for response models. */
+  code?: number | string;
+
+  // ---- Schema-derived augmentation (augmentModelFromSchema) ----------------
+  /** The raw OpenAPI `type` (used to distinguish integer from number). */
+  openapiType?: string | string[];
+  /** Vendor extensions (`x-*`) copied from the schema. */
+  vendorExtensions?: VendorExtensions;
+  /** True when the schema has additionalProperties. */
+  hasAdditionalProperties?: boolean;
+  /** The model describing additionalProperties values. */
+  additionalPropertiesModel?: Model;
+  /** True when the schema has patternProperties. */
+  hasPatternProperties?: boolean;
+  /** The models describing each pattern's values. */
+  patternPropertiesModels?: PatternPropertyModel[];
+
+  // ---- Composite augmentation (resolveComposedModels) ----------------------
+  /** For composites: the referenced (object) models composed together. */
+  composedModels?: Model[];
+  /** For composites: the primitive/enum/array members composed together. */
+  composedPrimitives?: Model[];
+
+  // ---- Language augmentation (addLanguageTypes) ----------------------------
+  /** The TypeScript identifier for this model/property. */
+  typescriptName?: string;
+  /** The rendered TypeScript type. */
+  typescriptType?: string;
+  /** The Python identifier for this model/property. */
+  pythonName?: string;
+  /** The rendered Python type. */
+  pythonType?: string;
+  /** snake_case model name (Python). */
+  nameSnakeCase?: string;
+  /** True when the model is a renderable primitive (not composite/collection). */
+  isPrimitive?: boolean;
+  /** True when the schema declares an enum. */
+  isEnum?: boolean;
+  /** Unique referenced model names to import (excludes self-references). */
+  uniqueImports?: string[];
+
+  // ---- Streaming augmentation (response models) ----------------------------
+  /** True for JSON-lines streaming responses. */
+  isJsonlStreaming?: boolean;
+  /** The model describing each streamed item. */
+  itemSchemaModel?: Model;
+
+  // ---- Parameter serialisation augmentation --------------------------------
+  /** Collection serialisation format for array query/header parameters. */
+  collectionFormat?: CollectionFormat;
+}
+
+/** Vendor extension bag (`x-*` keys copied from a schema/operation/spec). */
+export type VendorExtensions = { [key: string]: unknown };
+
+/**
+ * An operation represents a single OpenAPI path + method. Produced by the
+ * parser and augmented by `../codegen-data.ts`.
+ */
+export interface Operation {
+  // ---- Core fields (populated by the parser) -------------------------------
+  id: string;
+  name: string;
+  method: string;
+  path: string;
+  description: string | null;
+  tags?: string[] | null;
+  deprecated: boolean;
+  imports: string[];
+  parameters: Model[];
+  /** The request body parameter (same object reference as in `parameters`). */
+  parametersBody?: Model | null;
+  responses: Model[];
+
+  // ---- Naming augmentation -------------------------------------------------
+  /** Deduplicated operation name used throughout generated code. */
+  uniqueName?: string;
+  /** Dot-notation name (tag-qualified), used for metadata keys. */
+  dotNotationName?: string;
+  operationIdPascalCase?: string;
+  operationIdKebabCase?: string;
+  operationIdSnakeCase?: string;
+  /** The generated request type name (e.g. `FooRequest`). */
+  requestTypeName?: string;
+
+  // ---- Response augmentation -----------------------------------------------
+  /** The response model used as the operation's result. */
+  result?: Model;
+
+  // ---- Request-body augmentation -------------------------------------------
+  /** The explicit body parameter when the body is not inlined. */
+  explicitRequestBodyParameter?: Model;
+
+  // ---- Behavioural augmentation --------------------------------------------
+  vendorExtensions?: VendorExtensions;
+  isMutation?: boolean;
+  isQuery?: boolean;
+  isStreaming?: boolean;
+  isInfiniteQuery?: boolean;
+  /** The cursor parameter, for infinite queries. */
+  infiniteQueryCursorProperty?: Model;
+}
+
+/**
+ * A service groups operations. Currently the parser produces a single
+ * `Default` service; operations are re-grouped by tag downstream.
+ */
+export interface Service {
+  name: string;
+  operations: Operation[];
+  imports: string[];
+
+  // ---- Augmentation --------------------------------------------------------
+  /** All model names the service (API client) needs to import. */
+  modelImports?: string[];
+  className?: string;
+  classNameSnakeCase?: string;
+  nameSnakeCase?: string;
+}
+
+/**
+ * The initial data structure produced by the OpenAPI parser.
+ */
+export interface ClientData {
+  models: Model[];
+  services: Service[];
+}
+
+/**
+ * The full data structure handed to the code generation templates.
+ */
 export interface CodeGenData extends ClientData {
   className: string;
   info: OpenAPIV3.InfoObject | OpenAPIV3_1.InfoObject;
   allOperations: Operation[];
   operationsByTag: { [tag: string]: Operation[] };
   untaggedOperations: Operation[];
-  vendorExtensions: { [key: string]: any };
+  vendorExtensions: VendorExtensions;
 }
 
-export const flattenModelLink = (link?: Model | Model[]): Model =>
-  link === undefined ? undefined : Array.isArray(link) ? link[0] : link;
+/**
+ * Create a {@link Model} with the default fields the parser always emits.
+ * Callers override the fields relevant to their specific schema.
+ */
+export const createModel = (overrides: Partial<Model> = {}): Model => ({
+  name: '',
+  export: 'interface',
+  type: 'unknown',
+  description: null,
+  deprecated: false,
+  isNullable: false,
+  isReadOnly: false,
+  isRequired: false,
+  link: null,
+  properties: [],
+  enum: [],
+  imports: [],
+  in: '',
+  ...overrides,
+});
+
+export const flattenModelLink = (link?: Model | Model[] | null): Model =>
+  link === undefined || link === null
+    ? undefined
+    : Array.isArray(link)
+      ? link[0]
+      : link;
 
 // Model types which indicate it is composed (ie inherits/mixin's another schema)
-export const COMPOSED_SCHEMA_TYPES = new Set(['one-of', 'any-of', 'all-of']);
-export const COLLECTION_TYPES = new Set(['array', 'dictionary']);
+export const COMPOSED_SCHEMA_TYPES = new Set<ModelExport>([
+  'one-of',
+  'any-of',
+  'all-of',
+]);
+export const COLLECTION_TYPES = new Set<ModelExport>(['array', 'dictionary']);
 export const PRIMITIVE_TYPES = new Set([
   'string',
   'integer',

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -90,7 +90,7 @@ export interface Model {
   /** Whether an array enforces uniqueness (rendered as a `Set`). */
   uniqueItems?: boolean;
   /** For arrays/dictionaries, the model describing the element/value type. */
-  link?: Model | Model[] | null;
+  link?: Model | null;
   /** Child properties (for interfaces) or members (for composites). */
   properties: Model[];
   /** Enum members, when `export === 'enum'`. */
@@ -145,8 +145,6 @@ export interface Model {
   isPrimitive?: boolean;
   /** True when the schema declares an enum. */
   isEnum?: boolean;
-  /** Unique referenced model names to import (excludes self-references). */
-  uniqueImports?: string[];
 
   // ---- Streaming augmentation (response models) ----------------------------
   /** True for JSON-lines streaming responses. */
@@ -187,7 +185,6 @@ export interface Operation {
   /** Dot-notation name (tag-qualified), used for metadata keys. */
   dotNotationName?: string;
   operationIdPascalCase?: string;
-  operationIdKebabCase?: string;
   operationIdSnakeCase?: string;
   /** The generated request type name (e.g. `FooRequest`). */
   requestTypeName?: string;
@@ -223,7 +220,6 @@ export interface Service {
   /** All model names the service (API client) needs to import. */
   modelImports?: string[];
   className?: string;
-  classNameSnakeCase?: string;
   nameSnakeCase?: string;
 }
 
@@ -267,13 +263,6 @@ export const createModel = (overrides: Partial<Model> = {}): Model => ({
   in: '',
   ...overrides,
 });
-
-export const flattenModelLink = (link?: Model | Model[] | null): Model =>
-  link === undefined || link === null
-    ? undefined
-    : Array.isArray(link)
-      ? link[0]
-      : link;
 
 // Model types which indicate it is composed (ie inherits/mixin's another schema)
 export const COMPOSED_SCHEMA_TYPES = new Set<ModelExport>([

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -58,14 +58,10 @@ export interface PatternPropertyModel {
  * property, parameter, or response). It is produced by the parser
  * (`../parser.ts`) and progressively augmented by `../codegen-data.ts` with
  * language-specific and code-generation fields before being handed to the
- * templates.
- *
- * Fields are grouped by the stage that populates them. All augmentation fields
- * are optional because they are absent on the raw parser output and only
- * present once the relevant augmentation pass has run.
+ * templates. Augmentation fields are optional as they are absent on raw parser
+ * output.
  */
 export interface Model {
-  // ---- Core structural fields (populated by the parser) --------------------
   /** The schema, property, or parameter name. */
   name: string;
   /** How this model should be rendered. */
@@ -98,7 +94,6 @@ export interface Model {
   /** Names of other models this model references (for import generation). */
   imports: string[];
 
-  // ---- Parameter / response fields (populated by the parser) ---------------
   /** Where a parameter appears; `''` for non-parameter models. */
   in: ModelIn;
   /** The source property name for a parameter (body parameters use `body`). */
@@ -110,7 +105,6 @@ export interface Model {
   /** The response status code, for response models. */
   code?: number | string;
 
-  // ---- Schema-derived augmentation (augmentModelFromSchema) ----------------
   /** The raw OpenAPI `type` (used to distinguish integer from number). */
   openapiType?: string | string[];
   /** Vendor extensions (`x-*`) copied from the schema. */
@@ -124,13 +118,11 @@ export interface Model {
   /** The models describing each pattern's values. */
   patternPropertiesModels?: PatternPropertyModel[];
 
-  // ---- Composite augmentation (resolveComposedModels) ----------------------
   /** For composites: the referenced (object) models composed together. */
   composedModels?: Model[];
   /** For composites: the primitive/enum/array members composed together. */
   composedPrimitives?: Model[];
 
-  // ---- Language augmentation (addLanguageTypes) ----------------------------
   /** The TypeScript identifier for this model/property. */
   typescriptName?: string;
   /** The rendered TypeScript type. */
@@ -146,13 +138,11 @@ export interface Model {
   /** True when the schema declares an enum. */
   isEnum?: boolean;
 
-  // ---- Streaming augmentation (response models) ----------------------------
   /** True for JSON-lines streaming responses. */
   isJsonlStreaming?: boolean;
   /** The model describing each streamed item. */
   itemSchemaModel?: Model;
 
-  // ---- Parameter serialisation augmentation --------------------------------
   /** Collection serialisation format for array query/header parameters. */
   collectionFormat?: CollectionFormat;
 }
@@ -165,7 +155,6 @@ export type VendorExtensions = { [key: string]: unknown };
  * parser and augmented by `../codegen-data.ts`.
  */
 export interface Operation {
-  // ---- Core fields (populated by the parser) -------------------------------
   id: string;
   name: string;
   method: string;
@@ -179,7 +168,6 @@ export interface Operation {
   parametersBody?: Model | null;
   responses: Model[];
 
-  // ---- Naming augmentation -------------------------------------------------
   /** Deduplicated operation name used throughout generated code. */
   uniqueName?: string;
   /** Dot-notation name (tag-qualified), used for metadata keys. */
@@ -189,15 +177,12 @@ export interface Operation {
   /** The generated request type name (e.g. `FooRequest`). */
   requestTypeName?: string;
 
-  // ---- Response augmentation -----------------------------------------------
   /** The response model used as the operation's result. */
   result?: Model;
 
-  // ---- Request-body augmentation -------------------------------------------
   /** The explicit body parameter when the body is not inlined. */
   explicitRequestBodyParameter?: Model;
 
-  // ---- Behavioural augmentation --------------------------------------------
   vendorExtensions?: VendorExtensions;
   isMutation?: boolean;
   isQuery?: boolean;
@@ -216,7 +201,6 @@ export interface Service {
   operations: Operation[];
   imports: string[];
 
-  // ---- Augmentation --------------------------------------------------------
   /** All model names the service (API client) needs to import. */
   modelImports?: string[];
   className?: string;

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -40,7 +40,7 @@ export type ModelIn =
   | 'response';
 
 /** How array/dictionary query & header parameters are serialised on the wire. */
-export type CollectionFormat = 'multi' | 'csv' | 'ssv' | 'tsv';
+export type CollectionFormat = 'multi' | 'csv' | 'ssv' | 'pipes';
 
 /** A single enum member value. */
 export interface EnumMember {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -59,8 +59,10 @@ export interface DiscriminatorMapping {
 }
 
 /**
- * The discriminator of a `oneOf`/`anyOf` composite, used to marshal directly to
- * the matching branch rather than merging every branch.
+ * The discriminator of a composite (`oneOf`/`anyOf`) or an inheritance base
+ * (an `object` schema whose subtypes `allOf`-compose it), used to marshal
+ * directly to the matching branch/subtype rather than merging every branch or
+ * dropping subtype-only fields.
  */
 export interface Discriminator {
   /** The wire property name carrying the discriminator value. */
@@ -69,6 +71,14 @@ export interface Discriminator {
   typescriptPropertyName?: string;
   /** The value → composed-model mapping. */
   mapping: DiscriminatorMapping[];
+  /**
+   * True when this discriminator sits on an inheritance base (an `object`
+   * schema selected by `allOf`-composing subtypes) rather than a `oneOf`/
+   * `anyOf` composite. The base marshals via dispatch to its subtypes, but its
+   * subtypes compose the base's own (non-dispatching) body — so the base emits
+   * a separate non-dispatching marshaller to break the recursion.
+   */
+  isBase?: boolean;
 }
 
 /** A pattern-property entry: a regex pattern and the model for its values. */

--- a/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
@@ -241,6 +241,36 @@ describe('normaliseOpenApiSpecForCodeGen', () => {
     });
   });
 
+  it('should throw when a normalised schema name clashes with an existing schema', () => {
+    const spec: Spec = {
+      components: {
+        schemas: {
+          'Foo-Bar': { type: 'object', properties: { a: { type: 'string' } } },
+          FooBar: { type: 'object', properties: { b: { type: 'number' } } },
+        },
+      },
+    } as any;
+
+    expect(() => normaliseOpenApiSpecForCodeGen(spec)).toThrow(
+      /would be normalized to "FooBar", but a schema with that name already exists/,
+    );
+  });
+
+  it('should throw when two schemas normalise to the same name', () => {
+    const spec: Spec = {
+      components: {
+        schemas: {
+          'Foo-Bar': { type: 'object', properties: { a: { type: 'string' } } },
+          'Foo.Bar': { type: 'object', properties: { b: { type: 'number' } } },
+        },
+      },
+    } as any;
+
+    expect(() => normaliseOpenApiSpecForCodeGen(spec)).toThrow(
+      /both normalize to "FooBar"/,
+    );
+  });
+
   it('should handle composite schemas', () => {
     const spec: Spec = {
       components: {

--- a/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
@@ -361,6 +361,67 @@ describe('normaliseOpenApiSpecForCodeGen', () => {
     });
   });
 
+  it('should hoist an inline object parameter schema to a named model', () => {
+    const spec: Spec = {
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                style: 'deepObject',
+                schema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    expect(
+      (result.paths?.['/search'] as any).get.parameters[0].schema,
+    ).toEqual({ $ref: '#/components/schemas/SearchRequestQueryFilter' });
+    expect(
+      result.components?.schemas?.SearchRequestQueryFilter,
+    ).toMatchObject({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    });
+  });
+
+  it('should not hoist a primitive parameter schema', () => {
+    const spec: Spec = {
+      paths: {
+        '/search': {
+          get: {
+            operationId: 'search',
+            parameters: [
+              { name: 'q', in: 'query', schema: { type: 'string' } },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    expect((result.paths?.['/search'] as any).get.parameters[0].schema).toEqual(
+      { type: 'string' },
+    );
+    expect(result.components?.schemas?.SearchRequestQueryQ).toBeUndefined();
+  });
+
   it('should inline $ref path items', () => {
     const spec: Spec = {
       paths: {

--- a/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
@@ -331,6 +331,133 @@ describe('normaliseOpenApiSpecForCodeGen', () => {
     });
   });
 
+  it('should inline $ref path items', () => {
+    const spec: Spec = {
+      paths: {
+        '/a': { $ref: '#/components/pathItems/Shared' },
+        '/b': { $ref: '#/components/pathItems/Shared' },
+      },
+      components: {
+        pathItems: {
+          Shared: {
+            get: {
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+        schemas: {},
+      },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    expect((result.paths?.['/a'] as any).get).toBeDefined();
+    expect((result.paths?.['/b'] as any).get).toBeDefined();
+    expect((result.paths?.['/a'] as any).$ref).toBeUndefined();
+    // Each path gets its own copy, so each operation gets its own
+    // (path-derived) operationId
+    expect((result.paths?.['/a'] as any).get.operationId).toBe('getA');
+    expect((result.paths?.['/b'] as any).get.operationId).toBe('getB');
+  });
+
+  it('should hoist inline schemas for vendored +json media types', () => {
+    const spec: Spec = {
+      paths: {
+        '/test': {
+          post: {
+            operationId: 'testPost',
+            requestBody: {
+              content: {
+                'application/vnd.api+json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/problem+json': {
+                    schema: {
+                      type: 'object',
+                      properties: { detail: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: {} },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    expect(
+      (result.paths?.['/test'].post.requestBody as any).content[
+        'application/vnd.api+json'
+      ].schema,
+    ).toEqual({ $ref: '#/components/schemas/TestPostRequestContent' });
+    expect(
+      (result.paths?.['/test'].post.responses['200'] as any).content[
+        'application/problem+json'
+      ].schema,
+    ).toEqual({ $ref: '#/components/schemas/TestPost200Response' });
+  });
+
+  it('should rewrite multi-type schemas nested inside rewritten schemas', () => {
+    const spec: Spec = {
+      components: {
+        schemas: {
+          Thing: {
+            type: ['array', 'null'],
+            items: { type: ['integer', 'string'] },
+          },
+        },
+      },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    const thing = result.components?.schemas?.Thing as any;
+    expect(thing.type).toEqual('array');
+    expect(thing.nullable).toBe(true);
+    // The rewritten multi-type items are a composite, so they are hoisted
+    expect(thing.items).toEqual({ $ref: '#/components/schemas/ThingItem' });
+    expect(result.components?.schemas?.ThingItem).toMatchObject({
+      anyOf: [{ type: 'integer' }, { type: 'string' }],
+    });
+  });
+
+  it('should rewrite const schemas nested inside rewritten schemas', () => {
+    const spec: Spec = {
+      components: {
+        schemas: {
+          Thing: {
+            type: ['object', 'null'],
+            properties: {
+              kind: { type: 'string', const: 'fixed' },
+            },
+          },
+        },
+      },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    const thing = result.components?.schemas?.Thing as any;
+    expect(thing.nullable).toBe(true);
+    // The const property is rewritten to an enum (and hoisted as one)
+    expect(result.components?.schemas?.ThingKind).toMatchObject({
+      type: 'string',
+      enum: ['fixed'],
+    });
+  });
+
   it('should preserve schema titles when hoisting', () => {
     const spec: Spec = {
       components: {

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import camelCase from 'lodash.camelcase';
 import cloneDeepWith from 'lodash.clonedeepwith';
 import type { OpenAPIV3 } from 'openapi-types';
-import { pascalCase, toClassName, upperFirst } from '../../utils/names';
+import { camelCase, pascalCase, toClassName, upperFirst } from '../../utils/names';
 import { isRef, resolveIfRef, resolveRef, splitRef } from './refs';
 import type { Spec } from './types';
 
@@ -125,7 +124,11 @@ const createUniqueModelName = (
   nameParts: string[],
   seenModelNameCounts: { [name: string]: number },
 ): string => {
-  const candidateName = nameParts.map(upperFirst).join('');
+  // Normalise each part to a class-name form (stripping `_`, hyphens, etc) so
+  // the hoisted schema name matches what `toTypeScriptModelName`/`toClassName`
+  // later derive — otherwise a part like `store_photos` yields a `Store_photos`
+  // schema whose reference (`StorePhotos`) no longer resolves.
+  const candidateName = nameParts.map((part) => toClassName(part)).join('');
 
   const seenModelNameCount = seenModelNameCounts[candidateName];
 

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -5,7 +5,12 @@
 
 import cloneDeepWith from 'lodash.clonedeepwith';
 import type { OpenAPIV3 } from 'openapi-types';
-import { camelCase, pascalCase, toClassName, upperFirst } from '../../utils/names';
+import {
+  camelCase,
+  pascalCase,
+  toClassName,
+  upperFirst,
+} from '../../utils/names';
 import { isRef, resolveIfRef, resolveRef, splitRef } from './refs';
 import type { Spec } from './types';
 
@@ -128,7 +133,7 @@ const createUniqueModelName = (
   // the hoisted schema name matches what `toTypeScriptModelName`/`toClassName`
   // later derive — otherwise a part like `store_photos` yields a `Store_photos`
   // schema whose reference (`StorePhotos`) no longer resolves.
-  const candidateName = nameParts.map((part) => toClassName(part)).join('');
+  const candidateName = nameParts.map(toClassName).join('');
 
   const seenModelNameCount = seenModelNameCounts[candidateName];
 

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -262,9 +262,9 @@ const hoistInlineObjectSubSchemas = (
 
 /**
  * Rewrites OpenAPI 3.1 `const` schemas to the semantically equivalent `enum`
- * form. FastAPI emits `{type: 'string', const: 'X'}` for `Literal['X']`;
- * downstream hey-api/openapi-ts handles the enum shape but synthesises
- * phantom named references for the const shape.
+ * form. FastAPI emits `{type: 'string', const: 'X'}` for `Literal['X']`; the
+ * parser understands the enum shape, whereas the const shape would synthesise
+ * phantom named references.
  */
 const rewriteConstToEnum = (spec: Spec): Spec =>
   cloneDeepWith(spec, (v) => {

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -585,15 +585,20 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
           }
         }
 
-        // Hoist parameter schemas
+        // Hoist parameter schemas. Composite and inline-object schemas are
+        // hoisted to named models so the parameter is fully typed (e.g. a
+        // `deepObject` query param's members are marshalled, not left `unknown`).
         if ('parameters' in operation) {
           (operation.parameters ?? []).forEach((p) => {
             const param = resolveIfRef(spec, p);
-            const paramSchema = param?.schema;
+            const paramSchema = param?.schema as
+              | OpenAPIV3.SchemaObject
+              | undefined;
             if (
               paramSchema &&
               !isRef(paramSchema) &&
-              isCompositeSchema(paramSchema as OpenAPIV3.SchemaObject)
+              (isCompositeSchema(paramSchema) ||
+                (paramSchema.type === 'object' && !!paramSchema.properties))
             ) {
               const schemaName = `${upperFirst(deduplicatedOpId)}Request${upperFirst(param.in)}${upperFirst(camelCase(param.name))}`;
               spec.components!.schemas![schemaName] = paramSchema;

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -281,6 +281,43 @@ const rewriteConstToEnum = (spec: Spec): Spec =>
   });
 
 /**
+ * Rewrites an OpenAPI 3.1 multi-type schema (`type: ['integer', 'string']`)
+ * into the equivalent `anyOf` of single-type schemas, dropping `null` from the
+ * list and marking the schema nullable instead. This lets the parser render a
+ * proper union rather than collapsing to the first declared type.
+ */
+const rewriteMultiTypeToAnyOf = (spec: Spec): Spec =>
+  cloneDeepWith(spec, (v) => {
+    if (
+      v &&
+      typeof v === 'object' &&
+      !Array.isArray(v) &&
+      Array.isArray(v.type) &&
+      !('anyOf' in v) &&
+      !('oneOf' in v) &&
+      !('allOf' in v) &&
+      !('enum' in v)
+    ) {
+      const { type, nullable, ...rest } = v;
+      const nonNull = (type as string[]).filter((t) => t !== 'null');
+      const isNullable = nullable === true || nonNull.length !== type.length;
+      // A single non-null type is not a union; keep it as a plain typed schema.
+      if (nonNull.length <= 1) {
+        return cloneDeepWith({
+          ...rest,
+          ...(nonNull.length === 1 ? { type: nonNull[0] } : {}),
+          ...(isNullable ? { nullable: true } : {}),
+        });
+      }
+      return cloneDeepWith({
+        ...rest,
+        anyOf: nonNull.map((t) => ({ type: t })),
+        ...(isNullable ? { nullable: true } : {}),
+      });
+    }
+  });
+
+/**
  * In order to ensure we generate models consistently whether or not users used refs or inline schemas,
  * we hoist any inline refs to non-primitives
  */
@@ -289,6 +326,7 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
   let spec = cloneDeepWith(inSpec);
 
   spec = rewriteConstToEnum(spec);
+  spec = rewriteMultiTypeToAnyOf(spec);
 
   // Ensure spec has schemas set
   if (!spec?.components?.schemas) {

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -87,6 +87,15 @@ const normaliseSchemaNames = (spec: Spec): Spec => {
 const isCompositeSchema = (schema: OpenAPIV3.SchemaObject) =>
   !!schema.allOf || !!schema.anyOf || !!schema.oneOf;
 
+/**
+ * The media type whose schema is hoisted for a request/response: prefer
+ * `application/json`, falling back to any `+json` vendored type (e.g.
+ * `application/problem+json`).
+ */
+const preferredJsonMediaType = (mediaTypes: string[]): string | undefined =>
+  mediaTypes.find((mediaType) => mediaType === 'application/json') ??
+  mediaTypes.find((mediaType) => mediaType.split(';')[0].endsWith('+json'));
+
 const hasSubSchemasToVisit = (
   schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
 ): schema is OpenAPIV3.SchemaObject =>
@@ -275,8 +284,8 @@ const hoistInlineObjectSubSchemas = (
  * parser understands the enum shape, whereas the const shape would synthesise
  * phantom named references.
  */
-const rewriteConstToEnum = (spec: Spec): Spec =>
-  cloneDeepWith(spec, (v) => {
+const rewriteConstToEnum = (spec: Spec): Spec => {
+  const rewrite = (v: any): any => {
     if (
       v &&
       typeof v === 'object' &&
@@ -285,9 +294,13 @@ const rewriteConstToEnum = (spec: Spec): Spec =>
       !('enum' in v)
     ) {
       const { const: constValue, ...rest } = v;
-      return cloneDeepWith({ ...rest, enum: [constValue] });
+      // Recurse with the same rewrite so consts nested within a rewritten
+      // schema are also rewritten.
+      return cloneDeepWith({ ...rest, enum: [constValue] }, rewrite);
     }
-  });
+  };
+  return cloneDeepWith(spec, rewrite);
+};
 
 /**
  * Rewrites a composite schema with sibling `properties`/`required` (a valid
@@ -331,8 +344,8 @@ const rewriteCompositeSiblingProperties = (spec: Spec): Spec => {
  * list and marking the schema nullable instead. This lets the parser render a
  * proper union rather than collapsing to the first declared type.
  */
-const rewriteMultiTypeToAnyOf = (spec: Spec): Spec =>
-  cloneDeepWith(spec, (v) => {
+const rewriteMultiTypeToAnyOf = (spec: Spec): Spec => {
+  const rewrite = (v: any): any => {
     if (
       v &&
       typeof v === 'object' &&
@@ -346,21 +359,50 @@ const rewriteMultiTypeToAnyOf = (spec: Spec): Spec =>
       const { type, nullable, ...rest } = v;
       const nonNull = (type as string[]).filter((t) => t !== 'null');
       const isNullable = nullable === true || nonNull.length !== type.length;
+      // Recurse with the same rewrite so multi-type schemas nested within a
+      // rewritten schema (e.g. the items of a nullable array) are also
+      // rewritten.
       // A single non-null type is not a union; keep it as a plain typed schema.
       if (nonNull.length <= 1) {
-        return cloneDeepWith({
-          ...rest,
-          ...(nonNull.length === 1 ? { type: nonNull[0] } : {}),
-          ...(isNullable ? { nullable: true } : {}),
-        });
+        return cloneDeepWith(
+          {
+            ...rest,
+            ...(nonNull.length === 1 ? { type: nonNull[0] } : {}),
+            ...(isNullable ? { nullable: true } : {}),
+          },
+          rewrite,
+        );
       }
-      return cloneDeepWith({
+      return cloneDeepWith(
+        {
+          ...rest,
+          anyOf: nonNull.map((t) => ({ type: t })),
+          ...(isNullable ? { nullable: true } : {}),
+        },
+        rewrite,
+      );
+    }
+  };
+  return cloneDeepWith(spec, rewrite);
+};
+
+/**
+ * Inlines `$ref` path items so that every operation is visited by the
+ * normalisation below (operationId assignment, schema hoisting). Each path
+ * gets its own copy, so paths sharing a path item are normalised
+ * independently.
+ */
+const inlinePathItemRefs = (spec: Spec): void => {
+  Object.entries(spec.paths ?? {}).forEach(([path, pathItem]) => {
+    if (isRef(pathItem)) {
+      const { $ref, ...rest } = pathItem;
+      spec.paths![path] = {
+        ...structuredClone(resolveRef(spec, $ref)),
         ...rest,
-        anyOf: nonNull.map((t) => ({ type: t })),
-        ...(isNullable ? { nullable: true } : {}),
-      });
+      };
     }
   });
+};
 
 /**
  * In order to ensure we generate models consistently whether or not users used refs or inline schemas,
@@ -370,6 +412,7 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
   // Clone the spec so we're free to mutate it
   let spec = cloneDeepWith(inSpec);
 
+  inlinePathItemRefs(spec);
   spec = rewriteConstToEnum(spec);
   spec = rewriteMultiTypeToAnyOf(spec);
   spec = rewriteCompositeSiblingProperties(spec);
@@ -460,8 +503,12 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
         if ('responses' in operation) {
           Object.entries(operation.responses ?? {}).forEach(([code, res]) => {
             const response = resolveIfRef(spec, res);
-            const jsonResponseSchema =
-              response?.content?.['application/json']?.schema;
+            const jsonMediaType = preferredJsonMediaType(
+              Object.keys(response?.content ?? {}),
+            );
+            const jsonResponseSchema = jsonMediaType
+              ? response!.content![jsonMediaType].schema
+              : undefined;
             if (
               jsonResponseSchema &&
               !isRef(jsonResponseSchema) &&
@@ -472,7 +519,7 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
             ) {
               const schemaName = `${upperFirst(deduplicatedOpId)}${code}Response`;
               spec.components!.schemas![schemaName] = jsonResponseSchema;
-              response!.content!['application/json'].schema = {
+              response!.content![jsonMediaType!].schema = {
                 $ref: `#/components/schemas/${schemaName}`,
               };
             }
@@ -502,8 +549,12 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
         }
         if ('requestBody' in operation) {
           const requestBody = resolveIfRef(spec, operation.requestBody);
-          const jsonRequestSchema =
-            requestBody?.content?.['application/json']?.schema;
+          const jsonMediaType = preferredJsonMediaType(
+            Object.keys(requestBody?.content ?? {}),
+          );
+          const jsonRequestSchema = jsonMediaType
+            ? requestBody!.content![jsonMediaType].schema
+            : undefined;
           if (
             jsonRequestSchema &&
             !isRef(jsonRequestSchema) &&
@@ -513,7 +564,7 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
           ) {
             const schemaName = `${upperFirst(deduplicatedOpId)}RequestContent`;
             spec.components!.schemas![schemaName] = jsonRequestSchema;
-            requestBody!.content!['application/json'].schema = {
+            requestBody!.content![jsonMediaType!].schema = {
               $ref: `#/components/schemas/${schemaName}`,
             };
           }

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -34,12 +34,16 @@ interface SubSchemaRef {
  */
 const normaliseSchemaNames = (spec: Spec): Spec => {
   const schemaNameMapping: { [oldName: string]: string } = {};
-  const existingSchemaNames = new Set(
-    Object.keys(spec.components?.schemas ?? {}),
-  );
+  const originalNames = Object.keys(spec.components?.schemas ?? {});
+  const existingSchemaNames = new Set(originalNames);
+
+  // The name each schema resolves to (its normalised form, or itself when it
+  // needs no normalisation). Used to detect two distinct schemas that would
+  // collapse onto the same identifier.
+  const resolvedNameOwners: { [resolvedName: string]: string } = {};
 
   // Build mapping of old names to new names
-  Object.keys(spec.components?.schemas ?? {}).forEach((name) => {
+  originalNames.forEach((name) => {
     const normalizedName = toClassName(name);
     if (normalizedName !== name) {
       // Check if the normalized name would clash with an existing schema
@@ -50,6 +54,17 @@ const normaliseSchemaNames = (spec: Spec): Spec => {
       }
       schemaNameMapping[name] = normalizedName;
     }
+
+    // Detect two distinct schemas resolving to the same name (e.g. "Foo-Bar"
+    // and "Foo.Bar" both normalise to "FooBar"), which would otherwise
+    // silently overwrite one another.
+    const owner = resolvedNameOwners[normalizedName];
+    if (owner !== undefined) {
+      throw new Error(
+        `Schema name normalization conflict: "${name}" and "${owner}" both normalize to "${normalizedName}". Please rename one of these schemas in your OpenAPI specification.`,
+      );
+    }
+    resolvedNameOwners[normalizedName] = name;
   });
 
   // If no normalization needed, return spec as-is

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -11,6 +11,7 @@ import {
   toClassName,
   upperFirst,
 } from '../../utils/names';
+import { STREAMING_CONTENT_TYPES } from './codegen-data/types';
 import { isRef, resolveIfRef, resolveRef, splitRef } from './refs';
 import type { Spec } from './types';
 
@@ -289,6 +290,42 @@ const rewriteConstToEnum = (spec: Spec): Spec =>
   });
 
 /**
+ * Rewrites a composite schema with sibling `properties`/`required` (a valid
+ * JSON Schema conjunction, common in FastAPI/Pydantic output) into an
+ * equivalent extra `allOf` member, so the parser sees a pure composite and the
+ * sibling fields are neither dropped from the type nor stripped when
+ * marshalling.
+ */
+const rewriteCompositeSiblingProperties = (spec: Spec): Spec => {
+  const rewrite = (v: any): any => {
+    if (
+      v &&
+      typeof v === 'object' &&
+      !Array.isArray(v) &&
+      Array.isArray(v.allOf) &&
+      v.properties
+    ) {
+      const { properties, required, type: _type, ...rest } = v;
+      return cloneDeepWith(
+        {
+          ...rest,
+          allOf: [
+            ...v.allOf,
+            {
+              type: 'object',
+              properties,
+              ...(required ? { required } : {}),
+            },
+          ],
+        },
+        rewrite,
+      );
+    }
+  };
+  return cloneDeepWith(spec, rewrite);
+};
+
+/**
  * Rewrites an OpenAPI 3.1 multi-type schema (`type: ['integer', 'string']`)
  * into the equivalent `anyOf` of single-type schemas, dropping `null` from the
  * list and marking the schema nullable instead. This lets the parser render a
@@ -335,6 +372,7 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
 
   spec = rewriteConstToEnum(spec);
   spec = rewriteMultiTypeToAnyOf(spec);
+  spec = rewriteCompositeSiblingProperties(spec);
 
   // Ensure spec has schemas set
   if (!spec?.components?.schemas) {
@@ -438,6 +476,28 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
                 $ref: `#/components/schemas/${schemaName}`,
               };
             }
+
+            // Hoist inline streaming item schemas (OpenAPI 3.2 itemSchema) so
+            // each streamed item gets a named model.
+            STREAMING_CONTENT_TYPES.forEach((mediaType) => {
+              const streamingContent = response?.content?.[mediaType] as
+                | { itemSchema?: OpenAPIV3.SchemaObject }
+                | undefined;
+              const itemSchema = streamingContent?.itemSchema;
+              if (
+                itemSchema &&
+                !isRef(itemSchema) &&
+                (['object', 'array'].includes(itemSchema.type!) ||
+                  isCompositeSchema(itemSchema) ||
+                  (itemSchema.type === 'string' && itemSchema.enum))
+              ) {
+                const schemaName = `${upperFirst(deduplicatedOpId)}${code}ResponseItem`;
+                spec.components!.schemas![schemaName] = itemSchema;
+                streamingContent.itemSchema = {
+                  $ref: `#/components/schemas/${schemaName}`,
+                } as OpenAPIV3.SchemaObject;
+              }
+            });
           });
         }
         if ('requestBody' in operation) {

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -54,15 +54,6 @@ const HTTP_METHODS = [
 
 type HttpMethod = (typeof HTTP_METHODS)[number];
 
-/**
- * A stable sort (preserves original order of equal elements).
- */
-const stableSort = <T>(items: T[], compare: (a: T, b: T) => number): T[] =>
-  items
-    .map((item, index) => ({ item, index }))
-    .sort((a, b) => compare(a.item, b.item) || a.index - b.index)
-    .map(({ item }) => item);
-
 const schemaType = (schema: Schema): string | string[] | undefined =>
   (schema as { type?: string | string[] }).type;
 
@@ -423,10 +414,10 @@ export class OpenApiParser {
       params.push(body);
     }
 
-    // Order parameters required-first with a stable sort that preserves the
-    // original relative order within each group (the body parameter takes part
-    // in the sort at its appended position).
-    return stableSort(params, (a, b) =>
+    // Order parameters required-first. `Array.prototype.sort` is stable, so the
+    // original relative order within each group is preserved (the body
+    // parameter takes part in the sort at its appended position).
+    return params.sort((a, b) =>
       a.isRequired === b.isRequired ? 0 : a.isRequired ? -1 : 1,
     );
   }

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -3,18 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Parses an OpenAPI spec into the initial {@link ClientData} structure consumed
- * by {@link buildOpenApiCodeGenData}, which then enriches it with
- * language-specific and code-generation fields.
- *
- * The spec must already have been run through
- * {@link normaliseOpenApiSpecForCodeGen}, which hoists inline
- * object/enum/composite schemas into named components and inlines refs to
- * primitives, so that every non-primitive is a named schema and every operation
- * has an `operationId`.
- */
-
 import type { OpenAPIV3 } from 'openapi-types';
 import {
   type ClientData,
@@ -123,8 +111,6 @@ const parseResponseCode = (code: string): number | string =>
 const collectImports = (models: Model[]): string[] => [
   ...new Set(models.flatMap((m) => m.imports)),
 ];
-
-// --- Models -----------------------------------------------------------------
 
 /**
  * The structural fields (export/type/link/properties/enum/imports/format) a
@@ -327,8 +313,6 @@ const buildModels = (spec: Spec): Model[] =>
       buildDefinitionModel(spec, name, resolveIfRef(spec, schemaOrRef)),
     ),
   );
-
-// --- Services & operations --------------------------------------------------
 
 /**
  * The synthetic `body` parameter for an operation's request body.

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -130,9 +130,12 @@ const collectImports = (models: Model[]): string[] => [
  */
 const schemaStructure = (spec: Spec, schema: Schema): Partial<Model> => {
   if (isEnumSchema(schema)) {
+    // A string (or untyped) enum renders as a literal union; a boolean/number
+    // enum renders as its bare primitive, so it must carry the declared type.
+    const declared = primaryType(schema);
     return {
       export: 'enum',
-      type: 'string',
+      type: (declared && PRIMITIVE_TYPE_MAP[declared]) ?? 'string',
       enum: schema.enum!.map(
         (value): EnumMember => ({ value: value as EnumMember['value'] }),
       ),
@@ -355,16 +358,18 @@ const buildRequestBody = (
   if (!requestBody?.content) return null;
 
   const mediaType = preferredMediaType(requestBody.content);
+  const base = buildInlineModel(
+    spec,
+    (requestBody.content[mediaType]?.schema ?? {}) as Schema,
+  );
   return {
-    ...buildInlineModel(
-      spec,
-      (requestBody.content[mediaType]?.schema ?? {}) as Schema,
-    ),
+    ...base,
     name: 'requestBody',
     prop: 'requestBody',
     in: 'body',
     mediaType,
     isRequired: !!requestBody.required,
+    description: requestBody.description ?? base.description,
   };
 };
 
@@ -376,8 +381,11 @@ const buildRequestBody = (
 const buildParameters = (
   spec: Spec,
   specOp: OpenAPIV3.OperationObject,
+  pathParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] = [],
 ): Model[] => {
-  const declared: Model[] = (specOp.parameters ?? []).flatMap((p) => {
+  const declared: Model[] = mergeParameters(spec, pathParameters, [
+    ...(specOp.parameters ?? []),
+  ]).flatMap((p) => {
     const param = resolveIfRef<OpenAPIV3.ParameterObject | undefined>(spec, p);
     if (!param) return [];
     const base = buildInlineModel(spec, (param.schema ?? {}) as Schema);
@@ -400,6 +408,28 @@ const buildParameters = (
   return [...params].sort((a, b) =>
     a.isRequired === b.isRequired ? 0 : a.isRequired ? -1 : 1,
   );
+};
+
+/**
+ * Merge path-level parameters with operation-level parameters. Per the OpenAPI
+ * spec, path-level parameters apply to every operation in the path unless an
+ * operation-level parameter overrides one with the same `name` + `in`.
+ */
+const mergeParameters = (
+  spec: Spec,
+  pathParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[],
+  operationParameters: (
+    | OpenAPIV3.ParameterObject
+    | OpenAPIV3.ReferenceObject
+  )[],
+): (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] => {
+  const key = (p: OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject) => {
+    const param = resolveIfRef<OpenAPIV3.ParameterObject | undefined>(spec, p);
+    return param ? `${param.in}:${param.name}` : null;
+  };
+  const overridden = new Set(operationParameters.map(key));
+  const inherited = pathParameters.filter((p) => !overridden.has(key(p)));
+  return [...inherited, ...operationParameters];
 };
 
 /**
@@ -442,8 +472,9 @@ const buildOperation = (
   path: string,
   method: string,
   specOp: OpenAPIV3.OperationObject,
+  pathParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] = [],
 ): Operation => {
-  const parameters = buildParameters(spec, specOp);
+  const parameters = buildParameters(spec, specOp, pathParameters);
   const responses = buildResponses(spec, specOp);
   const id = (specOp as { operationId: string }).operationId;
 
@@ -469,9 +500,12 @@ const buildOperations = (spec: Spec): Operation[] =>
       pathItemOrRef,
     );
     if (!pathItem) return [];
+    const pathParameters = pathItem.parameters ?? [];
     return HTTP_METHODS.flatMap((method: HttpMethod) => {
       const specOp = pathItem[method as OpenAPIV3.HttpMethods];
-      return specOp ? [buildOperation(spec, path, method, specOp)] : [];
+      return specOp
+        ? [buildOperation(spec, path, method, specOp, pathParameters)]
+        : [];
     });
   });
 
@@ -496,18 +530,38 @@ export const getSpecOperation = (
   ];
 
 /**
- * An operation's resolved parameters indexed by name.
+ * An operation's resolved parameters indexed by name, including any path-level
+ * parameters inherited from the containing path item (operation-level
+ * parameters take precedence when both declare the same name).
  */
 export const getSpecParametersByName = (
   spec: Spec,
   specOp: OpenAPIV3.OperationObject | undefined,
+  pathParameters: (
+    | OpenAPIV3.ParameterObject
+    | OpenAPIV3.ReferenceObject
+  )[] = [],
 ): { [name: string]: OpenAPIV3.ParameterObject } =>
   Object.fromEntries(
-    (specOp?.parameters ?? []).map((p) => {
+    [...pathParameters, ...(specOp?.parameters ?? [])].map((p) => {
       const param = resolveIfRef(spec, p);
       return [param.name, param];
     }),
   );
+
+/**
+ * The path-level parameters declared on the path item containing an operation.
+ */
+export const getSpecPathParameters = (
+  spec: Spec,
+  op: Operation,
+): (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] => {
+  const pathItem = resolveIfRef<OpenAPIV3.PathItemObject | undefined>(
+    spec,
+    spec.paths?.[op.path],
+  );
+  return pathItem?.parameters ?? [];
+};
 
 /**
  * The member sub-schemas of a composite (allOf/anyOf/oneOf) schema, in order.

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -24,8 +24,8 @@ import {
 } from './codegen-data/types';
 import { isRef, resolveIfRef, splitRef } from './refs';
 import type {
-  OpenApiSchema as Schema,
   OpenApiSchemaOrRef,
+  OpenApiSchema as Schema,
   Spec,
 } from './types';
 
@@ -131,16 +131,21 @@ const collectImports = (models: Model[]): string[] => [
  * schema contributes to a model.
  */
 const schemaStructure = (spec: Spec, schema: Schema): Partial<Model> => {
-  if (isEnumSchema(schema)) {
+  // A null member (3.0 nullable enums list null as a value) marks the model
+  // nullable rather than becoming a literal. An enum of only null degrades to
+  // a plain (nullable) schema.
+  const enumMembers = (schema.enum ?? []).filter((value) => value !== null);
+  if (isEnumSchema(schema) && enumMembers.length > 0) {
     // A string (or untyped) enum renders as a literal union; a boolean/number
     // enum renders as its bare primitive, so it must carry the declared type.
     const declared = primaryType(schema);
     return {
       export: 'enum',
       type: (declared && PRIMITIVE_TYPE_MAP[declared]) ?? 'string',
-      enum: schema.enum!.map(
+      enum: enumMembers.map(
         (value): EnumMember => ({ value: value as EnumMember['value'] }),
       ),
+      ...(enumMembers.length < schema.enum!.length ? { isNullable: true } : {}),
     };
   }
 
@@ -424,7 +429,7 @@ const mergeParameters = (
 ): ParameterOrRef[] => {
   const key = (p: ParameterOrRef) => {
     const param = resolveIfRef<OpenAPIV3.ParameterObject | undefined>(spec, p);
-    return param ? `${param.in}:${param.name}` : null;
+    return param ? specParameterKey(param) : null;
   };
   const overridden = new Set(operationParameters.map(key));
   const inherited = pathParameters.filter((p) => !overridden.has(key(p)));
@@ -529,19 +534,29 @@ export const getSpecOperation = (
   ];
 
 /**
- * An operation's resolved parameters indexed by name, including any path-level
- * parameters inherited from the containing path item (operation-level
- * parameters take precedence when both declare the same name).
+ * The `in`-qualified key for a parameter, distinguishing parameters that share
+ * a name across positions (e.g. `id` in both path and query).
  */
-export const getSpecParametersByName = (
+export const specParameterKey = (parameter: {
+  in: string;
+  name: string;
+}): string => `${parameter.in}:${parameter.name}`;
+
+/**
+ * An operation's resolved parameters indexed by `in:name`, including any
+ * path-level parameters inherited from the containing path item
+ * (operation-level parameters take precedence when both declare the same
+ * `name` + `in`).
+ */
+export const getSpecParametersByKey = (
   spec: Spec,
   specOp: OpenAPIV3.OperationObject | undefined,
   pathParameters: ParameterOrRef[] = [],
-): { [name: string]: OpenAPIV3.ParameterObject } =>
+): { [key: string]: OpenAPIV3.ParameterObject } =>
   Object.fromEntries(
     [...pathParameters, ...(specOp?.parameters ?? [])].map((p) => {
       const param = resolveIfRef(spec, p);
-      return [param.name, param];
+      return [specParameterKey(param), param];
     }),
   );
 
@@ -656,10 +671,17 @@ const linkModels = (spec: Spec, data: ClientData): void => {
   data.services.forEach((service) => {
     service.operations.forEach((op) => {
       const specOp = getSpecOperation(spec, op);
-      const specParametersByName = getSpecParametersByName(spec, specOp);
+      const specParametersByKey = getSpecParametersByKey(
+        spec,
+        specOp,
+        getSpecPathParameters(spec, op),
+      );
 
       op.parameters.forEach((parameter) => {
-        const specParameter = specParametersByName[parameter.prop];
+        const specParameter =
+          specParametersByKey[
+            specParameterKey({ in: parameter.in, name: parameter.prop })
+          ];
         const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
         if (specParameterSchema) {
           linkModel(

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -12,6 +12,8 @@ import {
   COMPOSED_SCHEMA_TYPES,
   createModel,
   DEFAULT_SERVICE_NAME,
+  type Discriminator,
+  type DiscriminatorMapping,
   type EnumMember,
   indexModelsByName,
   type Model,
@@ -787,6 +789,60 @@ const resolveComposedModels = (data: ClientData): void => {
 };
 
 /**
+ * Build the {@link Discriminator} for a composite schema, if it declares one.
+ *
+ * An explicit `mapping` maps each discriminator value to a schema ref; without
+ * a mapping, OpenAPI implies each composed member's schema name is its own
+ * discriminator value. Only mappings that resolve to a model composed by this
+ * schema are kept, so unknown values fall through to the default marshalling.
+ */
+const buildDiscriminator = (
+  model: Model,
+  schema: Schema,
+): Discriminator | undefined => {
+  const { discriminator } = schema;
+  if (!discriminator?.propertyName) return undefined;
+
+  const composedNames = new Set((model.composedModels ?? []).map((m) => m.name));
+
+  const mapping: DiscriminatorMapping[] = [];
+  if (discriminator.mapping) {
+    for (const [value, ref] of Object.entries(discriminator.mapping)) {
+      if (typeof ref !== 'string' || !ref.startsWith('#/')) continue;
+      const modelName = splitRef(ref)[2];
+      if (composedNames.has(modelName)) mapping.push({ value, modelName });
+    }
+  } else {
+    // Implicit mapping: each composed member's name is its discriminator value.
+    for (const composed of model.composedModels ?? []) {
+      mapping.push({ value: composed.name, modelName: composed.name });
+    }
+  }
+
+  return mapping.length > 0
+    ? { propertyName: discriminator.propertyName, mapping }
+    : undefined;
+};
+
+/**
+ * Attach discriminator metadata to discriminated one-of/any-of composites so
+ * the generator can marshal directly to the matching branch. all-of is a
+ * conjunction (not a choice) so it is never discriminated.
+ */
+const resolveDiscriminators = (spec: Spec, data: ClientData): void => {
+  data.models.forEach((model) => {
+    if (model.export !== 'one-of' && model.export !== 'any-of') return;
+    const schema = resolveIfRef<Schema | undefined>(
+      spec,
+      spec.components?.schemas?.[model.name],
+    );
+    if (!schema) return;
+    const discriminator = buildDiscriminator(model, schema);
+    if (discriminator) model.discriminator = discriminator;
+  });
+};
+
+/**
  * Build the client data structure from a (normalised) OpenAPI spec: a fully
  * linked model graph with composite members resolved, ready for augmentation.
  */
@@ -797,5 +853,6 @@ export const buildClientData = (spec: Spec): ClientData => {
   };
   linkModels(spec, data);
   resolveComposedModels(data);
+  resolveDiscriminators(spec, data);
   return data;
 };

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -1,0 +1,521 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parses an OpenAPI spec into the initial {@link ClientData} structure consumed
+ * by {@link buildOpenApiCodeGenData}, which then enriches it with
+ * language-specific and code-generation fields.
+ *
+ * The spec must already have been run through
+ * {@link normaliseOpenApiSpecForCodeGen}, which hoists inline
+ * object/enum/composite schemas into named components and inlines refs to
+ * primitives, so that every non-primitive is a named schema and every operation
+ * has an `operationId`.
+ */
+
+import type { OpenAPIV3 } from 'openapi-types';
+import {
+  type ClientData,
+  createModel,
+  type EnumMember,
+  type Model,
+  type ModelExport,
+  type ModelIn,
+  type Operation,
+  type Service,
+} from './codegen-data/types';
+import { isRef, resolveIfRef, splitRef } from './refs';
+import type { OpenApiSchema as Schema, Spec } from './types';
+
+/**
+ * The set of OpenAPI primitive `type` values, mapped to the internal model
+ * `type` used by the code generator.
+ */
+const PRIMITIVE_TYPE_MAP: { [openApiType: string]: string } = {
+  string: 'string',
+  number: 'number',
+  integer: 'number',
+  boolean: 'boolean',
+  null: 'null',
+};
+
+const HTTP_METHODS = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+] as const;
+
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+/**
+ * A stable sort (preserves original order of equal elements).
+ */
+const stableSort = <T>(items: T[], compare: (a: T, b: T) => number): T[] =>
+  items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => compare(a.item, b.item) || a.index - b.index)
+    .map(({ item }) => item);
+
+const schemaType = (schema: Schema): string | string[] | undefined =>
+  (schema as { type?: string | string[] }).type;
+
+const isNullable = (schema: Schema): boolean => {
+  const type = schemaType(schema);
+  return (
+    schema.nullable === true ||
+    type === 'null' ||
+    (Array.isArray(type) && type.includes('null'))
+  );
+};
+
+/**
+ * Resolve the "primary" type of a schema, ignoring 'null' in a 3.1 type array.
+ */
+const primaryType = (schema: Schema): string | undefined => {
+  const type = schemaType(schema);
+  return Array.isArray(type) ? type.find((t) => t !== 'null') : type;
+};
+
+const isEnumSchema = (schema: Schema): boolean =>
+  Array.isArray(schema.enum) && schema.enum.length > 0;
+
+const compositeExport = (schema: Schema): ModelExport | undefined => {
+  if (schema.allOf) return 'all-of';
+  if (schema.anyOf) return 'any-of';
+  if (schema.oneOf) return 'one-of';
+  return undefined;
+};
+
+const compositeMembers = (
+  schema: Schema,
+): (Schema | OpenAPIV3.ReferenceObject)[] =>
+  (schema.allOf ?? schema.anyOf ?? schema.oneOf ?? []) as (
+    | Schema
+    | OpenAPIV3.ReferenceObject
+  )[];
+
+/**
+ * A schema is a "dictionary" (map) when it is an object with no explicit
+ * properties (it may have `additionalProperties`, or be a bare `object`).
+ */
+const isDictionarySchema = (schema: Schema): boolean => {
+  if (primaryType(schema) !== 'object') return false;
+  if (compositeExport(schema) || isEnumSchema(schema)) return false;
+  const hasProperties = Object.keys(schema.properties ?? {}).length > 0;
+  return !hasProperties && !schema.patternProperties;
+};
+
+export class OpenApiParser {
+  constructor(private readonly spec: Spec) {}
+
+  /**
+   * Build the full client data structure from the spec.
+   */
+  public build(): ClientData {
+    return {
+      models: this.buildModels(),
+      services: [this.buildDefaultService()],
+    };
+  }
+
+  // --- Models ---------------------------------------------------------------
+
+  private buildModels(): Model[] {
+    const schemas = this.spec.components?.schemas ?? {};
+    const models = Object.entries(schemas).map(([name, schemaOrRef]) =>
+      this.buildDefinitionModel(name, resolveIfRef(this.spec, schemaOrRef)),
+    );
+    this.collapseDiscriminatorProperties(models);
+    return models;
+  }
+
+  /**
+   * Build a model for a top-level named schema (a definition).
+   */
+  private buildDefinitionModel(name: string, schema: Schema): Model {
+    const model = createModel({
+      name,
+      description: schema.description ?? null,
+      deprecated: !!schema.deprecated,
+      isNullable: isNullable(schema),
+    });
+    this.populateModelFromSchema(model, schema);
+    return model;
+  }
+
+  /**
+   * Build a model for an inline sub-schema (property value, array item,
+   * dictionary value, composite member, parameter, or response).
+   */
+  private buildInlineModel(
+    schemaOrRef: Schema | OpenAPIV3.ReferenceObject,
+  ): Model {
+    if (isRef(schemaOrRef)) {
+      const name = splitRef(schemaOrRef.$ref)[2];
+      return createModel({
+        export: 'reference',
+        type: name,
+        imports: [name],
+      });
+    }
+
+    const schema = schemaOrRef;
+    const model = createModel({
+      description: schema.description ?? null,
+      deprecated: !!schema.deprecated,
+      isNullable: isNullable(schema),
+      isReadOnly: !!schema.readOnly,
+    });
+    this.populateModelFromSchema(model, schema);
+    return model;
+  }
+
+  /**
+   * Populate a model's structural fields (export/type/link/properties/imports)
+   * from a schema.
+   */
+  private populateModelFromSchema(model: Model, schema: Schema): void {
+    // Enums (string enums are hoisted to definitions by normalise; integer and
+    // other enums may remain inline on properties).
+    if (isEnumSchema(schema)) {
+      model.export = 'enum';
+      model.type = 'string';
+      model.enum = schema.enum!.map(
+        (value): EnumMember => ({ value: value as EnumMember['value'] }),
+      );
+      return;
+    }
+
+    // Composite schemas (allOf/anyOf/oneOf).
+    const composite = compositeExport(schema);
+    if (composite) {
+      model.export = composite;
+      model.type = 'unknown';
+      model.properties = compositeMembers(schema).map((member) =>
+        this.buildInlineModel(member),
+      );
+      model.imports = collectImports(model.properties);
+      return;
+    }
+
+    const type = primaryType(schema);
+
+    // Arrays.
+    if (type === 'array') {
+      model.export = 'array';
+      const items = (schema as { items?: Schema | OpenAPIV3.ReferenceObject })
+        .items;
+      this.applyCollectionValue(model, items);
+      return;
+    }
+
+    // Dictionaries (maps): objects with additionalProperties / bare objects.
+    if (isDictionarySchema(schema)) {
+      model.export = 'dictionary';
+      this.applyDictionaryValue(model, schema);
+      return;
+    }
+
+    // Objects with properties → interface.
+    if (type === 'object' || schema.properties || schema.patternProperties) {
+      model.export = 'interface';
+      model.type = 'unknown';
+      model.properties = this.buildProperties(schema);
+      model.imports = collectImports(model.properties);
+      return;
+    }
+
+    // A schema with no type (e.g. `{}`) is treated as an untyped object.
+    if (type === undefined) {
+      model.export = 'interface';
+      model.type = 'unknown';
+      return;
+    }
+
+    // Primitives.
+    model.export = 'generic';
+    model.type = primitiveType(schema);
+    if (schema.format) {
+      model.format = schema.format;
+    }
+  }
+
+  /**
+   * Apply the value type of a dictionary (map) to a model.
+   */
+  private applyDictionaryValue(model: Model, schema: Schema): void {
+    const additional = schema.additionalProperties;
+    if (additional && additional !== true) {
+      // additionalProperties with a schema (or a ref).
+      this.applyCollectionValue(model, additional);
+    } else if (schema.properties && additional !== true) {
+      // An object with an (empty) `properties` map but no additionalProperties
+      // renders as `{}` (a dictionary with no value type / link).
+      model.type = 'unknown';
+      model.link = null;
+    } else {
+      // `additionalProperties: true`, or a bare `{ type: 'object' }` → an "any"
+      // value type (represented as an interface/unknown link).
+      model.type = 'unknown';
+      model.link = createModel({ export: 'interface', type: 'unknown' });
+    }
+  }
+
+  /**
+   * Apply the value type of a collection (array items / dictionary values) to a
+   * model, setting `type`, `link` and `imports`.
+   *
+   * - ref value → `type` is the referenced model name; `link` is left null and
+   *   resolved later by `ensureModelLinks`.
+   * - non-ref value → recurse to build a `link` model, propagating the
+   *   (innermost) type and imports up the collection chain.
+   */
+  private applyCollectionValue(
+    model: Model,
+    value: Schema | OpenAPIV3.ReferenceObject | undefined,
+  ): void {
+    if (value && isRef(value)) {
+      model.type = splitRef(value.$ref)[2];
+      model.imports = [model.type];
+      model.link = null;
+      return;
+    }
+
+    const link = createModel();
+    this.populateModelFromSchema(link, (value ?? {}) as Schema);
+    model.link = link;
+    model.type = link.type;
+    model.imports = [...link.imports];
+  }
+
+  /**
+   * Build the property models for an object schema.
+   */
+  private buildProperties(schema: Schema): Model[] {
+    const required = new Set(schema.required ?? []);
+    return Object.entries(schema.properties ?? {}).map(([name, propSchema]) => {
+      const property = this.buildInlineModel(propSchema);
+      property.name = name;
+      property.isRequired = required.has(name);
+      return property;
+    });
+  }
+
+  /**
+   * When a composite schema declares a `discriminator` with an explicit
+   * `mapping`, collapse the discriminator property in each mapped schema from
+   * its enum reference to the bare primitive type: `export` stays `reference`,
+   * `type` becomes the primitive (e.g. `string`), and `imports` are cleared.
+   * The referenced enum models are left in place. This drops the literal
+   * narrowing but keeps the emitted code valid.
+   */
+  private collapseDiscriminatorProperties(models: Model[]): void {
+    const modelsByName = new Map(models.map((m) => [m.name, m]));
+    const schemas = this.spec.components?.schemas ?? {};
+
+    for (const schemaOrRef of Object.values(schemas)) {
+      const discriminator = (resolveIfRef(this.spec, schemaOrRef) as Schema)
+        .discriminator;
+      if (!discriminator?.propertyName || !discriminator.mapping) continue;
+
+      for (const mappedRef of Object.values(discriminator.mapping)) {
+        if (typeof mappedRef !== 'string' || !mappedRef.startsWith('#/')) {
+          continue;
+        }
+        const mappedModel = modelsByName.get(splitRef(mappedRef)[2]);
+        const property = mappedModel?.properties.find(
+          (p) => p.name === discriminator.propertyName,
+        );
+        if (property?.export !== 'reference') continue;
+
+        const referenced = modelsByName.get(property.type);
+        if (referenced?.export !== 'enum') continue;
+
+        property.type = referenced.type;
+        property.imports = [];
+      }
+    }
+  }
+
+  // --- Services & operations ------------------------------------------------
+
+  private buildDefaultService(): Service {
+    const operations = this.buildOperations();
+    return {
+      name: 'Default',
+      operations,
+      imports: [...new Set(operations.flatMap((op) => op.imports))],
+    };
+  }
+
+  private buildOperations(): Operation[] {
+    return Object.entries(this.spec.paths ?? {}).flatMap(
+      ([path, pathItemOrRef]) => {
+        const pathItem = resolveIfRef(this.spec, pathItemOrRef) as
+          | OpenAPIV3.PathItemObject
+          | undefined;
+        if (!pathItem) return [];
+        return HTTP_METHODS.flatMap((method: HttpMethod) => {
+          const specOp = pathItem[method as OpenAPIV3.HttpMethods];
+          return specOp ? [this.buildOperation(path, method, specOp)] : [];
+        });
+      },
+    );
+  }
+
+  private buildOperation(
+    path: string,
+    method: string,
+    specOp: OpenAPIV3.OperationObject,
+  ): Operation {
+    const parameters = this.buildParameters(specOp);
+    const responses = this.buildResponses(specOp);
+    const id = (specOp as { operationId: string }).operationId;
+
+    return {
+      id,
+      name: id,
+      method: method.toUpperCase(),
+      path,
+      description: specOp.description ?? null,
+      tags: specOp.tags ?? null,
+      deprecated: !!specOp.deprecated,
+      parameters,
+      parametersBody: parameters.find((p) => p.in === 'body') ?? null,
+      responses,
+      imports: collectImports([...parameters, ...responses]),
+    };
+  }
+
+  /**
+   * Build the parameter models for an operation, including a synthetic body
+   * parameter for the request body. The body parameter object is the same
+   * reference stored on `parametersBody`, so downstream mutations propagate to
+   * both.
+   */
+  private buildParameters(specOp: OpenAPIV3.OperationObject): Model[] {
+    const params: Model[] = (specOp.parameters ?? []).flatMap((p) => {
+      const param = resolveIfRef(this.spec, p) as
+        | OpenAPIV3.ParameterObject
+        | undefined;
+      if (!param) return [];
+      const model = this.buildInlineModel((param.schema ?? {}) as Schema);
+      model.name = param.name;
+      model.prop = param.name;
+      model.in = param.in as ModelIn;
+      model.mediaType = null;
+      model.isRequired = !!param.required;
+      if (param.description) {
+        model.description = param.description;
+      }
+      return [model];
+    });
+
+    const body = this.buildRequestBody(specOp);
+    if (body) {
+      params.push(body);
+    }
+
+    // Order parameters required-first with a stable sort that preserves the
+    // original relative order within each group (the body parameter takes part
+    // in the sort at its appended position).
+    return stableSort(params, (a, b) =>
+      a.isRequired === b.isRequired ? 0 : a.isRequired ? -1 : 1,
+    );
+  }
+
+  /**
+   * Build the synthetic `body` parameter for an operation's request body.
+   */
+  private buildRequestBody(specOp: OpenAPIV3.OperationObject): Model | null {
+    const requestBody = resolveIfRef(this.spec, specOp.requestBody) as
+      | OpenAPIV3.RequestBodyObject
+      | undefined;
+    if (!requestBody?.content) return null;
+
+    const mediaType = preferredMediaType(requestBody.content);
+    const model = this.buildInlineModel(
+      (requestBody.content[mediaType]?.schema ?? {}) as Schema,
+    );
+    model.name = 'requestBody';
+    model.prop = 'requestBody';
+    model.in = 'body';
+    model.mediaType = mediaType;
+    model.isRequired = !!requestBody.required;
+    return model;
+  }
+
+  /**
+   * Build the response models for an operation.
+   */
+  private buildResponses(specOp: OpenAPIV3.OperationObject): Model[] {
+    return Object.entries(specOp.responses ?? {}).flatMap(
+      ([code, resOrRef]) => {
+        const response = resolveIfRef(this.spec, resOrRef) as
+          | OpenAPIV3.ResponseObject
+          | undefined;
+        if (!response) return [];
+
+        const content = response.content ?? {};
+        const mediaType = Object.keys(content).length
+          ? preferredMediaType(content)
+          : undefined;
+        const responseSchema = mediaType
+          ? (content[mediaType]?.schema as
+              | Schema
+              | OpenAPIV3.ReferenceObject
+              | undefined)
+          : undefined;
+
+        const model = responseSchema
+          ? this.buildInlineModel(responseSchema)
+          : createModel({ export: 'generic', type: 'void' });
+
+        model.name = '';
+        model.code = parseResponseCode(code);
+        model.in = 'response';
+        model.description = response.description ?? null;
+        return [model];
+      },
+    );
+  }
+}
+
+/**
+ * Determine the internal primitive type name for a primitive schema.
+ */
+const primitiveType = (schema: Schema): string => {
+  const type = primaryType(schema);
+  if (type === 'string' && schema.format === 'binary') return 'binary';
+  return (type && PRIMITIVE_TYPE_MAP[type]) ?? 'unknown';
+};
+
+/**
+ * Prefer application/json, falling back to the first declared media type.
+ */
+const preferredMediaType = (content: { [media: string]: unknown }): string =>
+  'application/json' in content ? 'application/json' : Object.keys(content)[0];
+
+const parseResponseCode = (code: string): number | string =>
+  /^\d+$/.test(code) ? parseInt(code, 10) : code;
+
+/**
+ * Collect the unique imports declared across a set of models, in first-seen
+ * order.
+ */
+const collectImports = (models: Model[]): string[] => [
+  ...new Set(models.flatMap((m) => m.imports)),
+];
+
+/**
+ * Build the initial client data structure from a (normalised) OpenAPI spec.
+ */
+export const buildClientData = (spec: Spec): ClientData =>
+  new OpenApiParser(spec).build();

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -362,7 +362,9 @@ const buildRequestBody = (
     spec,
     specOp.requestBody,
   );
-  if (!requestBody?.content) return null;
+  // An empty content map declares no acceptable media types, ie no body.
+  if (!requestBody?.content || Object.keys(requestBody.content).length === 0)
+    return null;
 
   const mediaType = preferredMediaType(requestBody.content);
   const base = buildInlineModel(

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -7,6 +7,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import {
   type ClientData,
   createModel,
+  DEFAULT_SERVICE_NAME,
   type EnumMember,
   type Model,
   type ModelExport,
@@ -451,7 +452,7 @@ const buildOperations = (spec: Spec): Operation[] =>
 const buildDefaultService = (spec: Spec): Service => {
   const operations = buildOperations(spec);
   return {
-    name: 'Default',
+    name: DEFAULT_SERVICE_NAME,
     operations,
     imports: [...new Set(operations.flatMap((op) => op.imports))],
   };

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -3,20 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import camelCase from 'lodash.camelcase';
+import trim from 'lodash.trim';
 import type { OpenAPIV3 } from 'openapi-types';
 import {
   type ClientData,
+  COLLECTION_TYPES,
+  COMPOSED_SCHEMA_TYPES,
   createModel,
   DEFAULT_SERVICE_NAME,
   type EnumMember,
+  indexModelsByName,
   type Model,
   type ModelExport,
   type ModelIn,
+  type ModelsByName,
   type Operation,
+  PRIMITIVE_TYPES,
   type Service,
 } from './codegen-data/types';
 import { isRef, resolveIfRef, splitRef } from './refs';
-import type { OpenApiSchema as Schema, Spec } from './types';
+import type {
+  OpenApiSchema as Schema,
+  OpenApiSchemaOrRef,
+  Spec,
+} from './types';
 
 /**
  * OpenAPI primitive `type` values mapped to the internal model `type`.
@@ -179,7 +190,7 @@ const schemaStructure = (spec: Spec, schema: Schema): Partial<Model> => {
  * `link` and `imports`.
  *
  * - ref value → `type` is the referenced model name; `link` is left null and
- *   resolved later by `ensureModelLinks`.
+ *   resolved later by `linkModels`.
  * - non-ref value → a `link` model carrying the (innermost) type and imports.
  */
 const collectionValue = (
@@ -219,7 +230,10 @@ const dictionaryValue = (spec: Spec, schema: Schema): Partial<Model> => {
  * A model for an inline sub-schema (property value, array item, dictionary
  * value, composite member, parameter, or response).
  */
-const buildInlineModel = (spec: Spec, schemaOrRef: SchemaOrRef): Model => {
+export const buildInlineModel = (
+  spec: Spec,
+  schemaOrRef: SchemaOrRef,
+): Model => {
   if (isRef(schemaOrRef)) {
     const name = splitRef(schemaOrRef.$ref)[2];
     return createModel({ export: 'reference', type: name, imports: [name] });
@@ -234,16 +248,27 @@ const buildInlineModel = (spec: Spec, schemaOrRef: SchemaOrRef): Model => {
 };
 
 /**
- * A model for a top-level named schema (a definition).
+ * A model for a top-level named schema (a definition). Object definitions are
+ * typed as their own name (the type the generator emits for them).
  */
-const buildDefinitionModel = (spec: Spec, name: string, schema: Schema): Model =>
-  createModel({
+const buildDefinitionModel = (
+  spec: Spec,
+  name: string,
+  schema: Schema,
+): Model => {
+  const structure = schemaStructure(spec, schema);
+  const isNamedObject =
+    schema.type === 'object' &&
+    !!(schema.properties || schema.patternProperties);
+  return createModel({
     name,
     description: schema.description ?? null,
     deprecated: !!schema.deprecated,
     isNullable: isNullable(schema),
-    ...schemaStructure(spec, schema),
+    ...structure,
+    ...(isNamedObject ? { type: name } : {}),
   });
+};
 
 /**
  * The property models for an object schema.
@@ -267,7 +292,8 @@ const discriminatorTargets = (spec: Spec): Map<string, Set<string>> => {
     const { discriminator } = resolveIfRef(spec, schemaOrRef) as Schema;
     if (!discriminator?.propertyName || !discriminator.mapping) continue;
     for (const mappedRef of Object.values(discriminator.mapping)) {
-      if (typeof mappedRef !== 'string' || !mappedRef.startsWith('#/')) continue;
+      if (typeof mappedRef !== 'string' || !mappedRef.startsWith('#/'))
+        continue;
       const modelName = splitRef(mappedRef)[2];
       const properties = targets.get(modelName) ?? new Set<string>();
       properties.add(discriminator.propertyName);
@@ -459,9 +485,243 @@ const buildDefaultService = (spec: Spec): Service => {
 };
 
 /**
- * Build the initial client data structure from a (normalised) OpenAPI spec.
+ * Look up the spec operation object for a parsed operation.
  */
-export const buildClientData = (spec: Spec): ClientData => ({
-  models: buildModels(spec),
-  services: [buildDefaultService(spec)],
-});
+export const getSpecOperation = (
+  spec: Spec,
+  op: Operation,
+): OpenAPIV3.OperationObject | undefined =>
+  (spec.paths?.[op.path] as OpenAPIV3.PathItemObject | undefined)?.[
+    op.method.toLowerCase() as OpenAPIV3.HttpMethods
+  ];
+
+/**
+ * An operation's resolved parameters indexed by name.
+ */
+export const getSpecParametersByName = (
+  spec: Spec,
+  specOp: OpenAPIV3.OperationObject | undefined,
+): { [name: string]: OpenAPIV3.ParameterObject } =>
+  Object.fromEntries(
+    (specOp?.parameters ?? []).map((p) => {
+      const param = resolveIfRef(spec, p);
+      return [param.name, param];
+    }),
+  );
+
+/**
+ * The member sub-schemas of a composite (allOf/anyOf/oneOf) schema, in order.
+ */
+export const compositeMemberSchemas = (
+  schema: Schema,
+  compositeExport: ModelExport,
+): OpenApiSchemaOrRef[] => {
+  const keyword = camelCase(compositeExport) as 'allOf' | 'anyOf' | 'oneOf';
+  return (schema[keyword] as OpenApiSchemaOrRef[] | undefined) ?? [];
+};
+
+/**
+ * Recursively stitch a model's collection `link` to the named model it
+ * references (ref values are left null by the builders, since the target model
+ * does not exist until every definition is built).
+ */
+export const linkModel = (
+  spec: Spec,
+  modelsByName: ModelsByName,
+  model: Model,
+  schema: Schema,
+  visited: Set<Model> = new Set(),
+): void => {
+  if (visited.has(model)) return;
+  visited.add(model);
+
+  if (
+    model.export === 'dictionary' &&
+    'additionalProperties' in schema &&
+    schema.additionalProperties
+  ) {
+    if (isRef(schema.additionalProperties)) {
+      const name = splitRef(schema.additionalProperties.$ref)[2];
+      if (modelsByName[name] && !model.link) {
+        model.link = modelsByName[name];
+      }
+    } else if (model.link && typeof schema.additionalProperties !== 'boolean') {
+      linkModel(
+        spec,
+        modelsByName,
+        model.link,
+        schema.additionalProperties,
+        visited,
+      );
+    }
+  } else if (model.export === 'array' && 'items' in schema && schema.items) {
+    if (isRef(schema.items)) {
+      const name = splitRef(schema.items.$ref)[2];
+      if (modelsByName[name] && !model.link) {
+        model.link = modelsByName[name];
+      }
+    } else if (model.link) {
+      linkModel(spec, modelsByName, model.link, schema.items, visited);
+    }
+  }
+
+  model.properties
+    .filter((p) => !visited.has(p) && schema.properties?.[trim(p.name, `"'`)])
+    .forEach((property) => {
+      const subSchema = resolveIfRef(
+        spec,
+        schema.properties![trim(property.name, `"'`)],
+      );
+      linkModel(spec, modelsByName, property, subSchema, visited);
+    });
+
+  if (COMPOSED_SCHEMA_TYPES.has(model.export)) {
+    const memberSchemas = compositeMemberSchemas(schema, model.export);
+    model.properties.forEach((property, i) => {
+      const subSchema = resolveIfRef(spec, memberSchemas[i]);
+      if (subSchema) {
+        linkModel(spec, modelsByName, property, subSchema, visited);
+      }
+    });
+  }
+};
+
+/**
+ * Stitch collection links across every model, operation parameter and response.
+ */
+const linkModels = (spec: Spec, data: ClientData): void => {
+  const modelsByName = indexModelsByName(data.models);
+  const visited = new Set<Model>();
+
+  data.models.forEach((model) => {
+    const schema = resolveIfRef<Schema | undefined>(
+      spec,
+      spec.components?.schemas?.[model.name],
+    );
+    if (schema) {
+      linkModel(spec, modelsByName, model, schema, visited);
+    }
+  });
+
+  data.services.forEach((service) => {
+    service.operations.forEach((op) => {
+      const specOp = getSpecOperation(spec, op);
+      const specParametersByName = getSpecParametersByName(spec, specOp);
+
+      op.parameters.forEach((parameter) => {
+        const specParameter = specParametersByName[parameter.prop];
+        const specParameterSchema = resolveIfRef(spec, specParameter?.schema);
+        if (specParameterSchema) {
+          linkModel(
+            spec,
+            modelsByName,
+            parameter,
+            specParameterSchema,
+            visited,
+          );
+        } else if (parameter.in === 'body') {
+          const specBody = resolveIfRef(spec, specOp?.requestBody);
+          const specBodySchema = resolveIfRef(
+            spec,
+            specBody?.content?.[parameter.mediaType]?.schema,
+          );
+          if (specBodySchema) {
+            linkModel(spec, modelsByName, parameter, specBodySchema, visited);
+          }
+        }
+      });
+
+      op.responses.forEach((response) => {
+        const specResponse = resolveIfRef(
+          spec,
+          specOp?.responses?.[response.code],
+        );
+        Object.keys(specResponse?.content ?? {}).forEach((mediaType) => {
+          const responseSchema = resolveIfRef(
+            spec,
+            specResponse?.content?.[mediaType]?.schema,
+          );
+          if (responseSchema) {
+            linkModel(spec, modelsByName, response, responseSchema, visited);
+          }
+        });
+      });
+    });
+  });
+};
+
+/**
+ * Populate `composedModels` and `composedPrimitives` on each composite model
+ * with the models and primitive types it is composed of.
+ */
+const resolveComposedModel = (
+  modelsByName: ModelsByName,
+  model: Model,
+  visited: Set<Model>,
+): void => {
+  if (!COMPOSED_SCHEMA_TYPES.has(model.export) || visited.has(model)) return;
+  visited.add(model);
+
+  const members = model.properties.filter((p) => !p.name);
+  const referenced = members
+    .filter((p) => p.export === 'reference')
+    .flatMap((r) => (modelsByName[r.type] ? [modelsByName[r.type]] : []));
+
+  // Resolve recursively so all-of mixins include nested all-of properties
+  referenced.forEach((m) => resolveComposedModel(modelsByName, m, visited));
+
+  // Enums serialise as primitives, so group them with the primitives
+  const composedModels = referenced.filter((m) => m.export !== 'enum');
+  const composedPrimitives = [
+    ...members.filter((p) => p.export !== 'reference'),
+    ...referenced.filter((m) => m.export === 'enum'),
+  ];
+
+  // Composing multiple arrays of non-primitives is not distinguishable at
+  // runtime, so it's validated away.
+  // TODO: honour `discriminator` to support this case.
+  const isPrimitiveArray = (m: Model): boolean =>
+    m.link && COLLECTION_TYPES.has(m.export)
+      ? isPrimitiveArray(m.link)
+      : PRIMITIVE_TYPES.has(m.type) &&
+        !['date', 'date-time'].includes(m.format ?? '');
+  const arrayComposedModels = composedPrimitives.filter(
+    (m) => m.export === 'array' && !isPrimitiveArray(m),
+  );
+  if (arrayComposedModels.length > 1) {
+    throw new Error(
+      `Schema "${model.name}" defines ${camelCase(model.export)} with multiple array types which cannot be distinguished at runtime.`,
+    );
+  }
+
+  if (model.export === 'all-of' && composedPrimitives.length > 0) {
+    throw new Error(
+      `Schema "${model.name}" defines allOf with non-object types. allOf may only compose object types in the OpenAPI specification.`,
+    );
+  }
+
+  model.composedModels = composedModels;
+  model.composedPrimitives = composedPrimitives;
+};
+
+const resolveComposedModels = (data: ClientData): void => {
+  const modelsByName = indexModelsByName(data.models);
+  const visited = new Set<Model>();
+  data.models.forEach((model) =>
+    resolveComposedModel(modelsByName, model, visited),
+  );
+};
+
+/**
+ * Build the client data structure from a (normalised) OpenAPI spec: a fully
+ * linked model graph with composite members resolved, ready for augmentation.
+ */
+export const buildClientData = (spec: Spec): ClientData => {
+  const data: ClientData = {
+    models: buildModels(spec),
+    services: [buildDefaultService(spec)],
+  };
+  linkModels(spec, data);
+  resolveComposedModels(data);
+  return data;
+};

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -788,36 +788,57 @@ const resolveComposedModels = (data: ClientData): void => {
   );
 };
 
+const isHoisted = (spec: Spec, name: string): boolean =>
+  !!(
+    resolveIfRef<Schema | undefined>(
+      spec,
+      spec.components?.schemas?.[name],
+    ) as { 'x-aws-nx-hoisted'?: boolean } | undefined
+  )?.['x-aws-nx-hoisted'];
+
 /**
- * Build the {@link Discriminator} for a composite schema, if it declares one.
- *
- * An explicit `mapping` maps each discriminator value to a schema ref; without
- * a mapping, OpenAPI implies each composed member's schema name is its own
- * discriminator value. Only mappings that resolve to a model composed by this
- * schema are kept, so unknown values fall through to the default marshalling.
+ * The value → model-name mapping for a discriminator, resolved either from an
+ * explicit `mapping` (value → schema ref) or implicitly (each candidate model's
+ * schema name is its own discriminator value). Only candidates in
+ * `candidateNames` are kept, so unknown values fall through to the default
+ * marshalling; hoisted synthetic names (which never appear on the wire) are
+ * excluded from the implicit form.
  */
-const buildDiscriminator = (
+const buildDiscriminatorMapping = (
+  spec: Spec,
+  discriminator: OpenAPIV3.DiscriminatorObject,
+  candidateNames: Set<string>,
+): DiscriminatorMapping[] => {
+  if (discriminator.mapping) {
+    const mapping: DiscriminatorMapping[] = [];
+    for (const [value, ref] of Object.entries(discriminator.mapping)) {
+      if (typeof ref !== 'string' || !ref.startsWith('#/')) continue;
+      const modelName = splitRef(ref)[2];
+      if (candidateNames.has(modelName)) mapping.push({ value, modelName });
+    }
+    return mapping;
+  }
+  return [...candidateNames]
+    .filter((name) => !isHoisted(spec, name))
+    .map((name) => ({ value: name, modelName: name }));
+};
+
+/**
+ * Build the {@link Discriminator} for a `oneOf`/`anyOf` composite, if declared.
+ * The candidates are the models composed by the union.
+ */
+const buildCompositeDiscriminator = (
+  spec: Spec,
   model: Model,
   schema: Schema,
 ): Discriminator | undefined => {
   const { discriminator } = schema;
   if (!discriminator?.propertyName) return undefined;
 
-  const composedNames = new Set((model.composedModels ?? []).map((m) => m.name));
-
-  const mapping: DiscriminatorMapping[] = [];
-  if (discriminator.mapping) {
-    for (const [value, ref] of Object.entries(discriminator.mapping)) {
-      if (typeof ref !== 'string' || !ref.startsWith('#/')) continue;
-      const modelName = splitRef(ref)[2];
-      if (composedNames.has(modelName)) mapping.push({ value, modelName });
-    }
-  } else {
-    // Implicit mapping: each composed member's name is its discriminator value.
-    for (const composed of model.composedModels ?? []) {
-      mapping.push({ value: composed.name, modelName: composed.name });
-    }
-  }
+  const candidateNames = new Set(
+    (model.composedModels ?? []).map((m) => m.name),
+  );
+  const mapping = buildDiscriminatorMapping(spec, discriminator, candidateNames);
 
   return mapping.length > 0
     ? { propertyName: discriminator.propertyName, mapping }
@@ -825,20 +846,67 @@ const buildDiscriminator = (
 };
 
 /**
- * Attach discriminator metadata to discriminated one-of/any-of composites so
- * the generator can marshal directly to the matching branch. all-of is a
- * conjunction (not a choice) so it is never discriminated.
+ * Build the {@link Discriminator} for an inheritance base — an `object` schema
+ * carrying a `discriminator` whose subtypes `allOf`-compose it. The candidates
+ * are those subtypes (found by scanning every model for one that composes this
+ * base). Marked `isBase` so the generator emits a non-dispatching body the
+ * subtypes can compose without recursing.
+ */
+const buildBaseDiscriminator = (
+  spec: Spec,
+  base: Model,
+  schema: Schema,
+  models: Model[],
+): Discriminator | undefined => {
+  const { discriminator } = schema;
+  if (!discriminator?.propertyName) return undefined;
+
+  const subtypeNames = new Set(
+    models
+      .filter(
+        (m) =>
+          m.export === 'all-of' &&
+          (m.composedModels ?? []).some((c) => c.name === base.name),
+      )
+      .map((m) => m.name),
+  );
+  if (subtypeNames.size === 0) return undefined;
+
+  const mapping = buildDiscriminatorMapping(spec, discriminator, subtypeNames);
+
+  return mapping.length > 0
+    ? { propertyName: discriminator.propertyName, mapping, isBase: true }
+    : undefined;
+};
+
+/**
+ * Attach discriminator metadata so the generator can marshal directly to the
+ * matching branch/subtype. Two shapes carry a discriminator:
+ *  - a `oneOf`/`anyOf` composite (dispatch to the matching member), and
+ *  - an inheritance base `object` whose subtypes `allOf`-compose it (dispatch
+ *    to the matching subtype so subtype-only fields survive marshalling).
+ * `allOf` itself is a conjunction (not a choice) so it is never discriminated.
  */
 const resolveDiscriminators = (spec: Spec, data: ClientData): void => {
   data.models.forEach((model) => {
-    if (model.export !== 'one-of' && model.export !== 'any-of') return;
     const schema = resolveIfRef<Schema | undefined>(
       spec,
       spec.components?.schemas?.[model.name],
     );
     if (!schema) return;
-    const discriminator = buildDiscriminator(model, schema);
-    if (discriminator) model.discriminator = discriminator;
+
+    if (model.export === 'one-of' || model.export === 'any-of') {
+      const discriminator = buildCompositeDiscriminator(spec, model, schema);
+      if (discriminator) model.discriminator = discriminator;
+    } else if (model.export === 'interface') {
+      const discriminator = buildBaseDiscriminator(
+        spec,
+        model,
+        schema,
+        data.models,
+      );
+      if (discriminator) model.discriminator = discriminator;
+    }
   });
 };
 

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -321,9 +321,10 @@ const buildRequestBody = (
   spec: Spec,
   specOp: OpenAPIV3.OperationObject,
 ): Model | null => {
-  const requestBody = resolveIfRef(spec, specOp.requestBody) as
-    | OpenAPIV3.RequestBodyObject
-    | undefined;
+  const requestBody = resolveIfRef<OpenAPIV3.RequestBodyObject | undefined>(
+    spec,
+    specOp.requestBody,
+  );
   if (!requestBody?.content) return null;
 
   const mediaType = preferredMediaType(requestBody.content);
@@ -350,7 +351,7 @@ const buildParameters = (
   specOp: OpenAPIV3.OperationObject,
 ): Model[] => {
   const declared: Model[] = (specOp.parameters ?? []).flatMap((p) => {
-    const param = resolveIfRef(spec, p) as OpenAPIV3.ParameterObject | undefined;
+    const param = resolveIfRef<OpenAPIV3.ParameterObject | undefined>(spec, p);
     if (!param) return [];
     const base = buildInlineModel(spec, (param.schema ?? {}) as Schema);
     return [
@@ -382,9 +383,10 @@ const buildResponses = (
   specOp: OpenAPIV3.OperationObject,
 ): Model[] =>
   Object.entries(specOp.responses ?? {}).flatMap(([code, resOrRef]) => {
-    const response = resolveIfRef(spec, resOrRef) as
-      | OpenAPIV3.ResponseObject
-      | undefined;
+    const response = resolveIfRef<OpenAPIV3.ResponseObject | undefined>(
+      spec,
+      resOrRef,
+    );
     if (!response) return [];
 
     const content = response.content ?? {};
@@ -435,9 +437,10 @@ const buildOperation = (
 
 const buildOperations = (spec: Spec): Operation[] =>
   Object.entries(spec.paths ?? {}).flatMap(([path, pathItemOrRef]) => {
-    const pathItem = resolveIfRef(spec, pathItemOrRef) as
-      | OpenAPIV3.PathItemObject
-      | undefined;
+    const pathItem = resolveIfRef<OpenAPIV3.PathItemObject | undefined>(
+      spec,
+      pathItemOrRef,
+    );
     if (!pathItem) return [];
     return HTTP_METHODS.flatMap((method: HttpMethod) => {
       const specOp = pathItem[method as OpenAPIV3.HttpMethods];

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -55,6 +55,8 @@ type HttpMethod = (typeof HTTP_METHODS)[number];
 
 type SchemaOrRef = Schema | OpenAPIV3.ReferenceObject;
 
+type ParameterOrRef = OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject;
+
 const schemaType = (schema: Schema): string | string[] | undefined =>
   (schema as { type?: string | string[] }).type;
 
@@ -381,7 +383,7 @@ const buildRequestBody = (
 const buildParameters = (
   spec: Spec,
   specOp: OpenAPIV3.OperationObject,
-  pathParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] = [],
+  pathParameters: ParameterOrRef[] = [],
 ): Model[] => {
   const declared: Model[] = mergeParameters(spec, pathParameters, [
     ...(specOp.parameters ?? []),
@@ -417,13 +419,10 @@ const buildParameters = (
  */
 const mergeParameters = (
   spec: Spec,
-  pathParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[],
-  operationParameters: (
-    | OpenAPIV3.ParameterObject
-    | OpenAPIV3.ReferenceObject
-  )[],
-): (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] => {
-  const key = (p: OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject) => {
+  pathParameters: ParameterOrRef[],
+  operationParameters: ParameterOrRef[],
+): ParameterOrRef[] => {
+  const key = (p: ParameterOrRef) => {
     const param = resolveIfRef<OpenAPIV3.ParameterObject | undefined>(spec, p);
     return param ? `${param.in}:${param.name}` : null;
   };
@@ -472,7 +471,7 @@ const buildOperation = (
   path: string,
   method: string,
   specOp: OpenAPIV3.OperationObject,
-  pathParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] = [],
+  pathParameters: ParameterOrRef[] = [],
 ): Operation => {
   const parameters = buildParameters(spec, specOp, pathParameters);
   const responses = buildResponses(spec, specOp);
@@ -537,10 +536,7 @@ export const getSpecOperation = (
 export const getSpecParametersByName = (
   spec: Spec,
   specOp: OpenAPIV3.OperationObject | undefined,
-  pathParameters: (
-    | OpenAPIV3.ParameterObject
-    | OpenAPIV3.ReferenceObject
-  )[] = [],
+  pathParameters: ParameterOrRef[] = [],
 ): { [name: string]: OpenAPIV3.ParameterObject } =>
   Object.fromEntries(
     [...pathParameters, ...(specOp?.parameters ?? [])].map((p) => {
@@ -555,7 +551,7 @@ export const getSpecParametersByName = (
 export const getSpecPathParameters = (
   spec: Spec,
   op: Operation,
-): (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] => {
+): ParameterOrRef[] => {
   const pathItem = resolveIfRef<OpenAPIV3.PathItemObject | undefined>(
     spec,
     spec.paths?.[op.path],

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -30,8 +30,7 @@ import { isRef, resolveIfRef, splitRef } from './refs';
 import type { OpenApiSchema as Schema, Spec } from './types';
 
 /**
- * The set of OpenAPI primitive `type` values, mapped to the internal model
- * `type` used by the code generator.
+ * OpenAPI primitive `type` values mapped to the internal model `type`.
  */
 const PRIMITIVE_TYPE_MAP: { [openApiType: string]: string } = {
   string: 'string',
@@ -54,6 +53,8 @@ const HTTP_METHODS = [
 
 type HttpMethod = (typeof HTTP_METHODS)[number];
 
+type SchemaOrRef = Schema | OpenAPIV3.ReferenceObject;
+
 const schemaType = (schema: Schema): string | string[] | undefined =>
   (schema as { type?: string | string[] }).type;
 
@@ -67,7 +68,7 @@ const isNullable = (schema: Schema): boolean => {
 };
 
 /**
- * Resolve the "primary" type of a schema, ignoring 'null' in a 3.1 type array.
+ * The "primary" type of a schema, ignoring 'null' in a 3.1 type array.
  */
 const primaryType = (schema: Schema): string | undefined => {
   const type = schemaType(schema);
@@ -84,13 +85,8 @@ const compositeExport = (schema: Schema): ModelExport | undefined => {
   return undefined;
 };
 
-const compositeMembers = (
-  schema: Schema,
-): (Schema | OpenAPIV3.ReferenceObject)[] =>
-  (schema.allOf ?? schema.anyOf ?? schema.oneOf ?? []) as (
-    | Schema
-    | OpenAPIV3.ReferenceObject
-  )[];
+const compositeMembers = (schema: Schema): SchemaOrRef[] =>
+  (schema.allOf ?? schema.anyOf ?? schema.oneOf ?? []) as SchemaOrRef[];
 
 /**
  * A schema is a "dictionary" (map) when it is an object with no explicit
@@ -103,384 +99,8 @@ const isDictionarySchema = (schema: Schema): boolean => {
   return !hasProperties && !schema.patternProperties;
 };
 
-export class OpenApiParser {
-  constructor(private readonly spec: Spec) {}
-
-  /**
-   * Build the full client data structure from the spec.
-   */
-  public build(): ClientData {
-    return {
-      models: this.buildModels(),
-      services: [this.buildDefaultService()],
-    };
-  }
-
-  // --- Models ---------------------------------------------------------------
-
-  private buildModels(): Model[] {
-    const schemas = this.spec.components?.schemas ?? {};
-    const models = Object.entries(schemas).map(([name, schemaOrRef]) =>
-      this.buildDefinitionModel(name, resolveIfRef(this.spec, schemaOrRef)),
-    );
-    this.collapseDiscriminatorProperties(models);
-    return models;
-  }
-
-  /**
-   * Build a model for a top-level named schema (a definition).
-   */
-  private buildDefinitionModel(name: string, schema: Schema): Model {
-    const model = createModel({
-      name,
-      description: schema.description ?? null,
-      deprecated: !!schema.deprecated,
-      isNullable: isNullable(schema),
-    });
-    this.populateModelFromSchema(model, schema);
-    return model;
-  }
-
-  /**
-   * Build a model for an inline sub-schema (property value, array item,
-   * dictionary value, composite member, parameter, or response).
-   */
-  private buildInlineModel(
-    schemaOrRef: Schema | OpenAPIV3.ReferenceObject,
-  ): Model {
-    if (isRef(schemaOrRef)) {
-      const name = splitRef(schemaOrRef.$ref)[2];
-      return createModel({
-        export: 'reference',
-        type: name,
-        imports: [name],
-      });
-    }
-
-    const schema = schemaOrRef;
-    const model = createModel({
-      description: schema.description ?? null,
-      deprecated: !!schema.deprecated,
-      isNullable: isNullable(schema),
-      isReadOnly: !!schema.readOnly,
-    });
-    this.populateModelFromSchema(model, schema);
-    return model;
-  }
-
-  /**
-   * Populate a model's structural fields (export/type/link/properties/imports)
-   * from a schema.
-   */
-  private populateModelFromSchema(model: Model, schema: Schema): void {
-    // Enums (string enums are hoisted to definitions by normalise; integer and
-    // other enums may remain inline on properties).
-    if (isEnumSchema(schema)) {
-      model.export = 'enum';
-      model.type = 'string';
-      model.enum = schema.enum!.map(
-        (value): EnumMember => ({ value: value as EnumMember['value'] }),
-      );
-      return;
-    }
-
-    // Composite schemas (allOf/anyOf/oneOf).
-    const composite = compositeExport(schema);
-    if (composite) {
-      model.export = composite;
-      model.type = 'unknown';
-      model.properties = compositeMembers(schema).map((member) =>
-        this.buildInlineModel(member),
-      );
-      model.imports = collectImports(model.properties);
-      return;
-    }
-
-    const type = primaryType(schema);
-
-    // Arrays.
-    if (type === 'array') {
-      model.export = 'array';
-      const items = (schema as { items?: Schema | OpenAPIV3.ReferenceObject })
-        .items;
-      this.applyCollectionValue(model, items);
-      return;
-    }
-
-    // Dictionaries (maps): objects with additionalProperties / bare objects.
-    if (isDictionarySchema(schema)) {
-      model.export = 'dictionary';
-      this.applyDictionaryValue(model, schema);
-      return;
-    }
-
-    // Objects with properties → interface.
-    if (type === 'object' || schema.properties || schema.patternProperties) {
-      model.export = 'interface';
-      model.type = 'unknown';
-      model.properties = this.buildProperties(schema);
-      model.imports = collectImports(model.properties);
-      return;
-    }
-
-    // A schema with no type (e.g. `{}`) is treated as an untyped object.
-    if (type === undefined) {
-      model.export = 'interface';
-      model.type = 'unknown';
-      return;
-    }
-
-    // Primitives.
-    model.export = 'generic';
-    model.type = primitiveType(schema);
-    if (schema.format) {
-      model.format = schema.format;
-    }
-  }
-
-  /**
-   * Apply the value type of a dictionary (map) to a model.
-   */
-  private applyDictionaryValue(model: Model, schema: Schema): void {
-    const additional = schema.additionalProperties;
-    if (additional && additional !== true) {
-      // additionalProperties with a schema (or a ref).
-      this.applyCollectionValue(model, additional);
-    } else if (schema.properties && additional !== true) {
-      // An object with an (empty) `properties` map but no additionalProperties
-      // renders as `{}` (a dictionary with no value type / link).
-      model.type = 'unknown';
-      model.link = null;
-    } else {
-      // `additionalProperties: true`, or a bare `{ type: 'object' }` → an "any"
-      // value type (represented as an interface/unknown link).
-      model.type = 'unknown';
-      model.link = createModel({ export: 'interface', type: 'unknown' });
-    }
-  }
-
-  /**
-   * Apply the value type of a collection (array items / dictionary values) to a
-   * model, setting `type`, `link` and `imports`.
-   *
-   * - ref value → `type` is the referenced model name; `link` is left null and
-   *   resolved later by `ensureModelLinks`.
-   * - non-ref value → recurse to build a `link` model, propagating the
-   *   (innermost) type and imports up the collection chain.
-   */
-  private applyCollectionValue(
-    model: Model,
-    value: Schema | OpenAPIV3.ReferenceObject | undefined,
-  ): void {
-    if (value && isRef(value)) {
-      model.type = splitRef(value.$ref)[2];
-      model.imports = [model.type];
-      model.link = null;
-      return;
-    }
-
-    const link = createModel();
-    this.populateModelFromSchema(link, (value ?? {}) as Schema);
-    model.link = link;
-    model.type = link.type;
-    model.imports = [...link.imports];
-  }
-
-  /**
-   * Build the property models for an object schema.
-   */
-  private buildProperties(schema: Schema): Model[] {
-    const required = new Set(schema.required ?? []);
-    return Object.entries(schema.properties ?? {}).map(([name, propSchema]) => {
-      const property = this.buildInlineModel(propSchema);
-      property.name = name;
-      property.isRequired = required.has(name);
-      return property;
-    });
-  }
-
-  /**
-   * When a composite schema declares a `discriminator` with an explicit
-   * `mapping`, collapse the discriminator property in each mapped schema from
-   * its enum reference to the bare primitive type: `export` stays `reference`,
-   * `type` becomes the primitive (e.g. `string`), and `imports` are cleared.
-   * The referenced enum models are left in place. This drops the literal
-   * narrowing but keeps the emitted code valid.
-   */
-  private collapseDiscriminatorProperties(models: Model[]): void {
-    const modelsByName = new Map(models.map((m) => [m.name, m]));
-    const schemas = this.spec.components?.schemas ?? {};
-
-    for (const schemaOrRef of Object.values(schemas)) {
-      const discriminator = (resolveIfRef(this.spec, schemaOrRef) as Schema)
-        .discriminator;
-      if (!discriminator?.propertyName || !discriminator.mapping) continue;
-
-      for (const mappedRef of Object.values(discriminator.mapping)) {
-        if (typeof mappedRef !== 'string' || !mappedRef.startsWith('#/')) {
-          continue;
-        }
-        const mappedModel = modelsByName.get(splitRef(mappedRef)[2]);
-        const property = mappedModel?.properties.find(
-          (p) => p.name === discriminator.propertyName,
-        );
-        if (property?.export !== 'reference') continue;
-
-        const referenced = modelsByName.get(property.type);
-        if (referenced?.export !== 'enum') continue;
-
-        property.type = referenced.type;
-        property.imports = [];
-      }
-    }
-  }
-
-  // --- Services & operations ------------------------------------------------
-
-  private buildDefaultService(): Service {
-    const operations = this.buildOperations();
-    return {
-      name: 'Default',
-      operations,
-      imports: [...new Set(operations.flatMap((op) => op.imports))],
-    };
-  }
-
-  private buildOperations(): Operation[] {
-    return Object.entries(this.spec.paths ?? {}).flatMap(
-      ([path, pathItemOrRef]) => {
-        const pathItem = resolveIfRef(this.spec, pathItemOrRef) as
-          | OpenAPIV3.PathItemObject
-          | undefined;
-        if (!pathItem) return [];
-        return HTTP_METHODS.flatMap((method: HttpMethod) => {
-          const specOp = pathItem[method as OpenAPIV3.HttpMethods];
-          return specOp ? [this.buildOperation(path, method, specOp)] : [];
-        });
-      },
-    );
-  }
-
-  private buildOperation(
-    path: string,
-    method: string,
-    specOp: OpenAPIV3.OperationObject,
-  ): Operation {
-    const parameters = this.buildParameters(specOp);
-    const responses = this.buildResponses(specOp);
-    const id = (specOp as { operationId: string }).operationId;
-
-    return {
-      id,
-      name: id,
-      method: method.toUpperCase(),
-      path,
-      description: specOp.description ?? null,
-      tags: specOp.tags ?? null,
-      deprecated: !!specOp.deprecated,
-      parameters,
-      parametersBody: parameters.find((p) => p.in === 'body') ?? null,
-      responses,
-      imports: collectImports([...parameters, ...responses]),
-    };
-  }
-
-  /**
-   * Build the parameter models for an operation, including a synthetic body
-   * parameter for the request body. The body parameter object is the same
-   * reference stored on `parametersBody`, so downstream mutations propagate to
-   * both.
-   */
-  private buildParameters(specOp: OpenAPIV3.OperationObject): Model[] {
-    const params: Model[] = (specOp.parameters ?? []).flatMap((p) => {
-      const param = resolveIfRef(this.spec, p) as
-        | OpenAPIV3.ParameterObject
-        | undefined;
-      if (!param) return [];
-      const model = this.buildInlineModel((param.schema ?? {}) as Schema);
-      model.name = param.name;
-      model.prop = param.name;
-      model.in = param.in as ModelIn;
-      model.mediaType = null;
-      model.isRequired = !!param.required;
-      if (param.description) {
-        model.description = param.description;
-      }
-      return [model];
-    });
-
-    const body = this.buildRequestBody(specOp);
-    if (body) {
-      params.push(body);
-    }
-
-    // Order parameters required-first. `Array.prototype.sort` is stable, so the
-    // original relative order within each group is preserved (the body
-    // parameter takes part in the sort at its appended position).
-    return params.sort((a, b) =>
-      a.isRequired === b.isRequired ? 0 : a.isRequired ? -1 : 1,
-    );
-  }
-
-  /**
-   * Build the synthetic `body` parameter for an operation's request body.
-   */
-  private buildRequestBody(specOp: OpenAPIV3.OperationObject): Model | null {
-    const requestBody = resolveIfRef(this.spec, specOp.requestBody) as
-      | OpenAPIV3.RequestBodyObject
-      | undefined;
-    if (!requestBody?.content) return null;
-
-    const mediaType = preferredMediaType(requestBody.content);
-    const model = this.buildInlineModel(
-      (requestBody.content[mediaType]?.schema ?? {}) as Schema,
-    );
-    model.name = 'requestBody';
-    model.prop = 'requestBody';
-    model.in = 'body';
-    model.mediaType = mediaType;
-    model.isRequired = !!requestBody.required;
-    return model;
-  }
-
-  /**
-   * Build the response models for an operation.
-   */
-  private buildResponses(specOp: OpenAPIV3.OperationObject): Model[] {
-    return Object.entries(specOp.responses ?? {}).flatMap(
-      ([code, resOrRef]) => {
-        const response = resolveIfRef(this.spec, resOrRef) as
-          | OpenAPIV3.ResponseObject
-          | undefined;
-        if (!response) return [];
-
-        const content = response.content ?? {};
-        const mediaType = Object.keys(content).length
-          ? preferredMediaType(content)
-          : undefined;
-        const responseSchema = mediaType
-          ? (content[mediaType]?.schema as
-              | Schema
-              | OpenAPIV3.ReferenceObject
-              | undefined)
-          : undefined;
-
-        const model = responseSchema
-          ? this.buildInlineModel(responseSchema)
-          : createModel({ export: 'generic', type: 'void' });
-
-        model.name = '';
-        model.code = parseResponseCode(code);
-        model.in = 'response';
-        model.description = response.description ?? null;
-        return [model];
-      },
-    );
-  }
-}
-
 /**
- * Determine the internal primitive type name for a primitive schema.
+ * The internal primitive type name for a primitive schema.
  */
 const primitiveType = (schema: Schema): string => {
   const type = primaryType(schema);
@@ -498,15 +118,362 @@ const parseResponseCode = (code: string): number | string =>
   /^\d+$/.test(code) ? parseInt(code, 10) : code;
 
 /**
- * Collect the unique imports declared across a set of models, in first-seen
- * order.
+ * The unique imports declared across a set of models, in first-seen order.
  */
 const collectImports = (models: Model[]): string[] => [
   ...new Set(models.flatMap((m) => m.imports)),
 ];
 
+// --- Models -----------------------------------------------------------------
+
+/**
+ * The structural fields (export/type/link/properties/enum/imports/format) a
+ * schema contributes to a model.
+ */
+const schemaStructure = (spec: Spec, schema: Schema): Partial<Model> => {
+  if (isEnumSchema(schema)) {
+    return {
+      export: 'enum',
+      type: 'string',
+      enum: schema.enum!.map(
+        (value): EnumMember => ({ value: value as EnumMember['value'] }),
+      ),
+    };
+  }
+
+  const composite = compositeExport(schema);
+  if (composite) {
+    const properties = compositeMembers(schema).map((member) =>
+      buildInlineModel(spec, member),
+    );
+    return {
+      export: composite,
+      type: 'unknown',
+      properties,
+      imports: collectImports(properties),
+    };
+  }
+
+  const type = primaryType(schema);
+
+  if (type === 'array') {
+    const items = (schema as { items?: SchemaOrRef }).items;
+    return { export: 'array', ...collectionValue(spec, items) };
+  }
+
+  if (isDictionarySchema(schema)) {
+    return { export: 'dictionary', ...dictionaryValue(spec, schema) };
+  }
+
+  if (type === 'object' || schema.properties || schema.patternProperties) {
+    const properties = buildProperties(spec, schema);
+    return {
+      export: 'interface',
+      type: 'unknown',
+      properties,
+      imports: collectImports(properties),
+    };
+  }
+
+  // A schema with no type (e.g. `{}`) is an untyped object.
+  if (type === undefined) {
+    return { export: 'interface', type: 'unknown' };
+  }
+
+  return {
+    export: 'generic',
+    type: primitiveType(schema),
+    ...(schema.format ? { format: schema.format } : {}),
+  };
+};
+
+/**
+ * The value type of a collection (array items / dictionary values): a `type`,
+ * `link` and `imports`.
+ *
+ * - ref value → `type` is the referenced model name; `link` is left null and
+ *   resolved later by `ensureModelLinks`.
+ * - non-ref value → a `link` model carrying the (innermost) type and imports.
+ */
+const collectionValue = (
+  spec: Spec,
+  value: SchemaOrRef | undefined,
+): Partial<Model> => {
+  if (value && isRef(value)) {
+    const type = splitRef(value.$ref)[2];
+    return { type, imports: [type], link: null };
+  }
+  const link = createModel(schemaStructure(spec, (value ?? {}) as Schema));
+  return { link, type: link.type, imports: [...link.imports] };
+};
+
+/**
+ * The value type of a dictionary (map).
+ */
+const dictionaryValue = (spec: Spec, schema: Schema): Partial<Model> => {
+  const additional = schema.additionalProperties;
+  if (additional && additional !== true) {
+    return collectionValue(spec, additional);
+  }
+  if (schema.properties && additional !== true) {
+    // An object with an (empty) `properties` map but no additionalProperties
+    // renders as `{}`.
+    return { type: 'unknown', link: null };
+  }
+  // `additionalProperties: true`, or a bare `{ type: 'object' }` → an "any"
+  // value type.
+  return {
+    type: 'unknown',
+    link: createModel({ export: 'interface', type: 'unknown' }),
+  };
+};
+
+/**
+ * A model for an inline sub-schema (property value, array item, dictionary
+ * value, composite member, parameter, or response).
+ */
+const buildInlineModel = (spec: Spec, schemaOrRef: SchemaOrRef): Model => {
+  if (isRef(schemaOrRef)) {
+    const name = splitRef(schemaOrRef.$ref)[2];
+    return createModel({ export: 'reference', type: name, imports: [name] });
+  }
+  return createModel({
+    description: schemaOrRef.description ?? null,
+    deprecated: !!schemaOrRef.deprecated,
+    isNullable: isNullable(schemaOrRef),
+    isReadOnly: !!schemaOrRef.readOnly,
+    ...schemaStructure(spec, schemaOrRef),
+  });
+};
+
+/**
+ * A model for a top-level named schema (a definition).
+ */
+const buildDefinitionModel = (spec: Spec, name: string, schema: Schema): Model =>
+  createModel({
+    name,
+    description: schema.description ?? null,
+    deprecated: !!schema.deprecated,
+    isNullable: isNullable(schema),
+    ...schemaStructure(spec, schema),
+  });
+
+/**
+ * The property models for an object schema.
+ */
+const buildProperties = (spec: Spec, schema: Schema): Model[] => {
+  const required = new Set(schema.required ?? []);
+  return Object.entries(schema.properties ?? {}).map(([name, propSchema]) => ({
+    ...buildInlineModel(spec, propSchema),
+    name,
+    isRequired: required.has(name),
+  }));
+};
+
+/**
+ * A `{ modelName → { propertyName } }` map of the discriminator properties
+ * declared by composite schemas with an explicit `mapping`.
+ */
+const discriminatorTargets = (spec: Spec): Map<string, Set<string>> => {
+  const targets = new Map<string, Set<string>>();
+  for (const schemaOrRef of Object.values(spec.components?.schemas ?? {})) {
+    const { discriminator } = resolveIfRef(spec, schemaOrRef) as Schema;
+    if (!discriminator?.propertyName || !discriminator.mapping) continue;
+    for (const mappedRef of Object.values(discriminator.mapping)) {
+      if (typeof mappedRef !== 'string' || !mappedRef.startsWith('#/')) continue;
+      const modelName = splitRef(mappedRef)[2];
+      const properties = targets.get(modelName) ?? new Set<string>();
+      properties.add(discriminator.propertyName);
+      targets.set(modelName, properties);
+    }
+  }
+  return targets;
+};
+
+/**
+ * For discriminated composites, collapse each mapped schema's discriminator
+ * property from its enum reference to the bare primitive type (`export` stays
+ * `reference`, `type` becomes the primitive, `imports` are cleared). The
+ * referenced enum models are left in place. This drops the literal narrowing
+ * but keeps the emitted code valid.
+ */
+const collapseDiscriminators = (spec: Spec, models: Model[]): Model[] => {
+  const targets = discriminatorTargets(spec);
+  if (targets.size === 0) return models;
+
+  const byName = new Map(models.map((m) => [m.name, m]));
+  return models.map((model) => {
+    const properties = targets.get(model.name);
+    if (!properties) return model;
+    return {
+      ...model,
+      properties: model.properties.map((property) => {
+        if (!properties.has(property.name) || property.export !== 'reference') {
+          return property;
+        }
+        const referenced = byName.get(property.type);
+        return referenced?.export === 'enum'
+          ? { ...property, type: referenced.type, imports: [] }
+          : property;
+      }),
+    };
+  });
+};
+
+const buildModels = (spec: Spec): Model[] =>
+  collapseDiscriminators(
+    spec,
+    Object.entries(spec.components?.schemas ?? {}).map(([name, schemaOrRef]) =>
+      buildDefinitionModel(spec, name, resolveIfRef(spec, schemaOrRef)),
+    ),
+  );
+
+// --- Services & operations --------------------------------------------------
+
+/**
+ * The synthetic `body` parameter for an operation's request body.
+ */
+const buildRequestBody = (
+  spec: Spec,
+  specOp: OpenAPIV3.OperationObject,
+): Model | null => {
+  const requestBody = resolveIfRef(spec, specOp.requestBody) as
+    | OpenAPIV3.RequestBodyObject
+    | undefined;
+  if (!requestBody?.content) return null;
+
+  const mediaType = preferredMediaType(requestBody.content);
+  return {
+    ...buildInlineModel(
+      spec,
+      (requestBody.content[mediaType]?.schema ?? {}) as Schema,
+    ),
+    name: 'requestBody',
+    prop: 'requestBody',
+    in: 'body',
+    mediaType,
+    isRequired: !!requestBody.required,
+  };
+};
+
+/**
+ * The parameter models for an operation, including a synthetic body parameter.
+ * Ordered required-first with a stable sort (`Array.prototype.sort`), so the
+ * original relative order within each group is preserved.
+ */
+const buildParameters = (
+  spec: Spec,
+  specOp: OpenAPIV3.OperationObject,
+): Model[] => {
+  const declared: Model[] = (specOp.parameters ?? []).flatMap((p) => {
+    const param = resolveIfRef(spec, p) as OpenAPIV3.ParameterObject | undefined;
+    if (!param) return [];
+    const base = buildInlineModel(spec, (param.schema ?? {}) as Schema);
+    return [
+      {
+        ...base,
+        name: param.name,
+        prop: param.name,
+        in: param.in as ModelIn,
+        mediaType: null,
+        isRequired: !!param.required,
+        description: param.description ? param.description : base.description,
+      },
+    ];
+  });
+
+  const body = buildRequestBody(spec, specOp);
+  const params = body ? [...declared, body] : declared;
+
+  return [...params].sort((a, b) =>
+    a.isRequired === b.isRequired ? 0 : a.isRequired ? -1 : 1,
+  );
+};
+
+/**
+ * The response models for an operation.
+ */
+const buildResponses = (
+  spec: Spec,
+  specOp: OpenAPIV3.OperationObject,
+): Model[] =>
+  Object.entries(specOp.responses ?? {}).flatMap(([code, resOrRef]) => {
+    const response = resolveIfRef(spec, resOrRef) as
+      | OpenAPIV3.ResponseObject
+      | undefined;
+    if (!response) return [];
+
+    const content = response.content ?? {};
+    const mediaType = Object.keys(content).length
+      ? preferredMediaType(content)
+      : undefined;
+    const responseSchema = mediaType
+      ? (content[mediaType]?.schema as SchemaOrRef | undefined)
+      : undefined;
+
+    return [
+      {
+        ...(responseSchema
+          ? buildInlineModel(spec, responseSchema)
+          : createModel({ export: 'generic', type: 'void' })),
+        name: '',
+        code: parseResponseCode(code),
+        in: 'response' as ModelIn,
+        description: response.description ?? null,
+      },
+    ];
+  });
+
+const buildOperation = (
+  spec: Spec,
+  path: string,
+  method: string,
+  specOp: OpenAPIV3.OperationObject,
+): Operation => {
+  const parameters = buildParameters(spec, specOp);
+  const responses = buildResponses(spec, specOp);
+  const id = (specOp as { operationId: string }).operationId;
+
+  return {
+    id,
+    name: id,
+    method: method.toUpperCase(),
+    path,
+    description: specOp.description ?? null,
+    tags: specOp.tags ?? null,
+    deprecated: !!specOp.deprecated,
+    parameters,
+    parametersBody: parameters.find((p) => p.in === 'body') ?? null,
+    responses,
+    imports: collectImports([...parameters, ...responses]),
+  };
+};
+
+const buildOperations = (spec: Spec): Operation[] =>
+  Object.entries(spec.paths ?? {}).flatMap(([path, pathItemOrRef]) => {
+    const pathItem = resolveIfRef(spec, pathItemOrRef) as
+      | OpenAPIV3.PathItemObject
+      | undefined;
+    if (!pathItem) return [];
+    return HTTP_METHODS.flatMap((method: HttpMethod) => {
+      const specOp = pathItem[method as OpenAPIV3.HttpMethods];
+      return specOp ? [buildOperation(spec, path, method, specOp)] : [];
+    });
+  });
+
+const buildDefaultService = (spec: Spec): Service => {
+  const operations = buildOperations(spec);
+  return {
+    name: 'Default',
+    operations,
+    imports: [...new Set(operations.flatMap((op) => op.imports))],
+  };
+};
+
 /**
  * Build the initial client data structure from a (normalised) OpenAPI spec.
  */
-export const buildClientData = (spec: Spec): ClientData =>
-  new OpenApiParser(spec).build();
+export const buildClientData = (spec: Spec): ClientData => ({
+  models: buildModels(spec),
+  services: [buildDefaultService(spec)],
+});

--- a/packages/nx-plugin/src/open-api/utils/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/types.ts
@@ -5,3 +5,23 @@
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
 export type Spec = OpenAPIV3.Document | OpenAPIV3_1.Document;
+
+/**
+ * An OpenAPI schema object, spanning the 3.0 and 3.1 shapes plus the additional
+ * JSON-Schema / 3.1 keywords the code generator inspects that are absent from
+ * the `openapi-types` 3.0 definition (`patternProperties`, `const`, and the 3.0
+ * `nullable` flag).
+ */
+export type OpenApiSchema = (
+  | OpenAPIV3.SchemaObject
+  | OpenAPIV3_1.SchemaObject
+) & {
+  nullable?: boolean;
+  const?: unknown;
+  patternProperties?: {
+    [pattern: string]: OpenApiSchemaOrRef;
+  };
+  discriminator?: OpenAPIV3.DiscriminatorObject;
+};
+
+export type OpenApiSchemaOrRef = OpenApiSchema | OpenAPIV3.ReferenceObject;

--- a/packages/nx-plugin/src/utils/names.ts
+++ b/packages/nx-plugin/src/utils/names.ts
@@ -2,8 +2,16 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import camelCase from 'lodash.camelcase';
+import lodashCamelCase from 'lodash.camelcase';
 import deburr from 'lodash.deburr';
+
+/**
+ * camelCase that first transliterates accents and strips any character that is
+ * not a valid identifier character, so inputs like `getFoo≠Bar` or `café` yield
+ * valid JS/TS identifiers rather than leaking the raw symbol into generated code.
+ */
+export const camelCase = (str: string): string =>
+  lodashCamelCase(deburr(str ?? '').replace(/[^a-zA-Z0-9]+/g, ' '));
 
 export const toClassName = (str?: string): string => {
   if (!str) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       '@getgrit/gritql':
         specifier: 0.0.3
         version: 0.0.3
-      '@hey-api/openapi-ts':
-        specifier: 0.64.13
-        version: 0.64.13(typescript@6.0.3)
       '@iarna/toml':
         specifier: 2.2.5
         version: 2.2.5
@@ -403,9 +400,6 @@ importers:
       '@getgrit/gritql':
         specifier: 0.0.3
         version: 0.0.3
-      '@hey-api/openapi-ts':
-        specifier: 0.64.13
-        version: 0.64.13(typescript@6.0.3)
       '@iarna/toml':
         specifier: 2.2.5
         version: 2.2.5
@@ -2314,17 +2308,6 @@ packages:
     resolution: {integrity: sha512-qT975UszVMHLSoNJh5tKmyImeUxYRwV+XshDwkVGY37OoUE71PT/bMiVjfISYwJpTzfOHkJLk6Wt1K7Qpd5X6A==}
     engines: {node: '>= 10'}
 
-  '@hey-api/json-schema-ref-parser@1.0.3':
-    resolution: {integrity: sha512-jgyNFPUReGpdB0ihWv6m+Q3dcawtXx4t6cvi0NS4xxblulcCfEjThP5xVwShFiTRScckIQ/GsuZv20arRTIDkg==}
-    engines: {node: '>= 16'}
-
-  '@hey-api/openapi-ts@0.64.13':
-    resolution: {integrity: sha512-KOf/bQ9JbGJFsdQjUrne3ZttoJm/68kG00oc/5VovduMAoX0gUyGNpZ+yppvUdLvmxL1GvaGut2JFk0XSZxIlw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=22.10.0}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.5.3
-
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
@@ -2541,9 +2524,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
-  '@jsdevtools/ono@7.1.3':
-    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
@@ -5469,14 +5449,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  c12@2.0.1:
-    resolution: {integrity: sha512-Z4JgsKXHG37C6PYUtIxCfLJZvo6FyhHJoClwwb9ftUkLpPSkuYqn6Tr+vnaN8hymm0kIbcg6Ey3kv/Q71k5w/A==}
-    peerDependencies:
-      magicast: ^0.3.5
-    peerDependenciesMeta:
-      magicast:
-        optional: true
-
   cacheable-lookup@6.1.0:
     resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
     engines: {node: '>=10.6.0'}
@@ -5567,17 +5539,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -5586,9 +5550,6 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
-
-  citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -5684,10 +5645,6 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
-  commander@13.0.0:
-    resolution: {integrity: sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==}
-    engines: {node: '>=18'}
-
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -5757,13 +5714,6 @@ packages:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
     engines: {node: '>=18'}
     hasBin: true
-
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -6032,9 +5982,6 @@ packages:
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
-
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -6680,10 +6627,6 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -6761,10 +6704,6 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-
-  giget@1.2.5:
-    resolution: {integrity: sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==}
-    hasBin: true
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
@@ -6845,11 +6784,6 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
-
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -8075,29 +8009,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -8252,11 +8171,6 @@ packages:
       '@swc/core':
         optional: true
 
-  nypm@0.5.4:
-    resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
-    engines: {node: ^14.16.0 || >=16.10.0}
-    hasBin: true
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -8270,9 +8184,6 @@ packages:
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
-
-  ohash@1.1.6:
-    resolution: {integrity: sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -8471,9 +8382,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -8482,9 +8390,6 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
-  perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
@@ -8541,9 +8446,6 @@ packages:
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
@@ -8716,9 +8618,6 @@ packages:
     resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
     engines: {node: '>= 0.10'}
 
-  rc9@2.1.2:
-    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
-
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -8802,10 +8701,6 @@ packages:
 
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
-
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -9517,11 +9412,6 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   terminal-link@5.0.0:
     resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
     engines: {node: '>=20'}
@@ -9599,9 +9489,6 @@ packages:
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
-
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -10337,9 +10224,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -12472,22 +12356,6 @@ snapshots:
       '@getgrit/gritql-win32-arm64-msvc': 0.0.3
       '@getgrit/gritql-win32-x64-msvc': 0.0.3
 
-  '@hey-api/json-schema-ref-parser@1.0.3':
-    dependencies:
-      '@jsdevtools/ono': 7.1.3
-      '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
-
-  '@hey-api/openapi-ts@0.64.13(typescript@6.0.3)':
-    dependencies:
-      '@hey-api/json-schema-ref-parser': 1.0.3
-      c12: 2.0.1
-      commander: 13.0.0
-      handlebars: 4.7.8
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - magicast
-
   '@hono/node-server@1.19.9(hono@4.11.9)':
     dependencies:
       hono: 4.11.9
@@ -12648,8 +12516,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jsdevtools/ono@7.1.3': {}
 
   '@keyv/serialize@1.1.1': {}
 
@@ -16093,21 +15959,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@2.0.1:
-    dependencies:
-      chokidar: 4.0.3
-      confbox: 0.1.8
-      defu: 6.1.4
-      dotenv: 16.6.1
-      giget: 1.2.5
-      jiti: 2.7.0
-      mlly: 1.8.0
-      ohash: 1.1.6
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.3.1
-      rc9: 2.1.2
-
   cacheable-lookup@6.1.0: {}
 
   cacheable-lookup@7.0.0: {}
@@ -16191,23 +16042,13 @@ snapshots:
 
   chardet@2.1.1: {}
 
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@2.0.0: {}
-
   chrome-trace-event@1.0.4: {}
 
   ci-info@4.4.0: {}
-
-  citty@0.1.6:
-    dependencies:
-      consola: 3.4.2
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -16298,8 +16139,6 @@ snapshots:
   command-exists@1.2.9: {}
 
   commander@11.1.0: {}
-
-  commander@13.0.0: {}
 
   commander@13.1.0: {}
 
@@ -16402,10 +16241,6 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
-
-  confbox@0.1.8: {}
-
-  consola@3.4.2: {}
 
   content-disposition@0.5.2: {}
 
@@ -16660,8 +16495,6 @@ snapshots:
   define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
-
-  defu@6.1.4: {}
 
   defu@6.1.7: {}
 
@@ -17516,10 +17349,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -17586,16 +17415,6 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
-
-  giget@1.2.5:
-    dependencies:
-      citty: 0.1.6
-      consola: 3.4.2
-      defu: 6.1.4
-      node-fetch-native: 1.6.7
-      nypm: 0.5.4
-      pathe: 2.0.3
-      tar: 6.2.1
 
   git-raw-commits@5.0.1(conventional-commits-parser@6.3.0):
     dependencies:
@@ -17731,15 +17550,6 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.3
       uncrypto: 0.1.3
-
-  handlebars@4.7.8:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
 
   handlebars@4.7.9:
     dependencies:
@@ -19339,27 +19149,9 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minipass@7.1.2: {}
 
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
   mkdirp@1.0.4: {}
-
-  mlly@1.8.0:
-    dependencies:
-      acorn: 8.16.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.3
 
   mrmime@2.0.1: {}
 
@@ -19605,15 +19397,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  nypm@0.5.4:
-    dependencies:
-      citty: 0.1.6
-      consola: 3.4.2
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      tinyexec: 0.3.2
-      ufo: 1.6.3
-
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -19625,8 +19408,6 @@ snapshots:
       destr: 2.0.5
       node-fetch-native: 1.6.7
       ufo: 1.6.3
-
-  ohash@1.1.6: {}
 
   ohash@2.0.11: {}
 
@@ -19848,8 +19629,6 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
 
   peek-stream@1.1.3:
@@ -19859,8 +19638,6 @@ snapshots:
       through2: 2.0.5
 
   pend@1.2.0: {}
-
-  perfect-debounce@1.0.0: {}
 
   performance-now@2.1.0: {}
 
@@ -19914,12 +19691,6 @@ snapshots:
   pkce-challenge@4.1.0: {}
 
   pkce-challenge@5.0.0: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.8.0
-      pathe: 2.0.3
 
   playwright-core@1.61.1: {}
 
@@ -20094,11 +19865,6 @@ snapshots:
       iconv-lite: 0.7.0
       unpipe: 1.0.0
 
-  rc9@2.1.2:
-    dependencies:
-      defu: 6.1.4
-      destr: 2.0.5
-
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -20198,8 +19964,6 @@ snapshots:
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.8
-
-  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 
@@ -21155,15 +20919,6 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
   terminal-link@5.0.0:
     dependencies:
       ansi-escapes: 7.1.0
@@ -21215,8 +20970,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyclip@0.1.12: {}
-
-  tinyexec@0.3.2: {}
 
   tinyexec@1.0.4: {}
 
@@ -21854,8 +21607,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
 
   yaml@1.10.2: {}
 


### PR DESCRIPTION
### Reason for this change

The OpenAPI code generators (`open-api#ts-client`, `open-api#ts-hooks`, `open-api#ts-metadata`) built their code generation data structure from `@hey-api/openapi-ts`'s legacy parser. That parser was removed upstream, so the dependency was pinned and could not be updated, and the data structure it produced only ever "nearly" fit our needs — requiring extensive `as any` workarounds to patch and reshape it downstream. Several parts of the OpenAPI 3.0/3.1 spec were also handled approximately or incorrectly as a result.

`@hey-api/openapi-ts` was also a **runtime dependency** of the published `@aws/nx-plugin` package, so its transitive closure (a config loader, a Handlebars templating engine, file watchers, a tar extractor, etc.) was installed by every consumer of the plugin, despite us only using its parser.

### What this means for customers

Generated API clients, hooks and metadata now handle more of the OpenAPI 3.0/3.1 spec correctly, and the plugin installs lighter.

**More correct & complete generated clients**

- **Polymorphism** — discriminated `oneOf`/`anyOf` unions and inheritance-style base schemas (subtypes composing a base via `allOf`) now marshal to the matching subtype. Subtype fields round-trip correctly instead of being dropped, and fields no longer leak between variants (previously a value could come back with spurious/`Invalid Date` fields from a non-matching branch).
- **`deepObject` query parameters** serialise as `filter[prop]=value` pairs — including nested objects/arrays — instead of `filter=[object Object]`.
- **`spaceDelimited` / `pipeDelimited` query arrays** serialise with the correct delimiter (and compile — they previously emitted collection formats the runtime neither typed nor honoured).
- **Object query/path parameters** are now fully typed and marshalled, so nested values such as dates convert correctly rather than being passed through untouched.
- **Broader spec coverage** — `$ref` path items, vendored `+json` media types, empty request bodies, and OpenAPI 3.1 `const` / multi-type (`type: [...]`) schemas are all handled.
- **Clear errors on ambiguous specs** — colliding schema, property or parameter names (e.g. two that normalise to the same identifier, or a query and header sharing a name) now fail with an actionable message instead of emitting code that silently misbehaves or fails to compile.

**Lighter install footprint**

- **28 fewer packages** in the plugin's install closure (the transitive closure of `@hey-api/openapi-ts`), and **~8.9 MiB less unpacked** on disk — fetched and extracted on every clean install of the plugin.
- Retires `tar@6.2.1`, which npm now flags as deprecated for known vulnerabilities.

### Description of changes

Replaces the `@hey-api/openapi-ts` parser with an in-house OpenAPI parser (`open-api/utils/parser.ts`) that produces the code generation data structure directly, then extends it to close the spec-coverage gaps above.

- **In-house parser** — `buildClientData` walks a normalised spec (schemas, operations, parameters, responses) into the models/services structure the generators consume.
- **Fully-typed data structure** — `Model`, `Operation`, `Service` and `CodeGenData` are proper interfaces, with no `as any` casts in the parser or codegen-data pipeline (the hey-api structure previously required extensive ones).
- **Correctness fixes** — discriminator dispatch (composite + inheritance base), `deepObject` serialisation, collection-format delimiters, object-parameter typing/marshalling, `$ref` path items, vendored `+json` hoisting, nested `const`/multi-type rewrites, and name-clash validation.
- **Dependency removed** — `@hey-api/openapi-ts` is dropped from `package.json`; `LICENSE-THIRD-PARTY` and the lockfile are regenerated accordingly.

### Description of how you validated changes

The generator test suites render clients/hooks/metadata from a wide range of specs (enums, arrays, dictionaries, additional/pattern properties, `allOf`/`oneOf`/`anyOf` composites, discriminated unions and inheritance bases, recursive refs, streaming, form data, duplicate/colliding names, void-vs-any responses, OpenAPI 3.1 null/const/multi-type, deepObject and collection-format serialisation) and snapshot the output, with runtime round-trip assertions against a mock `fetch`.

- All `@aws/nx-plugin` tests pass, including new coverage for every behaviour above.
- Snapshots were updated where output intentionally changed (discriminators, deepObject, collection-format delimiters, typed object parameters); output is unchanged for specs that don't exercise those features.
- `tsc` typechecks cleanly, with no `as any` in the parser or codegen-data pipeline.

### Follow-ups (not in this PR)

- Emit discriminated unions as true TypeScript *tagged* unions (literal discriminator tags for `switch` narrowing) — currently a usable but untagged union.
- Auto-disambiguate colliding property/parameter names rather than erroring (the wire and TypeScript names are already tracked separately, so this is safe).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

