### PR TITLE
test(dungeon-adventure): defer per-generator installs and enable the Nx daemon

### DIFF
--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -14,6 +14,7 @@ import {
   createTestWorkspace,
   getDungeonAdventureElectroDbDependencies,
   runCLI,
+  runInstall,
   tmpProjPath,
 } from '../utils';
 import { startLlmMock } from '../utils/llm-mock';
@@ -186,7 +187,11 @@ describe('smoke test - dungeon-adventure', () => {
   const pkgMgr = 'pnpm';
   const targetDir = `${tmpProjPath()}/dungeon-adventure-${pkgMgr}`;
   const projectRoot = `${targetDir}/dungeon-adventure`;
-  const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
+  // Keep the Nx daemon on so the project graph and TypeScript state stay warm
+  // across the tutorial's repeated sync/lint/build invocations. This matters
+  // most on Windows, where the dungeon-adventure smoke test is the CI critical
+  // path and a cold graph per command dominates its runtime.
+  const opts = { cwd: projectRoot, env: { NX_DAEMON: 'true' } };
   const runningProcesses: ChildProcess[] = [];
   let llmMock: MockServer | undefined;
 
@@ -246,67 +251,79 @@ describe('smoke test - dungeon-adventure', () => {
 
     await createTestWorkspace(pkgMgr, targetDir, 'dungeon-adventure', 'cdk');
 
+    // Every generator runs with `--prefer-install-dependencies=false` so the
+    // per-generator package install is deferred; `runInstall` below installs the
+    // full accumulated set once before the first sync/build. This mirrors the
+    // generic smoke test and removes ~a dozen redundant installs — the single
+    // biggest chunk of the generation phase, especially on Windows. Generators
+    // still self-install when skipping would leave a graph-critical dependency
+    // unresolvable (see utils/install.ts).
+    const preferNoInstall = '--prefer-install-dependencies=false';
     await runCLI(
-      `generate @aws/nx-plugin:ts#api --name=GameApi --no-interactive`,
+      `generate @aws/nx-plugin:ts#api --name=GameApi --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:py#project --name=story --no-interactive`,
+      `generate @aws/nx-plugin:py#project --name=story --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:py#agent --project=story --auth=cognito --protocol=ag-ui --no-interactive`,
+      `generate @aws/nx-plugin:py#agent --project=story --auth=cognito --protocol=ag-ui --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:ts#project --name=inventory --no-interactive`,
+      `generate @aws/nx-plugin:ts#project --name=inventory --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:ts#mcp-server --project=inventory --no-interactive`,
+      `generate @aws/nx-plugin:ts#mcp-server --project=inventory --no-interactive ${preferNoInstall}`,
       opts,
     );
     // The DynamoDB table backing the game's state, with local development
     // support via DynamoDB Local
     await runCLI(
-      `generate @aws/nx-plugin:ts#dynamodb --name=DungeonDb --no-interactive`,
+      `generate @aws/nx-plugin:ts#dynamodb --name=DungeonDb --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:ts#website --name=GameUI --ux=shadcn --no-interactive`,
+      `generate @aws/nx-plugin:ts#website --name=GameUI --ux=shadcn --no-interactive ${preferNoInstall}`,
       opts,
     );
     // No need to allow signup for the e2e tests
     await runCLI(
-      `generate @aws/nx-plugin:ts#website#auth --cognitoDomain=game-ui --project=@dungeon-adventure/game-ui --no-interactive --allowSignup=false`,
+      `generate @aws/nx-plugin:ts#website#auth --cognitoDomain=game-ui --project=@dungeon-adventure/game-ui --no-interactive --allowSignup=false ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/game-ui --targetProject=@dungeon-adventure/game-api --no-interactive`,
+      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/game-ui --targetProject=@dungeon-adventure/game-api --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:connection --sourceProject=story --targetProject=inventory --no-interactive`,
+      `generate @aws/nx-plugin:connection --sourceProject=story --targetProject=inventory --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/game-ui --targetProject=story --no-interactive`,
+      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/game-ui --targetProject=story --no-interactive ${preferNoInstall}`,
       opts,
     );
     // Wire the Game API and the Inventory MCP server to the DynamoDB table so
     // their dev targets boot DynamoDB Local automatically
     await runCLI(
-      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/game-api --targetProject=@dungeon-adventure/dungeon-db --no-interactive`,
+      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/game-api --targetProject=@dungeon-adventure/dungeon-db --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/inventory --targetProject=@dungeon-adventure/dungeon-db --no-interactive`,
+      `generate @aws/nx-plugin:connection --sourceProject=@dungeon-adventure/inventory --targetProject=@dungeon-adventure/dungeon-db --no-interactive ${preferNoInstall}`,
       opts,
     );
     await runCLI(
-      `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive`,
+      `generate @aws/nx-plugin:ts#infra --name=infra --no-interactive ${preferNoInstall}`,
       opts,
     );
+
+    // Install the full set of dependencies accumulated across all generators
+    // above, in one pass, before the first sync/build.
+    await runInstall(opts);
 
     // Check application stack matches application-stack.ts.original.template
     const applicationStackPath = `${opts.cwd}/packages/infra/src/stacks/application-stack.ts`;


### PR DESCRIPTION
### Reason for this change

The **Windows dungeon-adventure smoke test** is the single longest job in the PR workflow and therefore gates overall PR wall-clock. Across the four most recent PR runs it took **37–40 min**, while the *same* test on Linux finishes in **~8.5 min**. Since all jobs run in parallel, this one job determines how long a PR takes to go green.

We can't move it to the faster CodeBuild Windows runners (no Docker there, and it needs to stay a faithful end-to-end tutorial test), and sharding would fracture the tutorial's integrity. This PR attempts to remove wasted work *inside* the job instead.

### Description of changes

Two changes to `e2e/src/smoke-tests/dungeon-adventure.spec.ts`:

- **Defer per-generator installs.** Every module-1 generator runs with `--prefer-install-dependencies=false`, and the full accumulated dependency set is installed once via `runInstall` before the first sync/build — mirroring the generic smoke test (`smoke-test.ts`).
- **Enable the Nx daemon** (`NX_DAEMON=true`) for the generate/build phase, to keep the project graph and TypeScript state warm across the tutorial's four repeated sync/lint/build waves.

### Description of how you validated changes

Pushed and measured the real Windows CI timing against the baseline (run [`28704975842`](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/28704975842)).

> [!WARNING]
> **Result: no measurable speedup.** The changes are green and correct, but the `Windows Smoke Tests - dungeon-adventure` job did not get faster.

**Before → After (Windows dungeon-adventure):**

| Phase | Baseline (#887) | This PR | Δ |
|-------|----------------|---------|---|
| Generation (workspace + generators + install) | 10.5 min | 10.2 min | ~0 |
| Build / validate (4 waves incl. Docker) | 25.6 min | 27.9 min | +2.3 (within run-to-run noise) |
| **Test step total** | **36.2 min** | **38.1 min** | **no improvement** |
| Full job (queue + init + test) | ~38.8 min (4-run avg) | 41.7 min | no improvement |

**Why it didn't help (from the completed job log):**

- **`preferInstallDependencies=false` was largely ineffective here.** The generation phase still shows installs firing (`40s / 35s / 9s / 47s / 1m9s`). `installDependencies` (`utils/install.ts`) runs anyway whenever a graph-critical dependency isn't yet linked, and this test's generator mix trips that condition on nearly every step — so the batch-once deferral mostly doesn't happen. Generation stayed ~10.5 min either way.
- **The daemon engaged (`NX_DAEMON: true` confirmed) but didn't move the needle.** The build/validate phase is dominated by actual `tsc` / `vite` / **Docker image** builds (e.g. `inventory:mcp-server-docker` = `added 278 packages in 2m`), none of which the daemon accelerates. The graph computation it keeps warm is a small fraction of the phase.

### Recommendation

Since neither change delivers a speedup, and the daemon flip reverses a deliberate prior decision (`f2b5939d "test: disable daemon for e2e tests"`), the leading option is to **close/revert this PR** and pursue the real cost centres instead:

- The 4 sequential full-workspace **build waves** (~26 min) are the dominant cost — reducing intermediate rebuilds is where the time is.
- The **Docker image builds** inside the test are a large fixed cost on the slow GitHub-hosted `windows-latest` runner.

Keeping the PR is low-risk (green, tutorial-faithful) but adds complexity for no benefit.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*