### PR TITLE
test(dungeon-adventure): build once per pristine + assembled state, not per module

### DIFF
--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -391,21 +391,18 @@ describe('smoke test - dungeon-adventure', () => {
       '2/stacks/application-stack.ts.template',
     );
 
-    // The tutorial documents a build after each module. The `build` target is
-    // an umbrella that recompiles, tests, bundles, synths, runs checkov and
-    // rebuilds the Docker images for every project; because each module edits
-    // source, none of that caches between modules, so four full builds is the
-    // dominant cost of this (CI-critical-path) test. We build only the pristine
-    // generator output (module 1, above) and the fully-assembled tutorial
-    // (module 4, below): every file an intermediate build would compile is
-    // still compiled by the final build over the cumulative source, so the only
-    // thing dropped is per-module failure localisation, not coverage. `sync`,
-    // `lint` and the file-content assertions still run at every module.
     await runCLI(`sync --verbose`, opts);
     await runCLI(`${buildPackageManagerShortCommand(pkgMgr, 'lint')}`, {
       ...opts,
       prefixWithPackageManagerCmd: false,
     });
+    // Skip intermediate build to reduce test time on Windows
+    if (process.platform !== 'win32') {
+      await runCLI(
+        `${buildPackageManagerShortCommand(pkgMgr, 'build')} --output-style=stream --verbose`,
+        { ...opts, prefixWithPackageManagerCmd: false },
+      );
+    }
 
     // Module 3: Story Agent
 
@@ -425,13 +422,18 @@ describe('smoke test - dungeon-adventure', () => {
     );
     writeFromTemplate(agentPyPath, '3/agent.py.template');
 
-    // Intermediate build skipped — see the note in Module 2. `sync` and `lint`
-    // still run here; the fully-assembled workspace is built in Module 4.
     await runCLI(`sync --verbose`, opts);
     await runCLI(`${buildPackageManagerShortCommand(pkgMgr, 'lint')}`, {
       ...opts,
       prefixWithPackageManagerCmd: false,
     });
+    // Skip intermediate build to reduce test time on Windows
+    if (process.platform !== 'win32') {
+      await runCLI(
+        `${buildPackageManagerShortCommand(pkgMgr, 'build')} --output-style=stream --verbose`,
+        { ...opts, prefixWithPackageManagerCmd: false },
+      );
+    }
 
     // Module 4: UI
 

--- a/e2e/src/smoke-tests/dungeon-adventure.spec.ts
+++ b/e2e/src/smoke-tests/dungeon-adventure.spec.ts
@@ -391,15 +391,21 @@ describe('smoke test - dungeon-adventure', () => {
       '2/stacks/application-stack.ts.template',
     );
 
+    // The tutorial documents a build after each module. The `build` target is
+    // an umbrella that recompiles, tests, bundles, synths, runs checkov and
+    // rebuilds the Docker images for every project; because each module edits
+    // source, none of that caches between modules, so four full builds is the
+    // dominant cost of this (CI-critical-path) test. We build only the pristine
+    // generator output (module 1, above) and the fully-assembled tutorial
+    // (module 4, below): every file an intermediate build would compile is
+    // still compiled by the final build over the cumulative source, so the only
+    // thing dropped is per-module failure localisation, not coverage. `sync`,
+    // `lint` and the file-content assertions still run at every module.
     await runCLI(`sync --verbose`, opts);
     await runCLI(`${buildPackageManagerShortCommand(pkgMgr, 'lint')}`, {
       ...opts,
       prefixWithPackageManagerCmd: false,
     });
-    await runCLI(
-      `${buildPackageManagerShortCommand(pkgMgr, 'build')} --output-style=stream --verbose`,
-      { ...opts, prefixWithPackageManagerCmd: false },
-    );
 
     // Module 3: Story Agent
 
@@ -419,15 +425,13 @@ describe('smoke test - dungeon-adventure', () => {
     );
     writeFromTemplate(agentPyPath, '3/agent.py.template');
 
+    // Intermediate build skipped — see the note in Module 2. `sync` and `lint`
+    // still run here; the fully-assembled workspace is built in Module 4.
     await runCLI(`sync --verbose`, opts);
     await runCLI(`${buildPackageManagerShortCommand(pkgMgr, 'lint')}`, {
       ...opts,
       prefixWithPackageManagerCmd: false,
     });
-    await runCLI(
-      `${buildPackageManagerShortCommand(pkgMgr, 'build')} --output-style=stream --verbose`,
-      { ...opts, prefixWithPackageManagerCmd: false },
-    );
 
     // Module 4: UI
 


### PR DESCRIPTION
### Reason for this change

The **Windows dungeon-adventure smoke test** is the single longest job in the PR workflow (~38-40 min test step) and therefore gates overall PR wall-clock — the same test on Linux finishes in ~8.5 min.

Profiling the completed job log ([run 28704975842](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/28704975842)) shows the dominant cost is **four full `build` waves**, one after each tutorial module:

| Wave | Duration (Windows) |
|------|------:|
| Module 1 build (`--skip-nx-cache`) | 7.2 min |
| Module 2 build | 6.8 min |
| Module 3 build | 6.8 min |
| Module 4 build | 4.8 min |
| **Total (+ 3 lint:fix waves ~2.4 min)** | **~28 min** |

`build` is an umbrella target that recompiles, tests, bundles, synths, runs checkov and rebuilds **two Docker images** across all ~11 generated projects. Because each module edits source, almost nothing caches between waves — the workspace is rebuilt end to end four times.

(A prior attempt — deferring per-generator installs + enabling the Nx daemon, #888 — produced no speedup, because the generation phase and the daemon aren't the bottleneck. This targets the actual cost centre.)

### Description of changes

**On Windows only**, skip the two intermediate builds (tutorial modules 2 and 3) in `e2e/src/smoke-tests/dungeon-adventure.spec.ts`, keeping:

- the **module-1** build of pristine generator output (still `--skip-nx-cache`), and
- the **module-4** build of the fully-assembled tutorial.

**Linux is unchanged** — it still runs all four per-module builds, then the full local end-to-end validation (dev servers + DynamoDB Local + agent), and finishes in ~8.5 min regardless. So per-module build coverage is fully retained on Linux; only the CI-critical-path Windows leg trims the redundant intermediate rebuilds. `sync`, `lint` and every file-content assertion still run at every module on both platforms.

### Why this preserves test integrity

- On Windows, every file an intermediate build would compile is **still compiled** by the final build over the cumulative source — the tutorial's later modules add/modify code but the final workspace is a superset.
- Each project's Docker image, synth output and test suite is built/run at its **final** state; later modules edit *different* projects, so an intermediate image would be byte-identical to the final one. The run log confirms module 4 already saw most targets as `CACHED` precisely because the intermediate waves had produced identical outputs.
- The only thing lost on Windows is **per-module failure localisation**, not any build/test/synth/docker **coverage** — and Linux still provides that localisation.

### Description of how you validated changes

Measured on CI ([run 28706688048](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/28706688048)) — **all 49 jobs green**. (That run skipped on both platforms; this PR now restricts the skip to Windows, so Linux returns to its prior ~8.5 min behaviour while the Windows numbers below are unchanged.)

**Before → After (`Windows Smoke Tests - dungeon-adventure`):**

| Metric | Baseline | This PR | Saved |
|--------|---------:|--------:|------:|
| Test step | 38.1 min | 25.8 min | **12.3 min (−32%)** |
| Full job (queue + init + test) | 41.6 min | 29.3 min | 12.3 min |
| **PR workflow wall-clock** | ~41 min | **33.7 min** | ~7 min |

The Windows build phase dropped from ~28 min (4 waves) to ~15 min (2 waves). dungeon-adventure (29.4 min) is now roughly in line with the Windows standalone shards (~27 min) rather than being the outlier — so the Windows standalone leg becomes the next thing to look at for further wall-clock gains.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*