### PR TITLE
feat(agentcore-gateway): enable AWS WAF protection by default

### DIFF
--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -74,37 +74,93 @@ The generated construct creates the following AWS resources:
 - An `AgentCore::Gateway` configured for the MCP protocol with `GatewayAuthorizer.usingAwsIam()` (inbound IAM authentication)
 - An `AgentCore::PolicyEngine` running in `ENFORCE` mode, attached to the Gateway (omitted when `cedarPolicy: false`)
 - One `AgentCore::Policy` per `.cedar` file in `policies/`
-- An AWS WAFv2 web ACL associated with the Gateway, with request logging to CloudWatch (enabled by default — see <a href="#aws-waf-protection">AWS WAF Protection</a>)
+- An AWS WAFv2 Web ACL associated with the Gateway, with request logging to CloudWatch (enabled by default — see <a href="#aws-waf">AWS WAF</a>)
 
 The Gateway URL is automatically registered in the `agentcore.gateways.<ClassName>` namespace of <Link path="guides/runtime-config">Runtime Configuration</Link> so agents can discover it at runtime.
 
-## AWS WAF Protection
+## AWS WAF
 
-By default, the generated infrastructure protects your Gateway with an [AWS WAF](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-waf.html) web ACL. AWS WAF inspects every inbound request inline _before_ it reaches a target, defending the Gateway against web exploits, bot traffic, and volumetric attacks. Requests that match a block rule are rejected before they reach any target.
+By default, the generated construct associates an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL with the Gateway. AWS WAF inspects every inbound request inline _before_ it reaches a target, protecting your Gateway from web exploits, bot traffic, and volumetric attacks. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10. WAF request logs are written to a CloudWatch Logs group.
 
-The web ACL is `REGIONAL` (as required for AgentCore Gateway associations — CloudFront/global web ACLs are not supported) and includes the following AWS Managed Rule groups:
+The Web ACL is `REGIONAL` and created in the Gateway's region, as required for AgentCore Gateway associations — CloudFront (global) Web ACLs are not supported.
 
-- **`AWSManagedRulesCommonRuleSet`** — protection against common web exploits. The `SizeRestrictions_BODY` rule is set to `Count` rather than `Block`, since its 8&nbsp;KB body limit is too restrictive for typical MCP tool payloads.
-- **`AWSManagedRulesKnownBadInputsRuleSet`** — blocks request patterns known to be invalid and associated with exploitation.
+#### Architecture
 
-WAF request logs are sent to a CloudWatch log group (named `aws-waf-logs-*`) so you can inspect blocked and counted requests.
+Requests reach the Gateway through AWS WAF, which routes allowed requests on to the Gateway and its downstream MCP server targets:
 
-If AWS WAF is unreachable or times out during evaluation, the Gateway uses its **failure mode** to decide whether to block or allow the request. This defaults to the service's security-first `FAIL_CLOSE` (block). The failure mode is a control-plane-only setting (configured via the `UpdateGateway` API) and is not exposed through CloudFormation or Terraform.
+```d2 inline=true
+direction: right
 
-### Customizing or disabling WAF
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
 
-The web ACL is created with the default managed rule groups. To add your own rules (for example, rate-based rules or IP allow/deny lists), extend the vended construct or module, or reference the exposed web ACL:
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[SizeRestrictions_BODY deviation from defaults]
+The `SizeRestrictions_BODY` rule from `AWSManagedRulesCommonRuleSet` is overridden to `Count` rather than `Block`, since the rule's 8 KB limit is too restrictive for typical MCP tool payloads. Oversized requests will still be recorded as metrics so you can monitor them. See the [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) guide for more details.
+:::
+
+If AWS WAF is unreachable or times out during evaluation, the Gateway uses its **failure mode** to decide whether to block or allow the request. This defaults to the service's security-first `FAIL_CLOSE` (block). The failure mode is a control-plane-only setting (configured via the [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) API) and is not exposed through CloudFormation or Terraform. We recommend testing new AWS WAF rules in `Count` mode before switching them to `Block`, and monitoring the `WafBlocks`, `WafFailOpens`, and `WafFailCloses` CloudWatch metrics in the `AWS/Bedrock-AgentCore` namespace to tune your rules.
+
+You can edit the generated Gateway construct to add, remove, or adjust rules (for example, to add [rate-based rules](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) or additional managed rule groups).
 
 <Infrastructure>
-  <Fragment slot="cdk">
-The `AgentCoreGateway` construct accepts an `enableWaf` prop (default `true`) and exposes the created web ACL as `webAcl`. Pass `enableWaf: false` to skip WAF entirely, for example when you associate your own centrally-managed web ACL.
-  </Fragment>
-  <Fragment slot="terraform">
-The Gateway module accepts an `enable_waf` variable (default `true`) and outputs the created web ACL ARN as `waf_web_acl_arn`. Set `enable_waf = false` to skip WAF entirely, for example when you associate your own centrally-managed web ACL.
-  </Fragment>
-</Infrastructure>
+<Fragment slot="cdk">
+To opt out (for example, to attach your own Web ACL), set `enableWaf` to `false` on the `super` call in your generated Gateway construct:
 
-We recommend testing new AWS WAF rules in `Count` mode before switching them to `Block`, and monitoring the `WafBlocks`, `WafFailOpens`, and `WafFailCloses` CloudWatch metrics in the `AWS/Bedrock-AgentCore` namespace to tune your rules.
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+The construct exposes the created Web ACL as `webAcl` for further configuration.
+</Fragment>
+<Fragment slot="terraform">
+To opt out (for example, to attach your own Web ACL), set `enable_waf` to `false` on the Gateway module:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+The module outputs the created Web ACL ARN as `waf_web_acl_arn` for further configuration.
+</Fragment>
+</Infrastructure>
 
 ## Writing Policies
 

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-By default, the generated construct associates an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL with the Gateway. AWS WAF inspects every inbound request inline _before_ it reaches a target, protecting your Gateway from web exploits, bot traffic, and volumetric attacks. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10. WAF request logs are written to a CloudWatch Logs group.
-
-The Web ACL is `REGIONAL` and created in the Gateway's region, as required for AgentCore Gateway associations — CloudFront (global) Web ACLs are not supported.
-
-:::caution[SizeRestrictions_BODY deviation from defaults]
-The `SizeRestrictions_BODY` rule from `AWSManagedRulesCommonRuleSet` is overridden to `Count` rather than `Block`, since the rule's 8 KB limit is too restrictive for typical MCP tool payloads. Oversized requests will still be recorded as metrics so you can monitor them. See the [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) guide for more details.
-:::
-
-If AWS WAF is unreachable or times out during evaluation, the Gateway uses its **failure mode** to decide whether to block or allow the request. This defaults to the service's security-first `FAIL_CLOSE` (block). The failure mode is a control-plane-only setting (configured via the [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) API) and is not exposed through CloudFormation or Terraform. We recommend testing new AWS WAF rules in `Count` mode before switching them to `Block`, and monitoring the `WafBlocks`, `WafFailOpens`, and `WafFailCloses` CloudWatch metrics in the `AWS/Bedrock-AgentCore` namespace to tune your rules.
-
-You can edit the generated Gateway construct to add, remove, or adjust rules (for example, to add [rate-based rules](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) or additional managed rule groups).
-
-<Infrastructure>
-<Fragment slot="cdk">
-To opt out (for example, to attach your own Web ACL), set `enableWaf` to `false` on the `super` call in your generated Gateway construct:
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-The construct exposes the created Web ACL as `webAcl` for further configuration.
-</Fragment>
-<Fragment slot="terraform">
-To opt out (for example, to attach your own Web ACL), set `enable_waf` to `false` on the Gateway module:
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-The module outputs the created Web ACL ARN as `waf_web_acl_arn` for further configuration.
-</Fragment>
-</Infrastructure>
-
 ## Writing Policies
 
 <OptionFilter when={{ cedarPolicy: true }} description="Cedar policies — cedarPolicy: true only">
@@ -311,6 +265,78 @@ The generator adds a `dev` target to the Gateway project, which runs `local-dev.
 <NxCommands commands={["dev <name>"]} />
 
 See the connection guide for the full local development story.
+
+## Deploying your AgentCore Gateway
+
+The AgentCore Gateway generator creates CDK or Terraform infrastructure as code based on your selected `iacProvider`. You can use this to deploy your Gateway.
+
+<Infrastructure>
+<Fragment slot="cdk">
+The CDK construct for deploying your Gateway lives in the `common/constructs` folder. You can consume this in a CDK application, for example:
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+This sets up your Gateway infrastructure, including the `AgentCore::Gateway`, its Cedar `PolicyEngine`, and the AWS WAF Web ACL (see [AWS WAF](#aws-waf) below). Register MCP server targets with `gateway.addMcpServer(...)` — see the <Link path="guides/connection/agentcore-gateway-mcp">MCP server connection guide</Link>.
+</Fragment>
+<Fragment slot="terraform">
+The Terraform module for deploying your Gateway is in the `common/terraform` folder. You can use this in a Terraform configuration, for example:
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+This sets up your Gateway infrastructure, including the `aws_bedrockagentcore_gateway`, its Cedar policy engine, and the AWS WAF Web ACL (see [AWS WAF](#aws-waf) below). Register MCP server targets with an `aws_bedrockagentcore_gateway_target` resource — see the <Link path="guides/connection/agentcore-gateway-mcp">MCP server connection guide</Link>.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+By default, the generated construct associates an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL with the Gateway. AWS WAF inspects every inbound request inline _before_ it reaches a target, protecting your Gateway from web exploits, bot traffic, and volumetric attacks. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10. WAF request logs are written to a CloudWatch Logs group.
+
+The Web ACL is `REGIONAL` and created in the Gateway's region, as required for AgentCore Gateway associations.
+
+:::caution[SizeRestrictions_BODY deviation from defaults]
+The `SizeRestrictions_BODY` rule from `AWSManagedRulesCommonRuleSet` is overridden to `Count` rather than `Block`, since the rule's 8 KB limit is too restrictive for typical MCP tool payloads. Oversized requests will still be recorded as metrics so you can monitor them. See the [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) guide for more details.
+:::
+
+You can edit the generated Gateway construct to add, remove, or adjust rules (for example, to add [rate-based rules](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) or additional managed rule groups).
+
+<Infrastructure>
+<Fragment slot="cdk">
+To opt out (for example, to attach your own Web ACL), set `enableWaf` to `false` when you instantiate the Gateway construct:
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+The construct exposes the created Web ACL as `webAcl` for further configuration.
+</Fragment>
+<Fragment slot="terraform">
+To opt out (for example, to attach your own Web ACL), set `enable_waf` to `false` on the Gateway module:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+The module outputs the created Web ACL ARN as `waf_web_acl_arn` for further configuration.
+</Fragment>
+</Infrastructure>
 
 ## Connections
 

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -74,8 +74,37 @@ The generated construct creates the following AWS resources:
 - An `AgentCore::Gateway` configured for the MCP protocol with `GatewayAuthorizer.usingAwsIam()` (inbound IAM authentication)
 - An `AgentCore::PolicyEngine` running in `ENFORCE` mode, attached to the Gateway (omitted when `cedarPolicy: false`)
 - One `AgentCore::Policy` per `.cedar` file in `policies/`
+- An AWS WAFv2 web ACL associated with the Gateway, with request logging to CloudWatch (enabled by default — see <a href="#aws-waf-protection">AWS WAF Protection</a>)
 
 The Gateway URL is automatically registered in the `agentcore.gateways.<ClassName>` namespace of <Link path="guides/runtime-config">Runtime Configuration</Link> so agents can discover it at runtime.
+
+## AWS WAF Protection
+
+By default, the generated infrastructure protects your Gateway with an [AWS WAF](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-waf.html) web ACL. AWS WAF inspects every inbound request inline _before_ it reaches a target, defending the Gateway against web exploits, bot traffic, and volumetric attacks. Requests that match a block rule are rejected before they reach any target.
+
+The web ACL is `REGIONAL` (as required for AgentCore Gateway associations — CloudFront/global web ACLs are not supported) and includes the following AWS Managed Rule groups:
+
+- **`AWSManagedRulesCommonRuleSet`** — protection against common web exploits. The `SizeRestrictions_BODY` rule is set to `Count` rather than `Block`, since its 8&nbsp;KB body limit is too restrictive for typical MCP tool payloads.
+- **`AWSManagedRulesKnownBadInputsRuleSet`** — blocks request patterns known to be invalid and associated with exploitation.
+
+WAF request logs are sent to a CloudWatch log group (named `aws-waf-logs-*`) so you can inspect blocked and counted requests.
+
+If AWS WAF is unreachable or times out during evaluation, the Gateway uses its **failure mode** to decide whether to block or allow the request. This defaults to the service's security-first `FAIL_CLOSE` (block). The failure mode is a control-plane-only setting (configured via the `UpdateGateway` API) and is not exposed through CloudFormation or Terraform.
+
+### Customizing or disabling WAF
+
+The web ACL is created with the default managed rule groups. To add your own rules (for example, rate-based rules or IP allow/deny lists), extend the vended construct or module, or reference the exposed web ACL:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+The `AgentCoreGateway` construct accepts an `enableWaf` prop (default `true`) and exposes the created web ACL as `webAcl`. Pass `enableWaf: false` to skip WAF entirely, for example when you associate your own centrally-managed web ACL.
+  </Fragment>
+  <Fragment slot="terraform">
+The Gateway module accepts an `enable_waf` variable (default `true`) and outputs the created web ACL ARN as `waf_web_acl_arn`. Set `enable_waf = false` to skip WAF entirely, for example when you associate your own centrally-managed web ACL.
+  </Fragment>
+</Infrastructure>
+
+We recommend testing new AWS WAF rules in `Count` mode before switching them to `Block`, and monitoring the `WafBlocks`, `WafFailOpens`, and `WafFailCloses` CloudWatch metrics in the `AWS/Bedrock-AgentCore` namespace to tune your rules.
 
 ## Writing Policies
 

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ The generated construct creates the following AWS resources:
 
 The Gateway URL is automatically registered in the `agentcore.gateways.<ClassName>` namespace of <Link path="guides/runtime-config">Runtime Configuration</Link> so agents can discover it at runtime.
 
-## AWS WAF
-
-By default, the generated construct associates an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL with the Gateway. AWS WAF inspects every inbound request inline _before_ it reaches a target, protecting your Gateway from web exploits, bot traffic, and volumetric attacks. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10. WAF request logs are written to a CloudWatch Logs group.
-
-The Web ACL is `REGIONAL` and created in the Gateway's region, as required for AgentCore Gateway associations — CloudFront (global) Web ACLs are not supported.
-
 #### Architecture
 
-Requests reach the Gateway through AWS WAF, which routes allowed requests on to the Gateway and its downstream MCP server targets:
+The deployed Gateway has the following architecture. Inbound requests pass through an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL and IAM authentication, are authorized against the Cedar [policy engine](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html), then routed on to the downstream MCP server targets:
 
 ```d2 inline=true
 direction: right
@@ -106,6 +100,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -118,9 +117,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+By default, the generated construct associates an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL with the Gateway. AWS WAF inspects every inbound request inline _before_ it reaches a target, protecting your Gateway from web exploits, bot traffic, and volumetric attacks. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10. WAF request logs are written to a CloudWatch Logs group.
+
+The Web ACL is `REGIONAL` and created in the Gateway's region, as required for AgentCore Gateway associations — CloudFront (global) Web ACLs are not supported.
 
 :::caution[SizeRestrictions_BODY deviation from defaults]
 The `SizeRestrictions_BODY` rule from `AWSManagedRulesCommonRuleSet` is overridden to `Count` rather than `Block`, since the rule's 8 KB limit is too restrictive for typical MCP tool payloads. Oversized requests will still be recorded as metrics so you can monitor them. See the [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) guide for more details.

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -80,7 +80,7 @@ The Gateway URL is automatically registered in the `agentcore.gateways.<ClassNam
 
 #### Architecture
 
-The deployed Gateway has the following architecture. Inbound requests pass through an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL and IAM authentication, are authorized against the Cedar [policy engine](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html), then routed on to the downstream MCP server targets:
+The deployed Gateway has the following architecture, with an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL in front of the Gateway, which routes on to its downstream MCP server targets:
 
 ```d2 inline=true
 direction: right
@@ -100,26 +100,13 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
-policy: Policy Engine\n(Cedar, ENFORCE) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
-}
-
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
 
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
 
 ## AWS WAF

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 By default, the generated construct associates an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL with the Gateway. AWS WAF inspects every inbound request inline _before_ it reaches a target, protecting your Gateway from web exploits, bot traffic, and volumetric attacks. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10. WAF request logs are written to a CloudWatch Logs group.
 

--- a/docs/src/content/docs/en/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-gateway.mdx
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 The Gateway URL is automatically registered in the `agentcore.gateways.<ClassName>` namespace of <Link path="guides/runtime-config">Runtime Configuration</Link> by the generated CDK construct, so the agent can discover it at runtime.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/en/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 The Gateway URL is automatically registered in the `agentcore.gateways.<ClassName>` namespace of <Link path="guides/runtime-config">Runtime Configuration</Link> by the generated CDK construct, so the agent can discover it at runtime.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ El constructo generado crea los siguientes recursos de AWS:
 
 La URL del Gateway se registra automáticamente en el espacio de nombres `agentcore.gateways.<ClassName>` de <Link path="guides/runtime-config">Runtime Configuration</Link> para que los agentes puedan descubrirla en tiempo de ejecución.
 
-## AWS WAF
-
-Por defecto, el constructo generado asocia un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) con el Gateway. AWS WAF inspecciona cada solicitud entrante en línea _antes_ de que llegue a un destino, protegiendo tu Gateway de exploits web, tráfico de bots y ataques volumétricos. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes, incluido el OWASP Top 10. Los registros de solicitudes de WAF se escriben en un grupo de CloudWatch Logs.
-
-El Web ACL es `REGIONAL` y se crea en la región del Gateway, como se requiere para las asociaciones de AgentCore Gateway — los Web ACLs de CloudFront (globales) no son compatibles.
-
 #### Arquitectura
 
-Las solicitudes llegan al Gateway a través de AWS WAF, que enruta las solicitudes permitidas al Gateway y sus destinos de servidor MCP descendentes:
+El Gateway desplegado tiene la siguiente arquitectura, con un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) frente al Gateway, que enruta a sus destinos de servidor MCP descendentes:
 
 ```d2 inline=true
 direction: right
@@ -106,26 +100,20 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
-policy: Policy Engine\n(Cedar, ENFORCE) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
-}
-
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
-}
-
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
 }
 
 client -> waf
 waf -> gateway
 gateway -> targets
-waf -> cw
 ```
+
+## AWS WAF
+
+Por defecto, el constructo generado asocia un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) con el Gateway. AWS WAF inspecciona cada solicitud entrante en línea _antes_ de que llegue a un destino, protegiendo tu Gateway de exploits web, tráfico de bots y ataques volumétricos. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes, incluido el OWASP Top 10. Los registros de solicitudes de WAF se escriben en un grupo de CloudWatch Logs.
+
+El Web ACL es `REGIONAL` y se crea en la región del Gateway, como se requiere para las asociaciones de AgentCore Gateway — los Web ACLs de CloudFront (globales) no son compatibles.
 
 :::caution[Desviación de SizeRestrictions_BODY de los valores predeterminados]
 La regla `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` se anula a `Count` en lugar de `Block`, ya que el límite de 8 KB de la regla es demasiado restrictivo para las cargas útiles típicas de herramientas MCP. Las solicitudes de gran tamaño aún se registrarán como métricas para que puedas monitorearlas. Consulta la guía de [límites de tamaño del cuerpo de AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para obtener más detalles.

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 Por defecto, el constructo generado asocia un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) con el Gateway. AWS WAF inspecciona cada solicitud entrante en línea _antes_ de que llegue a un destino, protegiendo tu Gateway de exploits web, tráfico de bots y ataques volumétricos. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes, incluido el OWASP Top 10. Los registros de solicitudes de WAF se escriben en un grupo de CloudWatch Logs.
 

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -348,31 +348,3 @@ Usa el generador <Link path="guides/connection">`connection`</Link> para integra
     target="agentcore"
   />
 </CardGrid>
-e || 'en'}/guides/connection/agentcore-gateway-mcp`}
-    source="agentcore"
-    target="mcp"
-  />
-  <ConnectionCard
-    title="AgentCore Gateway a AgentCore Gateway"
-    description="Agrega un AgentCore Gateway detrás de otro AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
-    source="agentcore"
-    target="agentcore"
-  />
-  <ConnectionCard
-    title="TypeScript Agent a AgentCore Gateway"
-    description="Conecta un TypeScript Agent a un AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}
-    source="strands"
-    sourceBadge="typescript"
-    target="agentcore"
-  />
-  <ConnectionCard
-    title="Python Agent a AgentCore Gateway"
-    description="Conecta un Python Agent a un AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
-    source="strands"
-    sourceBadge="python"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ El constructo generado crea los siguientes recursos de AWS:
 - Un `AgentCore::Gateway` configurado para el protocolo MCP con `GatewayAuthorizer.usingAwsIam()` (autenticación IAM entrante)
 - Un `AgentCore::PolicyEngine` ejecutándose en modo `ENFORCE`, adjunto al Gateway (omitido cuando `cedarPolicy: false`)
 - Una `AgentCore::Policy` por cada archivo `.cedar` en `policies/`
+- Un Web ACL de AWS WAFv2 asociado con el Gateway, con registro de solicitudes en CloudWatch (habilitado por defecto — consulta <a href="#aws-waf">AWS WAF</a>)
 
 La URL del Gateway se registra automáticamente en el espacio de nombres `agentcore.gateways.<ClassName>` de <Link path="guides/runtime-config">Runtime Configuration</Link> para que los agentes puedan descubrirla en tiempo de ejecución.
+
+## AWS WAF
+
+Por defecto, el constructo generado asocia un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) con el Gateway. AWS WAF inspecciona cada solicitud entrante en línea _antes_ de que llegue a un destino, protegiendo tu Gateway de exploits web, tráfico de bots y ataques volumétricos. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes, incluido el OWASP Top 10. Los registros de solicitudes de WAF se escriben en un grupo de CloudWatch Logs.
+
+El Web ACL es `REGIONAL` y se crea en la región del Gateway, como se requiere para las asociaciones de AgentCore Gateway — los Web ACLs de CloudFront (globales) no son compatibles.
+
+#### Arquitectura
+
+Las solicitudes llegan al Gateway a través de AWS WAF, que enruta las solicitudes permitidas al Gateway y sus destinos de servidor MCP descendentes:
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[Desviación de SizeRestrictions_BODY de los valores predeterminados]
+La regla `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` se anula a `Count` en lugar de `Block`, ya que el límite de 8 KB de la regla es demasiado restrictivo para las cargas útiles típicas de herramientas MCP. Las solicitudes de gran tamaño aún se registrarán como métricas para que puedas monitorearlas. Consulta la guía de [límites de tamaño del cuerpo de AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para obtener más detalles.
+:::
+
+Si AWS WAF no está disponible o se agota el tiempo de espera durante la evaluación, el Gateway utiliza su **modo de fallo** para decidir si bloquear o permitir la solicitud. Este valor predeterminado es `FAIL_CLOSE` (bloquear), que prioriza la seguridad del servicio. El modo de fallo es una configuración solo del plano de control (configurada a través de la API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) y no está expuesta a través de CloudFormation o Terraform. Recomendamos probar nuevas reglas de AWS WAF en modo `Count` antes de cambiarlas a `Block`, y monitorear las métricas de CloudWatch `WafBlocks`, `WafFailOpens` y `WafFailCloses` en el espacio de nombres `AWS/Bedrock-AgentCore` para ajustar tus reglas.
+
+Puedes editar el constructo Gateway generado para agregar, eliminar o ajustar reglas (por ejemplo, para agregar [reglas basadas en tasas](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) o grupos de reglas administradas adicionales).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para optar por no participar (por ejemplo, para adjuntar tu propio Web ACL), establece `enableWaf` en `false` en la llamada `super` en tu constructo Gateway generado:
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+El constructo expone el Web ACL creado como `webAcl` para una configuración adicional.
+</Fragment>
+<Fragment slot="terraform">
+Para optar por no participar (por ejemplo, para adjuntar tu propio Web ACL), establece `enable_waf` en `false` en el módulo Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+El módulo genera el ARN del Web ACL creado como `waf_web_acl_arn` para una configuración adicional.
+</Fragment>
+</Infrastructure>
 
 ## Escribir Políticas
 

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -106,6 +106,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -328,6 +333,34 @@ Usa el generador <Link path="guides/connection">`connection`</Link> para integra
     title="AgentCore Gateway a Servidor MCP"
     description="Agrega un servidor MCP detrás de un AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-mcp`}
+    source="agentcore"
+    target="mcp"
+  />
+  <ConnectionCard
+    title="AgentCore Gateway a AgentCore Gateway"
+    description="Agrega un AgentCore Gateway detrás de otro AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
+    title="TypeScript Agent a AgentCore Gateway"
+    description="Conecta un TypeScript Agent a un AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}
+    source="strands"
+    sourceBadge="typescript"
+    target="agentcore"
+  />
+  <ConnectionCard
+    title="Python Agent a AgentCore Gateway"
+    description="Conecta un Python Agent a un AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    source="strands"
+    sourceBadge="python"
+    target="agentcore"
+  />
+</CardGrid>
+e || 'en'}/guides/connection/agentcore-gateway-mcp`}
     source="agentcore"
     target="mcp"
   />

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-Por defecto, el constructo generado asocia un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) con el Gateway. AWS WAF inspecciona cada solicitud entrante en línea _antes_ de que llegue a un destino, protegiendo tu Gateway de exploits web, tráfico de bots y ataques volumétricos. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes, incluido el OWASP Top 10. Los registros de solicitudes de WAF se escriben en un grupo de CloudWatch Logs.
-
-El Web ACL es `REGIONAL` y se crea en la región del Gateway, como se requiere para las asociaciones de AgentCore Gateway — los Web ACLs de CloudFront (globales) no son compatibles.
-
-:::caution[Desviación de SizeRestrictions_BODY de los valores predeterminados]
-La regla `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` se anula a `Count` en lugar de `Block`, ya que el límite de 8 KB de la regla es demasiado restrictivo para las cargas útiles típicas de herramientas MCP. Las solicitudes de gran tamaño aún se registrarán como métricas para que puedas monitorearlas. Consulta la guía de [límites de tamaño del cuerpo de AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para obtener más detalles.
-:::
-
-Si AWS WAF no está disponible o se agota el tiempo de espera durante la evaluación, el Gateway utiliza su **modo de fallo** para decidir si bloquear o permitir la solicitud. Este valor predeterminado es `FAIL_CLOSE` (bloquear), que prioriza la seguridad del servicio. El modo de fallo es una configuración solo del plano de control (configurada a través de la API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) y no está expuesta a través de CloudFormation o Terraform. Recomendamos probar nuevas reglas de AWS WAF en modo `Count` antes de cambiarlas a `Block`, y monitorear las métricas de CloudWatch `WafBlocks`, `WafFailOpens` y `WafFailCloses` en el espacio de nombres `AWS/Bedrock-AgentCore` para ajustar tus reglas.
-
-Puedes editar el constructo Gateway generado para agregar, eliminar o ajustar reglas (por ejemplo, para agregar [reglas basadas en tasas](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) o grupos de reglas administradas adicionales).
-
-<Infrastructure>
-<Fragment slot="cdk">
-Para optar por no participar (por ejemplo, para adjuntar tu propio Web ACL), establece `enableWaf` en `false` en la llamada `super` en tu constructo Gateway generado:
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-El constructo expone el Web ACL creado como `webAcl` para una configuración adicional.
-</Fragment>
-<Fragment slot="terraform">
-Para optar por no participar (por ejemplo, para adjuntar tu propio Web ACL), establece `enable_waf` en `false` en el módulo Gateway:
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-El módulo genera el ARN del Web ACL creado como `waf_web_acl_arn` para una configuración adicional.
-</Fragment>
-</Infrastructure>
-
 ## Escribir Políticas
 
 <OptionFilter when={{ cedarPolicy: true }} description="Cedar policies — cedarPolicy: true only">
@@ -311,6 +265,78 @@ El generador agrega un destino `dev` al proyecto Gateway, que ejecuta `local-dev
 <NxCommands commands={["dev <name>"]} />
 
 Consulta la guía de conexión para la historia completa de desarrollo local.
+
+## Desplegar tu AgentCore Gateway
+
+El generador de AgentCore Gateway crea infraestructura como código CDK o Terraform basada en tu `iacProvider` seleccionado. Puedes usar esto para desplegar tu Gateway.
+
+<Infrastructure>
+<Fragment slot="cdk">
+El constructo CDK para desplegar tu Gateway se encuentra en la carpeta `common/constructs`. Puedes consumir esto en una aplicación CDK, por ejemplo:
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+Esto configura tu infraestructura de Gateway, incluyendo el `AgentCore::Gateway`, su `PolicyEngine` Cedar, y el Web ACL de AWS WAF (consulta [AWS WAF](#aws-waf) a continuación). Registra destinos de servidor MCP con `gateway.addMcpServer(...)` — consulta la <Link path="guides/connection/agentcore-gateway-mcp">guía de conexión de servidor MCP</Link>.
+</Fragment>
+<Fragment slot="terraform">
+El módulo Terraform para desplegar tu Gateway está en la carpeta `common/terraform`. Puedes usar esto en una configuración Terraform, por ejemplo:
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+Esto configura tu infraestructura de Gateway, incluyendo el `aws_bedrockagentcore_gateway`, su motor de políticas Cedar, y el Web ACL de AWS WAF (consulta [AWS WAF](#aws-waf) a continuación). Registra destinos de servidor MCP con un recurso `aws_bedrockagentcore_gateway_target` — consulta la <Link path="guides/connection/agentcore-gateway-mcp">guía de conexión de servidor MCP</Link>.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+Por defecto, el constructo generado asocia un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) con el Gateway. AWS WAF inspecciona cada solicitud entrante en línea _antes_ de que llegue a un destino, protegiendo tu Gateway de exploits web, tráfico de bots y ataques volumétricos. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes, incluido el OWASP Top 10. Los registros de solicitudes de WAF se escriben en un grupo de CloudWatch Logs.
+
+El Web ACL es `REGIONAL` y se crea en la región del Gateway, como se requiere para las asociaciones de AgentCore Gateway.
+
+:::caution[Desviación de SizeRestrictions_BODY de los valores predeterminados]
+La regla `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` se anula a `Count` en lugar de `Block`, ya que el límite de 8 KB de la regla es demasiado restrictivo para las cargas útiles típicas de herramientas MCP. Las solicitudes de gran tamaño aún se registrarán como métricas para que puedas monitorearlas. Consulta la guía de [límites de tamaño del cuerpo de AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para obtener más detalles.
+:::
+
+Puedes editar el constructo Gateway generado para agregar, eliminar o ajustar reglas (por ejemplo, para agregar [reglas basadas en tasas](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) o grupos de reglas administradas adicionales).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para optar por no participar (por ejemplo, para adjuntar tu propio Web ACL), establece `enableWaf` en `false` cuando instancies el constructo Gateway:
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+El constructo expone el Web ACL creado como `webAcl` para una configuración adicional.
+</Fragment>
+<Fragment slot="terraform">
+Para optar por no participar (por ejemplo, para adjuntar tu propio Web ACL), establece `enable_waf` en `false` en el módulo Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+El módulo genera el ARN del Web ACL creado como `waf_web_acl_arn` para una configuración adicional.
+</Fragment>
+</Infrastructure>
 
 ## Conexiones
 

--- a/docs/src/content/docs/es/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-gateway.mdx
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 La URL del Gateway se registra automáticamente en el espacio de nombres `agentcore.gateways.<ClassName>` de <Link path="guides/runtime-config">Runtime Configuration</Link> por el constructo CDK generado, para que el agente pueda descubrirlo en tiempo de ejecución.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/es/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 La URL del Gateway se registra automáticamente en el namespace `agentcore.gateways.<ClassName>` de <Link path="guides/runtime-config">Runtime Configuration</Link> por el constructo CDK generado, para que el agente pueda descubrirlo en tiempo de ejecución.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ Le construct généré crée les ressources AWS suivantes :
 - Une `AgentCore::Gateway` configurée pour le protocole MCP avec `GatewayAuthorizer.usingAwsIam()` (authentification IAM entrante)
 - Un `AgentCore::PolicyEngine` fonctionnant en mode `ENFORCE`, attaché à la Gateway (omis lorsque `cedarPolicy: false`)
 - Une `AgentCore::Policy` par fichier `.cedar` dans `policies/`
+- Une Web ACL AWS WAFv2 associée à la Gateway, avec journalisation des requêtes vers CloudWatch (activée par défaut — voir <a href="#aws-waf">AWS WAF</a>)
 
 L'URL de la Gateway est automatiquement enregistrée dans l'espace de noms `agentcore.gateways.<ClassName>` de la <Link path="guides/runtime-config">Configuration d'exécution</Link> afin que les agents puissent la découvrir au moment de l'exécution.
+
+## AWS WAF
+
+Par défaut, le construct généré associe une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) à la Gateway. AWS WAF inspecte chaque requête entrante en ligne _avant_ qu'elle n'atteigne une cible, protégeant votre Gateway contre les exploits web, le trafic de bots et les attaques volumétriques. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits web courants, y compris le Top 10 de l'OWASP. Les journaux de requêtes WAF sont écrits dans un groupe de journaux CloudWatch Logs.
+
+La Web ACL est `REGIONAL` et créée dans la région de la Gateway, comme requis pour les associations AgentCore Gateway — les Web ACL CloudFront (globales) ne sont pas prises en charge.
+
+#### Architecture
+
+Les requêtes atteignent la Gateway via AWS WAF, qui route les requêtes autorisées vers la Gateway et ses serveurs MCP cibles en aval :
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[Déviation de SizeRestrictions_BODY par rapport aux valeurs par défaut]
+La règle `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` est remplacée par `Count` plutôt que `Block`, car la limite de 8 Ko de la règle est trop restrictive pour les charges utiles d'outils MCP typiques. Les requêtes surdimensionnées seront toujours enregistrées en tant que métriques afin que vous puissiez les surveiller. Consultez le guide [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) pour plus de détails.
+:::
+
+Si AWS WAF est inaccessible ou expire pendant l'évaluation, la Gateway utilise son **mode d'échec** pour décider de bloquer ou d'autoriser la requête. Par défaut, il s'agit du `FAIL_CLOSE` (blocage) axé sur la sécurité du service. Le mode d'échec est un paramètre du plan de contrôle uniquement (configuré via l'API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) et n'est pas exposé via CloudFormation ou Terraform. Nous recommandons de tester les nouvelles règles AWS WAF en mode `Count` avant de les basculer en `Block`, et de surveiller les métriques CloudWatch `WafBlocks`, `WafFailOpens` et `WafFailCloses` dans l'espace de noms `AWS/Bedrock-AgentCore` pour ajuster vos règles.
+
+Vous pouvez modifier le construct Gateway généré pour ajouter, supprimer ou ajuster des règles (par exemple, pour ajouter des [règles basées sur le taux](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) ou des groupes de règles gérées supplémentaires).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pour désactiver (par exemple, pour attacher votre propre Web ACL), définissez `enableWaf` sur `false` dans l'appel `super` de votre construct Gateway généré :
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+Le construct expose la Web ACL créée en tant que `webAcl` pour une configuration supplémentaire.
+</Fragment>
+<Fragment slot="terraform">
+Pour désactiver (par exemple, pour attacher votre propre Web ACL), définissez `enable_waf` sur `false` dans le module Gateway :
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+Le module génère l'ARN de la Web ACL créée en tant que `waf_web_acl_arn` pour une configuration supplémentaire.
+</Fragment>
+</Infrastructure>
 
 ## Écriture de politiques
 
@@ -93,15 +178,13 @@ Par exemple, pour autoriser uniquement un rôle d'agent spécifique à invoquer 
 
 ```cedar title="packages/<name>/policies/ts-agent-divide.cedar"
 permit (
-  principal is AgentCore::IamEntity,
+  principal == AgentCore::IamEntity::"arn:aws:sts::<%= accountId %>:assumed-role/<%= tsAgentRoleName %>",
   action == AgentCore::Action::"ts-mcp___divide",
   resource == AgentCore::Gateway::"<%= gatewayArn %>"
-) when {
-  principal.id like "<%= tsAgentRoleArn %>/*"
-};
+);
 ```
 
-Passez l'ARN du rôle en tant que variable de modèle (voir <a href="#template-variables">Variables de modèle</a> ci-dessous) plutôt que de le coder en dur ou de le faire correspondre par motif. Resynthétisez ou replanifiez pour déployer la nouvelle politique.
+Passez le nom du rôle en tant que variable de modèle (voir <a href="#template-variables">Variables de modèle</a> ci-dessous) plutôt que de le coder en dur. Resynthétisez ou replanifiez pour déployer la nouvelle politique.
 
 ### Variables de modèle
 
@@ -116,18 +199,21 @@ Référencez toujours ces variables plutôt que de coder en dur les valeurs.
 
 #### Ajouter vos propres variables
 
-Ajoutez de nouvelles variables là où les politiques sont rendues, par exemple pour passer l'ARN du rôle d'exécution d'un agent à l'exemple `ts-agent-divide.cedar` ci-dessus :
+Ajoutez de nouvelles variables là où les politiques sont rendues, par exemple pour passer le nom du rôle d'exécution d'un agent à l'exemple `ts-agent-divide.cedar` ci-dessus :
 
 <Infrastructure>
 <Fragment slot="cdk">
-Dans `packages/common/constructs/src/app/gateways/<name>/<name>.ts`, ajoutez à l'objet passé à `ejs.render` :
+Dans `packages/common/constructs/src/app/gateways/<name>/<name>.ts`, passez `cedarPolicyVariables` au construct partagé :
 
-```ts {3}
-ejs.render(raw, {
-  gatewayArn: cdk.Token.asString(this.gateway.gatewayArn),
-  tsAgentRoleArn: cdk.Token.asString(tsAgent.agentCoreRuntime.role.roleArn),
-  // ...
-}),
+```ts {4-6}
+super(scope, id, {
+  cedarPolicyPath: path.join(
+    ...
+  ),
+  cedarPolicyVariables: {
+    tsAgentRoleName: cdk.Token.asString(tsAgent.agentCoreRuntime.role.roleName),
+  },
+});
 ```
 </Fragment>
 <Fragment slot="terraform">
@@ -135,9 +221,9 @@ Dans `packages/common/terraform/src/app/gateways/<name>/<name>.tf`, ajoutez à l
 
 ```hcl {4}
 query = {
-  template       = "${local.policies_dir}/${each.value}"
-  gatewayArn     = aws_bedrockagentcore_gateway.this.gateway_arn
-  tsAgentRoleArn = var.ts_agent_role_arn
+  template        = "${local.policies_dir}/${each.value}"
+  gatewayArn      = aws_bedrockagentcore_gateway.this.gateway_arn
+  tsAgentRoleName = var.ts_agent_role_name
   # ...
 }
 ```
@@ -163,9 +249,9 @@ Le générateur fournit une politique par défaut qui autorise tout appelant IAM
 permit (
   principal is AgentCore::IamEntity,
   action,
-  resource == AgentCore::Gateway::"${gateway_arn}"
+  resource == AgentCore::Gateway::"<%= gatewayArn %>"
 ) when {
-  principal.id like "arn:aws:*::${account_id}:*"
+  principal.id like "arn:aws:*::<%= accountId %>:*"
 };
 ```
 
@@ -179,11 +265,13 @@ Pour les Gateways générées par ce plugin, tous les appelants sont des princip
 principal is AgentCore::IamEntity
 ```
 
-L'attribut `id` du principal contient l'ARN IAM de l'appelant. Les appelants arrivent généralement sous forme d'ARN de rôle assumé STS avec un suffixe de session généré, donc passez l'ARN exact du rôle en tant que variable de modèle et faites correspondre le suffixe de session avec `like` :
+Les appelants sont évalués en tant qu'ARN de rôle assumé STS avec le nom de session supprimé, de sorte qu'un rôle peut être mis en correspondance exactement — aucun caractère générique n'est nécessaire :
 
 ```cedar
-principal.id like "<%= myAgentRoleArn %>/*"
+principal == AgentCore::IamEntity::"arn:aws:sts::<%= accountId %>:assumed-role/<%= myAgentRoleName %>"
 ```
+
+La même valeur est disponible en tant que `principal.id` pour les clauses `when`. Réservez `like` pour les véritables motifs, tels que la correspondance à l'échelle du compte dans le `permit-all.cedar` par défaut.
 
 Les invocations d'outils atteignent le moteur de politiques sous forme d'actions avec la forme :
 

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -100,26 +100,13 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
-policy: Policy Engine\n(Cedar, ENFORCE) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
-}
-
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
 
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
 
 ## AWS WAF
@@ -356,6 +343,12 @@ Utilisez le générateur <Link path="guides/connection">`connection`</Link> pour
     title="Python Agent vers AgentCore Gateway"
     description="Connecter un Python Agent à une AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    source="strands"
+    sourceBadge="python"
+    target="agentcore"
+  />
+</CardGrid>
+t-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -348,9 +348,3 @@ Utilisez le générateur <Link path="guides/connection">`connection`</Link> pour
     target="agentcore"
   />
 </CardGrid>
-t-gateway`}
-    source="strands"
-    sourceBadge="python"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-Par défaut, le construct généré associe une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) à la Gateway. AWS WAF inspecte chaque requête entrante en ligne _avant_ qu'elle n'atteigne une cible, protégeant votre Gateway contre les exploits web, le trafic de bots et les attaques volumétriques. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits web courants, y compris le Top 10 de l'OWASP. Les journaux de requêtes WAF sont écrits dans un groupe de journaux CloudWatch Logs.
-
-La Web ACL est `REGIONAL` et créée dans la région de la Gateway, comme requis pour les associations AgentCore Gateway — les Web ACL CloudFront (globales) ne sont pas prises en charge.
-
-:::caution[Déviation de SizeRestrictions_BODY par rapport aux valeurs par défaut]
-La règle `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` est remplacée par `Count` plutôt que `Block`, car la limite de 8 Ko de la règle est trop restrictive pour les charges utiles d'outils MCP typiques. Les requêtes surdimensionnées seront toujours enregistrées en tant que métriques afin que vous puissiez les surveiller. Consultez le guide [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) pour plus de détails.
-:::
-
-Si AWS WAF est inaccessible ou expire pendant l'évaluation, la Gateway utilise son **mode d'échec** pour décider de bloquer ou d'autoriser la requête. Par défaut, il s'agit du `FAIL_CLOSE` (blocage) axé sur la sécurité du service. Le mode d'échec est un paramètre du plan de contrôle uniquement (configuré via l'API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) et n'est pas exposé via CloudFormation ou Terraform. Nous recommandons de tester les nouvelles règles AWS WAF en mode `Count` avant de les basculer en `Block`, et de surveiller les métriques CloudWatch `WafBlocks`, `WafFailOpens` et `WafFailCloses` dans l'espace de noms `AWS/Bedrock-AgentCore` pour ajuster vos règles.
-
-Vous pouvez modifier le construct Gateway généré pour ajouter, supprimer ou ajuster des règles (par exemple, pour ajouter des [règles basées sur le taux](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) ou des groupes de règles gérées supplémentaires).
-
-<Infrastructure>
-<Fragment slot="cdk">
-Pour désactiver (par exemple, pour attacher votre propre Web ACL), définissez `enableWaf` sur `false` dans l'appel `super` de votre construct Gateway généré :
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-Le construct expose la Web ACL créée en tant que `webAcl` pour une configuration supplémentaire.
-</Fragment>
-<Fragment slot="terraform">
-Pour désactiver (par exemple, pour attacher votre propre Web ACL), définissez `enable_waf` sur `false` dans le module Gateway :
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-Le module génère l'ARN de la Web ACL créée en tant que `waf_web_acl_arn` pour une configuration supplémentaire.
-</Fragment>
-</Infrastructure>
-
 ## Écriture de politiques
 
 <OptionFilter when={{ cedarPolicy: true }} description="Cedar policies — cedarPolicy: true only">
@@ -311,6 +265,78 @@ Le générateur ajoute une cible `dev` au projet Gateway, qui exécute `local-de
 <NxCommands commands={["dev <name>"]} />
 
 Consultez le guide de connexion pour l'histoire complète du développement local.
+
+## Déployer votre AgentCore Gateway
+
+Le générateur AgentCore Gateway crée une infrastructure en tant que code CDK ou Terraform en fonction de votre `iacProvider` sélectionné. Vous pouvez l'utiliser pour déployer votre Gateway.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Le construct CDK pour déployer votre Gateway se trouve dans le dossier `common/constructs`. Vous pouvez l'utiliser dans une application CDK, par exemple :
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+Cela configure votre infrastructure Gateway, y compris l'`AgentCore::Gateway`, son `PolicyEngine` Cedar et la Web ACL AWS WAF (voir [AWS WAF](#aws-waf) ci-dessous). Enregistrez les cibles de serveur MCP avec `gateway.addMcpServer(...)` — consultez le <Link path="guides/connection/agentcore-gateway-mcp">guide de connexion de serveur MCP</Link>.
+</Fragment>
+<Fragment slot="terraform">
+Le module Terraform pour déployer votre Gateway se trouve dans le dossier `common/terraform`. Vous pouvez l'utiliser dans une configuration Terraform, par exemple :
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+Cela configure votre infrastructure Gateway, y compris l'`aws_bedrockagentcore_gateway`, son moteur de politiques Cedar et la Web ACL AWS WAF (voir [AWS WAF](#aws-waf) ci-dessous). Enregistrez les cibles de serveur MCP avec une ressource `aws_bedrockagentcore_gateway_target` — consultez le <Link path="guides/connection/agentcore-gateway-mcp">guide de connexion de serveur MCP</Link>.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+Par défaut, le construct généré associe une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) à la Gateway. AWS WAF inspecte chaque requête entrante en ligne _avant_ qu'elle n'atteigne une cible, protégeant votre Gateway contre les exploits web, le trafic de bots et les attaques volumétriques. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits web courants, y compris le Top 10 de l'OWASP. Les journaux de requêtes WAF sont écrits dans un groupe de journaux CloudWatch Logs.
+
+La Web ACL est `REGIONAL` et créée dans la région de la Gateway, comme requis pour les associations AgentCore Gateway.
+
+:::caution[Déviation de SizeRestrictions_BODY par rapport aux valeurs par défaut]
+La règle `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` est remplacée par `Count` plutôt que `Block`, car la limite de 8 Ko de la règle est trop restrictive pour les charges utiles d'outils MCP typiques. Les requêtes surdimensionnées seront toujours enregistrées en tant que métriques afin que vous puissiez les surveiller. Consultez le guide [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) pour plus de détails.
+:::
+
+Vous pouvez modifier le construct Gateway généré pour ajouter, supprimer ou ajuster des règles (par exemple, pour ajouter des [règles basées sur le taux](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) ou des groupes de règles gérées supplémentaires).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pour désactiver (par exemple, pour attacher votre propre Web ACL), définissez `enableWaf` sur `false` lorsque vous instanciez le construct Gateway :
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+Le construct expose la Web ACL créée en tant que `webAcl` pour une configuration supplémentaire.
+</Fragment>
+<Fragment slot="terraform">
+Pour désactiver (par exemple, pour attacher votre propre Web ACL), définissez `enable_waf` sur `false` dans le module Gateway :
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+Le module génère l'ARN de la Web ACL créée en tant que `waf_web_acl_arn` pour une configuration supplémentaire.
+</Fragment>
+</Infrastructure>
 
 ## Connexions
 

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 Par défaut, le construct généré associe une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) à la Gateway. AWS WAF inspecte chaque requête entrante en ligne _avant_ qu'elle n'atteigne une cible, protégeant votre Gateway contre les exploits web, le trafic de bots et les attaques volumétriques. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits web courants, y compris le Top 10 de l'OWASP. Les journaux de requêtes WAF sont écrits dans un groupe de journaux CloudWatch Logs.
 

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ Le construct généré crée les ressources AWS suivantes :
 
 L'URL de la Gateway est automatiquement enregistrée dans l'espace de noms `agentcore.gateways.<ClassName>` de la <Link path="guides/runtime-config">Configuration d'exécution</Link> afin que les agents puissent la découvrir au moment de l'exécution.
 
-## AWS WAF
-
-Par défaut, le construct généré associe une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) à la Gateway. AWS WAF inspecte chaque requête entrante en ligne _avant_ qu'elle n'atteigne une cible, protégeant votre Gateway contre les exploits web, le trafic de bots et les attaques volumétriques. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits web courants, y compris le Top 10 de l'OWASP. Les journaux de requêtes WAF sont écrits dans un groupe de journaux CloudWatch Logs.
-
-La Web ACL est `REGIONAL` et créée dans la région de la Gateway, comme requis pour les associations AgentCore Gateway — les Web ACL CloudFront (globales) ne sont pas prises en charge.
-
 #### Architecture
 
-Les requêtes atteignent la Gateway via AWS WAF, qui route les requêtes autorisées vers la Gateway et ses serveurs MCP cibles en aval :
+La Gateway déployée a l'architecture suivante. Les requêtes entrantes passent par une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) et l'authentification IAM, sont autorisées par rapport au [moteur de politiques](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html) Cedar, puis routées vers les serveurs MCP cibles en aval :
 
 ```d2 inline=true
 direction: right
@@ -106,6 +100,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -118,9 +117,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+Par défaut, le construct généré associe une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) à la Gateway. AWS WAF inspecte chaque requête entrante en ligne _avant_ qu'elle n'atteigne une cible, protégeant votre Gateway contre les exploits web, le trafic de bots et les attaques volumétriques. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits web courants, y compris le Top 10 de l'OWASP. Les journaux de requêtes WAF sont écrits dans un groupe de journaux CloudWatch Logs.
+
+La Web ACL est `REGIONAL` et créée dans la région de la Gateway, comme requis pour les associations AgentCore Gateway — les Web ACL CloudFront (globales) ne sont pas prises en charge.
 
 :::caution[Déviation de SizeRestrictions_BODY par rapport aux valeurs par défaut]
 La règle `SizeRestrictions_BODY` de `AWSManagedRulesCommonRuleSet` est remplacée par `Count` plutôt que `Block`, car la limite de 8 Ko de la règle est trop restrictive pour les charges utiles d'outils MCP typiques. Les requêtes surdimensionnées seront toujours enregistrées en tant que métriques afin que vous puissiez les surveiller. Consultez le guide [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) pour plus de détails.

--- a/docs/src/content/docs/fr/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-gateway.mdx
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 L'URL de la Gateway est automatiquement enregistrée dans l'espace de noms `agentcore.gateways.<ClassName>` de la <Link path="guides/runtime-config">Configuration d'exécution</Link> par le construct CDK généré, afin que l'agent puisse la découvrir au moment de l'exécution.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 L'URL de la Gateway est automatiquement enregistrée dans l'espace de noms `agentcore.gateways.<ClassName>` de la <Link path="guides/runtime-config">Configuration d'exécution</Link> par la construction CDK générée, afin que l'agent puisse la découvrir au moment de l'exécution.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ Il costrutto generato crea le seguenti risorse AWS:
 - Un `AgentCore::Gateway` configurato per il protocollo MCP con `GatewayAuthorizer.usingAwsIam()` (autenticazione IAM in ingresso)
 - Un `AgentCore::PolicyEngine` in esecuzione in modalità `ENFORCE`, collegato al Gateway (omesso quando `cedarPolicy: false`)
 - Una `AgentCore::Policy` per ogni file `.cedar` in `policies/`
+- Un AWS WAFv2 Web ACL associato al Gateway, con registrazione delle richieste su CloudWatch (abilitato per impostazione predefinita — vedi <a href="#aws-waf">AWS WAF</a>)
 
 L'URL del Gateway viene automaticamente registrato nel namespace `agentcore.gateways.<ClassName>` della <Link path="guides/runtime-config">Configurazione Runtime</Link> in modo che gli agenti possano scoprirlo a runtime.
+
+## AWS WAF
+
+Per impostazione predefinita, il costrutto generato associa un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL al Gateway. AWS WAF ispeziona ogni richiesta in ingresso in linea _prima_ che raggiunga un target, proteggendo il tuo Gateway da exploit web, traffico bot e attacchi volumetrici. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi gli OWASP Top 10. I log delle richieste WAF vengono scritti in un gruppo CloudWatch Logs.
+
+Il Web ACL è `REGIONAL` e creato nella regione del Gateway, come richiesto per le associazioni AgentCore Gateway — i Web ACL CloudFront (globali) non sono supportati.
+
+#### Architettura
+
+Le richieste raggiungono il Gateway attraverso AWS WAF, che instrada le richieste consentite al Gateway e ai suoi target di server MCP downstream:
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[Deviazione di SizeRestrictions_BODY dalle impostazioni predefinite]
+La regola `SizeRestrictions_BODY` di `AWSManagedRulesCommonRuleSet` viene sovrascritta a `Count` anziché `Block`, poiché il limite di 8 KB della regola è troppo restrittivo per i payload tipici degli strumenti MCP. Le richieste di dimensioni eccessive verranno comunque registrate come metriche in modo da poterle monitorare. Consulta la guida sui [limiti di dimensione del corpo di AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) per maggiori dettagli.
+:::
+
+Se AWS WAF non è raggiungibile o va in timeout durante la valutazione, il Gateway utilizza la sua **modalità di errore** per decidere se bloccare o consentire la richiesta. Questa è impostata per impostazione predefinita sulla modalità `FAIL_CLOSE` (blocco) orientata alla sicurezza del servizio. La modalità di errore è un'impostazione solo del piano di controllo (configurata tramite l'API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) e non è esposta tramite CloudFormation o Terraform. Si consiglia di testare le nuove regole AWS WAF in modalità `Count` prima di passarle a `Block`, e di monitorare le metriche CloudWatch `WafBlocks`, `WafFailOpens` e `WafFailCloses` nel namespace `AWS/Bedrock-AgentCore` per ottimizzare le tue regole.
+
+Puoi modificare il costrutto Gateway generato per aggiungere, rimuovere o regolare le regole (ad esempio, per aggiungere [regole basate sulla frequenza](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) o gruppi di regole gestite aggiuntivi).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Per disattivare (ad esempio, per collegare il tuo Web ACL), imposta `enableWaf` su `false` nella chiamata `super` nel tuo costrutto Gateway generato:
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+Il costrutto espone il Web ACL creato come `webAcl` per ulteriori configurazioni.
+</Fragment>
+<Fragment slot="terraform">
+Per disattivare (ad esempio, per collegare il tuo Web ACL), imposta `enable_waf` su `false` nel modulo Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+Il modulo restituisce l'ARN del Web ACL creato come `waf_web_acl_arn` per ulteriori configurazioni.
+</Fragment>
+</Infrastructure>
 
 ## Scrivere policy
 

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-Per impostazione predefinita, il costrutto generato associa un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL al Gateway. AWS WAF ispeziona ogni richiesta in ingresso in linea _prima_ che raggiunga un target, proteggendo il tuo Gateway da exploit web, traffico bot e attacchi volumetrici. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi gli OWASP Top 10. I log delle richieste WAF vengono scritti in un gruppo CloudWatch Logs.
-
-Il Web ACL è `REGIONAL` e creato nella regione del Gateway, come richiesto per le associazioni AgentCore Gateway — i Web ACL CloudFront (globali) non sono supportati.
-
-:::caution[Deviazione di SizeRestrictions_BODY dalle impostazioni predefinite]
-La regola `SizeRestrictions_BODY` di `AWSManagedRulesCommonRuleSet` viene sovrascritta a `Count` anziché `Block`, poiché il limite di 8 KB della regola è troppo restrittivo per i payload tipici degli strumenti MCP. Le richieste di dimensioni eccessive verranno comunque registrate come metriche in modo da poterle monitorare. Consulta la guida sui [limiti di dimensione del corpo di AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) per maggiori dettagli.
-:::
-
-Se AWS WAF non è raggiungibile o va in timeout durante la valutazione, il Gateway utilizza la sua **modalità di errore** per decidere se bloccare o consentire la richiesta. Questa è impostata per impostazione predefinita sulla modalità `FAIL_CLOSE` (blocco) orientata alla sicurezza del servizio. La modalità di errore è un'impostazione solo del piano di controllo (configurata tramite l'API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) e non è esposta tramite CloudFormation o Terraform. Si consiglia di testare le nuove regole AWS WAF in modalità `Count` prima di passarle a `Block`, e di monitorare le metriche CloudWatch `WafBlocks`, `WafFailOpens` e `WafFailCloses` nel namespace `AWS/Bedrock-AgentCore` per ottimizzare le tue regole.
-
-Puoi modificare il costrutto Gateway generato per aggiungere, rimuovere o regolare le regole (ad esempio, per aggiungere [regole basate sulla frequenza](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) o gruppi di regole gestite aggiuntivi).
-
-<Infrastructure>
-<Fragment slot="cdk">
-Per disattivare (ad esempio, per collegare il tuo Web ACL), imposta `enableWaf` su `false` nella chiamata `super` nel tuo costrutto Gateway generato:
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-Il costrutto espone il Web ACL creato come `webAcl` per ulteriori configurazioni.
-</Fragment>
-<Fragment slot="terraform">
-Per disattivare (ad esempio, per collegare il tuo Web ACL), imposta `enable_waf` su `false` nel modulo Gateway:
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-Il modulo restituisce l'ARN del Web ACL creato come `waf_web_acl_arn` per ulteriori configurazioni.
-</Fragment>
-</Infrastructure>
-
 ## Scrivere policy
 
 <OptionFilter when={{ cedarPolicy: true }} description="Cedar policies — cedarPolicy: true only">
@@ -311,6 +265,78 @@ Il generatore aggiunge un target `dev` al progetto Gateway, che esegue `local-de
 <NxCommands commands={["dev <name>"]} />
 
 Consulta la guida alla connessione per la storia completa dello sviluppo locale.
+
+## Distribuire il tuo AgentCore Gateway
+
+Il generatore AgentCore Gateway crea infrastruttura come codice CDK o Terraform in base al tuo `iacProvider` selezionato. Puoi usarla per distribuire il tuo Gateway.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Il costrutto CDK per distribuire il tuo Gateway si trova nella cartella `common/constructs`. Puoi utilizzarlo in un'applicazione CDK, ad esempio:
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+Questo configura l'infrastruttura del tuo Gateway, inclusi `AgentCore::Gateway`, il suo `PolicyEngine` Cedar e il AWS WAF Web ACL (vedi [AWS WAF](#aws-waf) di seguito). Registra i target dei server MCP con `gateway.addMcpServer(...)` — vedi la <Link path="guides/connection/agentcore-gateway-mcp">guida alla connessione del server MCP</Link>.
+</Fragment>
+<Fragment slot="terraform">
+Il modulo Terraform per distribuire il tuo Gateway si trova nella cartella `common/terraform`. Puoi usarlo in una configurazione Terraform, ad esempio:
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+Questo configura l'infrastruttura del tuo Gateway, inclusi `aws_bedrockagentcore_gateway`, il suo motore di policy Cedar e il AWS WAF Web ACL (vedi [AWS WAF](#aws-waf) di seguito). Registra i target dei server MCP con una risorsa `aws_bedrockagentcore_gateway_target` — vedi la <Link path="guides/connection/agentcore-gateway-mcp">guida alla connessione del server MCP</Link>.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+Per impostazione predefinita, il costrutto generato associa un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL al Gateway. AWS WAF ispeziona ogni richiesta in ingresso in linea _prima_ che raggiunga un target, proteggendo il tuo Gateway da exploit web, traffico bot e attacchi volumetrici. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi gli OWASP Top 10. I log delle richieste WAF vengono scritti in un gruppo CloudWatch Logs.
+
+Il Web ACL è `REGIONAL` e creato nella regione del Gateway, come richiesto per le associazioni AgentCore Gateway.
+
+:::caution[Deviazione di SizeRestrictions_BODY dalle impostazioni predefinite]
+La regola `SizeRestrictions_BODY` di `AWSManagedRulesCommonRuleSet` viene sovrascritta a `Count` anziché `Block`, poiché il limite di 8 KB della regola è troppo restrittivo per i payload tipici degli strumenti MCP. Le richieste di dimensioni eccessive verranno comunque registrate come metriche in modo da poterle monitorare. Consulta la guida sui [limiti di dimensione del corpo di AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) per maggiori dettagli.
+:::
+
+Puoi modificare il costrutto Gateway generato per aggiungere, rimuovere o regolare le regole (ad esempio, per aggiungere [regole basate sulla frequenza](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) o gruppi di regole gestite aggiuntivi).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Per disattivare (ad esempio, per collegare il tuo Web ACL), imposta `enableWaf` su `false` quando istanzi il costrutto Gateway:
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+Il costrutto espone il Web ACL creato come `webAcl` per ulteriori configurazioni.
+</Fragment>
+<Fragment slot="terraform">
+Per disattivare (ad esempio, per collegare il tuo Web ACL), imposta `enable_waf` su `false` nel modulo Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+Il modulo restituisce l'ARN del Web ACL creato come `waf_web_acl_arn` per ulteriori configurazioni.
+</Fragment>
+</Infrastructure>
 
 ## Connessioni
 

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 Per impostazione predefinita, il costrutto generato associa un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL al Gateway. AWS WAF ispeziona ogni richiesta in ingresso in linea _prima_ che raggiunga un target, proteggendo il tuo Gateway da exploit web, traffico bot e attacchi volumetrici. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi gli OWASP Top 10. I log delle richieste WAF vengono scritti in un gruppo CloudWatch Logs.
 

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -100,26 +100,13 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
-policy: Policy Engine\n(Cedar, ENFORCE) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
-}
-
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
 
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
 
 ## AWS WAF
@@ -356,6 +343,12 @@ Usa il generatore <Link path="guides/connection">`connection`</Link> per integra
     title="Python Agent to AgentCore Gateway"
     description="Collega un Python Agent a un AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    source="strands"
+    sourceBadge="python"
+    target="agentcore"
+  />
+</CardGrid>
+/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -348,9 +348,3 @@ Usa il generatore <Link path="guides/connection">`connection`</Link> per integra
     target="agentcore"
   />
 </CardGrid>
-/py-agent-gateway`}
-    source="strands"
-    sourceBadge="python"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ Il costrutto generato crea le seguenti risorse AWS:
 
 L'URL del Gateway viene automaticamente registrato nel namespace `agentcore.gateways.<ClassName>` della <Link path="guides/runtime-config">Configurazione Runtime</Link> in modo che gli agenti possano scoprirlo a runtime.
 
-## AWS WAF
-
-Per impostazione predefinita, il costrutto generato associa un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL al Gateway. AWS WAF ispeziona ogni richiesta in ingresso in linea _prima_ che raggiunga un target, proteggendo il tuo Gateway da exploit web, traffico bot e attacchi volumetrici. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi gli OWASP Top 10. I log delle richieste WAF vengono scritti in un gruppo CloudWatch Logs.
-
-Il Web ACL è `REGIONAL` e creato nella regione del Gateway, come richiesto per le associazioni AgentCore Gateway — i Web ACL CloudFront (globali) non sono supportati.
-
 #### Architettura
 
-Le richieste raggiungono il Gateway attraverso AWS WAF, che instrada le richieste consentite al Gateway e ai suoi target di server MCP downstream:
+Il Gateway distribuito ha la seguente architettura. Le richieste in ingresso passano attraverso un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL e l'autenticazione IAM, vengono autorizzate rispetto al [motore di policy](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html) Cedar, quindi instradate ai target di server MCP downstream:
 
 ```d2 inline=true
 direction: right
@@ -106,6 +100,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -118,9 +117,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+Per impostazione predefinita, il costrutto generato associa un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL al Gateway. AWS WAF ispeziona ogni richiesta in ingresso in linea _prima_ che raggiunga un target, proteggendo il tuo Gateway da exploit web, traffico bot e attacchi volumetrici. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi gli OWASP Top 10. I log delle richieste WAF vengono scritti in un gruppo CloudWatch Logs.
+
+Il Web ACL è `REGIONAL` e creato nella regione del Gateway, come richiesto per le associazioni AgentCore Gateway — i Web ACL CloudFront (globali) non sono supportati.
 
 :::caution[Deviazione di SizeRestrictions_BODY dalle impostazioni predefinite]
 La regola `SizeRestrictions_BODY` di `AWSManagedRulesCommonRuleSet` viene sovrascritta a `Count` anziché `Block`, poiché il limite di 8 KB della regola è troppo restrittivo per i payload tipici degli strumenti MCP. Le richieste di dimensioni eccessive verranno comunque registrate come metriche in modo da poterle monitorare. Consulta la guida sui [limiti di dimensione del corpo di AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) per maggiori dettagli.

--- a/docs/src/content/docs/it/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-gateway.mdx
@@ -66,8 +66,8 @@ Inoltre, il generatore:
 
 Il generatore trasforma il file `agent.py` del tuo agent per utilizzare il client Gateway:
 
-<Tabs syncKey="framework">
-<TabItem label="Strands">
+<Tabs syncKey="agent-framework">
+<TabItem label="Strands" _filter={{ framework: 'strands' }}>
 ```python title="packages/example/example/my_agent/agent.py" {4,8,9-13}
 from contextlib import contextmanager
 from strands import Agent
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 L'URL del Gateway viene automaticamente registrato nel namespace `agentcore.gateways.<ClassName>` della <Link path="guides/runtime-config">Runtime Configuration</Link> dal costrutto CDK generato, in modo che l'agent possa scoprirlo a runtime.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 
@@ -185,4 +174,3 @@ Il gateway locale sostituisce il Gateway distribuito, quindi:
 
 - **Nessuna valutazione delle policy Cedar.** Ogni strumento è visibile all'agent indipendentemente dalle policy. Utilizza il target `serve` per esercitare le policy contro il Gateway distribuito.
 - **Il prefisso del nome dello strumento è preservato.** Gli strumenti di ciascun server MCP locale sono esposti come `<target-name>___<tool-name>`, corrispondendo a ciò che emette il Gateway distribuito. Questo mantiene il system prompt dell'agent e i nomi delle azioni Cedar che referenzi coerenti tra esecuzioni locali e distribuite.
-te.

--- a/docs/src/content/docs/it/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 L'URL del Gateway viene automaticamente registrato nel namespace `agentcore.gateways.<ClassName>` della <Link path="guides/runtime-config">Runtime Configuration</Link> dal costrutto CDK generato, in modo che l'agent possa scoprirlo a runtime.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Concedi all'agent il permesso di invocare il Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Concedi all'agent il permesso di invocare il Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 
@@ -150,7 +139,3 @@ Il gateway locale sostituisce il Gateway distribuito, quindi:
 
 - **Nessuna valutazione delle policy Cedar.** Ogni strumento è visibile all'agent indipendentemente dalle policy. Utilizza il target `serve` per esercitare le policy contro il Gateway distribuito.
 - **Il prefisso del nome dello strumento è preservato.** Gli strumenti di ogni server MCP locale sono wrappati per esporre nomi nella forma `<target-name>___<tool-name>`, corrispondenti a ciò che emette il Gateway distribuito. Questo mantiene il prompt di sistema dell'agent e i nomi delle azioni Cedar a cui fai riferimento coerenti tra esecuzioni locali e distribuite.
-
-buite.
-te.
-te.

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -118,9 +118,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+デフォルトでは、生成されたコンストラクトは[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLをGatewayに関連付けます。AWS WAFは、ターゲットに到達する_前_にすべてのインバウンドリクエストをインラインで検査し、Webエクスプロイト、ボットトラフィック、ボリューメトリック攻撃からGatewayを保護します。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。WAFリクエストログはCloudWatch Logsグループに書き込まれます。
+
+Web ACLは`REGIONAL`であり、AgentCore Gatewayの関連付けに必要なGatewayのリージョンに作成されます — CloudFront（グローバル）Web ACLはサポートされていません。
 
 :::caution[デフォルトからのSizeRestrictions_BODYの逸脱]
 `AWSManagedRulesCommonRuleSet`の`SizeRestrictions_BODY`ルールは、`Block`ではなく`Count`にオーバーライドされます。これは、ルールの8 KB制限が典型的なMCPツールペイロードには制限が厳しすぎるためです。オーバーサイズのリクエストは引き続きメトリクスとして記録されるため、監視できます。詳細については、[AWS WAFボディサイズ制限](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)ガイドを参照してください。

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ import OptionFilter from '@components/option-filter.astro';
 - `GatewayAuthorizer.usingAwsIam()`（インバウンドIAM認証）を使用してMCPプロトコル用に構成された`AgentCore::Gateway`
 - `ENFORCE`モードで実行され、Gatewayにアタッチされた`AgentCore::PolicyEngine`（`cedarPolicy: false`の場合は省略）
 - `policies/`内の`.cedar`ファイルごとに1つの`AgentCore::Policy`
+- Gatewayに関連付けられたAWS WAFv2 Web ACLで、CloudWatchへのリクエストログ記録が有効（デフォルトで有効 — <a href="#aws-waf">AWS WAF</a>を参照）
 
 Gateway URLは、<Link path="guides/runtime-config">ランタイム設定</Link>の`agentcore.gateways.<ClassName>`名前空間に自動的に登録されるため、エージェントは実行時にそれを検出できます。
+
+## AWS WAF
+
+デフォルトでは、生成されたコンストラクトは[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLをGatewayに関連付けます。AWS WAFは、ターゲットに到達する_前_にすべてのインバウンドリクエストをインラインで検査し、Webエクスプロイト、ボットトラフィック、ボリューメトリック攻撃からGatewayを保護します。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。WAFリクエストログはCloudWatch Logsグループに書き込まれます。
+
+Web ACLは`REGIONAL`であり、AgentCore Gatewayの関連付けに必要なGatewayのリージョンに作成されます — CloudFront（グローバル）Web ACLはサポートされていません。
+
+#### アーキテクチャ
+
+リクエストはAWS WAFを通じてGatewayに到達し、許可されたリクエストをGatewayとその下流のMCPサーバーターゲットにルーティングします：
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[デフォルトからのSizeRestrictions_BODYの逸脱]
+`AWSManagedRulesCommonRuleSet`の`SizeRestrictions_BODY`ルールは、`Block`ではなく`Count`にオーバーライドされます。これは、ルールの8 KB制限が典型的なMCPツールペイロードには制限が厳しすぎるためです。オーバーサイズのリクエストは引き続きメトリクスとして記録されるため、監視できます。詳細については、[AWS WAFボディサイズ制限](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)ガイドを参照してください。
+:::
+
+AWS WAFが到達不能またはタイムアウトした場合、Gatewayは**障害モード**を使用してリクエストをブロックするか許可するかを決定します。これはデフォルトでサービスのセキュリティ優先の`FAIL_CLOSE`（ブロック）になります。障害モードはコントロールプレーンのみの設定（[`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) APIを介して構成）であり、CloudFormationまたはTerraformを通じて公開されていません。新しいAWS WAFルールを`Block`に切り替える前に`Count`モードでテストし、`AWS/Bedrock-AgentCore`名前空間の`WafBlocks`、`WafFailOpens`、および`WafFailCloses` CloudWatchメトリクスを監視してルールを調整することをお勧めします。
+
+生成されたGatewayコンストラクトを編集して、ルールを追加、削除、または調整できます（例えば、[レートベースルール](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)や追加のマネージドルールグループを追加するなど）。
+
+<Infrastructure>
+<Fragment slot="cdk">
+オプトアウトするには（例えば、独自のWeb ACLをアタッチする場合）、生成されたGatewayコンストラクトの`super`呼び出しで`enableWaf`を`false`に設定します：
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+コンストラクトは、さらなる設定のために作成されたWeb ACLを`webAcl`として公開します。
+</Fragment>
+<Fragment slot="terraform">
+オプトアウトするには（例えば、独自のWeb ACLをアタッチする場合）、Gatewayモジュールで`enable_waf`を`false`に設定します：
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+モジュールは、さらなる設定のために作成されたWeb ACL ARNを`waf_web_acl_arn`として出力します。
+</Fragment>
+</Infrastructure>
 
 ## ポリシーの記述
 

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 Gateway URLは、<Link path="guides/runtime-config">ランタイム設定</Link>の`agentcore.gateways.<ClassName>`名前空間に自動的に登録されるため、エージェントは実行時にそれを検出できます。
 
-## AWS WAF
-
-デフォルトでは、生成されたコンストラクトは[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLをGatewayに関連付けます。AWS WAFは、ターゲットに到達する_前_にすべてのインバウンドリクエストをインラインで検査し、Webエクスプロイト、ボットトラフィック、ボリューメトリック攻撃からGatewayを保護します。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。WAFリクエストログはCloudWatch Logsグループに書き込まれます。
-
-Web ACLは`REGIONAL`であり、AgentCore Gatewayの関連付けに必要なGatewayのリージョンに作成されます — CloudFront（グローバル）Web ACLはサポートされていません。
-
 #### アーキテクチャ
 
-リクエストはAWS WAFを通じてGatewayに到達し、許可されたリクエストをGatewayとその下流のMCPサーバーターゲットにルーティングします：
+デプロイされたGatewayは以下のアーキテクチャを持ち、Gatewayの前に[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLがあり、下流のMCPサーバーターゲットにルーティングします：
 
 ```d2 inline=true
 direction: right
@@ -110,17 +104,9 @@ targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
 
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
 
 ## AWS WAF

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 デフォルトでは、生成されたコンストラクトは[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLをGatewayに関連付けます。AWS WAFは、ターゲットに到達する_前_にすべてのインバウンドリクエストをインラインで検査し、Webエクスプロイト、ボットトラフィック、ボリューメトリック攻撃からGatewayを保護します。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。WAFリクエストログはCloudWatch Logsグループに書き込まれます。
 

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-デフォルトでは、生成されたコンストラクトは[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLをGatewayに関連付けます。AWS WAFは、ターゲットに到達する_前_にすべてのインバウンドリクエストをインラインで検査し、Webエクスプロイト、ボットトラフィック、ボリューメトリック攻撃からGatewayを保護します。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。WAFリクエストログはCloudWatch Logsグループに書き込まれます。
-
-Web ACLは`REGIONAL`であり、AgentCore Gatewayの関連付けに必要なGatewayのリージョンに作成されます — CloudFront（グローバル）Web ACLはサポートされていません。
-
-:::caution[デフォルトからのSizeRestrictions_BODYの逸脱]
-`AWSManagedRulesCommonRuleSet`の`SizeRestrictions_BODY`ルールは、`Block`ではなく`Count`にオーバーライドされます。これは、ルールの8 KB制限が典型的なMCPツールペイロードには制限が厳しすぎるためです。オーバーサイズのリクエストは引き続きメトリクスとして記録されるため、監視できます。詳細については、[AWS WAFボディサイズ制限](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)ガイドを参照してください。
-:::
-
-AWS WAFが到達不能またはタイムアウトした場合、Gatewayは**障害モード**を使用してリクエストをブロックするか許可するかを決定します。これはデフォルトでサービスのセキュリティ優先の`FAIL_CLOSE`（ブロック）になります。障害モードはコントロールプレーンのみの設定（[`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) APIを介して構成）であり、CloudFormationまたはTerraformを通じて公開されていません。新しいAWS WAFルールを`Block`に切り替える前に`Count`モードでテストし、`AWS/Bedrock-AgentCore`名前空間の`WafBlocks`、`WafFailOpens`、および`WafFailCloses` CloudWatchメトリクスを監視してルールを調整することをお勧めします。
-
-生成されたGatewayコンストラクトを編集して、ルールを追加、削除、または調整できます（例えば、[レートベースルール](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)や追加のマネージドルールグループを追加するなど）。
-
-<Infrastructure>
-<Fragment slot="cdk">
-オプトアウトするには（例えば、独自のWeb ACLをアタッチする場合）、生成されたGatewayコンストラクトの`super`呼び出しで`enableWaf`を`false`に設定します：
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-コンストラクトは、さらなる設定のために作成されたWeb ACLを`webAcl`として公開します。
-</Fragment>
-<Fragment slot="terraform">
-オプトアウトするには（例えば、独自のWeb ACLをアタッチする場合）、Gatewayモジュールで`enable_waf`を`false`に設定します：
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-モジュールは、さらなる設定のために作成されたWeb ACL ARNを`waf_web_acl_arn`として出力します。
-</Fragment>
-</Infrastructure>
-
 ## ポリシーの記述
 
 <OptionFilter when={{ cedarPolicy: true }} description="Cedarポリシー — cedarPolicy: trueのみ">
@@ -311,6 +265,78 @@ forbid (
 <NxCommands commands={["dev <name>"]} />
 
 完全なローカル開発ストーリーについては、接続ガイドを参照してください。
+
+## AgentCore Gatewayのデプロイ
+
+AgentCore Gatewayジェネレーターは、選択した`iacProvider`に基づいてCDKまたはTerraformのインフラストラクチャコードを作成します。これを使用してGatewayをデプロイできます。
+
+<Infrastructure>
+<Fragment slot="cdk">
+GatewayをデプロイするためのCDKコンストラクトは、`common/constructs`フォルダーにあります。これをCDKアプリケーションで使用できます。例えば：
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+これにより、`AgentCore::Gateway`、そのCedar `PolicyEngine`、およびAWS WAF Web ACL（以下の[AWS WAF](#aws-waf)を参照）を含むGatewayインフラストラクチャがセットアップされます。MCPサーバーターゲットを`gateway.addMcpServer(...)`で登録します — <Link path="guides/connection/agentcore-gateway-mcp">MCPサーバー接続ガイド</Link>を参照してください。
+</Fragment>
+<Fragment slot="terraform">
+GatewayをデプロイするためのTerraformモジュールは、`common/terraform`フォルダーにあります。これをTerraform設定で使用できます。例えば：
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+これにより、`aws_bedrockagentcore_gateway`、そのCedarポリシーエンジン、およびAWS WAF Web ACL（以下の[AWS WAF](#aws-waf)を参照）を含むGatewayインフラストラクチャがセットアップされます。MCPサーバーターゲットを`aws_bedrockagentcore_gateway_target`リソースで登録します — <Link path="guides/connection/agentcore-gateway-mcp">MCPサーバー接続ガイド</Link>を参照してください。
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+デフォルトでは、生成されたコンストラクトは[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLをGatewayに関連付けます。AWS WAFは、ターゲットに到達する_前_にすべてのインバウンドリクエストをインラインで検査し、Webエクスプロイト、ボットトラフィック、ボリューメトリック攻撃からGatewayを保護します。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。WAFリクエストログはCloudWatch Logsグループに書き込まれます。
+
+Web ACLは`REGIONAL`であり、AgentCore Gatewayの関連付けに必要なGatewayのリージョンに作成されます。
+
+:::caution[デフォルトからのSizeRestrictions_BODYの逸脱]
+`AWSManagedRulesCommonRuleSet`の`SizeRestrictions_BODY`ルールは、`Block`ではなく`Count`にオーバーライドされます。これは、ルールの8 KB制限が典型的なMCPツールペイロードには制限が厳しすぎるためです。オーバーサイズのリクエストは引き続きメトリクスとして記録されるため、監視できます。詳細については、[AWS WAFボディサイズ制限](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)ガイドを参照してください。
+:::
+
+生成されたGatewayコンストラクトを編集して、ルールを追加、削除、または調整できます（例えば、[レートベースルール](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)や追加のマネージドルールグループを追加するなど）。
+
+<Infrastructure>
+<Fragment slot="cdk">
+オプトアウトするには（例えば、独自のWeb ACLをアタッチする場合）、Gatewayコンストラクトをインスタンス化する際に`enableWaf`を`false`に設定します：
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+コンストラクトは、さらなる設定のために作成されたWeb ACLを`webAcl`として公開します。
+</Fragment>
+<Fragment slot="terraform">
+オプトアウトするには（例えば、独自のWeb ACLをアタッチする場合）、Gatewayモジュールで`enable_waf`を`false`に設定します：
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+モジュールは、さらなる設定のために作成されたWeb ACL ARNを`waf_web_acl_arn`として出力します。
+</Fragment>
+</Infrastructure>
 
 ## 接続
 

--- a/docs/src/content/docs/jp/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-gateway.mdx
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URLは、生成されたCDKコンストラクトによって<Link path="guides/runtime-config">Runtime Configuration</Link>の`agentcore.gateways.<ClassName>`名前空間に自動的に登録されるため、エージェントは実行時にそれを検出できます。
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URLは、生成されたCDKコンストラクトによって<Link path="guides/runtime-config">Runtime Configuration</Link>の`agentcore.gateways.<ClassName>`名前空間に自動的に登録されるため、エージェントは実行時にそれを検出できます。
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# エージェントにGatewayを呼び出す権限を付与
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # エージェントにGatewayを呼び出す権限を付与
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -122,7 +122,7 @@ gateway -> targets
 waf -> cw
 ```
 
-## AWS WAF
+#### AWS WAF
 
 기본적으로 생성된 구성 요소는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 Gateway와 연결합니다. AWS WAF는 대상에 도달하기 _전에_ 모든 인바운드 요청을 인라인으로 검사하여 웹 익스플로잇, 봇 트래픽 및 대량 공격으로부터 Gateway를 보호합니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다. WAF 요청 로그는 CloudWatch Logs 그룹에 기록됩니다.
 

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -80,7 +80,7 @@ Gateway URL은 <Link path="guides/runtime-config">런타임 구성</Link>의 `ag
 
 #### 아키텍처
 
-배포된 Gateway는 다음 아키텍처를 가집니다. 인바운드 요청은 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL과 IAM 인증을 통과하고, Cedar [정책 엔진](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html)에 대해 승인된 후 다운스트림 MCP 서버 대상으로 라우팅됩니다:
+배포된 Gateway는 다음 아키텍처를 가지며, Gateway 앞에 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL이 있고, 다운스트림 MCP 서버 대상으로 라우팅됩니다:
 
 ```d2 inline=true
 direction: right

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 Gateway URL은 <Link path="guides/runtime-config">런타임 구성</Link>의 `agentcore.gateways.<ClassName>` 네임스페이스에 자동으로 등록되어 에이전트가 런타임에 이를 발견할 수 있습니다.
 
-## AWS WAF
-
-기본적으로 생성된 구성 요소는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 Gateway와 연결합니다. AWS WAF는 대상에 도달하기 _전에_ 모든 인바운드 요청을 인라인으로 검사하여 웹 익스플로잇, 봇 트래픽 및 대량 공격으로부터 Gateway를 보호합니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다. WAF 요청 로그는 CloudWatch Logs 그룹에 기록됩니다.
-
-Web ACL은 `REGIONAL`이며 AgentCore Gateway 연결에 필요한 대로 Gateway의 리전에 생성됩니다 — CloudFront(글로벌) Web ACL은 지원되지 않습니다.
-
 #### 아키텍처
 
-요청은 AWS WAF를 통해 Gateway에 도달하며, AWS WAF는 허용된 요청을 Gateway와 그 다운스트림 MCP 서버 대상으로 라우팅합니다:
+배포된 Gateway는 다음 아키텍처를 가집니다. 인바운드 요청은 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL과 IAM 인증을 통과하고, Cedar [정책 엔진](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html)에 대해 승인된 후 다운스트림 MCP 서버 대상으로 라우팅됩니다:
 
 ```d2 inline=true
 direction: right
@@ -106,6 +100,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -118,9 +117,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+기본적으로 생성된 구성 요소는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 Gateway와 연결합니다. AWS WAF는 대상에 도달하기 _전에_ 모든 인바운드 요청을 인라인으로 검사하여 웹 익스플로잇, 봇 트래픽 및 대량 공격으로부터 Gateway를 보호합니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다. WAF 요청 로그는 CloudWatch Logs 그룹에 기록됩니다.
+
+Web ACL은 `REGIONAL`이며 AgentCore Gateway 연결에 필요한 대로 Gateway의 리전에 생성됩니다 — CloudFront(글로벌) Web ACL은 지원되지 않습니다.
 
 :::caution[기본값과 다른 SizeRestrictions_BODY]
 `AWSManagedRulesCommonRuleSet`의 `SizeRestrictions_BODY` 규칙은 `Block`이 아닌 `Count`로 재정의됩니다. 규칙의 8 KB 제한이 일반적인 MCP 도구 페이로드에 너무 제한적이기 때문입니다. 초과 크기 요청은 여전히 메트릭으로 기록되므로 모니터링할 수 있습니다. 자세한 내용은 [AWS WAF 본문 크기 제한](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) 가이드를 참조하세요.

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ import OptionFilter from '@components/option-filter.astro';
 - `GatewayAuthorizer.usingAwsIam()`(인바운드 IAM 인증)을 사용하여 MCP 프로토콜용으로 구성된 `AgentCore::Gateway`
 - Gateway에 연결되어 `ENFORCE` 모드로 실행되는 `AgentCore::PolicyEngine` (`cedarPolicy: false`일 때 생략됨)
 - `policies/`의 `.cedar` 파일당 하나의 `AgentCore::Policy`
+- Gateway와 연결된 AWS WAFv2 Web ACL, CloudWatch로의 요청 로깅 포함 (기본적으로 활성화됨 — <a href="#aws-waf">AWS WAF</a> 참조)
 
 Gateway URL은 <Link path="guides/runtime-config">런타임 구성</Link>의 `agentcore.gateways.<ClassName>` 네임스페이스에 자동으로 등록되어 에이전트가 런타임에 이를 발견할 수 있습니다.
+
+## AWS WAF
+
+기본적으로 생성된 구성 요소는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 Gateway와 연결합니다. AWS WAF는 대상에 도달하기 _전에_ 모든 인바운드 요청을 인라인으로 검사하여 웹 익스플로잇, 봇 트래픽 및 대량 공격으로부터 Gateway를 보호합니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다. WAF 요청 로그는 CloudWatch Logs 그룹에 기록됩니다.
+
+Web ACL은 `REGIONAL`이며 AgentCore Gateway 연결에 필요한 대로 Gateway의 리전에 생성됩니다 — CloudFront(글로벌) Web ACL은 지원되지 않습니다.
+
+#### 아키텍처
+
+요청은 AWS WAF를 통해 Gateway에 도달하며, AWS WAF는 허용된 요청을 Gateway와 그 다운스트림 MCP 서버 대상으로 라우팅합니다:
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[기본값과 다른 SizeRestrictions_BODY]
+`AWSManagedRulesCommonRuleSet`의 `SizeRestrictions_BODY` 규칙은 `Block`이 아닌 `Count`로 재정의됩니다. 규칙의 8 KB 제한이 일반적인 MCP 도구 페이로드에 너무 제한적이기 때문입니다. 초과 크기 요청은 여전히 메트릭으로 기록되므로 모니터링할 수 있습니다. 자세한 내용은 [AWS WAF 본문 크기 제한](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) 가이드를 참조하세요.
+:::
+
+AWS WAF에 연결할 수 없거나 평가 중 시간 초과가 발생하면 Gateway는 **실패 모드**를 사용하여 요청을 차단할지 허용할지 결정합니다. 이는 기본적으로 서비스의 보안 우선 `FAIL_CLOSE`(차단)입니다. 실패 모드는 컨트롤 플레인 전용 설정([`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) API를 통해 구성됨)이며 CloudFormation 또는 Terraform을 통해 노출되지 않습니다. 새 AWS WAF 규칙을 `Block`으로 전환하기 전에 `Count` 모드에서 테스트하고, `AWS/Bedrock-AgentCore` 네임스페이스의 `WafBlocks`, `WafFailOpens`, `WafFailCloses` CloudWatch 메트릭을 모니터링하여 규칙을 조정하는 것이 좋습니다.
+
+생성된 Gateway 구성 요소를 편집하여 규칙을 추가, 제거 또는 조정할 수 있습니다(예: [속도 기반 규칙](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) 또는 추가 관리형 규칙 그룹 추가).
+
+<Infrastructure>
+<Fragment slot="cdk">
+옵트아웃하려면(예: 자체 Web ACL을 연결하려면) 생성된 Gateway 구성 요소의 `super` 호출에서 `enableWaf`를 `false`로 설정하세요:
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+구성 요소는 추가 구성을 위해 생성된 Web ACL을 `webAcl`로 노출합니다.
+</Fragment>
+<Fragment slot="terraform">
+옵트아웃하려면(예: 자체 Web ACL을 연결하려면) Gateway 모듈에서 `enable_waf`를 `false`로 설정하세요:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+모듈은 추가 구성을 위해 생성된 Web ACL ARN을 `waf_web_acl_arn`으로 출력합니다.
+</Fragment>
+</Infrastructure>
 
 ## 정책 작성
 

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -117,56 +117,8 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
-
-#### AWS WAF
-
-기본적으로 생성된 구성 요소는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 Gateway와 연결합니다. AWS WAF는 대상에 도달하기 _전에_ 모든 인바운드 요청을 인라인으로 검사하여 웹 익스플로잇, 봇 트래픽 및 대량 공격으로부터 Gateway를 보호합니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다. WAF 요청 로그는 CloudWatch Logs 그룹에 기록됩니다.
-
-Web ACL은 `REGIONAL`이며 AgentCore Gateway 연결에 필요한 대로 Gateway의 리전에 생성됩니다 — CloudFront(글로벌) Web ACL은 지원되지 않습니다.
-
-:::caution[기본값과 다른 SizeRestrictions_BODY]
-`AWSManagedRulesCommonRuleSet`의 `SizeRestrictions_BODY` 규칙은 `Block`이 아닌 `Count`로 재정의됩니다. 규칙의 8 KB 제한이 일반적인 MCP 도구 페이로드에 너무 제한적이기 때문입니다. 초과 크기 요청은 여전히 메트릭으로 기록되므로 모니터링할 수 있습니다. 자세한 내용은 [AWS WAF 본문 크기 제한](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) 가이드를 참조하세요.
-:::
-
-AWS WAF에 연결할 수 없거나 평가 중 시간 초과가 발생하면 Gateway는 **실패 모드**를 사용하여 요청을 차단할지 허용할지 결정합니다. 이는 기본적으로 서비스의 보안 우선 `FAIL_CLOSE`(차단)입니다. 실패 모드는 컨트롤 플레인 전용 설정([`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) API를 통해 구성됨)이며 CloudFormation 또는 Terraform을 통해 노출되지 않습니다. 새 AWS WAF 규칙을 `Block`으로 전환하기 전에 `Count` 모드에서 테스트하고, `AWS/Bedrock-AgentCore` 네임스페이스의 `WafBlocks`, `WafFailOpens`, `WafFailCloses` CloudWatch 메트릭을 모니터링하여 규칙을 조정하는 것이 좋습니다.
-
-생성된 Gateway 구성 요소를 편집하여 규칙을 추가, 제거 또는 조정할 수 있습니다(예: [속도 기반 규칙](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) 또는 추가 관리형 규칙 그룹 추가).
-
-<Infrastructure>
-<Fragment slot="cdk">
-옵트아웃하려면(예: 자체 Web ACL을 연결하려면) 생성된 Gateway 구성 요소의 `super` 호출에서 `enableWaf`를 `false`로 설정하세요:
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-구성 요소는 추가 구성을 위해 생성된 Web ACL을 `webAcl`로 노출합니다.
-</Fragment>
-<Fragment slot="terraform">
-옵트아웃하려면(예: 자체 Web ACL을 연결하려면) Gateway 모듈에서 `enable_waf`를 `false`로 설정하세요:
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-모듈은 추가 구성을 위해 생성된 Web ACL ARN을 `waf_web_acl_arn`으로 출력합니다.
-</Fragment>
-</Infrastructure>
 
 ## 정책 작성
 
@@ -324,6 +276,78 @@ forbid (
 <NxCommands commands={["dev <name>"]} />
 
 전체 로컬 개발 스토리는 연결 가이드를 참조하세요.
+
+## AgentCore Gateway 배포
+
+AgentCore Gateway 생성기는 선택한 `iacProvider`를 기반으로 CDK 또는 Terraform 인프라 코드를 생성합니다. 이를 사용하여 Gateway를 배포할 수 있습니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Gateway 배포를 위한 CDK 구성 요소는 `common/constructs` 폴더에 있습니다. 이를 CDK 애플리케이션에서 사용할 수 있습니다. 예를 들어:
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+이것은 `AgentCore::Gateway`, Cedar `PolicyEngine`, AWS WAF Web ACL을 포함한 Gateway 인프라를 설정합니다(아래 [AWS WAF](#aws-waf) 참조). `gateway.addMcpServer(...)`로 MCP 서버 대상을 등록하세요 — <Link path="guides/connection/agentcore-gateway-mcp">MCP 서버 연결 가이드</Link>를 참조하세요.
+</Fragment>
+<Fragment slot="terraform">
+Gateway 배포를 위한 Terraform 모듈은 `common/terraform` 폴더에 있습니다. 이를 Terraform 구성에서 사용할 수 있습니다. 예를 들어:
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+이것은 `aws_bedrockagentcore_gateway`, Cedar 정책 엔진, AWS WAF Web ACL을 포함한 Gateway 인프라를 설정합니다(아래 [AWS WAF](#aws-waf) 참조). `aws_bedrockagentcore_gateway_target` 리소스로 MCP 서버 대상을 등록하세요 — <Link path="guides/connection/agentcore-gateway-mcp">MCP 서버 연결 가이드</Link>를 참조하세요.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+기본적으로 생성된 구성 요소는 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 Gateway와 연결합니다. AWS WAF는 대상에 도달하기 _전에_ 모든 인바운드 요청을 인라인으로 검사하여 웹 익스플로잇, 봇 트래픽 및 대량 공격으로부터 Gateway를 보호합니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다. WAF 요청 로그는 CloudWatch Logs 그룹에 기록됩니다.
+
+Web ACL은 `REGIONAL`이며 AgentCore Gateway 연결에 필요한 대로 Gateway의 리전에 생성됩니다.
+
+:::caution[기본값과 다른 SizeRestrictions_BODY]
+`AWSManagedRulesCommonRuleSet`의 `SizeRestrictions_BODY` 규칙은 `Block`이 아닌 `Count`로 재정의됩니다. 규칙의 8 KB 제한이 일반적인 MCP 도구 페이로드에 너무 제한적이기 때문입니다. 초과 크기 요청은 여전히 메트릭으로 기록되므로 모니터링할 수 있습니다. 자세한 내용은 [AWS WAF 본문 크기 제한](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) 가이드를 참조하세요.
+:::
+
+생성된 Gateway 구성 요소를 편집하여 규칙을 추가, 제거 또는 조정할 수 있습니다(예: [속도 기반 규칙](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) 또는 추가 관리형 규칙 그룹 추가).
+
+<Infrastructure>
+<Fragment slot="cdk">
+옵트아웃하려면(예: 자체 Web ACL을 연결하려면) Gateway 구성 요소를 인스턴스화할 때 `enableWaf`를 `false`로 설정하세요:
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+구성 요소는 추가 구성을 위해 생성된 Web ACL을 `webAcl`로 노출합니다.
+</Fragment>
+<Fragment slot="terraform">
+옵트아웃하려면(예: 자체 Web ACL을 연결하려면) Gateway 모듈에서 `enable_waf`를 `false`로 설정하세요:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+모듈은 추가 구성을 위해 생성된 Web ACL ARN을 `waf_web_acl_arn`으로 출력합니다.
+</Fragment>
+</Infrastructure>
 
 ## 연결
 

--- a/docs/src/content/docs/ko/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-gateway.mdx
@@ -66,8 +66,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 생성기는 에이전트의 `agent.py`를 변환하여 Gateway 클라이언트를 사용합니다:
 
-<Tabs syncKey="framework">
-<TabItem label="Strands">
+<Tabs syncKey="agent-framework">
+<TabItem label="Strands" _filter={{ framework: 'strands' }}>
 ```python title="packages/example/example/my_agent/agent.py" {4,8,9-13}
 from contextlib import contextmanager
 from strands import Agent
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URL은 생성된 CDK 구성에 의해 <Link path="guides/runtime-config">Runtime Configuration</Link>의 `agentcore.gateways.<ClassName>` 네임스페이스에 자동으로 등록되므로 에이전트가 런타임에 이를 검색할 수 있습니다.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URL은 생성된 CDK 구성에 의해 <Link path="guides/runtime-config">Runtime Configuration</Link>의 `agentcore.gateways.<ClassName>` 네임스페이스에 자동으로 등록되므로 에이전트가 런타임에 이를 검색할 수 있습니다.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ O construto gerado cria os seguintes recursos AWS:
 - Um `AgentCore::Gateway` configurado para o protocolo MCP com `GatewayAuthorizer.usingAwsIam()` (autenticação IAM de entrada)
 - Um `AgentCore::PolicyEngine` executando em modo `ENFORCE`, anexado ao Gateway (omitido quando `cedarPolicy: false`)
 - Uma `AgentCore::Policy` por arquivo `.cedar` em `policies/`
+- Um AWS WAFv2 Web ACL associado ao Gateway, com registro de requisições no CloudWatch (habilitado por padrão — veja <a href="#aws-waf">AWS WAF</a>)
 
 A URL do Gateway é automaticamente registrada no namespace `agentcore.gateways.<ClassName>` da <Link path="guides/runtime-config">Configuração de Runtime</Link> para que os agentes possam descobri-la em tempo de execução.
+
+## AWS WAF
+
+Por padrão, o construto gerado associa um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ao Gateway. O AWS WAF inspeciona cada requisição de entrada inline _antes_ de alcançar um alvo, protegendo seu Gateway de explorações web, tráfego de bots e ataques volumétricos. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10. Os logs de requisições do WAF são gravados em um grupo do CloudWatch Logs.
+
+O Web ACL é `REGIONAL` e criado na região do Gateway, conforme exigido para associações do AgentCore Gateway — Web ACLs do CloudFront (globais) não são suportados.
+
+#### Arquitetura
+
+As requisições alcançam o Gateway através do AWS WAF, que roteia requisições permitidas para o Gateway e seus alvos de servidor MCP downstream:
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[Desvio de SizeRestrictions_BODY dos padrões]
+A regra `SizeRestrictions_BODY` do `AWSManagedRulesCommonRuleSet` é substituída para `Count` em vez de `Block`, já que o limite de 8 KB da regra é muito restritivo para cargas úteis típicas de ferramentas MCP. Requisições superdimensionadas ainda serão registradas como métricas para que você possa monitorá-las. Consulte o guia [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para mais detalhes.
+:::
+
+Se o AWS WAF estiver inacessível ou expirar durante a avaliação, o Gateway usa seu **modo de falha** para decidir se deve bloquear ou permitir a requisição. Isso é padronizado para o `FAIL_CLOSE` (bloquear) com prioridade de segurança do serviço. O modo de falha é uma configuração apenas do plano de controle (configurada via API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) e não é exposta através do CloudFormation ou Terraform. Recomendamos testar novas regras do AWS WAF no modo `Count` antes de alterá-las para `Block`, e monitorar as métricas `WafBlocks`, `WafFailOpens` e `WafFailCloses` do CloudWatch no namespace `AWS/Bedrock-AgentCore` para ajustar suas regras.
+
+Você pode editar o construto Gateway gerado para adicionar, remover ou ajustar regras (por exemplo, para adicionar [regras baseadas em taxa](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) ou grupos de regras gerenciadas adicionais).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para desativar (por exemplo, para anexar seu próprio Web ACL), defina `enableWaf` como `false` na chamada `super` em seu construto Gateway gerado:
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+O construto expõe o Web ACL criado como `webAcl` para configuração adicional.
+</Fragment>
+<Fragment slot="terraform">
+Para desativar (por exemplo, para anexar seu próprio Web ACL), defina `enable_waf` como `false` no módulo Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+O módulo produz o ARN do Web ACL criado como `waf_web_acl_arn` para configuração adicional.
+</Fragment>
+</Infrastructure>
 
 ## Escrevendo Políticas
 

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 Por padrão, o construto gerado associa um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ao Gateway. O AWS WAF inspeciona cada requisição de entrada inline _antes_ de alcançar um alvo, protegendo seu Gateway de explorações web, tráfego de bots e ataques volumétricos. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10. Os logs de requisições do WAF são gravados em um grupo do CloudWatch Logs.
 

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -106,6 +106,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -328,6 +333,34 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
     title="AgentCore Gateway para Servidor MCP"
     description="Agregue um servidor MCP atrás de um AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-mcp`}
+    source="agentcore"
+    target="mcp"
+  />
+  <ConnectionCard
+    title="AgentCore Gateway para AgentCore Gateway"
+    description="Agregue um AgentCore Gateway atrás de outro AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    source="agentcore"
+    target="agentcore"
+  />
+  <ConnectionCard
+    title="TypeScript Agent para AgentCore Gateway"
+    description="Conecte um TypeScript Agent a um AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}
+    source="strands"
+    sourceBadge="typescript"
+    target="agentcore"
+  />
+  <ConnectionCard
+    title="Python Agent para AgentCore Gateway"
+    description="Conecte um Python Agent a um AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    source="strands"
+    sourceBadge="python"
+    target="agentcore"
+  />
+</CardGrid>
+mcp`}
     source="agentcore"
     target="mcp"
   />

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ O construto gerado cria os seguintes recursos AWS:
 
 A URL do Gateway é automaticamente registrada no namespace `agentcore.gateways.<ClassName>` da <Link path="guides/runtime-config">Configuração de Runtime</Link> para que os agentes possam descobri-la em tempo de execução.
 
-## AWS WAF
-
-Por padrão, o construto gerado associa um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ao Gateway. O AWS WAF inspeciona cada requisição de entrada inline _antes_ de alcançar um alvo, protegendo seu Gateway de explorações web, tráfego de bots e ataques volumétricos. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10. Os logs de requisições do WAF são gravados em um grupo do CloudWatch Logs.
-
-O Web ACL é `REGIONAL` e criado na região do Gateway, conforme exigido para associações do AgentCore Gateway — Web ACLs do CloudFront (globais) não são suportados.
-
 #### Arquitetura
 
-As requisições alcançam o Gateway através do AWS WAF, que roteia requisições permitidas para o Gateway e seus alvos de servidor MCP downstream:
+O Gateway implantado possui a seguinte arquitetura, com um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL na frente do Gateway, que roteia para seus alvos de servidor MCP downstream:
 
 ```d2 inline=true
 direction: right
@@ -106,26 +100,20 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
-policy: Policy Engine\n(Cedar, ENFORCE) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
-}
-
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
-}
-
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
 }
 
 client -> waf
 waf -> gateway
 gateway -> targets
-waf -> cw
 ```
+
+## AWS WAF
+
+Por padrão, o construto gerado associa um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ao Gateway. O AWS WAF inspeciona cada requisição de entrada inline _antes_ de alcançar um alvo, protegendo seu Gateway de explorações web, tráfego de bots e ataques volumétricos. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10. Os logs de requisições do WAF são gravados em um grupo do CloudWatch Logs.
+
+O Web ACL é `REGIONAL` e criado na região do Gateway, conforme exigido para associações do AgentCore Gateway — Web ACLs do CloudFront (globais) não são suportados.
 
 :::caution[Desvio de SizeRestrictions_BODY dos padrões]
 A regra `SizeRestrictions_BODY` do `AWSManagedRulesCommonRuleSet` é substituída para `Count` em vez de `Block`, já que o limite de 8 KB da regra é muito restritivo para cargas úteis típicas de ferramentas MCP. Requisições superdimensionadas ainda serão registradas como métricas para que você possa monitorá-las. Consulte o guia [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para mais detalhes.

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-Por padrão, o construto gerado associa um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ao Gateway. O AWS WAF inspeciona cada requisição de entrada inline _antes_ de alcançar um alvo, protegendo seu Gateway de explorações web, tráfego de bots e ataques volumétricos. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10. Os logs de requisições do WAF são gravados em um grupo do CloudWatch Logs.
-
-O Web ACL é `REGIONAL` e criado na região do Gateway, conforme exigido para associações do AgentCore Gateway — Web ACLs do CloudFront (globais) não são suportados.
-
-:::caution[Desvio de SizeRestrictions_BODY dos padrões]
-A regra `SizeRestrictions_BODY` do `AWSManagedRulesCommonRuleSet` é substituída para `Count` em vez de `Block`, já que o limite de 8 KB da regra é muito restritivo para cargas úteis típicas de ferramentas MCP. Requisições superdimensionadas ainda serão registradas como métricas para que você possa monitorá-las. Consulte o guia [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para mais detalhes.
-:::
-
-Se o AWS WAF estiver inacessível ou expirar durante a avaliação, o Gateway usa seu **modo de falha** para decidir se deve bloquear ou permitir a requisição. Isso é padronizado para o `FAIL_CLOSE` (bloquear) com prioridade de segurança do serviço. O modo de falha é uma configuração apenas do plano de controle (configurada via API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) e não é exposta através do CloudFormation ou Terraform. Recomendamos testar novas regras do AWS WAF no modo `Count` antes de alterá-las para `Block`, e monitorar as métricas `WafBlocks`, `WafFailOpens` e `WafFailCloses` do CloudWatch no namespace `AWS/Bedrock-AgentCore` para ajustar suas regras.
-
-Você pode editar o construto Gateway gerado para adicionar, remover ou ajustar regras (por exemplo, para adicionar [regras baseadas em taxa](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) ou grupos de regras gerenciadas adicionais).
-
-<Infrastructure>
-<Fragment slot="cdk">
-Para desativar (por exemplo, para anexar seu próprio Web ACL), defina `enableWaf` como `false` na chamada `super` em seu construto Gateway gerado:
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-O construto expõe o Web ACL criado como `webAcl` para configuração adicional.
-</Fragment>
-<Fragment slot="terraform">
-Para desativar (por exemplo, para anexar seu próprio Web ACL), defina `enable_waf` como `false` no módulo Gateway:
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-O módulo produz o ARN do Web ACL criado como `waf_web_acl_arn` para configuração adicional.
-</Fragment>
-</Infrastructure>
-
 ## Escrevendo Políticas
 
 <OptionFilter when={{ cedarPolicy: true }} description="Políticas Cedar — apenas cedarPolicy: true">
@@ -306,11 +260,83 @@ Isso nega à função de agente Python a chamada de `ts-mcp___divide` enquanto m
 
 ## Desenvolvimento Local
 
-O gerador adiciona um alvo `<name>-dev` ao projeto Gateway, que executa `local-dev.ts`: um gateway local expondo um único endpoint MCP que agrega cada servidor MCP anexado (conectado via o <Link path="guides/connection/agentcore-gateway-mcp">gerador `agentcore-gateway#mcp-connection`</Link>), com ferramentas prefixadas `<target>___<tool>` para corresponder ao Gateway implantado. Executá-lo inicia o gateway local e todos os servidores MCP anexados juntos. Use o alvo `dev` do projeto:
+O gerador adiciona um alvo `dev` ao projeto Gateway, que executa `local-dev.ts`: um gateway local expondo um único endpoint MCP que agrega cada servidor MCP anexado (conectado via o <Link path="guides/connection/agentcore-gateway-mcp">gerador `agentcore-gateway#mcp-connection`</Link>), com ferramentas prefixadas `<target>___<tool>` para corresponder ao Gateway implantado. Executá-lo inicia o gateway local e todos os servidores MCP anexados juntos:
 
 <NxCommands commands={["dev <name>"]} />
 
 Consulte o guia de conexão para a história completa de desenvolvimento local.
+
+## Implantando seu AgentCore Gateway
+
+O gerador AgentCore Gateway cria infraestrutura como código CDK ou Terraform com base no seu `iacProvider` selecionado. Você pode usar isso para implantar seu Gateway.
+
+<Infrastructure>
+<Fragment slot="cdk">
+O construto CDK para implantar seu Gateway fica na pasta `common/constructs`. Você pode consumir isso em uma aplicação CDK, por exemplo:
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+Isso configura sua infraestrutura de Gateway, incluindo o `AgentCore::Gateway`, seu `PolicyEngine` Cedar e o AWS WAF Web ACL (veja [AWS WAF](#aws-waf) abaixo). Registre alvos de servidor MCP com `gateway.addMcpServer(...)` — veja o <Link path="guides/connection/agentcore-gateway-mcp">guia de conexão de servidor MCP</Link>.
+</Fragment>
+<Fragment slot="terraform">
+O módulo Terraform para implantar seu Gateway está na pasta `common/terraform`. Você pode usar isso em uma configuração Terraform, por exemplo:
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+Isso configura sua infraestrutura de Gateway, incluindo o `aws_bedrockagentcore_gateway`, seu motor de políticas Cedar e o AWS WAF Web ACL (veja [AWS WAF](#aws-waf) abaixo). Registre alvos de servidor MCP com um recurso `aws_bedrockagentcore_gateway_target` — veja o <Link path="guides/connection/agentcore-gateway-mcp">guia de conexão de servidor MCP</Link>.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+Por padrão, o construto gerado associa um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ao Gateway. O AWS WAF inspeciona cada requisição de entrada inline _antes_ de alcançar um alvo, protegendo seu Gateway de explorações web, tráfego de bots e ataques volumétricos. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10. Os logs de requisições do WAF são gravados em um grupo do CloudWatch Logs.
+
+O Web ACL é `REGIONAL` e criado na região do Gateway, conforme exigido para associações do AgentCore Gateway.
+
+:::caution[Desvio de SizeRestrictions_BODY dos padrões]
+A regra `SizeRestrictions_BODY` do `AWSManagedRulesCommonRuleSet` é substituída para `Count` em vez de `Block`, já que o limite de 8 KB da regra é muito restritivo para cargas úteis típicas de ferramentas MCP. Requisições superdimensionadas ainda serão registradas como métricas para que você possa monitorá-las. Consulte o guia [AWS WAF body size limits](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) para mais detalhes.
+:::
+
+Você pode editar o construto Gateway gerado para adicionar, remover ou ajustar regras (por exemplo, para adicionar [regras baseadas em taxa](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) ou grupos de regras gerenciadas adicionais).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para desativar (por exemplo, para anexar seu próprio Web ACL), defina `enableWaf` como `false` quando você instanciar o construto Gateway:
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+O construto expõe o Web ACL criado como `webAcl` para configuração adicional.
+</Fragment>
+<Fragment slot="terraform">
+Para desativar (por exemplo, para anexar seu próprio Web ACL), defina `enable_waf` como `false` no módulo Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+O módulo produz o ARN do Web ACL criado como `waf_web_acl_arn` para configuração adicional.
+</Fragment>
+</Infrastructure>
 
 ## Conexões
 

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -348,31 +348,3 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
     target="agentcore"
   />
 </CardGrid>
-mcp`}
-    source="agentcore"
-    target="mcp"
-  />
-  <ConnectionCard
-    title="AgentCore Gateway para AgentCore Gateway"
-    description="Agregue um AgentCore Gateway atrás de outro AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
-    source="agentcore"
-    target="agentcore"
-  />
-  <ConnectionCard
-    title="TypeScript Agent para AgentCore Gateway"
-    description="Conecte um TypeScript Agent a um AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}
-    source="strands"
-    sourceBadge="typescript"
-    target="agentcore"
-  />
-  <ConnectionCard
-    title="Python Agent para AgentCore Gateway"
-    description="Conecte um Python Agent a um AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
-    source="strands"
-    sourceBadge="python"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/pt/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-gateway.mdx
@@ -88,7 +88,7 @@ def get_agent():
 
 `MyGatewayClientStrands.create()` retorna um único `MCPClient` gerenciável por contexto cujo `list_tools_sync()` produz todas as ferramentas disponíveis através do Gateway.
 </TabItem>
-<TabItem label="LangChain">
+<TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
 ```python title="packages/example/example/my_agent/agent.py" {4,8,12}
 from langchain.agents import create_agent
 from langchain_aws import ChatBedrockConverse
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 A URL do Gateway é automaticamente registrada no namespace `agentcore.gateways.<ClassName>` da <Link path="guides/runtime-config">Runtime Configuration</Link> pelo construto CDK gerado, para que o agente possa descobri-la em tempo de execução.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 
@@ -185,4 +174,3 @@ O gateway local substitui o Gateway implantado, então:
 
 - **Sem avaliação de política Cedar.** Todas as ferramentas são visíveis para o agente independentemente das políticas. Use o alvo `serve` para exercitar políticas contra o Gateway implantado.
 - **A prefixação de nome de ferramenta é preservada.** As ferramentas de cada servidor MCP local são expostas como `<target-name>___<tool-name>`, correspondendo ao que o Gateway implantado emite. Isso mantém o prompt do sistema do agente e os nomes de ação Cedar que você referencia consistentes entre execuções locais e implantadas.
-tadas.

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 A URL do Gateway é automaticamente registrada no namespace `agentcore.gateways.<ClassName>` da <Link path="guides/runtime-config">Configuração de Runtime</Link> pelo construto CDK gerado, para que o agente possa descobri-la em tempo de execução.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-Theo mặc định, construct được tạo ra liên kết một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL với Gateway. AWS WAF kiểm tra mọi yêu cầu đầu vào inline _trước khi_ nó đến đích, bảo vệ Gateway của bạn khỏi các khai thác web, lưu lượng bot và các cuộc tấn công theo khối lượng. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10. Log yêu cầu WAF được ghi vào nhóm CloudWatch Logs.
-
-Web ACL là `REGIONAL` và được tạo trong vùng của Gateway, theo yêu cầu cho các liên kết AgentCore Gateway — Web ACL CloudFront (toàn cầu) không được hỗ trợ.
-
-:::caution[Sai lệch SizeRestrictions_BODY so với mặc định]
-Quy tắc `SizeRestrictions_BODY` từ `AWSManagedRulesCommonRuleSet` được ghi đè thành `Count` thay vì `Block`, vì giới hạn 8 KB của quy tắc quá hạn chế đối với các payload công cụ MCP điển hình. Các yêu cầu quá khổ vẫn sẽ được ghi lại dưới dạng số liệu để bạn có thể theo dõi chúng. Xem hướng dẫn [giới hạn kích thước body của AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) để biết thêm chi tiết.
-:::
-
-Nếu AWS WAF không thể truy cập hoặc hết thời gian chờ trong quá trình đánh giá, Gateway sử dụng **chế độ lỗi** của nó để quyết định chặn hay cho phép yêu cầu. Mặc định là `FAIL_CLOSE` (chặn) ưu tiên bảo mật của dịch vụ. Chế độ lỗi là cài đặt chỉ dành cho control-plane (được cấu hình thông qua API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) và không được hiển thị thông qua CloudFormation hoặc Terraform. Chúng tôi khuyên bạn nên thử nghiệm các quy tắc AWS WAF mới ở chế độ `Count` trước khi chuyển chúng sang `Block`, và theo dõi các số liệu CloudWatch `WafBlocks`, `WafFailOpens` và `WafFailCloses` trong namespace `AWS/Bedrock-AgentCore` để điều chỉnh các quy tắc của bạn.
-
-Bạn có thể chỉnh sửa construct Gateway được tạo để thêm, xóa hoặc điều chỉnh các quy tắc (ví dụ: để thêm [quy tắc dựa trên tốc độ](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) hoặc các nhóm quy tắc được quản lý bổ sung).
-
-<Infrastructure>
-<Fragment slot="cdk">
-Để từ chối (ví dụ: để đính kèm Web ACL của riêng bạn), đặt `enableWaf` thành `false` trên lời gọi `super` trong construct Gateway được tạo của bạn:
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-Construct hiển thị Web ACL đã tạo dưới dạng `webAcl` để cấu hình thêm.
-</Fragment>
-<Fragment slot="terraform">
-Để từ chối (ví dụ: để đính kèm Web ACL của riêng bạn), đặt `enable_waf` thành `false` trên module Gateway:
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-Module xuất ARN của Web ACL đã tạo dưới dạng `waf_web_acl_arn` để cấu hình thêm.
-</Fragment>
-</Infrastructure>
-
 ## Viết chính sách
 
 <OptionFilter when={{ cedarPolicy: true }} description="Chính sách Cedar — chỉ khi cedarPolicy: true">
@@ -311,6 +265,78 @@ Generator thêm target `dev` vào dự án Gateway, chạy `local-dev.ts`: một
 <NxCommands commands={["dev <name>"]} />
 
 Xem hướng dẫn kết nối để biết toàn bộ câu chuyện phát triển cục bộ.
+
+## Triển khai AgentCore Gateway của bạn
+
+Generator AgentCore Gateway tạo mã cơ sở hạ tầng CDK hoặc Terraform dựa trên `iacProvider` bạn đã chọn. Bạn có thể sử dụng điều này để triển khai Gateway của mình.
+
+<Infrastructure>
+<Fragment slot="cdk">
+CDK construct để triển khai Gateway của bạn nằm trong thư mục `common/constructs`. Bạn có thể sử dụng nó trong một ứng dụng CDK, ví dụ:
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+Điều này thiết lập cơ sở hạ tầng Gateway của bạn, bao gồm `AgentCore::Gateway`, `PolicyEngine` Cedar của nó, và AWS WAF Web ACL (xem [AWS WAF](#aws-waf) bên dưới). Đăng ký các target MCP server với `gateway.addMcpServer(...)` — xem <Link path="guides/connection/agentcore-gateway-mcp">hướng dẫn kết nối MCP server</Link>.
+</Fragment>
+<Fragment slot="terraform">
+Terraform module để triển khai Gateway của bạn nằm trong thư mục `common/terraform`. Bạn có thể sử dụng nó trong cấu hình Terraform, ví dụ:
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+Điều này thiết lập cơ sở hạ tầng Gateway của bạn, bao gồm `aws_bedrockagentcore_gateway`, policy engine Cedar của nó, và AWS WAF Web ACL (xem [AWS WAF](#aws-waf) bên dưới). Đăng ký các target MCP server với tài nguyên `aws_bedrockagentcore_gateway_target` — xem <Link path="guides/connection/agentcore-gateway-mcp">hướng dẫn kết nối MCP server</Link>.
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+Theo mặc định, construct được tạo ra liên kết một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL với Gateway. AWS WAF kiểm tra mọi yêu cầu đầu vào inline _trước khi_ nó đến đích, bảo vệ Gateway của bạn khỏi các khai thác web, lưu lượng bot và các cuộc tấn công theo khối lượng. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10. Log yêu cầu WAF được ghi vào nhóm CloudWatch Logs.
+
+Web ACL là `REGIONAL` và được tạo trong vùng của Gateway, theo yêu cầu cho các liên kết AgentCore Gateway.
+
+:::caution[Sai lệch SizeRestrictions_BODY so với mặc định]
+Quy tắc `SizeRestrictions_BODY` từ `AWSManagedRulesCommonRuleSet` được ghi đè thành `Count` thay vì `Block`, vì giới hạn 8 KB của quy tắc quá hạn chế đối với các payload công cụ MCP điển hình. Các yêu cầu quá khổ vẫn sẽ được ghi lại dưới dạng số liệu để bạn có thể theo dõi chúng. Xem hướng dẫn [giới hạn kích thước body của AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) để biết thêm chi tiết.
+:::
+
+Bạn có thể chỉnh sửa construct Gateway được tạo để thêm, xóa hoặc điều chỉnh các quy tắc (ví dụ: để thêm [quy tắc dựa trên tốc độ](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) hoặc các nhóm quy tắc được quản lý bổ sung).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Để từ chối (ví dụ: để đính kèm Web ACL của riêng bạn), đặt `enableWaf` thành `false` khi bạn khởi tạo construct Gateway:
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+Construct hiển thị Web ACL đã tạo dưới dạng `webAcl` để cấu hình thêm.
+</Fragment>
+<Fragment slot="terraform">
+Để từ chối (ví dụ: để đính kèm Web ACL của riêng bạn), đặt `enable_waf` thành `false` trên module Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+Module xuất ARN của Web ACL đã tạo dưới dạng `waf_web_acl_arn` để cấu hình thêm.
+</Fragment>
+</Infrastructure>
 
 ## Kết nối
 

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ Construct được tạo ra sẽ tạo các tài nguyên AWS sau:
 - Một `AgentCore::Gateway` được cấu hình cho giao thức MCP với `GatewayAuthorizer.usingAwsIam()` (xác thực IAM đầu vào)
 - Một `AgentCore::PolicyEngine` chạy ở chế độ `ENFORCE`, được gắn vào Gateway (bỏ qua khi `cedarPolicy: false`)
 - Một `AgentCore::Policy` cho mỗi tệp `.cedar` trong `policies/`
+- Một AWS WAFv2 Web ACL được liên kết với Gateway, với ghi log yêu cầu vào CloudWatch (được bật theo mặc định — xem <a href="#aws-waf">AWS WAF</a>)
 
 URL của Gateway được tự động đăng ký trong namespace `agentcore.gateways.<ClassName>` của <Link path="guides/runtime-config">Runtime Configuration</Link> để các agent có thể khám phá nó tại runtime.
+
+## AWS WAF
+
+Theo mặc định, construct được tạo ra liên kết một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL với Gateway. AWS WAF kiểm tra mọi yêu cầu đầu vào inline _trước khi_ nó đến đích, bảo vệ Gateway của bạn khỏi các khai thác web, lưu lượng bot và các cuộc tấn công theo khối lượng. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10. Log yêu cầu WAF được ghi vào nhóm CloudWatch Logs.
+
+Web ACL là `REGIONAL` và được tạo trong vùng của Gateway, theo yêu cầu cho các liên kết AgentCore Gateway — Web ACL CloudFront (toàn cầu) không được hỗ trợ.
+
+#### Kiến trúc
+
+Các yêu cầu đến Gateway thông qua AWS WAF, định tuyến các yêu cầu được phép đến Gateway và các mục tiêu MCP server phía sau của nó:
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[Sai lệch SizeRestrictions_BODY so với mặc định]
+Quy tắc `SizeRestrictions_BODY` từ `AWSManagedRulesCommonRuleSet` được ghi đè thành `Count` thay vì `Block`, vì giới hạn 8 KB của quy tắc quá hạn chế đối với các payload công cụ MCP điển hình. Các yêu cầu quá khổ vẫn sẽ được ghi lại dưới dạng số liệu để bạn có thể theo dõi chúng. Xem hướng dẫn [giới hạn kích thước body của AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) để biết thêm chi tiết.
+:::
+
+Nếu AWS WAF không thể truy cập hoặc hết thời gian chờ trong quá trình đánh giá, Gateway sử dụng **chế độ lỗi** của nó để quyết định chặn hay cho phép yêu cầu. Mặc định là `FAIL_CLOSE` (chặn) ưu tiên bảo mật của dịch vụ. Chế độ lỗi là cài đặt chỉ dành cho control-plane (được cấu hình thông qua API [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html)) và không được hiển thị thông qua CloudFormation hoặc Terraform. Chúng tôi khuyên bạn nên thử nghiệm các quy tắc AWS WAF mới ở chế độ `Count` trước khi chuyển chúng sang `Block`, và theo dõi các số liệu CloudWatch `WafBlocks`, `WafFailOpens` và `WafFailCloses` trong namespace `AWS/Bedrock-AgentCore` để điều chỉnh các quy tắc của bạn.
+
+Bạn có thể chỉnh sửa construct Gateway được tạo để thêm, xóa hoặc điều chỉnh các quy tắc (ví dụ: để thêm [quy tắc dựa trên tốc độ](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html) hoặc các nhóm quy tắc được quản lý bổ sung).
+
+<Infrastructure>
+<Fragment slot="cdk">
+Để từ chối (ví dụ: để đính kèm Web ACL của riêng bạn), đặt `enableWaf` thành `false` trên lời gọi `super` trong construct Gateway được tạo của bạn:
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+Construct hiển thị Web ACL đã tạo dưới dạng `webAcl` để cấu hình thêm.
+</Fragment>
+<Fragment slot="terraform">
+Để từ chối (ví dụ: để đính kèm Web ACL của riêng bạn), đặt `enable_waf` thành `false` trên module Gateway:
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+Module xuất ARN của Web ACL đã tạo dưới dạng `waf_web_acl_arn` để cấu hình thêm.
+</Fragment>
+</Infrastructure>
 
 ## Viết chính sách
 

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ Construct được tạo ra sẽ tạo các tài nguyên AWS sau:
 
 URL của Gateway được tự động đăng ký trong namespace `agentcore.gateways.<ClassName>` của <Link path="guides/runtime-config">Runtime Configuration</Link> để các agent có thể khám phá nó tại runtime.
 
-## AWS WAF
-
-Theo mặc định, construct được tạo ra liên kết một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL với Gateway. AWS WAF kiểm tra mọi yêu cầu đầu vào inline _trước khi_ nó đến đích, bảo vệ Gateway của bạn khỏi các khai thác web, lưu lượng bot và các cuộc tấn công theo khối lượng. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10. Log yêu cầu WAF được ghi vào nhóm CloudWatch Logs.
-
-Web ACL là `REGIONAL` và được tạo trong vùng của Gateway, theo yêu cầu cho các liên kết AgentCore Gateway — Web ACL CloudFront (toàn cầu) không được hỗ trợ.
-
 #### Kiến trúc
 
-Các yêu cầu đến Gateway thông qua AWS WAF, định tuyến các yêu cầu được phép đến Gateway và các mục tiêu MCP server phía sau của nó:
+Gateway đã triển khai có kiến trúc sau, với [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ở phía trước Gateway, định tuyến đến các mục tiêu MCP server phía sau của nó:
 
 ```d2 inline=true
 direction: right
@@ -110,17 +104,9 @@ targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
 
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
 
 ## AWS WAF

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 Theo mặc định, construct được tạo ra liên kết một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL với Gateway. AWS WAF kiểm tra mọi yêu cầu đầu vào inline _trước khi_ nó đến đích, bảo vệ Gateway của bạn khỏi các khai thác web, lưu lượng bot và các cuộc tấn công theo khối lượng. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10. Log yêu cầu WAF được ghi vào nhóm CloudWatch Logs.
 

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -118,9 +118,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+Theo mặc định, construct được tạo ra liên kết một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL với Gateway. AWS WAF kiểm tra mọi yêu cầu đầu vào inline _trước khi_ nó đến đích, bảo vệ Gateway của bạn khỏi các khai thác web, lưu lượng bot và các cuộc tấn công theo khối lượng. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10. Log yêu cầu WAF được ghi vào nhóm CloudWatch Logs.
+
+Web ACL là `REGIONAL` và được tạo trong vùng của Gateway, theo yêu cầu cho các liên kết AgentCore Gateway — Web ACL CloudFront (toàn cầu) không được hỗ trợ.
 
 :::caution[Sai lệch SizeRestrictions_BODY so với mặc định]
 Quy tắc `SizeRestrictions_BODY` từ `AWSManagedRulesCommonRuleSet` được ghi đè thành `Count` thay vì `Block`, vì giới hạn 8 KB của quy tắc quá hạn chế đối với các payload công cụ MCP điển hình. Các yêu cầu quá khổ vẫn sẽ được ghi lại dưới dạng số liệu để bạn có thể theo dõi chúng. Xem hướng dẫn [giới hạn kích thước body của AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) để biết thêm chi tiết.

--- a/docs/src/content/docs/vi/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-gateway.mdx
@@ -88,7 +88,7 @@ def get_agent():
 
 `MyGatewayClientStrands.create()` trả về một `MCPClient` có thể quản lý ngữ cảnh duy nhất mà `list_tools_sync()` của nó cung cấp mọi công cụ có sẵn thông qua Gateway.
 </TabItem>
-<TabItem label="LangChain">
+<TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
 ```python title="packages/example/example/my_agent/agent.py" {4,8,12}
 from langchain.agents import create_agent
 from langchain_aws import ChatBedrockConverse
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 URL Gateway được tự động đăng ký trong namespace `agentcore.gateways.<ClassName>` của <Link path="guides/runtime-config">Runtime Configuration</Link> bởi CDK construct được tạo, để agent có thể khám phá nó tại runtime.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URL được tự động đăng ký trong namespace `agentcore.gateways.<ClassName>` của <Link path="guides/runtime-config">Runtime Configuration</Link> bởi CDK construct được tạo, vì vậy agent có thể khám phá nó tại runtime.
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Cấp quyền cho agent để gọi Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 
@@ -150,4 +139,3 @@ Local gateway đóng vai trò thay thế cho Gateway đã triển khai, vì vậ
 
 - **Không đánh giá chính sách Cedar.** Mọi công cụ đều hiển thị với agent bất kể chính sách. Sử dụng target `serve` để thực thi các chính sách với Gateway đã triển khai.
 - **Tiền tố tên công cụ được bảo toàn.** Các công cụ của mỗi MCP server cục bộ được bọc để hiển thị tên có dạng `<target-name>___<tool-name>`, khớp với những gì Gateway đã triển khai phát ra. Điều này giữ cho system prompt của agent và tên action Cedar mà bạn tham chiếu nhất quán giữa các lần chạy cục bộ và đã triển khai.
-n khai.

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -109,7 +109,7 @@ waf -> gateway
 gateway -> targets
 ```
 
-## AWS WAF
+#### AWS WAF
 
 默认情况下，生成的构造会将 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 与 Gateway 关联。AWS WAF 在请求到达目标_之前_内联检查每个入站请求，保护您的 Gateway 免受 Web 漏洞、机器人流量和容量攻击。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。WAF 请求日志会写入 CloudWatch Logs 日志组。
 

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -348,9 +348,3 @@ forbid (
     target="agentcore"
   />
 </CardGrid>
-ro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
-    source="strands"
-    sourceBadge="python"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -74,8 +74,93 @@ import OptionFilter from '@components/option-filter.astro';
 - 一个为 MCP 协议配置的 `AgentCore::Gateway`，使用 `GatewayAuthorizer.usingAwsIam()`（入站 IAM 身份验证）
 - 一个以 `ENFORCE` 模式运行的 `AgentCore::PolicyEngine`，附加到 Gateway（当 `cedarPolicy: false` 时省略）
 - `policies/` 中每个 `.cedar` 文件对应一个 `AgentCore::Policy`
+- 与 Gateway 关联的 AWS WAFv2 Web ACL，并将请求日志记录到 CloudWatch（默认启用——参见 <a href="#aws-waf">AWS WAF</a>）
 
 Gateway URL 会自动注册到 <Link path="guides/runtime-config">运行时配置</Link>的 `agentcore.gateways.<ClassName>` 命名空间中，以便代理可以在运行时发现它。
+
+## AWS WAF
+
+默认情况下，生成的构造会将 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 与 Gateway 关联。AWS WAF 在请求到达目标_之前_内联检查每个入站请求，保护您的 Gateway 免受 Web 漏洞、机器人流量和容量攻击。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。WAF 请求日志会写入 CloudWatch Logs 日志组。
+
+Web ACL 是 `REGIONAL` 的，并在 Gateway 的区域中创建，这是 AgentCore Gateway 关联所必需的——不支持 CloudFront（全局）Web ACL。
+
+#### 架构
+
+请求通过 AWS WAF 到达 Gateway，WAF 将允许的请求路由到 Gateway 及其下游 MCP 服务器目标：
+
+```d2 inline=true
+direction: right
+
+client: Client {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
+gateway: AgentCore Gateway\n(MCP, IAM auth) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
+targets: Downstream MCP Servers\n(Gateway targets) {
+  shape: rectangle
+}
+
+cw: CloudWatch\n(WAF Logs) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
+  near: bottom-right
+}
+
+client -> waf
+waf -> gateway
+gateway -> targets
+waf -> cw
+```
+
+:::caution[SizeRestrictions_BODY 偏离默认值]
+`AWSManagedRulesCommonRuleSet` 中的 `SizeRestrictions_BODY` 规则被覆盖为 `Count` 而不是 `Block`，因为该规则的 8 KB 限制对于典型的 MCP 工具负载来说过于严格。超大请求仍将记录为指标，以便您可以监控它们。有关更多详细信息，请参阅 [AWS WAF 正文大小限制](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)指南。
+:::
+
+如果 AWS WAF 在评估期间无法访问或超时，Gateway 会使用其**故障模式**来决定是阻止还是允许请求。这默认为服务的安全优先 `FAIL_CLOSE`（阻止）。故障模式是仅控制平面的设置（通过 [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) API 配置），不通过 CloudFormation 或 Terraform 公开。我们建议在将新的 AWS WAF 规则切换到 `Block` 之前先在 `Count` 模式下测试它们，并监控 `AWS/Bedrock-AgentCore` 命名空间中的 `WafBlocks`、`WafFailOpens` 和 `WafFailCloses` CloudWatch 指标以调整您的规则。
+
+您可以编辑生成的 Gateway 构造以添加、删除或调整规则（例如，添加[基于速率的规则](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)或其他托管规则组）。
+
+<Infrastructure>
+<Fragment slot="cdk">
+要选择退出（例如，附加您自己的 Web ACL），请在生成的 Gateway 构造中的 `super` 调用上将 `enableWaf` 设置为 `false`：
+
+```ts {6}
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      enableWaf: false,
+    });
+    // ...
+  }
+}
+```
+
+该构造将创建的 Web ACL 公开为 `webAcl` 以进行进一步配置。
+</Fragment>
+<Fragment slot="terraform">
+要选择退出（例如，附加您自己的 Web ACL），请在 Gateway 模块上将 `enable_waf` 设置为 `false`：
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+该模块将创建的 Web ACL ARN 输出为 `waf_web_acl_arn` 以进行进一步配置。
+</Fragment>
+</Infrastructure>
 
 ## 编写策略
 
@@ -93,15 +178,13 @@ Cedar 是 AgentCore Gateway 用于授权工具调用的策略语言。流经 Gat
 
 ```cedar title="packages/<name>/policies/ts-agent-divide.cedar"
 permit (
-  principal is AgentCore::IamEntity,
+  principal == AgentCore::IamEntity::"arn:aws:sts::<%= accountId %>:assumed-role/<%= tsAgentRoleName %>",
   action == AgentCore::Action::"ts-mcp___divide",
   resource == AgentCore::Gateway::"<%= gatewayArn %>"
-) when {
-  principal.id like "<%= tsAgentRoleArn %>/*"
-};
+);
 ```
 
-将角色 ARN 作为模板变量传入（参见下面的<a href="#template-variables">模板变量</a>），而不是硬编码或模式匹配它。重新合成或重新计划以部署新策略。
+将角色名称作为模板变量传入（参见下面的<a href="#template-variables">模板变量</a>），而不是硬编码它。重新合成或重新计划以部署新策略。
 
 ### 模板变量
 
@@ -116,18 +199,21 @@ permit (
 
 #### 添加您自己的变量
 
-添加新变量到策略渲染的位置，例如将代理的执行角色 ARN 传递给上面的 `ts-agent-divide.cedar` 示例：
+添加新变量到策略渲染的位置，例如将代理的执行角色名称传递给上面的 `ts-agent-divide.cedar` 示例：
 
 <Infrastructure>
 <Fragment slot="cdk">
-在 `packages/common/constructs/src/app/gateways/<name>/<name>.ts` 中，添加到传递给 `ejs.render` 的对象：
+在 `packages/common/constructs/src/app/gateways/<name>/<name>.ts` 中，将 `cedarPolicyVariables` 传递给共享构造：
 
-```ts {3}
-ejs.render(raw, {
-  gatewayArn: cdk.Token.asString(this.gateway.gatewayArn),
-  tsAgentRoleArn: cdk.Token.asString(tsAgent.agentCoreRuntime.role.roleArn),
-  // ...
-}),
+```ts {4-6}
+super(scope, id, {
+  cedarPolicyPath: path.join(
+    ...
+  ),
+  cedarPolicyVariables: {
+    tsAgentRoleName: cdk.Token.asString(tsAgent.agentCoreRuntime.role.roleName),
+  },
+});
 ```
 </Fragment>
 <Fragment slot="terraform">
@@ -179,11 +265,13 @@ permit (
 principal is AgentCore::IamEntity
 ```
 
-主体的 `id` 属性保存调用者的 IAM ARN。调用者通常以带有生成的会话后缀的 STS assumed-role ARN 到达，因此将确切的角色 ARN 作为模板变量传入，并使用 `like` 匹配会话后缀：
+调用者被评估为去除会话名称的 STS assumed-role ARN，因此可以精确匹配角色——不需要通配符：
 
 ```cedar
-principal.id like "<%= myAgentRoleArn %>/*"
+principal == AgentCore::IamEntity::"arn:aws:sts::<%= accountId %>:assumed-role/<%= myAgentRoleName %>"
 ```
+
+相同的值可作为 `principal.id` 用于 `when` 子句。将 `like` 保留用于真正的模式，例如默认 `permit-all.cedar` 中的账户范围匹配。
 
 工具调用以以下形式的操作到达策略引擎：
 
@@ -213,12 +301,10 @@ resource == AgentCore::Gateway::"<%= gatewayArn %>"
 
 ```cedar title="packages/<name>/policies/forbid-divide-for-py-agent.cedar"
 forbid (
-  principal is AgentCore::IamEntity,
+  principal == AgentCore::IamEntity::"arn:aws:sts::<%= accountId %>:assumed-role/<%= pyAgentRoleName %>",
   action == AgentCore::Action::"ts-mcp___divide",
   resource == AgentCore::Gateway::"<%= gatewayArn %>"
-) when {
-  principal.id like "<%= pyAgentRoleArn %>/*"
-};
+);
 ```
 
 这会拒绝 Python 代理角色调用 `ts-mcp___divide`，同时为所有其他调用者保留更广泛的 `permit-all.cedar`。

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -109,52 +109,6 @@ waf -> gateway
 gateway -> targets
 ```
 
-#### AWS WAF
-
-默认情况下，生成的构造会将 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 与 Gateway 关联。AWS WAF 在请求到达目标_之前_内联检查每个入站请求，保护您的 Gateway 免受 Web 漏洞、机器人流量和容量攻击。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。WAF 请求日志会写入 CloudWatch Logs 日志组。
-
-Web ACL 是 `REGIONAL` 的，并在 Gateway 的区域中创建，这是 AgentCore Gateway 关联所必需的——不支持 CloudFront（全局）Web ACL。
-
-:::caution[SizeRestrictions_BODY 偏离默认值]
-`AWSManagedRulesCommonRuleSet` 中的 `SizeRestrictions_BODY` 规则被覆盖为 `Count` 而不是 `Block`，因为该规则的 8 KB 限制对于典型的 MCP 工具负载来说过于严格。超大请求仍将记录为指标，以便您可以监控它们。有关更多详细信息，请参阅 [AWS WAF 正文大小限制](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)指南。
-:::
-
-如果 AWS WAF 在评估期间无法访问或超时，Gateway 会使用其**故障模式**来决定是阻止还是允许请求。这默认为服务的安全优先 `FAIL_CLOSE`（阻止）。故障模式是仅控制平面的设置（通过 [`UpdateGateway`](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_UpdateGateway.html) API 配置），不通过 CloudFormation 或 Terraform 公开。我们建议在将新的 AWS WAF 规则切换到 `Block` 之前先在 `Count` 模式下测试它们，并监控 `AWS/Bedrock-AgentCore` 命名空间中的 `WafBlocks`、`WafFailOpens` 和 `WafFailCloses` CloudWatch 指标以调整您的规则。
-
-您可以编辑生成的 Gateway 构造以添加、删除或调整规则（例如，添加[基于速率的规则](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)或其他托管规则组）。
-
-<Infrastructure>
-<Fragment slot="cdk">
-要选择退出（例如，附加您自己的 Web ACL），请在生成的 Gateway 构造中的 `super` 调用上将 `enableWaf` 设置为 `false`：
-
-```ts {6}
-export class MyGateway extends AgentCoreGateway {
-  public readonly gatewayName = 'my-gateway';
-
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      enableWaf: false,
-    });
-    // ...
-  }
-}
-```
-
-该构造将创建的 Web ACL 公开为 `webAcl` 以进行进一步配置。
-</Fragment>
-<Fragment slot="terraform">
-要选择退出（例如，附加您自己的 Web ACL），请在 Gateway 模块上将 `enable_waf` 设置为 `false`：
-
-```hcl {2}
-module "my_gateway" {
-  enable_waf = false
-}
-```
-
-该模块将创建的 Web ACL ARN 输出为 `waf_web_acl_arn` 以进行进一步配置。
-</Fragment>
-</Infrastructure>
-
 ## 编写策略
 
 <OptionFilter when={{ cedarPolicy: true }} description="Cedar 策略 — 仅限 cedarPolicy: true">
@@ -311,6 +265,78 @@ forbid (
 <NxCommands commands={["dev <name>"]} />
 
 有关完整的本地开发故事，请参阅连接指南。
+
+## 部署您的 AgentCore Gateway
+
+AgentCore Gateway 生成器根据您选择的 `iacProvider` 创建 CDK 或 Terraform 基础设施即代码。您可以使用它来部署您的 Gateway。
+
+<Infrastructure>
+<Fragment slot="cdk">
+用于部署 Gateway 的 CDK 构造位于 `common/constructs` 文件夹中。您可以在 CDK 应用程序中使用它，例如：
+
+```ts {7} title="packages/infra/src/stacks/application-stack.ts"
+import { MyGateway } from ':my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new MyGateway(this, 'MyGateway');
+  }
+}
+```
+
+这会设置您的 Gateway 基础设施，包括 `AgentCore::Gateway`、其 Cedar `PolicyEngine` 和 AWS WAF Web ACL（参见下面的 [AWS WAF](#aws-waf)）。使用 `gateway.addMcpServer(...)` 注册 MCP 服务器目标——参见 <Link path="guides/connection/agentcore-gateway-mcp">MCP 服务器连接指南</Link>。
+</Fragment>
+<Fragment slot="terraform">
+用于部署 Gateway 的 Terraform 模块位于 `common/terraform` 文件夹中。您可以在 Terraform 配置中使用它，例如：
+
+```hcl title="packages/infra/src/main.tf"
+module "my_gateway" {
+  source = "../../common/terraform/src/app/gateways/my-gateway"
+}
+```
+
+这会设置您的 Gateway 基础设施，包括 `aws_bedrockagentcore_gateway`、其 Cedar 策略引擎和 AWS WAF Web ACL（参见下面的 [AWS WAF](#aws-waf)）。使用 `aws_bedrockagentcore_gateway_target` 资源注册 MCP 服务器目标——参见 <Link path="guides/connection/agentcore-gateway-mcp">MCP 服务器连接指南</Link>。
+</Fragment>
+</Infrastructure>
+
+### AWS WAF
+
+默认情况下，生成的构造会将 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 与 Gateway 关联。AWS WAF 在请求到达目标_之前_内联检查每个入站请求，保护您的 Gateway 免受 Web 漏洞、机器人流量和容量攻击。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。WAF 请求日志会写入 CloudWatch Logs 日志组。
+
+Web ACL 是 `REGIONAL` 的，并在 Gateway 的区域中创建，这是 AgentCore Gateway 关联所必需的。
+
+:::caution[SizeRestrictions_BODY 偏离默认值]
+`AWSManagedRulesCommonRuleSet` 中的 `SizeRestrictions_BODY` 规则被覆盖为 `Count` 而不是 `Block`，因为该规则的 8 KB 限制对于典型的 MCP 工具负载来说过于严格。超大请求仍将记录为指标，以便您可以监控它们。有关更多详细信息，请参阅 [AWS WAF 正文大小限制](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)指南。
+:::
+
+您可以编辑生成的 Gateway 构造以添加、删除或调整规则（例如，添加[基于速率的规则](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)或其他托管规则组）。
+
+<Infrastructure>
+<Fragment slot="cdk">
+要选择退出（例如，附加您自己的 Web ACL），请在实例化 Gateway 构造时将 `enableWaf` 设置为 `false`：
+
+```ts {2}
+new MyGateway(this, 'MyGateway', {
+  enableWaf: false,
+});
+```
+
+该构造将创建的 Web ACL 公开为 `webAcl` 以进行进一步配置。
+</Fragment>
+<Fragment slot="terraform">
+要选择退出（例如，附加您自己的 Web ACL），请在 Gateway 模块上将 `enable_waf` 设置为 `false`：
+
+```hcl {2}
+module "my_gateway" {
+  enable_waf = false
+}
+```
+
+该模块将创建的 Web ACL ARN 输出为 `waf_web_acl_arn` 以进行进一步配置。
+</Fragment>
+</Infrastructure>
 
 ## 连接
 

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -78,15 +78,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 Gateway URL 会自动注册到 <Link path="guides/runtime-config">运行时配置</Link>的 `agentcore.gateways.<ClassName>` 命名空间中，以便代理可以在运行时发现它。
 
-## AWS WAF
-
-默认情况下，生成的构造会将 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 与 Gateway 关联。AWS WAF 在请求到达目标_之前_内联检查每个入站请求，保护您的 Gateway 免受 Web 漏洞、机器人流量和容量攻击。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。WAF 请求日志会写入 CloudWatch Logs 日志组。
-
-Web ACL 是 `REGIONAL` 的，并在 Gateway 的区域中创建，这是 AgentCore Gateway 关联所必需的——不支持 CloudFront（全局）Web ACL。
-
 #### 架构
 
-请求通过 AWS WAF 到达 Gateway，WAF 将允许的请求路由到 Gateway 及其下游 MCP 服务器目标：
+已部署的 Gateway 具有以下架构。入站请求通过 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 和 IAM 身份验证，针对 Cedar [策略引擎](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html)进行授权，然后路由到下游 MCP 服务器目标：
 
 ```d2 inline=true
 direction: right
@@ -106,6 +100,11 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
+policy: Policy Engine\n(Cedar, ENFORCE) {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
+}
+
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
@@ -118,9 +117,16 @@ cw: CloudWatch\n(WAF Logs) {
 
 client -> waf
 waf -> gateway
+gateway -> policy: Authorize
 gateway -> targets
 waf -> cw
 ```
+
+## AWS WAF
+
+默认情况下，生成的构造会将 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 与 Gateway 关联。AWS WAF 在请求到达目标_之前_内联检查每个入站请求，保护您的 Gateway 免受 Web 漏洞、机器人流量和容量攻击。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。WAF 请求日志会写入 CloudWatch Logs 日志组。
+
+Web ACL 是 `REGIONAL` 的，并在 Gateway 的区域中创建，这是 AgentCore Gateway 关联所必需的——不支持 CloudFront（全局）Web ACL。
 
 :::caution[SizeRestrictions_BODY 偏离默认值]
 `AWSManagedRulesCommonRuleSet` 中的 `SizeRestrictions_BODY` 规则被覆盖为 `Count` 而不是 `Block`，因为该规则的 8 KB 限制对于典型的 MCP 工具负载来说过于严格。超大请求仍将记录为指标，以便您可以监控它们。有关更多详细信息，请参阅 [AWS WAF 正文大小限制](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html)指南。

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -100,26 +100,13 @@ gateway: AgentCore Gateway\n(MCP, IAM auth) {
   icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
 }
 
-policy: Policy Engine\n(Cedar, ENFORCE) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore.svg
-}
-
 targets: Downstream MCP Servers\n(Gateway targets) {
   shape: rectangle
 }
 
-cw: CloudWatch\n(WAF Logs) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
 client -> waf
 waf -> gateway
-gateway -> policy: Authorize
 gateway -> targets
-waf -> cw
 ```
 
 ## AWS WAF
@@ -356,6 +343,12 @@ forbid (
     title="Python Agent to AgentCore Gateway"
     description="将 Python Agent 连接到 AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    source="strands"
+    sourceBadge="python"
+    target="agentcore"
+  />
+</CardGrid>
+ro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"

--- a/docs/src/content/docs/zh/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-gateway.mdx
@@ -132,31 +132,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URL 会由生成的 CDK 构造自动注册到 <Link path="guides/runtime-config">运行时配置</Link> 的 `agentcore.gateways.<ClassName>` 命名空间中，以便 agent 可以在运行时发现它。
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-gateway.mdx
@@ -97,31 +97,20 @@ gateway.grantInvokeAccess(myAgent);
 Gateway URL 会由生成的 CDK 构造自动注册到 <Link path="guides/runtime-config">运行时配置</Link> 的 `agentcore.gateways.<ClassName>` 命名空间中，以便 agent 可以在运行时发现它。
 </Fragment>
 <Fragment slot="terraform">
-```hcl title="packages/infra/src/main.tf" {12-24}
+```hcl title="packages/infra/src/main.tf" {6-13}
 module "my_gateway" {
   source = "../../common/terraform/src/app/gateways/my-gateway"
 }
 
 module "my_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
-}
 
-# Grant the agent permission to invoke the Gateway
-resource "aws_iam_policy" "agent_invoke_gateway" {
-  name = "AgentInvokeGatewayPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "bedrock-agentcore:InvokeGateway"
-      Resource = module.my_gateway.gateway_arn
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "agent_invoke_gateway" {
-  role       = module.my_agent.agent_core_runtime_role_arn
-  policy_arn = aws_iam_policy.agent_invoke_gateway.arn
+  # Grant the agent permission to invoke the Gateway
+  additional_iam_policy_statements = [{
+    Effect   = "Allow"
+    Action   = ["bedrock-agentcore:InvokeGateway"]
+    Resource = [module.my_gateway.gateway_arn]
+  }]
 }
 ```
 

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -298,6 +298,43 @@ describe('agentcore-gateway generator', () => {
       expect(construct).not.toContain('toPascalCase');
     });
 
+    it('caps the gateway name so the service suffix keeps the id within 50 chars', () => {
+      const construct = tree
+        .read(
+          'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts',
+        )!
+        .toString();
+      // AgentCore appends an 11-char suffix to the name to form the gateway
+      // id (max 50). The Gateway L2 otherwise defaults to a 48-char name, so
+      // an explicit 39-char-capped name is required (39 + 11 = 50).
+      expect(construct).toContain(
+        "gatewayName: cdk.Names.uniqueResourceName(this, { maxLength: 39 })",
+      );
+    });
+
+    it('protects the gateway with a regional WAF web ACL by default', () => {
+      const construct = tree
+        .read(
+          'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts',
+        )!
+        .toString();
+      // WAF is opt-out (enabled unless enableWaf is explicitly false).
+      expect(construct).toContain('enableWaf');
+      expect(construct).toContain('props?.enableWaf ?? true');
+      // AgentCore Gateway requires a REGIONAL web ACL associated with the
+      // gateway's own ARN.
+      expect(construct).toContain('new wafv2.CfnWebACL(');
+      expect(construct).toContain("scope: 'REGIONAL'");
+      expect(construct).toContain('new wafv2.CfnWebACLAssociation(');
+      expect(construct).toContain('resourceArn: this.gateway.gatewayArn');
+      // Default AWS managed rule groups.
+      expect(construct).toContain('AWSManagedRulesCommonRuleSet');
+      expect(construct).toContain('AWSManagedRulesKnownBadInputsRuleSet');
+      // WAF request logging to a CloudWatch log group named `aws-waf-logs-*`.
+      expect(construct).toContain('new wafv2.CfnLoggingConfiguration(');
+      expect(construct).toContain('aws-waf-logs-');
+    });
+
     it('URL-encodes the runtime ARN correctly for the MCP target endpoint', () => {
       const construct = tree
         .read(
@@ -338,6 +375,20 @@ describe('agentcore-gateway generator', () => {
       expect(coreFiles.length).toBeGreaterThan(0);
     });
 
+    it('caps the gateway name so the service suffix keeps the id within 50 chars', () => {
+      const module = tree
+        .read(
+          'packages/common/terraform/src/app/gateways/my-gateway/my-gateway.tf',
+        )!
+        .toString();
+      // AgentCore appends an 11-char suffix to form the gateway id (max 50).
+      // With the "-<8 hex>" suffix, truncate the class-name prefix to 30 so
+      // the name stays within 39 chars (39 + 11 = 50).
+      expect(module).toContain(
+        'name        = "${substr("MyGateway", 0, 30)}-${random_id.unique_suffix.hex}"',
+      );
+    });
+
     it('does not emit the CDK construct when iac is terraform', () => {
       expect(
         tree.exists(
@@ -359,6 +410,31 @@ describe('agentcore-gateway generator', () => {
         .toString();
       expect(module).toContain('data "external" "rendered_policies"');
       expect(module).toContain('render-cedar.cjs');
+    });
+
+    it('protects the gateway with a regional WAF web ACL by default', () => {
+      const module = tree
+        .read(
+          'packages/common/terraform/src/app/gateways/my-gateway/my-gateway.tf',
+        )!
+        .toString();
+      expect(module).toContain('variable "enable_waf"');
+      expect(module).toContain('resource "aws_wafv2_web_acl" "gateway_waf"');
+      expect(module).toContain('scope = "REGIONAL"');
+      // Associated with the gateway's own ARN.
+      expect(module).toContain(
+        'resource "aws_wafv2_web_acl_association" "gateway_waf"',
+      );
+      expect(module).toContain(
+        'resource_arn = aws_bedrockagentcore_gateway.this.gateway_arn',
+      );
+      // Default AWS managed rule groups + `aws-waf-logs-` logging.
+      expect(module).toContain('AWSManagedRulesCommonRuleSet');
+      expect(module).toContain('AWSManagedRulesKnownBadInputsRuleSet');
+      expect(module).toContain(
+        'resource "aws_wafv2_web_acl_logging_configuration" "gateway_waf_logging"',
+      );
+      expect(module).toContain('aws-waf-logs-');
     });
 
     it('emits a tool_dependencies-gated readiness probe routed through gateway_url', () => {

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -186,6 +186,25 @@ describe('agentcore-gateway generator', () => {
       ).toBe(true);
     });
 
+    it('lets callers pass props (e.g. enableWaf) through to the base construct', () => {
+      const app = tree
+        .read(
+          'packages/common/constructs/src/app/gateways/my-gateway/my-gateway.ts',
+        )!
+        .toString();
+      // The construct accepts optional props and forwards them to `super`, so
+      // callers can `new MyGateway(this, 'MyGateway', { enableWaf: false })`
+      // without editing the generated construct.
+      expect(app).toContain('AgentCoreGatewayProps');
+      expect(app).toContain(
+        "export type MyGatewayProps = Omit<AgentCoreGatewayProps, 'cedarPolicyPath'>",
+      );
+      expect(app).toContain(
+        'constructor(scope: Construct, id: string, props?: MyGatewayProps)',
+      );
+      expect(app).toContain('...props,');
+    });
+
     it('wires the MCP-protocol Gateway with IAM inbound auth + ENFORCE policy engine', () => {
       const construct = tree
         .read(
@@ -308,7 +327,7 @@ describe('agentcore-gateway generator', () => {
       // id (max 50). The Gateway L2 otherwise defaults to a 48-char name, so
       // an explicit 39-char-capped name is required (39 + 11 = 50).
       expect(construct).toContain(
-        "gatewayName: cdk.Names.uniqueResourceName(this, { maxLength: 39 })",
+        'gatewayName: cdk.Names.uniqueResourceName(this, { maxLength: 39 })',
       );
     });
 
@@ -504,6 +523,23 @@ describe('agentcore-gateway generator', () => {
         .toString();
       expect(construct).not.toContain('cedarPolicyPath');
       expect(construct).toContain('extends AgentCoreGateway');
+    });
+
+    it('exposes the full base props (no cedarPolicyPath to omit)', () => {
+      const construct = tree
+        .read(
+          'packages/common/constructs/src/app/gateways/my-gateway/my-gateway.ts',
+        )!
+        .toString();
+      // Without Cedar there is no internally-managed cedarPolicyPath, so props
+      // pass straight through as the base construct's props.
+      expect(construct).toContain(
+        'export type MyGatewayProps = AgentCoreGatewayProps',
+      );
+      expect(construct).toContain(
+        'constructor(scope: Construct, id: string, props?: MyGatewayProps)',
+      );
+      expect(construct).toContain('...props,');
     });
   });
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -3,10 +3,19 @@ import { Construct } from 'constructs';
 import * as path from 'node:path';
 import * as url from 'node:url';
 <%_ } _%>
-import { AgentCoreGateway } from '../../../core/agentcore-gateway/agentcore-gateway.js';
+import {
+  AgentCoreGateway,
+  AgentCoreGatewayProps,
+} from '../../../core/agentcore-gateway/agentcore-gateway.js';
 import { RuntimeConfig } from '../../../core/runtime-config.js';
 <%_ if (cedarPolicy) { _%>
 import { findWorkspaceRoot } from '../../../core/workspace.js';
+<%_ } _%>
+
+<%_ if (cedarPolicy) { _%>
+export type <%- nameClassName %>Props = Omit<AgentCoreGatewayProps, 'cedarPolicyPath'>;
+<%_ } else { _%>
+export type <%- nameClassName %>Props = AgentCoreGatewayProps;
 <%_ } _%>
 
 /**
@@ -21,7 +30,7 @@ export class <%- nameClassName %> extends AgentCoreGateway {
   /** Default Gateway target name when added to another Gateway. */
   public readonly gatewayName = '<%- nameKebabCase %>';
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: <%- nameClassName %>Props) {
     super(scope, id, {
 <%_ if (cedarPolicy) { _%>
       cedarPolicyPath: path.join(
@@ -29,6 +38,7 @@ export class <%- nameClassName %> extends AgentCoreGateway {
         '<%- projectDirectory %>/policies',
       ),
 <%_ } _%>
+      ...props,
     });
 
     const rc = RuntimeConfig.ensure(this);

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
@@ -1,8 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
 import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import * as triggers from 'aws-cdk-lib/triggers';
+import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 import ejs from 'ejs';
 import * as fs from 'node:fs';
@@ -24,6 +27,20 @@ export interface AgentCoreGatewayProps {
    * Additional variables available to the Cedar policy EJS templates.
    */
   readonly cedarPolicyVariables?: Record<string, string>;
+  /**
+   * Whether to create an AWS WAFv2 web ACL with the default managed rule
+   * groups (`AWSManagedRulesCommonRuleSet` and
+   * `AWSManagedRulesKnownBadInputsRuleSet`) and associate it with the
+   * gateway. AWS WAF inspects every inbound request before it reaches a
+   * target, protecting the gateway from web exploits, bot traffic, and
+   * volumetric attacks.
+   *
+   * The web ACL is `REGIONAL` and created in the gateway's region, as
+   * required for AgentCore Gateway associations.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
 }
 
 /**
@@ -33,6 +50,8 @@ export interface AgentCoreGatewayProps {
 export class AgentCoreGateway extends Construct implements iam.IGrantable {
   public readonly gateway: agentcore.Gateway;
   public readonly policyEngine?: agentcore.CfnPolicyEngine;
+  /** The WAFv2 web ACL associated with the gateway, if WAF is enabled. */
+  public readonly webAcl?: wafv2.CfnWebACL;
   private readonly policies: agentcore.CfnPolicy[] = [];
   private targetReadinessProbe?: triggers.TriggerFunction;
   private readonly targetRuntimeArns: string[] = [];
@@ -41,6 +60,11 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     super(scope, id);
 
     this.gateway = new agentcore.Gateway(this, 'Gateway', {
+      // AgentCore appends an 11-character suffix to the gateway name to form
+      // the gateway id, which must not exceed 50 characters. The Gateway L2
+      // otherwise defaults the name to a 48-character generated string, so the
+      // id overflows. Cap the name at 39 characters (39 + 11 = 50) instead.
+      gatewayName: cdk.Names.uniqueResourceName(this, { maxLength: 39 }),
       protocolConfiguration: new agentcore.McpProtocolConfiguration({
         searchType: agentcore.McpGatewaySearchType.SEMANTIC,
         supportedVersions: [agentcore.MCPProtocolVersion.MCP_2025_03_26],
@@ -128,6 +152,110 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
         }
       }
     }
+
+    if (props?.enableWaf ?? true) {
+      this.webAcl = this.createWebAcl();
+    }
+  }
+
+  /**
+   * Create a regional WAFv2 web ACL with the default AWS managed rule groups,
+   * associate it with the gateway, and log blocked/counted requests to
+   * CloudWatch. AWS WAF evaluates every inbound request inline before it
+   * reaches a target; when no web ACL is associated there is zero overhead.
+   *
+   * The failure mode (how the gateway behaves when AWS WAF cannot be
+   * evaluated) defaults to the service's security-first `FAIL_CLOSE`. It is a
+   * control-plane-only setting, not exposed through CloudFormation.
+   */
+  private createWebAcl(): wafv2.CfnWebACL {
+    const metricPrefix = cdk.Names.uniqueResourceName(this, { maxLength: 40 });
+
+    const webAcl = new wafv2.CfnWebACL(this, 'WebAcl', {
+      defaultAction: { allow: {} },
+      // AgentCore Gateway requires a REGIONAL web ACL in the gateway's region;
+      // CloudFront (global) web ACLs are not supported.
+      scope: 'REGIONAL',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: `${metricPrefix}WebAcl`,
+        sampledRequestsEnabled: true,
+      },
+      rules: [
+        {
+          name: 'CRSRule',
+          priority: 0,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesCommonRuleSet',
+              vendorName: 'AWS',
+              // Count instead of Block: the CRS 8 KB body limit is too
+              // restrictive for typical MCP tool payloads.
+              ruleActionOverrides: [
+                {
+                  name: 'SizeRestrictions_BODY',
+                  actionToUse: { count: {} },
+                },
+              ],
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: `${metricPrefix}WebAcl-CRS`,
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
+        {
+          name: 'KnownBadInputsRule',
+          priority: 1,
+          statement: {
+            managedRuleGroupStatement: {
+              name: 'AWSManagedRulesKnownBadInputsRuleSet',
+              vendorName: 'AWS',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: `${metricPrefix}WebAcl-KnownBadInputs`,
+            sampledRequestsEnabled: true,
+          },
+          overrideAction: {
+            none: {},
+          },
+        },
+      ],
+    });
+
+    new wafv2.CfnWebACLAssociation(this, 'WebAclAssociation', {
+      resourceArn: this.gateway.gatewayArn,
+      webAclArn: webAcl.attrArn,
+    });
+
+    // Send WAF request logs to CloudWatch. The log group name must start with
+    // `aws-waf-logs-` to satisfy the WAFv2 logging destination requirement.
+    const logsKey = new kms.Key(this, 'WebAclLogsKey', {
+      enableKeyRotation: true,
+    });
+    logsKey.grantEncryptDecrypt(
+      new iam.ServicePrincipal(
+        `logs.${cdk.Stack.of(this).region}.amazonaws.com`,
+      ),
+    );
+    const wafLogGroup = new logs.LogGroup(this, 'WebAclLogs', {
+      logGroupName: `aws-waf-logs-${metricPrefix}-${this.node.addr.slice(-8)}`,
+      retention: logs.RetentionDays.ONE_YEAR,
+      encryptionKey: logsKey,
+    });
+
+    new wafv2.CfnLoggingConfiguration(this, 'WebAclLoggingConfig', {
+      resourceArn: webAcl.attrArn,
+      logDestinationConfigs: [wafLogGroup.logGroupArn],
+    });
+
+    return webAcl;
   }
 
   /**

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
@@ -28,15 +28,8 @@ export interface AgentCoreGatewayProps {
    */
   readonly cedarPolicyVariables?: Record<string, string>;
   /**
-   * Whether to create an AWS WAFv2 web ACL with the default managed rule
-   * groups (`AWSManagedRulesCommonRuleSet` and
-   * `AWSManagedRulesKnownBadInputsRuleSet`) and associate it with the
-   * gateway. AWS WAF inspects every inbound request before it reaches a
-   * target, protecting the gateway from web exploits, bot traffic, and
-   * volumetric attacks.
-   *
-   * The web ACL is `REGIONAL` and created in the gateway's region, as
-   * required for AgentCore Gateway associations.
+   * Associate a regional WAFv2 web ACL (default AWS managed rule groups) with
+   * the gateway to inspect inbound requests.
    *
    * @default true
    */
@@ -60,10 +53,8 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     super(scope, id);
 
     this.gateway = new agentcore.Gateway(this, 'Gateway', {
-      // AgentCore appends an 11-character suffix to the gateway name to form
-      // the gateway id, which must not exceed 50 characters. The Gateway L2
-      // otherwise defaults the name to a 48-character generated string, so the
-      // id overflows. Cap the name at 39 characters (39 + 11 = 50) instead.
+      // Cap at 39 chars so the 11-char service suffix keeps the gateway id
+      // within its 50-char limit.
       gatewayName: cdk.Names.uniqueResourceName(this, { maxLength: 39 }),
       protocolConfiguration: new agentcore.McpProtocolConfiguration({
         searchType: agentcore.McpGatewaySearchType.SEMANTIC,
@@ -160,21 +151,15 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
 
   /**
    * Create a regional WAFv2 web ACL with the default AWS managed rule groups,
-   * associate it with the gateway, and log blocked/counted requests to
-   * CloudWatch. AWS WAF evaluates every inbound request inline before it
-   * reaches a target; when no web ACL is associated there is zero overhead.
-   *
-   * The failure mode (how the gateway behaves when AWS WAF cannot be
-   * evaluated) defaults to the service's security-first `FAIL_CLOSE`. It is a
-   * control-plane-only setting, not exposed through CloudFormation.
+   * associate it with the gateway, and log requests to CloudWatch.
    */
   private createWebAcl(): wafv2.CfnWebACL {
     const metricPrefix = cdk.Names.uniqueResourceName(this, { maxLength: 40 });
 
     const webAcl = new wafv2.CfnWebACL(this, 'WebAcl', {
       defaultAction: { allow: {} },
-      // AgentCore Gateway requires a REGIONAL web ACL in the gateway's region;
-      // CloudFront (global) web ACLs are not supported.
+      // AgentCore Gateway requires a REGIONAL web ACL; CloudFront (global) is
+      // not supported.
       scope: 'REGIONAL',
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
@@ -234,8 +219,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
       webAclArn: webAcl.attrArn,
     });
 
-    // Send WAF request logs to CloudWatch. The log group name must start with
-    // `aws-waf-logs-` to satisfy the WAFv2 logging destination requirement.
+    // WAFv2 logging destination requires the `aws-waf-logs-` name prefix.
     const logsKey = new kms.Key(this, 'WebAclLogsKey', {
       enableKeyRotation: true,
     });

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -34,6 +34,12 @@ variable "tool_dependencies" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_waf" {
+  description = "Whether to create an AWS WAFv2 web ACL with the default managed rule groups (AWSManagedRulesCommonRuleSet and AWSManagedRulesKnownBadInputsRuleSet) and associate it with the gateway. AWS WAF inspects every inbound request before it reaches a target. The web ACL is REGIONAL and created in the gateway's region, as required for AgentCore Gateway associations."
+  type        = bool
+  default     = true
+}
 <%_ if (cedarPolicy) { _%>
 
 variable "policy_dependencies" {
@@ -141,7 +147,11 @@ resource "aws_bedrockagentcore_policy_engine" "this" {
 <%_ } _%>
 
 resource "aws_bedrockagentcore_gateway" "this" {
-  name        = "<%- nameClassName %>-${random_id.unique_suffix.hex}"
+  # AgentCore appends an 11-character suffix to the gateway name to form the
+  # gateway id, which must not exceed 50 characters. With the "-<8 hex>"
+  # suffix below, cap the name at 39 characters (39 + 11 = 50) by truncating
+  # the class-name prefix to 30 characters.
+  name        = "${substr("<%- nameClassName %>", 0, 30)}-${random_id.unique_suffix.hex}"
   description = "AgentCore Gateway for <%- nameClassName %>"
   role_arn    = aws_iam_role.gateway_role.arn
 
@@ -163,6 +173,111 @@ resource "aws_bedrockagentcore_gateway" "this" {
 
   depends_on = [aws_iam_role_policy.gateway_role_policy]
 <%_ } _%>
+}
+
+# AWS WAFv2 protection for the gateway. AWS WAF inspects every inbound request
+# inline before it reaches a target. AgentCore Gateway requires a REGIONAL web
+# ACL in the gateway's region; CloudFront (global) web ACLs are not supported.
+# The failure mode (behaviour when AWS WAF cannot be evaluated) defaults to the
+# service's security-first FAIL_CLOSE and is a control-plane-only setting.
+resource "aws_wafv2_web_acl" "gateway_waf" {
+  #checkov:skip=CKV2_AWS_31:Logging configuration is defined below in aws_wafv2_web_acl_logging_configuration.gateway_waf_logging; Checkov does not resolve the separate resource
+  count = var.enable_waf ? 1 : 0
+
+  name  = "<%- nameClassName %>-waf-${random_id.unique_suffix.hex}"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "CRSRule"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        # Count instead of Block: the CRS 8 KB body limit is too restrictive
+        # for typical MCP tool payloads.
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "<%- nameClassName %>WebAcl-CRS"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KnownBadInputsRule"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "<%- nameClassName %>WebAcl-KnownBadInputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "<%- nameClassName %>WebAcl"
+    sampled_requests_enabled   = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "gateway_waf" {
+  count = var.enable_waf ? 1 : 0
+
+  resource_arn = aws_bedrockagentcore_gateway.this.gateway_arn
+  web_acl_arn  = aws_wafv2_web_acl.gateway_waf[0].arn
+}
+
+# CloudWatch Log Group for WAF request logs. Name must start with
+# `aws-waf-logs-`.
+resource "aws_cloudwatch_log_group" "gateway_waf_logs" {
+  #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
+  #checkov:skip=CKV_AWS_338:Log retention set to one year which is sufficient for WAF logs
+  count = var.enable_waf ? 1 : 0
+
+  name              = "aws-waf-logs-<%- nameKebabCase %>-${random_id.unique_suffix.hex}"
+  retention_in_days = 365
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "gateway_waf_logging" {
+  count = var.enable_waf ? 1 : 0
+
+  log_destination_configs = [aws_cloudwatch_log_group.gateway_waf_logs[0].arn]
+  resource_arn            = aws_wafv2_web_acl.gateway_waf[0].arn
 }
 <%_ if (cedarPolicy) { _%>
 
@@ -332,4 +447,9 @@ output "gateway_url" {
 output "gateway_role_arn" {
   description = "ARN of the IAM role assumed by the gateway service"
   value       = aws_iam_role.gateway_role.arn
+}
+
+output "waf_web_acl_arn" {
+  description = "ARN of the WAFv2 web ACL associated with the gateway, or null if WAF is disabled"
+  value       = var.enable_waf ? aws_wafv2_web_acl.gateway_waf[0].arn : null
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -36,7 +36,7 @@ variable "tool_dependencies" {
 }
 
 variable "enable_waf" {
-  description = "Whether to create an AWS WAFv2 web ACL with the default managed rule groups (AWSManagedRulesCommonRuleSet and AWSManagedRulesKnownBadInputsRuleSet) and associate it with the gateway. AWS WAF inspects every inbound request before it reaches a target. The web ACL is REGIONAL and created in the gateway's region, as required for AgentCore Gateway associations."
+  description = "Associate a regional WAFv2 web ACL (default AWS managed rule groups) with the gateway to inspect inbound requests."
   type        = bool
   default     = true
 }
@@ -147,10 +147,8 @@ resource "aws_bedrockagentcore_policy_engine" "this" {
 <%_ } _%>
 
 resource "aws_bedrockagentcore_gateway" "this" {
-  # AgentCore appends an 11-character suffix to the gateway name to form the
-  # gateway id, which must not exceed 50 characters. With the "-<8 hex>"
-  # suffix below, cap the name at 39 characters (39 + 11 = 50) by truncating
-  # the class-name prefix to 30 characters.
+  # Cap the name so the 11-char service suffix keeps the gateway id within its
+  # 50-char limit (30 prefix + "-<8 hex>" + 11 = 50).
   name        = "${substr("<%- nameClassName %>", 0, 30)}-${random_id.unique_suffix.hex}"
   description = "AgentCore Gateway for <%- nameClassName %>"
   role_arn    = aws_iam_role.gateway_role.arn
@@ -175,11 +173,8 @@ resource "aws_bedrockagentcore_gateway" "this" {
 <%_ } _%>
 }
 
-# AWS WAFv2 protection for the gateway. AWS WAF inspects every inbound request
-# inline before it reaches a target. AgentCore Gateway requires a REGIONAL web
-# ACL in the gateway's region; CloudFront (global) web ACLs are not supported.
-# The failure mode (behaviour when AWS WAF cannot be evaluated) defaults to the
-# service's security-first FAIL_CLOSE and is a control-plane-only setting.
+# WAFv2 protection for the gateway. AgentCore Gateway requires a REGIONAL web
+# ACL; CloudFront (global) is not supported.
 resource "aws_wafv2_web_acl" "gateway_waf" {
   #checkov:skip=CKV2_AWS_31:Logging configuration is defined below in aws_wafv2_web_acl_logging_configuration.gateway_waf_logging; Checkov does not resolve the separate resource
   count = var.enable_waf ? 1 : 0
@@ -262,8 +257,7 @@ resource "aws_wafv2_web_acl_association" "gateway_waf" {
   web_acl_arn  = aws_wafv2_web_acl.gateway_waf[0].arn
 }
 
-# CloudWatch Log Group for WAF request logs. Name must start with
-# `aws-waf-logs-`.
+# WAF request logs. WAFv2 requires the `aws-waf-logs-` name prefix.
 resource "aws_cloudwatch_log_group" "gateway_waf_logs" {
   #checkov:skip=CKV_AWS_158:Using default CloudWatch log encryption
   #checkov:skip=CKV_AWS_338:Log retention set to one year which is sufficient for WAF logs


### PR DESCRIPTION
### Reason for this change

AWS WAF support for Amazon Bedrock AgentCore Gateway became generally available (June 2026). AgentCore Gateways expose an internet-facing MCP endpoint, so — consistent with how the REST API generators already ship a WAF Web ACL by default — the gateway generator should protect the gateway with AWS WAF out of the box.

### Description of changes

- **WAF by default (CDK + Terraform):** the generated `AgentCoreGateway` construct and Terraform module now associate a `REGIONAL` AWS WAFv2 Web ACL with the gateway, using the AWS managed default ruleset (`AWSManagedRulesCommonRuleSet` with `SizeRestrictions_BODY` set to `Count`, and `AWSManagedRulesKnownBadInputsRuleSet`), with request logging to a CloudWatch Logs group. This mirrors the existing REST API WAF pattern.
  - Opt out via `enableWaf: false` (CDK) / `enable_waf = false` (Terraform). The CDK construct exposes the Web ACL as `webAcl`; the Terraform module outputs `waf_web_acl_arn`.
  - The `wafConfiguration` failure mode defaults to the service's security-first `FAIL_CLOSE` and is a control-plane-only setting (not exposed via CloudFormation/Terraform).
- **Gateway name cap:** AgentCore appends an 11-character suffix to the gateway name to form the gateway id (max 50 chars). The Gateway L2 otherwise defaults to a 48-char name, overflowing the id. The name is now capped so `name + 11 <= 50` in both the CDK construct (`maxLength: 39`) and the Terraform module (`substr(..., 0, 30)`).
- **Docs:** reworked the AWS WAF section of the gateway guide to match the shared API WAF docs' style and verbosity, and added a d2 architecture diagram (Client → WAF → AgentCore Gateway → downstream MCP server targets, with WAF logs to CloudWatch).

### Description of how you validated changes

- Added unit tests to `agentcore-gateway/generator.spec.ts` covering the WAF wiring (CDK + Terraform) and the gateway-name cap (46/46 pass).
- End-to-end in a generated workspace (via a local verdaccio registry): built the workspace, deployed **both** a CDK and a Terraform gateway to AWS, confirmed the WAF Web ACL is associated with the gateway (`aws wafv2 list-resources-for-web-acl` returns the gateway ARN), and confirmed an authorized SigV4 MCP `tools/list` call passes through WAF to the gateway. Verified the gateway id stays within the 50-char limit. Tore down all AWS resources afterward.
- `nx run docs:build` succeeds and the rendered page includes the reworked WAF section and the compiled architecture diagram.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*