### PR TITLE
fix(ts#rdb): connect postgres migrations to the cluster directly and stop container on log-stream exit

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -68,7 +68,7 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
       [
         \`CREATE USER IF NOT EXISTS \${quotedUser}@\${quotedHost} IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'\`,
         \`ALTER USER \${quotedUser}@\${quotedHost} IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS' REQUIRE SSL\`,
-        \`GRANT ALL PRIVILEGES ON \${quotedDbName}.* TO \${quotedUser}@\${quotedHost}\`,
+        \`GRANT SELECT, INSERT, UPDATE, DELETE ON \${quotedDbName}.* TO \${quotedUser}@\${quotedHost}\`,
       ].join(';\\n'),
     );
   } finally {
@@ -706,32 +706,19 @@ export abstract class AuroraDatabase extends Construct {
       timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
-      environment:
-        engine.type === 'mysql'
-          ? {
-              DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
-            }
-          : {
-              HOSTNAME: databaseHostname,
-              DATABASE: databaseName,
-              PORT: databasePort.toString(),
-              DBUSER: this.dbUser,
-            },
+      environment: {
+        DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
+      },
       architecture: Architecture.ARM_64,
     });
 
-    if (engine.type === 'mysql') {
-      this.cluster.connections.allowDefaultPortFrom(migrationHandler);
-      this.grantSecretRead(migrationHandler);
-    } else {
-      this.allowDefaultPortFrom(migrationHandler);
-      this.grantConnect(migrationHandler);
-    }
+    this.cluster.connections.allowDefaultPortFrom(migrationHandler);
+    this.grantSecretRead(migrationHandler);
 
-    const trigger = new Trigger(this, 'MigrationTrigger', {
+    const migrationTrigger = new Trigger(this, 'MigrationTrigger', {
       handler: migrationHandler,
     });
-    trigger.node.addDependency(createDbUserResource);
+    migrationTrigger.node.addDependency(createDbUserResource);
 
     new CfnOutput(this, 'ClusterEndpoint', {
       value: this.cluster.clusterEndpoint.hostname,
@@ -1909,11 +1896,16 @@ resource "aws_iam_role_policy" "migration_handler_access" {
       {
         Effect = "Allow"
         Action = [
-          "rds-db:connect"
+          "secretsmanager:GetSecretValue"
         ]
-        Resource = [
-          "arn:aws:rds-db:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:dbuser:\${var.enable_rds_proxy ? module.aurora.proxy_resource_id : module.aurora.cluster_resource_id}/\${local.database_runtime_user}"
+        Resource = [module.aurora.secret_arn]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt"
         ]
+        Resource = [module.aurora.kms_key_arn]
       }
     ]
   })
@@ -2002,7 +1994,7 @@ resource "aws_security_group" "migration_handler" {
 
 resource "aws_vpc_security_group_egress_rule" "migration_handler_to_database" {
   security_group_id            = aws_security_group.migration_handler.id
-  referenced_security_group_id = module.aurora.security_group_id
+  referenced_security_group_id = module.aurora.database_security_group_id
   from_port   = module.aurora.cluster_port
   to_port     = module.aurora.cluster_port
   ip_protocol = "tcp"
@@ -2044,7 +2036,7 @@ resource "aws_vpc_security_group_egress_rule" "create_db_user_https" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "migration_handler_to_database" {
-  security_group_id            = module.aurora.security_group_id
+  security_group_id            = module.aurora.database_security_group_id
   referenced_security_group_id = aws_security_group.migration_handler.id
   from_port                    = module.aurora.cluster_port
   to_port                      = module.aurora.cluster_port
@@ -2165,10 +2157,7 @@ resource "aws_lambda_function" "migration_handler" {
 
   environment {
     variables = {
-      HOSTNAME = module.aurora.cluster_endpoint
-      DATABASE = module.aurora.database_name
-      PORT     = tostring(module.aurora.cluster_port)
-      DBUSER   = local.database_runtime_user
+      DATABASE_SECRET_ARN = module.aurora.secret_arn
     }
   }
 
@@ -3841,14 +3830,12 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
 
     await client.query(
       \`ALTER ROLE \${quotedDbUser} WITH LOGIN;
-      GRANT ALL PRIVILEGES ON DATABASE \${quotedDbName} TO \${quotedDbUser};
-      GRANT USAGE, CREATE ON SCHEMA public TO \${quotedDbUser};
-      GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \${quotedDbUser};
-      GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO \${quotedDbUser};
-      GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO \${quotedDbUser};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \${quotedDbUser};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO \${quotedDbUser};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON FUNCTIONS TO \${quotedDbUser};
+      GRANT CONNECT ON DATABASE \${quotedDbName} TO \${quotedDbUser};
+      GRANT USAGE ON SCHEMA public TO \${quotedDbUser};
+      GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \${quotedDbUser};
+      GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \${quotedDbUser};
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \${quotedDbUser};
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO \${quotedDbUser};
       GRANT rds_iam TO \${quotedDbUser};\`,
     );
 
@@ -3890,28 +3877,16 @@ exports[`ts#rdb generator > should generate the aurora shared construct > packag
 exports[`ts#rdb generator > should generate the aurora shared construct > packages/db/src/migration-handler.ts 1`] = `
 "import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { Signer } from '@aws-sdk/rds-signer';
-import { withConnectionRetry } from './utils.js';
+import { getDatabaseSecret, withConnectionRetry } from './utils.js';
 
 const buildDatabaseUrl = async (): Promise<string> => {
-  const hostname = process.env.HOSTNAME!;
-  const port = process.env.PORT!;
-  const database = process.env.DATABASE!;
-  const dbUser = process.env.DBUSER!;
-  const region = process.env.AWS_REGION!;
-
-  const iamAuthToken = await new Signer({
-    hostname,
-    port: Number(port),
-    region,
-    username: dbUser,
-  }).getAuthToken();
+  const { host, port, dbname, username, password } = await getDatabaseSecret();
 
   return (
-    \`postgresql://\${encodeURIComponent(dbUser)}\` +
-    \`:\${encodeURIComponent(iamAuthToken)}\` +
-    \`@\${hostname}:\${port}/\${database}\` +
-    \`?sslaccept=strict\` // \`sslaccept\` is the correct parameter here for postgresql. The Prisma CLI Rust engine does not use the standard libpq \`sslmode\` option.
+    \`postgresql://\${encodeURIComponent(username)}\` +
+    \`:\${encodeURIComponent(password)}\` +
+    \`@\${host}:\${port}/\${dbname}\` +
+    \`?sslaccept=strict\`
   );
 };
 
@@ -4515,32 +4490,19 @@ export abstract class AuroraDatabase extends Construct {
       timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
-      environment:
-        engine.type === 'mysql'
-          ? {
-              DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
-            }
-          : {
-              HOSTNAME: databaseHostname,
-              DATABASE: databaseName,
-              PORT: databasePort.toString(),
-              DBUSER: this.dbUser,
-            },
+      environment: {
+        DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
+      },
       architecture: Architecture.ARM_64,
     });
 
-    if (engine.type === 'mysql') {
-      this.cluster.connections.allowDefaultPortFrom(migrationHandler);
-      this.grantSecretRead(migrationHandler);
-    } else {
-      this.allowDefaultPortFrom(migrationHandler);
-      this.grantConnect(migrationHandler);
-    }
+    this.cluster.connections.allowDefaultPortFrom(migrationHandler);
+    this.grantSecretRead(migrationHandler);
 
-    const trigger = new Trigger(this, 'MigrationTrigger', {
+    const migrationTrigger = new Trigger(this, 'MigrationTrigger', {
       handler: migrationHandler,
     });
-    trigger.node.addDependency(createDbUserResource);
+    migrationTrigger.node.addDependency(createDbUserResource);
 
     new CfnOutput(this, 'ClusterEndpoint', {
       value: this.cluster.clusterEndpoint.hostname,

--- a/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/create-db-user-handler.ts.template
@@ -49,7 +49,7 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
       [
         `CREATE USER IF NOT EXISTS ${quotedUser}@${quotedHost} IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'`,
         `ALTER USER ${quotedUser}@${quotedHost} IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS' REQUIRE SSL`,
-        `GRANT ALL PRIVILEGES ON ${quotedDbName}.* TO ${quotedUser}@${quotedHost}`,
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON ${quotedDbName}.* TO ${quotedUser}@${quotedHost}`,
       ].join(';\n'),
     );
   } finally {
@@ -87,14 +87,12 @@ const ensureDatabaseUser = async (dbUser: string): Promise<void> => {
 
     await client.query(
       `ALTER ROLE ${quotedDbUser} WITH LOGIN;
-      GRANT ALL PRIVILEGES ON DATABASE ${quotedDbName} TO ${quotedDbUser};
-      GRANT USAGE, CREATE ON SCHEMA public TO ${quotedDbUser};
-      GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ${quotedDbUser};
-      GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ${quotedDbUser};
-      GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO ${quotedDbUser};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO ${quotedDbUser};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO ${quotedDbUser};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON FUNCTIONS TO ${quotedDbUser};
+      GRANT CONNECT ON DATABASE ${quotedDbName} TO ${quotedDbUser};
+      GRANT USAGE ON SCHEMA public TO ${quotedDbUser};
+      GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${quotedDbUser};
+      GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${quotedDbUser};
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${quotedDbUser};
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO ${quotedDbUser};
       GRANT rds_iam TO ${quotedDbUser};`,
     );
 

--- a/packages/nx-plugin/src/ts/rdb/files/src/migration-handler.ts.template
+++ b/packages/nx-plugin/src/ts/rdb/files/src/migration-handler.ts.template
@@ -1,43 +1,16 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-<%_ if (engine === 'mysql') { _%>
 import { getDatabaseSecret, withConnectionRetry } from './utils.js';
-<%_ } else { _%>
-import { Signer } from '@aws-sdk/rds-signer';
-import { withConnectionRetry } from './utils.js';
-<%_ } _%>
 
 const buildDatabaseUrl = async (): Promise<string> => {
-<%_ if (engine === 'mysql') { _%>
   const { host, port, dbname, username, password } = await getDatabaseSecret();
 
   return (
-    `mysql://${encodeURIComponent(username)}` +
+    `<%= engine === 'mysql' ? 'mysql' : 'postgresql' %>://${encodeURIComponent(username)}` +
     `:${encodeURIComponent(password)}` +
     `@${host}:${port}/${dbname}` +
     `?sslaccept=strict`
   );
-<%_ } else { _%>
-  const hostname = process.env.HOSTNAME!;
-  const port = process.env.PORT!;
-  const database = process.env.DATABASE!;
-  const dbUser = process.env.DBUSER!;
-  const region = process.env.AWS_REGION!;
-
-  const iamAuthToken = await new Signer({
-    hostname,
-    port: Number(port),
-    region,
-    username: dbUser,
-  }).getAuthToken();
-
-  return (
-    `postgresql://${encodeURIComponent(dbUser)}` +
-    `:${encodeURIComponent(iamAuthToken)}` +
-    `@${hostname}:${port}/${database}` +
-    `?sslaccept=strict` // `sslaccept` is the correct parameter here for postgresql. The Prisma CLI Rust engine does not use the standard libpq `sslmode` option.
-  );
-<%_ } _%>
 };
 
 export const handler = async () => {

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -127,10 +127,7 @@ export const tsRdbGenerator = async (
     templateOptions,
   );
   updateGitIgnore(tree, dir, (patterns) => [...patterns, 'generated/prisma']);
-  await sharedRdbScriptsGenerator(
-    tree,
-    options.engine === 'mysql' ? 'mysql' : 'postgres',
-  );
+  await sharedRdbScriptsGenerator(tree, options.engine);
   const waitForDbScript =
     options.engine === 'mysql'
       ? 'wait-for-mysql-db.ts'
@@ -266,7 +263,7 @@ export const tsRdbGenerator = async (
       databasePackageAlias: toScopeAlias(fullyQualifiedName),
       databaseName,
       adminUser: databaseUser,
-      engine: options.engine === 'mysql' ? 'mysql' : 'postgres',
+      engine: options.engine,
       migrationBundleDir,
       createDbUserBundleDir: joinPathFragments(
         'dist',

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/rdb/shared/start-container.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/rdb/shared/start-container.ts.template
@@ -112,6 +112,6 @@ process.on("SIGTERM", cleanup);
 process.on("SIGINT", cleanup);
 process.on("SIGHUP", cleanup);
 
-logs.on("exit", (code) => {
-  if (!exiting) process.exit(code ?? 0);
+logs.on("exit", () => {
+  if (!exiting) cleanup();
 });

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
@@ -350,29 +350,19 @@ export abstract class AuroraDatabase extends Construct {
       timeout: Duration.minutes(5),
       tracing: Tracing.ACTIVE,
       vpc,
-      environment: engine.type === 'mysql' ? {
+      environment: {
         DATABASE_SECRET_ARN: this.cluster.secret!.secretArn,
-      } : {
-        HOSTNAME: databaseHostname,
-        DATABASE: databaseName,
-        PORT: databasePort.toString(),
-        DBUSER: this.dbUser,
       },
       architecture: Architecture.ARM_64,
     });
 
-    if (engine.type === 'mysql') {
-      this.cluster.connections.allowDefaultPortFrom(migrationHandler);
-      this.grantSecretRead(migrationHandler);
-    } else {
-      this.allowDefaultPortFrom(migrationHandler);
-      this.grantConnect(migrationHandler);
-    }
+    this.cluster.connections.allowDefaultPortFrom(migrationHandler);
+    this.grantSecretRead(migrationHandler);
 
-    const trigger = new Trigger(this, 'MigrationTrigger', {
+    const migrationTrigger = new Trigger(this, 'MigrationTrigger', {
       handler: migrationHandler,
     });
-    trigger.node.addDependency(createDbUserResource);
+    migrationTrigger.node.addDependency(createDbUserResource);
 
     new CfnOutput(this, 'ClusterEndpoint', {
       value: this.cluster.clusterEndpoint.hostname,

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -347,7 +347,6 @@ resource "aws_iam_role_policy" "migration_handler_access" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
-<%_ if (engine === 'mysql') { _%>
       {
         Effect = "Allow"
         Action = [
@@ -362,17 +361,6 @@ resource "aws_iam_role_policy" "migration_handler_access" {
         ]
         Resource = [module.aurora.kms_key_arn]
       }
-<%_ } else { _%>
-      {
-        Effect = "Allow"
-        Action = [
-          "rds-db:connect"
-        ]
-        Resource = [
-          "arn:aws:rds-db:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:dbuser:${var.enable_rds_proxy ? module.aurora.proxy_resource_id : module.aurora.cluster_resource_id}/${local.database_runtime_user}"
-        ]
-      }
-<%_ } _%>
     ]
   })
 }
@@ -459,13 +447,8 @@ resource "aws_security_group" "migration_handler" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "migration_handler_to_database" {
-<%_ if (engine === 'mysql') { _%>
   security_group_id            = aws_security_group.migration_handler.id
   referenced_security_group_id = module.aurora.database_security_group_id
-<%_ } else { _%>
-  security_group_id            = aws_security_group.migration_handler.id
-  referenced_security_group_id = module.aurora.security_group_id
-<%_ } _%>
   from_port   = module.aurora.cluster_port
   to_port     = module.aurora.cluster_port
   ip_protocol = "tcp"
@@ -507,11 +490,7 @@ resource "aws_vpc_security_group_egress_rule" "create_db_user_https" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "migration_handler_to_database" {
-<%_ if (engine === 'mysql') { _%>
   security_group_id            = module.aurora.database_security_group_id
-<%_ } else { _%>
-  security_group_id            = module.aurora.security_group_id
-<%_ } _%>
   referenced_security_group_id = aws_security_group.migration_handler.id
   from_port                    = module.aurora.cluster_port
   to_port                      = module.aurora.cluster_port
@@ -632,14 +611,7 @@ resource "aws_lambda_function" "migration_handler" {
 
   environment {
     variables = {
-<%_ if (engine === 'mysql') { _%>
       DATABASE_SECRET_ARN = module.aurora.secret_arn
-<%_ } else { _%>
-      HOSTNAME = module.aurora.cluster_endpoint
-      DATABASE = module.aurora.database_name
-      PORT     = tostring(module.aurora.cluster_port)
-      DBUSER   = local.database_runtime_user
-<%_ } _%>
     }
   }
 


### PR DESCRIPTION
### Reason for this change

- Postgres migrations connected through the RDS Proxy using the app user's IAM credentials, while MySQL migrations already connected directly to the cluster with the admin secret. This inconsistency had no real justification.
- `dbUser` should only ever be used by the API, not by migrations. Because it also had to run Postgres migrations, it was granted far more privileges than the API itself needs (`ALL PRIVILEGES` on database/tables/sequences/functions, plus schema `CREATE`).
- Migrations now always run as admin via `DATABASE_SECRET_ARN`, so `dbUser` no longer needs DDL-level access and can be scoped down to basic CRUD.
- The `logs.on("exit")` handler in `start-container.ts.template` was introduced before `cleanup()` existed, just to exit the script if the container died or crashed. It was never updated to actually clean up the container. Since the `logs -f` child shares the terminal's signal group, a Ctrl+C can also reach it directly, racing with the parent's `SIGINT` handler. If `logs.on("exit")` won that race it exited the script directly, leaving the container running.

### Description of changes

- Unified migration handler (CDK + Terraform) to always connect to the cluster directly via the admin secret, regardless of engine.
- Trimmed the API `dbUser`'s database grants down to basic CRUD.
- `logs.on("exit")` now calls `cleanup()` instead of `process.exit(code)`.

### Description of how you validated changes

Unit tests.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*