### PR TITLE
docs(agent): add security best practices caution to agentcore guides

### DIFF
--- a/docs/src/content/docs/en/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/en/snippets/agent/bedrock-deployment.mdx
@@ -170,3 +170,7 @@ module "my_project_agent" {
 :::note[Custom OIDC Providers]
 If you require custom JWT authentication with a non-Cognito OIDC provider, you can modify the generated CDK construct or Terraform module for your agent directly. Note that the connection generator will only support `IAM` or `Cognito` authentication.
 :::
+
+:::caution[Security Best Practices]
+When implementing your agent's business logic, review the [Bedrock AgentCore Runtime security best practices](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/en/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/en/snippets/mcp/bedrock-deployment.mdx
@@ -165,3 +165,7 @@ module "my_project_mcp_server" {
 :::note[Custom OIDC Providers]
 If you require custom JWT authentication with a non-Cognito OIDC provider, you can modify the generated CDK construct or Terraform module for your MCP server directly. Note that the connection generator will only support `IAM` or `Cognito` authentication.
 :::
+
+:::caution[Security Best Practices]
+When implementing your MCP server's business logic, review the [Bedrock AgentCore Runtime security best practices](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/es/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/es/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[Proveedores OIDC personalizados]
 Si requieres autenticación JWT personalizada con un proveedor OIDC que no sea Cognito, puedes modificar directamente la construcción CDK o el módulo Terraform generado para tu agente. Ten en cuenta que el generador de conexión solo admitirá autenticación `IAM` o `Cognito`.
 :::
+
+:::caution[Mejores Prácticas de Seguridad]
+Al implementar la lógica de negocio de tu agente, revisa las [mejores prácticas de seguridad de Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/es/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/es/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[Proveedores OIDC personalizados]
 Si requieres autenticación JWT personalizada con un proveedor OIDC que no sea Cognito, puedes modificar directamente el constructo CDK generado o el módulo Terraform para tu servidor MCP. Ten en cuenta que el generador de conexiones solo admitirá autenticación `IAM` o `Cognito`.
 :::
+
+:::caution[Mejores prácticas de seguridad]
+Al implementar la lógica de negocio de tu servidor MCP, revisa las [mejores prácticas de seguridad de Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/fr/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/fr/snippets/agent/bedrock-deployment.mdx
@@ -170,3 +170,7 @@ module "my_project_agent" {
 :::note[Fournisseurs OIDC personnalisés]
 Si vous avez besoin d'une authentification JWT personnalisée avec un fournisseur OIDC non-Cognito, vous pouvez modifier directement le construct CDK ou le module Terraform généré pour votre agent. Notez que le générateur de connexion ne prendra en charge que l'authentification `IAM` ou `Cognito`.
 :::
+
+:::caution[Bonnes pratiques de sécurité]
+Lors de l'implémentation de la logique métier de votre agent, consultez les [bonnes pratiques de sécurité Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/fr/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/fr/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[Fournisseurs OIDC personnalisés]
 Si vous avez besoin d'une authentification JWT personnalisée avec un fournisseur OIDC non-Cognito, vous pouvez modifier directement le construct CDK ou le module Terraform généré pour votre serveur MCP. Notez que le générateur de connexion ne prendra en charge que l'authentification `IAM` ou `Cognito`.
 :::
+
+:::caution[Bonnes pratiques de sécurité]
+Lors de l'implémentation de la logique métier de votre serveur MCP, consultez les [bonnes pratiques de sécurité Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/it/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/it/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[Provider OIDC personalizzati]
 Se hai bisogno di autenticazione JWT personalizzata con un provider OIDC non-Cognito, puoi modificare direttamente il costrutto CDK o il modulo Terraform generato per il tuo agent. Nota che il generatore di connessioni supporterà solo l'autenticazione `IAM` o `Cognito`.
 :::
+
+:::caution[Best Practice di Sicurezza]
+Quando implementi la logica di business del tuo agent, rivedi le [best practice di sicurezza di Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/it/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/it/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[Provider OIDC personalizzati]
 Se hai bisogno di un'autenticazione JWT personalizzata con un provider OIDC non-Cognito, puoi modificare direttamente il costrutto CDK o il modulo Terraform generato per il tuo server MCP. Nota che il generatore di connessione supporterà solo l'autenticazione `IAM` o `Cognito`.
 :::
+
+:::caution[Best Practice di Sicurezza]
+Quando implementi la logica di business del tuo server MCP, rivedi le [best practice di sicurezza di Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/jp/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/jp/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[カスタムOIDCプロバイダー]
 Cognito以外のOIDCプロバイダーを使用したカスタムJWT認証が必要な場合は、エージェント用に生成されたCDKコンストラクトまたはTerraformモジュールを直接変更できます。なお、接続ジェネレーターは`IAM`または`Cognito`認証のみをサポートします。
 :::
+
+:::caution[セキュリティのベストプラクティス]
+エージェントのビジネスロジックを実装する際は、[Bedrock AgentCore Runtimeセキュリティのベストプラクティス](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)を確認してください。
+:::

--- a/docs/src/content/docs/jp/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/jp/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[カスタムOIDCプロバイダー]
 Cognito以外のOIDCプロバイダーでカスタムJWT認証が必要な場合は、MCPサーバー用に生成されたCDKコンストラクトまたはTerraformモジュールを直接変更できます。ただし、接続ジェネレーターは`IAM`または`Cognito`認証のみをサポートすることに注意してください。
 :::
+
+:::caution[セキュリティのベストプラクティス]
+MCPサーバーのビジネスロジックを実装する際は、[Bedrock AgentCore Runtimeセキュリティのベストプラクティス](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)を確認してください。
+:::

--- a/docs/src/content/docs/ko/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/ko/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[사용자 정의 OIDC 프로바이더]
 Cognito가 아닌 OIDC 공급자를 사용하는 사용자 지정 JWT 인증이 필요한 경우 에이전트에 대해 생성된 CDK 구성 또는 Terraform 모듈을 직접 수정할 수 있습니다. 연결 생성기는 `IAM` 또는 `Cognito` 인증만 지원합니다.
 :::
+
+:::caution[보안 모범 사례]
+에이전트의 비즈니스 로직을 구현할 때 [Bedrock AgentCore Runtime 보안 모범 사례](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)를 검토하세요.
+:::

--- a/docs/src/content/docs/ko/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/ko/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[사용자 정의 OIDC 프로바이더]
 Cognito가 아닌 OIDC 공급자를 사용한 사용자 정의 JWT 인증이 필요한 경우 MCP 서버용으로 생성된 CDK 구성 요소 또는 Terraform 모듈을 직접 수정할 수 있습니다. 연결 생성기는 `IAM` 또는 `Cognito` 인증만 지원한다는 점에 유의하세요.
 :::
+
+:::caution[보안 모범 사례]
+MCP 서버의 비즈니스 로직을 구현할 때 [Bedrock AgentCore Runtime 보안 모범 사례](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)를 검토하세요.
+:::

--- a/docs/src/content/docs/pt/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/pt/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[Provedores OIDC personalizados]
 Se você precisar de autenticação JWT personalizada com um provedor OIDC não-Cognito, você pode modificar o construto CDK gerado ou o módulo Terraform para o seu agente diretamente. Note que o gerador de conexão suportará apenas autenticação `IAM` ou `Cognito`.
 :::
+
+:::caution[Melhores Práticas de Segurança]
+Ao implementar a lógica de negócios do seu agente, revise as [melhores práticas de segurança do Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/pt/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/pt/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[Provedores OIDC personalizados]
 Se você precisar de autenticação JWT personalizada com um provedor OIDC que não seja Cognito, você pode modificar o construto CDK gerado ou o módulo Terraform para seu servidor MCP diretamente. Observe que o gerador de conexão suportará apenas autenticação `IAM` ou `Cognito`.
 :::
+
+:::caution[Melhores Práticas de Segurança]
+Ao implementar a lógica de negócios do seu servidor MCP, revise as [melhores práticas de segurança do Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/vi/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/vi/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[Nhà cung cấp OIDC tùy chỉnh]
 Nếu bạn yêu cầu xác thực JWT tùy chỉnh với nhà cung cấp OIDC không phải Cognito, bạn có thể chỉnh sửa trực tiếp CDK construct hoặc module Terraform được tạo cho agent của mình. Lưu ý rằng trình tạo kết nối sẽ chỉ hỗ trợ xác thực `IAM` hoặc `Cognito`.
 :::
+
+:::caution[Thực hành Bảo mật Tốt nhất]
+Khi triển khai logic nghiệp vụ cho agent của bạn, hãy xem xét [các thực hành bảo mật tốt nhất của Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/vi/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/vi/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[Nhà cung cấp OIDC tùy chỉnh]
 Nếu bạn cần xác thực JWT tùy chỉnh với OIDC provider không phải Cognito, bạn có thể chỉnh sửa trực tiếp CDK construct hoặc Terraform module được tạo cho MCP server của mình. Lưu ý rằng trình tạo kết nối sẽ chỉ hỗ trợ xác thực `IAM` hoặc `Cognito`.
 :::
+
+:::caution[Thực hành tốt nhất về bảo mật]
+Khi triển khai logic nghiệp vụ cho MCP server của bạn, hãy xem xét [các thực hành tốt nhất về bảo mật Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html).
+:::

--- a/docs/src/content/docs/zh/snippets/agent/bedrock-deployment.mdx
+++ b/docs/src/content/docs/zh/snippets/agent/bedrock-deployment.mdx
@@ -171,3 +171,7 @@ module "my_project_agent" {
 :::note[自定义OIDC提供者]
 如果您需要使用非 Cognito OIDC 提供商的自定义 JWT 身份验证，您可以直接修改为您的代理生成的 CDK 构造或 Terraform 模块。请注意，连接生成器仅支持 `IAM` 或 `Cognito` 身份验证。
 :::
+
+:::caution[安全最佳实践]
+在实现代理的业务逻辑时，请查看 [Bedrock AgentCore Runtime 安全最佳实践](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)。
+:::

--- a/docs/src/content/docs/zh/snippets/mcp/bedrock-deployment.mdx
+++ b/docs/src/content/docs/zh/snippets/mcp/bedrock-deployment.mdx
@@ -166,3 +166,7 @@ module "my_project_mcp_server" {
 :::note[自定义OIDC提供者]
 如果您需要使用非 Cognito OIDC 提供商的自定义 JWT 认证，您可以直接修改为 MCP 服务器生成的 CDK 构造或 Terraform 模块。请注意，连接生成器仅支持 `IAM` 或 `Cognito` 认证。
 :::
+
+:::caution[安全最佳实践]
+在实现 MCP 服务器的业务逻辑时，请查阅 [Bedrock AgentCore Runtime 安全最佳实践](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html)。
+:::


### PR DESCRIPTION
### Reason for this change

The generator guides for AgentCore-backed resources (agents and MCP servers) don't point users toward the security best practices they should follow when implementing their own business logic on Bedrock AgentCore Runtime.

### Description of changes

Added a short `:::caution[Security Best Practices]` aside recommending users review the [Bedrock AgentCore Runtime security best practices](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-security-best-practices.html) when implementing their business logic.

The aside was added to the two shared deployment snippets, so it flows through to all four guides (only rendered when the `agentcore` infra option is selected):

- `en/snippets/agent/bedrock-deployment.mdx` — backs the `py#agent` and `ts#agent` guides
- `en/snippets/mcp/bedrock-deployment.mdx` — backs the `py#mcp-server` and `ts#mcp-server` guides

Only the English source was edited; the `translate-docs` workflow will auto-generate the other locales on this PR.

### Description of how you validated changes

Documentation-only change. Verified the snippets are shared across the four target guides and that the aside sits within the `infra: 'agentcore'` filtered deployment section.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*