### PR TITLE
docs: expand CLAUDE.md with contributor guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Instructions for Claude
 
+## Required Reading
+
+Read the following before making changes:
+
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — the authoritative guide for generator idempotency, testing expectations, writing documentation, and the PR process.
+- [Contributing a Generator tutorial](./docs/src/content/docs/en/get_started/tutorials/contribute-generator.mdx) — how to build a generator end to end, including working backwards from a real project to inform the generator changes.
+
 ## Commands
 
 Install dependencies:
@@ -24,10 +31,26 @@ pnpm nx run @aws/nx-plugin:test -u
 
 - Always use `npx -y` (not bare `npx`) to avoid the "Ok to proceed?" prompt hanging in non-interactive environments.
 
+## Code Style
+
+- Keep comments succinct and always describe the current state — never include historical context or changelog-style notes.
+- Comments in generated/template files should be minimal.
+- Use the existing codebase to inform code style, testing style, etc.
+
+## Testing Changes End-to-End
+
+Before raising a PR, validate changed generators in an example workspace using locally compiled versions:
+
+- Consult the Nx Plugin for AWS MCP server (`create-workspace-command`, `list-generators`, `generator-guide`, `general-guidance`) as the baseline for creating workspaces and running generators. Expect deviations driven by the local changes under test.
+- Make the locally compiled packages available to the workspace — either publish them to a local Verdaccio registry, or use `pnpm link`.
+- Create a fresh workspace, then invoke the relevant changed generators with the locally compiled versions.
+- Confirm everything builds and runs locally, including the `dev` target.
+- If the change warrants it, deploy to AWS, test there, then tear down all provisioned resources.
+
 ## Best Practices
 
-- Always ensure the build passes before raising a PR
-- Update snapshots if there are failures due to snapshot changes
-- Use conventional commits, referencing the generator you are working on, eg "feat(ts#project): my commit message"
-- Raise PRs following the PR template
-- Use the existing codebase to inform code style, testing style, etc
+- Always ensure the build passes before raising a PR.
+- Update snapshots if there are failures due to snapshot changes.
+- Use conventional commits, referencing the generator you are working on, eg "feat(ts#project): my commit message".
+- Raise PRs following the PR template.
+- After pushing to a PR, monitor the checks and iterate on any failures until all are green.


### PR DESCRIPTION
### Reason for this change

`CLAUDE.md` gave only a short list of commands and best practices. It didn't point contributors (or agents) at the authoritative contributing guides, nor capture the code-style and end-to-end testing expectations that keep generator changes consistent and validated.

### Description of changes

Expanded `CLAUDE.md` with:

- **Required Reading** section linking to `CONTRIBUTING.md` and the *Contributing a Generator* tutorial (including working backwards from a real project).
- **Code Style** section: succinct, present-state comments; minimal comments in generated/template files.
- **Testing Changes End-to-End** section: consult the Nx Plugin for AWS MCP server as the baseline, make locally compiled packages available (Verdaccio or `pnpm link`), create a workspace and run the changed generators, verify build + `dev` target, and optionally deploy/test/tear down on AWS.
- Minor tidy-ups to the existing Best Practices list, adding a note to monitor PR checks until green.

### Description of how you validated changes

Documentation-only change to `CLAUDE.md`; no code or generators affected. Verified the referenced files/paths exist.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
