### PR TITLE
chore(ts#react-website): link CloudFront docs above CKV_AWS_174 suppression

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -552,6 +552,7 @@ resource "aws_cloudfront_response_headers_policy" "website" {
 
 # CloudFront Distribution
 resource "aws_cloudfront_distribution" "website" {
+  # See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html
   #checkov:skip=CKV_AWS_174:Using CloudFront default certificate which does not support TLS v1.2
   #checkov:skip=CKV_AWS_310:Origin failover not required for single S3 origin static website
   #checkov:skip=CKV_AWS_374:Geo restrictions not required for global web application
@@ -1731,6 +1732,7 @@ export class StaticWebsite extends Construct {
         ],
       },
     );
+    // See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html
     suppressRules(
       this.cloudFrontDistribution,
       ['CKV_AWS_174'],
@@ -3306,6 +3308,7 @@ export class StaticWebsite extends Construct {
         ],
       },
     );
+    // See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html
     suppressRules(
       this.cloudFrontDistribution,
       ['CKV_AWS_174'],
@@ -4808,6 +4811,7 @@ export class StaticWebsite extends Construct {
         ],
       },
     );
+    // See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html
     suppressRules(
       this.cloudFrontDistribution,
       ['CKV_AWS_174'],

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -192,6 +192,7 @@ export class StaticWebsite extends Construct {
         ],
       },
     );
+    // See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html
     suppressRules(
       this.cloudFrontDistribution,
       ['CKV_AWS_174'],

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -423,6 +423,7 @@ resource "aws_cloudfront_response_headers_policy" "website" {
 
 # CloudFront Distribution
 resource "aws_cloudfront_distribution" "website" {
+  # See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html
   #checkov:skip=CKV_AWS_174:Using CloudFront default certificate which does not support TLS v1.2
   #checkov:skip=CKV_AWS_310:Origin failover not required for single S3 origin static website
   #checkov:skip=CKV_AWS_374:Geo restrictions not required for global web application


### PR DESCRIPTION
### Reason for this change

The `CKV_AWS_174` checkov suppression (CloudFront distribution using the default certificate, which does not enforce TLS v1.2) in the static website templates had no context explaining why the default certificate behaves this way. Readers had to look up the CloudFront certificate behaviour externally to understand the suppression.

### Description of changes

Added a one-line comment linking the CloudFront [Values That You Specify When You Create or Update a Distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesGeneral.html) documentation directly above the `CKV_AWS_174` suppression in both static website templates:

- `packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template` (above the `suppressRules(...)` call)
- `packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template` (above the `#checkov:skip` comment)

Each comment matches the surrounding file's comment idiom (`//` for TypeScript, `#` for HCL). No functional or generated-output behaviour changes beyond the added comment line.

### Description of how you validated changes

Documentation-only comment addition to template files; no logic changes. Verified the comment renders above the correct suppression in both templates via the diff.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
