### PR TITLE
test(preset): raise beforeEach hook timeout for interactive create-workspace

### DIFF
--- a/e2e/src/smoke-tests/create-workspace.spec.ts
+++ b/e2e/src/smoke-tests/create-workspace.spec.ts
@@ -184,26 +184,29 @@ describe('smoke test - create-workspace', () => {
     let projectRoot: string;
     let gitConfigDir: string;
 
-    beforeEach(async () => {
-      if (existsSync(targetDir)) {
-        rmSync(targetDir, { force: true, recursive: true });
-      }
-      ensureDirSync(targetDir);
+    beforeEach(
+      async () => {
+        if (existsSync(targetDir)) {
+          rmSync(targetDir, { force: true, recursive: true });
+        }
+        ensureDirSync(targetDir);
 
-      // Isolate git config so the preset detects an "Amazonian" email without
-      // touching the user's real git config.
-      gitConfigDir = mkdtempSync(join(tmpdir(), 'nx-e2e-gitconfig-'));
-      writeFileSync(
-        join(gitConfigDir, 'global'),
-        '[user]\n\temail = e2e-test@amazon.com\n\tname = E2E Test\n',
-      );
-      // Empty file so no system git config (e.g. an @example.com email) leaks
-      // in and masks the amazon.com email above.
-      writeFileSync(join(gitConfigDir, 'system'), '');
+        // Isolate git config so the preset detects an "Amazonian" email without
+        // touching the user's real git config.
+        gitConfigDir = mkdtempSync(join(tmpdir(), 'nx-e2e-gitconfig-'));
+        writeFileSync(
+          join(gitConfigDir, 'global'),
+          '[user]\n\temail = e2e-test@amazon.com\n\tname = E2E Test\n',
+        );
+        // Empty file so no system git config (e.g. an @example.com email) leaks
+        // in and masks the amazon.com email above.
+        writeFileSync(join(gitConfigDir, 'system'), '');
 
-      // Non-interactive workspace to re-run the preset generator inside.
-      projectRoot = await createTestWorkspace(pkgMgr, targetDir, 'e2e-test');
-    });
+        // Non-interactive workspace to re-run the preset generator inside.
+        projectRoot = await createTestWorkspace(pkgMgr, targetDir, 'e2e-test');
+      },
+      10 * 60 * 1000,
+    );
     afterEach(() => {
       if (gitConfigDir && existsSync(gitConfigDir)) {
         rmSync(gitConfigDir, { force: true, recursive: true });


### PR DESCRIPTION
## Description

Follow-up to #898. The interactive `create-workspace` smoke test's `beforeEach` calls `createTestWorkspace`, which retries workspace creation up to 3× on flaky installs. Each attempt can take ~40s, so the total can exceed vitest's default 120s `hookTimeout`, failing the setup before the test body runs.

Raise the hook timeout to 10 minutes (matching the `it` timeouts used elsewhere in the e2e suite).

## Verification

Confirmed the interactive preset prompt works end-to-end via a PTY: `enquirer.prompt` renders, accepts the typed engagementId, the generator exits 0, and the value is persisted to `aws-nx-plugin.config.mts` as `tags: ['MyEngagementId']`.

## Type of change
- [x] Bug fix (test infra)
