### PR TITLE
docs(terraform-project): fix typo 'seperate' -> 'separate'

### DIFF
--- a/docs/src/content/docs/en/guides/terraform-project.mdx
+++ b/docs/src/content/docs/en/guides/terraform-project.mdx
@@ -108,7 +108,7 @@ You can start writing your Terraform infrastructure inside `src/main.tf`, for ex
 
 ### Cross project dependencies
 
-If you wanted to execute a module from a seperate project (lib), you could do so as follows:
+If you wanted to execute a module from a separate project (lib), you could do so as follows:
 
 ```
 module "lib_module" {

--- a/docs/src/content/docs/es/guides/terraform-project.mdx
+++ b/docs/src/content/docs/es/guides/terraform-project.mdx
@@ -108,7 +108,7 @@ Puedes comenzar a escribir tu infraestructura Terraform en `src/main.tf`, por ej
 
 ### Dependencias entre proyectos
 
-Si deseas ejecutar un módulo de otro proyecto (biblioteca), puedes hacerlo de la siguiente manera:
+Si deseas ejecutar un módulo de un proyecto separado (biblioteca), puedes hacerlo de la siguiente manera:
 
 ```
 module "lib_module" {


### PR DESCRIPTION
### Reason for this change

Minor spelling error in the Terraform project guide: "seperate" instead of "separate".

### Description of changes

Fixed the typo in the "Cross project dependencies" section of `docs/src/content/docs/en/guides/terraform-project.mdx`.

### Description of how you validated changes

Documentation-only wording fix; no code changes and no tests required.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*