### PR TITLE
test: isolate git env in git.spec so hooks can't corrupt the repo

### DIFF
--- a/packages/nx-plugin/src/utils/git.spec.ts
+++ b/packages/nx-plugin/src/utils/git.spec.ts
@@ -11,10 +11,39 @@ import * as path from 'path';
 import { getGitIncludedFiles, isWithinGitRepo, updateGitIgnore } from './git';
 import { createTreeUsingTsSolutionSetup } from './test';
 
+/**
+ * Remove inherited GIT_* environment variables (eg GIT_DIR, GIT_INDEX_FILE)
+ * before each test and restore them afterwards. When these tests run inside a
+ * git hook (eg pre-commit), git exports these variables pointing at the
+ * surrounding repository. Since they take precedence over `cwd`, the git
+ * commands run here would otherwise operate on that repository - committing
+ * test fixtures and deleting real files - instead of the isolated temp repo.
+ */
+const useIsolatedGitEnv = () => {
+  const savedGitEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('GIT_')) {
+        savedGitEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedGitEnv)) {
+      process.env[key] = value;
+    }
+  });
+};
+
 describe('git utils', () => {
   describe('getGitIncludedFiles', () => {
     let tmpDir: string;
     let tree: FsTree;
+
+    useIsolatedGitEnv();
 
     beforeEach(() => {
       tmpDir = mkdtempSync(path.join(os.tmpdir(), 'test-dir'));
@@ -107,6 +136,8 @@ describe('git utils', () => {
   describe('isWithinGitRepo', () => {
     let tmpDir: string;
     let tree: FsTree;
+
+    useIsolatedGitEnv();
 
     beforeEach(() => {
       tmpDir = mkdtempSync(path.join(os.tmpdir(), 'test-git-repo'));


### PR DESCRIPTION
### Reason for this change

Agents working in this repository reported that committing could delete tracked files and replace them with unexpected fixtures.

The root cause is `packages/nx-plugin/src/utils/git.spec.ts`, which runs real, destructive git commands (`git add .`, `git commit`) via `execSync` to exercise `getGitIncludedFiles` / `isWithinGitRepo`. The `.husky/pre-commit` hook runs the full test suite on every commit. When git invokes a hook it exports `GIT_DIR` and `GIT_INDEX_FILE` pointing at the committing repository, and these variables take precedence over the `cwd` passed to `execSync`. The test's `git commit` therefore ran against the real repository instead of its temp directory — committing test fixtures (`.gitignore`, `committed.ts`) and deleting the developer's tracked files.

### Description of changes

Added a `useIsolatedGitEnv()` helper in `git.spec.ts` that strips all `GIT_*` environment variables from `process.env` in `beforeEach` and restores them in `afterEach`. It is applied to the two describe blocks (`getGitIncludedFiles`, `isWithinGitRepo`) that shell out to git, so git commands resolve via `cwd` to the isolated temp repo regardless of any surrounding hook environment.

### Description of how you validated changes

- Reproduced the corruption: with `GIT_DIR`/`GIT_INDEX_FILE` set to a fixture repo (simulating a pre-commit hook), the test commit deleted the fixture's tracked files and committed the test fixtures.
- After the fix, ran the suite with `GIT_DIR`/`GIT_INDEX_FILE` pointed at the real repo: all 8 git tests pass and the repo is untouched (tracked file count unchanged, clean `git status`).
- Ran the full `@aws/nx-plugin:test` target via the pre-commit hook: 2417 tests pass and the hook's "Pre-commit modified your working directory" guard did not trip.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
