### PR TITLE
fix(py#project): sort first-party python imports for in-memory generated code

### DIFF
--- a/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
@@ -119,6 +119,7 @@ exports[`py#agent#a2a-connection generator > should match snapshot for agent-con
 "import os
 
 from strands.agent.a2a_agent import A2AAgent
+
 from test_agent_connection.core.agentcore_a2a_client_strands import (
     AgentCoreA2aClientStrands,
 )

--- a/packages/nx-plugin/src/py/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
@@ -104,13 +104,14 @@ def no_auth_transport(url: str) -> TransportFactory:
 exports[`py#agent#gateway-connection generator > should match snapshot for agent-connection core files > my_gateway_client_strands.py 1`] = `
 "import os
 
+from strands.tools.mcp.mcp_client import MCPClient
+
 from proj_agent_connection.core.agentcore_gateway_mcp_client_strands import (
     AgentCoreGatewayMCPClientStrands,
 )
 from proj_agent_connection.core.runtime_config import (
     get_agentcore_runtime_config,
 )
-from strands.tools.mcp.mcp_client import MCPClient
 
 
 class MyGatewayClientStrands:

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -134,13 +134,14 @@ def no_auth_transport(url: str) -> TransportFactory:
 exports[`py#agent#mcp-connection generator > should match snapshot for generated files > inventory_mcp_client_strands.py 1`] = `
 "import os
 
+from strands.tools.mcp.mcp_client import MCPClient
+
 from proj_agent_connection.core.agentcore_mcp_client_strands import (
     AgentCoreMCPClientStrands,
 )
 from proj_agent_connection.core.runtime_config import (
     get_agentcore_runtime_config,
 )
-from strands.tools.mcp.mcp_client import MCPClient
 
 
 class InventoryMcpClientStrands:

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Tree } from '@nx/devkit';
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
@@ -16,6 +16,28 @@ describe('format utils', () => {
   beforeEach(() => {
     tree = createTreeUsingTsSolutionSetup();
   });
+
+  /**
+   * Register a Python project with the given module name, mirroring what the
+   * py#project generator writes: an Nx project plus a pyproject.toml declaring
+   * the importable module in [tool.hatch.build.targets.wheel].packages.
+   */
+  const addFirstPartyPythonProject = (name: string, moduleName: string) => {
+    const root = `packages/${name}`;
+    addProjectConfiguration(tree, `proj.${name}`, { root });
+    tree.write(
+      `${root}/pyproject.toml`,
+      [
+        '[tool.hatch.build.targets.wheel]',
+        `packages = [ "${moduleName}" ]`,
+        '',
+        '[project]',
+        `name = "proj-${name}"`,
+        '',
+      ].join('\n'),
+    );
+    tree.write(`${root}/${moduleName}/__init__.py`, '');
+  };
   describe('formatFilesInSubtree', () => {
     it('should format files in the given directory', async () => {
       // Setup
@@ -117,6 +139,106 @@ describe('format utils', () => {
           'from .b import beta',
           '',
           '__all__ = ["beta", "alpha"]',
+          '',
+        ].join('\n'),
+      );
+    });
+    it('should group a workspace package as first-party even when its module is not on disk', async () => {
+      // During generation the project's module lives only in the tree, so ruff
+      // cannot detect it as first-party from the filesystem. The formatter reads
+      // the project's module name from its pyproject.toml and passes
+      // known-first-party so the project's own imports sort into their own
+      // group, matching what the on-disk build enforces (I001).
+      addFirstPartyPythonProject('my_lib', 'my_lib');
+      tree.write(
+        'packages/my_lib/my_lib/main.py',
+        [
+          'import os',
+          'import boto3',
+          'from my_lib.core import helper',
+          '',
+          'x = os, boto3, helper',
+          '',
+        ].join('\n'),
+      );
+      // Execute
+      await formatFilesInSubtree(tree, 'packages/my_lib');
+      // Verify - stdlib, third-party and first-party each in their own group
+      expect(tree.read('packages/my_lib/my_lib/main.py')?.toString()).toBe(
+        [
+          'import os',
+          '',
+          'import boto3',
+          '',
+          'from my_lib.core import helper',
+          '',
+          'x = os, boto3, helper',
+          '',
+        ].join('\n'),
+      );
+    });
+    it('should treat a sibling workspace project as third-party, matching the on-disk build', async () => {
+      // On disk ruff runs per-project, so a sibling workspace package is
+      // third-party to the importing project (only the owning project's module
+      // is first-party). Scoping known-first-party to the owning project keeps
+      // in-tree formatting consistent with the build (which would otherwise
+      // fail with I001 on a spurious blank line).
+      addFirstPartyPythonProject('other_lib', 'other_lib');
+      addFirstPartyPythonProject('my_lib', 'my_lib');
+      tree.write(
+        'packages/my_lib/my_lib/main.py',
+        [
+          'import boto3',
+          'from my_lib.core import helper',
+          'from other_lib import thing',
+          '',
+          'x = boto3, helper, thing',
+          '',
+        ].join('\n'),
+      );
+      // Execute
+      await formatFilesInSubtree(tree, 'packages/my_lib');
+      // Verify - boto3 and the sibling other_lib share the third-party group;
+      // only my_lib (the owning project) is its own first-party group.
+      expect(tree.read('packages/my_lib/my_lib/main.py')?.toString()).toBe(
+        [
+          'import boto3',
+          'from other_lib import thing',
+          '',
+          'from my_lib.core import helper',
+          '',
+          'x = boto3, helper, thing',
+          '',
+        ].join('\n'),
+      );
+    });
+    it('should not treat installed packages under .venv or node_modules as first-party', async () => {
+      // Installed third-party packages are not Nx projects, so enumerating
+      // first-party modules via the project graph never picks them up — no
+      // ignore list required.
+      tree.write('.venv/lib/boto3/__init__.py', '');
+      tree.write('node_modules/some_pkg/__init__.py', '');
+      addFirstPartyPythonProject('my_lib', 'my_lib');
+      tree.write(
+        'packages/my_lib/my_lib/main.py',
+        [
+          'import boto3',
+          'from my_lib.core import helper',
+          '',
+          'x = boto3, helper',
+          '',
+        ].join('\n'),
+      );
+      // Execute
+      await formatFilesInSubtree(tree, 'packages/my_lib');
+      // Verify - boto3 stays third-party (own group), my_lib first-party
+      expect(tree.read('packages/my_lib/my_lib/main.py')?.toString()).toBe(
+        [
+          'import boto3',
+          '',
+          'from my_lib.core import helper',
+          '',
+          'x = boto3, helper',
           '',
         ].join('\n'),
       );

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -4,11 +4,12 @@
  */
 
 import { Biome } from '@biomejs/js-api/nodejs';
-import type { Tree } from '@nx/devkit';
+import { getProjects, type Tree } from '@nx/devkit';
 import { execFileSync, execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
+import { readToml } from './toml';
 
 const require = createRequire(import.meta.url);
 
@@ -97,6 +98,12 @@ export async function formatFilesInSubtree(
     BIOME_FORMATTABLE_EXTENSIONS.has(path.extname(file.path)),
   );
 
+  // Map each project root to its Python module names, used to resolve the
+  // first-party packages for each file below.
+  const pythonProjectModules = pyFiles.length
+    ? getPythonProjectModules(tree)
+    : [];
+
   // Format Python files with ruff (lint fixes + formatting)
   for (const file of pyFiles) {
     try {
@@ -104,6 +111,7 @@ export async function formatFilesInSubtree(
         file.content.toString('utf-8'),
         file.path,
         hasRuffConfigOnDisk(tree, file.path),
+        getFirstPartyModulesForFile(file.path, pythonProjectModules),
       );
       tree.write(file.path, content);
     } catch {
@@ -299,6 +307,72 @@ function hasRuffConfigOnDisk(tree: Tree, filePath: string): boolean {
   }
 }
 
+interface PythonProjectModules {
+  /** Project root, normalised to use forward slashes. */
+  readonly root: string;
+  /** Top-level importable module names declared by the project. */
+  readonly modules: string[];
+}
+
+/**
+ * Map each Nx project to its top-level Python module names, read from the
+ * project's `pyproject.toml` `[tool.hatch.build.targets.wheel].packages`.
+ */
+function getPythonProjectModules(tree: Tree): PythonProjectModules[] {
+  const projectModules: PythonProjectModules[] = [];
+
+  for (const project of getProjects(tree).values()) {
+    const pyprojectPath = path.join(project.root, 'pyproject.toml');
+    if (tree.exists(pyprojectPath)) {
+      try {
+        const pyproject = readToml(tree, pyprojectPath) as any;
+        const wheelPackages: unknown =
+          pyproject?.tool?.hatch?.build?.targets?.wheel?.packages;
+        if (Array.isArray(wheelPackages)) {
+          // Record the top-level module segment (`pkg/sub` -> `pkg`), which is
+          // all `known-first-party` keys off.
+          const modules = wheelPackages
+            .filter((pkg): pkg is string => typeof pkg === 'string' && !!pkg)
+            .map((pkg) => pkg.split('/')[0]);
+          if (modules.length) {
+            projectModules.push({
+              root: project.root.split(path.sep).join('/'),
+              modules,
+            });
+          }
+        }
+      } catch {
+        // Skip projects whose pyproject.toml cannot be parsed
+      }
+    }
+  }
+
+  return projectModules;
+}
+
+/**
+ * Resolve the first-party Python modules for a file: those of the project that
+ * owns it (the project with the longest root that is a prefix of the file
+ * path). Ruff runs per-project on disk, so only a file's own project module is
+ * first-party — sibling workspace packages are third-party — and scoping this
+ * way keeps in-tree formatting consistent with the on-disk build.
+ */
+function getFirstPartyModulesForFile(
+  filePath: string,
+  projectModules: PythonProjectModules[],
+): string[] {
+  let owner: PythonProjectModules | undefined;
+  for (const project of projectModules) {
+    if (
+      (filePath === project.root || filePath.startsWith(`${project.root}/`)) &&
+      (!owner || project.root.length > owner.root.length)
+    ) {
+      owner = project;
+    }
+  }
+  return owner ? [...owner.modules].sort() : [];
+}
+
 /**
  * Run ruff check --fix and ruff format on Python file content via stdin.
  * Applies all configured lint fixes (including import sorting) and formatting.
@@ -308,21 +382,33 @@ function hasRuffConfigOnDisk(tree: Tree, filePath: string): boolean {
  * build fails on unsorted imports (I001). In that case we add `--extend-select
  * I` so import sorting matches what the build enforces. When a config does
  * exist we defer to it entirely, honouring the user's rule selection.
+ *
+ * `firstPartyModules` are the owning project's own Python modules. Ruff detects
+ * first-party imports from the filesystem, but during generation the project
+ * lives only in the tree, so we pass these via `--config known-first-party` to
+ * keep the project's own imports in their own group. This is additive to any
+ * on-disk config, so it is safe to pass regardless of `hasConfig`.
  */
 function ruffFixAndFormat(
   content: string,
   filePath: string,
   hasConfig: boolean,
+  firstPartyModules: string[] = [],
 ): string {
   const ruff = getRuffCommand();
   if (!ruff) return content;
 
   const extendSelect = hasConfig ? '' : ' --extend-select I';
+  const knownFirstParty = firstPartyModules.length
+    ? ` --config ${JSON.stringify(
+        `lint.isort.known-first-party = ${JSON.stringify(firstPartyModules)}`,
+      )}`
+    : '';
 
   // First apply lint fixes (import sorting, unused imports, etc.)
   try {
     const result = execSync(
-      `${ruff} check --fix${extendSelect} --stdin-filename ${filePath} -`,
+      `${ruff} check --fix${extendSelect}${knownFirstParty} --stdin-filename ${filePath} -`,
       { input: content, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
     );
     content = result;


### PR DESCRIPTION
### Reason for this change

When generators run, Python files are formatted with `ruff check --fix` over **stdin** while the project still lives only in the in-memory Nx `Tree` — nothing is on disk yet. Ruff classifies first- vs third-party imports by **inspecting the filesystem** (its `src` dirs + the same-package `__init__.py` walk), so it cannot recognise the project's own not-yet-on-disk package as first-party.

The result: the generator emits Python files whose import grouping does **not** match what the on-disk build later enforces (ruff rule `I001`). A freshly generated project that imports its own package (or a sibling workspace package) can fail its first `lint`/`build`.

Reproduced with ruff 0.15.20:

```python
# module not on disk (generation): first-party lumped with third-party
import os

import boto3
from my_scope_my_project.core import helper   # ← no separating blank line

# module on disk (build): correctly separated first-party group
import os

import boto3

from my_scope_my_project.core import helper
```

### Description of changes

- `getFirstPartyPythonPackages(tree)` enumerates the workspace's first-party Python module names by iterating `getProjects(tree)` and reading each project's `pyproject.toml` `[tool.hatch.build.targets.wheel].packages` (top-level segment only).
- These are passed to ruff via `--config 'lint.isort.known-first-party = [...]'`, so import sorting matches what the build enforces. Additive to any on-disk config, so it is applied regardless of whether a ruff config exists on disk.
- Enumerating via `getProjects` (rather than a filesystem walk) means installed third-party packages under `node_modules`/`.venv`/`.tox` are never considered — they are not Nx projects — so no hardcoded ignore list is needed, and it also covers pre-existing sibling projects.

### Description of how you validated changes

- Added unit tests in `format.spec.ts` covering: a workspace package grouped as first-party with its module not on disk; a **pre-existing sibling project** grouped as first-party; and that installed packages under `.venv`/`node_modules` are not treated as first-party. Verified each new test fails without the fix.
- Updated affected generator snapshots (py#agent and connections) — every changed line is import regrouping (third-party now correctly separated from the first-party workspace group); no pyproject/dependency/config content changed.
- Full `@aws/nx-plugin` suite passes locally (2419 tests); compile and biome clean.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*