### PR TITLE
fix(py#project): apply project line-length when formatting in-memory python

### DIFF
--- a/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
@@ -27,18 +27,12 @@ class AgentCoreA2aClientConfig:
         """SigV4-authenticated A2A client config for a Bedrock AgentCore runtime."""
         region = region_from_arn(agent_runtime_arn)
         credentials = boto3.Session(region_name=region).get_credentials()
-        return _config(
-            a2a_url_from_arn(agent_runtime_arn), sigv4_auth(credentials, region)
-        )
+        return _config(a2a_url_from_arn(agent_runtime_arn), sigv4_auth(credentials, region))
 
     @staticmethod
-    def with_jwt_auth(
-        agent_runtime_arn: str, access_token_provider: Callable[[], str]
-    ) -> tuple[str, ClientConfig]:
+    def with_jwt_auth(agent_runtime_arn: str, access_token_provider: Callable[[], str]) -> tuple[str, ClientConfig]:
         """Bearer-authenticated A2A client config for a Bedrock AgentCore runtime."""
-        return _config(
-            a2a_url_from_arn(agent_runtime_arn), jwt_auth(access_token_provider)
-        )
+        return _config(a2a_url_from_arn(agent_runtime_arn), jwt_auth(access_token_provider))
 
     @staticmethod
     def without_auth(url: str) -> tuple[str, ClientConfig]:
@@ -92,9 +86,7 @@ class AgentCoreA2aClientStrands:
     ) -> A2AAgent:
         """Bearer-authenticated client for a Bedrock AgentCore runtime."""
         return _build(
-            AgentCoreA2aClientConfig.with_jwt_auth(
-                agent_runtime_arn, access_token_provider
-            ),
+            AgentCoreA2aClientConfig.with_jwt_auth(agent_runtime_arn, access_token_provider),
             name=name,
             description=description,
         )
@@ -138,9 +130,7 @@ class RemoteClientStrands:
         config = get_agentcore_runtime_config()
         agent_runtime_arn = config.get("agentRuntimes", {}).get("Remote")
         if not agent_runtime_arn:
-            raise RuntimeError(
-                "No connected agent runtime named 'Remote' found in runtime configuration."
-            )
+            raise RuntimeError("No connected agent runtime named 'Remote' found in runtime configuration.")
         return AgentCoreA2aClientStrands.with_iam_auth(agent_runtime_arn)
 "
 `;
@@ -176,9 +166,7 @@ class SessionHeaderAuth(httpx.Auth):
         yield from self._inner.auth_flow(request)
 
 
-def sigv4_auth(
-    credentials, region: str, service: str = "bedrock-agentcore"
-) -> httpx.Auth:
+def sigv4_auth(credentials, region: str, service: str = "bedrock-agentcore") -> httpx.Auth:
     """Session-forwarding SigV4 auth (per-request, body-aware)."""
     return SessionHeaderAuth(SigV4HTTPXAuth(credentials, service, region))
 

--- a/packages/nx-plugin/src/py/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
@@ -15,9 +15,7 @@ class AgentCoreGatewayMCPClientStrands:
         region: str | None = None,
     ) -> MCPClient:
         """Create a gateway MCP client authenticated with IAM SigV4."""
-        return MCPClient(
-            AgentCoreGatewayMCPTransport.with_iam_auth(gateway_url, region)
-        )
+        return MCPClient(AgentCoreGatewayMCPTransport.with_iam_auth(gateway_url, region))
 
     @staticmethod
     def without_auth(gateway_url: str) -> MCPClient:
@@ -47,9 +45,7 @@ class AgentCoreGatewayMCPTransport:
         region: str | None = None,
     ) -> TransportFactory:
         """Create a gateway MCP transport authenticated with IAM SigV4."""
-        return sigv4_transport(
-            gateway_url, region or region_from_gateway_url(gateway_url)
-        )
+        return sigv4_transport(gateway_url, region or region_from_gateway_url(gateway_url))
 
     @staticmethod
     def without_auth(gateway_url: str) -> TransportFactory:
@@ -88,9 +84,7 @@ def sigv4_transport(url: str, region: str) -> TransportFactory:
     return _factory(url, sigv4_auth(credentials, region))
 
 
-def jwt_transport(
-    url: str, access_token_provider: Callable[[], str]
-) -> TransportFactory:
+def jwt_transport(url: str, access_token_provider: Callable[[], str]) -> TransportFactory:
     """Bearer-token transport factory for a resolved AgentCore endpoint."""
     return _factory(url, jwt_auth(access_token_provider))
 
@@ -127,15 +121,11 @@ class MyGatewayClientStrands:
     @staticmethod
     def create() -> MCPClient:
         if os.environ.get("LOCAL_DEV") == "true":
-            return AgentCoreGatewayMCPClientStrands.without_auth(
-                gateway_url="http://localhost:8100/mcp"
-            )
+            return AgentCoreGatewayMCPClientStrands.without_auth(gateway_url="http://localhost:8100/mcp")
         config = get_agentcore_runtime_config()
         gateway_url = config.get("gateways", {}).get("MyGateway")
         if not gateway_url:
-            raise RuntimeError(
-                "No connected gateway named 'MyGateway' found in runtime configuration."
-            )
+            raise RuntimeError("No connected gateway named 'MyGateway' found in runtime configuration.")
         return AgentCoreGatewayMCPClientStrands.with_iam_auth(gateway_url=gateway_url)
 "
 `;
@@ -171,9 +161,7 @@ class SessionHeaderAuth(httpx.Auth):
         yield from self._inner.auth_flow(request)
 
 
-def sigv4_auth(
-    credentials, region: str, service: str = "bedrock-agentcore"
-) -> httpx.Auth:
+def sigv4_auth(credentials, region: str, service: str = "bedrock-agentcore") -> httpx.Auth:
     """Session-forwarding SigV4 auth (per-request, body-aware)."""
     return SessionHeaderAuth(SigV4HTTPXAuth(credentials, service, region))
 

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -35,15 +35,9 @@ class AgentCoreMCPClientStrands:
         return MCPClient(AgentCoreMCPTransport.with_iam_auth(agent_runtime_arn))
 
     @staticmethod
-    def with_jwt_auth(
-        agent_runtime_arn: str, access_token_provider: Callable[[], str]
-    ) -> MCPClient:
+    def with_jwt_auth(agent_runtime_arn: str, access_token_provider: Callable[[], str]) -> MCPClient:
         """Bearer-authenticated client for a Bedrock AgentCore runtime."""
-        return MCPClient(
-            AgentCoreMCPTransport.with_jwt_auth(
-                agent_runtime_arn, access_token_provider
-            )
-        )
+        return MCPClient(AgentCoreMCPTransport.with_jwt_auth(agent_runtime_arn, access_token_provider))
 
     @staticmethod
     def without_auth(url: str) -> MCPClient:
@@ -70,14 +64,10 @@ class AgentCoreMCPTransport:
     @staticmethod
     def with_iam_auth(agent_runtime_arn: str) -> TransportFactory:
         """SigV4-authenticated transport for a Bedrock AgentCore runtime."""
-        return sigv4_transport(
-            mcp_url_from_arn(agent_runtime_arn), region_from_arn(agent_runtime_arn)
-        )
+        return sigv4_transport(mcp_url_from_arn(agent_runtime_arn), region_from_arn(agent_runtime_arn))
 
     @staticmethod
-    def with_jwt_auth(
-        agent_runtime_arn: str, access_token_provider: Callable[[], str]
-    ) -> TransportFactory:
+    def with_jwt_auth(agent_runtime_arn: str, access_token_provider: Callable[[], str]) -> TransportFactory:
         """Bearer-authenticated transport for a Bedrock AgentCore runtime."""
         return jwt_transport(mcp_url_from_arn(agent_runtime_arn), access_token_provider)
 
@@ -118,9 +108,7 @@ def sigv4_transport(url: str, region: str) -> TransportFactory:
     return _factory(url, sigv4_auth(credentials, region))
 
 
-def jwt_transport(
-    url: str, access_token_provider: Callable[[], str]
-) -> TransportFactory:
+def jwt_transport(url: str, access_token_provider: Callable[[], str]) -> TransportFactory:
     """Bearer-token transport factory for a resolved AgentCore endpoint."""
     return _factory(url, jwt_auth(access_token_provider))
 
@@ -154,9 +142,7 @@ class InventoryMcpClientStrands:
         config = get_agentcore_runtime_config()
         agent_runtime_arn = config.get("agentRuntimes", {}).get("InventoryMcp")
         if not agent_runtime_arn:
-            raise RuntimeError(
-                "No connected MCP server runtime named 'InventoryMcp' found in runtime configuration."
-            )
+            raise RuntimeError("No connected MCP server runtime named 'InventoryMcp' found in runtime configuration.")
         return AgentCoreMCPClientStrands.with_iam_auth(agent_runtime_arn)
 "
 `;
@@ -192,9 +178,7 @@ class SessionHeaderAuth(httpx.Auth):
         yield from self._inner.auth_flow(request)
 
 
-def sigv4_auth(
-    credentials, region: str, service: str = "bedrock-agentcore"
-) -> httpx.Auth:
+def sigv4_auth(credentials, region: str, service: str = "bedrock-agentcore") -> httpx.Auth:
     """Session-forwarding SigV4 auth (per-request, body-aware)."""
     return SessionHeaderAuth(SigV4HTTPXAuth(credentials, service, region))
 

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -70,9 +70,7 @@ class JsonStreamingResponse(StreamingResponse):
             "description": description,
             "content": {
                 "application/jsonl": {
-                    "itemSchema": {
-                        "$ref": f"#/components/schemas/{item_model.__name__}"
-                    },
+                    "itemSchema": {"$ref": f"#/components/schemas/{item_model.__name__}"},
                 }
             },
             # Include the model so FastAPI registers the schema in components/schemas
@@ -93,11 +91,7 @@ async def cors_middleware(request: Request, call_next):
     response = await call_next(request)
 
     origin = request.headers.get("origin")
-    allowed_origins = (
-        os.environ.get("ALLOWED_ORIGINS", "").split(",")
-        if os.environ.get("ALLOWED_ORIGINS")
-        else []
-    )
+    allowed_origins = os.environ.get("ALLOWED_ORIGINS", "").split(",") if os.environ.get("ALLOWED_ORIGINS") else []
 
     is_localhost = origin and urlparse(origin).hostname in ["localhost", "127.0.0.1"]
     is_allowed_origin = origin and origin in allowed_origins
@@ -124,8 +118,7 @@ async def unhandled_exception_handler(request, err):
     metrics.add_metric(name="Failure", unit=MetricUnit.Count, value=1)
 
     return JSONResponse(
-        status_code=500,
-        content=InternalServerErrorDetails(detail="Internal Server Error").model_dump(),
+        status_code=500, content=InternalServerErrorDetails(detail="Internal Server Error").model_dump()
     )
 
 

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -20,9 +20,14 @@ describe('format utils', () => {
   /**
    * Register a Python project with the given module name, mirroring what the
    * py#project generator writes: an Nx project plus a pyproject.toml declaring
-   * the importable module in [tool.hatch.build.targets.wheel].packages.
+   * the importable module in [tool.hatch.build.targets.wheel].packages and an
+   * optional [tool.ruff] line-length.
    */
-  const addFirstPartyPythonProject = (name: string, moduleName: string) => {
+  const addFirstPartyPythonProject = (
+    name: string,
+    moduleName: string,
+    lineLength?: number,
+  ) => {
     const root = `packages/${name}`;
     addProjectConfiguration(tree, `proj.${name}`, { root });
     tree.write(
@@ -31,6 +36,9 @@ describe('format utils', () => {
         '[tool.hatch.build.targets.wheel]',
         `packages = [ "${moduleName}" ]`,
         '',
+        ...(lineLength !== undefined
+          ? ['[tool.ruff]', `line-length = ${lineLength}`, '']
+          : []),
         '[project]',
         `name = "proj-${name}"`,
         '',
@@ -241,6 +249,24 @@ describe('format utils', () => {
           'x = boto3, helper',
           '',
         ].join('\n'),
+      );
+    });
+    it("should apply the owning project's line-length when its config is not on disk", async () => {
+      // The project's [tool.ruff] line-length lives only in the tree during
+      // generation, so ruff would otherwise wrap at its default of 88 and
+      // produce output the on-disk build (line-length 120) reformats.
+      addFirstPartyPythonProject('my_lib', 'my_lib', 120);
+      const line =
+        'def compute(first_value, second_value, third_value, fourth_value, fifth_value, sixth_val):';
+      tree.write(
+        'packages/my_lib/my_lib/main.py',
+        [line, '    return first_value', ''].join('\n'),
+      );
+      // Execute
+      await formatFilesInSubtree(tree, 'packages/my_lib');
+      // Verify - the 90-char signature stays on one line at line-length 120
+      expect(tree.read('packages/my_lib/my_lib/main.py')?.toString()).toBe(
+        [line, '    return first_value', ''].join('\n'),
       );
     });
     it('should format json and css files', async () => {

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -98,10 +98,10 @@ export async function formatFilesInSubtree(
     BIOME_FORMATTABLE_EXTENSIONS.has(path.extname(file.path)),
   );
 
-  // Map each project root to its Python module names, used to resolve the
-  // first-party packages for each file below.
-  const pythonProjectModules = pyFiles.length
-    ? getPythonProjectModules(tree)
+  // Resolve each project's ruff settings (module names, line-length) so files
+  // are formatted to match the on-disk build (see getPythonProjectRuffConfigs).
+  const pythonProjectConfigs = pyFiles.length
+    ? getPythonProjectRuffConfigs(tree)
     : [];
 
   // Format Python files with ruff (lint fixes + formatting)
@@ -111,7 +111,7 @@ export async function formatFilesInSubtree(
         file.content.toString('utf-8'),
         file.path,
         hasRuffConfigOnDisk(tree, file.path),
-        getFirstPartyModulesForFile(file.path, pythonProjectModules),
+        getOwningProjectRuffConfig(file.path, pythonProjectConfigs),
       );
       tree.write(file.path, content);
     } catch {
@@ -307,19 +307,22 @@ function hasRuffConfigOnDisk(tree: Tree, filePath: string): boolean {
   }
 }
 
-interface PythonProjectModules {
+interface PythonProjectRuffConfig {
   /** Project root, normalised to use forward slashes. */
   readonly root: string;
   /** Top-level importable module names declared by the project. */
   readonly modules: string[];
+  /** The project's `[tool.ruff].line-length`, if set. */
+  readonly lineLength?: number;
 }
 
 /**
- * Map each Nx project to its top-level Python module names, read from the
- * project's `pyproject.toml` `[tool.hatch.build.targets.wheel].packages`.
+ * Map each Nx project with a `pyproject.toml` to the ruff settings the on-disk
+ * build enforces for it: its top-level module names (from
+ * `[tool.hatch.build.targets.wheel].packages`) and its `[tool.ruff].line-length`.
  */
-function getPythonProjectModules(tree: Tree): PythonProjectModules[] {
-  const projectModules: PythonProjectModules[] = [];
+function getPythonProjectRuffConfigs(tree: Tree): PythonProjectRuffConfig[] {
+  const configs: PythonProjectRuffConfig[] = [];
 
   for (const project of getProjects(tree).values()) {
     const pyprojectPath = path.join(project.root, 'pyproject.toml');
@@ -328,18 +331,20 @@ function getPythonProjectModules(tree: Tree): PythonProjectModules[] {
         const pyproject = readToml(tree, pyprojectPath) as any;
         const wheelPackages: unknown =
           pyproject?.tool?.hatch?.build?.targets?.wheel?.packages;
-        if (Array.isArray(wheelPackages)) {
-          // Record the top-level module segment (`pkg/sub` -> `pkg`), which is
-          // all `known-first-party` keys off.
-          const modules = wheelPackages
-            .filter((pkg): pkg is string => typeof pkg === 'string' && !!pkg)
-            .map((pkg) => pkg.split('/')[0]);
-          if (modules.length) {
-            projectModules.push({
-              root: project.root.split(path.sep).join('/'),
-              modules,
-            });
-          }
+        // Record the top-level module segment (`pkg/sub` -> `pkg`), which is
+        // all `known-first-party` keys off.
+        const modules = Array.isArray(wheelPackages)
+          ? wheelPackages
+              .filter((pkg): pkg is string => typeof pkg === 'string' && !!pkg)
+              .map((pkg) => pkg.split('/')[0])
+          : [];
+        const lineLength: unknown = pyproject?.tool?.ruff?.['line-length'];
+        if (modules.length || typeof lineLength === 'number') {
+          configs.push({
+            root: project.root.split(path.sep).join('/'),
+            modules,
+            lineLength: typeof lineLength === 'number' ? lineLength : undefined,
+          });
         }
       } catch {
         // Skip projects whose pyproject.toml cannot be parsed
@@ -347,30 +352,31 @@ function getPythonProjectModules(tree: Tree): PythonProjectModules[] {
     }
   }
 
-  return projectModules;
+  return configs;
 }
 
 /**
- * Resolve the first-party Python modules for a file: those of the project that
- * owns it (the project with the longest root that is a prefix of the file
- * path). Ruff runs per-project on disk, so only a file's own project module is
- * first-party — sibling workspace packages are third-party — and scoping this
- * way keeps in-tree formatting consistent with the on-disk build.
+ * Resolve the ruff config for the project that owns a file (the project with
+ * the longest root that is a prefix of the file path). Ruff runs per-project on
+ * disk, so a file's settings come from its own project — only its own module is
+ * first-party (sibling workspace packages are third-party) and its own
+ * line-length applies — and scoping this way keeps in-tree formatting
+ * consistent with the on-disk build.
  */
-function getFirstPartyModulesForFile(
+function getOwningProjectRuffConfig(
   filePath: string,
-  projectModules: PythonProjectModules[],
-): string[] {
-  let owner: PythonProjectModules | undefined;
-  for (const project of projectModules) {
+  configs: PythonProjectRuffConfig[],
+): PythonProjectRuffConfig | undefined {
+  let owner: PythonProjectRuffConfig | undefined;
+  for (const config of configs) {
     if (
-      (filePath === project.root || filePath.startsWith(`${project.root}/`)) &&
-      (!owner || project.root.length > owner.root.length)
+      (filePath === config.root || filePath.startsWith(`${config.root}/`)) &&
+      (!owner || config.root.length > owner.root.length)
     ) {
-      owner = project;
+      owner = config;
     }
   }
-  return owner ? [...owner.modules].sort() : [];
+  return owner;
 }
 
 /**
@@ -383,32 +389,41 @@ function getFirstPartyModulesForFile(
  * I` so import sorting matches what the build enforces. When a config does
  * exist we defer to it entirely, honouring the user's rule selection.
  *
- * `firstPartyModules` are the owning project's own Python modules. Ruff detects
- * first-party imports from the filesystem, but during generation the project
- * lives only in the tree, so we pass these via `--config known-first-party` to
- * keep the project's own imports in their own group. This is additive to any
- * on-disk config, so it is safe to pass regardless of `hasConfig`.
+ * `projectConfig` carries the owning project's ruff settings, which ruff cannot
+ * detect from the filesystem during generation because the project lives only
+ * in the tree. We pass them via `--config` so in-tree formatting matches the
+ * on-disk build: `known-first-party` (the project's own modules) keeps its
+ * imports in their own group, and `line-length` keeps wrapping consistent (the
+ * generated config raises it above ruff's default of 88). These are additive to
+ * any on-disk config, so they are safe to pass regardless of `hasConfig`.
  */
 function ruffFixAndFormat(
   content: string,
   filePath: string,
   hasConfig: boolean,
-  firstPartyModules: string[] = [],
+  projectConfig?: PythonProjectRuffConfig,
 ): string {
   const ruff = getRuffCommand();
   if (!ruff) return content;
 
   const extendSelect = hasConfig ? '' : ' --extend-select I';
-  const knownFirstParty = firstPartyModules.length
-    ? ` --config ${JSON.stringify(
-        `lint.isort.known-first-party = ${JSON.stringify(firstPartyModules)}`,
-      )}`
-    : '';
+  const configArgs: string[] = [];
+  if (projectConfig?.modules.length) {
+    configArgs.push(
+      `lint.isort.known-first-party = ${JSON.stringify(projectConfig.modules)}`,
+    );
+  }
+  if (typeof projectConfig?.lineLength === 'number') {
+    configArgs.push(`line-length = ${projectConfig.lineLength}`);
+  }
+  const config = configArgs
+    .map((arg) => ` --config ${JSON.stringify(arg)}`)
+    .join('');
 
   // First apply lint fixes (import sorting, unused imports, etc.)
   try {
     const result = execSync(
-      `${ruff} check --fix${extendSelect}${knownFirstParty} --stdin-filename ${filePath} -`,
+      `${ruff} check --fix${extendSelect}${config} --stdin-filename ${filePath} -`,
       { input: content, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
     );
     content = result;
@@ -422,11 +437,14 @@ function ruffFixAndFormat(
 
   // Then apply formatting
   try {
-    content = execSync(`${ruff} format --stdin-filename ${filePath} -`, {
-      input: content,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    content = execSync(
+      `${ruff} format${config} --stdin-filename ${filePath} -`,
+      {
+        input: content,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
   } catch {
     // Fall through with whatever content we have
   }


### PR DESCRIPTION
### Reason for this change

Follow-up to #904. Generated Python projects set `line-length` in their `pyproject.toml` (`[tool.ruff]`, e.g. 120), but during generation that config lives only in the in-memory Nx `Tree`. The formatter runs `ruff format` over stdin with nothing on disk, so ruff falls back to its default line-length of **88** and wraps lines that the on-disk build (at the project's configured line-length) leaves on a single line.

The result: generated Python files diverge from what the build produces, and the first `format`/`build` reformats them.

Reproduced with ruff 0.15.20 on a 90-char function signature:

```python
# in-memory (default 88): wrapped
def compute(
    first_value, second_value, third_value, fourth_value, fifth_value, sixth_val
):
    return first_value

# on-disk build (line-length 120): unwrapped
def compute(first_value, second_value, third_value, fourth_value, fifth_value, sixth_val):
    return first_value
```

### Description of changes

- Extended the per-project ruff config resolution added in #904 to also read `[tool.ruff].line-length` from each project's `pyproject.toml`.
- `ruffFixAndFormat` now passes the owning project's `line-length` to both `ruff check` and `ruff format` via `--config`, scoped to the file's owning project (same longest-matching-root logic used for `known-first-party`). Additive to any on-disk config.

### Description of how you validated changes

- Added a unit test in `format.spec.ts` asserting a 90-char signature stays on one line when the owning project's `line-length` is 120 (config not on disk). Verified it wraps — and the test fails — without the fix.
- Updated affected generator snapshots (agent connections, fast-api) — every changed line is previously-wrapped code now kept on one line, matching the on-disk build; no semantic changes.
- Full `@aws/nx-plugin` suite passes locally (2421 tests); compile and biome clean.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*