### PR TITLE
docs(mcp): recommend leaving --infra at its default in general guidance

### DIFF
--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -62,6 +62,7 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
   - (Omit -D for production dependencies)
 - When specifying project names as arguments to generators, prefer the _fully qualified_ project name, for example \`@workspace-name/project-name\`. Check the \`project.json\` file for the specific package to find its fully qualified name
 - When no generator exists for a specific framework required, use the base \`ts#project\` and \`py#project\` generators and build on top.
+- Leave the \`--infra\` option at its default value unless the user has explicitly instructed otherwise. Generators choose a sensible default type of infrastructure to deploy the project with, so only override \`--infra\` when the user has specified a particular requirement.
 
 ## Useful Commands
 


### PR DESCRIPTION
### Reason for this change

The `--infra` option on generators (e.g. `ts#api`, `py#fast-api`, `ts#lambda-function`, `agentcore-gateway`) already defaults to a sensible infrastructure type for each project. Coding agents consuming the MCP server's `general-guidance` tool were not steered to leave this default in place, and could override `--infra` without a clear reason.

### Description of changes

Added a bullet to the "General Instructions" section of the `general-guidance` MCP tool recommending that `--infra` be left at its default value unless the user has explicitly instructed otherwise.

### Description of how you validated changes

- Ran the MCP server unit tests (`src/mcp-server/server.spec.ts`) — all pass.
- Compiled the `@aws/nx-plugin` package successfully.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*