### PR TITLE
fix(utils#api-constructs): add VPC vars to Terraform API Lambda module

### DIFF
--- a/docs/src/content/docs/en/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/en/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/es/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/es/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/fr/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/fr/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/it/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/it/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/jp/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/jp/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 
@@ -66,7 +67,7 @@ module "api" {
 }
 ```
 
-API Lambda関数は、プライベート分離サブネットではなく、**エグレス付きプライベートサブネット**にデプロイしてください。API LambdaロールがIAM `rds-db:connect`権限を持ち、そのセキュリティグループがデータベースポートでデータベースセキュリティグループに到達できることを確認してください。
+API Lambda関数は、プライベート分離サブネットではなく、**エグレス付きプライベートサブネット**にデプロイしてください。API Lambdaロールが`rds-db:connect`権限を持ち、そのセキュリティグループがデータベースポートでデータベースセキュリティグループに到達できることを確認してください。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/ko/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/pt/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/pt/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/vi/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/vi/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/docs/src/content/docs/zh/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/zh/snippets/connection/rdb-api-infrastructure.mdx
@@ -51,6 +51,7 @@ module "my_database" {
 
 module "api" {
   source             = "..."
+  enable_vpc         = true
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -295,6 +295,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -381,10 +394,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -408,6 +443,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   # Enable SnapStart for faster cold starts
   snap_start {
     apply_on = "PublishedVersions"
@@ -422,6 +465,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -453,6 +498,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -633,6 +685,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -949,6 +1006,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -1035,10 +1105,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -1062,6 +1154,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   # Enable SnapStart for faster cold starts
   snap_start {
     apply_on = "PublishedVersions"
@@ -1076,6 +1176,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -1107,6 +1209,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -1369,6 +1478,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -1685,6 +1799,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -1771,10 +1898,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -1798,6 +1947,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   # Enable SnapStart for faster cold starts
   snap_start {
     apply_on = "PublishedVersions"
@@ -1812,6 +1969,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -1843,6 +2002,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -2010,6 +2176,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -2345,6 +2516,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -2441,9 +2625,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -2467,6 +2673,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   # Enable SnapStart for faster cold starts
   snap_start {
     apply_on = "PublishedVersions"
@@ -2481,6 +2695,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -2512,6 +2728,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -2921,6 +3144,11 @@ output "lambda_execution_role_name" {
   value       = aws_iam_role.lambda_execution_role.name
 }
 
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+}
+
 # Integration Outputs
 output "integration_id" {
   description = "ID of the Lambda integration"
@@ -3245,6 +3473,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -3341,9 +3582,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -3367,6 +3630,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   # Enable SnapStart for faster cold starts
   snap_start {
     apply_on = "PublishedVersions"
@@ -3381,6 +3652,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -3412,6 +3685,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -3820,6 +4100,11 @@ output "lambda_execution_role_name" {
   value       = aws_iam_role.lambda_execution_role.name
 }
 
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+}
+
 # Integration Outputs
 output "integration_id" {
   description = "ID of the Lambda integration"
@@ -4144,6 +4429,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -4240,9 +4538,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -4266,6 +4586,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   # Enable SnapStart for faster cold starts
   snap_start {
     apply_on = "PublishedVersions"
@@ -4280,6 +4608,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -4311,6 +4641,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -4800,6 +5137,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -296,14 +296,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -396,7 +407,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -406,7 +417,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -444,7 +455,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -503,7 +514,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -688,8 +699,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -1007,14 +1018,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -1107,7 +1129,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -1117,7 +1139,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -1155,7 +1177,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -1214,7 +1236,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -1481,8 +1503,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -1800,14 +1822,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -1900,7 +1933,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -1910,7 +1943,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -1948,7 +1981,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -2007,7 +2040,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -2179,8 +2212,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -2517,14 +2550,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -2627,7 +2671,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -2637,7 +2681,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -2674,7 +2718,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -2733,7 +2777,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -3145,8 +3189,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -3474,14 +3518,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -3584,7 +3639,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -3594,7 +3649,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -3631,7 +3686,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -3690,7 +3745,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -4101,8 +4156,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -4430,14 +4485,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -4540,7 +4606,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -4550,7 +4616,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -4587,7 +4653,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -4646,7 +4712,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -5140,8 +5206,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -690,14 +690,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -800,7 +811,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -810,7 +821,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -845,7 +856,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -897,7 +908,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -1369,8 +1380,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -2110,14 +2121,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -2220,7 +2242,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -2230,7 +2252,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -2265,7 +2287,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -2317,7 +2339,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -2707,8 +2729,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -3036,14 +3058,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -3146,7 +3179,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -3156,7 +3189,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -3191,7 +3224,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -3243,7 +3276,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -3632,8 +3665,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -3701,14 +3734,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -3811,7 +3855,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "custom-api-lambda-"
@@ -3821,7 +3865,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -3856,7 +3900,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -3908,7 +3952,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -4380,8 +4424,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -689,6 +689,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -785,9 +798,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -809,6 +844,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -816,6 +859,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -847,6 +892,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -1314,6 +1366,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -2052,6 +2109,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -2148,9 +2218,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -2172,6 +2264,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -2179,6 +2279,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -2210,6 +2312,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -2597,6 +2706,11 @@ output "lambda_execution_role_name" {
   value       = aws_iam_role.lambda_execution_role.name
 }
 
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+}
+
 # Integration Outputs
 output "integration_id" {
   description = "ID of the Lambda integration"
@@ -2921,6 +3035,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -3017,9 +3144,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -3041,6 +3190,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -3048,6 +3205,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -3079,6 +3238,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -3465,6 +3631,11 @@ output "lambda_execution_role_name" {
   value       = aws_iam_role.lambda_execution_role.name
 }
 
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+}
+
 # Integration Outputs
 output "integration_id" {
   description = "ID of the Lambda integration"
@@ -3527,6 +3698,19 @@ variable "additional_iam_policy_statements" {
 variable "asset_bucket_name" {
   description = "Name of the shared asset S3 bucket used to stage the Lambda deployment zip. Instantiate the \`core/asset-bucket\` module once per deployment and pass its \`bucket_name\` output here."
   type        = string
+}
+
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
 }
 
 # CORS Configuration (passed to core module)
@@ -3625,9 +3809,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "custom-api-lambda-"
+  description = "Security group for the CustomApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -3649,6 +3855,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -3656,6 +3870,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -3687,6 +3903,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -4154,6 +4377,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3427,14 +3427,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -3527,7 +3538,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -3537,7 +3548,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -3573,7 +3584,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -3625,7 +3636,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -3801,8 +3812,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -4120,14 +4131,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -4220,7 +4242,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -4230,7 +4252,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -4266,7 +4288,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -4318,7 +4340,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -4576,8 +4598,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -4895,14 +4917,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -4995,7 +5028,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -5005,7 +5038,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -5041,7 +5074,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -5093,7 +5126,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -5256,8 +5289,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -5594,14 +5627,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -5704,7 +5748,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -5714,7 +5758,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -5749,7 +5793,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -5801,7 +5845,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -6192,8 +6236,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -6521,14 +6565,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -6631,7 +6686,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -6641,7 +6696,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -6676,7 +6731,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -6728,7 +6783,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -7118,8 +7173,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -7447,14 +7502,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -7557,7 +7623,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "test-api-lambda-"
@@ -7567,7 +7633,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -7602,7 +7668,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -7654,7 +7720,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -8127,8 +8193,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3426,6 +3426,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -3512,10 +3525,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -3537,6 +3572,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -3544,6 +3587,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -3575,6 +3620,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -3746,6 +3798,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -4062,6 +4119,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -4148,10 +4218,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -4173,6 +4265,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -4180,6 +4280,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -4211,6 +4313,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -4464,6 +4573,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -4780,6 +4894,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -4866,10 +4993,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -4891,6 +5040,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -4898,6 +5055,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -4929,6 +5088,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -5087,6 +5253,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs
@@ -5422,6 +5593,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -5518,9 +5702,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -5542,6 +5748,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -5549,6 +5763,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -5580,6 +5796,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -5968,6 +6191,11 @@ output "lambda_execution_role_name" {
   value       = aws_iam_role.lambda_execution_role.name
 }
 
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+}
+
 # Integration Outputs
 output "integration_id" {
   description = "ID of the Lambda integration"
@@ -6292,6 +6520,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -6388,9 +6629,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -6412,6 +6675,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -6419,6 +6690,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -6450,6 +6723,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -6837,6 +7117,11 @@ output "lambda_execution_role_name" {
   value       = aws_iam_role.lambda_execution_role.name
 }
 
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+}
+
 # Integration Outputs
 output "integration_id" {
   description = "ID of the Lambda integration"
@@ -7161,6 +7446,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -7257,9 +7555,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "test-api-lambda-"
+  description = "Security group for the TestApi API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -7281,6 +7601,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
 
   environment {
     variables = merge({
@@ -7288,6 +7616,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -7319,6 +7649,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -7787,6 +8124,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -44,14 +44,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -144,7 +155,7 @@ module "http_api" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "<%- apiNameKebabCase %>-lambda-"
@@ -154,7 +165,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -199,7 +210,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -262,7 +273,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -580,8 +591,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -43,6 +43,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 variable "cors_allow_credentials" {
   description = "Whether to allow credentials in CORS requests"
@@ -129,10 +142,32 @@ module "http_api" {
   tags = var.tags
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "<%- apiNameKebabCase %>-lambda-"
+  description = "Security group for the <%- apiNameClassName %> API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 # This configures a single "router" lambda to serve all requests
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -163,6 +198,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   <%_ if (backend.type === 'fastapi') { _%>
   # Enable SnapStart for faster cold starts
   snap_start {
@@ -181,6 +224,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -212,6 +257,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -525,6 +577,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -43,6 +43,19 @@ variable "asset_bucket_name" {
   type        = string
 }
 
+# VPC Configuration (optional)
+variable "vpc_id" {
+  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
 # CORS Configuration (passed to core module)
 
 variable "cors_allow_headers" {
@@ -139,9 +152,31 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
   depends_on = [aws_api_gateway_stage.api_stage]
 }
 
+# Security group for the API Lambda function, used when deployed into a VPC
+resource "aws_security_group" "api_lambda" {
+  count = var.vpc_id != null ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
+  name_prefix = "<%- apiNameKebabCase %>-lambda-"
+  description = "Security group for the <%- apiNameClassName %> API Lambda function"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
+  count = var.vpc_id != null ? 1 : 0
+
+  security_group_id = aws_security_group.api_lambda[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Lambda function
 resource "aws_lambda_function" "api_lambda" {
-  #checkov:skip=CKV_AWS_117:Lambda function does not need to be in VPC for this use case
+  #checkov:skip=CKV_AWS_117:Lambda function is optionally deployed into a VPC via vpc_id/subnet_ids; not required for this use case
   #checkov:skip=CKV_AWS_116:Dead Letter Queue not required for this simple API use case
   #checkov:skip=CKV_AWS_272:Code signing not required for this use case
   #checkov:skip=CKV_AWS_115:Concurrent execution limit not required for this use case
@@ -172,6 +207,14 @@ resource "aws_lambda_function" "api_lambda" {
     mode = "Active"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != null ? [1] : []
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = [aws_security_group.api_lambda[0].id]
+    }
+  }
+
   <%_ if (backend.type === 'fastapi') { _%>
   # Enable SnapStart for faster cold starts
   snap_start {
@@ -190,6 +233,8 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_iam_role_policy_attachment.lambda_vpc_access]
 }
 
 # IAM role for Lambda execution
@@ -221,6 +266,13 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 # Attach X-Ray tracing policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  role       = aws_iam_role.lambda_execution_role.name
+}
+
+# Attach VPC access policy to Lambda role when deployed into a VPC
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.vpc_id != null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
 
@@ -792,6 +844,11 @@ output "lambda_execution_role_arn" {
 output "lambda_execution_role_name" {
   description = "Name of the Lambda execution role"
   value       = aws_iam_role.lambda_execution_role.name
+}
+
+output "security_group_id" {
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
+  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -44,14 +44,25 @@ variable "asset_bucket_name" {
 }
 
 # VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Deploy the Lambda function into a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
-  description = "VPC ID to deploy the Lambda function into. Leave unset to keep the Lambda outside a VPC."
+  description = "VPC ID to deploy the Lambda function into. Required when enable_vpc is true."
   type        = string
   default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs to deploy the Lambda function into. Required when vpc_id is set."
+  description = "Subnet IDs to deploy the Lambda function into. Required when enable_vpc is true."
   type        = list(string)
   default     = null
 }
@@ -154,7 +165,7 @@ resource "aws_wafv2_web_acl_association" "api_waf_association" {
 
 # Security group for the API Lambda function, used when deployed into a VPC
 resource "aws_security_group" "api_lambda" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   #checkov:skip=CKV2_AWS_5:Attached to api_lambda via vpc_config block; Checkov cannot resolve this reference
   name_prefix = "<%- apiNameKebabCase %>-lambda-"
@@ -164,7 +175,7 @@ resource "aws_security_group" "api_lambda" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "api_lambda_https" {
-  count = var.vpc_id != null ? 1 : 0
+  count = var.enable_vpc ? 1 : 0
 
   security_group_id = aws_security_group.api_lambda[0].id
   cidr_ipv4         = "0.0.0.0/0"
@@ -208,7 +219,7 @@ resource "aws_lambda_function" "api_lambda" {
   }
 
   dynamic "vpc_config" {
-    for_each = var.vpc_id != null ? [1] : []
+    for_each = var.enable_vpc ? [1] : []
     content {
       subnet_ids         = var.subnet_ids
       security_group_ids = [aws_security_group.api_lambda[0].id]
@@ -271,7 +282,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray_execution" {
 
 # Attach VPC access policy to Lambda role when deployed into a VPC
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  count      = var.vpc_id != null ? 1 : 0
+  count      = var.enable_vpc ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.lambda_execution_role.name
 }
@@ -847,8 +858,8 @@ output "lambda_execution_role_name" {
 }
 
 output "security_group_id" {
-  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless vpc_id is set."
-  value       = var.vpc_id != null ? aws_security_group.api_lambda[0].id : null
+  description = "Security group ID of the API Lambda function, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.api_lambda[0].id : null
 }
 
 # Integration Outputs


### PR DESCRIPTION
### Reason for this change

The Terraform module generated for REST/HTTP APIs (used by `py#fast-api`, `ts#trpc-api` and `ts#smithy-api`) had no way to deploy the API's Lambda function into a VPC. This is needed, for example, to reach an RDS database from a `fast-api`/`trpc`/`smithy` backend. The CDK construct already supports this generically via `FunctionProps` (`vpc`/`vpcSubnets`/`securityGroups`), so this was a Terraform-only gap.

### Description of changes

- Added optional `vpc_id` and `subnet_ids` variables to the REST and HTTP API Terraform templates (`utils/api-constructs/files/terraform/app/apis/{rest,http}/__apiNameKebabCase__/__apiNameKebabCase__.tf.template`).
- When `vpc_id` is set, the module creates and manages its own security group for the API Lambda (mirroring the pattern already used by the `rdb-constructs` Terraform module), attaches a `vpc_config` block, and conditionally attaches `AWSLambdaVPCAccessExecutionRole` to the Lambda's execution role.
- Added a `security_group_id` output so other modules (e.g. a database module) can add ingress rules for the API Lambda.
- Left VPC config fully optional/backward compatible — Lambdas remain outside a VPC by default.

### Description of how you validated changes

- Updated and reviewed the affected generator snapshot tests (`py/fast-api`, `trpc/backend`, `smithy/ts/api`) which cover the rendered Terraform output for both REST and HTTP APIs.
- Ran the full `@aws/nx-plugin:test` suite (triggered via the pre-commit hook) — all green.

### Checklist
- [x] My code adheres to the CONTRIBUTING GUIDE and DESIGN GUIDELINES

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*