### PR TITLE
chore(preset): drop @next tag from vended MCP server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Create a workspace and start adding components — zero configuration required:
 
 ```bash
 # Create a new workspace
-pnpm create @aws/nx-workspace@next my-project
+pnpm create @aws/nx-workspace my-project
 cd my-project
 
 # Add a tRPC API

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -133,7 +133,7 @@ Create a workspace and start adding components — zero configuration required:
 
 ```bash
 # Create a new workspace
-pnpm create @aws/nx-workspace@next my-project
+pnpm create @aws/nx-workspace my-project
 cd my-project
 
 # Add a tRPC API

--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -75,9 +75,7 @@ describe('MCP Server', () => {
     // Verify result
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toContain(
-      'pnpm create @aws/nx-workspace@next',
-    );
+    expect(result.content[0].text).toContain('pnpm create @aws/nx-workspace');
   });
 
   it('should execute list-generators tool', async () => {

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -27,7 +27,7 @@ export const addCreateWorkspaceCommandTool = (server: McpServer) => {
           text: `Run the following command to create a workspace:
 
 \`\`\`bash
-${buildCreateNxWorkspaceCommand(packageManager, '<workspace-name>', undefined, 'next')} --no-interactive
+${buildCreateNxWorkspaceCommand(packageManager, '<workspace-name>')} --no-interactive
 \`\`\`
 
 This will create a new workspace within the \`<workspace-name>\` directory.
@@ -35,7 +35,7 @@ This will create a new workspace within the \`<workspace-name>\` directory.
 If you are already inside an empty directory intended for this project, you can pass \`.\` as the workspace name to create the workspace in the current directory:
 
 \`\`\`bash
-${buildCreateNxWorkspaceCommand(packageManager, '.', undefined, 'next')} --no-interactive
+${buildCreateNxWorkspaceCommand(packageManager, '.')} --no-interactive
 \`\`\`
 
 Note that this will prompt for an Infrastructure as Code provider (${IAC_PROVIDERS.join(', ')}).

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`preset generator > should run successfully > .codex/config.toml 1`] = `
 "[mcp_servers.nx-plugin-for-aws]
 command = "npx"
-args = [ "-y", "@aws/nx-plugin-mcp@next" ]
+args = [ "-y", "@aws/nx-plugin-mcp" ]
 "
 `;
 
@@ -12,7 +12,7 @@ exports[`preset generator > should run successfully > .cursor/mcp.json 1`] = `
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp@next"]
+      "args": ["-y", "@aws/nx-plugin-mcp"]
     }
   }
 }
@@ -24,7 +24,7 @@ exports[`preset generator > should run successfully > .gemini/settings.json 1`] 
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp@next"]
+      "args": ["-y", "@aws/nx-plugin-mcp"]
     }
   }
 }
@@ -38,7 +38,7 @@ exports[`preset generator > should run successfully > .kiro/settings/mcp.json 1`
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp@next"]
+      "args": ["-y", "@aws/nx-plugin-mcp"]
     }
   }
 }
@@ -50,7 +50,7 @@ exports[`preset generator > should run successfully > .mcp.json 1`] = `
   "mcpServers": {
     "nx-plugin-for-aws": {
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp@next"]
+      "args": ["-y", "@aws/nx-plugin-mcp"]
     }
   }
 }
@@ -65,7 +65,7 @@ exports[`preset generator > should run successfully > .vscode/mcp.json 1`] = `
     "nx-plugin-for-aws": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp@next"]
+      "args": ["-y", "@aws/nx-plugin-mcp"]
     }
   }
 }

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -119,7 +119,7 @@ describe('preset generator', () => {
     expect(readJson(tree, '.mcp.json').mcpServers['nx-plugin-for-aws']).toEqual(
       {
         command: 'npx',
-        args: ['-y', '@aws/nx-plugin-mcp@next'],
+        args: ['-y', '@aws/nx-plugin-mcp'],
       },
     );
   });

--- a/packages/nx-plugin/src/utils/mcp.spec.ts
+++ b/packages/nx-plugin/src/utils/mcp.spec.ts
@@ -26,7 +26,7 @@ describe('mcp utils', () => {
         const config = readJson(tree, filePath);
         expect(config.mcpServers[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
           command: 'npx',
-          args: ['-y', '@aws/nx-plugin-mcp@next'],
+          args: ['-y', '@aws/nx-plugin-mcp'],
         });
       }
 
@@ -35,14 +35,14 @@ describe('mcp utils', () => {
       expect(vscode.servers[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
         type: 'stdio',
         command: 'npx',
-        args: ['-y', '@aws/nx-plugin-mcp@next'],
+        args: ['-y', '@aws/nx-plugin-mcp'],
       });
 
       // OpenAI Codex CLI uses TOML
       const codex = TOML.parse(tree.read('.codex/config.toml', 'utf-8'));
       expect((codex.mcp_servers as any)[NX_PLUGIN_MCP_SERVER_NAME]).toEqual({
         command: 'npx',
-        args: ['-y', '@aws/nx-plugin-mcp@next'],
+        args: ['-y', '@aws/nx-plugin-mcp'],
       });
     });
 

--- a/packages/nx-plugin/src/utils/mcp.ts
+++ b/packages/nx-plugin/src/utils/mcp.ts
@@ -18,7 +18,7 @@ export const NX_PLUGIN_MCP_SERVER_COMMAND = 'npx';
 /**
  * Arguments used to launch the Nx Plugin for AWS MCP server.
  */
-export const NX_PLUGIN_MCP_SERVER_ARGS = ['-y', '@aws/nx-plugin-mcp@next'];
+export const NX_PLUGIN_MCP_SERVER_ARGS = ['-y', '@aws/nx-plugin-mcp'];
 
 /**
  * A single stdio MCP server entry, shared by agents that use the `mcpServers` config shape.


### PR DESCRIPTION
### Reason for this change

The MCP server configuration vended into new workspaces (and the `create-workspace-command` MCP tool output and README quickstart) pointed at the `@next` pre-release tag. This pinned scaffolded workspaces and users following the docs to the pre-release channel rather than the latest published release.

### Description of changes

- `utils/mcp.ts`: `NX_PLUGIN_MCP_SERVER_ARGS` now uses `@aws/nx-plugin-mcp` (drops `@next`). This flows into every vended agent config (`.mcp.json`, `.cursor/mcp.json`, `.kiro/settings/mcp.json`, `.gemini/settings.json`, `.vscode/mcp.json`, `.codex/config.toml`).
- `mcp-server/tools/create-workspace-command.ts`: dropped the `'next'` tag from the `buildCreateNxWorkspaceCommand` calls, so the tool outputs `pnpm create @aws/nx-workspace`.
- `README.md` / `packages/nx-plugin/README.md`: quickstart now uses `pnpm create @aws/nx-workspace` (no `@next`).
- Updated the corresponding unit tests and snapshots.

The blog migration guides intentionally pin explicit versions (e.g. `create-nx-workspace@21.4.1`, `@aws/nx-plugin@0.50.0`) and were left untouched.

### Description of how you validated changes

Updated and ran the affected unit tests and snapshots (`utils/mcp.spec.ts`, `preset/generator.spec.ts`, `mcp-server/server.spec.ts`) — all pass. A repo-wide search confirms no remaining `@next` references outside `node_modules`/`dist`/lockfiles.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
