### PR TITLE
feat(open-api): tagged discriminated unions and composite array marshalling

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -1,5 +1,270 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`openApiTsClientGenerator - composite schemas > marshals a polymorphic list as an array of a discriminated union > client.gen.ts 1`] = `
+"import type { Animal, Cat, Dog } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Animal = {
+    toJson: (model: Animal): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).kind) {
+        case 'cat':
+          return $IO.Cat.toJson(model as Cat);
+        case 'dog':
+          return $IO.Dog.toJson(model as Dog);
+      }
+      return {
+        ...$IO.Cat.toJson(model as Cat),
+        ...$IO.Dog.toJson(model as Dog),
+      };
+    },
+    fromJson: (json: any): Animal => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.['kind']) {
+        case 'cat':
+          return $IO.Cat.fromJson(json);
+        case 'dog':
+          return $IO.Dog.fromJson(json);
+      }
+      return {
+        ...$IO.Cat.fromJson(json),
+        ...$IO.Dog.fromJson(json),
+      };
+    },
+  };
+
+  public static Cat = {
+    toJson: (model: Cat): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Cat => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static Dog = {
+    toJson: (model: Dog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Dog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.listPets = this.listPets.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async listPets(): Promise<Array<Animal>> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/pets', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return ((await response.json()) as Array<any>).map($IO.Animal.fromJson);
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - composite schemas > marshals a polymorphic list as an array of a discriminated union > types.gen.ts 1`] = `
+"export type Animal = Cat | Dog;
+export type Cat = {
+  kind: 'cat';
+  napAt: Date;
+};
+export type Dog = {
+  kind: 'dog';
+  walkAt: Date;
+};
+export type ListPetsError = never;
+"
+`;
+
 exports[`openApiTsClientGenerator - composite schemas > should generate valid TypeScript for composite types 1`] = `
 "export type PutTest200Response = PutTest200ResponseAllOf &
   PutTest200ResponseAllOf1;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -394,7 +394,7 @@ export class TestApi {
 
 exports[`openApiTsClientGenerator - composite schemas > should handle FastAPI-style discriminated unions with string const (Literal) 1`] = `
 "export type Circle = {
-  kind: string;
+  kind: 'circle';
   radius: number;
 };
 export type Kind = 'circle';
@@ -404,7 +404,7 @@ export type ShapesOut = {
 };
 export type ShapesOutCanonical = Circle | Square;
 export type Square = {
-  kind: string;
+  kind: 'square';
   side: number;
 };
 export type GetShapesError = never;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -3746,7 +3746,9 @@ export class $IO {
           ? {}
           : {
               data:
-                model.data === null ? null : model.data.map((item0) => item0),
+                model.data === null
+                  ? null
+                  : model.data.map($IO.ThingDataItem.toJson),
             }),
       };
     },
@@ -3761,7 +3763,9 @@ export class $IO {
               data:
                 json['data'] === null
                   ? null
-                  : (json['data'] as Array<any>).map((item0) => item0),
+                  : (json['data'] as Array<any>).map(
+                      $IO.ThingDataItem.fromJson,
+                    ),
             }),
       };
     },

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -5240,3 +5240,268 @@ exports[`openApiTsClientGenerator - edge cases > treats a requestBody with an em
 "export type DoNoopError = never;
 "
 `;
+
+exports[`openApiTsClientGenerator - edge cases > uses the original schema name as the discriminator value for normalised names > client.gen.ts 1`] = `
+"import type { Pet, PetCat, PetDog } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Pet = {
+    toJson: (model: Pet): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).kind) {
+        case 'pet-cat':
+          return $IO.PetCat.toJson(model as PetCat);
+        case 'pet-dog':
+          return $IO.PetDog.toJson(model as PetDog);
+      }
+      return {
+        ...$IO.PetCat.toJson(model as PetCat),
+        ...$IO.PetDog.toJson(model as PetDog),
+      };
+    },
+    fromJson: (json: any): Pet => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.['kind']) {
+        case 'pet-cat':
+          return $IO.PetCat.fromJson(json);
+        case 'pet-dog':
+          return $IO.PetDog.fromJson(json);
+      }
+      return {
+        ...$IO.PetCat.fromJson(json),
+        ...$IO.PetDog.fromJson(json),
+      };
+    },
+  };
+
+  public static PetCat = {
+    toJson: (model: PetCat): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): PetCat => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static PetDog = {
+    toJson: (model: PetDog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): PetDog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getPet = this.getPet.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getPet(): Promise<Pet> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/pets', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Pet.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > uses the original schema name as the discriminator value for normalised names > types.gen.ts 1`] = `
+"export type Pet = PetCat | PetDog;
+export type PetCat = {
+  kind: 'pet-cat';
+  napAt: Date;
+};
+export type PetDog = {
+  kind: 'pet-dog';
+  walkAt: Date;
+};
+export type GetPetError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -258,11 +258,11 @@ export class TestApi {
 
 exports[`openApiTsClientGenerator - edge cases > dispatches a discriminator whose wire name differs from its TS name > types.gen.ts 1`] = `
 "export type Cat = {
-  petType: string;
+  petType: 'cat';
   napAt: Date;
 };
 export type Dog = {
-  petType: string;
+  petType: 'dog';
   walkAt: Date;
 };
 export type Shape = Cat | Dog;
@@ -522,6 +522,278 @@ export type ShapeOneOf1 = {
   walkAt: Date;
 };
 export type GetShapeError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > emits a tagged union that narrows on the discriminator > client.gen.ts 1`] = `
+"import type { Cat, Dog, Shape, PostShapeRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Cat = {
+    toJson: (model: Cat): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.napAt === undefined
+          ? {}
+          : {
+              napAt: model.napAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Cat => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        napAt: new Date(json['napAt']),
+      };
+    },
+  };
+
+  public static Dog = {
+    toJson: (model: Dog): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.kind === undefined
+          ? {}
+          : {
+              kind: model.kind,
+            }),
+        ...(model.walkAt === undefined
+          ? {}
+          : {
+              walkAt: model.walkAt.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Dog => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        kind: json['kind'],
+        walkAt: new Date(json['walkAt']),
+      };
+    },
+  };
+
+  public static Shape = {
+    toJson: (model: Shape): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      switch ((model as any).kind) {
+        case 'cat':
+          return $IO.Cat.toJson(model as Cat);
+        case 'dog':
+          return $IO.Dog.toJson(model as Dog);
+      }
+      return {
+        ...$IO.Cat.toJson(model as Cat),
+        ...$IO.Dog.toJson(model as Dog),
+      };
+    },
+    fromJson: (json: any): Shape => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      switch (json?.['kind']) {
+        case 'cat':
+          return $IO.Cat.fromJson(json);
+        case 'dog':
+          return $IO.Dog.fromJson(json);
+      }
+      return {
+        ...$IO.Cat.fromJson(json),
+        ...$IO.Dog.fromJson(json),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.postShape = this.postShape.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async postShape(input: PostShapeRequest): Promise<Shape> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.Shape.toJson(input))
+        : String($IO.Shape.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/shapes', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Shape.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - edge cases > emits a tagged union that narrows on the discriminator > types.gen.ts 1`] = `
+"export type Cat = {
+  kind: 'cat';
+  napAt: Date;
+};
+export type Dog = {
+  kind: 'dog';
+  walkAt: Date;
+};
+export type Shape = Cat | Dog;
+
+export type PostShapeRequest = Shape;
+export type PostShapeError = never;
 "
 `;
 
@@ -2310,11 +2582,11 @@ export class TestApi {
 
 exports[`openApiTsClientGenerator - edge cases > marshals a discriminated oneOf to the matching branch (explicit mapping) > types.gen.ts 1`] = `
 "export type Cat = {
-  kind: string;
+  kind: 'cat';
   napAt: Date;
 };
 export type Dog = {
-  kind: string;
+  kind: 'dog';
   walkAt: Date;
 };
 export type Shape = Cat | Dog;
@@ -2582,11 +2854,11 @@ export class TestApi {
 
 exports[`openApiTsClientGenerator - edge cases > marshals a discriminated oneOf using implicit (schema-name) mapping > types.gen.ts 1`] = `
 "export type Cat = {
-  kind: string;
+  kind: 'Cat';
   napAt: Date;
 };
 export type Dog = {
-  kind: string;
+  kind: 'Dog';
   walkAt: Date;
 };
 export type Shape = Cat | Dog;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.fast-api.spec.ts.snap
@@ -185,7 +185,7 @@ export class $IO {
         ...(model.loc === undefined
           ? {}
           : {
-              loc: model.loc.map((item0) => item0),
+              loc: model.loc.map($IO.LocationItem.toJson),
             }),
         ...(model.msg === undefined
           ? {}
@@ -204,7 +204,7 @@ export class $IO {
         return json;
       }
       return {
-        loc: (json['loc'] as Array<any>).map((item0) => item0),
+        loc: (json['loc'] as Array<any>).map($IO.LocationItem.fromJson),
         msg: json['msg'],
         type: json['type'],
       };
@@ -509,7 +509,7 @@ export class $IO {
         ...(model.loc === undefined
           ? {}
           : {
-              loc: model.loc.map((item0) => item0),
+              loc: model.loc.map($IO.LocationItem.toJson),
             }),
         ...(model.msg === undefined
           ? {}
@@ -528,7 +528,7 @@ export class $IO {
         return json;
       }
       return {
-        loc: (json['loc'] as Array<any>).map((item0) => item0),
+        loc: (json['loc'] as Array<any>).map($IO.LocationItem.fromJson),
         msg: json['msg'],
         type: json['type'],
       };
@@ -1755,7 +1755,7 @@ export class $IO {
         ...(model.loc === undefined
           ? {}
           : {
-              loc: model.loc.map((item0) => item0),
+              loc: model.loc.map($IO.LocationItem.toJson),
             }),
         ...(model.msg === undefined
           ? {}
@@ -1774,7 +1774,7 @@ export class $IO {
         return json;
       }
       return {
-        loc: (json['loc'] as Array<any>).map((item0) => item0),
+        loc: (json['loc'] as Array<any>).map($IO.LocationItem.fromJson),
         msg: json['msg'],
         type: json['type'],
       };

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -65,7 +65,9 @@ const renderNestedToJsonValue = (type, argumentType = undefined, depth = 0) => {
     return `(${itemIdentifier}${argType}) => ${itemIdentifier}.map(${renderNestedToJsonValue(type.link, argumentType, depth + 1)})`;
   } else if (type.export === "dictionary") {
     return `(${itemIdentifier}${argType}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedToJsonValue(type.link, argumentType, depth + 1)})`;
-  } else if (type.type === 'unknown') {
+  } else if (type.type === 'unknown' && !["one-of", "any-of", "all-of"].includes(type.export)) {
+    // A bare `unknown` element passes through; a composite has type `unknown`
+    // but must still be marshalled via its own $IO entry.
     return `(${itemIdentifier}${argType}) => ${itemIdentifier}`;
   }
   return `$IO.${type.typescriptType || type.typescriptName}.toJson`;
@@ -106,7 +108,9 @@ const renderNestedFromJsonValue = (type, argumentType = undefined, depth = 0) =>
         return `(${itemIdentifier}${argType}) => ${itemIdentifier}.map(${renderNestedFromJsonValue(type.link, argumentType, depth + 1)})`;
     } else if (type.export === "dictionary") {
         return `(${itemIdentifier}${argType}) => $IO.$mapValues(${itemIdentifier}, ${renderNestedFromJsonValue(type.link, argumentType, depth + 1)})`;
-    } else if (type.type === 'unknown') {
+    } else if (type.type === 'unknown' && !["one-of", "any-of", "all-of"].includes(type.export)) {
+      // A bare `unknown` element passes through; a composite has type `unknown`
+      // but must still be marshalled via its own $IO entry.
       return `(${itemIdentifier}${argType}) => ${itemIdentifier}`;
     }
     return `$IO.${type.typescriptType || type.typescriptName}.fromJson`;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -1440,4 +1440,99 @@ describe('openApiTsClientGenerator - composite schemas', () => {
       lastNapAt: '2024-01-02T03:04:05.000Z',
     });
   });
+
+  it('marshals a polymorphic list as an array of a discriminated union', async () => {
+    // The supported shape for a polymorphic list: an array whose items are a
+    // discriminated union (not a oneOf of arrays). Each element marshals to its
+    // matching branch, so branch-only dates round-trip without leaking.
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/pets': {
+          get: {
+            operationId: 'listPets',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Animal' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Cat: {
+            type: 'object',
+            required: ['kind', 'napAt'],
+            properties: {
+              kind: { type: 'string' },
+              napAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Dog: {
+            type: 'object',
+            required: ['kind', 'walkAt'],
+            properties: {
+              kind: { type: 'string' },
+              walkAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Animal: {
+            oneOf: [
+              { $ref: '#/components/schemas/Cat' },
+              { $ref: '#/components/schemas/Dog' },
+            ],
+            discriminator: {
+              propertyName: 'kind',
+              mapping: {
+                cat: '#/components/schemas/Cat',
+                dog: '#/components/schemas/Dog',
+              },
+            },
+          } as never,
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    expect(types).toMatchSnapshot('types.gen.ts');
+    expect(client).toMatchSnapshot('client.gen.ts');
+
+    // A mixed list: each element deserialises via its own branch, so the Cat
+    // keeps napAt and the Dog keeps walkAt with no cross-branch leakage.
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue([
+        { kind: 'cat', napAt: '2024-01-02T03:04:05.000Z' },
+        { kind: 'dog', walkAt: '2024-06-07T08:09:10.000Z' },
+      ]),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'listPets');
+    expect(response).toEqual([
+      { kind: 'cat', napAt: new Date('2024-01-02T03:04:05.000Z') },
+      { kind: 'dog', walkAt: new Date('2024-06-07T08:09:10.000Z') },
+    ]);
+    expect('walkAt' in response[0]).toBe(false);
+    expect('napAt' in response[1]).toBe(false);
+  });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -1271,13 +1271,10 @@ describe('openApiTsClientGenerator - composite schemas', () => {
     expect(client).not.toMatch(/\b_String\b/);
     expect(types).not.toMatch(/:\s*undefined\b/);
 
-    // After rewriteConstToEnum + languages.ts defence-in-depth the property
-    // resolves to bare `string` (the generator does not currently propagate
-    // the literal back to the reference site — it's compiled cleanly by tsc
-    // but loses the Literal narrowing). Assert the concrete current shape so
-    // any future tightening of this path is a deliberate, visible change.
-    expect(types).toMatch(/kind:\s*string\b/);
-    expect(types).not.toMatch(/kind:\s*'circle'/);
+    // The discriminator property is typed as its literal per subtype, making
+    // the union a true tagged union that narrows on `kind`.
+    expect(types).toMatch(/kind:\s*'circle'/);
+    expect(types).toMatch(/kind:\s*'square'/);
 
     // The discriminator must marshal directly to the matching branch, so a
     // Square must not gain a spurious `radius` from the Circle branch.

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -40,6 +40,8 @@ import {
  *  N. a discriminator whose wire name differs from its TS name (e.g. `pet-type`)
  *     must dispatch on the TS name in toJson and the wire name in fromJson
  *  O. a `deepObject` query parameter must serialise as `key[prop]=value` pairs
+ *  P. a discriminated union must be a true tagged union that narrows on the
+ *     discriminator (each branch's discriminator typed as its literal)
  */
 describe('openApiTsClientGenerator - edge cases', () => {
   let tree: Tree;
@@ -818,7 +820,12 @@ describe('openApiTsClientGenerator - edge cases', () => {
     }) as unknown as Spec;
 
   it('marshals a discriminated oneOf to the matching branch (explicit mapping)', async () => {
-    const { client } = await generate(discriminatedShapeSpec(true));
+    const { types, client } = await generate(discriminatedShapeSpec(true));
+
+    // The union is tagged: each branch's discriminator is its literal, so it
+    // narrows on `kind`.
+    expect(types).toMatch(/kind:\s*'cat'/);
+    expect(types).toMatch(/kind:\s*'dog'/);
 
     // fromJson dispatches on the wire discriminator and picks a single branch.
     const mockFetch = vi.fn();
@@ -1166,5 +1173,34 @@ describe('openApiTsClientGenerator - edge cases', () => {
     expect(url).toBe(
       `${baseUrl}/search?filter[page][size]=10&filter[page][sort]=asc`,
     );
+  });
+
+  // ---- P. tagged discriminated union narrows -------------------------------
+
+  it('emits a tagged union that narrows on the discriminator', async () => {
+    const { types } = await generate(discriminatedShapeSpec(true));
+
+    // Each branch's discriminator is typed as its literal.
+    expect(types).toMatch(/kind:\s*'cat'/);
+    expect(types).toMatch(/kind:\s*'dog'/);
+
+    // A consumer that narrows on the discriminator must type-check: accessing a
+    // branch-only field after checking `kind` is only valid for a tagged union.
+    tree.write(
+      'src/generated/consumer.ts',
+      `import type { Shape } from './types.gen';
+       export const napAt = (shape: Shape): Date | undefined => {
+         switch (shape.kind) {
+           case 'cat':
+             return shape.napAt;
+           case 'dog':
+             return shape.walkAt;
+         }
+       };`,
+    );
+    expectTypeScriptToCompile(tree, [
+      'src/generated/types.gen.ts',
+      'src/generated/consumer.ts',
+    ]);
   });
 });

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -1203,4 +1203,80 @@ describe('openApiTsClientGenerator - edge cases', () => {
       'src/generated/consumer.ts',
     ]);
   });
+
+  it('uses the original schema name as the discriminator value for normalised names', async () => {
+    // Implicit discriminator over subtypes whose names need normalisation
+    // (`pet-cat` -> `PetCat`). The discriminator value on the wire is the
+    // ORIGINAL name, so both the type literal and the runtime dispatch must use
+    // `pet-cat`, not the normalised `PetCat`.
+    const spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/pets': {
+          get: {
+            operationId: 'getPet',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          'pet-cat': {
+            type: 'object',
+            required: ['kind', 'napAt'],
+            properties: {
+              kind: { type: 'string' },
+              napAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          'pet-dog': {
+            type: 'object',
+            required: ['kind', 'walkAt'],
+            properties: {
+              kind: { type: 'string' },
+              walkAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          Pet: {
+            oneOf: [
+              { $ref: '#/components/schemas/pet-cat' },
+              { $ref: '#/components/schemas/pet-dog' },
+            ],
+            discriminator: { propertyName: 'kind' },
+          },
+        },
+      },
+    } as unknown as Spec;
+    const { types, client } = await generate(spec);
+
+    // Literal tag and dispatch both use the original wire name.
+    expect(types).toMatch(/kind:\s*'pet-cat'/);
+    expect(client).toContain("case 'pet-cat'");
+    expect(types).not.toMatch(/kind:\s*'PetCat'/);
+
+    // A `pet-cat` payload dispatches to the PetCat branch and revives its date.
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ kind: 'pet-cat', napAt: '2024-01-02T03:04:05.000Z' }),
+    });
+    const response = await callGeneratedClient(client, mockFetch, 'getPet');
+    expect(response).toEqual({
+      kind: 'pet-cat',
+      napAt: new Date('2024-01-02T03:04:05.000Z'),
+    });
+    expect('walkAt' in response).toBe(false);
+  });
 });

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -710,6 +710,105 @@ describe('openapi codegen data utils', () => {
       );
     });
 
+    it('should not honour a discriminator on a oneOf of arrays (still throws with guidance)', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            CatList: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/Pet' },
+            },
+            DogList: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/NewPet' },
+            },
+            // A discriminator on the composite can't disambiguate arrays — the
+            // discriminator names a property on an object, not on an array.
+            AnyList: {
+              oneOf: [
+                { $ref: '#/components/schemas/CatList' },
+                { $ref: '#/components/schemas/DogList' },
+              ],
+              discriminator: {
+                propertyName: 'type',
+                mapping: {
+                  cat: '#/components/schemas/CatList',
+                  dog: '#/components/schemas/DogList',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expect(() => buildOpenApiCodeGenData(spec)).toThrow(
+        /array whose items are a discriminated union/,
+      );
+    });
+
+    it('should support a polymorphic list as an array of a discriminated union', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        paths: {
+          '/pets': {
+            get: {
+              operationId: 'listPets',
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/Animal' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Cat: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' }, meow: { type: 'boolean' } },
+            },
+            Dog: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' }, bark: { type: 'boolean' } },
+            },
+            Animal: {
+              oneOf: [
+                { $ref: '#/components/schemas/Cat' },
+                { $ref: '#/components/schemas/Dog' },
+              ],
+              discriminator: {
+                propertyName: 'kind',
+                mapping: {
+                  cat: '#/components/schemas/Cat',
+                  dog: '#/components/schemas/Dog',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // The recommended shape builds cleanly and tags the union.
+      const data = buildOpenApiCodeGenData(spec);
+      const animal = data.models.find((m) => m.name === 'Animal')!;
+      expect(animal.discriminator?.mapping).toEqual([
+        { value: 'cat', modelName: 'Cat' },
+        { value: 'dog', modelName: 'Dog' },
+      ]);
+    });
+
     it('should throw when two properties map to the same TypeScript name', () => {
       const spec: Spec = {
         ...sampleSpec,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -821,6 +821,53 @@ describe('openapi codegen data utils', () => {
           { value: 'dog', modelName: 'Dog' },
         ],
       });
+
+      // Each subtype's discriminator property is typed as its literal tag.
+      const catKind = data.models
+        .find((m) => m.name === 'Cat')!
+        .properties.find((p) => p.name === 'kind')!;
+      const dogKind = data.models
+        .find((m) => m.name === 'Dog')!
+        .properties.find((p) => p.name === 'kind')!;
+      expect(catKind.typescriptType).toBe('"cat"');
+      expect(dogKind.typescriptType).toBe('"dog"');
+    });
+
+    it('should fall back to the primitive tag when a subtype is tagged differently across unions', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            Cat: {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' } },
+            },
+            Pet: {
+              oneOf: [{ $ref: '#/components/schemas/Cat' }],
+              discriminator: {
+                propertyName: 'kind',
+                mapping: { cat: '#/components/schemas/Cat' },
+              },
+            },
+            Animal: {
+              oneOf: [{ $ref: '#/components/schemas/Cat' }],
+              discriminator: {
+                propertyName: 'kind',
+                mapping: { feline: '#/components/schemas/Cat' },
+              },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const catKind = data.models
+        .find((m) => m.name === 'Cat')!
+        .properties.find((p) => p.name === 'kind')!;
+      // 'cat' vs 'feline' conflict → no single literal, stays a string.
+      expect(catKind.typescriptType).toBe('string');
     });
 
     it('should build implicit discriminator mapping from member names', () => {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -1004,6 +1004,47 @@ describe('openapi codegen data utils', () => {
       ]);
     });
 
+    it('should use the original (pre-normalisation) schema name as the implicit discriminator value', () => {
+      const spec: Spec = {
+        ...sampleSpec,
+        components: {
+          schemas: {
+            ...sampleSpec.components.schemas,
+            'pet-cat': {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' }, meow: { type: 'boolean' } },
+            },
+            'pet-dog': {
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { type: 'string' }, bark: { type: 'boolean' } },
+            },
+            Animal: {
+              oneOf: [
+                { $ref: '#/components/schemas/pet-cat' },
+                { $ref: '#/components/schemas/pet-dog' },
+              ],
+              discriminator: { propertyName: 'kind' },
+            },
+          },
+        },
+      };
+
+      const data = buildOpenApiCodeGenData(spec);
+      const animal = data.models.find((m) => m.name === 'Animal')!;
+      // The wire value is the original name; it selects the normalised model.
+      expect(animal.discriminator?.mapping).toEqual([
+        { value: 'pet-cat', modelName: 'PetCat' },
+        { value: 'pet-dog', modelName: 'PetDog' },
+      ]);
+      // The subtype's discriminator literal is the wire value, not the model name.
+      const catKind = data.models
+        .find((m) => m.name === 'PetCat')!
+        .properties.find((p) => p.name === 'kind')!;
+      expect(catKind.typescriptType).toBe('"pet-cat"');
+    });
+
     it('should exclude hoisted inline members from implicit discriminator mapping', () => {
       const spec: Spec = {
         ...sampleSpec,

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -19,6 +19,11 @@ const toTypescriptPrimitive = (property: Model): string => {
 };
 
 export const toTypeScriptType = (property: Model): string => {
+  // A discriminated subtype's discriminator property renders as its literal
+  // tag, making the union a true (narrowable) tagged union.
+  if (property.discriminatorValue) {
+    return property.discriminatorValue;
+  }
   const link = property.link;
   // Enum links serialise as their primitive; use the model's own type instead.
   const valueType = () =>

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -142,6 +142,15 @@ export interface Model {
   /** The response status code, for response models. */
   code?: number | string;
 
+  /**
+   * For a discriminated subtype's discriminator property: the rendered literal
+   * TypeScript type (e.g. `'cat'`, or `'cat' | 'kitten'` when several values
+   * map to one subtype) that makes the union a true tagged union. Absent when
+   * the subtype's tag can't be pinned to a literal (e.g. it appears in
+   * multiple unions with different values).
+   */
+  discriminatorValue?: string;
+
   /** The raw OpenAPI `type` (used to distinguish integer from number). */
   openapiType?: string | string[];
   /** Vendor extensions (`x-*`) copied from the schema. */

--- a/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
@@ -271,6 +271,24 @@ describe('normaliseOpenApiSpecForCodeGen', () => {
     );
   });
 
+  it('should record the original name when normalising a schema name', () => {
+    const spec: Spec = {
+      components: {
+        schemas: {
+          'pet-cat': { type: 'object', properties: { a: { type: 'string' } } },
+        },
+      },
+    } as any;
+
+    const result = normaliseOpenApiSpecForCodeGen(spec);
+
+    expect(result.components?.schemas?.['pet-cat']).toBeUndefined();
+    expect(result.components?.schemas?.PetCat).toMatchObject({
+      type: 'object',
+      'x-aws-nx-original-name': 'pet-cat',
+    });
+  });
+
   it('should handle composite schemas', () => {
     const spec: Spec = {
       components: {

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -90,9 +90,17 @@ const normaliseSchemaNames = (spec: Spec): Spec => {
     }
   });
 
-  // Rename schema keys
+  // Rename schema keys, recording the original name so downstream code can
+  // recover the on-the-wire value (e.g. an implicit discriminator matches on
+  // the original schema name, not its normalised identifier).
   Object.entries(schemaNameMapping).forEach(([oldName, newName]) => {
-    spec.components!.schemas![newName] = spec.components!.schemas![oldName];
+    const schema = spec.components!.schemas![oldName];
+    if (schema && !isRef(schema)) {
+      (schema as { 'x-aws-nx-original-name'?: string })[
+        'x-aws-nx-original-name'
+      ] = oldName;
+    }
+    spec.components!.schemas![newName] = schema;
     delete spec.components!.schemas![oldName];
   });
 

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -799,6 +799,19 @@ const isHoisted = (spec: Spec, name: string): boolean =>
   )?.['x-aws-nx-hoisted'];
 
 /**
+ * The on-the-wire name of a schema: its original name before normalisation to
+ * a valid identifier (recorded by the normaliser), or its current name. An
+ * implicit discriminator matches on this, not the normalised model name.
+ */
+const wireName = (spec: Spec, name: string): string =>
+  (
+    resolveIfRef<Schema | undefined>(
+      spec,
+      spec.components?.schemas?.[name],
+    ) as { 'x-aws-nx-original-name'?: string } | undefined
+  )?.['x-aws-nx-original-name'] ?? name;
+
+/**
  * The value → model-name mapping for a discriminator, resolved either from an
  * explicit `mapping` (value → schema ref) or implicitly (each candidate model's
  * schema name is its own discriminator value). Only candidates in
@@ -822,7 +835,9 @@ const buildDiscriminatorMapping = (
   }
   return [...candidateNames]
     .filter((name) => !isHoisted(spec, name))
-    .map((name) => ({ value: name, modelName: name }));
+    // The wire value is the schema's original name; the model it selects is the
+    // normalised name.
+    .map((name) => ({ value: wireName(spec, name), modelName: name }));
 };
 
 /**

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -911,6 +911,67 @@ const resolveDiscriminators = (spec: Spec, data: ClientData): void => {
 };
 
 /**
+ * Type each discriminated subtype's discriminator property as its literal
+ * value(s), turning `Cat | Dog` into a true TypeScript tagged union that
+ * narrows on the discriminator (e.g. `Cat.petType: 'cat'`).
+ *
+ * The literal is taken from every discriminator's `mapping` (value → subtype).
+ * A subtype selected by several values within one discriminator becomes a union
+ * of those literals. A subtype that appears in multiple discriminators with
+ * conflicting values can't be pinned to a single literal, so it is left as the
+ * plain primitive (`string`) — the marshalling dispatch is unaffected either
+ * way, this only affects the emitted type.
+ */
+const resolveDiscriminatorLiterals = (data: ClientData): void => {
+  const modelsByName = indexModelsByName(data.models);
+
+  // Collect, per (subtype, discriminator property), the set of literal values
+  // that select it — across every discriminator in the spec.
+  const valuesBySubtypeProp = new Map<string, Set<string>>();
+  const conflicting = new Set<string>();
+
+  for (const model of data.models) {
+    const discriminator = model.discriminator;
+    if (!discriminator) continue;
+    const byName = new Map<string, string[]>();
+    for (const { value, modelName } of discriminator.mapping) {
+      byName.set(modelName, [...(byName.get(modelName) ?? []), value]);
+    }
+    for (const [modelName, values] of byName) {
+      const key = `${modelName} ${discriminator.propertyName}`;
+      const existing = valuesBySubtypeProp.get(key);
+      const incoming = new Set(values);
+      if (existing && !setsEqual(existing, incoming)) {
+        // Same subtype+property tagged differently by another union.
+        conflicting.add(key);
+      }
+      valuesBySubtypeProp.set(key, existing ? union(existing, incoming) : incoming);
+    }
+  }
+
+  for (const [key, values] of valuesBySubtypeProp) {
+    if (conflicting.has(key)) continue;
+    const [modelName, propertyName] = key.split(' ');
+    const property = modelsByName[modelName]?.properties.find(
+      (p) => p.name === propertyName,
+    );
+    // Only pin a literal when the property is a plain (string/enum) scalar —
+    // never an object/array reference.
+    if (property && (property.type === 'string' || property.isEnum)) {
+      property.discriminatorValue = [...values]
+        .map((v) => JSON.stringify(v))
+        .join(' | ');
+    }
+  }
+};
+
+const setsEqual = (a: Set<string>, b: Set<string>): boolean =>
+  a.size === b.size && [...a].every((v) => b.has(v));
+
+const union = (a: Set<string>, b: Set<string>): Set<string> =>
+  new Set([...a, ...b]);
+
+/**
  * Build the client data structure from a (normalised) OpenAPI spec: a fully
  * linked model graph with composite members resolved, ready for augmentation.
  */
@@ -922,5 +983,6 @@ export const buildClientData = (spec: Spec): ClientData => {
   linkModels(spec, data);
   resolveComposedModels(data);
   resolveDiscriminators(spec, data);
+  resolveDiscriminatorLiterals(data);
   return data;
 };

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -753,9 +753,11 @@ const resolveComposedModel = (
     ...referenced.filter((m) => m.export === 'enum'),
   ];
 
-  // Composing multiple arrays of non-primitives is not distinguishable at
-  // runtime, so it's validated away.
-  // TODO: honour `discriminator` to support this case.
+  // A composite of multiple non-primitive array members can't be told apart at
+  // runtime: each arrives as a plain JSON array with no property to switch on.
+  // A `discriminator` can't disambiguate here either — it names a property on
+  // an object member, not on an array. Model a polymorphic list as an array of
+  // a discriminated union instead (`type: array` whose `items` is the oneOf).
   const isPrimitiveArray = (m: Model): boolean =>
     m.link && COLLECTION_TYPES.has(m.export)
       ? isPrimitiveArray(m.link)
@@ -766,7 +768,7 @@ const resolveComposedModel = (
   );
   if (arrayComposedModels.length > 1) {
     throw new Error(
-      `Schema "${model.name}" defines ${camelCase(model.export)} with multiple array types which cannot be distinguished at runtime.`,
+      `Schema "${model.name}" defines ${camelCase(model.export)} with multiple array types which cannot be distinguished at runtime. Model a polymorphic list as an array whose items are a discriminated union instead (a "type: array" schema with a "oneOf" in "items").`,
     );
   }
 


### PR DESCRIPTION
### Reason for this change

Two follow-ups to the OpenAPI generator overhaul (#886), both improving how discriminated unions are generated and consumed.

### What this means for customers

**1. Discriminated unions are now true TypeScript tagged unions**

Each discriminated subtype's discriminator property is typed as its literal value (e.g. `Cat.petType: 'cat'`) rather than the bare primitive. A union like `Pet = Cat | Dog` now narrows on the discriminator:

```ts
if (pet.petType === 'cat') {
  pet.meow; // ✅ narrows — previously an error (petType was `string`)
}
```

The literal comes from the discriminator `mapping` (explicit) or the subtype schema name (implicit). A subtype selected by several values becomes a union of literals; a subtype tagged differently across multiple unions safely falls back to the primitive. This is a type-only change — runtime marshalling already dispatched on the value.

**2. Composite (`oneOf`/`anyOf`) elements inside arrays and maps are now marshalled**

Previously a polymorphic list — an array whose items are a discriminated union — did not marshal its elements (dates and other non-trivial fields round-tripped as raw strings), because a composite model has an `unknown` value type that the nested renderer treated as passthrough. Elements are now routed through their own marshaller, so e.g. a `Cat[]` of dates deserialises correctly per branch.

The "multiple array types cannot be distinguished at runtime" error is also clarified: a `discriminator` can't disambiguate a `oneOf` of arrays (it names a property on an object, not an array), so the message now points to the supported shape — an array whose `items` are a discriminated union.

### Description of changes

- **Tagged unions** — `Model.discriminatorValue` carries the per-subtype literal, resolved in a new parser pass (`resolveDiscriminatorLiterals`) and rendered by `toTypeScriptType`. Conflict detection falls back to the primitive.
- **Composite array/map marshalling** — `renderNestedToJsonValue`/`renderNestedFromJsonValue` no longer treat a composite element (type `unknown`) as passthrough.
- **Clearer error + removed stale TODO** in `resolveComposedModel`.

### Description of how you validated changes

- Parser unit tests: literal tagging (explicit/implicit/union-of-values), multi-union conflict fallback, the array-union error guidance, and the supported array-of-union shape.
- ts-client tests: a `switch` that narrows on the discriminator and type-checks, and a runtime round-trip of a polymorphic list (array of a discriminated union) asserting per-branch dates revive without cross-branch leakage.
- Snapshots updated for the affected fixtures (discriminated unions, FastAPI anyOf lists); all `@aws/nx-plugin` open-api suites pass (305).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
