### PR TITLE
feat(open-api): support multipart/form-data file uploads

### DIFF
--- a/docs/src/content/docs/en/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### File Uploads
+
+For endpoints that accept a file upload, the generated client sends the request as `FormData`. Define an operation with a `multipart/form-data` body in your FastAPI, for example using `UploadFile`:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+Binary fields are typed as `Blob` on the generated client, and other fields (such as `description` above) keep their modelled types. Pass a `Blob` or `File` — for example one obtained from an `<input type="file">`:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+The client builds a `FormData` body and lets `fetch` set the `Content-Type` (including the multipart boundary) automatically.
+
 ### Pagination with Infinite Queries
 
 For endpoints that accept a `cursor` parameter as input, the generated hooks provide support for infinite queries using TanStack Query's `useInfiniteQuery` hook. This makes it easy to implement "load more" or infinite scrolling functionality.

--- a/docs/src/content/docs/es/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### Carga de Archivos
+
+Para endpoints que aceptan una carga de archivos, el cliente generado envía la petición como `FormData`. Define una operación con un cuerpo `multipart/form-data` en tu FastAPI, por ejemplo usando `UploadFile`:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+Los campos binarios se tipan como `Blob` en el cliente generado, y otros campos (como `description` arriba) mantienen sus tipos modelados. Pasa un `Blob` o `File` — por ejemplo uno obtenido de un `<input type="file">`:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+El cliente construye un cuerpo `FormData` y permite que `fetch` establezca el `Content-Type` (incluyendo el límite multipart) automáticamente.
+
 ### Paginación con Consultas Infinitas
 
 Para endpoints que aceptan un parámetro `cursor` como entrada, los hooks generados proveen soporte para consultas infinitas usando el hook `useInfiniteQuery` de TanStack Query. Esto facilita implementar funcionalidad de "cargar más" o scroll infinito.

--- a/docs/src/content/docs/fr/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### Téléchargement de fichiers
+
+Pour les endpoints qui acceptent un téléchargement de fichier, le client généré envoie la requête sous forme de `FormData`. Définissez une opération avec un corps `multipart/form-data` dans votre FastAPI, par exemple en utilisant `UploadFile` :
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+Les champs binaires sont typés comme `Blob` sur le client généré, et les autres champs (comme `description` ci-dessus) conservent leurs types modélisés. Passez un `Blob` ou `File` — par exemple obtenu depuis un `<input type="file">` :
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+Le client construit un corps `FormData` et laisse `fetch` définir le `Content-Type` (incluant la limite multipart) automatiquement.
+
 ### Pagination avec requêtes infinies
 
 Pour les endpoints acceptant un paramètre `cursor` en entrée, les hooks générés prennent en charge les requêtes infinies via le hook `useInfiniteQuery` de TanStack Query. Cela facilite l'implémentation de fonctionnalités "charger plus" ou de défilement infini.
@@ -1459,6 +1495,7 @@ function ItemForm() {
 </Drawer>
 
 Les types sont générés automatiquement à partir du schéma OpenAPI de votre FastAPI, garantissant que toute modification de votre API est reflétée dans votre code frontend après une compilation.
-## Custom Auth
 
-If your FastAPI uses `Custom` authentication (Lambda Authorizer), you will need to edit the generated client provider to add the authorization headers your authorizer expects. Look for the `fetch` configuration in the generated `<ApiName>Provider.tsx` and add your token or API key to the request headers.
+## Authentification personnalisée
+
+Si votre FastAPI utilise l'authentification `Custom` (Lambda Authorizer), vous devrez modifier le provider client généré pour ajouter les en-têtes d'autorisation attendus par votre authorizer. Recherchez la configuration `fetch` dans le fichier généré `<ApiName>Provider.tsx` et ajoutez votre token ou clé API aux en-têtes de requête.

--- a/docs/src/content/docs/it/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### Caricamento File
+
+Per endpoint che accettano il caricamento di file, il client generato invia la richiesta come `FormData`. Definisci un'operazione con un body `multipart/form-data` nel tuo FastAPI, ad esempio usando `UploadFile`:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+I campi binari sono tipizzati come `Blob` nel client generato, mentre altri campi (come `description` sopra) mantengono i loro tipi modellati. Passa un `Blob` o `File` — ad esempio uno ottenuto da un `<input type="file">`:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+Il client costruisce un body `FormData` e lascia che `fetch` imposti automaticamente il `Content-Type` (incluso il boundary multipart).
+
 ### Paginazione con Infinite Queries
 
 Per endpoint che accettano un parametro `cursor` come input, gli hook generati supportano infinite queries usando l'hook `useInfiniteQuery` di TanStack Query. Questo semplifica l'implementazione di funzionalità "carica più" o scroll infinito.
@@ -1469,6 +1505,7 @@ function ItemForm() {
 </Drawer>
 
 I tipi sono generati automaticamente dallo schema OpenAPI del FastAPI, assicurando che ogni modifica all'API si rifletta nel codice frontend dopo un build.
-## Custom Auth
 
-If your FastAPI uses `Custom` authentication (Lambda Authorizer), you will need to edit the generated client provider to add the authorization headers your authorizer expects. Look for the `fetch` configuration in the generated `<ApiName>Provider.tsx` and add your token or API key to the request headers.
+## Autenticazione Personalizzata
+
+Se il tuo FastAPI utilizza autenticazione `Custom` (Lambda Authorizer), dovrai modificare il provider del client generato per aggiungere gli header di autorizzazione che il tuo authorizer si aspetta. Cerca la configurazione `fetch` nel file generato `<ApiName>Provider.tsx` e aggiungi il tuo token o API key agli header della richiesta.

--- a/docs/src/content/docs/jp/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### ファイルアップロード
+
+ファイルアップロードを受け入れるエンドポイントの場合、生成クライアントはリクエストを `FormData` として送信します。FastAPI で `multipart/form-data` ボディを持つ操作を定義します。例えば `UploadFile` を使用:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+バイナリフィールドは生成クライアントで `Blob` として型指定され、その他のフィールド（上記の `description` など）はモデル化された型を保持します。`Blob` または `File` を渡します。例えば `<input type="file">` から取得したもの:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+クライアントは `FormData` ボディを構築し、`fetch` が `Content-Type`（マルチパート境界を含む）を自動的に設定します。
+
 ### 無限クエリによるページネーション
 
 `cursor` パラメータを受け入れるエンドポイントの場合、生成フックは TanStack Query の `useInfiniteQuery` フックを使用した無限クエリをサポートします。「さらに読み込む」や無限スクロール機能の実装が容易になります。
@@ -1469,6 +1505,7 @@ function ItemForm() {
 </Drawer>
 
 型は FastAPI の OpenAPI スキーマから自動生成されるため、API への変更はビルド後にフロントエンドコードに反映されます。
-## Custom Auth
 
-If your FastAPI uses `Custom` authentication (Lambda Authorizer), you will need to edit the generated client provider to add the authorization headers your authorizer expects. Look for the `fetch` configuration in the generated `<ApiName>Provider.tsx` and add your token or API key to the request headers.
+## カスタム認証
+
+FastAPI が `Custom` 認証（Lambda Authorizer）を使用している場合、生成されたクライアントプロバイダを編集して、オーソライザーが期待する認証ヘッダーを追加する必要があります。生成された `<ApiName>Provider.tsx` の `fetch` 設定を探し、リクエストヘッダーにトークンまたは API キーを追加してください。

--- a/docs/src/content/docs/ko/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### 파일 업로드
+
+파일 업로드를 받는 엔드포인트의 경우, 생성된 클라이언트는 요청을 `FormData`로 전송합니다. FastAPI에서 `multipart/form-data` 본문을 사용하는 작업을 정의하세요. 예를 들어 `UploadFile`을 사용:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+바이너리 필드는 생성된 클라이언트에서 `Blob` 타입으로 지정되며, 다른 필드(위의 `description` 등)는 모델링된 타입을 유지합니다. `Blob` 또는 `File`을 전달하세요 — 예를 들어 `<input type="file">`에서 얻은 것:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+클라이언트는 `FormData` 본문을 빌드하고 `fetch`가 `Content-Type`(multipart boundary 포함)을 자동으로 설정하도록 합니다.
+
 ### 무한 쿼리로 페이지네이션
 
 `cursor` 파라미터를 입력으로 받는 엔드포인트의 경우, TanStack Query의 `useInfiniteQuery` 훅을 사용한 무한 쿼리 지원이 제공됩니다. 이는 "더 보기" 또는 무한 스크롤 기능 구현을 쉽게 합니다.
@@ -1469,6 +1505,7 @@ function ItemForm() {
 </Drawer>
 
 타입은 FastAPI의 OpenAPI 스키마에서 자동 생성되므로 API 변경사항은 빌드 후 프론트엔드 코드에 반영됩니다.
-## Custom Auth
 
-If your FastAPI uses `Custom` authentication (Lambda Authorizer), you will need to edit the generated client provider to add the authorization headers your authorizer expects. Look for the `fetch` configuration in the generated `<ApiName>Provider.tsx` and add your token or API key to the request headers.
+## 커스텀 인증
+
+FastAPI가 `Custom` 인증(Lambda Authorizer)을 사용하는 경우, 생성된 클라이언트 제공자를 편집하여 인증자가 예상하는 인증 헤더를 추가해야 합니다. 생성된 `<ApiName>Provider.tsx`의 `fetch` 구성을 찾아 요청 헤더에 토큰 또는 API 키를 추가하세요.

--- a/docs/src/content/docs/pt/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### Upload de Arquivos
+
+Para endpoints que aceitam upload de arquivo, o cliente gerado envia a requisição como `FormData`. Defina uma operação com um corpo `multipart/form-data` no seu FastAPI, por exemplo usando `UploadFile`:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+Campos binários são tipados como `Blob` no cliente gerado, e outros campos (como `description` acima) mantêm seus tipos modelados. Passe um `Blob` ou `File` — por exemplo, um obtido de um `<input type="file">`:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+O cliente constrói um corpo `FormData` e deixa o `fetch` definir o `Content-Type` (incluindo o boundary multipart) automaticamente.
+
 ### Paginação com Infinite Queries
 
 Para endpoints que aceitam um parâmetro `cursor` como entrada, os hooks gerados fornecem suporte para infinite queries usando o hook `useInfiniteQuery` do TanStack Query. Isso facilita a implementação de funcionalidades "carregar mais" ou scroll infinito.

--- a/docs/src/content/docs/vi/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### Tải lên File
+
+Đối với các endpoint chấp nhận tải lên file, client được sinh sẽ gửi request dưới dạng `FormData`. Định nghĩa một operation với body `multipart/form-data` trong FastAPI của bạn, ví dụ sử dụng `UploadFile`:
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+Các trường binary được type là `Blob` trên client được sinh, và các trường khác (như `description` ở trên) giữ nguyên các modelled types của chúng. Truyền một `Blob` hoặc `File` — ví dụ một file thu được từ `<input type="file">`:
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+Client xây dựng body `FormData` và để `fetch` tự động đặt `Content-Type` (bao gồm multipart boundary).
+
 ### Phân trang với Infinite Queries
 
 Đối với các endpoint chấp nhận tham số `cursor` làm input, các hooks được sinh cung cấp hỗ trợ cho infinite queries sử dụng hook `useInfiniteQuery` của TanStack Query. Điều này giúp dễ dàng triển khai chức năng "load more" hoặc infinite scrolling.

--- a/docs/src/content/docs/zh/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-fastapi.mdx
@@ -312,6 +312,42 @@ function CreateItemForm() {
 ```
 </Drawer>
 
+### 文件上传
+
+对于接受文件上传的端点，生成的客户端将请求作为 `FormData` 发送。在 FastAPI 中定义一个带有 `multipart/form-data` 主体的操作，例如使用 `UploadFile`：
+
+```python
+from fastapi import UploadFile
+
+@app.post("/files")
+async def upload_file(file: UploadFile, description: str = "") -> FileMetadata:
+    contents = await file.read()
+    ...
+```
+
+二进制字段在生成的客户端上类型为 `Blob`，其他字段（如上面的 `description`）保持其建模类型。传递 `Blob` 或 `File` —— 例如从 `<input type="file">` 获取的文件：
+
+```tsx {9-12}
+import { useMutation } from '@tanstack/react-query';
+import { useMyApi } from './hooks/useMyApi';
+
+function UploadForm() {
+  const api = useMyApi();
+  const uploadFile = useMutation(api.uploadFile.mutationOptions());
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadFile.mutate({ file, description: file.name });
+    }
+  };
+
+  return <input type="file" onChange={handleChange} />;
+}
+```
+
+客户端构建 `FormData` 主体并让 `fetch` 自动设置 `Content-Type`（包括 multipart 边界）。
+
 ### 无限滚动分页
 
 对于接受 `cursor` 参数的端点，生成的钩子支持使用 TanStack Query 的 `useInfiniteQuery` 实现无限查询，便于实现"加载更多"或无限滚动功能。
@@ -1468,6 +1504,7 @@ function ItemForm() {
 </Drawer>
 
 类型根据 FastAPI 的 OpenAPI 模式自动生成，确保 API 的更改在构建后反映到前端代码中。
-## Custom Auth
 
-If your FastAPI uses `Custom` authentication (Lambda Authorizer), you will need to edit the generated client provider to add the authorization headers your authorizer expects. Look for the `fetch` configuration in the generated `<ApiName>Provider.tsx` and add your token or API key to the request headers.
+## 自定义身份验证
+
+如果 FastAPI 使用 `Custom` 身份验证（Lambda 授权器），需要编辑生成的客户端提供者以添加授权器所需的授权标头。在生成的 `<ApiName>Provider.tsx` 中查找 `fetch` 配置，并将令牌或 API 密钥添加到请求标头中。

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -1,7 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`openApiTsClientGenerator - content type header > should not force Content-Type for multipart/form-data bodies > client.gen.ts 1`] = `
-"import type { PostUploadRequest } from './types.gen.js';
+"import type {
+  PostUploadRequestContent,
+  PostUploadRequest,
+} from './types.gen.js';
 
 /**
  * Utility for serialisation and deserialisation of API types.
@@ -9,6 +12,39 @@ exports[`openApiTsClientGenerator - content type header > should not force Conte
 export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static PostUploadRequestContent = {
+    toJson: (model: PostUploadRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.file === undefined
+          ? {}
+          : {
+              file: model.file,
+            }),
+        ...(model.description === undefined
+          ? {}
+          : {
+              description: model.description,
+            }),
+      };
+    },
+    fromJson: (json: any): PostUploadRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        file: json['file'],
+        ...(json['description'] === undefined
+          ? {}
+          : {
+              description: json['description'],
+            }),
+      };
+    },
+  };
 }
 
 /**
@@ -130,6 +166,26 @@ export class TestApi {
     });
   };
 
+  private $formData = (model: { [key: string]: any }): FormData => {
+    const formData = new FormData();
+    const append = (key: string, value: any): void => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      if (value instanceof Blob || typeof value === 'string') {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => append(key, v));
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    };
+    Object.entries(model).forEach(([key, value]) => append(key, value));
+    return formData;
+  };
+
   private $fetch: typeof fetch = (...args) =>
     (this.$config.fetch ?? fetch)(...args);
 
@@ -137,7 +193,7 @@ export class TestApi {
     const pathParameters: { [key: string]: any } = {};
     const queryParameters: { [key: string]: any } = {};
     const headerParameters: { [key: string]: any } = {};
-    const body = input as any;
+    const body = this.$formData($IO.PostUploadRequestContent.toJson(input));
 
     const response = await this.$fetch(
       this.$url('/upload', pathParameters, queryParameters),
@@ -160,7 +216,12 @@ export class TestApi {
 `;
 
 exports[`openApiTsClientGenerator - content type header > should not force Content-Type for multipart/form-data bodies > types.gen.ts 1`] = `
-"export type PostUploadRequest = unknown;
+"export type PostUploadRequestContent = {
+  file: Blob;
+  description?: string;
+};
+
+export type PostUploadRequest = PostUploadRequestContent;
 export type PostUploadError = never;
 "
 `;

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.multipart.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.multipart.spec.ts.snap
@@ -1,0 +1,280 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - multipart/form-data > should match the generated client snapshot > client.gen.ts 1`] = `
+"import type {
+  Upload200Response,
+  UploadRequestContent,
+  UploadRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static Upload200Response = {
+    toJson: (model: Upload200Response): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.size === undefined
+          ? {}
+          : {
+              size: model.size,
+            }),
+        ...(model.note === undefined
+          ? {}
+          : {
+              note: model.note,
+            }),
+      };
+    },
+    fromJson: (json: any): Upload200Response => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        ...(json['size'] === undefined
+          ? {}
+          : {
+              size: json['size'],
+            }),
+        ...(json['note'] === undefined
+          ? {}
+          : {
+              note: json['note'],
+            }),
+      };
+    },
+  };
+
+  public static UploadRequestContent = {
+    toJson: (model: UploadRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.file === undefined
+          ? {}
+          : {
+              file: model.file,
+            }),
+        ...(model.note === undefined
+          ? {}
+          : {
+              note: model.note,
+            }),
+        ...(model.tags === undefined
+          ? {}
+          : {
+              tags: model.tags,
+            }),
+      };
+    },
+    fromJson: (json: any): UploadRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        file: json['file'],
+        ...(json['note'] === undefined
+          ? {}
+          : {
+              note: json['note'],
+            }),
+        ...(json['tags'] === undefined
+          ? {}
+          : {
+              tags: json['tags'],
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.upload = this.upload.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $formData = (model: { [key: string]: any }): FormData => {
+    const formData = new FormData();
+    const append = (key: string, value: any): void => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      if (value instanceof Blob || typeof value === 'string') {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => append(key, v));
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    };
+    Object.entries(model).forEach(([key, value]) => append(key, value));
+    return formData;
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async upload(input: UploadRequest): Promise<Upload200Response> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    const body = this.$formData($IO.UploadRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/upload', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.Upload200Response.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - multipart/form-data > should match the generated client snapshot > types.gen.ts 1`] = `
+"export type Upload200Response = {
+  size?: number;
+  note?: string;
+};
+export type UploadRequestContent = {
+  file: Blob;
+  note?: string;
+  tags?: Array<string>;
+};
+
+export type UploadRequest = UploadRequestContent;
+export type UploadError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -29,6 +29,13 @@ const composedMarshaller = (property, method) =>
   property.export === 'reference' && discriminatorBaseNames.has(property.type)
     ? `$IO.${property.typescriptType}.$${method}Base`
     : `$IO.${property.typescriptType}.${method}`;
+// The single wire media type chosen for an operation's request body, if any.
+const bodyMediaTypeOf = (op) => {
+  if (!op.parametersBody || !op.parametersBody.mediaTypes) return undefined;
+  const mediaTypes = Array.isArray(op.parametersBody.mediaTypes) ? op.parametersBody.mediaTypes : [op.parametersBody.mediaTypes];
+  return mediaTypes.find(mt => mt === 'application/json' || mt.endsWith('+json')) || mediaTypes[0];
+};
+const hasMultipartBody = allOperations.some(op => bodyMediaTypeOf(op) === 'multipart/form-data');
 _%>
 <%_ if ((models.length + allOperations.filter(p => p.parameters.length > 0).length) > 0) { _%>
 import type {
@@ -474,6 +481,28 @@ export class <%- className %> {
     });
   };
 
+  <%_ if (hasMultipartBody) { _%>
+  private $formData = (model: { [key: string]: any }): FormData => {
+    const formData = new FormData();
+    const append = (key: string, value: any): void => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      if (value instanceof Blob || typeof value === 'string') {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => append(key, v));
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    };
+    Object.entries(model).forEach(([key, value]) => append(key, value));
+    return formData;
+  };
+
+  <%_ } _%>
   private $fetch: typeof fetch = (...args) => (this.$config.fetch ?? fetch)(...args);
   <%_ allOperations.forEach((op) => { _%>
   <%_ const hasTag = op.tags && op.tags.length > 0; _%>
@@ -534,7 +563,13 @@ export class <%- className %> {
     } as const;
     <%_ } _%>
     <%_ if (op.parametersBody) { _%>
-    <%_ if (op.parametersBody.isPrimitive && ['number', 'boolean', 'string'].includes(op.parametersBody.type) && !['array', 'dictionary'].includes(op.parametersBody.export) && !["date", "date-time"].includes(op.parametersBody.format)) { _%>
+    <%_ if (bodyMediaTypeOf(op) === 'multipart/form-data') { _%>
+    <%_ /* A multipart body is sent as FormData: Blob fields stream as file
+           parts, primitives serialise to strings, and fetch computes the
+           boundary itself (so the Content-Type header is intentionally unset
+           above). */ _%>
+    const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>this.$formData(<%- op.explicitRequestBodyParameter ? `$IO.${op.operationIdPascalCase}RequestBodyParameters.toJson(input).${op.explicitRequestBodyParameter.prop}` : renderToJsonValue(op.parametersBody, 'input') %>);
+    <%_ } else if (op.parametersBody.isPrimitive && ['number', 'boolean', 'string'].includes(op.parametersBody.type) && !['array', 'dictionary'].includes(op.parametersBody.export) && !["date", "date-time"].includes(op.parametersBody.format)) { _%>
     const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>String(input<%- op.explicitRequestBodyParameter ? `.${op.explicitRequestBodyParameter.typescriptName}` : '' %>);
     <%_ } else if (op.parametersBody.isPrimitive && ["date", "date-time"].includes(op.parametersBody.format)) { _%>
     const body = <%- renderToJsonDateValue('input', op.parametersBody.format) %>;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.multipart.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.multipart.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
+import type { Spec } from '../utils/types';
+import { openApiTsClientGenerator } from './generator';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+
+describe('openApiTsClientGenerator - multipart/form-data', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths);
+  };
+
+  const clientPaths = [
+    'src/generated/client.gen.ts',
+    'src/generated/types.gen.ts',
+  ];
+
+  // A wrapper-object multipart body with a binary file field (3.1 idiom, as
+  // emitted by FastAPI for UploadFile), a text field, and an array field.
+  const uploadSpec: Spec = {
+    info: { title, version: '1.0.0' },
+    openapi: '3.1.0',
+    paths: {
+      '/upload': {
+        post: {
+          operationId: 'upload',
+          requestBody: {
+            required: true,
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    file: {
+                      type: 'string',
+                      contentMediaType: 'application/octet-stream',
+                    },
+                    note: { type: 'string' },
+                    tags: { type: 'array', items: { type: 'string' } },
+                  },
+                  required: ['file'],
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      size: { type: 'integer' },
+                      note: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it('should type a binary multipart field as Blob', async () => {
+    tree.write('openapi.json', JSON.stringify(uploadSpec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    expect(types).toContain('file: Blob');
+  });
+
+  it('should keep a string field with a textual contentMediaType as a string', async () => {
+    // A string field carrying e.g. an embedded JSON document is a string on
+    // the wire, not a Blob — only non-textual content media types are binary.
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.1.0',
+      paths: {
+        '/upload': {
+          post: {
+            operationId: 'upload',
+            requestBody: {
+              required: true,
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      binary: {
+                        type: 'string',
+                        contentMediaType: 'application/octet-stream',
+                      },
+                      metadata: {
+                        type: 'string',
+                        contentMediaType: 'application/json',
+                      },
+                    },
+                    required: ['binary'],
+                  },
+                },
+              },
+            },
+            responses: { '204': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    expect(types).toContain('binary: Blob');
+    expect(types).toContain('metadata?: string');
+  });
+
+  it('should match the generated client snapshot', async () => {
+    tree.write('openapi.json', JSON.stringify(uploadSpec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    expect(tree.read('src/generated/client.gen.ts', 'utf-8')).toMatchSnapshot(
+      'client.gen.ts',
+    );
+    expect(tree.read('src/generated/types.gen.ts', 'utf-8')).toMatchSnapshot(
+      'types.gen.ts',
+    );
+  });
+
+  it('should compile', async () => {
+    tree.write('openapi.json', JSON.stringify(uploadSpec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript(clientPaths);
+  });
+
+  it('should send a FormData body with file, primitive and array parts', async () => {
+    tree.write('openapi.json', JSON.stringify(uploadSpec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({ size: 5, note: 'hi' }),
+    });
+
+    const fileBlob = new Blob(['hello']);
+    const result = await callGeneratedClient(client, mockFetch, 'upload', {
+      file: fileBlob,
+      note: 'hi',
+      tags: ['a', 'b'],
+    });
+    expect(result).toEqual({ size: 5, note: 'hi' });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`${baseUrl}/upload`);
+    expect(init.method).toBe('POST');
+    // fetch computes the multipart boundary itself: no Content-Type header set
+    expect(
+      (init.headers as [string, string][]).find(
+        ([k]) => k.toLowerCase() === 'content-type',
+      ),
+    ).toBeUndefined();
+
+    const body = init.body as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    // FormData wraps an appended Blob in a File; assert its content, not identity
+    const filePart = body.get('file') as Blob;
+    expect(filePart).toBeInstanceOf(Blob);
+    expect(await filePart.text()).toBe('hello');
+    expect(body.get('note')).toBe('hi');
+    expect(body.getAll('tags')).toEqual(['a', 'b']);
+  });
+
+  it('should omit undefined optional multipart fields', async () => {
+    tree.write('openapi.json', JSON.stringify(uploadSpec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({ size: 5 }),
+    });
+
+    const fileBlob = new Blob(['hello']);
+    await callGeneratedClient(client, mockFetch, 'upload', { file: fileBlob });
+
+    const body = mockFetch.mock.calls[0][1].body as FormData;
+    expect(body.has('file')).toBe(true);
+    expect(body.has('note')).toBe(false);
+    expect(body.has('tags')).toBe(false);
+  });
+});

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -564,22 +564,31 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
         }
         if ('requestBody' in operation) {
           const requestBody = resolveIfRef(spec, operation.requestBody);
-          const jsonMediaType = preferredJsonMediaType(
-            Object.keys(requestBody?.content ?? {}),
-          );
-          const jsonRequestSchema = jsonMediaType
-            ? requestBody!.content![jsonMediaType].schema
+          const contentMediaTypes = Object.keys(requestBody?.content ?? {});
+          // Hoist the JSON body, falling back to a form-data body (multipart or
+          // urlencoded) so an inline form object is fully typed and marshalled
+          // rather than left `unknown`.
+          const bodyMediaType =
+            preferredJsonMediaType(contentMediaTypes) ??
+            contentMediaTypes.find((mt) =>
+              [
+                'multipart/form-data',
+                'application/x-www-form-urlencoded',
+              ].includes(mt.split(';')[0]),
+            );
+          const bodyRequestSchema = bodyMediaType
+            ? requestBody!.content![bodyMediaType].schema
             : undefined;
           if (
-            jsonRequestSchema &&
-            !isRef(jsonRequestSchema) &&
-            (['object', 'array'].includes(jsonRequestSchema.type!) ||
-              isCompositeSchema(jsonRequestSchema) ||
-              (jsonRequestSchema?.type === 'string' && jsonRequestSchema.enum))
+            bodyRequestSchema &&
+            !isRef(bodyRequestSchema) &&
+            (['object', 'array'].includes(bodyRequestSchema.type!) ||
+              isCompositeSchema(bodyRequestSchema) ||
+              (bodyRequestSchema?.type === 'string' && bodyRequestSchema.enum))
           ) {
             const schemaName = `${upperFirst(deduplicatedOpId)}RequestContent`;
-            spec.components!.schemas![schemaName] = jsonRequestSchema;
-            requestBody!.content![jsonMediaType!].schema = {
+            spec.components!.schemas![schemaName] = bodyRequestSchema;
+            requestBody!.content![bodyMediaType!].schema = {
               $ref: `#/components/schemas/${schemaName}`,
             };
           }

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -108,8 +108,26 @@ const isDictionarySchema = (schema: Schema): boolean => {
  */
 const primitiveType = (schema: Schema): string => {
   const type = primaryType(schema);
-  if (type === 'string' && schema.format === 'binary') return 'binary';
+  if (type === 'string' && isBinaryStringSchema(schema)) return 'binary';
   return (type && PRIMITIVE_TYPE_MAP[type]) ?? 'unknown';
+};
+
+/**
+ * Whether a `string` schema denotes raw binary content (rendered as a `Blob`).
+ * Covers the 3.0 `format: binary` idiom and the 3.1 `contentMediaType` idiom
+ * (as emitted by FastAPI for `UploadFile`). A base64 `contentEncoding`, or a
+ * textual/JSON media type, keeps the value a string on the wire.
+ */
+const isBinaryStringSchema = (schema: Schema): boolean => {
+  if (schema.format === 'binary') return true;
+  const contentMediaType = schema.contentMediaType;
+  if (!contentMediaType || schema.contentEncoding) return false;
+  return !(
+    contentMediaType.startsWith('text/') ||
+    contentMediaType === 'application/json' ||
+    contentMediaType.endsWith('+json') ||
+    contentMediaType === 'application/xml'
+  );
 };
 
 /**
@@ -790,10 +808,9 @@ const resolveComposedModels = (data: ClientData): void => {
 
 const isHoisted = (spec: Spec, name: string): boolean =>
   !!(
-    resolveIfRef<Schema | undefined>(
-      spec,
-      spec.components?.schemas?.[name],
-    ) as { 'x-aws-nx-hoisted'?: boolean } | undefined
+    resolveIfRef<Schema | undefined>(spec, spec.components?.schemas?.[name]) as
+      | { 'x-aws-nx-hoisted'?: boolean }
+      | undefined
   )?.['x-aws-nx-hoisted'];
 
 /**
@@ -838,7 +855,11 @@ const buildCompositeDiscriminator = (
   const candidateNames = new Set(
     (model.composedModels ?? []).map((m) => m.name),
   );
-  const mapping = buildDiscriminatorMapping(spec, discriminator, candidateNames);
+  const mapping = buildDiscriminatorMapping(
+    spec,
+    discriminator,
+    candidateNames,
+  );
 
   return mapping.length > 0
     ? { propertyName: discriminator.propertyName, mapping }

--- a/packages/nx-plugin/src/open-api/utils/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/types.ts
@@ -10,7 +10,8 @@ export type Spec = OpenAPIV3.Document | OpenAPIV3_1.Document;
  * An OpenAPI schema object, spanning the 3.0 and 3.1 shapes plus the additional
  * JSON-Schema / 3.1 keywords the code generator inspects that are absent from
  * the `openapi-types` 3.0 definition (`patternProperties`, `const`, and the 3.0
- * `nullable` flag).
+ * `nullable` flag), and the 3.1 `contentMediaType`/`contentEncoding` keywords
+ * used to detect binary string fields.
  */
 export type OpenApiSchema = (
   | OpenAPIV3.SchemaObject
@@ -18,6 +19,8 @@ export type OpenApiSchema = (
 ) & {
   nullable?: boolean;
   const?: unknown;
+  contentMediaType?: string;
+  contentEncoding?: string;
   patternProperties?: {
     [pattern: string]: OpenApiSchemaOrRef;
   };


### PR DESCRIPTION
### Reason for this change

The generated OpenAPI TypeScript client did not support `multipart/form-data` request bodies. For an upload operation the client serialised the body with `JSON.stringify`, so it sent a JSON string instead of a multipart form — servers rejected it (FastAPI returned `422 "Field required"`). Binary file fields were also typed `unknown`/`string` rather than `Blob`, so a file upload could not be expressed in a type-safe way.

This is the multipart gap surfaced while validating #886; single-part binary (`application/octet-stream`) bodies already worked, but `multipart/form-data` did not.

### Description of changes

- **Binary field detection (parser)** — `string` fields are recognised as binary (rendered as `Blob`) for both the 3.0 `format: binary` idiom and the 3.1 `contentMediaType` idiom (as emitted by FastAPI for `UploadFile`). Base64 `contentEncoding` and textual/JSON content types (`text/*`, `application/json`, `+json`, `application/xml`) stay `string`.
- **Body hoisting (normalise)** — an inline `multipart/form-data` (or `application/x-www-form-urlencoded`) form body is hoisted to a named model, just like an inline JSON body, so the request is fully typed and marshalled rather than left `unknown`.
- **FormData construction (client template)** — multipart operations build a `FormData` body via a new `$formData` helper: `Blob` fields stream as file parts, primitives serialise to strings, arrays append repeatedly, and nested objects serialise to JSON. Undefined/null fields are omitted. The helper is only emitted when an operation actually has a multipart body, and `fetch` computes the multipart boundary itself (the `Content-Type` header stays unset).

The field marshalling reuses the existing `toJson` pipeline, so dates/enums/nested models inside a form body serialise consistently with JSON bodies.

### Description of how you validated changes

- Added `generator.multipart.spec.ts` covering: binary field → `Blob` typing, textual-vs-binary `contentMediaType` distinction, a generated-client snapshot, TypeScript compilation, and runtime invocation asserting the `FormData` body carries file/primitive/array parts and omits undefined optional fields.
- Updated the existing `content-type` multipart snapshot to the new (correct) output.
- Full plugin suite green (2516 tests) and full workspace build passes.
- **End-to-end**: regenerated the client for a FastAPI backend with an `UploadFile` endpoint and uploaded a file through the generated client against the live server — the file bytes and form fields arrive intact (the case that previously returned `422`).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
