### PR TITLE
ci: guard Windows Defender disable step against runner failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Disable Windows Defender real-time monitoring
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: pwsh
+        run: |
+          # Defender may not be running/ready on the runner; best-effort speed optimization.
+          try { Set-MpPreference -DisableRealtimeMonitoring $true } catch { }
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,7 +177,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Disable Windows Defender real-time monitoring
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: pwsh
+        run: |
+          # Defender may not be running/ready on the runner; best-effort speed optimization.
+          try { Set-MpPreference -DisableRealtimeMonitoring $true } catch { }
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
### Reason for this change

The latest CI run on \`main\` ([run 29057865104](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/29057865104)) failed in the \`Windows Smoke Tests - git-secrets\` job — not because of any code change, but at the *Disable Windows Defender real-time monitoring* step:

\`\`\`
Set-MpPreference: Operation failed with the following error: 0x800106ba.
Operation: Set-MpPreference. Target: DisableRealtimeMonitoring.
##[error]Process completed with exit code 1.
\`\`\`

\`0x800106ba\` means the Windows Defender service wasn't running/ready on that \`windows-latest\` runner. The step ran \`Set-MpPreference\` unguarded, so its failure exited PowerShell with code 1 and took the whole smoke-test job down. This is pure runner flakiness — the sibling \`dungeon-adventure\` job in the same matrix passed.

Disabling Defender is only a test-speed optimization (it reduces AV scanning overhead during heavy workspace-generation I/O); it is not required for the tests to be valid.

### Description of changes

Wrapped the \`Set-MpPreference\` call on the \`windows-latest\` smoke-test jobs in \`ci.yml\` and \`pr.yml\` in a best-effort \`try { ... } catch { }\`, matching the guard already present on the CodeBuild Windows standalone jobs. A runner where the call fails now runs the smoke test with Defender enabled (slightly slower, still valid) instead of failing the build.

### Description of how you validated changes

CI-only change. Validated by inspecting the failing run's logs to confirm the root cause, and by aligning the two unguarded steps with the existing guarded pattern already proven on the CodeBuild legs. The Windows smoke-test jobs in this PR's own CI run exercise the changed steps.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*