### PR TITLE
fix(open-api): select matching branch for non-discriminated unions & scope binary form fields

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.composite-types.spec.ts.snap
@@ -314,6 +314,30 @@ exports[`openApiTsClientGenerator - composite schemas > should generate valid Ty
 export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+  // Select the best-matching branch of a non-discriminated oneOf/anyOf: the
+  // candidate whose required properties are all present, preferring the one
+  // matching the most properties. Falls back to the first candidate so a value
+  // still round-trips when none matches cleanly.
+  public static $selectBranch = (
+    value: any,
+    candidates: {
+      required: string[];
+      all: string[];
+      convert: (v: any) => any;
+    }[],
+  ): any => {
+    if (value === null || typeof value !== 'object') {
+      return candidates[0].convert(value);
+    }
+    const scored = candidates
+      .filter((c) => c.required.every((k) => value[k] !== undefined))
+      .map((c) => ({
+        c,
+        score: c.all.filter((k) => value[k] !== undefined).length,
+      }));
+    const best = scored.sort((a, b) => b.score - a.score)[0];
+    return (best ? best.c : candidates[0]).convert(value);
+  };
 
   public static PutTest200Response = {
     toJson: (model: PutTest200Response): any => {
@@ -422,23 +446,41 @@ export class $IO {
       if (model === undefined || model === null) {
         return model;
       }
-      return {
-        ...$IO.PutTestRequestContentOneOf.toJson(
-          model as PutTestRequestContentOneOf,
-        ),
-        ...$IO.PutTestRequestContentOneOf1.toJson(
-          model as PutTestRequestContentOneOf1,
-        ),
-      };
+      return $IO.$selectBranch(model, [
+        {
+          required: ['type', 'valueA'],
+          all: ['type', 'valueA'],
+          convert: (v) =>
+            $IO.PutTestRequestContentOneOf.toJson(
+              v as PutTestRequestContentOneOf,
+            ),
+        },
+        {
+          required: ['type', 'valueB'],
+          all: ['type', 'valueB'],
+          convert: (v) =>
+            $IO.PutTestRequestContentOneOf1.toJson(
+              v as PutTestRequestContentOneOf1,
+            ),
+        },
+      ]);
     },
     fromJson: (json: any): PutTestRequestContent => {
       if (json === undefined || json === null) {
         return json;
       }
-      return {
-        ...$IO.PutTestRequestContentOneOf.fromJson(json),
-        ...$IO.PutTestRequestContentOneOf1.fromJson(json),
-      };
+      return $IO.$selectBranch(json, [
+        {
+          required: ['type', 'valueA'],
+          all: ['type', 'valueA'],
+          convert: (v) => $IO.PutTestRequestContentOneOf.fromJson(v),
+        },
+        {
+          required: ['type', 'valueB'],
+          all: ['type', 'valueB'],
+          convert: (v) => $IO.PutTestRequestContentOneOf1.fromJson(v),
+        },
+      ]);
     },
   };
 
@@ -1913,6 +1955,30 @@ exports[`openApiTsClientGenerator - composite schemas > should handle inline pri
 export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+  // Select the best-matching branch of a non-discriminated oneOf/anyOf: the
+  // candidate whose required properties are all present, preferring the one
+  // matching the most properties. Falls back to the first candidate so a value
+  // still round-trips when none matches cleanly.
+  public static $selectBranch = (
+    value: any,
+    candidates: {
+      required: string[];
+      all: string[];
+      convert: (v: any) => any;
+    }[],
+  ): any => {
+    if (value === null || typeof value !== 'object') {
+      return candidates[0].convert(value);
+    }
+    const scored = candidates
+      .filter((c) => c.required.every((k) => value[k] !== undefined))
+      .map((c) => ({
+        c,
+        score: c.all.filter((k) => value[k] !== undefined).length,
+      }));
+    const best = scored.sort((a, b) => b.score - a.score)[0];
+    return (best ? best.c : candidates[0]).convert(value);
+  };
 
   public static TestArrays200Response = {
     toJson: (model: TestArrays200Response): any => {
@@ -2019,23 +2085,41 @@ export class $IO {
       if (model === undefined || model === null) {
         return model;
       }
-      return {
-        ...$IO.TestComposites200ResponseAnyOf.toJson(
-          model as TestComposites200ResponseAnyOf,
-        ),
-        ...$IO.TestComposites200ResponseAnyOf1.toJson(
-          model as TestComposites200ResponseAnyOf1,
-        ),
-      };
+      return $IO.$selectBranch(model, [
+        {
+          required: [],
+          all: ['foo'],
+          convert: (v) =>
+            $IO.TestComposites200ResponseAnyOf.toJson(
+              v as TestComposites200ResponseAnyOf,
+            ),
+        },
+        {
+          required: [],
+          all: ['bar'],
+          convert: (v) =>
+            $IO.TestComposites200ResponseAnyOf1.toJson(
+              v as TestComposites200ResponseAnyOf1,
+            ),
+        },
+      ]);
     },
     fromJson: (json: any): TestComposites200Response => {
       if (json === undefined || json === null) {
         return json;
       }
-      return {
-        ...$IO.TestComposites200ResponseAnyOf.fromJson(json),
-        ...$IO.TestComposites200ResponseAnyOf1.fromJson(json),
-      };
+      return $IO.$selectBranch(json, [
+        {
+          required: [],
+          all: ['foo'],
+          convert: (v) => $IO.TestComposites200ResponseAnyOf.fromJson(v),
+        },
+        {
+          required: [],
+          all: ['bar'],
+          convert: (v) => $IO.TestComposites200ResponseAnyOf1.fromJson(v),
+        },
+      ]);
     },
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.duplicate-types.spec.ts.snap
@@ -292,25 +292,65 @@ exports[`openApiTsClientGenerator - duplicate types > should handle many duplica
 export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+  // Select the best-matching branch of a non-discriminated oneOf/anyOf: the
+  // candidate whose required properties are all present, preferring the one
+  // matching the most properties. Falls back to the first candidate so a value
+  // still round-trips when none matches cleanly.
+  public static $selectBranch = (
+    value: any,
+    candidates: {
+      required: string[];
+      all: string[];
+      convert: (v: any) => any;
+    }[],
+  ): any => {
+    if (value === null || typeof value !== 'object') {
+      return candidates[0].convert(value);
+    }
+    const scored = candidates
+      .filter((c) => c.required.every((k) => value[k] !== undefined))
+      .map((c) => ({
+        c,
+        score: c.all.filter((k) => value[k] !== undefined).length,
+      }));
+    const best = scored.sort((a, b) => b.score - a.score)[0];
+    return (best ? best.c : candidates[0]).convert(value);
+  };
 
   public static AnotherModel = {
     toJson: (model: AnotherModel): any => {
       if (model === undefined || model === null) {
         return model;
       }
-      return {
-        ...$IO.Clash3.toJson(model as Clash3),
-        ...$IO.Clash4.toJson(model as Clash4),
-      };
+      return $IO.$selectBranch(model, [
+        {
+          required: ['prop4'],
+          all: ['prop4'],
+          convert: (v) => $IO.Clash3.toJson(v as Clash3),
+        },
+        {
+          required: ['prop5'],
+          all: ['prop5'],
+          convert: (v) => $IO.Clash4.toJson(v as Clash4),
+        },
+      ]);
     },
     fromJson: (json: any): AnotherModel => {
       if (json === undefined || json === null) {
         return json;
       }
-      return {
-        ...$IO.Clash3.fromJson(json),
-        ...$IO.Clash4.fromJson(json),
-      };
+      return $IO.$selectBranch(json, [
+        {
+          required: ['prop4'],
+          all: ['prop4'],
+          convert: (v) => $IO.Clash3.fromJson(v),
+        },
+        {
+          required: ['prop5'],
+          all: ['prop5'],
+          convert: (v) => $IO.Clash4.fromJson(v),
+        },
+      ]);
     },
   };
 
@@ -434,19 +474,35 @@ export class $IO {
       if (model === undefined || model === null) {
         return model;
       }
-      return {
-        ...$IO.Clash1.toJson(model as Clash1),
-        ...$IO.Clash2.toJson(model as Clash2),
-      };
+      return $IO.$selectBranch(model, [
+        {
+          required: ['prop1'],
+          all: ['prop1'],
+          convert: (v) => $IO.Clash1.toJson(v as Clash1),
+        },
+        {
+          required: ['prop2'],
+          all: ['prop2'],
+          convert: (v) => $IO.Clash2.toJson(v as Clash2),
+        },
+      ]);
     },
     fromJson: (json: any): MyModel => {
       if (json === undefined || json === null) {
         return json;
       }
-      return {
-        ...$IO.Clash1.fromJson(json),
-        ...$IO.Clash2.fromJson(json),
-      };
+      return $IO.$selectBranch(json, [
+        {
+          required: ['prop1'],
+          all: ['prop1'],
+          convert: (v) => $IO.Clash1.fromJson(v),
+        },
+        {
+          required: ['prop2'],
+          all: ['prop2'],
+          convert: (v) => $IO.Clash2.fromJson(v),
+        },
+      ]);
     },
   };
 }

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -281,25 +281,65 @@ exports[`openApiTsClientGenerator - edge cases > does not build a discriminator 
 export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+  // Select the best-matching branch of a non-discriminated oneOf/anyOf: the
+  // candidate whose required properties are all present, preferring the one
+  // matching the most properties. Falls back to the first candidate so a value
+  // still round-trips when none matches cleanly.
+  public static $selectBranch = (
+    value: any,
+    candidates: {
+      required: string[];
+      all: string[];
+      convert: (v: any) => any;
+    }[],
+  ): any => {
+    if (value === null || typeof value !== 'object') {
+      return candidates[0].convert(value);
+    }
+    const scored = candidates
+      .filter((c) => c.required.every((k) => value[k] !== undefined))
+      .map((c) => ({
+        c,
+        score: c.all.filter((k) => value[k] !== undefined).length,
+      }));
+    const best = scored.sort((a, b) => b.score - a.score)[0];
+    return (best ? best.c : candidates[0]).convert(value);
+  };
 
   public static Shape = {
     toJson: (model: Shape): any => {
       if (model === undefined || model === null) {
         return model;
       }
-      return {
-        ...$IO.ShapeOneOf.toJson(model as ShapeOneOf),
-        ...$IO.ShapeOneOf1.toJson(model as ShapeOneOf1),
-      };
+      return $IO.$selectBranch(model, [
+        {
+          required: ['kind', 'napAt'],
+          all: ['kind', 'napAt'],
+          convert: (v) => $IO.ShapeOneOf.toJson(v as ShapeOneOf),
+        },
+        {
+          required: ['kind', 'walkAt'],
+          all: ['kind', 'walkAt'],
+          convert: (v) => $IO.ShapeOneOf1.toJson(v as ShapeOneOf1),
+        },
+      ]);
     },
     fromJson: (json: any): Shape => {
       if (json === undefined || json === null) {
         return json;
       }
-      return {
-        ...$IO.ShapeOneOf.fromJson(json),
-        ...$IO.ShapeOneOf1.fromJson(json),
-      };
+      return $IO.$selectBranch(json, [
+        {
+          required: ['kind', 'napAt'],
+          all: ['kind', 'napAt'],
+          convert: (v) => $IO.ShapeOneOf.fromJson(v),
+        },
+        {
+          required: ['kind', 'walkAt'],
+          all: ['kind', 'walkAt'],
+          convert: (v) => $IO.ShapeOneOf1.fromJson(v),
+        },
+      ]);
     },
   };
 

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -36,6 +36,16 @@ const bodyMediaTypeOf = (op) => {
   return mediaTypes.find(mt => mt === 'application/json' || mt.endsWith('+json')) || mediaTypes[0];
 };
 const hasMultipartBody = allOperations.some(op => bodyMediaTypeOf(op) === 'multipart/form-data');
+// A oneOf/anyOf of two or more object branches with no discriminator: the
+// branch can't be chosen by a discriminator property, so marshalling merges
+// every branch (leaking fields, e.g. an Invalid Date from a non-matching
+// branch). Such composites instead select the best-matching branch at runtime.
+const isNonDiscriminatedObjectUnion = (model) =>
+  (model.export === 'one-of' || model.export === 'any-of') &&
+  !model.discriminator &&
+  (model.composedPrimitives || []).length === 0 &&
+  (model.composedModels || []).length > 1;
+const hasNonDiscriminatedObjectUnion = models.some(isNonDiscriminatedObjectUnion);
 _%>
 <%_ if ((models.length + allOperations.filter(p => p.parameters.length > 0).length) > 0) { _%>
 import type {
@@ -192,6 +202,28 @@ _%>
 export class $IO {
   public static $mapValues = (data: any, fn: (item: any) => any) =>
     Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+  <%_ if (hasNonDiscriminatedObjectUnion) { _%>
+  // Select the best-matching branch of a non-discriminated oneOf/anyOf: the
+  // candidate whose required properties are all present, preferring the one
+  // matching the most properties. Falls back to the first candidate so a value
+  // still round-trips when none matches cleanly.
+  public static $selectBranch = (
+    value: any,
+    candidates: { required: string[]; all: string[]; convert: (v: any) => any }[],
+  ): any => {
+    if (value === null || typeof value !== 'object') {
+      return candidates[0].convert(value);
+    }
+    const scored = candidates
+      .filter((c) => c.required.every((k) => value[k] !== undefined))
+      .map((c) => ({
+        c,
+        score: c.all.filter((k) => value[k] !== undefined).length,
+      }));
+    const best = scored.sort((a, b) => b.score - a.score)[0];
+    return (best ? best.c : candidates[0]).convert(value);
+  };
+  <%_ } _%>
 <%_ models.filter(m => m.export !== 'enum').forEach((model) => { _%>
 <%_ const isComposite = model.export === "one-of" || model.export === "any-of" || model.export === "all-of"; _%>
 <%_ /* A discriminator base emits its plain (own-fields) body under a $-prefixed
@@ -271,7 +303,16 @@ export class $IO {
         <%_ }); _%>
       }
       <%_ } _%>
-      <%_ if (model.composedModels.length > 0) { _%>
+      <%_ /* A non-discriminated oneOf/anyOf of object branches selects the
+            best-matching branch rather than merging every branch (which would
+            leak fields from the non-matching branches). */ _%>
+      <%_ if (isNonDiscriminatedObjectUnion(model)) { _%>
+      return $IO.$selectBranch(model, [
+        <%_ model.composedModels.forEach((branch) => { _%>
+        { required: [<%- (branch.properties || []).filter(p => p.isRequired).map(p => JSON.stringify(p.typescriptName)).join(', ') %>], all: [<%- (branch.properties || []).map(p => JSON.stringify(p.typescriptName)).join(', ') %>], convert: (v) => $IO.<%- branch.typescriptName %>.toJson(v as <%- branch.typescriptName %>) },
+        <%_ }); _%>
+      ]);
+      <%_ } else if (model.composedModels.length > 0) { _%>
       return {
         <%_ model.properties.filter(p => !p.isPrimitive && p.export !== 'array').forEach((property, i) => { _%>
         <%_ if (property.export === 'reference' && discriminatorBaseNames.has(property.type)) { _%>
@@ -354,7 +395,16 @@ export class $IO {
         <%_ }); _%>
       }
       <%_ } _%>
-      <%_ if (model.composedModels.length > 0) { _%>
+      <%_ /* A non-discriminated oneOf/anyOf of object branches selects the
+            best-matching branch (matched on wire property names) rather than
+            merging every branch. */ _%>
+      <%_ if (isNonDiscriminatedObjectUnion(model)) { _%>
+      return $IO.$selectBranch(json, [
+        <%_ model.composedModels.forEach((branch) => { _%>
+        { required: [<%- (branch.properties || []).filter(p => p.isRequired).map(p => JSON.stringify(p.name)).join(', ') %>], all: [<%- (branch.properties || []).map(p => JSON.stringify(p.name)).join(', ') %>], convert: (v) => $IO.<%- branch.typescriptName %>.fromJson(v) },
+        <%_ }); _%>
+      ]);
+      <%_ } else if (model.composedModels.length > 0) { _%>
       return {
         <%_ model.properties.filter(p => !p.isPrimitive && p.export !== 'array').forEach((composedType) => { _%>
         <%_ if (composedType.export === 'reference' && discriminatorBaseNames.has(composedType.type)) { _%>

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -1186,6 +1186,120 @@ describe('openApiTsClientGenerator - composite schemas', () => {
     );
   });
 
+  it('should select the matching branch of a non-discriminated union rather than merging', async () => {
+    // FastAPI emits a plain `Union[A, B]` return as an anyOf/oneOf with no
+    // discriminator. Merging every branch leaks fields from the non-matching
+    // branch (e.g. an SmsEvent gaining a spurious `sentAt: Invalid Date` from
+    // the EmailEvent branch), so marshalling must select the matching branch.
+    const spec: Spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      components: {
+        schemas: {
+          EmailEvent: {
+            type: 'object',
+            properties: {
+              sentAt: { type: 'string', format: 'date-time' },
+              to: { type: 'string' },
+            },
+            required: ['sentAt', 'to'],
+          },
+          SmsEvent: {
+            type: 'object',
+            properties: {
+              deliveredOn: { type: 'string', format: 'date' },
+              number: { type: 'string' },
+            },
+            required: ['deliveredOn', 'number'],
+          },
+        } as any,
+      },
+      paths: {
+        '/last-event': {
+          get: {
+            operationId: 'lastEvent',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      anyOf: [
+                        { $ref: '#/components/schemas/EmailEvent' },
+                        { $ref: '#/components/schemas/SmsEvent' },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          post: {
+            operationId: 'putEvent',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    anyOf: [
+                      { $ref: '#/components/schemas/EmailEvent' },
+                      { $ref: '#/components/schemas/SmsEvent' },
+                    ],
+                  },
+                },
+              },
+            },
+            responses: { '204': { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+
+    // fromJson: an SMS payload must revive only SMS fields — no leaked
+    // sentAt/to, and deliveredOn is a valid Date.
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi
+        .fn()
+        .mockResolvedValue({ deliveredOn: '2026-05-01', number: '+1555' }),
+    });
+    const sms = await callGeneratedClient(client, mockFetch, 'lastEvent');
+    expect(sms.deliveredOn instanceof Date).toBe(true);
+    expect(isNaN((sms.deliveredOn as Date).getTime())).toBe(false);
+    expect('sentAt' in sms).toBe(false);
+    expect('to' in sms).toBe(false);
+    expect(Object.keys(sms).sort()).toEqual(['deliveredOn', 'number']);
+
+    // toJson: sending an email event must serialise only email fields.
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({ status: 204 });
+    await callGeneratedClient(client, mockFetch, 'putEvent', {
+      sentAt: new Date('2026-05-01T09:00:00Z'),
+      to: 'a@b.com',
+    });
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(sentBody).toEqual({
+      sentAt: '2026-05-01T09:00:00.000Z',
+      to: 'a@b.com',
+    });
+    expect('deliveredOn' in sentBody).toBe(false);
+  });
+
   it('should handle FastAPI-style discriminated unions with string const (Literal)', async () => {
     const spec: Spec = {
       openapi: '3.1.0',

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -119,6 +119,54 @@ const preferredJsonMediaType = (mediaTypes: string[]): string | undefined =>
   mediaTypes.find((mediaType) => mediaType === 'application/json') ??
   mediaTypes.find((mediaType) => mediaType.split(';')[0].endsWith('+json'));
 
+const FORM_MEDIA_TYPES = [
+  'multipart/form-data',
+  'application/x-www-form-urlencoded',
+];
+
+const isFormMediaType = (mediaType: string): boolean =>
+  FORM_MEDIA_TYPES.includes(mediaType.split(';')[0]);
+
+/**
+ * Whether a `contentMediaType` denotes binary (rather than textual/JSON)
+ * content — an octet-stream, image, audio, etc.
+ */
+const isBinaryContentMediaType = (contentMediaType: string): boolean =>
+  !(
+    contentMediaType.startsWith('text/') ||
+    contentMediaType === 'application/json' ||
+    contentMediaType.endsWith('+json') ||
+    contentMediaType === 'application/xml'
+  );
+
+/**
+ * Rewrite file string fields of a form body to `format: binary` so the
+ * generator types them as `Blob`. FastAPI emits an identical schema
+ * (`{type: string, contentMediaType: ...}`) for a multipart file field and for
+ * `bytes` in a JSON body; only the enclosing media type distinguishes them, so
+ * this promotion is scoped to form bodies. A base64 `contentEncoding` or a
+ * textual/JSON `contentMediaType` keeps the field a string. `format: binary` is
+ * left untouched (already binary anywhere).
+ */
+const markFormBinaryFields = (schema: OpenAPIV3.SchemaObject): void => {
+  Object.values(schema.properties ?? {}).forEach((prop) => {
+    if (isRef(prop)) return;
+    const s = prop as OpenAPIV3.SchemaObject & {
+      contentMediaType?: string;
+      contentEncoding?: string;
+    };
+    if (
+      s.type === 'string' &&
+      s.format !== 'binary' &&
+      s.contentMediaType &&
+      !s.contentEncoding &&
+      isBinaryContentMediaType(s.contentMediaType)
+    ) {
+      s.format = 'binary';
+    }
+  });
+};
+
 const hasSubSchemasToVisit = (
   schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
 ): schema is OpenAPIV3.SchemaObject =>
@@ -578,24 +626,27 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
           // rather than left `unknown`.
           const bodyMediaType =
             preferredJsonMediaType(contentMediaTypes) ??
-            contentMediaTypes.find((mt) =>
-              [
-                'multipart/form-data',
-                'application/x-www-form-urlencoded',
-              ].includes(mt.split(';')[0]),
-            );
-          const bodyRequestSchema = bodyMediaType
+            contentMediaTypes.find(isFormMediaType);
+          const bodyContentSchema = bodyMediaType
             ? requestBody!.content![bodyMediaType].schema
             : undefined;
+          // A form body's binary string fields are file uploads (Blob). Mark
+          // the resolved schema (inline or $ref target) before hoisting.
+          if (bodyMediaType && isFormMediaType(bodyMediaType)) {
+            const resolved = resolveIfRef(spec, bodyContentSchema) as
+              | OpenAPIV3.SchemaObject
+              | undefined;
+            if (resolved) markFormBinaryFields(resolved);
+          }
           if (
-            bodyRequestSchema &&
-            !isRef(bodyRequestSchema) &&
-            (['object', 'array'].includes(bodyRequestSchema.type!) ||
-              isCompositeSchema(bodyRequestSchema) ||
-              (bodyRequestSchema?.type === 'string' && bodyRequestSchema.enum))
+            bodyContentSchema &&
+            !isRef(bodyContentSchema) &&
+            (['object', 'array'].includes(bodyContentSchema.type!) ||
+              isCompositeSchema(bodyContentSchema) ||
+              (bodyContentSchema?.type === 'string' && bodyContentSchema.enum))
           ) {
             const schemaName = `${upperFirst(deduplicatedOpId)}RequestContent`;
-            spec.components!.schemas![schemaName] = bodyRequestSchema;
+            spec.components!.schemas![schemaName] = bodyContentSchema;
             requestBody!.content![bodyMediaType!].schema = {
               $ref: `#/components/schemas/${schemaName}`,
             };

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -104,30 +104,17 @@ const isDictionarySchema = (schema: Schema): boolean => {
 };
 
 /**
- * The internal primitive type name for a primitive schema.
+ * The internal primitive type name for a primitive schema. A `string` field
+ * denotes raw binary content (rendered as a `Blob`) only via `format: binary`.
+ * The 3.1 `contentMediaType` idiom is ambiguous in isolation — FastAPI emits it
+ * both for multipart file fields (binary) and for `bytes` in a JSON body
+ * (base64 string) — so `normalise` rewrites it to `format: binary` for form
+ * bodies only, and this stays context-free.
  */
 const primitiveType = (schema: Schema): string => {
   const type = primaryType(schema);
-  if (type === 'string' && isBinaryStringSchema(schema)) return 'binary';
+  if (type === 'string' && schema.format === 'binary') return 'binary';
   return (type && PRIMITIVE_TYPE_MAP[type]) ?? 'unknown';
-};
-
-/**
- * Whether a `string` schema denotes raw binary content (rendered as a `Blob`).
- * Covers the 3.0 `format: binary` idiom and the 3.1 `contentMediaType` idiom
- * (as emitted by FastAPI for `UploadFile`). A base64 `contentEncoding`, or a
- * textual/JSON media type, keeps the value a string on the wire.
- */
-const isBinaryStringSchema = (schema: Schema): boolean => {
-  if (schema.format === 'binary') return true;
-  const contentMediaType = schema.contentMediaType;
-  if (!contentMediaType || schema.contentEncoding) return false;
-  return !(
-    contentMediaType.startsWith('text/') ||
-    contentMediaType === 'application/json' ||
-    contentMediaType.endsWith('+json') ||
-    contentMediaType === 'application/xml'
-  );
 };
 
 /**
@@ -822,10 +809,9 @@ const isHoisted = (spec: Spec, name: string): boolean =>
  */
 const wireName = (spec: Spec, name: string): string =>
   (
-    resolveIfRef<Schema | undefined>(
-      spec,
-      spec.components?.schemas?.[name],
-    ) as { 'x-aws-nx-original-name'?: string } | undefined
+    resolveIfRef<Schema | undefined>(spec, spec.components?.schemas?.[name]) as
+      | { 'x-aws-nx-original-name'?: string }
+      | undefined
   )?.['x-aws-nx-original-name'] ?? name;
 
 /**
@@ -850,11 +836,13 @@ const buildDiscriminatorMapping = (
     }
     return mapping;
   }
-  return [...candidateNames]
-    .filter((name) => !isHoisted(spec, name))
-    // The wire value is the schema's original name; the model it selects is the
-    // normalised name.
-    .map((name) => ({ value: wireName(spec, name), modelName: name }));
+  return (
+    [...candidateNames]
+      .filter((name) => !isHoisted(spec, name))
+      // The wire value is the schema's original name; the model it selects is the
+      // normalised name.
+      .map((name) => ({ value: wireName(spec, name), modelName: name }))
+  );
 };
 
 /**
@@ -983,7 +971,10 @@ const resolveDiscriminatorLiterals = (data: ClientData): void => {
         // Same subtype+property tagged differently by another union.
         conflicting.add(key);
       }
-      valuesBySubtypeProp.set(key, existing ? union(existing, incoming) : incoming);
+      valuesBySubtypeProp.set(
+        key,
+        existing ? union(existing, incoming) : incoming,
+      );
     }
   }
 


### PR DESCRIPTION
### Reason for this change

Two marshalling issues in the generated OpenAPI TypeScript client, found while validating FastAPI feature coverage in an example workspace:

1. **Non-discriminated union field leak.** A `oneOf`/`anyOf` response with no discriminator — the shape FastAPI emits for a plain `Union[A, B]` return type — merged every branch in `toJson`/`fromJson`. For a value matching one branch, fields from the *other* branch leaked onto the result: e.g. an `SmsEvent` came back with a spurious `sentAt: Invalid Date` (from running the `EmailEvent` branch's `new Date(json['sentAt'])` on an absent field), and every branch's keys appeared on the object. #886 fixed this for *discriminated* unions; the discriminator-less case (very common in FastAPI) still merged.

2. **Binary form field over-detection.** FastAPI emits an identical schema (`{type: string, contentMediaType: application/octet-stream}`) for a multipart file field *and* for a `bytes` field in a JSON body. Detecting binary from `contentMediaType` in the context-free parser therefore typed a JSON `bytes` field as `Blob`, when FastAPI actually sends it as a base64 string in JSON.

### Description of changes

- **Non-discriminated union selection** — a `oneOf`/`anyOf` of two or more object branches with no discriminator now selects the best-matching branch at runtime via a `$selectBranch` helper (the branch whose required properties are all present, preferring the one matching the most properties; falls back to the first branch so a value still round-trips). `all-of` (a conjunction — merge is correct) and discriminated composites are unchanged.
- **Binary detection scoped to form bodies** — moved out of the parser (which now trusts only `format: binary`) and into `normalise`, which knows the enclosing media type. A `multipart/form-data` / `x-www-form-urlencoded` body's binary string fields are rewritten to `format: binary` (→ `Blob`); a textual/JSON `contentMediaType` or a base64 `contentEncoding` keeps the field a string. A `bytes` field in a JSON body therefore stays `string`.

### Description of how you validated changes

- Added a non-discriminated union round-trip test: `fromJson` revives only the SMS branch (valid `Date`, no leaked `sentAt`/`to`, keys are exactly `deliveredOn`/`number`); `toJson` serialises only the email branch. The existing multipart test confirms a form's octet-stream field → `Blob` while an `application/json` field → `string`.
- Full plugin suite green (2525 tests); full workspace build passes; snapshots updated for the shared `$selectBranch` helper.
- **End-to-end**: reproduced both issues against a live FastAPI backend in an example workspace, then confirmed the fixes there — the SMS union response carries only its own fields (no `Invalid Date`), and a JSON `bytes` field is typed `string` while a multipart file field stays `Blob`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
