### PR TITLE
chore(create-nx-workspace): remove pnpm_config_strict_dep_builds override

### DIFF
--- a/packages/create-nx-workspace/src/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/src/create-nx-workspace.ts
@@ -121,16 +121,6 @@ export const createNxWorkspace = (args: string[]): number => {
     ['-y', `create-nx-workspace@${NX_VERSION}`, ...allArgs],
     {
       stdio: 'inherit',
-      env: {
-        ...process.env,
-        // pnpm 11 defaults strictDepBuilds=true, which turns the initial
-        // `pnpm install --no-frozen-lockfile` run by `nx new` into a hard
-        // error on nx's postinstall script — before our preset generator
-        // gets a chance to write the workspace's pnpm-workspace.yaml. pnpm
-        // reads config from the lowercase `pnpm_config_` env-var prefix.
-        // Harmless under pnpm 10.
-        pnpm_config_strict_dep_builds: 'false',
-      },
       shell: process.platform === 'win32',
     },
   );


### PR DESCRIPTION
### Reason for this change

`@aws/create-nx-workspace` sets `pnpm_config_strict_dep_builds=false` in the env it hands to the `npx create-nx-workspace` child. This was a workaround (PR #633): pnpm 11 defaults `strictDepBuilds=true`, which turned the `ERR_PNPM_IGNORED_BUILDS` warning for nx's postinstall into a hard install error during the `nx new` install that runs **before** our preset generator writes the workspace's `pnpm-workspace.yaml`.

The upstream fix, [nrwl/nx#35564](https://github.com/nrwl/nx/pull/35564), makes `@nx/workspace`'s `generate-workspace-files.addPnpmSettings` emit `allowBuilds: { nx: true }` (pnpm 11) / `onlyBuiltDependencies: [nx]` (pnpm 10) in the initial `pnpm-workspace.yaml` that `nx new` writes, so nx's own install succeeds without our env override.

### Description of changes

- Remove the `pnpm_config_strict_dep_builds: 'false'` env override (and its now-empty `env` wrapper) from the `spawnSync` call in `packages/create-nx-workspace/src/create-nx-workspace.ts`. `spawnSync` inherits `process.env` by default, so behavior is otherwise unchanged.

nrwl/nx#35564 merged 2026-05-27 and shipped in nx **23.0.0**; we already pin `create-nx-workspace@23.0.1` (`TS_VERSIONS['create-nx-workspace']`), so the fix is present in the version we invoke — the workaround is now dead code.

### Description of how you validated changes

- `nx run @aws/create-nx-workspace:test` — 31/31 pass.
- `nx run @aws/create-nx-workspace:build` — succeeds.
- Full plugin test suite green via pre-commit (2524/2524).
- The `pnpm-10` and `pnpm-11` smoke tests in CI exercise the real `nx new` install path on this PR.

### Issue # (if applicable)

Closes #649.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*