### PR TITLE
fix(api-connection): retry unmodeled 429s when configuring the API Gateway account role

### DIFF
--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account/index.js.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/core/api/rest/api-gateway-account/index.js.template
@@ -16,8 +16,33 @@ const iam = new IAMClient();
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const RETRYABLE = ['BadRequestException', 'TooManyRequestsException'];
+
+// Throttling may surface as a bare 429 with no modeled error code, so check
+// response metadata as well as error names
+const isRetryable = (e) =>
+  RETRYABLE.includes(e.name) ||
+  e.$metadata?.httpStatusCode === 429 ||
+  e.$retryable?.throttling === true;
+
+// Retry while the freshly created role propagates through IAM, and on
+// throttling of the account-level API (shared across concurrent deployments)
+const send = async (command) => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await apigw.send(command);
+    } catch (e) {
+      if (isRetryable(e) && attempt < 11) {
+        await sleep(5000);
+      } else {
+        throw e;
+      }
+    }
+  }
+};
+
 const hasLiveRole = async () => {
-  const { cloudwatchRoleArn } = await apigw.send(new GetAccountCommand({}));
+  const { cloudwatchRoleArn } = await send(new GetAccountCommand({}));
   if (!cloudwatchRoleArn) return false;
   try {
     await iam.send(
@@ -30,25 +55,12 @@ const hasLiveRole = async () => {
   }
 };
 
-const RETRYABLE = ['BadRequestException', 'TooManyRequestsException'];
-
-const setRole = async (value) => {
-  const command = new UpdateAccountCommand({
-    patchOperations: [{ op: 'replace', path: '/cloudwatchRoleArn', value }],
-  });
-  // Retry while the freshly created role propagates through IAM, and on throttling
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await apigw.send(command);
-    } catch (e) {
-      if (RETRYABLE.includes(e.name) && attempt < 11) {
-        await sleep(5000);
-      } else {
-        throw e;
-      }
-    }
-  }
-};
+const setRole = (value) =>
+  send(
+    new UpdateAccountCommand({
+      patchOperations: [{ op: 'replace', path: '/cloudwatchRoleArn', value }],
+    }),
+  );
 
 exports.handler = async (event) => {
   if (event.RequestType !== 'Delete' && !(await hasLiveRole())) {


### PR DESCRIPTION
### Reason for this change

CI run [28991934852](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/28991934852) (cdk-deploy smoke test, 2026-07-09) failed with:

```
CREATE_FAILED | Custom::ApiGatewayAccount | ApiGatewayAccount6818CEC6
Received response status [FAILED] from custom resource. Message returned: Too Many Requests
```

The account-level API Gateway configuration is a per-region singleton shared across all concurrent deployments in an account, so it is prone to throttling. The custom resource handler already retried throttling — but only when the error deserialized to a *modeled* error name (`BadRequestException` / `TooManyRequestsException`). In this failure the service returned a bare 429 with no error code, so the AWS SDK surfaced it with message `Too Many Requests` under a generic error name, bypassing the retry and rolling back the whole stack. The initial `GetAccount` call additionally had no retry at all.

### Description of changes

In the vended `ApiGatewayAccount` custom resource handler (`api-gateway-account/index.js.template`):

- Broadened the retry predicate: retry when the error name is modeled retryable **or** `$metadata.httpStatusCode === 429` **or** the SDK marks it `$retryable.throttling`, so unmodeled throttles are covered.
- Routed both API Gateway calls (`GetAccount` in `hasLiveRole` and `UpdateAccount` in `setRole`) through the shared retrying `send` helper; previously only `UpdateAccount` retried.

Retry cadence is unchanged (12 attempts, 5s apart, within the 2-minute function timeout).

### Description of how you validated changes

- `pnpm nx run-many --target build --all` and the full `@aws/nx-plugin:test` suite pass (handler is vended verbatim; no snapshot contains it).
- Syntax-checked the handler and unit-tested the retry predicate against the exact failure shape (unmodeled 429 with `$metadata.httpStatusCode: 429`), a modeled `TooManyRequestsException`, an SDK-flagged throttle, and a non-retryable `AccessDeniedException` (correctly not retried).

### Issue # (if applicable)

N/A — addresses a CI flake found auditing main workflow failures.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*