### PR TITLE
test(e2e): retry AG-UI agent invocations that stream a RUN_ERROR event

### DIFF
--- a/e2e/src/smoke-tests/deploy-invocations.ts
+++ b/e2e/src/smoke-tests/deploy-invocations.ts
@@ -244,16 +244,20 @@ export async function invokeAgentCoreAgUi(
       }),
     });
 
-    if (response.status !== 200 && attempt < maxAttempts) {
-      const body = await response.text().catch(() => '');
+    // A RUN_ERROR event arrives in a 200 stream, so check the body as well as
+    // the status — transient failures (e.g. a dropped MCP connection mid-run)
+    // surface there rather than as a non-200.
+    const body = await response.text().catch(() => '');
+    if (
+      (response.status !== 200 || body.includes('RUN_ERROR')) &&
+      attempt < maxAttempts
+    ) {
       console.log(
         `${agentName} attempt ${attempt}/${maxAttempts} returned ${response.status}; retrying in 15s. Body: ${body.slice(0, 500)}`,
       );
       await new Promise((resolve) => setTimeout(resolve, 15_000));
       continue;
     }
-
-    const body = await response.text();
     console.log(
       `${agentName} (AG-UI) response status:`,
       response.status,


### PR DESCRIPTION
### Reason for this change

CI run [29073649347](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/29073649347) (terraform-deploy smoke test, 2026-07-10) failed exercising the deployed Python LangChain agent over AG-UI. A tool call to the connected MCP server's `add` tool failed transiently (the identical call had succeeded 2 seconds earlier in the same run), and the agent surfaced it as a `RUN_ERROR` event.

`invokeAgentCoreAgUi` already retries transient failures (4x/15s for AgentCore cold starts), but only on non-200 responses. AG-UI agent failures arrive as a `RUN_ERROR` event inside a 200 SSE stream, so the retry never fired and a single transient failure failed the smoke test.

### Description of changes

`invokeAgentCoreAgUi` now reads the body up front and retries — with the same cadence as the existing status-based retry — when the response is non-200 **or** the body contains `RUN_ERROR`. The final attempt still asserts a 200 with no `RUN_ERROR`, so persistent failures still fail the test.

Test-only change; no vended code is modified.

### Description of how you validated changes

- Full `@aws/nx-plugin:test` suite and lint pass.
- The failing run's log confirms the failure shape: HTTP 200 with `data: {"type":"RUN_ERROR",...}` in the stream, which the previous status-only check let through to the assertion on first attempt.

### Issue # (if applicable)

N/A — addresses a CI flake found auditing main workflow failures.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*