### PR TITLE
fix(ts#astro-docs): use import.meta.dirname in translate script for ESM workspaces

### DIFF
--- a/packages/nx-plugin/src/ts/astro-docs/files/translation/scripts/translate.ts.template
+++ b/packages/nx-plugin/src/ts/astro-docs/files/translation/scripts/translate.ts.template
@@ -44,8 +44,9 @@ interface TranslateConfig {
   translationCommitMessage?: string;
 }
 
-const PROJECT_ROOT = path.resolve(__dirname, '..');
-const CONFIG_PATH = path.resolve(__dirname, 'translate.config.json');
+const SCRIPTS_DIR = <% if (esm) { %>import.meta.dirname<% } else { %>__dirname<% } %>;
+const PROJECT_ROOT = path.resolve(SCRIPTS_DIR, '..');
+const CONFIG_PATH = path.resolve(SCRIPTS_DIR, 'translate.config.json');
 const config: TranslateConfig = JSON.parse(
   fs.readFileSync(CONFIG_PATH, 'utf-8'),
 );

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { getProjects, readJson, type Tree } from '@nx/devkit';
+import { getProjects, readJson, type Tree, updateJson } from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
@@ -99,6 +99,30 @@ describe('ts#astro-docs generator', () => {
     expect(deps).toHaveProperty('@strands-agents/sdk');
     expect(deps).toHaveProperty('commander');
     expect(deps).toHaveProperty('tsx');
+  });
+
+  it('should use import.meta.dirname in translate.ts in an ESM workspace', async () => {
+    await tsAstroDocsGenerator(tree, {
+      name: 'docs',
+      preferInstallDependencies: false,
+    });
+
+    const translateScript = tree.read('docs/scripts/translate.ts', 'utf-8');
+    expect(translateScript).toContain('import.meta.dirname');
+    expect(translateScript).not.toContain('__dirname');
+  });
+
+  it('should use __dirname in translate.ts in a CommonJS workspace', async () => {
+    updateJson(tree, 'package.json', (pkg) => ({ ...pkg, type: 'commonjs' }));
+
+    await tsAstroDocsGenerator(tree, {
+      name: 'docs',
+      preferInstallDependencies: false,
+    });
+
+    const translateScript = tree.read('docs/scripts/translate.ts', 'utf-8');
+    expect(translateScript).toContain('__dirname');
+    expect(translateScript).not.toContain('import.meta.dirname');
   });
 
   it('should use the project name as the site title', async () => {

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -6,6 +6,7 @@ import { getProjects, readJson, type Tree, updateJson } from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { TypeScriptVerifier } from '../../utils/test/ts.spec';
 import {
   TS_ASTRO_DOCS_GENERATOR_INFO,
   tsAstroDocsGenerator,
@@ -13,6 +14,14 @@ import {
 
 describe('ts#astro-docs generator', () => {
   let tree: Tree;
+  const verifier = new TypeScriptVerifier([
+    'commander',
+    'fs-extra',
+    '@types/fs-extra',
+    'simple-git',
+    'fast-glob',
+    '@strands-agents/sdk',
+  ]);
 
   beforeEach(() => {
     tree = createTreeUsingTsSolutionSetup();
@@ -101,7 +110,7 @@ describe('ts#astro-docs generator', () => {
     expect(deps).toHaveProperty('tsx');
   });
 
-  it('should use import.meta.dirname in translate.ts in an ESM workspace', async () => {
+  it('should generate a compiling translate.ts using import.meta.dirname in an ESM workspace', async () => {
     await tsAstroDocsGenerator(tree, {
       name: 'docs',
       preferInstallDependencies: false,
@@ -110,9 +119,11 @@ describe('ts#astro-docs generator', () => {
     const translateScript = tree.read('docs/scripts/translate.ts', 'utf-8');
     expect(translateScript).toContain('import.meta.dirname');
     expect(translateScript).not.toContain('__dirname');
+
+    verifier.expectTypeScriptToCompile(tree, ['docs/scripts/translate.ts']);
   });
 
-  it('should use __dirname in translate.ts in a CommonJS workspace', async () => {
+  it('should generate a compiling translate.ts using __dirname in a CommonJS workspace', async () => {
     updateJson(tree, 'package.json', (pkg) => ({ ...pkg, type: 'commonjs' }));
 
     await tsAstroDocsGenerator(tree, {
@@ -123,6 +134,8 @@ describe('ts#astro-docs generator', () => {
     const translateScript = tree.read('docs/scripts/translate.ts', 'utf-8');
     expect(translateScript).toContain('__dirname');
     expect(translateScript).not.toContain('import.meta.dirname');
+
+    verifier.expectTypeScriptToCompile(tree, ['docs/scripts/translate.ts']);
   });
 
   it('should use the project name as the site title', async () => {

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -15,6 +15,7 @@ import {
 import { formatFilesInSubtree } from '../../utils/format';
 import { installDependencies } from '../../utils/install';
 import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+import { isEsmWorkspace } from '../../utils/module-format';
 import { toKebabCase } from '../../utils/names';
 import { getNpmScopePrefix } from '../../utils/npm-scope';
 import {
@@ -106,6 +107,7 @@ export const tsAstroDocsGenerator = async (
     title: schema.name,
     includeTranslation,
     includeBlog,
+    esm: isEsmWorkspace(tree),
     pkgMgrCmd: getPackageManagerDisplayCommands().exec,
     today: new Date().toISOString().slice(0, 10),
   };


### PR DESCRIPTION
### Reason for this change

The vended `translate.ts` script from `ts#astro-docs` uses `__dirname` unconditionally. Generated workspaces are ESM by default (preset writes `"type": "module"`), so running the `translate` target crashes immediately:

```
ReferenceError: __dirname is not defined in ES module scope
```

Found while validating the ts#astro-docs generator end-to-end in a fresh workspace.

### Description of changes

- `translate.ts.template` resolves its script directory via the same `<% if (esm) %>import.meta.dirname<% } else { %>__dirname<% } %>` conditional used by other vending generators (e.g. `ts#nx-generator`, the nx-plugin MCP server templates).
- The `ts#astro-docs` generator now passes `esm: isEsmWorkspace(tree)` to its template options.

### Description of how you validated changes

- Added unit tests asserting the generated `translate.ts` uses `import.meta.dirname` in an ESM workspace and `__dirname` in a CommonJS workspace (28 astro-docs tests pass).
- Reproduced the crash in a generated workspace with the previous template, and verified the corrected script runs (`tsx ./scripts/translate.ts --help`).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
