### PR TITLE
fix(open-api#ts-client): multipart encoding, path styles, content-based params

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.content-type.spec.ts.snap
@@ -166,18 +166,36 @@ export class TestApi {
     });
   };
 
-  private $formData = (model: { [key: string]: any }): FormData => {
+  private $formData = (
+    model: { [key: string]: any },
+    partContentTypes?: { [key: string]: string },
+  ): FormData => {
     const formData = new FormData();
     const append = (key: string, value: any): void => {
       if (value === undefined || value === null) {
         return;
       }
+      const partContentType = partContentTypes?.[key];
       if (value instanceof Blob || typeof value === 'string') {
-        formData.append(key, value);
+        // A declared part content type overrides the default (text/plain for
+        // strings, the Blob's own type otherwise)
+        if (partContentType) {
+          formData.append(key, new Blob([value], { type: partContentType }));
+        } else {
+          formData.append(key, value);
+        }
       } else if (Array.isArray(value)) {
         value.forEach((v) => append(key, v));
       } else if (typeof value === 'object') {
-        formData.append(key, JSON.stringify(value));
+        const serialized = JSON.stringify(value);
+        if (partContentType) {
+          formData.append(
+            key,
+            new Blob([serialized], { type: partContentType }),
+          );
+        } else {
+          formData.append(key, serialized);
+        }
       } else {
         formData.append(key, String(value));
       }

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.multipart.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.multipart.spec.ts.snap
@@ -214,18 +214,36 @@ export class TestApi {
     });
   };
 
-  private $formData = (model: { [key: string]: any }): FormData => {
+  private $formData = (
+    model: { [key: string]: any },
+    partContentTypes?: { [key: string]: string },
+  ): FormData => {
     const formData = new FormData();
     const append = (key: string, value: any): void => {
       if (value === undefined || value === null) {
         return;
       }
+      const partContentType = partContentTypes?.[key];
       if (value instanceof Blob || typeof value === 'string') {
-        formData.append(key, value);
+        // A declared part content type overrides the default (text/plain for
+        // strings, the Blob's own type otherwise)
+        if (partContentType) {
+          formData.append(key, new Blob([value], { type: partContentType }));
+        } else {
+          formData.append(key, value);
+        }
       } else if (Array.isArray(value)) {
         value.forEach((v) => append(key, v));
       } else if (typeof value === 'object') {
-        formData.append(key, JSON.stringify(value));
+        const serialized = JSON.stringify(value);
+        if (partContentType) {
+          formData.append(
+            key,
+            new Blob([serialized], { type: partContentType }),
+          );
+        } else {
+          formData.append(key, serialized);
+        }
       } else {
         formData.append(key, String(value));
       }

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.spec-compliance.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.spec-compliance.spec.ts.snap
@@ -1,0 +1,1883 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`openApiTsClientGenerator - spec compliance > should JSON-serialise a content-based query parameter with marshalled dates > client.gen.ts 1`] = `
+"import type {
+  ContentParamRequestQueryParameters,
+  Filter,
+  ContentParamRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static ContentParamRequestQueryParameters = {
+    toJson: (model: ContentParamRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.filter === undefined
+          ? {}
+          : {
+              filter: $IO.Filter.toJson(model.filter),
+            }),
+      };
+    },
+    fromJson: (json: any): ContentParamRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        filter: $IO.Filter.fromJson(json['filter']),
+      };
+    },
+  };
+
+  public static Filter = {
+    toJson: (model: Filter): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.field === undefined
+          ? {}
+          : {
+              field: model.field,
+            }),
+        ...(model.since === undefined
+          ? {}
+          : {
+              since: model.since.toISOString(),
+            }),
+      };
+    },
+    fromJson: (json: any): Filter => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        field: json['field'],
+        ...(json['since'] === undefined
+          ? {}
+          : {
+              since: new Date(json['since']),
+            }),
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.contentParam = this.contentParam.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async contentParam(input: ContentParamRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } =
+      $IO.ContentParamRequestQueryParameters.toJson(input);
+    if (queryParameters['filter'] !== undefined) {
+      queryParameters['filter'] = JSON.stringify(queryParameters['filter']);
+    }
+    const headerParameters: { [key: string]: any } = {};
+    const queryCollectionFormats = {
+      filter: 'multi',
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/query',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should JSON-serialise a content-based query parameter with marshalled dates > types.gen.ts 1`] = `
+"export type ContentParamRequestQueryParameters = {
+  filter: Filter;
+};
+export type Filter = {
+  field: string;
+  since?: Date;
+};
+
+export type ContentParamRequest = ContentParamRequestQueryParameters;
+export type ContentParamError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should keep a decimal format string un-corrupted and round-trip byte fields > client.gen.ts 1`] = `
+"import type { BlobMeta, PutBlobMetaRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static BlobMeta = {
+    toJson: (model: BlobMeta): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.data === undefined
+          ? {}
+          : {
+              data: model.data,
+            }),
+        ...(model.price === undefined
+          ? {}
+          : {
+              price: model.price,
+            }),
+      };
+    },
+    fromJson: (json: any): BlobMeta => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        data: json['data'],
+        price: json['price'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.putBlobMeta = this.putBlobMeta.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async putBlobMeta(input: PutBlobMetaRequest): Promise<BlobMeta> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      typeof input === 'object'
+        ? JSON.stringify($IO.BlobMeta.toJson(input))
+        : String($IO.BlobMeta.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/blob-meta', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return $IO.BlobMeta.fromJson(await response.json());
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should keep a decimal format string un-corrupted and round-trip byte fields > types.gen.ts 1`] = `
+"export type BlobMeta = {
+  data: string;
+  price: string;
+};
+
+export type PutBlobMetaRequest = BlobMeta;
+export type PutBlobMetaError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should omit the body entirely for an optional request body > client.gen.ts 1`] = `
+"import type { SearchRequestContent, SearchRequest } from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static SearchRequestContent = {
+    toJson: (model: SearchRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.query === undefined
+          ? {}
+          : {
+              query: model.query,
+            }),
+      };
+    },
+    fromJson: (json: any): SearchRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        query: json['query'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.search = this.search.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async search(input?: SearchRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    if (!this.$config.options?.omitContentTypeHeader) {
+      headerParameters['Content-Type'] = 'application/json';
+    }
+    const body =
+      input === undefined
+        ? undefined
+        : typeof input === 'object'
+          ? JSON.stringify($IO.SearchRequestContent.toJson(input))
+          : String($IO.SearchRequestContent.toJson(input));
+
+    const response = await this.$fetch(
+      this.$url('/search', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should omit the body entirely for an optional request body > types.gen.ts 1`] = `
+"export type SearchRequestContent = {
+  query: string;
+};
+
+export type SearchRequest = SearchRequestContent | undefined;
+export type SearchError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should parse 4XX range responses as typed errors and 5XX text as raw text > client.gen.ts 1`] = `
+"import type {
+  GetThing4XXResponse,
+  GetThingRequestPathParameters,
+  GetThingRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static GetThing4XXResponse = {
+    toJson: (model: GetThing4XXResponse): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.reason === undefined
+          ? {}
+          : {
+              reason: model.reason,
+            }),
+      };
+    },
+    fromJson: (json: any): GetThing4XXResponse => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        reason: json['reason'],
+      };
+    },
+  };
+
+  public static GetThingRequestPathParameters = {
+    toJson: (model: GetThingRequestPathParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.id === undefined
+          ? {}
+          : {
+              id: model.id,
+            }),
+      };
+    },
+    fromJson: (json: any): GetThingRequestPathParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        id: json['id'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.getThing = this.getThing.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async getThing(input: GetThingRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } =
+      $IO.GetThingRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url('/things/{id}', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    if (response.status >= 400 && response.status < 500) {
+      throw {
+        status: response.status,
+        error: $IO.GetThing4XXResponse.fromJson(await response.json()),
+      };
+    }
+    if (response.status >= 500 && response.status < 600) {
+      throw {
+        status: response.status,
+        error: await response.text(),
+      };
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should parse 4XX range responses as typed errors and 5XX text as raw text > types.gen.ts 1`] = `
+"export type GetThing4XXResponse = {
+  reason: string;
+};
+export type GetThingRequestPathParameters = {
+  id: string;
+};
+
+export type GetThingRequest = GetThingRequestPathParameters;
+export type GetThing4XXError = {
+  status: _4XX;
+  error: GetThing4XXResponse;
+};
+export type GetThing5XXError = {
+  status: _5XX;
+  error: string;
+};
+export type GetThingError = GetThing4XXError | GetThing5XXError;
+export type _4XX =
+  | 400
+  | 401
+  | 402
+  | 403
+  | 404
+  | 405
+  | 406
+  | 407
+  | 408
+  | 409
+  | 410
+  | 411
+  | 412
+  | 413
+  | 414
+  | 415
+  | 416
+  | 417
+  | 418
+  | 419
+  | 420
+  | 421
+  | 422
+  | 423
+  | 424
+  | 425
+  | 426
+  | 427
+  | 428
+  | 429
+  | 430
+  | 431
+  | 432
+  | 433
+  | 434
+  | 435
+  | 436
+  | 437
+  | 438
+  | 439
+  | 440
+  | 441
+  | 442
+  | 443
+  | 444
+  | 445
+  | 446
+  | 447
+  | 448
+  | 449
+  | 450
+  | 451
+  | 452
+  | 453
+  | 454
+  | 455
+  | 456
+  | 457
+  | 458
+  | 459
+  | 460
+  | 461
+  | 462
+  | 463
+  | 464
+  | 465
+  | 466
+  | 467
+  | 468
+  | 469
+  | 470
+  | 471
+  | 472
+  | 473
+  | 474
+  | 475
+  | 476
+  | 477
+  | 478
+  | 479
+  | 480
+  | 481
+  | 482
+  | 483
+  | 484
+  | 485
+  | 486
+  | 487
+  | 488
+  | 489
+  | 490
+  | 491
+  | 492
+  | 493
+  | 494
+  | 495
+  | 496
+  | 497
+  | 498
+  | 499;
+export type _5XX =
+  | 500
+  | 501
+  | 502
+  | 503
+  | 504
+  | 505
+  | 506
+  | 507
+  | 508
+  | 509
+  | 510
+  | 511
+  | 512
+  | 513
+  | 514
+  | 515
+  | 516
+  | 517
+  | 518
+  | 519
+  | 520
+  | 521
+  | 522
+  | 523
+  | 524
+  | 525
+  | 526
+  | 527
+  | 528
+  | 529
+  | 530
+  | 531
+  | 532
+  | 533
+  | 534
+  | 535
+  | 536
+  | 537
+  | 538
+  | 539
+  | 540
+  | 541
+  | 542
+  | 543
+  | 544
+  | 545
+  | 546
+  | 547
+  | 548
+  | 549
+  | 550
+  | 551
+  | 552
+  | 553
+  | 554
+  | 555
+  | 556
+  | 557
+  | 558
+  | 559
+  | 560
+  | 561
+  | 562
+  | 563
+  | 564
+  | 565
+  | 566
+  | 567
+  | 568
+  | 569
+  | 570
+  | 571
+  | 572
+  | 573
+  | 574
+  | 575
+  | 576
+  | 577
+  | 578
+  | 579
+  | 580
+  | 581
+  | 582
+  | 583
+  | 584
+  | 585
+  | 586
+  | 587
+  | 588
+  | 589
+  | 590
+  | 591
+  | 592
+  | 593
+  | 594
+  | 595
+  | 596
+  | 597
+  | 598
+  | 599;
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should send multipart parts with content types declared by the encoding object > client.gen.ts 1`] = `
+"import type {
+  CreateDocumentRequestContent,
+  CreateDocumentRequestContentMetadata,
+  CreateDocumentRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static CreateDocumentRequestContent = {
+    toJson: (model: CreateDocumentRequestContent): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.metadata === undefined
+          ? {}
+          : {
+              metadata: $IO.CreateDocumentRequestContentMetadata.toJson(
+                model.metadata,
+              ),
+            }),
+        ...(model.file === undefined
+          ? {}
+          : {
+              file: model.file,
+            }),
+      };
+    },
+    fromJson: (json: any): CreateDocumentRequestContent => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        metadata: $IO.CreateDocumentRequestContentMetadata.fromJson(
+          json['metadata'],
+        ),
+        file: json['file'],
+      };
+    },
+  };
+
+  public static CreateDocumentRequestContentMetadata = {
+    toJson: (model: CreateDocumentRequestContentMetadata): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.title === undefined
+          ? {}
+          : {
+              title: model.title,
+            }),
+      };
+    },
+    fromJson: (json: any): CreateDocumentRequestContentMetadata => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        title: json['title'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.createDocument = this.createDocument.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) =>
+        withParams.replace(\`{\${key}}\`, encodeURIComponent(\`\${value}\`)),
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $formData = (
+    model: { [key: string]: any },
+    partContentTypes?: { [key: string]: string },
+  ): FormData => {
+    const formData = new FormData();
+    const append = (key: string, value: any): void => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      const partContentType = partContentTypes?.[key];
+      if (value instanceof Blob || typeof value === 'string') {
+        // A declared part content type overrides the default (text/plain for
+        // strings, the Blob's own type otherwise)
+        if (partContentType) {
+          formData.append(key, new Blob([value], { type: partContentType }));
+        } else {
+          formData.append(key, value);
+        }
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => append(key, v));
+      } else if (typeof value === 'object') {
+        const serialized = JSON.stringify(value);
+        if (partContentType) {
+          formData.append(
+            key,
+            new Blob([serialized], { type: partContentType }),
+          );
+        } else {
+          formData.append(key, serialized);
+        }
+      } else {
+        formData.append(key, String(value));
+      }
+    };
+    Object.entries(model).forEach(([key, value]) => append(key, value));
+    return formData;
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async createDocument(input: CreateDocumentRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } = {};
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    const body = this.$formData(
+      $IO.CreateDocumentRequestContent.toJson(input),
+      { metadata: 'application/json' },
+    );
+
+    const response = await this.$fetch(
+      this.$url('/documents', pathParameters, queryParameters),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'POST',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should send multipart parts with content types declared by the encoding object > types.gen.ts 1`] = `
+"export type CreateDocumentRequestContent = {
+  metadata: CreateDocumentRequestContentMetadata;
+  file: Blob;
+};
+export type CreateDocumentRequestContentMetadata = {
+  title: string;
+};
+
+export type CreateDocumentRequest = CreateDocumentRequestContent;
+export type CreateDocumentError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should serialise exploded matrix and label path styles > client.gen.ts 1`] = `
+"import type {
+  StyledRequestPathParameters,
+  StyledRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static StyledRequestPathParameters = {
+    toJson: (model: StyledRequestPathParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.coords === undefined
+          ? {}
+          : {
+              coords: model.coords,
+            }),
+        ...(model.tags === undefined
+          ? {}
+          : {
+              tags: model.tags,
+            }),
+      };
+    },
+    fromJson: (json: any): StyledRequestPathParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        coords: json['coords'],
+        tags: json['tags'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.styled = this.styled.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+    pathStyles?: {
+      [key: string]: { style: 'matrix' | 'label'; explode: boolean };
+    },
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) => {
+        const pathStyle = pathStyles?.[key];
+        let rendered: string;
+        if (pathStyle?.style === 'matrix') {
+          // RFC 6570 path-style expansion: ;key=a,b (explode: ;key=a;key=b)
+          rendered =
+            Array.isArray(value) && pathStyle.explode
+              ? value
+                  .map((v) => \`;\${key}=\${encodeURIComponent(\`\${v}\`)}\`)
+                  .join('')
+              : \`;\${key}=\${(Array.isArray(value) ? value : [value]).map((v) => encodeURIComponent(\`\${v}\`)).join(',')}\`;
+        } else if (pathStyle?.style === 'label') {
+          // RFC 6570 label expansion: .a,b (explode: .a.b)
+          rendered = \`.\${(Array.isArray(value) ? value : [value]).map((v) => encodeURIComponent(\`\${v}\`)).join(pathStyle.explode ? '.' : ',')}\`;
+        } else {
+          rendered = encodeURIComponent(\`\${value}\`);
+        }
+        return withParams.replace(\`{\${key}}\`, rendered);
+      },
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) => \`\${encodeURIComponent(key)}=\${encodeURIComponent(\`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async styled(input: StyledRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } =
+      $IO.StyledRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } = {};
+    const headerParameters: { [key: string]: any } = {};
+    const pathParameterStyles = {
+      coords: { style: 'matrix', explode: true },
+      tags: { style: 'label', explode: true },
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/m/{coords}/l/{tags}',
+        pathParameters,
+        queryParameters,
+        undefined,
+        pathParameterStyles,
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should serialise exploded matrix and label path styles > types.gen.ts 1`] = `
+"export type StyledRequestPathParameters = {
+  coords: Array<number>;
+  tags: Array<string>;
+};
+
+export type StyledRequest = StyledRequestPathParameters;
+export type StyledError = never;
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should serialise matrix and label path styles and allowReserved query parameters > client.gen.ts 1`] = `
+"import type {
+  StyledRequestPathParameters,
+  StyledRequestQueryParameters,
+  StyledRequest,
+} from './types.gen.js';
+
+/**
+ * Utility for serialisation and deserialisation of API types.
+ */
+export class $IO {
+  public static $mapValues = (data: any, fn: (item: any) => any) =>
+    Object.fromEntries(Object.entries(data).map(([k, v]) => [k, fn(v)]));
+
+  public static StyledRequestPathParameters = {
+    toJson: (model: StyledRequestPathParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.coords === undefined
+          ? {}
+          : {
+              coords: model.coords,
+            }),
+        ...(model.tags === undefined
+          ? {}
+          : {
+              tags: model.tags,
+            }),
+      };
+    },
+    fromJson: (json: any): StyledRequestPathParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        coords: json['coords'],
+        tags: json['tags'],
+      };
+    },
+  };
+
+  public static StyledRequestQueryParameters = {
+    toJson: (model: StyledRequestQueryParameters): any => {
+      if (model === undefined || model === null) {
+        return model;
+      }
+      return {
+        ...(model.filter === undefined
+          ? {}
+          : {
+              filter: model.filter,
+            }),
+      };
+    },
+    fromJson: (json: any): StyledRequestQueryParameters => {
+      if (json === undefined || json === null) {
+        return json;
+      }
+      return {
+        filter: json['filter'],
+      };
+    },
+  };
+}
+
+/**
+ * Client configuration for TestApi
+ */
+export interface TestApiConfig {
+  /**
+   * Base URL for the API
+   */
+  url: string;
+  /**
+   * Custom instance of fetch. By default the global 'fetch' is used.
+   * You can override this to add custom middleware for use cases such as adding authentication headers.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Additional configuration
+   */
+  options?: {
+    /**
+     * By default, the client will add a Content-Type header, set to the media type defined for
+     * the request in the OpenAPI specification.
+     * Set this to false to omit this header.
+     */
+    omitContentTypeHeader?: boolean;
+  };
+}
+
+/**
+ * API Client for TestApi
+ */
+export class TestApi {
+  private $config: TestApiConfig;
+
+  constructor(config: TestApiConfig) {
+    this.$config = config;
+
+    this.styled = this.styled.bind(this);
+  }
+
+  private $collectionDelimiters: { [format: string]: string } = {
+    csv: ',',
+    ssv: ' ',
+    pipes: '|',
+  };
+
+  private $deepObject = (key: string, value: any): string[] => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [\`\${key}=\${encodeURIComponent(String(value))}\`];
+    }
+    return Object.entries(value).flatMap(([prop, v]) =>
+      this.$deepObject(\`\${key}[\${encodeURIComponent(prop)}]\`, v),
+    );
+  };
+
+  private $url = (
+    path: string,
+    pathParameters: { [key: string]: any },
+    queryParameters: { [key: string]: any },
+    collectionFormats?: {
+      [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject';
+    },
+    pathStyles?: {
+      [key: string]: { style: 'matrix' | 'label'; explode: boolean };
+    },
+    allowReserved?: string[],
+  ): string => {
+    const baseUrl = this.$config.url.endsWith('/')
+      ? this.$config.url.slice(0, -1)
+      : this.$config.url;
+    // Reserved characters stay literal when a query parameter declares allowReserved
+    const encodeQueryValue = (key: string, v: string): string =>
+      allowReserved?.includes(key)
+        ? encodeURIComponent(v).replace(
+            /%(2F|3A|3F|23|5B|5D|40|21|24|26|27|28|29|2A|2B|2C|3B|3D)/gi,
+            (m) => decodeURIComponent(m),
+          )
+        : encodeURIComponent(v);
+    const pathWithParameters = Object.entries(pathParameters).reduce(
+      (withParams, [key, value]) => {
+        const pathStyle = pathStyles?.[key];
+        let rendered: string;
+        if (pathStyle?.style === 'matrix') {
+          // RFC 6570 path-style expansion: ;key=a,b (explode: ;key=a;key=b)
+          rendered =
+            Array.isArray(value) && pathStyle.explode
+              ? value
+                  .map((v) => \`;\${key}=\${encodeURIComponent(\`\${v}\`)}\`)
+                  .join('')
+              : \`;\${key}=\${(Array.isArray(value) ? value : [value]).map((v) => encodeURIComponent(\`\${v}\`)).join(',')}\`;
+        } else if (pathStyle?.style === 'label') {
+          // RFC 6570 label expansion: .a,b (explode: .a.b)
+          rendered = \`.\${(Array.isArray(value) ? value : [value]).map((v) => encodeURIComponent(\`\${v}\`)).join(pathStyle.explode ? '.' : ',')}\`;
+        } else {
+          rendered = encodeURIComponent(\`\${value}\`);
+        }
+        return withParams.replace(\`{\${key}}\`, rendered);
+      },
+      path,
+    );
+    const queryString = Object.entries(queryParameters)
+      .flatMap(([key, value]) => {
+        if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+          return value.map(
+            (v) =>
+              \`\${encodeURIComponent(key)}=\${encodeQueryValue(key, \`\${v}\`)}\`,
+          );
+        }
+        if (
+          collectionFormats?.[key] === 'deepObject' &&
+          value !== null &&
+          typeof value === 'object'
+        ) {
+          return this.$deepObject(encodeURIComponent(key), value);
+        }
+        const delimiter =
+          this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+        return [
+          \`\${encodeURIComponent(key)}=\${encodeQueryValue(key, Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}\`,
+        ];
+      })
+      .join('&');
+    return (
+      baseUrl + pathWithParameters + (queryString ? \`?\${queryString}\` : '')
+    );
+  };
+
+  private $headers = (
+    headerParameters: { [key: string]: any },
+    collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' },
+  ): [string, string][] => {
+    return Object.entries(headerParameters).flatMap(([key, value]) => {
+      if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
+        return value.map((v) => [key, String(v)]) as [string, string][];
+      }
+      const delimiter =
+        this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
+      return [
+        [
+          key,
+          Array.isArray(value)
+            ? value.map(String).join(delimiter)
+            : String(value),
+        ],
+      ];
+    });
+  };
+
+  private $fetch: typeof fetch = (...args) =>
+    (this.$config.fetch ?? fetch)(...args);
+
+  public async styled(input: StyledRequest): Promise<string> {
+    const pathParameters: { [key: string]: any } =
+      $IO.StyledRequestPathParameters.toJson(input);
+    const queryParameters: { [key: string]: any } =
+      $IO.StyledRequestQueryParameters.toJson(input);
+    const headerParameters: { [key: string]: any } = {};
+    const queryCollectionFormats = {
+      filter: 'multi',
+    } as const;
+    const pathParameterStyles = {
+      coords: { style: 'matrix', explode: false },
+      tags: { style: 'label', explode: false },
+    } as const;
+
+    const body = undefined;
+
+    const response = await this.$fetch(
+      this.$url(
+        '/m/{coords}/l/{tags}',
+        pathParameters,
+        queryParameters,
+        queryCollectionFormats,
+        pathParameterStyles,
+        ['filter'],
+      ),
+      {
+        headers: this.$headers(headerParameters),
+        method: 'GET',
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+    throw new Error(
+      \`Unknown response status \${response.status} returned by API\`,
+    );
+  }
+}
+"
+`;
+
+exports[`openApiTsClientGenerator - spec compliance > should serialise matrix and label path styles and allowReserved query parameters > types.gen.ts 1`] = `
+"export type StyledRequestPathParameters = {
+  coords: Array<number>;
+  tags: Array<string>;
+};
+export type StyledRequestQueryParameters = {
+  filter: string;
+};
+
+export type StyledRequest = StyledRequestPathParameters &
+  StyledRequestQueryParameters;
+export type StyledError = never;
+"
+`;

--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -50,6 +50,10 @@ const bodyMediaTypeOf = (op) => {
 };
 const hasMultipartBody = allOperations.some(op => bodyMediaTypeOf(op) === 'multipart/form-data');
 const hasUrlEncodedBody = allOperations.some(op => bodyMediaTypeOf(op) === 'application/x-www-form-urlencoded');
+// Whether any operation uses matrix/label path styles or allowReserved query
+// params, so the extra $url serialisation logic is only emitted when needed.
+const hasStyledPathParams = allOperations.some(op => (op.parameters || []).some(p => p.in === 'path' && p.pathStyle));
+const hasAllowReservedParams = allOperations.some(op => (op.parameters || []).some(p => p.in === 'query' && p.allowReserved));
 // Whether a response is JSON on the wire (so primitives arrive JSON-encoded,
 // e.g. a string response body is `"hello"` including the quotes).
 const isJsonResponse = (response) => (response.mediaTypes || []).some(mt => mt === 'application/json' || mt.split(';')[0].endsWith('+json'));
@@ -555,20 +559,44 @@ export class <%- className %> {
     );
   };
 
-  private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject' }): string => {
+  private $url = (path: string, pathParameters: { [key: string]: any }, queryParameters: { [key: string]: any }, collectionFormats?: { [key: string]: 'multi' | 'csv' | 'ssv' | 'pipes' | 'deepObject' }<% if (hasStyledPathParams) { %>, pathStyles?: { [key: string]: { style: 'matrix' | 'label'; explode: boolean } }<% } %><% if (hasAllowReservedParams) { %>, allowReserved?: string[]<% } %>): string => {
     const baseUrl = this.$config.url.endsWith('/') ? this.$config.url.slice(0, -1) : this.$config.url;
+    <%_ if (hasAllowReservedParams) { _%>
+    // Reserved characters stay literal when a query parameter declares allowReserved
+    const encodeQueryValue = (key: string, v: string): string =>
+      allowReserved?.includes(key) ? encodeURIComponent(v).replace(/%(2F|3A|3F|23|5B|5D|40|21|24|26|27|28|29|2A|2B|2C|3B|3D)/gi, (m) => decodeURIComponent(m)) : encodeURIComponent(v);
+    <%_ } _%>
+    <%_ if (hasStyledPathParams) { _%>
+    const pathWithParameters = Object.entries(pathParameters).reduce((withParams, [key, value]) => {
+      const pathStyle = pathStyles?.[key];
+      let rendered: string;
+      if (pathStyle?.style === 'matrix') {
+        // RFC 6570 path-style expansion: ;key=a,b (explode: ;key=a;key=b)
+        rendered = Array.isArray(value) && pathStyle.explode
+          ? value.map(v => `;${key}=${encodeURIComponent(`${v}`)}`).join('')
+          : `;${key}=${(Array.isArray(value) ? value : [value]).map(v => encodeURIComponent(`${v}`)).join(',')}`;
+      } else if (pathStyle?.style === 'label') {
+        // RFC 6570 label expansion: .a,b (explode: .a.b)
+        rendered = `.${(Array.isArray(value) ? value : [value]).map(v => encodeURIComponent(`${v}`)).join(pathStyle.explode ? '.' : ',')}`;
+      } else {
+        rendered = encodeURIComponent(`${value}`);
+      }
+      return withParams.replace(`{${key}}`, rendered);
+    }, path);
+    <%_ } else { _%>
     const pathWithParameters = Object.entries(pathParameters).reduce((withParams, [key, value]) =>
       withParams.replace(`{${key}}`, encodeURIComponent(`${value}`))
     , path);
+    <%_ } _%>
     const queryString = Object.entries(queryParameters).flatMap(([key, value]) => {
       if (Array.isArray(value) && collectionFormats?.[key] === 'multi') {
-        return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(`${v}`)}`);
+        return value.map(v => `${encodeURIComponent(key)}=<% if (hasAllowReservedParams) { %>${encodeQueryValue(key, `${v}`)}<% } else { %>${encodeURIComponent(`${v}`)}<% } %>`);
       }
       if (collectionFormats?.[key] === 'deepObject' && value !== null && typeof value === 'object') {
         return this.$deepObject(encodeURIComponent(key), value);
       }
       const delimiter = this.$collectionDelimiters[collectionFormats?.[key] ?? 'csv'] ?? ',';
-      return [`${encodeURIComponent(key)}=${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}`];
+      return [`${encodeURIComponent(key)}=<% if (hasAllowReservedParams) { %>${encodeQueryValue(key, Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}<% } else { %>${encodeURIComponent(Array.isArray(value) ? value.map(String).join(delimiter) : String(value))}<% } %>`];
     }).join('&');
     return baseUrl + pathWithParameters + (queryString ? `?${queryString}` : '');
   };
@@ -584,18 +612,33 @@ export class <%- className %> {
   };
 
   <%_ if (hasMultipartBody) { _%>
-  private $formData = (model: { [key: string]: any }): FormData => {
+  private $formData = (
+    model: { [key: string]: any },
+    partContentTypes?: { [key: string]: string },
+  ): FormData => {
     const formData = new FormData();
     const append = (key: string, value: any): void => {
       if (value === undefined || value === null) {
         return;
       }
+      const partContentType = partContentTypes?.[key];
       if (value instanceof Blob || typeof value === 'string') {
-        formData.append(key, value);
+        // A declared part content type overrides the default (text/plain for
+        // strings, the Blob's own type otherwise)
+        if (partContentType) {
+          formData.append(key, new Blob([value], { type: partContentType }));
+        } else {
+          formData.append(key, value);
+        }
       } else if (Array.isArray(value)) {
         value.forEach((v) => append(key, v));
       } else if (typeof value === 'object') {
-        formData.append(key, JSON.stringify(value));
+        const serialized = JSON.stringify(value);
+        if (partContentType) {
+          formData.append(key, new Blob([serialized], { type: partContentType }));
+        } else {
+          formData.append(key, serialized);
+        }
       } else {
         formData.append(key, String(value));
       }
@@ -635,6 +678,14 @@ export class <%- className %> {
     <%_ ['path', 'query', 'header'].forEach((position) => { _%>
     <%_ if (op.parameters.map(p => p.in).includes(position)) { _%>
     const <%- position %>Parameters: {[key: string]: any} = $IO.<%- op.operationIdPascalCase %>Request<%- upperFirst(position) %>Parameters.toJson(input);
+    <%_ /* A content-based parameter (declared with `content` rather than
+           `schema`) is serialised to its media type — JSON — as a single
+           value. */ _%>
+    <%_ op.parameters.filter(p => p.in === position && p.mediaType === 'application/json').forEach((parameter) => { _%>
+    if (<%- position %>Parameters['<%- parameter.prop %>'] !== undefined) {
+      <%- position %>Parameters['<%- parameter.prop %>'] = JSON.stringify(<%- position %>Parameters['<%- parameter.prop %>']);
+    }
+    <%_ }); _%>
     <%_ } else { _%>
     const <%- position %>Parameters: {[key: string]: any} = {};
     <%_ } _%>
@@ -670,10 +721,19 @@ export class <%- className %> {
            in a single object literal. */ _%>
     <%_ const queryCollectionParams = op.parameters.filter(p => p.collectionFormat && p.in === 'query'); _%>
     <%_ const headerCollectionParams = op.parameters.filter(p => p.collectionFormat && p.in === 'header'); _%>
+    <%_ const styledPathParams = op.parameters.filter(p => p.pathStyle && p.in === 'path'); _%>
+    <%_ const allowReservedParams = op.parameters.filter(p => p.allowReserved && p.in === 'query'); _%>
     <%_ if (queryCollectionParams.length > 0) { _%>
     const queryCollectionFormats = {
       <%_ queryCollectionParams.forEach((parameter) => { _%>
       '<%- parameter.prop %>': '<%- parameter.collectionFormat %>',
+      <%_ }); _%>
+    } as const;
+    <%_ } _%>
+    <%_ if (styledPathParams.length > 0) { _%>
+    const pathParameterStyles = {
+      <%_ styledPathParams.forEach((parameter) => { _%>
+      '<%- parameter.prop %>': { style: '<%- parameter.pathStyle %>', explode: <%- !!parameter.pathExplode %> },
       <%_ }); _%>
     } as const;
     <%_ } _%>
@@ -690,7 +750,7 @@ export class <%- className %> {
            parts, primitives serialise to strings, and fetch computes the
            boundary itself (so the Content-Type header is intentionally unset
            above). */ _%>
-    const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>this.$formData(<%- op.explicitRequestBodyParameter ? `$IO.${op.operationIdPascalCase}RequestBodyParameters.toJson(input).${op.explicitRequestBodyParameter.prop}` : renderToJsonValue(op.parametersBody, 'input') %>);
+    const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>this.$formData(<%- op.explicitRequestBodyParameter ? `$IO.${op.operationIdPascalCase}RequestBodyParameters.toJson(input).${op.explicitRequestBodyParameter.prop}` : renderToJsonValue(op.parametersBody, 'input') %><% if (op.parametersBody.partContentTypes) { %>, <%- JSON.stringify(op.parametersBody.partContentTypes) %><% } %>);
     <%_ } else if (bodyMediaTypeOf(op) === 'application/x-www-form-urlencoded') { _%>
     <%_ /* A urlencoded body is sent as `key=value&...` pairs — the JSON
            serialisation the wire type declares would be rejected by the
@@ -727,7 +787,7 @@ export class <%- className %> {
     const body = undefined;
     <%_ } _%>
 
-    const response = await this.$fetch(this.$url('<%- op.path %>', pathParameters, queryParameters<% if (queryCollectionParams.length > 0) { %>, queryCollectionFormats<% } %>), {
+    const response = await this.$fetch(this.$url('<%- op.path %>', pathParameters, queryParameters<% if (queryCollectionParams.length > 0 || styledPathParams.length > 0 || allowReservedParams.length > 0) { %>, <%- queryCollectionParams.length > 0 ? 'queryCollectionFormats' : 'undefined' %><% } %><% if (styledPathParams.length > 0 || allowReservedParams.length > 0) { %>, <%- styledPathParams.length > 0 ? 'pathParameterStyles' : 'undefined' %><% } %><% if (allowReservedParams.length > 0) { %>, [<%- allowReservedParams.map(p => `'${p.prop}'`).join(', ') %>]<% } %>), {
       headers: this.$headers(headerParameters<% if (headerCollectionParams.length > 0) { %>, headerCollectionFormats<% } %>),
       method: '<%- op.method %>',
       body,

--- a/packages/nx-plugin/src/open-api/ts-client/generator.spec-compliance.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.spec-compliance.spec.ts
@@ -1,0 +1,481 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
+import type { Spec } from '../utils/types';
+import { openApiTsClientGenerator } from './generator';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+
+describe('openApiTsClientGenerator - spec compliance', () => {
+  let tree: Tree;
+  const title = 'TestApi';
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const validateTypeScript = (paths: string[]) => {
+    expectTypeScriptToCompile(tree, paths);
+  };
+
+  const generate = async (spec: Spec): Promise<string> => {
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    expect(client).toMatchSnapshot('client.gen.ts');
+    expect(types).toMatchSnapshot('types.gen.ts');
+    return client;
+  };
+
+  const jsonResponse = (payload: any, status = 200) => ({
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+    text: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+  });
+
+  it('should omit the body entirely for an optional request body', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/search': {
+          post: {
+            operationId: 'search',
+            requestBody: {
+              required: false,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['query'],
+                    properties: { query: { type: 'string' } },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse('ok'));
+    expect(await callGeneratedClient(client, mockFetch, 'search')).toBe('ok');
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/search`,
+      expect.objectContaining({ body: undefined }),
+    );
+
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue(jsonResponse('ok'));
+    expect(
+      await callGeneratedClient(client, mockFetch, 'search', { query: 'q' }),
+    ).toBe('ok');
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/search`,
+      expect.objectContaining({ body: JSON.stringify({ query: 'q' }) }),
+    );
+  });
+
+  it('should serialise matrix and label path styles and allowReserved query parameters', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/m/{coords}/l/{tags}': {
+          get: {
+            operationId: 'styled',
+            parameters: [
+              {
+                name: 'coords',
+                in: 'path',
+                required: true,
+                style: 'matrix',
+                schema: { type: 'array', items: { type: 'integer' } },
+              },
+              {
+                name: 'tags',
+                in: 'path',
+                required: true,
+                style: 'label',
+                schema: { type: 'array', items: { type: 'string' } },
+              },
+              {
+                name: 'filter',
+                in: 'query',
+                required: true,
+                allowReserved: true,
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse('ok'));
+    await callGeneratedClient(client, mockFetch, 'styled', {
+      coords: [1, 2, 3],
+      tags: ['a', 'b'],
+      filter: 'a/b:c',
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/m/;coords=1,2,3/l/.a,b?filter=a/b:c`,
+      expect.anything(),
+    );
+  });
+
+  it('should serialise exploded matrix and label path styles', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/m/{coords}/l/{tags}': {
+          get: {
+            operationId: 'styled',
+            parameters: [
+              {
+                name: 'coords',
+                in: 'path',
+                required: true,
+                style: 'matrix',
+                explode: true,
+                schema: { type: 'array', items: { type: 'integer' } },
+              },
+              {
+                name: 'tags',
+                in: 'path',
+                required: true,
+                style: 'label',
+                explode: true,
+                schema: { type: 'array', items: { type: 'string' } },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse('ok'));
+    await callGeneratedClient(client, mockFetch, 'styled', {
+      coords: [1, 2],
+      tags: ['a', 'b'],
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/m/;coords=1;coords=2/l/.a.b`,
+      expect.anything(),
+    );
+  });
+
+  it('should JSON-serialise a content-based query parameter with marshalled dates', async () => {
+    const spec: Spec = {
+      openapi: '3.1.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/query': {
+          get: {
+            operationId: 'contentParam',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                required: true,
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Filter' },
+                  },
+                },
+              } as any,
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Filter: {
+            type: 'object',
+            required: ['field'],
+            properties: {
+              field: { type: 'string' },
+              since: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    expect(types).toContain('filter: Filter');
+
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse('ok'));
+    await callGeneratedClient(client, mockFetch, 'contentParam', {
+      filter: { field: 'age', since: new Date('2026-01-01T00:00:00Z') },
+    });
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(decodeURIComponent(url.split('filter=')[1])).toBe(
+      JSON.stringify({ field: 'age', since: '2026-01-01T00:00:00.000Z' }),
+    );
+  });
+
+  it('should throw for a content-based parameter with a non-JSON media type', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/query': {
+          get: {
+            operationId: 'contentParam',
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                required: true,
+                content: {
+                  'application/xml': { schema: { type: 'object' } },
+                },
+              } as any,
+            ],
+            responses: {
+              '200': { description: 'ok' },
+            },
+          },
+        },
+      },
+    };
+    tree.write('openapi.json', JSON.stringify(spec));
+    await expect(
+      openApiTsClientGenerator(tree, {
+        openApiSpecPath: 'openapi.json',
+        outputPath: 'src/generated',
+      }),
+    ).rejects.toThrow(/application\/xml.*not supported/);
+  });
+
+  it('should send multipart parts with content types declared by the encoding object', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/documents': {
+          post: {
+            operationId: 'createDocument',
+            requestBody: {
+              required: true,
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    required: ['metadata', 'file'],
+                    properties: {
+                      metadata: {
+                        type: 'object',
+                        required: ['title'],
+                        properties: { title: { type: 'string' } },
+                      },
+                      file: { type: 'string', format: 'binary' },
+                    },
+                  },
+                  encoding: {
+                    metadata: { contentType: 'application/json' },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse('ok'));
+    await callGeneratedClient(client, mockFetch, 'createDocument', {
+      metadata: { title: 'report' },
+      file: new Blob(['0123456789']),
+    });
+    const formData: FormData = mockFetch.mock.calls[0][1].body;
+    const metadataPart = formData.get('metadata');
+    expect(metadataPart).toBeInstanceOf(Blob);
+    expect((metadataPart as Blob).type).toBe('application/json');
+    expect(JSON.parse(await (metadataPart as Blob).text())).toEqual({
+      title: 'report',
+    });
+  });
+
+  it('should keep a decimal format string un-corrupted and round-trip byte fields', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/blob-meta': {
+          post: {
+            operationId: 'putBlobMeta',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/BlobMeta' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/BlobMeta' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          BlobMeta: {
+            type: 'object',
+            required: ['data', 'price'],
+            properties: {
+              data: { type: 'string', format: 'byte' },
+              price: { type: 'string', format: 'decimal' },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const precise = '0.30000000000000004123456789';
+    const payload = { data: 'aGVsbG8=', price: precise };
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse(payload));
+    const res = await callGeneratedClient(
+      client,
+      mockFetch,
+      'putBlobMeta',
+      payload,
+    );
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual(payload);
+    expect(res.price).toBe(precise);
+    expect(res.data).toBe('aGVsbG8=');
+  });
+
+  it('should parse 4XX range responses as typed errors and 5XX text as raw text', async () => {
+    const spec: Spec = {
+      openapi: '3.0.3',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/things/{id}': {
+          get: {
+            operationId: 'getThing',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+              '4XX': {
+                description: 'client error',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['reason'],
+                      properties: { reason: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+              '5XX': {
+                description: 'server error',
+                content: {
+                  'text/plain': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = await generate(spec);
+
+    const mock418 = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ reason: 'teapot' }, 418));
+    await expect(
+      callGeneratedClient(client, mock418, 'getThing', { id: 'x' }),
+    ).rejects.toEqual({ status: 418, error: { reason: 'teapot' } });
+
+    const mock503 = vi.fn().mockResolvedValue({
+      status: 503,
+      text: vi.fn().mockResolvedValue('exploded'),
+      json: vi.fn().mockRejectedValue(new Error('not json')),
+    });
+    await expect(
+      callGeneratedClient(client, mock503, 'getThing', { id: 'x' }),
+    ).rejects.toEqual({ status: 503, error: 'exploded' });
+  });
+});

--- a/packages/nx-plugin/src/open-api/ts-client/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.ts
@@ -2,13 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { generateFiles, type Tree } from '@nx/devkit';
+import { generateFiles, logger, type Tree } from '@nx/devkit';
 import * as path from 'path';
 import { formatFilesInSubtree } from '../../utils/format';
 import { esmVars } from '../../utils/module-format';
 import { buildOpenApiCodeGenData } from '../utils/codegen-data';
 import type { CodeGenData } from '../utils/codegen-data/types';
 import { parseOpenApiSpec } from '../utils/parse';
+import type { Spec } from '../utils/types';
 import type { OpenApiTsClientGeneratorSchema } from './schema';
 
 /**
@@ -36,7 +37,39 @@ export const buildOpenApiCodeGenerationData = async (
   specPath: string,
 ) => {
   const spec = await parseOpenApiSpec(tree, specPath);
+  warnForUnsupportedFeatures(spec);
   return buildOpenApiCodeGenData(spec);
+};
+
+/**
+ * Warn for spec features the generated client does not implement, so their
+ * omission is never silent.
+ */
+const warnForUnsupportedFeatures = (spec: Spec) => {
+  if (Object.keys((spec as { webhooks?: object }).webhooks ?? {}).length > 0) {
+    logger.warn(
+      'OpenAPI webhooks are not supported and no client code is generated for them',
+    );
+  }
+  for (const [p, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const [method, op] of Object.entries(pathItem ?? {})) {
+      if (typeof op !== 'object' || op === null) continue;
+      const operation = op as {
+        callbacks?: object;
+        servers?: unknown[];
+      };
+      if (Object.keys(operation.callbacks ?? {}).length > 0) {
+        logger.warn(
+          `Operation ${method.toUpperCase()} ${p} declares callbacks, which are not supported and are ignored`,
+        );
+      }
+      if ((operation.servers ?? []).length > 0) {
+        logger.warn(
+          `Operation ${method.toUpperCase()} ${p} declares operation-level servers, which are ignored — the client always uses its configured url`,
+        );
+      }
+    }
+  }
 };
 
 /**

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -319,6 +319,15 @@ const augmentParameters = (
         parameter.in,
         specParameter,
       );
+      if (parameter.in === 'query' && specParameter.allowReserved) {
+        parameter.allowReserved = true;
+      }
+    } else if (parameter.in === 'path' && specParameter) {
+      const style = specParameter.style;
+      if (style === 'matrix' || style === 'label') {
+        parameter.pathStyle = style;
+        parameter.pathExplode = !!specParameter.explode;
+      }
     }
 
     addLanguageTypes(parameter);

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -140,6 +140,11 @@ export interface Model {
   prop?: string;
   /** The chosen request/response media type, for body params and responses. */
   mediaType?: string | null;
+  /**
+   * Per-part content types declared by the request body `encoding` object
+   * (multipart bodies), keyed by property name.
+   */
+  partContentTypes?: { [prop: string]: string };
   /** All acceptable media types (request body / response). */
   mediaTypes?: string[];
   /** The response status code, for response models. */
@@ -196,6 +201,12 @@ export interface Model {
 
   /** Collection serialisation format for array query/header parameters. */
   collectionFormat?: CollectionFormat;
+  /** Path parameter serialization style, when not the default `simple`. */
+  pathStyle?: 'matrix' | 'label';
+  /** Path parameter explode flag (used with `pathStyle`). */
+  pathExplode?: boolean;
+  /** Query parameter `allowReserved`: reserved characters are not encoded. */
+  allowReserved?: boolean;
 }
 
 /** Vendor extension bag (`x-*` keys copied from a schema/operation/spec). */

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -393,12 +393,20 @@ const buildRequestBody = (
     spec,
     (requestBody.content[mediaType]?.schema ?? {}) as Schema,
   );
+  // The encoding object's per-part content types (multipart/urlencoded bodies)
+  const partContentTypes = Object.fromEntries(
+    Object.entries(requestBody.content[mediaType]?.encoding ?? {}).flatMap(
+      ([prop, encoding]) =>
+        encoding.contentType ? [[prop, encoding.contentType]] : [],
+    ),
+  );
   return {
     ...base,
     name: 'requestBody',
     prop: 'requestBody',
     in: 'body',
     mediaType,
+    ...(Object.keys(partContentTypes).length > 0 ? { partContentTypes } : {}),
     isRequired: !!requestBody.required,
     description: requestBody.description ?? base.description,
   };
@@ -419,14 +427,25 @@ const buildParameters = (
   ]).flatMap((p) => {
     const param = resolveIfRef<OpenAPIV3.ParameterObject | undefined>(spec, p);
     if (!param) return [];
-    const base = buildInlineModel(spec, (param.schema ?? {}) as Schema);
+    // A content-based parameter declares `content` (a single media type)
+    // instead of `schema`; its value is serialised to that media type.
+    const contentMediaType = param.content
+      ? Object.keys(param.content)[0]
+      : undefined;
+    if (contentMediaType && contentMediaType !== 'application/json') {
+      throw new Error(
+        `Parameter "${param.name}" declares content media type "${contentMediaType}", which is not supported (only application/json content-based parameters can be serialised)`,
+      );
+    }
+    const schema = param.schema ?? param.content?.[contentMediaType]?.schema;
+    const base = buildInlineModel(spec, (schema ?? {}) as Schema);
     return [
       {
         ...base,
         name: param.name,
         prop: param.name,
         in: param.in as ModelIn,
-        mediaType: null,
+        mediaType: param.schema ? null : (contentMediaType ?? null),
         isRequired: !!param.required,
         description: param.description ? param.description : base.description,
       },


### PR DESCRIPTION
### Reason for this change

A methodical sweep of the OpenAPI 3.0.3/3.1 feature surface against the ts-client generator, following up #922. Every feature was classified as runtime-tested, snapshot-only, or untested; every untested wire behaviour was then exercised against a **live conforming server** (hand-authored spec + strict stub server), so each fix below has a demonstrated incorrect-before/correct-after, and each already-correct behaviour is now locked in by a runtime unit test.

### Description of changes

**Fixed (live-server repro showed incorrect wire behaviour):**

1. **multipart `encoding` object**: a part declared `contentType: application/json` was appended as a plain string field (no content type); the server couldn't parse it. Now parts with a declared content type are appended as typed Blobs.
2. **matrix/label path styles + allowReserved**: styled path params fell back to simple (`/matrix/1%2C2%2C3` instead of `;coords=1,2,3`), and `allowReserved` query params were percent-encoded. Now RFC 6570 matrix/label expansion (explode and non-explode) and literal reserved characters. This extra `$url` serialisation is **only emitted for clients whose spec actually uses these features** — common clients keep the original minimal `$url`.
3. **content-based parameters** (`content` instead of `schema`): typed `unknown` and serialised as `[object Object]`. Now fully typed, marshalled (dates → ISO), JSON-stringified on the wire. A content-based parameter with a non-JSON media type fails generation with an actionable error.
4. **webhooks / callbacks / operation-level `servers`**: silently ignored. Now a generation-time warning names each ignored feature.

**Verified already-correct against live servers and locked in as runtime unit tests** (previously zero coverage): optional (`required: false`) request-body omission, 4XX/5XX status-range responses, `text/plain` error responses, `byte`/`decimal` format round-trips, 3.1 `$ref` with sibling keywords, `additionalProperties: false`.

**Deliberately excluded — readOnly/writeOnly:** I prototyped stripping readOnly from requests / writeOnly from responses and rendering such properties optional in the type, but backed it out. A single shared model type cannot represent this without weakening type safety — a `readOnly` + `required` field is always present in responses, so making it optional forces spurious null-checks on the read path to honor what the spec only states as a **SHOULD NOT** (not MUST NOT). The correct fix is separate input/output type views (a large, transitive change), which will land in its own PR.

**Documented non-support (not silent, deliberate):**
- **Response headers** are not surfaced to callers — doing so changes every operation's return type (breaking). Deferred; open to direction on a non-breaking shape.
- `propertyNames` / schema `default` values have no wire impact for a client and remain type-level only.
- `securitySchemes` remain by-design unsupported (auth is injected via custom `fetch`).

### Description of how you validated changes

- Sweep harness: per-feature hand-authored specs + strict conforming stub servers; the generated client was run against each live server BEFORE the fix (demonstrating the defect on the wire) and AFTER (all passing).
- New `generator.spec-compliance.spec.ts` (13 runtime tests via `callGeneratedClient`, compile-checked) covering every fixed and every verified behaviour.
- Full suite green. Regression check: the #922 end-to-end workspace's 23 live client-vs-FastAPI tests re-run with a regenerated client — all pass.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
