### PR TITLE
test(e2e): don't fail finch smoke test when engine is already finch

### DIFF
--- a/e2e/src/smoke-tests/finch-install.ts
+++ b/e2e/src/smoke-tests/finch-install.ts
@@ -312,9 +312,22 @@ export const setFinchAsContainerEngine = (projectRoot: string): void => {
   if (!existsSync(configPath)) {
     throw new Error(`Expected ${configPath} to exist after workspace creation`);
   }
+  const engineRegex = /containers:\s*\{\s*engine:\s*'([^']*)'\s*\}/;
   const original = readFileSync(configPath, 'utf-8');
+  const match = original.match(engineRegex);
+  if (!match) {
+    throw new Error(
+      `Failed to find containers.engine in ${configPath}:\n${original}`,
+    );
+  }
+  if (match[1] === 'finch') {
+    console.log(
+      `[finch-install] containers.engine already finch in ${configPath}`,
+    );
+    return;
+  }
   const updated = original.replace(
-    /containers:\s*\{\s*engine:\s*'[^']*'\s*\}/,
+    engineRegex,
     "containers: { engine: 'finch' }",
   );
   if (updated === original) {


### PR DESCRIPTION
### Reason for this change

On machines that already have finch installed and no docker, the workspace preset infers `containers: { engine: 'finch' }` at creation time. The finch smoke test's `setFinchAsContainerEngine` unconditionally tried to rewrite the engine to `finch` via a regex replace, and treated a no-op replace as a failure — throwing `Failed to rewrite containers.engine` even though the config was already correct.

### Description of changes

`setFinchAsContainerEngine` now captures the current engine value first and returns early (logging that it's already finch) when it's already `finch`, instead of attempting a no-op replace and throwing.

### Description of how you validated changes

Ran the full test suite (`pnpm nx run @aws/nx-plugin:test`) — all 2551 tests pass.

### Issue # (if applicable)

Closes #.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*