### PR TITLE
ci(e2e): apply pending sync changes before deploy in cdk-deploy-rdb variant

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -417,12 +417,23 @@ describe('smoke test - cdk-deploy-rdb', () => {
     );
     writeFileSync(`${opts.cwd}/packages/infra/src/main.ts`, mainContent);
 
+    // Auto-apply sync so the stack rewrites don't block `deploy` with a
+    // fatal "workspace is out of sync" error.
+    const nxJsonPath = `${opts.cwd}/nx.json`;
+    const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
+    nxJson.sync = { ...(nxJson.sync ?? {}), applyChanges: true };
+    writeFileSync(nxJsonPath, JSON.stringify(nxJson, null, 2));
+
     // Stage name is set by main.ts.template (`e2e-test-infra-sandbox-…`).
     const cdkStageName = `e2e-test-infra-sandbox-${testRunId}`;
 
     ensureRdsServiceLinkedRole();
 
     try {
+      // Apply any pending sync changes (license headers, tsconfig
+      // references) so `deploy` does not abort on an out-of-sync workspace.
+      await runCLI(`sync`, opts);
+
       await runCLI(
         `deploy infra ${cdkStageName}/* --output-style=stream`,
         opts,


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy-rdb` e2e smoke test fails at `nx deploy` with a fatal "The workspace is out of sync" error. The test swaps in `application-stack-rdb.ts` after generation, which leaves pending sync changes (license headers, TypeScript project references), but unlike the main `cdk-deploy` variant it neither enables `sync.applyChanges` in `nx.json` nor runs `nx sync` before deploying.

### Description of changes

Mirrors the main `cdk-deploy` variant's sync handling in the `cdk-deploy-rdb` variant:
- sets `sync.applyChanges: true` in the generated workspace's `nx.json` after the stack template rewrites
- runs `nx sync` before `nx deploy`

### Description of how you validated changes

Ran the `cdk-deploy-rdb` smoke test end-to-end against AWS with this fix: the workspace generates and builds, all four Aurora databases (`PostgresDb`, `MySqlDb`, `PyPostgresDb`, `PyMysqlDb`) deploy successfully, and the stack (including rotation nested stacks) is destroyed cleanly. Without the fix the same run fails at `nx deploy` with "The workspace is out of sync". Also ran the `terraform-deploy-rdb` variant to confirm it is unaffected (it already applies sync via the shared terraform smoke test helper).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
