### PR TITLE
docs: fix py#dynamodb title and remove duplicate granting access section

### DIFF
--- a/docs/src/content/docs/en/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Create a Python DynamoDB project
 generator: py#dynamodb
 ---

--- a/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: Deploying your DynamoDB Table
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 The DynamoDB generator creates CDK or Terraform infrastructure based on your selected `iac`.
 
@@ -50,10 +49,6 @@ This provisions a DynamoDB table with:
 - Table name registered in Runtime Config
 </Fragment>
 </Infrastructure>
-
-### Granting Access
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### Deletion Protection
 

--- a/docs/src/content/docs/es/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Crear un proyecto Python DynamoDB
 generator: py#dynamodb
 ---

--- a/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: Desplegando tu Tabla DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 El generador de DynamoDB crea infraestructura CDK o Terraform basada en tu `iac` seleccionado.
 
@@ -50,10 +49,6 @@ Esto aprovisiona una tabla DynamoDB con:
 - Nombre de tabla registrado en Runtime Config
 </Fragment>
 </Infrastructure>
-
-### Concediendo Acceso
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### Protección contra Eliminación
 

--- a/docs/src/content/docs/fr/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Créer un projet Python DynamoDB
 generator: py#dynamodb
 ---
@@ -465,8 +465,8 @@ Utilisez le générateur <Link path="guides/connection">`connection`</Link> pour
     targetBadge="python"
   />
   <ConnectionCard
-    title="Serveur MCP Python vers Python DynamoDB"
-    description="Connecter un serveur MCP Python à une table DynamoDB"
+    title="Python MCP Server vers Python DynamoDB"
+    description="Connecter un Python MCP Server à une table DynamoDB"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-mcp-server-dynamodb`}
     source="mcp"
     sourceBadge="python"

--- a/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: Déploiement de votre table DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 Le générateur DynamoDB crée une infrastructure CDK ou Terraform en fonction de votre `iac` sélectionné.
 
@@ -50,10 +49,6 @@ Cela provisionne une table DynamoDB avec :
 - Le nom de la table enregistré dans Runtime Config
 </Fragment>
 </Infrastructure>
-
-### Accorder l'accès
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### Protection contre la suppression
 

--- a/docs/src/content/docs/it/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Crea un progetto Python DynamoDB
 generator: py#dynamodb
 ---
@@ -437,14 +437,6 @@ item = ExampleModel.get_by_id('123')
 :::note[Configurazione runtime]
 Quando viene eseguito in AWS, `get_table_name()` recupera il nome della tabella da AWS AppConfig utilizzando la variabile d'ambiente `RUNTIME_CONFIG_APP_ID`. I progetti costruiti con questo plugin hanno già questa variabile configurata automaticamente. Per altri progetti Python, assicurati che `RUNTIME_CONFIG_APP_ID` sia impostata nell'ambiente di runtime con l'ID dell'applicazione AppConfig fornito dalla tua infrastruttura. Per maggiori informazioni, consulta la <Link path="guides/runtime-config">guida alla configurazione runtime</Link>.
 :::
-
-### Generatori di connessione
-
-Per tipi di progetto specifici, utilizza il generatore `connection` per collegare automaticamente le dipendenze di sviluppo locale in modo che DynamoDB Local si avvii automaticamente insieme al tuo progetto e aggiungi il package DynamoDB come dipendenza del workspace:
-
-- <Link path="guides/connection/py-fast-api-dynamodb">FastAPI → DynamoDB</Link>
-- <Link path="guides/connection/py-agent-dynamodb">Python Agent → DynamoDB</Link>
-- <Link path="guides/connection/py-mcp-server-dynamodb">Python MCP Server → DynamoDB</Link>
 
 ## Distribuzione della tabella
 

--- a/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: Distribuzione della tua tabella DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 Il generatore DynamoDB crea infrastruttura CDK o Terraform in base al tuo `iac` selezionato.
 
@@ -50,10 +49,6 @@ Questo esegue il provisioning di una tabella DynamoDB con:
 - Nome della tabella registrato in Runtime Config
 </Fragment>
 </Infrastructure>
-
-### Concessione dell'accesso
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### Protezione dalla cancellazione
 

--- a/docs/src/content/docs/jp/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Python DynamoDB プロジェクトを作成する
 generator: py#dynamodb
 ---

--- a/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: DynamoDBテーブルのデプロイ
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 DynamoDBジェネレーターは、選択した`iac`に基づいてCDKまたはTerraformインフラストラクチャを作成します。
 
@@ -50,10 +49,6 @@ module "my_table" {
 - ランタイム設定にテーブル名が登録
 </Fragment>
 </Infrastructure>
-
-### アクセス権限の付与
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### 削除保護
 

--- a/docs/src/content/docs/ko/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Python DynamoDB 프로젝트 생성
 generator: py#dynamodb
 ---
@@ -450,7 +450,7 @@ AWS에서 실행할 때 `get_table_name()`은 `RUNTIME_CONFIG_APP_ID` 환경 변
   <ConnectionCard
     title="FastAPI to Python DynamoDB"
     description="FastAPI를 DynamoDB 테이블에 연결하기"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-fast-api-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/py-fast-api-dynamodb`}
     source="fastapi"
     target="dynamodb"
     targetBadge="python"
@@ -458,7 +458,7 @@ AWS에서 실행할 때 `get_table_name()`은 `RUNTIME_CONFIG_APP_ID` 환경 변
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
     description="Python Agent를 DynamoDB 테이블에 연결하기"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
     target="dynamodb"
@@ -467,7 +467,7 @@ AWS에서 실행할 때 `get_table_name()`은 `RUNTIME_CONFIG_APP_ID` 환경 변
   <ConnectionCard
     title="Python MCP Server to Python DynamoDB"
     description="Python MCP Server를 DynamoDB 테이블에 연결하기"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-mcp-server-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/py-mcp-server-dynamodb`}
     source="mcp"
     sourceBadge="python"
     target="dynamodb"

--- a/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: DynamoDB 테이블 배포하기
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 DynamoDB 생성기는 선택한 `iac`에 따라 CDK 또는 Terraform 인프라를 생성합니다.
 
@@ -50,10 +49,6 @@ module "my_table" {
 - Runtime Config에 등록된 테이블 이름
 </Fragment>
 </Infrastructure>
-
-### 액세스 권한 부여
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### 삭제 보호
 

--- a/docs/src/content/docs/pt/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Criar um projeto Python DynamoDB
 generator: py#dynamodb
 ---

--- a/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: Implantando sua Tabela DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 O gerador DynamoDB cria infraestrutura CDK ou Terraform com base no seu `iac` selecionado.
 
@@ -50,10 +49,6 @@ Isso provisiona uma tabela DynamoDB com:
 - Nome da tabela registrado no Runtime Config
 </Fragment>
 </Infrastructure>
-
-### Concedendo Acesso
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### Proteção contra Exclusão
 

--- a/docs/src/content/docs/vi/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: Tạo dự án Python DynamoDB
 generator: py#dynamodb
 ---
@@ -14,7 +14,7 @@ import Snippet from '@components/snippet.astro';
 
 Generator này tạo một dự án Python mới được hỗ trợ bởi [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), sử dụng [PynamoDB](https://pynamodb.readthedocs.io/) để mô hình hóa thực thể. Nó tạo ra mã ứng dụng và cơ sở hạ tầng cần thiết để cung cấp và quản lý bảng DynamoDB bằng AWS CDK hoặc Terraform, với hỗ trợ thiết kế bảng đơn và phát triển cục bộ tích hợp sẵn thông qua DynamoDB Local.
 
-## Cách sử dụng
+## Sử dụng
 
 ### Tạo Dự án DynamoDB
 
@@ -438,14 +438,6 @@ item = ExampleModel.get_by_id('123')
 Khi chạy trong AWS, `get_table_name()` lấy tên bảng từ AWS AppConfig bằng biến môi trường `RUNTIME_CONFIG_APP_ID`. Các dự án được xây dựng với plugin này đã có biến này được cấu hình tự động. Đối với các dự án Python khác, đảm bảo `RUNTIME_CONFIG_APP_ID` được đặt trong môi trường runtime với ID ứng dụng AppConfig được cung cấp bởi cơ sở hạ tầng của bạn. Để biết thêm thông tin, xem <Link path="guides/runtime-config">hướng dẫn Cấu hình Runtime</Link>.
 :::
 
-### Connection Generators
-
-Đối với các loại dự án cụ thể, sử dụng generator `connection` để tự động kết nối các phụ thuộc phát triển cục bộ để DynamoDB Local khởi động tự động cùng với dự án của bạn, và thêm gói DynamoDB làm phụ thuộc workspace:
-
-- <Link path="guides/connection/py-fast-api-dynamodb">FastAPI → DynamoDB</Link>
-- <Link path="guides/connection/py-agent-dynamodb">Python Agent → DynamoDB</Link>
-- <Link path="guides/connection/py-mcp-server-dynamodb">Python MCP Server → DynamoDB</Link>
-
 ## Triển khai Bảng của bạn
 
 <Snippet name="dynamodb/deploying-table" parentHeading="Triển khai Bảng của bạn" />
@@ -458,7 +450,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="FastAPI to Python DynamoDB"
     description="Kết nối FastAPI với bảng DynamoDB"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-fast-api-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/py-fast-api-dynamodb`}
     source="fastapi"
     target="dynamodb"
     targetBadge="python"
@@ -466,7 +458,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
     description="Kết nối Python Agent với bảng DynamoDB"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
     target="dynamodb"
@@ -475,7 +467,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="Python MCP Server to Python DynamoDB"
     description="Kết nối Python MCP Server với bảng DynamoDB"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-mcp-server-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/py-mcp-server-dynamodb`}
     source="mcp"
     sourceBadge="python"
     target="dynamodb"

--- a/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: Triển khai DynamoDB Table của bạn
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 Trình tạo DynamoDB tạo cơ sở hạ tầng CDK hoặc Terraform dựa trên `iac` bạn đã chọn.
 
@@ -50,10 +49,6 @@ module "my_table" {
 - Tên bảng được đăng ký trong Runtime Config
 </Fragment>
 </Infrastructure>
-
-### Cấp quyền truy cập
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### Bảo vệ xóa
 

--- a/docs/src/content/docs/zh/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/py-dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-title: py#dynamodb
+title: Python DynamoDB
 description: 创建一个 Python DynamoDB 项目
 generator: py#dynamodb
 ---

--- a/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
@@ -2,7 +2,6 @@
 title: 部署您的 DynamoDB 表
 ---
 import Infrastructure from '@components/infrastructure.astro';
-import Snippet from '@components/snippet.astro';
 
 DynamoDB 生成器会根据您选择的 `iac` 创建 CDK 或 Terraform 基础设施。
 
@@ -50,10 +49,6 @@ module "my_table" {
 - 表名注册到运行时配置中
 </Fragment>
 </Infrastructure>
-
-### 授予访问权限
-
-<Snippet name="connection/lambda-dynamodb-access" />
 
 ### 删除保护
 


### PR DESCRIPTION
### Reason for this change

1. The py#dynamodb doc title was left as the raw generator name (`py#dynamodb`) instead of a readable title, inconsistent with ts#dynamodb ("TypeScript DynamoDB"), ts#rdb ("TypeScript Relational Database") and py#rdb ("Python Relational Database").
2. The shared DynamoDB deploying-table snippet (used by both ts#dynamodb and py#dynamodb docs) had a "Granting Access" section that duplicated the Infrastructure section already shown in the connection guides (trpc-dynamodb, smithy-dynamodb, py-fast-api-dynamodb).

### Description of changes

1. Fix the py#dynamodb doc title to "Python DynamoDB".
2. Remove the "Granting Access" section from the shared DynamoDB deploying-table snippet. Same cleanup done for the rdb docs in #902 ([review comment](https://github.com/awslabs/nx-plugin-for-aws/pull/902#discussion_r3555693163)).

### Description of how you validated changes

Manually reviewed the doc.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*