### PR TITLE
fix(open-api#ts-client): send primitive urlencoded request bodies verbatim

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
+++ b/packages/nx-plugin/src/open-api/ts-client/files/client.gen.ts.template
@@ -49,7 +49,10 @@ const bodyMediaTypeOf = (op) => {
   return mediaTypes.find(mt => mt === 'application/json' || mt.endsWith('+json')) || mediaTypes[0];
 };
 const hasMultipartBody = allOperations.some(op => bodyMediaTypeOf(op) === 'multipart/form-data');
-const hasUrlEncodedBody = allOperations.some(op => bodyMediaTypeOf(op) === 'application/x-www-form-urlencoded');
+// A urlencoded body is form-encoded only when its schema is an object; a
+// primitive schema (e.g. a raw pre-encoded string) is sent verbatim below.
+const isUrlEncodedObjectBody = (op) => bodyMediaTypeOf(op) === 'application/x-www-form-urlencoded' && !!op.parametersBody && !op.parametersBody.isPrimitive;
+const hasUrlEncodedBody = allOperations.some(op => isUrlEncodedObjectBody(op));
 // Whether any operation uses matrix/label path styles or allowReserved query
 // params, so the extra $url serialisation logic is only emitted when needed.
 const hasStyledPathParams = allOperations.some(op => (op.parameters || []).some(p => p.in === 'path' && p.pathStyle));
@@ -751,10 +754,11 @@ export class <%- className %> {
            boundary itself (so the Content-Type header is intentionally unset
            above). */ _%>
     const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>this.$formData(<%- op.explicitRequestBodyParameter ? `$IO.${op.operationIdPascalCase}RequestBodyParameters.toJson(input).${op.explicitRequestBodyParameter.prop}` : renderToJsonValue(op.parametersBody, 'input') %><% if (op.parametersBody.partContentTypes) { %>, <%- JSON.stringify(op.parametersBody.partContentTypes) %><% } %>);
-    <%_ } else if (bodyMediaTypeOf(op) === 'application/x-www-form-urlencoded') { _%>
-    <%_ /* A urlencoded body is sent as `key=value&...` pairs — the JSON
+    <%_ } else if (isUrlEncodedObjectBody(op)) { _%>
+    <%_ /* An object urlencoded body is sent as `key=value&...` pairs — the JSON
            serialisation the wire type declares would be rejected by the
-           server's form parser. */ _%>
+           server's form parser. A primitive urlencoded body (e.g. a raw
+           pre-encoded string) falls through to the String(input) branch. */ _%>
     const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>this.$urlEncodedForm(<%- op.explicitRequestBodyParameter ? `$IO.${op.operationIdPascalCase}RequestBodyParameters.toJson(input).${op.explicitRequestBodyParameter.prop}` : renderToJsonValue(op.parametersBody, 'input') %>).toString();
     <%_ } else if (op.parametersBody.isPrimitive && ['number', 'boolean', 'string'].includes(op.parametersBody.type) && !['array', 'dictionary'].includes(op.parametersBody.export) && !["date", "date-time"].includes(op.parametersBody.format)) { _%>
     const body = <% if (!op.parametersBody.isRequired) { %>input === undefined ? undefined : <% } %>String(input<%- op.explicitRequestBodyParameter ? `.${op.explicitRequestBodyParameter.typescriptName}` : '' %>);

--- a/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
@@ -401,4 +401,111 @@ describe('openApiTsClientGenerator - content type header', () => {
     expect(cookieHeader).toContain('session=s%3D1%3B%20path%3D%2F');
     expect(cookieHeader).toContain('preference=dark%20mode');
   });
+
+  it('should send a primitive urlencoded body verbatim and form-encode an object body', async () => {
+    const arrayResponse = {
+      '200': {
+        content: {
+          'application/json': {
+            schema: { type: 'array', items: { type: 'string' } },
+          },
+        },
+        description: 'Success',
+      },
+    };
+    const spec: Spec = {
+      info: {
+        title,
+        version: '1.0.0',
+      },
+      openapi: '3.0.0',
+      paths: {
+        // A raw @httpPayload string body: the schema is a primitive, so the
+        // body must be sent verbatim rather than passed to $urlEncodedForm
+        // (which expects an object and would fail to type-check).
+        '/urlencoded-string': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: { type: 'string' },
+                },
+              },
+            },
+            responses: arrayResponse,
+          },
+        },
+        // An object body is still form-encoded to `key=value` pairs.
+        '/urlencoded-object': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    properties: { token: { type: 'string' } },
+                  },
+                },
+              },
+            },
+            responses: arrayResponse,
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    // The regression guard: a primitive-string urlencoded body used to be
+    // passed to $urlEncodedForm (typed for an object), so the client failed to
+    // compile.
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue(['ok']),
+    });
+
+    // The string body is sent verbatim, with the urlencoded content type kept.
+    await callGeneratedClient(
+      client,
+      mockFetch,
+      'postUrlencodedString',
+      'some-token=abc123',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/urlencoded-string`,
+      expect.objectContaining({
+        method: 'POST',
+        body: 'some-token=abc123',
+        headers: [['Content-Type', 'application/x-www-form-urlencoded']],
+      }),
+    );
+
+    // The object body is form-encoded to `key=value` pairs.
+    await callGeneratedClient(client, mockFetch, 'postUrlencodedObject', {
+      token: 'abc 123',
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/urlencoded-object`,
+      expect.objectContaining({
+        method: 'POST',
+        body: 'token=abc+123',
+        headers: [['Content-Type', 'application/x-www-form-urlencoded']],
+      }),
+    );
+  });
 });


### PR DESCRIPTION
### Reason for this change

The ts-client generator emitted object marshalling — `this.$urlEncodedForm(input)` — for every `application/x-www-form-urlencoded` request body, without checking whether the body schema is an object or a primitive. `$urlEncodedForm` is typed `(model: { [key: string]: any })` and iterates `Object.entries(model)`, so an operation whose urlencoded body is a raw string produced a client that fails to type-check:

    error TS2345: Argument of type 'string' is not assignable to parameter
    of type '{ [key: string]: any; }'.

### Description of changes

Fix: treat a urlencoded body as form-encoded only when its schema is an object. A new `isUrlEncodedObjectBody(op)` predicate now gates both the `$urlEncodedForm` helper emission (`hasUrlEncodedBody`) and the urlencoded marshalling branch. A primitive urlencoded body falls through to the existing `String(input)` branch, sending the pre-encoded string verbatim. The Content-Type header is set independently of the body branch, so it stays `application/x-www-form-urlencoded` in both cases. Object urlencoded bodies are unchanged (still `$urlEncodedForm`).

Also fixes `open-api#ts-hooks`, which delegates to the ts-client generator and reuses this template.

Adds a `generator.content-type.spec.ts` case covering a primitive-string body (asserts the generated client compiles and sends the raw string, content type preserved) and an object body (asserts `key=value` form encoding).

### Description of how you validated changes

All existing ts-client tests and snapshots pass unchanged.

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*