### PR TITLE
fix(open-api#ts-client): fail loud on non-encodable urlencoded array bodies

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
@@ -508,4 +508,161 @@ describe('openApiTsClientGenerator - content type header', () => {
       }),
     );
   });
+
+  it('should form-encode a urlencoded dictionary (additionalProperties) body', async () => {
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.0.0',
+      paths: {
+        '/urlencoded-dict': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    additionalProperties: { type: 'string' },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+                description: 'Success',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue(['ok']),
+    });
+
+    // Each dictionary entry becomes a form field.
+    await callGeneratedClient(client, mockFetch, 'postUrlencodedDict', {
+      first: 'a b',
+      second: 'c&d',
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/urlencoded-dict`,
+      expect.objectContaining({
+        method: 'POST',
+        body: 'first=a+b&second=c%26d',
+        headers: [['Content-Type', 'application/x-www-form-urlencoded']],
+      }),
+    );
+  });
+
+  it('should throw for a urlencoded body whose schema is an array', async () => {
+    // A top-level array has no property names to key on, so it has no defined
+    // form encoding — fail fast rather than emit index-keyed pairs (0=a&1=b)
+    // that no form parser can decode.
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.0.0',
+      paths: {
+        '/urlencoded-array': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: { type: 'array', items: { type: 'string' } },
+                },
+              },
+            },
+            responses: { '204': { description: 'No content' } },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await expect(
+      openApiTsClientGenerator(tree, {
+        openApiSpecPath: 'openapi.json',
+        outputPath: 'src/generated',
+      }),
+    ).rejects.toThrow(/x-www-form-urlencoded.*array.*no defined form encoding/);
+  });
+
+  it('should not throw for an array body offering both JSON and urlencoded', async () => {
+    // JSON is the preferred wire type, so the array body is sent as JSON — the
+    // urlencoded offering is never used and must not trip the form-encoding guard.
+    const spec: Spec = {
+      info: { title, version: '1.0.0' },
+      openapi: '3.0.0',
+      paths: {
+        '/array-json-or-form': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { type: 'array', items: { type: 'string' } },
+                },
+                'application/x-www-form-urlencoded': {
+                  schema: { type: 'array', items: { type: 'string' } },
+                },
+              },
+            },
+            responses: { '204': { description: 'No content' } },
+          },
+        },
+      },
+    };
+
+    tree.write('openapi.json', JSON.stringify(spec));
+
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+
+    validateTypeScript([
+      'src/generated/client.gen.ts',
+      'src/generated/types.gen.ts',
+    ]);
+
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8');
+    const mockFetch = vi.fn();
+    mockFetch.mockResolvedValue({ status: 204 });
+
+    await callGeneratedClient(client, mockFetch, 'postArrayJsonOrForm', [
+      'a',
+      'b',
+    ]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${baseUrl}/array-json-or-form`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(['a', 'b']),
+        headers: [['Content-Type', 'application/json']],
+      }),
+    );
+  });
 });

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -92,6 +92,10 @@ export const buildOpenApiCodeGenData = (inSpec: Spec): CodeGenData => {
     assertNoConflictingUnionMemberMarshalling(model);
   }
 
+  for (const op of allOperations) {
+    assertEncodableUrlEncodedBody(op);
+  }
+
   data.models = orderBy(data.models, (d) => d.name);
   // Default service first, then by name.
   data.services = orderBy(data.services, (s) =>
@@ -569,6 +573,35 @@ const assertNoConflictingUnionMemberMarshalling = (model: Model): void => {
         seen.set(property.name, { memberName: member.name, key });
       }
     }
+  }
+};
+
+/**
+ * An `application/x-www-form-urlencoded` body is form-encoded as `key=value`
+ * pairs, so the wire form is only defined for a schema with named properties
+ * (an object) or a primitive sent verbatim. A top-level array or tuple has no
+ * property names to key on — encoding it would emit index keys (`0=a&1=b`) that
+ * no form parser can decode — so fail fast rather than generate a client that
+ * is silently wrong on the wire.
+ */
+const assertEncodableUrlEncodedBody = (op: Operation): void => {
+  const body = op.parametersBody;
+  if (!body?.mediaTypes) return;
+  const mediaTypes = Array.isArray(body.mediaTypes)
+    ? body.mediaTypes
+    : [body.mediaTypes];
+  // Match the wire media type the client actually sends: JSON is preferred, so
+  // an array body offering both JSON and urlencoded is sent as JSON and is fine.
+  const chosenMediaType =
+    mediaTypes.find(
+      (mt) => mt === 'application/json' || mt.endsWith('+json'),
+    ) ?? mediaTypes[0];
+  if (chosenMediaType !== 'application/x-www-form-urlencoded') return;
+  if (body.isPrimitive) return;
+  if (body.export === 'array' || body.export === 'tuple') {
+    throw new Error(
+      `Operation ${op.method} ${op.path} has an application/x-www-form-urlencoded request body whose schema is a ${body.export}, which has no defined form encoding. Use an object schema (its properties become the form fields) or a primitive schema (sent verbatim) in your OpenAPI specification.`,
+    );
   }
 };
 


### PR DESCRIPTION
### Reason for this change

Follow-up to #937. That PR fixed primitive `application/x-www-form-urlencoded` bodies, but a gap remained: a body whose schema is a **top-level array (or tuple)** is not primitive, so it still routed to the `$urlEncodedForm` helper. That helper builds the form via `Object.entries(model)`, so an array produced index-keyed pairs on the wire — `0=read&1=write` for a string array, and `0=%7B%22a%22...%7D` (index keys + JSON blobs) for an array of objects. This compiles but is silently unparseable by any form-body parser, which is the worst failure mode.

`application/x-www-form-urlencoded` only defines an encoding for the named properties of an object (and, by extension, a primitive sent verbatim). A top-level array has no property names to key on, so there is no correct wire form to generate.

For completeness I verified the other non-primitive shapes are already correct and should be left unchanged:

| urlencoded body schema | wire output | correct? |
|---|---|---|
| primitive (string) | sent verbatim | ✅ (#937) |
| object | `key=value` | ✅ |
| dictionary (`additionalProperties`) | `a=1&b=2` | ✅ |
| **top-level array / tuple** | `0=a&1=b` (index-keyed) | ❌ this PR |

### Description of changes

Add a generation-time guard `assertEncodableUrlEncodedBody(op)` in `codegen-data.ts` (run over `allOperations` alongside the existing model asserts). It throws an actionable error when an operation's urlencoded body schema is a top-level `array`/`tuple`, directing users to an object schema (properties become form fields) or a primitive (sent verbatim). This matches the codebase's existing fail-loud pattern for ambiguous unions and non-JSON content-based parameters, rather than inventing a non-standard encoding.

The guard tracks the client's actual chosen wire media type (JSON is preferred), so an array body offering **both** `application/json` and `application/x-www-form-urlencoded` is sent as JSON and is intentionally unaffected.

Object, dictionary, and primitive urlencoded bodies are all unchanged. No template change is needed and there is no snapshot churn.

### Description of how you validated changes

Added three cases to `generator.content-type.spec.ts`:
- an array-schema urlencoded body now fails generation with the expected error;
- a dictionary (`additionalProperties`) urlencoded body still form-encodes to `key=value` pairs (regression guard for an already-correct shape);
- an array body offering both JSON and urlencoded is generated and sent as JSON (guard must not false-positive).

I also empirically reproduced the pre-fix index-keyed wire output against generated clients before writing the guard. All 349 open-api generator tests pass; the full `@aws/nx-plugin` suite (2611 tests) passes via the pre-commit hook.

### Issue # (if applicable)

N/A — follow-up to #937.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
