### PR TITLE
feat(mcp-server,agent): add invocationUrl getter to vended AgentCore runtime constructs

### DIFF
--- a/docs/src/content/docs/en/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/en/guides/connection/agentcore-gateway-mcp.mdx
@@ -102,7 +102,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/en/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/en/snippets/agent/runtime-arn.mdx
@@ -61,4 +61,25 @@ The Bedrock AgentCore Runtime dataplane URL for invoking the agent is as follows
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[Invocation URL]
+Your infrastructure can also output the full invocation URL directly, with the ARN encoding handled for you:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 The exact way to invoke this URL depends upon the authentication method used.

--- a/docs/src/content/docs/es/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/es/guides/connection/agentcore-gateway-mcp.mdx
@@ -101,7 +101,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/es/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/es/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ La URL del plano de datos de Bedrock AgentCore Runtime para invocar el agente es
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[URL de invocación]
+Tu infraestructura también puede generar la URL de invocación completa directamente, con la codificación del ARN manejada por ti:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 La forma exacta de invocar esta URL depende del método de autenticación utilizado.

--- a/docs/src/content/docs/fr/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/fr/guides/connection/agentcore-gateway-mcp.mdx
@@ -102,7 +102,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }
@@ -131,6 +131,4 @@ démarre une passerelle locale plus chaque serveur MCP attaché sur son port loc
 Le développement local utilise une **passerelle de substitution locale** — un agrégateur MCP léger démarré par le projet de passerelle, et non le service de passerelle AgentCore. En conséquence, **les politiques Cedar ne sont pas évaluées localement**. Chaque agent voit tous les outils sur chaque serveur MCP attaché. Pour exercer les politiques Cedar, exécutez plutôt la cible `serve` de l'agent (voir les guides de connexion d'agent <Link path="guides/connection/ts-agent-gateway">TypeScript</Link> / <Link path="guides/connection/py-agent-gateway">Python</Link>) afin que l'agent s'exécutant localement appelle la passerelle déployée.
 
 Les noms d'outils sont toujours préfixés localement comme `<target-name>___<tool-name>` pour correspondre à l'espacement de noms de la passerelle déployée, de sorte que l'invite système d'un agent et les noms d'action Cedar que vous référencez restent cohérents entre les exécutions locales et déployées.
-:::
-les exécutions locales et déployées.
 :::

--- a/docs/src/content/docs/fr/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/fr/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ L'URL du plan de données Bedrock AgentCore Runtime pour invoquer l'agent est la
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[URL d'invocation]
+Votre infrastructure peut également générer directement l'URL d'invocation complète, avec l'encodage de l'ARN géré pour vous :
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 La manière exacte d'invoquer cette URL dépend de la méthode d'authentification utilisée.

--- a/docs/src/content/docs/it/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/it/guides/connection/agentcore-gateway-mcp.mdx
@@ -102,7 +102,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/it/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/it/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ L'URL dataplane di Bedrock AgentCore Runtime per invocare l'agent è il seguente
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[URL di invocazione]
+La tua infrastruttura può anche restituire direttamente l'URL di invocazione completo, con la codifica dell'ARN gestita per te:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 Il modo esatto per invocare questo URL dipende dal metodo di autenticazione utilizzato.

--- a/docs/src/content/docs/jp/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/jp/guides/connection/agentcore-gateway-mcp.mdx
@@ -101,7 +101,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/jp/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/jp/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ encodeURIComponent('arn:aws:bedrock-agentcore:<region>:<account>:runtime/<agent-
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[呼び出しURL]
+インフラストラクチャは、ARNエンコーディングを自動的に処理して、完全な呼び出しURLを直接出力することもできます:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 このURLを呼び出す正確な方法は、使用する認証方法によって異なります。

--- a/docs/src/content/docs/ko/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/ko/guides/connection/agentcore-gateway-mcp.mdx
@@ -101,7 +101,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/ko/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/ko/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ encodeURIComponent('arn:aws:bedrock-agentcore:<region>:<account>:runtime/<agent-
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[호출 URL]
+인프라에서 ARN 인코딩을 자동으로 처리하여 전체 호출 URL을 직접 출력할 수도 있습니다:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 이 URL을 호출하는 정확한 방법은 사용된 인증 방법에 따라 다릅니다.

--- a/docs/src/content/docs/pt/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/pt/guides/connection/agentcore-gateway-mcp.mdx
@@ -101,7 +101,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/pt/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/pt/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ A URL do dataplane do Bedrock AgentCore Runtime para invocar o agent é a seguin
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[URL de invocação]
+Sua infraestrutura também pode gerar a URL de invocação completa diretamente, com a codificação do ARN tratada para você:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 A maneira exata de invocar esta URL depende do método de autenticação usado.

--- a/docs/src/content/docs/vi/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/vi/guides/connection/agentcore-gateway-mcp.mdx
@@ -101,7 +101,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/vi/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/vi/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ URL dataplane của Bedrock AgentCore Runtime để gọi agent như sau:
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[URL gọi]
+Cơ sở hạ tầng của bạn cũng có thể xuất trực tiếp URL gọi đầy đủ, với việc mã hóa ARN được xử lý sẵn cho bạn:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 Cách chính xác để gọi URL này phụ thuộc vào phương thức xác thực được sử dụng.

--- a/docs/src/content/docs/zh/guides/connection/agentcore-gateway-mcp.mdx
+++ b/docs/src/content/docs/zh/guides/connection/agentcore-gateway-mcp.mdx
@@ -101,7 +101,7 @@ resource "aws_bedrockagentcore_gateway_target" "my_mcp_server" {
   target_configuration {
     mcp {
       mcp_server {
-        endpoint = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(module.my_mcp_server.agent_core_runtime_arn)}/invocations?qualifier=DEFAULT"
+        endpoint = module.my_mcp_server.invocation_url
       }
     }
   }

--- a/docs/src/content/docs/zh/snippets/agent/runtime-arn.mdx
+++ b/docs/src/content/docs/zh/snippets/agent/runtime-arn.mdx
@@ -62,4 +62,25 @@ encodeURIComponent('arn:aws:bedrock-agentcore:<region>:<account>:runtime/<agent-
 https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
 ```
 
+:::tip[调用 URL]
+您的基础设施还可以直接输出完整的调用 URL,ARN 编码会自动处理:
+
+<Infrastructure>
+<Fragment slot="cdk">
+```ts
+new CfnOutput(this, 'AgentUrl', {
+  value: agent.invocationUrl,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+```terraform
+output "agent_url" {
+  value = module.my_project_agent.invocation_url
+}
+```
+</Fragment>
+</Infrastructure>
+:::
+
 调用此 URL 的具体方式取决于所使用的身份验证方法。

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -20,7 +20,7 @@ CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_test_projec
 `;
 
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-construct.ts 1`] = `
-"import { Lazy, Names } from 'aws-cdk-lib';
+"import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
@@ -119,6 +119,22 @@ export class SnapshotBedrockAgent
    */
   public get connections(): Connections {
     return this.agentCoreRuntime.connections;
+  }
+
+  /**
+   * The HTTPS invocation URL of the runtime.
+   */
+  public get invocationUrl(): string {
+    // The URL must URL-encode the runtime ARN (':' -> '%3A', '/' -> '%2F').
+    // The ARN is a CDK token, so encode at deploy time via Fn.join/Fn.split.
+    const encodedArn = Fn.join(
+      '%2F',
+      Fn.split(
+        '/',
+        Fn.join('%3A', Fn.split(':', this.agentCoreRuntime.agentRuntimeArn)),
+      ),
+    );
+    return \`https://bedrock-agentcore.\${Stack.of(this).region}.amazonaws.com/runtimes/\${encodedArn}/invocations?qualifier=DEFAULT\`;
   }
 
   /**

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -110,6 +110,11 @@ output "agent_core_runtime_arn" {
   value       = module.agent_core_runtime.agent_core_runtime_arn
 }
 
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime"
+  value       = module.agent_core_runtime.invocation_url
+}
+
 output "appconfig_application_id" {
   description = "AppConfig Application ID for runtime config (passthrough of the shared \`appconfig_application_id\` input)."
   value       = var.appconfig_application_id
@@ -583,6 +588,12 @@ print(f'Runtime {runtime_arn} is serving MCP')
 }
 
 # Outputs
+locals {
+  # For MCP runtimes the ARN flows through the readiness probe, so consumers
+  # wait until the runtime serves MCP.
+  ready_runtime_arn = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+}
+
 output "agent_core_runtime_role_arn" {
   description = "ARN of the Agent Core Runtime IAM role"
   value       = aws_iam_role.agent_core_runtime_role.arn
@@ -600,7 +611,12 @@ output "agent_runtime_name" {
 
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime. For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
-  value       = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+  value       = local.ready_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime. MCP runtimes get the MCP endpoint (e.g. for use as a Gateway target endpoint), A2A runtimes the A2A endpoint (trailing slash required). For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
+  value       = "https://bedrock-agentcore.\${local.aws_region}.amazonaws.com/runtimes/\${urlencode(local.ready_runtime_arn)}/invocations\${var.server_protocol == "A2A" ? "/" : "?qualifier=DEFAULT"}"
 }
 
 output "agent_runtime_id" {

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -14,7 +14,7 @@ export * from './workspace.js';
 `;
 
 exports[`py#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > mcp-server-construct.ts 1`] = `
-"import { Lazy, Names } from 'aws-cdk-lib';
+"import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
@@ -100,6 +100,23 @@ export class SnapshotBedrockServer
    */
   public get connections(): Connections {
     return this.agentCoreRuntime.connections;
+  }
+
+  /**
+   * The MCP endpoint URL of the runtime, e.g. for use as a Gateway target
+   * endpoint.
+   */
+  public get invocationUrl(): string {
+    // The URL must URL-encode the runtime ARN (':' -> '%3A', '/' -> '%2F').
+    // The ARN is a CDK token, so encode at deploy time via Fn.join/Fn.split.
+    const encodedArn = Fn.join(
+      '%2F',
+      Fn.split(
+        '/',
+        Fn.join('%3A', Fn.split(':', this.agentCoreRuntime.agentRuntimeArn)),
+      ),
+    );
+    return \`https://bedrock-agentcore.\${Stack.of(this).region}.amazonaws.com/runtimes/\${encodedArn}/invocations?qualifier=DEFAULT\`;
   }
 
   /**
@@ -589,6 +606,12 @@ print(f'Runtime {runtime_arn} is serving MCP')
 }
 
 # Outputs
+locals {
+  # For MCP runtimes the ARN flows through the readiness probe, so consumers
+  # wait until the runtime serves MCP.
+  ready_runtime_arn = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+}
+
 output "agent_core_runtime_role_arn" {
   description = "ARN of the Agent Core Runtime IAM role"
   value       = aws_iam_role.agent_core_runtime_role.arn
@@ -606,7 +629,12 @@ output "agent_runtime_name" {
 
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime. For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
-  value       = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+  value       = local.ready_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime. MCP runtimes get the MCP endpoint (e.g. for use as a Gateway target endpoint), A2A runtimes the A2A endpoint (trailing slash required). For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
+  value       = "https://bedrock-agentcore.\${local.aws_region}.amazonaws.com/runtimes/\${urlencode(local.ready_runtime_arn)}/invocations\${var.server_protocol == "A2A" ? "/" : "?qualifier=DEFAULT"}"
 }
 
 output "agent_runtime_id" {
@@ -722,6 +750,11 @@ output "agent_core_runtime_role_arn" {
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime"
   value       = module.agent_core_runtime.agent_core_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime (the MCP endpoint, e.g. for use as a Gateway target endpoint)"
+  value       = module.agent_core_runtime.invocation_url
 }
 
 output "appconfig_application_id" {

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -585,7 +585,7 @@ CMD [ "node", "--require", "@aws/aws-distro-opentelemetry-node-autoinstrumentati
 `;
 
 exports[`ts#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-construct.ts 1`] = `
-"import { Lazy, Names } from 'aws-cdk-lib';
+"import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
@@ -684,6 +684,22 @@ export class SnapshotBedrockAgent
    */
   public get connections(): Connections {
     return this.agentCoreRuntime.connections;
+  }
+
+  /**
+   * The HTTPS invocation URL of the runtime.
+   */
+  public get invocationUrl(): string {
+    // The URL must URL-encode the runtime ARN (':' -> '%3A', '/' -> '%2F').
+    // The ARN is a CDK token, so encode at deploy time via Fn.join/Fn.split.
+    const encodedArn = Fn.join(
+      '%2F',
+      Fn.split(
+        '/',
+        Fn.join('%3A', Fn.split(':', this.agentCoreRuntime.agentRuntimeArn)),
+      ),
+    );
+    return \`https://bedrock-agentcore.\${Stack.of(this).region}.amazonaws.com/runtimes/\${encodedArn}/invocations?qualifier=DEFAULT\`;
   }
 
   /**
@@ -833,6 +849,11 @@ output "agent_core_runtime_role_arn" {
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime"
   value       = module.agent_core_runtime.agent_core_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime"
+  value       = module.agent_core_runtime.invocation_url
 }
 
 output "appconfig_application_id" {
@@ -1308,6 +1329,12 @@ print(f'Runtime {runtime_arn} is serving MCP')
 }
 
 # Outputs
+locals {
+  # For MCP runtimes the ARN flows through the readiness probe, so consumers
+  # wait until the runtime serves MCP.
+  ready_runtime_arn = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+}
+
 output "agent_core_runtime_role_arn" {
   description = "ARN of the Agent Core Runtime IAM role"
   value       = aws_iam_role.agent_core_runtime_role.arn
@@ -1325,7 +1352,12 @@ output "agent_runtime_name" {
 
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime. For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
-  value       = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+  value       = local.ready_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime. MCP runtimes get the MCP endpoint (e.g. for use as a Gateway target endpoint), A2A runtimes the A2A endpoint (trailing slash required). For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
+  value       = "https://bedrock-agentcore.\${local.aws_region}.amazonaws.com/runtimes/\${urlencode(local.ready_runtime_arn)}/invocations\${var.server_protocol == "A2A" ? "/" : "?qualifier=DEFAULT"}"
 }
 
 output "agent_runtime_id" {

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -14,7 +14,7 @@ export * from './workspace.js';
 `;
 
 exports[`ts#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > mcp-server-construct.ts 1`] = `
-"import { Lazy, Names } from 'aws-cdk-lib';
+"import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
@@ -100,6 +100,23 @@ export class SnapshotBedrockServer
    */
   public get connections(): Connections {
     return this.agentCoreRuntime.connections;
+  }
+
+  /**
+   * The MCP endpoint URL of the runtime, e.g. for use as a Gateway target
+   * endpoint.
+   */
+  public get invocationUrl(): string {
+    // The URL must URL-encode the runtime ARN (':' -> '%3A', '/' -> '%2F').
+    // The ARN is a CDK token, so encode at deploy time via Fn.join/Fn.split.
+    const encodedArn = Fn.join(
+      '%2F',
+      Fn.split(
+        '/',
+        Fn.join('%3A', Fn.split(':', this.agentCoreRuntime.agentRuntimeArn)),
+      ),
+    );
+    return \`https://bedrock-agentcore.\${Stack.of(this).region}.amazonaws.com/runtimes/\${encodedArn}/invocations?qualifier=DEFAULT\`;
   }
 
   /**
@@ -589,6 +606,12 @@ print(f'Runtime {runtime_arn} is serving MCP')
 }
 
 # Outputs
+locals {
+  # For MCP runtimes the ARN flows through the readiness probe, so consumers
+  # wait until the runtime serves MCP.
+  ready_runtime_arn = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+}
+
 output "agent_core_runtime_role_arn" {
   description = "ARN of the Agent Core Runtime IAM role"
   value       = aws_iam_role.agent_core_runtime_role.arn
@@ -606,7 +629,12 @@ output "agent_runtime_name" {
 
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime. For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
-  value       = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+  value       = local.ready_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime. MCP runtimes get the MCP endpoint (e.g. for use as a Gateway target endpoint), A2A runtimes the A2A endpoint (trailing slash required). For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
+  value       = "https://bedrock-agentcore.\${local.aws_region}.amazonaws.com/runtimes/\${urlencode(local.ready_runtime_arn)}/invocations\${var.server_protocol == "A2A" ? "/" : "?qualifier=DEFAULT"}"
 }
 
 output "agent_runtime_id" {
@@ -722,6 +750,11 @@ output "agent_core_runtime_role_arn" {
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime"
   value       = module.agent_core_runtime.agent_core_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime (the MCP endpoint, e.g. for use as a Gateway target endpoint)"
+  value       = module.agent_core_runtime.invocation_url
 }
 
 output "appconfig_application_id" {

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -1,4 +1,4 @@
-import { Lazy, Names } from 'aws-cdk-lib';
+import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
@@ -135,6 +135,29 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
    */
   public get connections(): Connections {
     return this.agentCoreRuntime.connections;
+  }
+
+  /**
+<%_ if (serverProtocol === 'mcp') { _%>
+   * The MCP endpoint URL of the runtime, e.g. for use as a Gateway target
+   * endpoint.
+<%_ } else if (serverProtocol === 'a2a') { _%>
+   * The A2A endpoint URL of the runtime (the trailing slash is required).
+<%_ } else { _%>
+   * The HTTPS invocation URL of the runtime.
+<%_ } _%>
+   */
+  public get invocationUrl(): string {
+    // The URL must URL-encode the runtime ARN (':' -> '%3A', '/' -> '%2F').
+    // The ARN is a CDK token, so encode at deploy time via Fn.join/Fn.split.
+    const encodedArn = Fn.join(
+      '%2F',
+      Fn.split(
+        '/',
+        Fn.join('%3A', Fn.split(':', this.agentCoreRuntime.agentRuntimeArn)),
+      ),
+    );
+    return `https://bedrock-agentcore.${Stack.of(this).region}.amazonaws.com/runtimes/${encodedArn}/invocations<%- serverProtocol === 'a2a' ? '/' : '?qualifier=DEFAULT' %>`;
   }
 <%_ if (auth === 'iam') { _%>
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -133,6 +133,11 @@ output "agent_core_runtime_arn" {
   value       = module.agent_core_runtime.agent_core_runtime_arn
 }
 
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime<% if (serverProtocol === 'mcp') { %> (the MCP endpoint, e.g. for use as a Gateway target endpoint)<% } else if (serverProtocol === 'a2a') { %> (the A2A endpoint)<% } %>"
+  value       = module.agent_core_runtime.invocation_url
+}
+
 output "appconfig_application_id" {
   description = "AppConfig Application ID for runtime config (passthrough of the shared `appconfig_application_id` input)."
   value       = var.appconfig_application_id

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -458,6 +458,12 @@ print(f'Runtime {runtime_arn} is serving MCP')
 }
 
 # Outputs
+locals {
+  # For MCP runtimes the ARN flows through the readiness probe, so consumers
+  # wait until the runtime serves MCP.
+  ready_runtime_arn = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+}
+
 output "agent_core_runtime_role_arn" {
   description = "ARN of the Agent Core Runtime IAM role"
   value       = aws_iam_role.agent_core_runtime_role.arn
@@ -475,7 +481,12 @@ output "agent_runtime_name" {
 
 output "agent_core_runtime_arn" {
   description = "ARN of the Bedrock Agent Core runtime. For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
-  value       = var.server_protocol == "MCP" ? null_resource.runtime_ready[0].triggers.runtime_arn : aws_bedrockagentcore_agent_runtime.agent_runtime.agent_runtime_arn
+  value       = local.ready_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime. MCP runtimes get the MCP endpoint (e.g. for use as a Gateway target endpoint), A2A runtimes the A2A endpoint (trailing slash required). For MCP runtimes the value flows through the readiness probe, so consumers wait until the runtime serves MCP."
+  value       = "https://bedrock-agentcore.${local.aws_region}.amazonaws.com/runtimes/${urlencode(local.ready_runtime_arn)}/invocations${var.server_protocol == "A2A" ? "/" : "?qualifier=DEFAULT"}"
 }
 
 output "agent_runtime_id" {


### PR DESCRIPTION
### Reason for this change

Neither the `aws-cdk-lib/aws-bedrockagentcore` Runtime L2 (checked at 2.261.0 — only `agentRuntimeArn`/`agentRuntimeId` are exposed) nor the terraform `aws_bedrockagentcore_agent_runtime` resource provide the runtime's HTTPS invocation URL. Users — and our own agentcore-gateway terraform docs — had to hand-build `https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations...` from the ARN, including manual URL-encoding.

### Description of changes

- **CDK**: adds an `invocationUrl` getter to the vended AgentCore runtime construct (agents and MCP servers). The ARN is a CDK token, so it is URL-encoded at deploy time via `Fn.join`/`Fn.split`, matching the existing approach in `AgentCoreGateway.addMcpServerTarget`.
- **Terraform**: adds an `invocation_url` output to the `core/agent-core` module and a passthrough output on the app-level agent/MCP server modules, using `urlencode()`. For MCP runtimes the value flows through the existing readiness probe (same as the `agent_core_runtime_arn` output) so consumers wait until the runtime serves MCP.
- **Protocol-aware**: MCP and HTTP runtimes get `/invocations?qualifier=DEFAULT`; A2A runtimes get the `/invocations/` root (trailing slash required), consistent with the URLs built by the vended connection clients.
- **Docs**: the terraform gateway→MCP connection guide now uses `module.<mcp-server>.invocation_url` for the gateway target endpoint instead of hand-building the URL, and the runtime-arn snippet mentions the new getter/output.

The CDK gateway construct's `addMcpServerTarget` keeps its own ARN-string-based encoding since it accepts raw ARNs from outside the construct.

### Description of how you validated changes

- Full unit test suite passes (`pnpm nx run @aws/nx-plugin:test -u`, 2608 tests); snapshots updated cover the new getter/outputs across MCP/HTTP/A2A and CDK/terraform variants.
- Rendered the CDK template for all protocol/auth variants and type-checked against `aws-cdk-lib@2.261.0` with `tsc --strict`.
- Rendered the terraform `core/agent-core` module and ran `terraform validate` (clean, apart from the pre-existing `data.aws_region.current.id` deprecation warning).
- Full build passes.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*