### PR TITLE
fix(ts#rdb): allow prisma install scripts under npm 12 in migration image

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4598,14 +4598,16 @@ export default defineConfig({
 exports[`ts#rdb generator > should generate the aurora shared construct 4`] = `
 "FROM public.ecr.aws/lambda/nodejs:24
 
-WORKDIR \${LAMBDA_TASK_ROOT}
-
-# Install prisma before upgrading npm: newer npm does not run prisma's
-# postinstall which downloads the schema-engine binary, breaking migrations.
-RUN npm install prisma@7.8.0
-
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@12.0.1
+
+WORKDIR \${LAMBDA_TASK_ROOT}
+
+# npm blocks dependency install scripts by default; allow prisma's so its
+# postinstall downloads the schema-engine binary needed to run migrations.
+RUN printf 'allow-scripts[]=prisma\\nallow-scripts[]=@prisma/engines\\n' > .npmrc \\
+    && npm install prisma@7.8.0 \\
+    && rm .npmrc
 
 COPY index.js ./index.js
 COPY prisma ./prisma

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4598,12 +4598,14 @@ export default defineConfig({
 exports[`ts#rdb generator > should generate the aurora shared construct 4`] = `
 "FROM public.ecr.aws/lambda/nodejs:24
 
-# Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
-RUN npm install -g npm@12.0.1
-
 WORKDIR \${LAMBDA_TASK_ROOT}
 
+# Install prisma before upgrading npm: newer npm does not run prisma's
+# postinstall which downloads the schema-engine binary, breaking migrations.
 RUN npm install prisma@7.8.0
+
+# Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
+RUN npm install -g npm@12.0.1
 
 COPY index.js ./index.js
 COPY prisma ./prisma

--- a/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
+++ b/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
@@ -1,13 +1,15 @@
 FROM public.ecr.aws/lambda/nodejs:24
 
-WORKDIR ${LAMBDA_TASK_ROOT}
-
-# Install prisma before upgrading npm: newer npm does not run prisma's
-# postinstall which downloads the schema-engine binary, breaking migrations.
-RUN npm install prisma@<%= prismaVersion %>
-
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@<%= npmVersion %>
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+# npm blocks dependency install scripts by default; allow prisma's so its
+# postinstall downloads the schema-engine binary needed to run migrations.
+RUN printf 'allow-scripts[]=prisma\nallow-scripts[]=@prisma/engines\n' > .npmrc \
+    && npm install prisma@<%= prismaVersion %> \
+    && rm .npmrc
 
 COPY index.js ./index.js
 COPY prisma ./prisma

--- a/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
+++ b/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
@@ -1,11 +1,13 @@
 FROM public.ecr.aws/lambda/nodejs:24
 
-# Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
-RUN npm install -g npm@<%= npmVersion %>
-
 WORKDIR ${LAMBDA_TASK_ROOT}
 
+# Install prisma before upgrading npm: newer npm does not run prisma's
+# postinstall which downloads the schema-engine binary, breaking migrations.
 RUN npm install prisma@<%= prismaVersion %>
+
+# Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
+RUN npm install -g npm@<%= npmVersion %>
 
 COPY index.js ./index.js
 COPY prisma ./prisma


### PR DESCRIPTION
### Reason for this change

The post-merge CI on `main` failed after #943 — the `cdk-deploy-rdb` smoke test failed when deploying the ts#rdb migration to AWS. The migration Lambda errored at runtime with:

```
Error: Schema engine exited. Error: Could not find schema-engine binary. Searched in:
  /var/task/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x
  ...
```

#943 added `RUN npm install -g npm@<pinned>` to the ts#rdb migration `Dockerfile` (to patch the base image's bundled npm for the Trivy scan). **npm 12 blocks dependency install scripts by default** (a new `allowScripts` gate), so `npm install prisma` no longer ran prisma's `postinstall`, which downloads the platform `schema-engine` binary — leaving it absent from the image and breaking migrations. (py#rdb uses a Python base image with no npm upgrade, so it was unaffected — matching the CI logs where the py migration succeeded and only the ts migration failed.)

### Description of changes

Keep the npm security upgrade (npm 12, which patches the base image's bundled-undici `HIGH`), and explicitly permit prisma's install scripts via a scoped `allow-scripts` `.npmrc` so its engine-download `postinstall` runs. The `.npmrc` is written and removed within the same `RUN` layer, so it is not shipped in the final image, and only `prisma` / `@prisma/engines` scripts are allowed (not all dependencies).

```dockerfile
RUN printf 'allow-scripts[]=prisma\nallow-scripts[]=@prisma/engines\n' > .npmrc \
    && npm install prisma@<version> \
    && rm .npmrc
```

### Description of how you validated changes

Reproduced and fixed against the real `public.ecr.aws/lambda/nodejs:24` image on `linux/arm64`:

- **Before:** `npm install prisma` under npm 12 emits `install scripts blocked because they are not covered by allowScripts`, and `node_modules/@prisma/engines` has no `schema-engine` binary — reproducing the CI failure.
- **After:** the built image has **npm 12.0.1** (undici `HIGH` patched), the `schema-engine-linux-arm64-openssl-3.0.x` binary present, `npx prisma` resolves it, no leftover `.npmrc`, and it scans clean with Trivy (exit 0).

Also confirmed via CI history that `cdk-deploy-rdb` passed on the three prior `main` runs and failed only on the #943 merge — a real regression, not transient.

Updated the ts#rdb Dockerfile snapshot; `nx run @aws/nx-plugin:test src/ts/rdb/generator.spec.ts` passes.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*