### PR TITLE
fix(utils): run formatters async with a bounded uv cache lock wait

### DIFF
--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -5,13 +5,59 @@
 
 import { Biome } from '@biomejs/js-api/nodejs';
 import { getProjects, type Tree } from '@nx/devkit';
-import { execFileSync, execSync } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
+import { promisify } from 'util';
 import { readToml } from './toml';
 
 const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
+
+/** Hard ceiling on any formatter subprocess so a hung tool cannot stall generation. */
+const EXEC_TIMEOUT_MS = 60_000;
+/** Seconds uv waits for its global cache lock before giving up on a ruff call. */
+const UV_LOCK_TIMEOUT_SECONDS = 20;
+
+/**
+ * uv serialises cache writes behind a global lock (`<uv cache>/.lock`) and by
+ * default waits minutes for it. Cap the wait so contention with other uv
+ * processes (e.g. parallel generator runs installing ruff) fails fast instead
+ * of stalling generation, honouring any user override.
+ */
+const uvEnv = (): NodeJS.ProcessEnv => ({
+  ...process.env,
+  UV_LOCK_TIMEOUT:
+    process.env.UV_LOCK_TIMEOUT ?? String(UV_LOCK_TIMEOUT_SECONDS),
+});
+
+/**
+ * Run a command asynchronously with content piped to stdin, capturing stdout.
+ * Async execution keeps the event loop free (so callers' timeouts can fire)
+ * and the timeout kills processes that hang.
+ */
+function execFileWithInput(
+  command: string,
+  args: string[],
+  input: string,
+  opts?: { env?: NodeJS.ProcessEnv; cwd?: string },
+): Promise<string> {
+  const promise = execFileAsync(command, args, {
+    encoding: 'utf-8',
+    timeout: EXEC_TIMEOUT_MS,
+    ...opts,
+  });
+  // Swallow EPIPE if the process exits before consuming its stdin
+  promise.child.stdin?.on('error', () => {});
+  promise.child.stdin?.end(input);
+  return promise.then(({ stdout }) => stdout);
+}
+
+/** Run ruff with the capped uv lock timeout applied. */
+function execRuff(argv: string[], input: string): Promise<string> {
+  return execFileWithInput(argv[0], argv.slice(1), input, { env: uvEnv() });
+}
 
 export const DEFAULT_BIOME_CONFIG = {
   $schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
@@ -107,7 +153,7 @@ export async function formatFilesInSubtree(
   // Format Python files with ruff (lint fixes + formatting)
   for (const file of pyFiles) {
     try {
-      const content = ruffFixAndFormat(
+      const content = await ruffFixAndFormat(
         file.content.toString('utf-8'),
         file.path,
         hasRuffConfigOnDisk(tree, file.path),
@@ -125,7 +171,7 @@ export async function formatFilesInSubtree(
   // exists on disk; otherwise format via the bundled library API with the
   // in-memory tree config. The CLI path does not see in-tree config changes.
   if (existsSync(path.join(tree.root, 'biome.json'))) {
-    formatWithBiomeCli(tree, otherFiles);
+    await formatWithBiomeCli(tree, otherFiles);
   } else {
     formatWithBiomeApi(tree, otherFiles);
   }
@@ -135,10 +181,10 @@ export async function formatFilesInSubtree(
  * Format files via the workspace's Biome CLI, run from the workspace root so it
  * discovers the on-disk biome.json.
  */
-function formatWithBiomeCli(
+async function formatWithBiomeCli(
   tree: Tree,
   files: { path: string; content: Buffer | null }[],
-): void {
+): Promise<void> {
   const biome = getBiomeCommand(tree.root);
   if (!biome) {
     // Fall back to the library API if the CLI cannot be resolved
@@ -148,15 +194,11 @@ function formatWithBiomeCli(
 
   for (const file of files) {
     try {
-      const content = execFileSync(
+      const content = await execFileWithInput(
         biome.command,
         [...biome.args, 'format', `--stdin-file-path=${file.path}`],
-        {
-          input: file.content?.toString('utf-8') ?? '',
-          encoding: 'utf-8',
-          cwd: tree.root,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
+        file.content?.toString('utf-8') ?? '',
+        { cwd: tree.root },
       );
       tree.write(file.path, content);
     } catch {
@@ -234,9 +276,10 @@ function getBiomeCommand(root: string): BiomeCommand | undefined {
   }
 
   try {
-    execSync('biome --version', {
+    execFileSync('biome', ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: EXEC_TIMEOUT_MS,
     });
     const command = { command: 'biome', args: [] };
     _biomeCommands.set(root, command);
@@ -251,24 +294,24 @@ function getBiomeCommand(root: string): BiomeCommand | undefined {
  * Find the ruff command. Tries 'uv run ruff', then 'uvx ruff'.
  * Matches how @nxlv/python runs ruff via the UV provider.
  */
-let _ruffCommand: string | undefined;
-function getRuffCommand(): string | undefined {
+let _ruffCommand: string[] | undefined;
+async function getRuffCommand(): Promise<string[] | undefined> {
   if (_ruffCommand !== undefined) {
-    return _ruffCommand || undefined;
+    return _ruffCommand.length ? _ruffCommand : undefined;
   }
-  for (const cmd of ['uv run ruff', 'uvx ruff']) {
+  for (const argv of [
+    ['uv', 'run', 'ruff'],
+    ['uvx', 'ruff'],
+  ]) {
     try {
-      execSync(`${cmd} --version`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      _ruffCommand = cmd;
-      return cmd;
+      await execRuff([...argv, '--version'], '');
+      _ruffCommand = argv;
+      return argv;
     } catch {
       // Try next command
     }
   }
-  _ruffCommand = '';
+  _ruffCommand = [];
   return undefined;
 }
 
@@ -397,53 +440,56 @@ function getOwningProjectRuffConfig(
  * generated config raises it above ruff's default of 88). These are additive to
  * any on-disk config, so they are safe to pass regardless of `hasConfig`.
  */
-function ruffFixAndFormat(
+async function ruffFixAndFormat(
   content: string,
   filePath: string,
   hasConfig: boolean,
   projectConfig?: PythonProjectRuffConfig,
-): string {
-  const ruff = getRuffCommand();
+): Promise<string> {
+  const ruff = await getRuffCommand();
   if (!ruff) return content;
 
-  const extendSelect = hasConfig ? '' : ' --extend-select I';
+  const extendSelect = hasConfig ? [] : ['--extend-select', 'I'];
   const configArgs: string[] = [];
   if (projectConfig?.modules.length) {
     configArgs.push(
+      '--config',
       `lint.isort.known-first-party = ${JSON.stringify(projectConfig.modules)}`,
     );
   }
   if (typeof projectConfig?.lineLength === 'number') {
-    configArgs.push(`line-length = ${projectConfig.lineLength}`);
+    configArgs.push('--config', `line-length = ${projectConfig.lineLength}`);
   }
-  const config = configArgs
-    .map((arg) => ` --config ${JSON.stringify(arg)}`)
-    .join('');
 
   // First apply lint fixes (import sorting, unused imports, etc.)
   try {
-    const result = execSync(
-      `${ruff} check --fix${extendSelect}${config} --stdin-filename ${filePath} -`,
-      { input: content, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    content = await execRuff(
+      [
+        ...ruff,
+        'check',
+        '--fix',
+        ...extendSelect,
+        ...configArgs,
+        '--stdin-filename',
+        filePath,
+        '-',
+      ],
+      content,
     );
-    content = result;
   } catch (e: any) {
-    // ruff check exits non-zero when it finds unfixable issues,
-    // but stdout still contains the fixed content
-    if (e.stdout) {
+    // ruff check exits non-zero when it finds unfixable issues, but stdout
+    // still contains the fixed content. A killed (timed-out) process may have
+    // written only part of it, so never use output from a killed process.
+    if (e.stdout && !e.killed) {
       content = e.stdout;
     }
   }
 
   // Then apply formatting
   try {
-    content = execSync(
-      `${ruff} format${config} --stdin-filename ${filePath} -`,
-      {
-        input: content,
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
+    content = await execRuff(
+      [...ruff, 'format', ...configArgs, '--stdin-filename', filePath, '-'],
+      content,
     );
   } catch {
     // Fall through with whatever content we have


### PR DESCRIPTION
### Reason for this change

On multi-core machines, `pnpm build:all` would frequently appear to **hang forever** on the two Python formatting tests in `packages/nx-plugin/src/utils/format.spec.ts` (the hang is the underlying formatter, not the tests themselves) — the test duration counting up indefinitely with no output, only recoverable by killing and re-running.

Root cause: Python formatting shells out to `ruff` via `uvx` using synchronous `execSync` with no timeout. `uv` serialises cache writes behind a global lock (`<uv cache>/.lock`) and, by default, waits minutes to acquire it. When many generators run in parallel (as under `build:all`) they race to install/resolve `ruff` and serialise on that one lock; if a holder is slow (cold cache, a new `ruff` release invalidating the cached resolution, a slow network, or another long-lived `uv` process such as an MCP server), the others block. Because `execSync` blocks the Node event loop, vitest's `testTimeout` can never fire — so instead of failing, the run hangs indefinitely. It's intermittent because a warm, fresh cache is read lock-free.

### Description of changes

- Run all formatter subprocesses (ruff check/format, ruff/biome version probes, biome CLI format) via **async `execFile`** with content piped to stdin, so the event loop stays free and any caller timeout can actually fire.
- Add a hard per-subprocess `timeout` (60s) so a genuinely wedged tool can't stall generation.
- Set **`UV_LOCK_TIMEOUT`** (default 20s, honouring any user-provided override) on ruff invocations so uv cache-lock contention fails fast rather than waiting minutes.
- Switch command construction from shell strings to argv arrays (`execFile`), and never adopt stdout from a killed (timed-out) process, since it may be partial.

Net effect: transient lock contention resolves in a bounded, short wait; a stuck tool degrades to a skipped format (the existing `catch` blocks) rather than an unbounded hang.

### Description of how you validated changes

- `format.spec.ts` passes 14/14 against a clean `origin/main` base (~6s), and the file is clean under Biome and `tsc`.
- Reproduced the original hang: holding the uv cache lock while running the spec left it running past 170s with no output (well beyond the 120s `testTimeout`).
- With the fix, exercised under lock contention:
  - lock held 12s and 18s (under the 20s timeout): **pass** (~15s / ~21s) — rides out the transient contention.
  - lock thrashing (2s hold / 0.2s gap): **pass** (~34s).
  - lock held permanently (worst case): **bounded** — completes in ~43s with formatting-dependent assertions failing loudly rather than hanging (a re-run on a freed lock passes).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
