### PR TITLE
fix(ts#project): add biome format target wired into lint

### DIFF
--- a/e2e/project.json
+++ b/e2e/project.json
@@ -8,10 +8,27 @@
     "build": {
       "dependsOn": ["lint"]
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "options": {
+        "command": "biome format {projectRoot}/src"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}/src"
+        },
+        "skip-lint": {
+          "command": "true"
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}/src"
       },

--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -370,7 +370,10 @@ describe('smoke test - cdk-deploy', () => {
         findOutput('PyMcpServerArn'),
         'Python MCP Server',
       );
-      await invokeAgentCoreNoAuthDenied(findOutput('PyAgentArn'), 'Python Agent');
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('PyAgentArn'),
+        'Python Agent',
+      );
       await invokeAgentCoreNoAuthDenied(
         findOutput('TsAgentArn'),
         'TypeScript Agent',

--- a/e2e/src/smoke-tests/idempotency.spec.ts
+++ b/e2e/src/smoke-tests/idempotency.spec.ts
@@ -81,7 +81,9 @@ describe('smoke test - idempotency', () => {
     // initial commit. The generated .gitignore keeps node_modules / build
     // output out of the snapshot. --no-verify skips the git-secrets hook.
     git('add -A');
-    git('-c user.name=e2e -c user.email=e2e@example.com commit -m baseline --no-verify');
+    git(
+      '-c user.name=e2e -c user.email=e2e@example.com commit -m baseline --no-verify',
+    );
 
     // Second pass — re-run the exact same matrix on the committed workspace.
     await runCLI(

--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -591,10 +591,13 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
       // Ensure the Playwright browser is available for the integration test.
       await installChromium();
 
-      // Lint fix + build
+      // Lint fix + build. Use `--configuration=fix` (the vended convenience
+      // script's flag) rather than the `--fix` passthrough: the fix
+      // configuration propagates through the lint -> format dependency so the
+      // format target writes its changes too, matching how users run it.
       await runCLI(`sync --verbose`, opts);
       await runCLI(
-        `run-many --target lint --all --fix --output-style=stream`,
+        `run-many --target lint --all --configuration=fix --output-style=stream`,
         opts,
       );
       await runCLI(

--- a/e2e/src/smoke-tests/mcp-server.spec.ts
+++ b/e2e/src/smoke-tests/mcp-server.spec.ts
@@ -92,7 +92,8 @@ describe('smoke test - mcp-server', () => {
         name: 'add-to-existing-project',
         arguments: {
           packageManager: 'pnpm',
-          errorMessage: 'IaC provider "inherit" requires iac.provider to be set',
+          errorMessage:
+            'IaC provider "inherit" requires iac.provider to be set',
         },
       });
       const existingText = (existingResult.content[0] as { text: string }).text;

--- a/e2e/src/smoke-tests/nx-plugin.spec.ts
+++ b/e2e/src/smoke-tests/nx-plugin.spec.ts
@@ -6,7 +6,7 @@
 import { existsSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
-import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 /**
@@ -24,18 +24,21 @@ describe('smoke test - nx-plugin', () => {
   const targetDir = `${tmpProjPath()}/nx-plugin-${pkgMgr}`;
   let projectRoot: string;
 
-  beforeAll(async () => {
-    if (existsSync(targetDir)) {
-      rmSync(targetDir, { force: true, recursive: true });
-    }
-    ensureDirSync(targetDir);
-    projectRoot = await createTestWorkspace(
-      pkgMgr,
-      targetDir,
-      'nx-plugin-test',
-      'cdk',
-    );
-  }, 15 * 60 * 1000);
+  beforeAll(
+    async () => {
+      if (existsSync(targetDir)) {
+        rmSync(targetDir, { force: true, recursive: true });
+      }
+      ensureDirSync(targetDir);
+      projectRoot = await createTestWorkspace(
+        pkgMgr,
+        targetDir,
+        'nx-plugin-test',
+        'cdk',
+      );
+    },
+    15 * 60 * 1000,
+  );
 
   afterAll(() => {
     if (existsSync(targetDir)) {

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -14,10 +14,27 @@
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "options": {
+        "command": "biome format {projectRoot}/src"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}/src"
+        },
+        "skip-lint": {
+          "command": "true"
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}/src"
       },

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -41,10 +41,27 @@
         ]
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "options": {
+        "command": "biome format {projectRoot}/src"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}/src"
+        },
+        "skip-lint": {
+          "command": "true"
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}/src"
       },

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -207,6 +207,24 @@ exports[`infra generator > should configure project.json with correct targets > 
         "cwd": "{projectRoot}",
       },
     },
+    "format": {
+      "cache": true,
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}",
+        },
+        "skip-lint": {
+          "command": "node -e """,
+        },
+      },
+      "executor": "nx:run-commands",
+      "inputs": [
+        "biome",
+      ],
+      "options": {
+        "command": "biome format {projectRoot}",
+      },
+    },
     "lint": {
       "cache": true,
       "configurations": {
@@ -217,6 +235,9 @@ exports[`infra generator > should configure project.json with correct targets > 
           "command": "node -e """,
         },
       },
+      "dependsOn": [
+        "format",
+      ],
       "executor": "nx:run-commands",
       "inputs": [
         "biome",
@@ -763,6 +784,24 @@ exports[`infra generator > should handle custom project names correctly > custom
         "cwd": "{projectRoot}",
       },
     },
+    "format": {
+      "cache": true,
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}",
+        },
+        "skip-lint": {
+          "command": "node -e """,
+        },
+      },
+      "executor": "nx:run-commands",
+      "inputs": [
+        "biome",
+      ],
+      "options": {
+        "command": "biome format {projectRoot}",
+      },
+    },
     "lint": {
       "cache": true,
       "configurations": {
@@ -773,6 +812,9 @@ exports[`infra generator > should handle custom project names correctly > custom
           "command": "node -e """,
         },
       },
+      "dependsOn": [
+        "format",
+      ],
       "executor": "nx:run-commands",
       "inputs": [
         "biome",

--- a/packages/nx-plugin/src/open-api/ts-client/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.ts
@@ -80,12 +80,10 @@ export const generateOpenApiTsClient = (
   data: CodeGenData,
   outputPath: string,
 ) => {
-  generateFiles(
-    tree,
-    path.join(import.meta.dirname, 'files'),
-    outputPath,
-    { ...data, ...esmVars(tree) },
-  );
+  generateFiles(tree, path.join(import.meta.dirname, 'files'), outputPath, {
+    ...data,
+    ...esmVars(tree),
+  });
 };
 
 export default openApiTsClientGenerator;

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
@@ -39,12 +39,10 @@ export const generateOpenApiTsHooks = (
   data: CodeGenData,
   outputPath: string,
 ) => {
-  generateFiles(
-    tree,
-    path.join(import.meta.dirname, 'files'),
-    outputPath,
-    { ...data, ...esmVars(tree) },
-  );
+  generateFiles(tree, path.join(import.meta.dirname, 'files'), outputPath, {
+    ...data,
+    ...esmVars(tree),
+  });
 };
 
 export default openApiTsHooksGenerator;

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -776,12 +776,18 @@ describe('openapi codegen data utils', () => {
             Cat: {
               type: 'object',
               required: ['kind'],
-              properties: { kind: { type: 'string' }, meow: { type: 'boolean' } },
+              properties: {
+                kind: { type: 'string' },
+                meow: { type: 'boolean' },
+              },
             },
             Dog: {
               type: 'object',
               required: ['kind'],
-              properties: { kind: { type: 'string' }, bark: { type: 'boolean' } },
+              properties: {
+                kind: { type: 'string' },
+                bark: { type: 'boolean' },
+              },
             },
             Animal: {
               oneOf: [
@@ -886,12 +892,18 @@ describe('openapi codegen data utils', () => {
             Cat: {
               type: 'object',
               required: ['kind'],
-              properties: { kind: { type: 'string' }, meow: { type: 'boolean' } },
+              properties: {
+                kind: { type: 'string' },
+                meow: { type: 'boolean' },
+              },
             },
             Dog: {
               type: 'object',
               required: ['kind'],
-              properties: { kind: { type: 'string' }, bark: { type: 'boolean' } },
+              properties: {
+                kind: { type: 'string' },
+                bark: { type: 'boolean' },
+              },
             },
             Animal: {
               oneOf: [
@@ -1013,12 +1025,18 @@ describe('openapi codegen data utils', () => {
             'pet-cat': {
               type: 'object',
               required: ['kind'],
-              properties: { kind: { type: 'string' }, meow: { type: 'boolean' } },
+              properties: {
+                kind: { type: 'string' },
+                meow: { type: 'boolean' },
+              },
             },
             'pet-dog': {
               type: 'object',
               required: ['kind'],
-              properties: { kind: { type: 'string' }, bark: { type: 'boolean' } },
+              properties: {
+                kind: { type: 'string' },
+                bark: { type: 'boolean' },
+              },
             },
             Animal: {
               oneOf: [

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -291,7 +291,8 @@ exports[`preset generator > should run successfully > biome.json 1`] = `
       "!**/.venv",
       "!**/*.css",
       "!**/*.gen.*",
-      "!**/generated/**"
+      "!**/generated/**",
+      "!**/tsconfig*.json"
     ]
   }
 }

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -289,7 +289,8 @@ exports[`preset generator > should run successfully > biome.json 1`] = `
       "!**/node_modules",
       "!**/.nx",
       "!**/.venv",
-      "!**/*.css"
+      "!**/*.css",
+      "!**/*.gen.*"
     ]
   }
 }

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -290,7 +290,8 @@ exports[`preset generator > should run successfully > biome.json 1`] = `
       "!**/.nx",
       "!**/.venv",
       "!**/*.css",
-      "!**/*.gen.*"
+      "!**/*.gen.*",
+      "!**/generated/**"
     ]
   }
 }

--- a/packages/nx-plugin/src/py/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { CONTAINER_VERSIONS } from '../../utils/versions';
 import { resolveContainers } from '../../utils/containers';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { readProjectConfigurationUnqualified } from '../../utils/nx';
@@ -12,6 +11,7 @@ import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
 } from '../../utils/test';
+import { CONTAINER_VERSIONS } from '../../utils/versions';
 import { PY_RDB_GENERATOR_INFO, pyRdbGenerator } from './generator';
 
 vi.mock('../../utils/containers', () => ({
@@ -200,7 +200,9 @@ describe('py#rdb generator', () => {
     expect(projectConfig.targets.trivy).toEqual({
       cache: true,
       inputs: ['default', '^production'],
-      outputs: ['{workspaceRoot}/dist/packages/db/trivy/proj-db-migration-latest'],
+      outputs: [
+        '{workspaceRoot}/dist/packages/db/trivy/proj-db-migration-latest',
+      ],
       executor: 'nx:run-commands',
       options: {
         commands: [

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1491,10 +1491,27 @@ exports[`tsSmithyApiGenerator > should generate smithy ts api with default optio
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["biome"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}"
       },

--- a/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lib/__snapshots__/generator.spec.ts.snap
@@ -95,10 +95,27 @@ exports[`ts lib generator > should generate library with custom directory > cust
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["biome"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}"
       },
@@ -163,10 +180,27 @@ exports[`ts lib generator > should generate library with default options > proje
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["biome"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}"
       },
@@ -229,10 +263,27 @@ exports[`ts lib generator > should generate library with subdirectory > subdir-p
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["biome"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}"
       },

--- a/packages/nx-plugin/src/ts/lib/biome.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/biome.spec.ts
@@ -30,7 +30,27 @@ describe('configureBiomeLint', () => {
     expect(targets.lint.inputs).toEqual(['biome']);
   });
 
-  it('should make the lint target a no-op when there is no root biome.json', async () => {
+  it('should configure a biome format target when a root biome.json exists', () => {
+    const { targets } = readProjectConfiguration(tree, '@proj/test');
+    expect(targets.format.executor).toBe('nx:run-commands');
+    // The base format target checks formatting (does not write)
+    expect(targets.format.options.command).toBe('biome format {projectRoot}');
+    expect(targets.format.configurations.fix.command).toBe(
+      'biome format --write {projectRoot}',
+    );
+    // skip-lint must be a cross-platform no-op (`true` is unavailable on Windows)
+    expect(targets.format.configurations['skip-lint'].command).toBe(
+      'node -e ""',
+    );
+    expect(targets.format.inputs).toEqual(['biome']);
+  });
+
+  it('should make the lint target depend on the format target', () => {
+    const { targets } = readProjectConfiguration(tree, '@proj/test');
+    expect(targets.lint.dependsOn).toContain('format');
+  });
+
+  it('should make the lint and format targets no-ops when there is no root biome.json', async () => {
     tree.delete('biome.json');
     await configureBiomeLint(tree, {
       dir: 'test',
@@ -38,5 +58,6 @@ describe('configureBiomeLint', () => {
     });
     const { targets } = readProjectConfiguration(tree, '@proj/test');
     expect(targets.lint).toEqual({ executor: 'nx:noop' });
+    expect(targets.format).toEqual({ executor: 'nx:noop' });
   });
 });

--- a/packages/nx-plugin/src/ts/lib/biome.ts
+++ b/packages/nx-plugin/src/ts/lib/biome.ts
@@ -21,9 +21,11 @@ export const configureBiomeLint = async (
     options.fullyQualifiedName,
   );
 
+  const biomeConfigured = tree.exists('biome.json');
+
   // When there's no root Biome configuration (eg the user removed it), make the
   // lint target a no-op rather than failing on a missing config.
-  const lintTarget = tree.exists('biome.json')
+  const lintTarget = biomeConfigured
     ? {
         executor: 'nx:run-commands',
         cache: true,
@@ -40,15 +42,44 @@ export const configureBiomeLint = async (
             command: 'node -e ""',
           },
         },
+        // Format before linting so any fixable formatting issues (eg line too
+        // long) are resolved first, mirroring the Python project generator.
+        dependsOn: ['format'],
+      }
+    : { executor: 'nx:noop' };
+
+  // The base format target checks formatting (failing when files aren't
+  // formatted); the `fix` configuration writes the changes. `skip-lint` is a
+  // no-op so `nx lint --configuration=skip-lint` propagates cleanly through the
+  // lint -> format dependency edge.
+  const formatTarget = biomeConfigured
+    ? {
+        executor: 'nx:run-commands',
+        cache: true,
+        inputs: ['biome'],
+        options: {
+          command: 'biome format {projectRoot}',
+        },
+        configurations: {
+          fix: {
+            command: 'biome format --write {projectRoot}',
+          },
+          'skip-lint': {
+            // Cross-platform no-op (`true` is not available on Windows cmd).
+            command: 'node -e ""',
+          },
+        },
       }
     : { executor: 'nx:noop' };
 
   updateProjectConfiguration(tree, options.fullyQualifiedName, {
     ...projectJson,
-    // Sort targets so the lint target lands in a deterministic position
-    // regardless of whether it already existed (keeps re-runs stable)
+    // Sort targets so the lint and format targets land in deterministic
+    // positions regardless of whether they already existed (keeps re-runs
+    // stable)
     targets: sortObjectKeys({
       ...projectJson?.targets,
+      format: formatTarget,
       lint: lintTarget,
     }),
   });

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1003,7 +1003,8 @@ exports[`react-website generator > Tanstack router integration > should generate
       "!**/node_modules",
       "!**/.nx",
       "!**/.venv",
-      "!**/*.css"
+      "!**/*.css",
+      "!**/*.gen.*"
     ]
   }
 }
@@ -2687,7 +2688,8 @@ exports[`react-website generator > Tanstack router integration > should generate
       "!**/node_modules",
       "!**/.nx",
       "!**/.venv",
-      "!**/*.css"
+      "!**/*.css",
+      "!**/*.gen.*"
     ]
   }
 }

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1005,7 +1005,8 @@ exports[`react-website generator > Tanstack router integration > should generate
       "!**/.venv",
       "!**/*.css",
       "!**/*.gen.*",
-      "!**/generated/**"
+      "!**/generated/**",
+      "!**/tsconfig*.json"
     ]
   }
 }
@@ -2691,7 +2692,8 @@ exports[`react-website generator > Tanstack router integration > should generate
       "!**/.venv",
       "!**/*.css",
       "!**/*.gen.*",
-      "!**/generated/**"
+      "!**/generated/**",
+      "!**/tsconfig*.json"
     ]
   }
 }

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1004,7 +1004,8 @@ exports[`react-website generator > Tanstack router integration > should generate
       "!**/.nx",
       "!**/.venv",
       "!**/*.css",
-      "!**/*.gen.*"
+      "!**/*.gen.*",
+      "!**/generated/**"
     ]
   }
 }
@@ -2689,7 +2690,8 @@ exports[`react-website generator > Tanstack router integration > should generate
       "!**/.nx",
       "!**/.venv",
       "!**/*.css",
-      "!**/*.gen.*"
+      "!**/*.gen.*",
+      "!**/generated/**"
     ]
   }
 }

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1207,10 +1207,27 @@ exports[`react-website generator > Tanstack router integration > should generate
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["biome"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}"
       },
@@ -2182,6 +2199,22 @@ exports[`react-website generator > Tanstack router integration > should generate
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
@@ -2196,7 +2229,8 @@ exports[`react-website generator > Tanstack router integration > should generate
         "skip-lint": {
           "command": "node -e \\"\\""
         }
-      }
+      },
+      "dependsOn": ["format"]
     },
     "load:runtime-config": {
       "executor": "nx:run-commands",
@@ -2862,10 +2896,27 @@ exports[`react-website generator > Tanstack router integration > should generate
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
       "inputs": ["biome"],
+      "dependsOn": ["format"],
       "options": {
         "command": "biome lint {projectRoot}"
       },
@@ -3837,6 +3888,22 @@ exports[`react-website generator > Tanstack router integration > should generate
         "cwd": "{projectRoot}"
       }
     },
+    "format": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["biome"],
+      "options": {
+        "command": "biome format {projectRoot}"
+      },
+      "configurations": {
+        "fix": {
+          "command": "biome format --write {projectRoot}"
+        },
+        "skip-lint": {
+          "command": "node -e \\"\\""
+        }
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "cache": true,
@@ -3851,7 +3918,8 @@ exports[`react-website generator > Tanstack router integration > should generate
         "skip-lint": {
           "command": "node -e \\"\\""
         }
-      }
+      },
+      "dependsOn": ["format"]
     },
     "load:runtime-config": {
       "executor": "nx:run-commands",

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -2006,9 +2006,13 @@ exports[`react-website generator > Tanstack router integration > should generate
     "emitDeclarationOnly": false,
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "references": [],
   "exclude": [
     "vite.config.ts",
@@ -2449,7 +2453,9 @@ exports[`react-website generator > Tanstack router integration > should generate
     "outDir": "../dist/test-app/tsc",
     "tsBuildInfoFile": "../dist/test-app/tsc/tsconfig.lib.tsbuildinfo",
     "jsx": "react-jsx",
-    "lib": ["DOM"],
+    "lib": [
+      "DOM"
+    ],
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
@@ -2476,7 +2482,12 @@ exports[`react-website generator > Tanstack router integration > should generate
     "vitest.config.ts",
     "vitest.config.mts"
   ],
-  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+  "include": [
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
 }
 "
 `;
@@ -2597,8 +2608,12 @@ exports[`react-website generator > Tanstack router integration > should generate
 "{
   "compilerOptions": {
     "paths": {
-      ":proj/test-app": ["./test-app/src/index.ts"],
-      ":proj/common-constructs": ["./packages/common/constructs/src/index.ts"]
+      ":proj/test-app": [
+        "./test-app/src/index.ts"
+      ],
+      ":proj/common-constructs": [
+        "./packages/common/constructs/src/index.ts"
+      ]
     },
     "composite": true,
     "rootDir": "."
@@ -3698,9 +3713,13 @@ exports[`react-website generator > Tanstack router integration > should generate
     "emitDeclarationOnly": false,
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "references": [],
   "exclude": [
     "vite.config.ts",
@@ -4325,7 +4344,9 @@ exports[`react-website generator > Tanstack router integration > should generate
     "outDir": "../dist/test-app/tsc",
     "tsBuildInfoFile": "../dist/test-app/tsc/tsconfig.lib.tsbuildinfo",
     "jsx": "react-jsx",
-    "lib": ["DOM"],
+    "lib": [
+      "DOM"
+    ],
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
@@ -4352,7 +4373,12 @@ exports[`react-website generator > Tanstack router integration > should generate
     "vitest.config.ts",
     "vitest.config.mts"
   ],
-  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+  "include": [
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
 }
 "
 `;
@@ -4482,8 +4508,12 @@ exports[`react-website generator > Tanstack router integration > should generate
 "{
   "compilerOptions": {
     "paths": {
-      ":proj/test-app": ["./test-app/src/index.ts"],
-      ":proj/common-constructs": ["./packages/common/constructs/src/index.ts"]
+      ":proj/test-app": [
+        "./test-app/src/index.ts"
+      ],
+      ":proj/common-constructs": [
+        "./packages/common/constructs/src/index.ts"
+      ]
     },
     "composite": true,
     "rootDir": "."

--- a/packages/nx-plugin/src/ts/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.spec.ts
@@ -216,4 +216,27 @@ describe('ts-sync generator', () => {
     });
     expect(result).toEqual({});
   });
+
+  it('should not format the tree (sync must have no formatting side effects)', async () => {
+    // Writing files (formatting or otherwise) that the caller did not ask for
+    // is a surprising side effect of `nx sync`, so the generator only syncs
+    // path aliases. tsconfigs are excluded from the biome format target
+    // instead, so their formatting does not need policing here.
+    writeJson('tsconfig.base.json', { compilerOptions: { paths: {} } });
+    addProjectConfiguration(tree, 'proj', {
+      root: 'packages/proj',
+      targets: {},
+    });
+    // No compilerOptions.paths to sync, and deliberately unformatted (expanded
+    // array, no trailing newline).
+    const unformatted =
+      '{\n  "include": [\n    "src/**/*.ts",\n    "src/**/*.tsx"\n  ]\n}';
+    tree.write('packages/proj/tsconfig.json', unformatted);
+
+    const result = await tsSyncGeneratorGenerator(tree);
+
+    expect(result).toEqual({});
+    // Left exactly as written — the generator did not reformat it.
+    expect(tree.read('packages/proj/tsconfig.json', 'utf-8')).toBe(unformatted);
+  });
 });

--- a/packages/nx-plugin/src/ts/sync/generator.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.ts
@@ -13,7 +13,6 @@ import {
 import type { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
 import { relative } from 'path';
 import PackageJson from '../../../package.json' with { type: 'json' };
-import { formatFilesInSubtree } from '../../utils/format';
 import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx';
 
 export const TS_SYNC_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
@@ -60,8 +59,6 @@ export const tsSyncGeneratorGenerator = async (
   if (Object.keys(changesByConfigFile).length === 0) {
     return {};
   }
-
-  await formatFilesInSubtree(tree);
 
   return {
     outOfSyncMessage: buildOutOfSyncMessage(changesByConfigFile),

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -22,7 +22,9 @@ const normalizeModuleSpecifier = (tree: Tree, from: string): string => {
     return from;
   }
   const isRelative = from.startsWith('./') || from.startsWith('../');
-  return isRelative && from.endsWith('.js') ? from.slice(0, -'.js'.length) : from;
+  return isRelative && from.endsWith('.js')
+    ? from.slice(0, -'.js'.length)
+    : from;
 };
 
 // Pin the gritql native library's "global" stdlib directory to <workspace>/.grit so it doesn't try to write to /usr/local/.grit (or wherever node's grandparent resolves to).

--- a/packages/nx-plugin/src/utils/docker.spec.ts
+++ b/packages/nx-plugin/src/utils/docker.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { type ProjectConfiguration, type Tree } from '@nx/devkit';
+import type { ProjectConfiguration, Tree } from '@nx/devkit';
 import { addDockerScanTarget } from './docker';
 import { createTreeUsingTsSolutionSetup } from './test';
 import { CONTAINER_VERSIONS } from './versions';
@@ -85,9 +85,8 @@ describe('docker utils', () => {
         imageTags: ['scope-my-agent:latest'],
       });
 
-      const joined = project.targets['my-agent-trivy'].options.commands.join(
-        '\n',
-      );
+      const joined =
+        project.targets['my-agent-trivy'].options.commands.join('\n');
       expect(joined).toContain(
         `public.ecr.aws/aquasecurity/trivy:${CONTAINER_VERSIONS.trivy}`,
       );
@@ -122,9 +121,8 @@ describe('docker utils', () => {
         imageTags: ['scope-my-agent:latest'],
       });
 
-      const joined = project.targets['my-agent-trivy'].options.commands.join(
-        '\n',
-      );
+      const joined =
+        project.targets['my-agent-trivy'].options.commands.join('\n');
       expect(joined).toContain('finch save');
       expect(joined).toContain('finch run --rm');
       expect(joined).not.toContain('docker save');

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -107,6 +107,7 @@ export const DEFAULT_BIOME_CONFIG = {
       '!**/.nx',
       '!**/.venv',
       '!**/*.css',
+      '!**/*.gen.*',
     ],
   },
 };

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -109,6 +109,7 @@ export const DEFAULT_BIOME_CONFIG = {
       '!**/*.css',
       '!**/*.gen.*',
       '!**/generated/**',
+      '!**/tsconfig*.json',
     ],
   },
 };

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -128,6 +128,10 @@ const BIOME_FORMATTABLE_EXTENSIONS = new Set([
   '.css',
 ]);
 
+/** Matches `tsconfig.json` and variants like `tsconfig.lib.json`. */
+const isTsConfig = (filePath: string): boolean =>
+  /(^|\/)tsconfig[^/]*\.json$/.test(filePath);
+
 /**
  * Format files in the given directory within the tree.
  * Handles both TypeScript/JavaScript/JSON (via biome) and Python (via ruff) files.
@@ -143,8 +147,15 @@ export async function formatFilesInSubtree(
     .filter((file) => (dir ? file.path.startsWith(dir) : true));
 
   const pyFiles = changedFiles.filter((file) => file.path.endsWith('.py'));
-  const otherFiles = changedFiles.filter((file) =>
-    BIOME_FORMATTABLE_EXTENSIONS.has(path.extname(file.path)),
+  const otherFiles = changedFiles.filter(
+    (file) =>
+      BIOME_FORMATTABLE_EXTENSIONS.has(path.extname(file.path)) &&
+      // tsconfigs are not biome-managed: they're excluded from the vended
+      // format target (Nx's typescript-sync rewrites them without formatting),
+      // so formatting them at generation would only diverge from the form
+      // written on later runs. Leave them as updateJson/writeJson emit them so
+      // repeated generation stays idempotent.
+      !isTsConfig(file.path),
   );
 
   // Resolve each project's ruff settings (module names, line-length) so files

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -108,6 +108,7 @@ export const DEFAULT_BIOME_CONFIG = {
       '!**/.venv',
       '!**/*.css',
       '!**/*.gen.*',
+      '!**/generated/**',
     ],
   },
 };


### PR DESCRIPTION
### Reason for this change

The biome `lint` target's base command (`biome lint`) only checks lint rules — it never checks formatting. Only the `fix` configuration (`biome check --write`) formatted, so **formatting was never verified in CI**. Unformatted code could (and did) merge to main without any target flagging it. Python projects already have a dedicated `format` target that `lint` depends on; TypeScript had no equivalent.

### Description of changes

Add a biome `format` target and wire it into `lint`, mirroring the Python project generator:

- **base `format`** = `biome format` (check-only, fails when files aren't formatted)
- **`fix`** configuration = `biome format --write`
- **`skip-lint`** configuration = cross-platform no-op
- **`lint` now `dependsOn: ["format"]`** so formatting runs first (resolving fixable issues like line-too-long before linting)

Because Nx propagates `--configuration` down `dependsOn` edges, `nx lint --configuration=fix|skip-lint` runs the matching `format` configuration. The `lint:fix` command is unchanged (`biome check --write`, which also runs biome's import-organizing assist).

Applied to **vended TypeScript projects** via `configureBiomeLint` (`ts/lib/biome.ts`) — used by all TS generators (lib, react-website, nx-plugin, nx-generator, shadcn); both targets become `nx:noop` when there's no root `biome.json` — and to **the plugin's own projects** (`packages/nx-plugin`, `packages/create-nx-workspace`, `e2e`).

**Files excluded from the vended biome config** (`files.includes`), because a check-based target must not fail on files the project doesn't hand-author cleanly:

- `**/*.gen.*` and `**/generated/**` — code-generated output (OpenAPI clients, TanStack `routeTree.gen.ts`, Prisma), which the codegen tools ask to exclude from linters/formatters. Matches the license generator's existing exclusion.
- `**/tsconfig*.json` — Nx's built-in `@nx/js:typescript-sync` rewrites tsconfig references (expanded arrays, no trailing newline) as part of `nx sync`, which a check-based target would flag. Biome's `files.includes` can't distinguish check from write, so these are excluded outright rather than policed.

The `ts#sync` generator no longer formats the tree: reformatting files as a side effect of `nx sync` is surprising and unwanted, and with tsconfigs excluded it is unnecessary — sync now only syncs path aliases and is idempotent.

Adding the target surfaced several pre-existing unformatted files (in `open-api`, `utils`, `py/rdb`, and `e2e` specs), which are formatted in this PR.

### Description of how you validated changes

- Full plugin test suite green (`nx run @aws/nx-plugin:test`): 2648 tests, no obsolete snapshots. Added `biome.spec.ts` tests for the `format` target and `lint → format` dependency, and a `ts#sync` test asserting sync has no formatting side effect.
- End-to-end in a real generated workspace (locally built plugin): generated a react-website + api + connection, then:
  - `nx sync` changes only tsconfig path aliases and is idempotent (a second sync is a no-op) — no formatting side effect.
  - `nx run-many --target format --all` and `--target lint --all` pass; a direct `biome format --check` on `tsconfig.app.json` exits non-zero, confirming the exclusion is what lets the target pass.
- CI smoke tests (react-website, local-dev, fast-api, smithy-api, infra-none, etc.) green.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
