### PR TITLE
test(e2e): assert unauthenticated (no SigV4) requests are denied

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -12,10 +12,13 @@ import {
   invokeAgentCoreA2a,
   invokeAgentCoreAgent,
   invokeAgentCoreAgUi,
+  invokeAgentCoreGatewayNoAuthDenied,
   invokeAgentCoreGatewayTool,
   invokeAgentCoreMcp,
+  invokeAgentCoreNoAuthDenied,
   invokeCustomAuthApi,
   invokeCustomAuthTrpcApi,
+  invokeIamApiNoAuthDenied,
   invokeLambda,
   invokeRestApi,
   invokeTrpcAgentCoreAgent,
@@ -218,6 +221,28 @@ describe('smoke test - cdk-deploy', () => {
         'FastAPI HTTP Custom Auth',
       );
 
+      // IAM-auth APIs — unsigned (no SigV4) requests must be denied
+      await invokeIamApiNoAuthDenied(
+        findOutput('MyApiEndpoint'),
+        'tRPC REST API',
+      );
+      await invokeIamApiNoAuthDenied(
+        findOutput('MyApiHttpMyApiHttpUrl'),
+        'tRPC HTTP API',
+      );
+      await invokeIamApiNoAuthDenied(
+        findOutput('PyApiEndpoint'),
+        'FastAPI REST',
+      );
+      await invokeIamApiNoAuthDenied(
+        findOutput('PyApiHttpPyApiHttpUrl'),
+        'FastAPI HTTP',
+      );
+      await invokeIamApiNoAuthDenied(
+        findOutput('MySmithyApiEndpoint'),
+        'Smithy REST',
+      );
+
       // MCP
       await invokeAgentCoreMcp(
         findOutput('TsMcpServerArn'),
@@ -332,6 +357,47 @@ describe('smoke test - cdk-deploy', () => {
         'my-gateway___hosted-mcp-server___divide',
         { a: 6, b: 2 },
         '3',
+      );
+
+      // AgentCore runtimes and gateway — unsigned (no SigV4) requests must be
+      // denied across every MCP server, agent (HTTP/AG-UI/tRPC), A2A runtime
+      // and the gateway.
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('TsMcpServerArn'),
+        'TypeScript MCP Server',
+      );
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('PyMcpServerArn'),
+        'Python MCP Server',
+      );
+      await invokeAgentCoreNoAuthDenied(findOutput('PyAgentArn'), 'Python Agent');
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('TsAgentArn'),
+        'TypeScript Agent',
+      );
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('PyLangchainAgentArn'),
+        'Python LangChain Agent (AG-UI)',
+      );
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('PyLangchainHttpAgentArn'),
+        'Python LangChain Agent (HTTP)',
+      );
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('TsA2aAgentArn'),
+        'TypeScript A2A Agent',
+      );
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('PyA2aAgentArn'),
+        'Python A2A Agent',
+      );
+      await invokeAgentCoreNoAuthDenied(
+        findOutput('PyLangchainA2aAgentArn'),
+        'Python LangChain A2A Agent',
+      );
+      await invokeAgentCoreGatewayNoAuthDenied(
+        findOutput('ParentGatewayUrl'),
+        'Parent Gateway',
       );
 
       // Lambda functions

--- a/e2e/src/smoke-tests/deploy-invocations.ts
+++ b/e2e/src/smoke-tests/deploy-invocations.ts
@@ -426,6 +426,76 @@ export async function invokeCustomAuthTrpcApi(
   expect([401, 403]).toContain(response.status);
 }
 
+/**
+ * IAM-authorized (SigV4) API Gateway endpoints must reject an unsigned request.
+ * API Gateway returns 403 ("Missing Authentication Token" / "Forbidden") when
+ * the SigV4 signature is absent, so a bare fetch should never reach the
+ * integration. Covers both the tRPC (`?input=`) and REST/FastAPI/Smithy
+ * (`?message=`) shapes — the query string is irrelevant since auth is rejected
+ * before routing.
+ */
+export async function invokeIamApiNoAuthDenied(
+  apiUrl: string,
+  apiName: string,
+): Promise<void> {
+  console.log(`Testing ${apiName} IAM deny (no SigV4) at ${apiUrl}`);
+  const response = await fetch(`${normalizeApiUrl(apiUrl)}/echo?message=test`);
+  console.log(`${apiName} response status (no auth):`, response.status);
+  expect([401, 403]).toContain(response.status);
+}
+
+/**
+ * AgentCore runtimes require SigV4 (`bedrock-agentcore`). An unsigned invoke
+ * must be denied before the runtime is reached. Used for MCP servers, agents
+ * (HTTP/AG-UI/tRPC) and A2A runtimes alike — all share the same runtime
+ * invocation URL and IAM auth, so an unsigned POST should be rejected
+ * regardless of the body the runtime expects.
+ */
+export async function invokeAgentCoreNoAuthDenied(
+  arn: string,
+  name: string,
+): Promise<void> {
+  console.log(`Testing ${name} AgentCore deny (no SigV4) with ARN ${arn}`);
+  const response = await fetch(buildAgentCoreUrl(arn), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': AGENT_CORE_SESSION_ID,
+    },
+    body: JSON.stringify({ prompt: 'hello' }),
+  });
+  console.log(`${name} response status (no auth):`, response.status);
+  expect([401, 403]).toContain(response.status);
+}
+
+/**
+ * AgentCore Gateways require SigV4 too. An unsigned MCP request to the gateway
+ * URL must be denied before Cedar authorization or tool routing is reached.
+ */
+export async function invokeAgentCoreGatewayNoAuthDenied(
+  gatewayUrl: string,
+  gatewayName: string,
+): Promise<void> {
+  console.log(
+    `Testing ${gatewayName} Gateway deny (no SigV4) at ${gatewayUrl}`,
+  );
+  const response = await fetch(gatewayUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    }),
+  });
+  console.log(`${gatewayName} response status (no auth):`, response.status);
+  expect([401, 403]).toContain(response.status);
+}
+
 export async function pingWebsite(domain: string): Promise<void> {
   console.log('Testing website with domain', domain);
   const status = (await fetch(`https://${domain}/`)).status;

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -12,10 +12,13 @@ import {
   invokeAgentCoreA2a,
   invokeAgentCoreAgent,
   invokeAgentCoreAgUi,
+  invokeAgentCoreGatewayNoAuthDenied,
   invokeAgentCoreGatewayTool,
   invokeAgentCoreMcp,
+  invokeAgentCoreNoAuthDenied,
   invokeCustomAuthApi,
   invokeCustomAuthTrpcApi,
+  invokeIamApiNoAuthDenied,
   invokeLambda,
   invokeRestApi,
   invokeTrpcAgentCoreAgent,
@@ -204,6 +207,28 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
             'FastAPI HTTP Custom Auth',
           );
 
+          // IAM-auth APIs — unsigned (no SigV4) requests must be denied
+          await invokeIamApiNoAuthDenied(
+            outputs.my_api_endpoint,
+            'tRPC REST API',
+          );
+          await invokeIamApiNoAuthDenied(
+            outputs.my_api_http_endpoint,
+            'tRPC HTTP API',
+          );
+          await invokeIamApiNoAuthDenied(
+            outputs.py_api_endpoint,
+            'FastAPI REST',
+          );
+          await invokeIamApiNoAuthDenied(
+            outputs.py_api_http_endpoint,
+            'FastAPI HTTP',
+          );
+          await invokeIamApiNoAuthDenied(
+            outputs.my_smithy_api_endpoint,
+            'Smithy REST',
+          );
+
           // MCP
           await invokeAgentCoreMcp(
             outputs.ts_mcp_server_arn,
@@ -314,6 +339,50 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
             'my-gateway___hosted-mcp-server___divide',
             { a: 6, b: 2 },
             '3',
+          );
+
+          // AgentCore runtimes and gateway — unsigned (no SigV4) requests must
+          // be denied across every MCP server, agent (HTTP/AG-UI/tRPC), A2A
+          // runtime and the gateway.
+          await invokeAgentCoreNoAuthDenied(
+            outputs.ts_mcp_server_arn,
+            'TypeScript MCP Server',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.py_mcp_server_arn,
+            'Python MCP Server',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.py_agent_arn,
+            'Python Agent',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.ts_agent_arn,
+            'TypeScript Agent',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.py_langchain_agent_arn,
+            'Python LangChain Agent (AG-UI)',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.py_langchain_http_agent_arn,
+            'Python LangChain Agent (HTTP)',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.ts_a2a_agent_arn,
+            'TypeScript A2A Agent',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.py_a2a_agent_arn,
+            'Python A2A Agent',
+          );
+          await invokeAgentCoreNoAuthDenied(
+            outputs.py_langchain_a2a_agent_arn,
+            'Python LangChain A2A Agent',
+          );
+          await invokeAgentCoreGatewayNoAuthDenied(
+            outputs.parent_gateway_url,
+            'Parent Gateway',
           );
 
           // Lambda functions


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` and `terraform-deploy` smoke tests only exercised the happy path for IAM/SigV4-protected surfaces — a properly-signed request that should succeed. There was no assertion that an **unsigned** request is actually *denied*. (The custom-auth APIs already had deny-path coverage via `invokeCustomAuth*`, but the IAM-auth APIs and every AgentCore runtime/gateway did not.)

### Description of changes

Added three deny-path helpers to `e2e/src/smoke-tests/deploy-invocations.ts`:

- `invokeIamApiNoAuthDenied` — a bare (unsigned) fetch to an IAM API Gateway endpoint must return 401/403
- `invokeAgentCoreNoAuthDenied` — an unsigned POST to an AgentCore runtime must return 401/403
- `invokeAgentCoreGatewayNoAuthDenied` — an unsigned MCP request to an AgentCore Gateway must return 401/403

Wired them into both deploy specs across every IAM/SigV4 surface:
- **APIs (5):** tRPC REST, tRPC HTTP, FastAPI REST, FastAPI HTTP, Smithy REST
- **AgentCore runtimes (9):** TS + Python MCP servers, Python + TS agents, Python LangChain AG-UI + HTTP agents, TS + Python + Python-LangChain A2A agents
- **Gateway (1):** parent gateway

### Description of how you validated changes

Ran both deploy suites end-to-end against AWS (`nx-e2e` profile), deploying real resources, exercising the new deny-checks, and tearing down:

- **terraform-deploy:** full clean pass (1 passed), 539 resources destroyed on teardown.
- **cdk-deploy:** all new deny-checks passed; stack cleaned up.

Observed results (identical across both IaC flavours):
- All 5 IAM APIs → **403**
- All 9 AgentCore runtimes → **403**
- Parent Gateway → **401**

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
