### PR TITLE
fix(ts#react-website): fix S3 access log delivery to CloudWatch

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -171,6 +171,10 @@ variable "acm_certificate_arn" {
 # connect-src to your specific origins once they are known.
 locals {
   content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+
+  # Delivery source/destination names have a 60 character maximum. Truncate the
+  # website name so the longest delivery name stays within the limit.
+  access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
 }
 
 
@@ -327,13 +331,13 @@ resource "aws_s3_bucket_ownership_controls" "website_ownership" {
 
 # Deliver the website bucket's server access logs to CloudWatch Logs.
 resource "aws_cloudwatch_log_delivery_source" "website" {
-  name         = "\${lower(var.website_name)}-website-access-logs-\${random_id.bucket_suffix.hex}"
+  name         = "\${local.access_logs_name_prefix}-website-logs-\${random_id.bucket_suffix.hex}"
   log_type     = "S3_SERVER_ACCESS_LOGS"
   resource_arn = aws_s3_bucket.website.arn
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "access_logs" {
-  name = "\${lower(var.website_name)}-access-logs-\${random_id.bucket_suffix.hex}"
+  name = "\${local.access_logs_name_prefix}-access-logs-\${random_id.bucket_suffix.hex}"
 
   delivery_destination_configuration {
     destination_resource_arn = aws_cloudwatch_log_group.access_logs.arn
@@ -401,7 +405,7 @@ resource "aws_s3_bucket_acl" "distribution_logs_acl" {
 
 # Deliver the distribution log bucket's server access logs to CloudWatch Logs.
 resource "aws_cloudwatch_log_delivery_source" "distribution_logs" {
-  name         = "\${lower(var.website_name)}-distribution-access-logs-\${random_id.bucket_suffix.hex}"
+  name         = "\${local.access_logs_name_prefix}-distribution-logs-\${random_id.bucket_suffix.hex}"
   log_type     = "S3_SERVER_ACCESS_LOGS"
   resource_arn = aws_s3_bucket.distribution_logs.arn
 }
@@ -1554,6 +1558,7 @@ exports[`react-website generator > Tanstack router integration > should generate
   CfnResource,
   Duration,
   Lazy,
+  Names,
   RemovalPolicy,
   Stack,
 } from 'aws-cdk-lib';
@@ -1866,23 +1871,33 @@ export class StaticWebsite extends Construct {
     bucket: IBucket,
     logGroup: LogGroup,
   ) {
-    const source = new CfnDeliverySource(this, \`\${id}AccessLogsSource\`, {
-      name: \`\${Stack.of(this).stackName}-\${id}-access-logs\`,
-      logType: 'S3_SERVER_ACCESS_LOGS',
-      resourceArn: bucket.bucketArn,
-    });
-    const destination = new CfnDeliveryDestination(
+    const source: CfnDeliverySource = new CfnDeliverySource(
+      this,
+      \`\${id}AccessLogsSource\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(source, { maxLength: 60 }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: bucket.bucketArn,
+      },
+    );
+    const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       \`\${id}AccessLogsDestination\`,
       {
-        name: \`\${Stack.of(this).stackName}-\${id}-access-logs\`,
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(destination, { maxLength: 60 }),
+        }),
         destinationResourceArn: logGroup.logGroupArn,
       },
     );
-    new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
+    const delivery = new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
       deliverySourceName: source.name,
       deliveryDestinationArn: destination.attrArn,
     });
+    delivery.addDependency(source);
   }
 }
 
@@ -3261,6 +3276,7 @@ exports[`react-website generator > Tanstack router integration > should generate
   CfnResource,
   Duration,
   Lazy,
+  Names,
   RemovalPolicy,
   Stack,
 } from 'aws-cdk-lib';
@@ -3573,23 +3589,33 @@ export class StaticWebsite extends Construct {
     bucket: IBucket,
     logGroup: LogGroup,
   ) {
-    const source = new CfnDeliverySource(this, \`\${id}AccessLogsSource\`, {
-      name: \`\${Stack.of(this).stackName}-\${id}-access-logs\`,
-      logType: 'S3_SERVER_ACCESS_LOGS',
-      resourceArn: bucket.bucketArn,
-    });
-    const destination = new CfnDeliveryDestination(
+    const source: CfnDeliverySource = new CfnDeliverySource(
+      this,
+      \`\${id}AccessLogsSource\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(source, { maxLength: 60 }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: bucket.bucketArn,
+      },
+    );
+    const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       \`\${id}AccessLogsDestination\`,
       {
-        name: \`\${Stack.of(this).stackName}-\${id}-access-logs\`,
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(destination, { maxLength: 60 }),
+        }),
         destinationResourceArn: logGroup.logGroupArn,
       },
     );
-    new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
+    const delivery = new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
       deliverySourceName: source.name,
       deliveryDestinationArn: destination.attrArn,
     });
+    delivery.addDependency(source);
   }
 }
 
@@ -4875,6 +4901,7 @@ exports[`react-website generator > should generate shared constructs > common/co
   CfnResource,
   Duration,
   Lazy,
+  Names,
   RemovalPolicy,
   Stack,
 } from 'aws-cdk-lib';
@@ -5187,23 +5214,33 @@ export class StaticWebsite extends Construct {
     bucket: IBucket,
     logGroup: LogGroup,
   ) {
-    const source = new CfnDeliverySource(this, \`\${id}AccessLogsSource\`, {
-      name: \`\${Stack.of(this).stackName}-\${id}-access-logs\`,
-      logType: 'S3_SERVER_ACCESS_LOGS',
-      resourceArn: bucket.bucketArn,
-    });
-    const destination = new CfnDeliveryDestination(
+    const source: CfnDeliverySource = new CfnDeliverySource(
+      this,
+      \`\${id}AccessLogsSource\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(source, { maxLength: 60 }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: bucket.bucketArn,
+      },
+    );
+    const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       \`\${id}AccessLogsDestination\`,
       {
-        name: \`\${Stack.of(this).stackName}-\${id}-access-logs\`,
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(destination, { maxLength: 60 }),
+        }),
         destinationResourceArn: logGroup.logGroupArn,
       },
     );
-    new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
+    const delivery = new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
       deliverySourceName: source.name,
       deliveryDestinationArn: destination.attrArn,
     });
+    delivery.addDependency(source);
   }
 }
 

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/asset-bucket/asset-bucket.tf.template
@@ -34,6 +34,12 @@ resource "random_string" "suffix" {
   upper   = false
 }
 
+locals {
+  # Delivery source/destination names have a 60 character maximum. Truncate the
+  # bucket name prefix so the delivery names stay within the limit.
+  access_logs_name_prefix = substr(var.bucket_name_prefix, 0, 16)
+}
+
 # KMS key encrypting the server access logs delivered to CloudWatch Logs.
 resource "aws_kms_key" "access_logs" {
   description             = "KMS key for ${var.bucket_name_prefix} asset bucket access logs"
@@ -124,13 +130,13 @@ resource "aws_s3_bucket_public_access_block" "assets" {
 
 # Deliver the asset bucket's server access logs to CloudWatch Logs.
 resource "aws_cloudwatch_log_delivery_source" "assets" {
-  name         = "${var.bucket_name_prefix}-access-logs-source-${random_string.suffix.result}"
+  name         = "${local.access_logs_name_prefix}-access-logs-source-${random_string.suffix.result}"
   log_type     = "S3_SERVER_ACCESS_LOGS"
   resource_arn = aws_s3_bucket.assets.arn
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "assets" {
-  name = "${var.bucket_name_prefix}-access-logs-dest-${random_string.suffix.result}"
+  name = "${local.access_logs_name_prefix}-access-logs-dest-${random_string.suffix.result}"
 
   delivery_destination_configuration {
     destination_resource_arn = aws_cloudwatch_log_group.access_logs.arn

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -1,4 +1,12 @@
-import { CfnOutput, CfnResource, Duration, Lazy, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import {
+  CfnOutput,
+  CfnResource,
+  Duration,
+  Lazy,
+  Names,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
 import {
   Distribution,
   HeadersFrameOption,
@@ -302,23 +310,32 @@ export class StaticWebsite extends Construct {
     bucket: IBucket,
     logGroup: LogGroup,
   ) {
-    const source = new CfnDeliverySource(this, `${id}AccessLogsSource`, {
-      name: `${Stack.of(this).stackName}-${id}-access-logs`,
-      logType: 'S3_SERVER_ACCESS_LOGS',
-      resourceArn: bucket.bucketArn,
-    });
-    const destination = new CfnDeliveryDestination(
+    const source: CfnDeliverySource = new CfnDeliverySource(
+      this,
+      `${id}AccessLogsSource`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(source, { maxLength: 60 }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: bucket.bucketArn,
+      },
+    );
+    const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       `${id}AccessLogsDestination`,
       {
-        name: `${Stack.of(this).stackName}-${id}-access-logs`,
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(destination, { maxLength: 60 }),
+        }),
         destinationResourceArn: logGroup.logGroupArn,
       },
     );
-    new CfnDelivery(this, `${id}AccessLogsDelivery`, {
+    const delivery = new CfnDelivery(this, `${id}AccessLogsDelivery`, {
       deliverySourceName: source.name,
       deliveryDestinationArn: destination.attrArn,
     });
+    delivery.addDependency(source);
   }
 }
 

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -42,6 +42,10 @@ variable "acm_certificate_arn" {
 # connect-src to your specific origins once they are known.
 locals {
   content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+
+  # Delivery source/destination names have a 60 character maximum. Truncate the
+  # website name so the longest delivery name stays within the limit.
+  access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
 }
 
 
@@ -198,13 +202,13 @@ resource "aws_s3_bucket_ownership_controls" "website_ownership" {
 
 # Deliver the website bucket's server access logs to CloudWatch Logs.
 resource "aws_cloudwatch_log_delivery_source" "website" {
-  name         = "${lower(var.website_name)}-website-access-logs-${random_id.bucket_suffix.hex}"
+  name         = "${local.access_logs_name_prefix}-website-logs-${random_id.bucket_suffix.hex}"
   log_type     = "S3_SERVER_ACCESS_LOGS"
   resource_arn = aws_s3_bucket.website.arn
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "access_logs" {
-  name = "${lower(var.website_name)}-access-logs-${random_id.bucket_suffix.hex}"
+  name = "${local.access_logs_name_prefix}-access-logs-${random_id.bucket_suffix.hex}"
 
   delivery_destination_configuration {
     destination_resource_arn = aws_cloudwatch_log_group.access_logs.arn
@@ -272,7 +276,7 @@ resource "aws_s3_bucket_acl" "distribution_logs_acl" {
 
 # Deliver the distribution log bucket's server access logs to CloudWatch Logs.
 resource "aws_cloudwatch_log_delivery_source" "distribution_logs" {
-  name         = "${lower(var.website_name)}-distribution-access-logs-${random_id.bucket_suffix.hex}"
+  name         = "${local.access_logs_name_prefix}-distribution-logs-${random_id.bucket_suffix.hex}"
   log_type     = "S3_SERVER_ACCESS_LOGS"
   resource_arn = aws_s3_bucket.distribution_logs.arn
 }


### PR DESCRIPTION
### Reason for this change

The main branch CI `Smoke Tests - cdk-deploy` failed after #953: deploying a website stack fails because the S3 access log delivery resources are misconfigured. Two issues:

1. **Names exceed the 60 character maximum** for `AWS::Logs::DeliverySource` / `DeliveryDestination`. Names were derived from the stack name (CDK) and the website name (Terraform), which pushed them past 60 characters with realistic project names, failing at CloudFormation change set validation.
2. **The CDK `AWS::Logs::Delivery` referenced its delivery source only by name**, so CloudFormation attempted to create the delivery before the source existed ("Requested Delivery Source does not exist").

### Description of changes

- **CDK:** name the delivery source and destination with `Names.uniqueResourceName` (bounded to 60 characters), produced lazily so each resource's name resolves from its own construct address, and add an explicit dependency from the delivery to its source.
- **Terraform:** truncate the website name to a bounded prefix for the delivery resource names (keeping a recognisable per-resource prefix) plus the existing random suffix, so the names stay within the limit regardless of project name length. The asset-bucket module's delivery names use a fixed prefix and were already within the limit.

### Description of how you validated changes

- Updated generator snapshots; full `@aws/nx-plugin` test suite passes (2644 tests).
- Vended a website + CDK infra project in an example workspace with the locally built plugin and **deployed to AWS**: the stack deploys successfully (`CREATE_COMPLETE`), the delivery sources are created with bounded unique names, and both deliveries are active against the KMS-encrypted log group. Confirmed the change set validation and delivery-creation steps that failed on main now succeed. Torn down afterwards.
- Terraform delivery names verified to stay within 60 characters even with a maximum-length website name.

### Issue # (if applicable)

Fixes the `Smoke Tests - cdk-deploy` failure on `main` introduced by #953.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
