### PR TITLE
test(e2e): format generated website integration-test page

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -129,7 +129,7 @@ describe('smoke test - cdk-deploy', () => {
       // Add the browser-driven integration-test page to the website before the
       // build so it is bundled into the deployed site.
       async (projectRoot) => {
-        writeIntegrationTestPage(
+        await writeIntegrationTestPage(
           `${projectRoot}/packages/website`,
           WEBSITE_APIS,
           WEBSITE_AGENTS,

--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -582,7 +582,7 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
       // Add the browser-driven integration-test page to the website. It uses
       // the website's vended hooks to invoke every connected API and agent, so
       // it must be written before the build so its imports resolve.
-      writeIntegrationTestPage(
+      await writeIntegrationTestPage(
         `${projectRoot}/packages/website`,
         WEBSITE_APIS,
         WEBSITE_AGENTS,

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -104,7 +104,7 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
         // application variant deploys the website.
         config.variant === 'terraform-deploy'
           ? async (projectRoot) => {
-              writeIntegrationTestPage(
+              await writeIntegrationTestPage(
                 `${projectRoot}/packages/website`,
                 WEBSITE_APIS,
                 WEBSITE_AGENTS,

--- a/e2e/src/smoke-tests/website-integration.ts
+++ b/e2e/src/smoke-tests/website-integration.ts
@@ -12,8 +12,9 @@ import {
   SetUserPoolMfaConfigCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { generateFiles } from '@nx/devkit';
-import { type Browser, type Page, chromium } from 'playwright';
 import { FsTree, flushChanges } from 'nx/src/generators/tree';
+import { type Browser, chromium, type Page } from 'playwright';
+import { formatFilesInSubtree } from '../../../packages/nx-plugin/src/utils/format';
 
 /**
  * Browser-driven website ↔ API/agent integration test.
@@ -63,13 +64,15 @@ export interface AgentSpec {
  * The page is rendered from `files/website-integration` via the same
  * `generateFiles` + `Tree` machinery the generators use, so only the hooks for
  * the connected APIs/agents are imported and called (satisfying the website's
- * `noUnusedLocals` build).
+ * `noUnusedLocals` build). It is also formatted with the plugin's own
+ * formatter, matching what the generators do, so the website's `format` check
+ * (wired into `build`) passes on the generated page.
  */
-export const writeIntegrationTestPage = (
+export const writeIntegrationTestPage = async (
   websiteRoot: string,
   apis: ApiSpec[],
   agents: AgentSpec[],
-): string => {
+): Promise<string> => {
   const tree = new FsTree(websiteRoot, false);
   generateFiles(
     tree,
@@ -84,6 +87,7 @@ export const writeIntegrationTestPage = (
       ),
     },
   );
+  await formatFilesInSubtree(tree);
   flushChanges(websiteRoot, tree.listChanges());
   return '/integration-test';
 };


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` and `terraform-deploy` smoke test jobs are failing on `main`. Both fail at the same point — the `@e2e-test/website:format` task during the workspace build, before any deploy happens:

```
@e2e-test/website: packages/website/src/routes/integration-test.tsx format ━━━
  × Formatter would have printed the following content:
  ...
  Found 1 error.
```

Root cause: PR #954 wired a biome `format` **check** into `build`. The e2e harness's `writeIntegrationTestPage` writes an `integration-test.tsx` page into the generated website via `generateFiles` + `flushChanges`, but never formats it — unlike the real generators, which run `formatFilesInSubtree` before flushing. When a long agent class name (e.g. `MyPyLangchainHttpAgent`) is connected, its invocation line exceeds biome's 80-column width, so biome would reformat it and the now-wired format check fails. This only manifests in the deploy smoke tests because they connect the long-named agents.

### Description of changes

- `writeIntegrationTestPage` now calls the plugin's own `formatFilesInSubtree(tree)` before `flushChanges`, mirroring exactly what the generators do, so the generated page matches the website's `format` check.
- Made the function `async` and updated its three call sites (`cdk-deploy`, `terraform-deploy`, `local-dev`) to `await` it. All three were already in async contexts.

### Description of how you validated changes

- Reproduced the exact CI failure: rendered the template with the `MyPyLangchainHttpAgent` agent and confirmed `biome format` flags the long invocation line (`Found 1 error`), matching the CI log byte-for-byte.
- Confirmed the fix: rendered the same page through `generateFiles` + `formatFilesInSubtree` + `flushChanges` and verified `biome format` passes (`Checked 1 file ... No fixes applied`).
- Full pre-commit test suite passed locally.

### Issue # (if applicable)

N/A — regression from #954 surfaced only in the deploy smoke tests on `main`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*