### PR TITLE
fix(dynamodb): stop container on log-stream exit

### DIFF
--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -604,9 +604,7 @@ process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 process.on('SIGHUP', cleanup);
 
-logs.on('exit', (code) => {
-  if (!exiting) process.exit(code ?? 0);
-});
+logs.on('exit', cleanup);
 "
 `;
 
@@ -1322,9 +1320,7 @@ process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 process.on('SIGHUP', cleanup);
 
-logs.on('exit', (code) => {
-  if (!exiting) process.exit(code ?? 0);
-});
+logs.on('exit', cleanup);
 "
 `;
 

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -604,9 +604,7 @@ process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 process.on('SIGHUP', cleanup);
 
-logs.on('exit', (code) => {
-  if (!exiting) process.exit(code ?? 0);
-});
+logs.on('exit', cleanup);
 "
 `;
 
@@ -1254,9 +1252,7 @@ process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 process.on('SIGHUP', cleanup);
 
-logs.on('exit', (code) => {
-  if (!exiting) process.exit(code ?? 0);
-});
+logs.on('exit', cleanup);
 "
 `;
 

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/dynamodb/start-container.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/dynamodb/start-container.ts.template
@@ -101,6 +101,4 @@ process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 process.on('SIGHUP', cleanup);
 
-logs.on('exit', (code) => {
-  if (!exiting) process.exit(code ?? 0);
-});
+logs.on('exit', cleanup);

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/rdb/shared/start-container.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/rdb/shared/start-container.ts.template
@@ -112,6 +112,4 @@ process.on("SIGTERM", cleanup);
 process.on("SIGINT", cleanup);
 process.on("SIGHUP", cleanup);
 
-logs.on("exit", () => {
-  if (!exiting) cleanup();
-});
+logs.on("exit", cleanup);


### PR DESCRIPTION
### Reason for this change

The dynamodb `start-container.ts.template` had the same bug fixed for rdb in #892: `logs.on('exit', ...)` called `process.exit(code ?? 0)` directly instead of `cleanup()`. Since the `logs -f` child shares the terminal's signal group, Ctrl+C can reach it directly and race the parent's SIGINT handler — if the log-stream's exit handler won that race, it exited without stopping the container, leaving it running.

### Description of changes

- `dynamodb/start-container.ts.template`: `logs.on('exit', ...)` now calls `cleanup()` instead of exiting directly.
- Simplified both the dynamodb and rdb templates' `logs.on('exit', ...)` handlers to `logs.on('exit', cleanup)` — the extra `if (!exiting)` check was redundant since `cleanup()` already guards re-entry internally.
- Updated corresponding snapshots for the `ts#dynamodb` and `py#dynamodb` generators.

### Description of how you validated changes

Ran the full test suite (`nx run @aws/nx-plugin:test`) — 2653 tests pass, including the `ts#dynamodb` and `py#dynamodb` generator snapshot tests.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*