### PR TITLE
test(py#rdb): source Python dep versions from PY_VERSIONS

### DIFF
--- a/packages/nx-plugin/src/py/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.spec.ts
@@ -11,7 +11,7 @@ import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
 } from '../../utils/test';
-import { CONTAINER_VERSIONS } from '../../utils/versions';
+import { CONTAINER_VERSIONS, withPyVersions } from '../../utils/versions';
 import { PY_RDB_GENERATOR_INFO, pyRdbGenerator } from './generator';
 
 vi.mock('../../utils/containers', () => ({
@@ -55,9 +55,9 @@ describe('py#rdb generator', () => {
     expect(tree.read('packages/db/config.json', 'utf-8')).toMatchSnapshot();
     expect(pyproject).toMatchSnapshot();
 
-    expect(pyproject).toContain('sqlmodel==0.0.38');
-    expect(pyproject).toContain('alembic==1.18.4');
-    expect(pyproject).toContain('asyncpg==0.31.0');
+    expect(pyproject).toContain(withPyVersions(['sqlmodel'])[0]);
+    expect(pyproject).toContain(withPyVersions(['alembic'])[0]);
+    expect(pyproject).toContain(withPyVersions(['asyncpg'])[0]);
     expect(pyproject).not.toContain('psycopg');
     expect(projectConfig.targets['bundle-arm']).toEqual({
       cache: true,
@@ -156,7 +156,7 @@ describe('py#rdb generator', () => {
     await pyRdbGenerator(tree, { ...defaultOptions, engine: 'mysql' });
 
     const pyproject = tree.read('packages/db/pyproject.toml', 'utf-8');
-    expect(pyproject).toContain('aiomysql==0.3.2');
+    expect(pyproject).toContain(withPyVersions(['aiomysql'])[0]);
     expect(pyproject).not.toContain('asyncpg');
     expect(
       tree.read('packages/db/proj_db/connection.py', 'utf-8'),


### PR DESCRIPTION
### Reason for this change

The `py#rdb` generator spec hardcoded Python dependency version literals (`sqlmodel==0.0.38`, `alembic==1.18.4`, `asyncpg==0.31.0`, `aiomysql==0.3.2`). The scheduled Update Versions workflow bumps these in `PY_VERSIONS` and runs `nx test -u`, but `-u` only updates snapshots — not `toContain` string assertions. So a `sqlmodel`/`alembic` bump failed the test, which blocked the weekly dependency-update PR from being created (see the failed run on 2026-07-19).

### Description of changes

Assert against `withPyVersions([...])` (the same helper the generator uses to render the versions) instead of hardcoded literals, so the checks track the version source of truth in `utils/versions.ts` and stay green across future bumps.

### Description of how you validated changes

- `vitest run src/py/rdb/generator.spec.ts` — all 20 tests pass.
- Full `@aws/nx-plugin:test` suite passes via the pre-commit hook.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*