### PR TITLE
test(e2e): stop bun and npm smoke lanes silently testing pnpm

### DIFF
--- a/e2e/src/smoke-tests/create-workspace.spec.ts
+++ b/e2e/src/smoke-tests/create-workspace.spec.ts
@@ -18,6 +18,7 @@ import { ensureDirSync } from 'fs-extra';
 import * as pty from 'node-pty';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  assertWorkspaceUsesPackageManager,
   buildCreateNxWorkspaceCommand,
   createTestWorkspace,
   runCLI,
@@ -166,6 +167,7 @@ describe('smoke test - create-workspace', () => {
         expect(existsSync(`${projectRoot}/aws-nx-plugin.config.mts`)).toBe(
           true,
         );
+        assertWorkspaceUsesPackageManager(projectRoot, pkgMgr);
       });
     });
   });

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -39,7 +39,7 @@ export async function runCLI(
   },
 ): Promise<string> {
   try {
-    const pm = getPackageManagerCommand();
+    const pm = getPackageManagerCommand({ path: opts.cwd || tmpProjPath() });
     const commandToRun = `${
       opts.prefixWithPackageManagerCmd !== false ? `${pm.runNxSilent} ` : ''
     }${command} ${opts.verbose ? ' --verbose' : ''}${
@@ -57,6 +57,14 @@ export async function runCLI(
           env: {
             PATH: process.env.PATH,
             ...process.env,
+            // The e2e suite itself runs under `pnpm nx`, which exports
+            // npm_config_user_agent=pnpm/... npm and bun treat an inherited
+            // user agent as config and pass it through to children, so
+            // user-agent-based package manager detection (e.g.
+            // @aws/create-nx-workspace resolving --pm) would see pnpm in
+            // every lane. Drop it so each spawned package manager sets its
+            // own.
+            npm_config_user_agent: undefined,
             ...opts.env,
           },
           shell: true,
@@ -107,7 +115,9 @@ export async function runCLI(
 }
 
 function detectPackageManager(dir = ''): PackageManager {
-  return existsSync(join(dir, 'bun.lockb'))
+  // bun >= 1.2 writes the text-based bun.lock; bun.lockb is the legacy
+  // binary lockfile.
+  return existsSync(join(dir, 'bun.lock')) || existsSync(join(dir, 'bun.lockb'))
     ? 'bun'
     : existsSync(join(dir, 'yarn.lock'))
       ? 'yarn'
@@ -288,7 +298,42 @@ export const createTestWorkspace = async (
       }
     }
   }
+  assertWorkspaceUsesPackageManager(workspaceDir, pkgMgr);
   return workspaceDir;
+};
+
+/**
+ * Assert the created workspace was installed with the package manager the test
+ * asked for, by checking its lockfile. Package manager detection is
+ * user-agent based and an environment leak can silently fall back to another
+ * package manager (e.g. the pnpm the e2e suite itself runs under), leaving a
+ * lane green while testing the wrong package manager.
+ */
+const LOCKFILES: Record<string, string[]> = {
+  npm: ['package-lock.json'],
+  pnpm: ['pnpm-lock.yaml'],
+  yarn: ['yarn.lock'],
+  bun: ['bun.lock', 'bun.lockb'],
+};
+
+export const assertWorkspaceUsesPackageManager = (
+  workspaceDir: string,
+  pkgMgr: string,
+) => {
+  const expected = LOCKFILES[pkgMgr];
+  if (!expected) {
+    throw new Error(`Unknown package manager: ${pkgMgr}`);
+  }
+  if (!expected.some((f) => existsSync(join(workspaceDir, f)))) {
+    const found = Object.values(LOCKFILES)
+      .flat()
+      .filter((f) => existsSync(join(workspaceDir, f)));
+    throw new Error(
+      `Expected a ${pkgMgr} workspace (one of: ${expected.join(', ')}) at ${workspaceDir}, ` +
+        `but found lockfiles: ${found.length ? found.join(', ') : '(none)'} — ` +
+        `the workspace was not created with ${pkgMgr}`,
+    );
+  }
 };
 
 // The ts#dynamodb generator already adds electrodb and @aws-sdk/client-dynamodb.

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -114,15 +114,26 @@ export async function runCLI(
   }
 }
 
+/**
+ * Lockfiles written by each package manager. bun >= 1.2 writes the text-based
+ * bun.lock; bun.lockb is the legacy binary lockfile.
+ */
+const LOCKFILES: Record<PackageManager, string[]> = {
+  npm: ['package-lock.json'],
+  pnpm: ['pnpm-lock.yaml'],
+  yarn: ['yarn.lock'],
+  bun: ['bun.lock', 'bun.lockb'],
+};
+
+const hasLockfile = (dir: string, pkgMgr: PackageManager): boolean =>
+  LOCKFILES[pkgMgr].some((lockfile) => existsSync(join(dir, lockfile)));
+
 function detectPackageManager(dir = ''): PackageManager {
-  // bun >= 1.2 writes the text-based bun.lock; bun.lockb is the legacy
-  // binary lockfile.
-  return existsSync(join(dir, 'bun.lock')) || existsSync(join(dir, 'bun.lockb'))
+  return hasLockfile(dir, 'bun')
     ? 'bun'
-    : existsSync(join(dir, 'yarn.lock'))
+    : hasLockfile(dir, 'yarn')
       ? 'yarn'
-      : existsSync(join(dir, 'pnpm-lock.yaml')) ||
-          existsSync(join(dir, 'pnpm-workspace.yaml'))
+      : hasLockfile(dir, 'pnpm') || existsSync(join(dir, 'pnpm-workspace.yaml'))
         ? 'pnpm'
         : 'npm';
 }
@@ -261,7 +272,7 @@ export { buildCreateNxWorkspaceCommand, buildPackageManagerShortCommand };
  * fail with an I/O error.
  */
 export const createTestWorkspace = async (
-  pkgMgr: string,
+  pkgMgr: PackageManager,
   targetDir: string,
   name: string,
   iac?: 'cdk' | 'terraform',
@@ -309,27 +320,16 @@ export const createTestWorkspace = async (
  * package manager (e.g. the pnpm the e2e suite itself runs under), leaving a
  * lane green while testing the wrong package manager.
  */
-const LOCKFILES: Record<string, string[]> = {
-  npm: ['package-lock.json'],
-  pnpm: ['pnpm-lock.yaml'],
-  yarn: ['yarn.lock'],
-  bun: ['bun.lock', 'bun.lockb'],
-};
-
 export const assertWorkspaceUsesPackageManager = (
   workspaceDir: string,
-  pkgMgr: string,
+  pkgMgr: PackageManager,
 ) => {
-  const expected = LOCKFILES[pkgMgr];
-  if (!expected) {
-    throw new Error(`Unknown package manager: ${pkgMgr}`);
-  }
-  if (!expected.some((f) => existsSync(join(workspaceDir, f)))) {
+  if (!hasLockfile(workspaceDir, pkgMgr)) {
     const found = Object.values(LOCKFILES)
       .flat()
       .filter((f) => existsSync(join(workspaceDir, f)));
     throw new Error(
-      `Expected a ${pkgMgr} workspace (one of: ${expected.join(', ')}) at ${workspaceDir}, ` +
+      `Expected a ${pkgMgr} workspace (one of: ${LOCKFILES[pkgMgr].join(', ')}) at ${workspaceDir}, ` +
         `but found lockfiles: ${found.length ? found.join(', ') : '(none)'} — ` +
         `the workspace was not created with ${pkgMgr}`,
     );

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -59,7 +59,7 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
   - pnpm add -w -D <package>
   - yarn add -D <package>
   - npm install --legacy-peer-deps -D <package>
-  - bun install -D <package>
+  - bun add -D <package>
   - (Omit -D for production dependencies)
 - When specifying project names as arguments to generators, prefer the _fully qualified_ project name, for example \`@workspace-name/project-name\`. Check the \`project.json\` file for the specific package to find its fully qualified name
 - When no generator exists for a specific framework required, use the base \`ts#project\` and \`py#project\` generators and build on top.

--- a/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-plugin/__snapshots__/generator.spec.ts.snap
@@ -127,7 +127,7 @@ exports[`ts#nx-plugin generator > should generate MCP server files > test-plugin
   - pnpm add -w -D <package>
   - yarn add -D <package>
   - npm install --legacy-peer-deps -D <package>
-  - bun install -D <package>
+  - bun add -D <package>
   - (Omit -D for production dependencies)
 - When specifying project names as arguments to generators, prefer the _fully qualified_ project name, for example \`@workspace-name/project-name\`. Check the \`project.json\` file for the specific package to find its fully qualified name
 - When no generator exists for a specific framework required, look for more generic project generators if availalbe and build on top of these.
@@ -482,7 +482,7 @@ export const buildInstallCommand = (pm: string, pkg: string) =>
     pnpm: \`pnpm add -Dw \${pkg}\`,
     yarn: \`yarn add -D \${pkg}\`,
     npm: \`npm install --legacy-peer-deps -D \${pkg}\`,
-    bun: \`bun install -D \${pkg}\`,
+    bun: \`bun add -D \${pkg}\`,
   })[pm];
 
 const renderSchema = (schema: any) =>

--- a/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/resources/GENERAL_GUIDANCE.md.template
+++ b/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/resources/GENERAL_GUIDANCE.md.template
@@ -30,7 +30,7 @@
   - pnpm add -w -D <package>
   - yarn add -D <package>
   - npm install --legacy-peer-deps -D <package>
-  - bun install -D <package>
+  - bun add -D <package>
   - (Omit -D for production dependencies)
 - When specifying project names as arguments to generators, prefer the _fully qualified_ project name, for example `@workspace-name/project-name`. Check the `project.json` file for the specific package to find its fully qualified name
 - When no generator exists for a specific framework required, look for more generic project generators if availalbe and build on top of these.

--- a/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template
+++ b/packages/nx-plugin/src/ts/nx-plugin/files/mcp-server/utils.ts.template
@@ -56,7 +56,7 @@ export const buildInstallCommand = (pm: string, pkg: string) =>
     pnpm: `pnpm add -Dw ${pkg}`,
     yarn: `yarn add -D ${pkg}`,
     npm: `npm install --legacy-peer-deps -D ${pkg}`,
-    bun: `bun install -D ${pkg}`,
+    bun: `bun add -D ${pkg}`,
   })[pm];
 
 const renderSchema = (schema: any) =>

--- a/packages/nx-plugin/src/utils/commands.ts
+++ b/packages/nx-plugin/src/utils/commands.ts
@@ -70,7 +70,7 @@ export const buildInstallCommand = (pm: string, pkg: string, dev: boolean) => {
     case 'npm':
       return `npm install --legacy-peer-deps ${dev ? '-D ' : ''}${pkg}`;
     case 'bun':
-      return `bun install ${dev ? '-D ' : ''}${pkg}`;
+      return `bun add ${dev ? '-D ' : ''}${pkg}`;
     default:
       return `${pm} install ${dev ? '-D ' : ''}${pkg}`;
   }


### PR DESCRIPTION
### Reason for this change

The bun smoke test lane has been silently creating **pnpm** workspaces while staying green, so bun support has not actually been exercised by CI. The npm lane was affected the same way.

The leak chain: the e2e suite itself runs under `pnpm nx`, and pnpm exports `npm_config_user_agent=pnpm/...`. The e2e `runCLI` helper spawned commands with the full inherited environment, and both bun and npm pass an inherited user agent through to child processes unchanged. `@aws/create-nx-workspace` detects the package manager from that user agent, so `bun create @aws/nx-workspace` resolved `--pm=pnpm` and produced a pnpm workspace. The yarn lanes were unaffected only because their corepack shims reset the user agent.

Two further e2e bugs compounded this and kept it invisible:
- The e2e-side package manager detection only looked for the legacy `bun.lockb` — bun ≥ 1.2 writes the text-based `bun.lock` — so even a genuine bun workspace would not have been detected as one.
- `runCLI` detected the package manager from the parent temp directory (which has no lockfiles) instead of the workspace under test, so every lane ran subsequent commands via `npx nx` regardless of package manager.

### Description of changes

- Scrub `npm_config_user_agent` from the `runCLI` spawn environment so each spawned package manager sets its own.
- Detect bun workspaces via `bun.lock` as well as legacy `bun.lockb`.
- Detect the package manager from the workspace under test (`opts.cwd`), so post-create commands run via the lane's package manager (`bun nx`, `npx nx`, etc.).
- Add `assertWorkspaceUsesPackageManager`, called after `createTestWorkspace` and in each `create-workspace` variant: the lane now fails loudly if the created workspace's lockfile doesn't match the package manager it claims to test, so a future detection regression can't silently fall back.
- Align vended/docs bun install guidance from `bun install -D <pkg>` to the idiomatic `bun add -D <pkg>` (bun aliases the former to the latter, but the `add` form is the documented one): `buildInstallCommand`, the MCP server general guidance, and the `ts#nx-plugin` vended MCP server templates (+ snapshots).

With the leak fixed, a genuine bun workspace passes the full smoke matrix — no bun-specific generator or build breakage had crept in.

### Description of how you validated changes

- Verified the leak empirically: with an inherited `pnpm/...` user agent, `bun run`/`bun create` and `npm run` all propagate it unchanged; with it scrubbed, each sets its own.
- Ran the bun smoke test locally end-to-end against a Verdaccio-published local build: the workspace is created with `bun.lock` and bun's isolated `node_modules/.bun` layout, and the full generator matrix + `nx run-many --target build --all` passes (16m40s).
- Ran the npm smoke lane locally to validate the same scrub on the npm side (workspace created with `package-lock.json`).
- Full unit suite passes (2653 tests, including via the pre-commit hook).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*