### PR TITLE
fix(ts#project): replace deprecated Biome linter `recommended` option with `preset`

### DIFF
--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -243,7 +243,7 @@ export default {
 
 exports[`preset generator > should run successfully > biome.json 1`] = `
 "{
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "root": true,
   "formatter": {
     "enabled": true,
@@ -268,7 +268,7 @@ exports[`preset generator > should run successfully > biome.json 1`] = `
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": false,
+      "preset": "none",
       "correctness": {
         "noUndeclaredDependencies": "warn"
       }

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -961,7 +961,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > biome.json 1`] = `
 "{
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "root": true,
   "formatter": {
     "enabled": true,
@@ -986,7 +986,7 @@ exports[`react-website generator > Tanstack router integration > should generate
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": false,
+      "preset": "none",
       "correctness": {
         "noUndeclaredDependencies": "warn"
       }
@@ -2674,7 +2674,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > biome.json 1`] = `
 "{
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "root": true,
   "formatter": {
     "enabled": true,
@@ -2699,7 +2699,7 @@ exports[`react-website generator > Tanstack router integration > should generate
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": false,
+      "preset": "none",
       "correctness": {
         "noUndeclaredDependencies": "warn"
       }

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -340,7 +340,7 @@ describe('format utils', () => {
       writeFileSync(
         path.join(workspaceDir, 'biome.json'),
         JSON.stringify({
-          $schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
+          $schema: 'https://biomejs.dev/schemas/2.5.4/schema.json',
           root: true,
           formatter: { indentStyle: 'space', indentWidth: 2 },
           javascript: {

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -11,11 +11,12 @@ import { createRequire } from 'module';
 import path from 'path';
 import { uvxCommand } from './py';
 import { readToml } from './toml';
+import { TS_VERSIONS } from './versions';
 
 const require = createRequire(import.meta.url);
 
 export const DEFAULT_BIOME_CONFIG = {
-  $schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
+  $schema: `https://biomejs.dev/schemas/${TS_VERSIONS['@biomejs/biome']}/schema.json`,
   root: true,
   formatter: {
     enabled: true,
@@ -40,7 +41,7 @@ export const DEFAULT_BIOME_CONFIG = {
   linter: {
     enabled: true,
     rules: {
-      recommended: false,
+      preset: 'none',
       correctness: {
         noUndeclaredDependencies: 'warn',
       },


### PR DESCRIPTION
### Reason for this change

Biome 2.5 deprecated the `linter.rules.recommended` option in favour of the new `preset` option. Running `biome lint` against a workspace created by the plugin emits a deprecation warning:

> The use of the recommended field has been deprecated, and will be removed in the next major version of Biome. Use preset instead.

Separately, the vended config's `$schema` URL was pinned to schema version `2.4.16` while the installed `@biomejs/biome` CLI (in `versions.ts`) is `2.5.4`, so the schema referenced an older version than the CLI in the generated workspace.

### Description of changes

- Update the vended default Biome config (`DEFAULT_BIOME_CONFIG` in `format.ts`) to use `"preset": "none"` in place of the deprecated `"recommended": false`. `biome migrate --write` produces exactly this replacement, and it is functionally equivalent (recommended rules stay disabled; `noUndeclaredDependencies` remains the only enabled rule).
- Derive the config `$schema` version from `TS_VERSIONS['@biomejs/biome']` so the schema URL always tracks the pinned CLI version and cannot drift again.
- Regenerate affected snapshots (`preset`, `react-website`).

No other deprecated or renamed Biome v2.x options are used by the vended config.

### Description of how you validated changes

- Ran the pinned Biome `2.5.4` CLI against the vended config: `biome lint` on the old config emits the `recommended` deprecation warning; after `biome migrate --write` (which yields `"preset": "none"` + schema `2.5.4`), `biome lint` is clean and `noUndeclaredDependencies` remains active.
- `pnpm nx run @aws/nx-plugin:test` passes (run in the pre-commit hook).
- `pnpm nx run @aws/nx-plugin:compile` passes.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*