### PR TITLE
fix(ts#rdb,py#rdb): patch OS packages in vended migration images to clear HIGH CVEs

### DIFF
--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -170,6 +170,10 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
 exports[`py#rdb generator > should generate MySQL dependencies and templates 4`] = `
 "FROM public.ecr.aws/lambda/python:3.14
 
+# Patch OS packages beyond the base image's pinned release so the image is
+# free of known HIGH/CRITICAL vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all
+
 WORKDIR \${LAMBDA_TASK_ROOT}
 
 COPY . .
@@ -183,6 +187,10 @@ CMD ["proj_db.migration_handler.handler"]
 
 exports[`py#rdb generator > should generate MySQL dependencies and templates 5`] = `
 "FROM public.ecr.aws/lambda/python:3.14
+
+# Patch OS packages beyond the base image's pinned release so the image is
+# free of known HIGH/CRITICAL vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all
 
 WORKDIR \${LAMBDA_TASK_ROOT}
 
@@ -1396,6 +1404,10 @@ datefmt = %H:%M:%S
 exports[`py#rdb generator > should generate a PostgreSQL SQLModel project with Alembic 2`] = `
 "FROM public.ecr.aws/lambda/python:3.14
 
+# Patch OS packages beyond the base image's pinned release so the image is
+# free of known HIGH/CRITICAL vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all
+
 WORKDIR \${LAMBDA_TASK_ROOT}
 
 COPY . .
@@ -1409,6 +1421,10 @@ CMD ["proj_db.migration_handler.handler"]
 
 exports[`py#rdb generator > should generate a PostgreSQL SQLModel project with Alembic 3`] = `
 "FROM public.ecr.aws/lambda/python:3.14
+
+# Patch OS packages beyond the base image's pinned release so the image is
+# free of known HIGH/CRITICAL vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all
 
 WORKDIR \${LAMBDA_TASK_ROOT}
 

--- a/packages/nx-plugin/src/py/rdb/files/Dockerfile.create-db-user.template
+++ b/packages/nx-plugin/src/py/rdb/files/Dockerfile.create-db-user.template
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.14
 
+# Patch OS packages beyond the base image's pinned release so the image is
+# free of known HIGH/CRITICAL vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all
+
 WORKDIR ${LAMBDA_TASK_ROOT}
 
 COPY . .

--- a/packages/nx-plugin/src/py/rdb/files/Dockerfile.migration.template
+++ b/packages/nx-plugin/src/py/rdb/files/Dockerfile.migration.template
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.14
 
+# Patch OS packages beyond the base image's pinned release so the image is
+# free of known HIGH/CRITICAL vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all
+
 WORKDIR ${LAMBDA_TASK_ROOT}
 
 COPY . .

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4669,6 +4669,13 @@ exports[`ts#rdb generator > should generate the aurora shared construct 4`] = `
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@12.0.1
 
+# Patch OS packages beyond the base image's pinned release, and drop the
+# runtime's convenience copy of the AWS SDK (the handler bundle inlines its
+# own dependencies), keeping the image free of known HIGH/CRITICAL
+# vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \\
+    && rm -rf /var/runtime/node_modules/@aws-sdk
+
 WORKDIR \${LAMBDA_TASK_ROOT}
 
 # npm blocks dependency install scripts by default; allow prisma's so its

--- a/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
+++ b/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
@@ -3,6 +3,13 @@ FROM public.ecr.aws/lambda/nodejs:24
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@<%= npmVersion %>
 
+# Patch OS packages beyond the base image's pinned release, and drop the
+# runtime's convenience copy of the AWS SDK (the handler bundle inlines its
+# own dependencies), keeping the image free of known HIGH/CRITICAL
+# vulnerabilities
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \
+    && rm -rf /var/runtime/node_modules/@aws-sdk
+
 WORKDIR ${LAMBDA_TASK_ROOT}
 
 # npm blocks dependency install scripts by default; allow prisma's so its


### PR DESCRIPTION
### Reason for this change

The `rdb` and `terraform` smoke test lanes are failing on the Trivy scan targets of the vended migration images. New Amazon Linux 2023 advisories landed for `glib2` (CVE-2026-58010 through CVE-2026-58016) and `libacl` (CVE-2026-54369, CVE-2026-54370), all HIGH. AL2023 pins `releasever`, so a plain `microdnf upgrade` cannot reach the fixed package versions — the base `public.ecr.aws/lambda/python:3.14` and `lambda/nodejs:24` images stay on the vulnerable release until AWS republishes them.

The nodejs image additionally flags HIGH/CRITICAL CVEs in the Lambda runtime's convenience copy of the AWS JS SDK under `/var/runtime/node_modules/@aws-sdk` (bundled `brace-expansion`, `tar`, `undici`).

### Description of changes

- All three vended migration/create-db-user Dockerfiles now run `microdnf upgrade -y --releasever latest && microdnf clean all` to patch OS packages beyond the base image's pinned release.
- The `ts#rdb` (nodejs) image also removes `/var/runtime/node_modules/@aws-sdk`: the migration handler is bundled with rolldown and inlines its own dependencies, so the runtime's convenience SDK copy is unused.
- Snapshots updated.

### Description of how you validated changes

- Reproduced each failing scan locally with the pinned Trivy 0.72.0 image, then verified replicas of all three vended Dockerfiles (including the full `ts#rdb` one with the prisma install) scan clean with the same flags CI uses (`--severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`).
- Functionally verified both patched images still serve invocations via the Lambda runtime interface emulator — including the nodejs image with the runtime SDK removed.
- `ts#rdb` and `py#rdb` unit suites pass (98 tests); full unit suite passes via the pre-commit hook.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*