### PR TITLE
fix(ts#agent): bundle @ag-ui/aws-strands peer deps into AG-UI runtime

### DIFF
--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -1045,6 +1045,8 @@ describe('ts#agent generator', () => {
 
     const rootPackageJson = JSON.parse(tree.read('package.json', 'utf-8'));
     expect(rootPackageJson.dependencies['@ag-ui/aws-strands']).toBeDefined();
+    expect(rootPackageJson.dependencies['@ag-ui/a2ui-toolkit']).toBeDefined();
+    expect(rootPackageJson.dependencies['@ag-ui/client']).toBeDefined();
     expect(rootPackageJson.dependencies['@ag-ui/core']).toBeDefined();
     expect(rootPackageJson.dependencies['@ag-ui/encoder']).toBeDefined();
     expect(rootPackageJson.dependencies['express']).toBeDefined();

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -221,6 +221,11 @@ export const tsAgentGenerator = async (
         : protocol === 'ag-ui'
           ? ([
               '@ag-ui/aws-strands',
+              // @ag-ui/aws-strands declares these as peer dependencies but
+              // statically imports them, so they must be installed for the
+              // bundler to resolve and inline them into the runtime image.
+              '@ag-ui/a2ui-toolkit',
+              '@ag-ui/client',
               '@ag-ui/core',
               '@ag-ui/encoder',
               'express',

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -35,6 +35,7 @@ export const TS_VERSIONS = {
   '@swc/core': '1.15.43',
   '@modelcontextprotocol/sdk': '1.29.0',
   '@modelcontextprotocol/inspector': '0.22.0',
+  '@ag-ui/a2ui-toolkit': '0.0.4',
   '@ag-ui/aws-strands': '0.2.3',
   '@ag-ui/client': '0.0.57',
   '@ag-ui/core': '0.0.57',


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` e2e smoke test on `main` fails: the TypeScript AG-UI agent (`MyTsAguiAgent`) AgentCore runtime returns **HTTP 424** ("An error occurred when starting the runtime"). Its CloudWatch runtime logs show the container crash-looping on startup with:

```
Error: Cannot find module '@ag-ui/a2ui-toolkit'
```

`@ag-ui/aws-strands` declares `@ag-ui/a2ui-toolkit` and `@ag-ui/client` as **peer dependencies** (its own `dependencies` is empty) but imports them **statically** in its compiled output. The `ts#agent` generator declared only `@ag-ui/aws-strands`, `@ag-ui/core`, and `@ag-ui/encoder`, so the two peers were never installed. Since the agent is bundled with rolldown (no externals) and the runtime image only ships the bundled `index.js`, rolldown could not resolve the missing peers at bundle time and left bare `require()` calls in the output — which crash the container at startup.

This surfaced as a nondeterministic green→red flip with no source change because there is no committed lockfile: the `cdk-deploy` and `terraform-deploy` jobs each install fresh, and whether the missing peer happened to be hoisted somewhere rolldown could resolve varied between installs.

### Description of changes

- Add `@ag-ui/a2ui-toolkit` to `TS_VERSIONS` (pinned `0.0.4`).
- Declare `@ag-ui/a2ui-toolkit` and `@ag-ui/client` in the AG-UI agent's dependencies in the `ts#agent` generator, so they are installed and deterministically inlined into the runtime image by rolldown.
- Add generator unit-test assertions for both new dependencies.

### Description of how you validated changes

- `ts#agent` generator unit tests pass (65/65); full `@aws/nx-plugin` suite green (2646/2646).
- Reproduced the root cause with a controlled rolldown bundle: **without** the fix the bundle leaves bare `require("@ag-ui/a2ui-toolkit")` / `require("@ag-ui/client")` (matching the CloudWatch crash); **with** the fix all `@ag-ui/*` modules are inlined and only Node built-ins remain external.
- Ran the `cdk-deploy` e2e smoke test locally against the compiled packages, deploying to AWS and exercising the website integration test that surfaced the 424. _(result to be appended)_

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
