### PR TITLE
fix(ts#website#auth): add custom domain names to cognito callback/logout urls

### DIFF
--- a/docs/src/content/docs/en/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/react-website-auth.mdx
@@ -195,7 +195,7 @@ The user identity module automatically adds the necessary <Link path="guides/rea
 </Infrastructure>
 
 :::caution[Remove localhost callback URLs for production]
-The generated User Pool client allows your CloudFront distribution URL as an OAuth callback/logout URL, plus `http://localhost:4200` and `http://localhost:4300` for local development against the deployed pool.
+The generated User Pool client allows your CloudFront distribution URL (and any custom domain names configured on it) as OAuth callback/logout URLs, plus `http://localhost:4200` and `http://localhost:4300` for local development against the deployed pool.
 
 It is recommended to **remove the `http://localhost` callback/logout URLs for production stages**, keeping the allowlist limited to your real application origins.
 

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -1,11 +1,8 @@
 ---
-title: "Autenticación de Sitios Web con React"
-description: "Documentación de referencia para Autenticación de Sitios Web con React"
+title: Autenticación de Sitios Web con React
+description: Documentación de referencia para Autenticación de Sitios Web con React
 generator: ts#website#auth
 ---
-
-
-
 import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -80,6 +77,11 @@ direction: right
 browser: Web Browser {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/client.svg
+}
+
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
 }
 
 cognito: Cognito\n(User + Identity Pool) {
@@ -193,7 +195,7 @@ El módulo de identidad de usuario agrega automáticamente la <Link path="guides
 </Infrastructure>
 
 :::caution[Eliminar URLs de callback localhost para producción]
-El cliente del User Pool generado permite la URL de tu distribución CloudFront como URL de callback/logout de OAuth, además de `http://localhost:4200` y `http://localhost:4300` para desarrollo local contra el pool implementado.
+El cliente del User Pool generado permite la URL de tu distribución CloudFront (y cualquier nombre de dominio personalizado configurado en ella) como URLs de callback/logout de OAuth, además de `http://localhost:4200` y `http://localhost:4300` para desarrollo local contra el pool implementado.
 
 Se recomienda **eliminar las URLs de callback/logout `http://localhost` para etapas de producción**, manteniendo la lista de permitidos limitada a los orígenes reales de tu aplicación.
 
@@ -209,7 +211,7 @@ Edita los `callback_urls`/`logout_urls` en `packages/common/terraform/src/core/u
 
 ### Otorgar acceso a usuarios autenticados
 
-Para permitir que usuarios autenticados realicen ciertas acciones, como otorgar permisos para invocar una API, puedes agregar políticas IAM al rol autenticado del identity pool:
+Para permitir que usuarios autenticados realicen ciertas acciones, como otorgar permisos para invocar una API, puedes agregar declaraciones de política IAM al rol autenticado del identity pool:
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -82,6 +82,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg
@@ -170,12 +175,12 @@ Le User Pool est soutenu par un rôle IAM que Cognito assume pour envoyer des me
 Vous devrez ajouter le module d'identité utilisateur et vous assurer que votre site web en dépend :
 
 ```hcl title="packages/infra/src/main.tf" {2-4,14-15}
-# Déployer d'abord l'identité utilisateur pour l'ajouter à la config d'exécution
+# Deploy user identity first to add to runtime config
 module "user_identity" {
   source = "../../common/terraform/src/core/user-identity"
 }
 
-# Déployer le site web après l'identité pour inclure la config d'exécution
+# Deploy website after identity to include runtime config
 module "my_website" {
   source = "../../common/terraform/src/app/static-websites/my-website"
 
@@ -183,7 +188,7 @@ module "my_website" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  # S'assurer que l'identité est déployée en premier
+  # Ensure identity is deployed first to add to runtime config
   depends_on = [module.user_identity]
 }
 ```
@@ -192,8 +197,8 @@ Le module d'identité utilisateur ajoute automatiquement la <Link path="guides/r
 </Fragment>
 </Infrastructure>
 
-:::caution[Supprimer les URLs de callback localhost pour la production]
-Le client User Pool généré autorise l'URL de votre distribution CloudFront comme URL de callback/déconnexion OAuth, ainsi que `http://localhost:4200` et `http://localhost:4300` pour le développement local contre le pool déployé.
+:::caution[Remove localhost callback URLs for production]
+Le client User Pool généré autorise l'URL de votre distribution CloudFront (et tous les noms de domaine personnalisés configurés dessus) comme URLs de callback/déconnexion OAuth, ainsi que `http://localhost:4200` et `http://localhost:4300` pour le développement local contre le pool déployé.
 
 Il est recommandé de **supprimer les URLs de callback/déconnexion `http://localhost` pour les environnements de production**, en limitant la liste d'autorisation à vos origines d'application réelles.
 
@@ -248,7 +253,7 @@ module "my_api" {
   asset_bucket_name = module.asset_bucket.bucket_name
 }
 
-# Ajouter des permissions pour les utilisateurs authentifiés d'appeler Fast API
+# Add permissions for authenticated users to invoke Fast API
 resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
   name = "authenticated-user-invoke-my-api"
   role = module.user_identity.authenticated_role_name

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -185,7 +185,7 @@ module "my_website" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  # Assicura che l'identità sia distribuita prima
+  # Assicura che l'identità sia distribuita prima per aggiungerla alla configurazione runtime
   depends_on = [module.user_identity]
 }
 ```
@@ -195,7 +195,7 @@ Il modulo per l'identità utente aggiunge automaticamente la necessaria <Link pa
 </Infrastructure>
 
 :::caution[Rimuovere gli URL di callback localhost per la produzione]
-Il client User Pool generato consente l'URL della distribuzione CloudFront come URL di callback/logout OAuth, oltre a `http://localhost:4200` e `http://localhost:4300` per lo sviluppo locale contro il pool distribuito.
+Il client User Pool generato consente l'URL della distribuzione CloudFront (e qualsiasi nome di dominio personalizzato configurato su di esso) come URL di callback/logout OAuth, oltre a `http://localhost:4200` e `http://localhost:4300` per lo sviluppo locale contro il pool distribuito.
 
 Si raccomanda di **rimuovere gli URL di callback/logout `http://localhost` per gli stage di produzione**, mantenendo l'allowlist limitata alle origini reali della tua applicazione.
 

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -82,6 +82,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -82,6 +82,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg

--- a/docs/src/content/docs/pt/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/react-website-auth.mdx
@@ -1,11 +1,8 @@
 ---
-title: "Autenticação de Website em React"
-description: "Documentação de referência para Autenticação de Website em React"
+title: React Website Authentication
+description: Documentação de referência para React Website Authentication
 generator: ts#website#auth
 ---
-
-
-
 import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -14,15 +11,15 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 
-O gerador de Autenticação para Website React adiciona autenticação ao seu site React usando [Amazon Cognito](https://aws.amazon.com/cognito/).
+O gerador React Website Authentication adiciona autenticação ao seu website React usando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
-Este gerador configura a infraestrutura CDK ou Terraform para criar um User Pool do Cognito e um Identity Pool associado, além de uma interface hospedada para gerenciar fluxos de login de usuários e sua integração com seu website React.
+Este gerador configura a infraestrutura CDK ou Terraform para criar um Cognito User Pool e um Identity Pool associado, bem como uma interface hospedada para gerenciar fluxos de login de usuários e sua integração com seu website React.
 
-## Utilização
+## Uso
 
-### Adicionar autenticação ao seu website React
+### Adicionar Autenticação ao seu React Website
 
-Você pode adicionar autenticação ao seu website React de duas formas:
+Você pode adicionar autenticação ao seu React website de duas maneiras:
 
 <RunGenerator generator="ts#website#auth" />
 
@@ -32,13 +29,13 @@ Você pode adicionar autenticação ao seu website React de duas formas:
 
 ## Saída do Gerador
 
-Você encontrará as seguintes alterações no seu website React:
+Você encontrará as seguintes alterações em seu React website:
 
 <FileTree>
   - src
     - components
       - CognitoAuth
-        - index.tsx Componente principal de autenticação
+        - index.tsx Componente de autenticação principal
     - main.tsx Atualizado para instrumentar o componente CognitoAuth
 </FileTree>
 
@@ -53,7 +50,7 @@ Você também encontrará o seguinte código de infraestrutura gerado com base n
 <FileTree>
   - packages/common/constructs/src
     - core
-      - user-identity.ts Construct que define o user pool e identity pool
+      - user-identity.ts Construct que define o user pool e o identity pool
 </FileTree>
 </Fragment>
 <Fragment slot="terraform">
@@ -61,18 +58,18 @@ Você também encontrará o seguinte código de infraestrutura gerado com base n
   - packages/common/terraform/src
     - core
       - user-identity
-        - main.tf Módulo wrapper para configuração de identidade
+        - main.tf Wrapper de módulo para a configuração de identidade
         - identity
-          - identity.tf Infraestrutura principal de identidade incluindo Cognito User Pool e Identity Pool
+          - identity.tf Infraestrutura de identidade principal incluindo Cognito User Pool e Identity Pool
         - add-callback-url
-          - add-callback-url.tf Módulo para adicionar URLs de callback a clientes existentes do user pool
+          - add-callback-url.tf Módulo para adicionar URLs de callback a clientes de user pool existentes
 </FileTree>
 </Fragment>
 </Infrastructure>
 
 #### Arquitetura
 
-Este gerador adiciona um user pool do Amazon Cognito (para login) e um identity pool (para federar usuários autenticados a credenciais IAM com escopo definido) à arquitetura existente de website estático:
+Este gerador adiciona um Amazon Cognito user pool (para login) e um identity pool (para federar usuários autenticados a credenciais IAM com escopo) à arquitetura de website estático existente:
 
 ```d2 inline=true
 direction: right
@@ -109,9 +106,9 @@ browser -> backend: IAM/Cognito
 
 #### Proteção contra ameaças
 
-O User Pool é criado no [plano de recursos Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) do Cognito com [proteção contra ameaças](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) definida no modo `AUDIT` para autenticação padrão. No modo de auditoria, o Cognito atribui um nível de risco a cada login e registra a avaliação no CloudWatch sem bloquear usuários.
+O User Pool é criado no [plano de recursos Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) do Cognito com [proteção contra ameaças](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) definida para o modo `AUDIT` para autenticação padrão. No modo de auditoria, o Cognito atribui um nível de risco a cada login e registra a avaliação no CloudWatch sem bloquear usuários.
 
-Depois de observar as avaliações de risco para seus usuários, você pode alternar para a aplicação de função completa para responder automaticamente a atividades arriscadas (por exemplo, exigindo MFA ou bloqueando o login):
+Uma vez que você tenha observado as avaliações de risco para seus usuários, você pode alternar para a aplicação de função completa para responder automaticamente a atividades arriscadas (por exemplo, exigindo MFA ou bloqueando o login):
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -147,7 +144,7 @@ module "user_identity" {
 
 <Infrastructure>
 <Fragment slot="cdk">
-Você precisará adicionar a infraestrutura de identidade do usuário à sua stack, declarando-a _antes_ do website:
+Você precisará adicionar a infraestrutura de identidade de usuário à sua stack, declarando-a _antes_ do website:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
 import { Stack } from 'aws-cdk-lib';
@@ -167,20 +164,20 @@ export class ApplicationStack extends Stack {
 
 O construct `UserIdentity` adiciona automaticamente a <Link path="guides/react-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu website possa apontar para o Cognito User Pool correto para autenticação.
 
-:::note[Retenção da função SMS]
-O User Pool é apoiado por uma função IAM que o Cognito assume para enviar mensagens SMS. A política de remoção da função espelha a do User Pool — por padrão, o `UserPool` do CDK usa `RemovalPolicy.RETAIN`, então ao executar `cdk destroy` tanto o User Pool quanto sua função SMS são retidos e precisarão ser limpos manualmente se não forem mais necessários.
+:::note[Retenção de função SMS]
+O User Pool é apoiado por uma função IAM que o Cognito assume para enviar mensagens SMS. A política de remoção da função espelha a do User Pool — por padrão, o `UserPool` do CDK usa `RemovalPolicy.RETAIN`, então no `cdk destroy` tanto o User Pool quanto sua função SMS são retidos e precisarão ser limpos manualmente se não forem mais necessários.
 :::
 </Fragment>
 <Fragment slot="terraform">
-Você precisará adicionar o módulo de identidade do usuário e garantir que seu website dependa dele:
+Você precisará adicionar o módulo de identidade de usuário e garantir que seu website dependa dele:
 
 ```hcl title="packages/infra/src/main.tf" {2-4,14-15}
-# Implanta identidade primeiro para adicionar à configuração de runtime
+# Implanta a identidade primeiro para adicionar à configuração de runtime
 module "user_identity" {
   source = "../../common/terraform/src/core/user-identity"
 }
 
-# Implanta website após identidade para incluir configuração de runtime
+# Implanta o website após a identidade para incluir a configuração de runtime
 module "my_website" {
   source = "../../common/terraform/src/app/static-websites/my-website"
 
@@ -188,19 +185,19 @@ module "my_website" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  # Garante que identidade seja implantada primeiro
+  # Garante que a identidade seja implantada primeiro para adicionar à configuração de runtime
   depends_on = [module.user_identity]
 }
 ```
 
-O módulo de identidade do usuário adiciona automaticamente a <Link path="guides/react-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu website possa apontar para o Cognito User Pool correto para autenticação.
+O módulo de identidade de usuário adiciona automaticamente a <Link path="guides/react-website#runtime-configuration">Configuração de Runtime</Link> necessária para garantir que seu website possa apontar para o Cognito User Pool correto para autenticação.
 </Fragment>
 </Infrastructure>
 
-:::caution[Remova URLs de callback localhost para produção]
-O cliente do User Pool gerado permite a URL de distribuição do CloudFront como URL de callback/logout OAuth, além de `http://localhost:4200` e `http://localhost:4300` para desenvolvimento local contra o pool implantado.
+:::caution[Remover URLs de callback localhost para produção]
+O cliente User Pool gerado permite a URL de distribuição do CloudFront (e quaisquer nomes de domínio personalizados configurados nele) como URLs de callback/logout OAuth, além de `http://localhost:4200` e `http://localhost:4300` para desenvolvimento local contra o pool implantado.
 
-É recomendado **remover as URLs de callback/logout `http://localhost` para ambientes de produção**, mantendo a lista de permissões limitada às origens reais da sua aplicação.
+É recomendado **remover as URLs de callback/logout `http://localhost` para estágios de produção**, mantendo a lista de permissões limitada às origens reais da sua aplicação.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -214,7 +211,7 @@ Edite os `callback_urls`/`logout_urls` em `packages/common/terraform/src/core/us
 
 ### Concedendo Acesso a Usuários Autenticados
 
-Para conceder acesso a usuários autenticados para realizar determinadas ações, como conceder permissões para invocar uma API, você pode adicionar políticas IAM à função autenticada do identity pool:
+Para conceder aos usuários autenticados acesso para realizar certas ações, como conceder permissões para invocar uma API, você pode adicionar declarações de política IAM à função autenticada do identity pool:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -253,7 +250,7 @@ module "my_api" {
   asset_bucket_name = module.asset_bucket.bucket_name
 }
 
-# Adiciona permissões para usuários autenticados invocarem Fast API
+# Adiciona permissões para usuários autenticados invocarem a API
 resource "aws_iam_role_policy" "authenticated_fast_api_invoke" {
   name = "authenticated-user-invoke-my-api"
   role = module.user_identity.authenticated_role_name

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -80,6 +80,11 @@ browser: Web Browser {
   icon: /nx-plugin-for-aws/icons/aws/client.svg
 }
 
+waf: WAF {
+  shape: image
+  icon: /nx-plugin-for-aws/icons/aws/waf.svg
+}
+
 cognito: Cognito\n(User + Identity Pool) {
   shape: image
   icon: /nx-plugin-for-aws/icons/aws/cognito.svg
@@ -191,7 +196,7 @@ Module user identity tự động thêm <Link path="guides/react-website#runtime
 </Infrastructure>
 
 :::caution[Xóa localhost callback URLs cho production]
-User Pool client được tạo cho phép URL phân phối CloudFront của bạn làm OAuth callback/logout URL, cộng với `http://localhost:4200` và `http://localhost:4300` để phát triển cục bộ với pool đã triển khai.
+User Pool client được tạo cho phép URL phân phối CloudFront của bạn (và bất kỳ tên miền tùy chỉnh nào được cấu hình trên đó) làm OAuth callback/logout URLs, cộng với `http://localhost:4200` và `http://localhost:4300` để phát triển cục bộ với pool đã triển khai.
 
 Khuyến nghị **xóa các `http://localhost` callback/logout URLs cho các stage production**, giữ danh sách cho phép chỉ giới hạn ở các origin ứng dụng thực của bạn.
 

--- a/docs/src/content/docs/zh/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/react-website-auth.mdx
@@ -198,7 +198,7 @@ module "my_website" {
 </Infrastructure>
 
 :::caution[生产环境请移除 localhost 回调 URL]
-生成的用户池客户端允许使用您的 CloudFront 分发 URL 作为 OAuth 回调/登出 URL，以及 `http://localhost:4200` 和 `http://localhost:4300` 用于针对已部署池的本地开发。
+生成的用户池客户端允许使用您的 CloudFront 分发 URL（以及在其上配置的任何自定义域名）作为 OAuth 回调/登出 URL，以及 `http://localhost:4200` 和 `http://localhost:4300` 用于针对已部署池的本地开发。
 
 建议**在生产阶段移除 `http://localhost` 回调/登出 URL**，将允许列表限制为您的真实应用程序来源。
 

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -118,7 +118,7 @@ import {
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import { suppressRules } from './checkov.js';
 
 const WEB_CLIENT_ID = 'WebClient';
@@ -334,9 +334,7 @@ export class UserIdentity extends Construct {
     const lazilyComputedCallbackUrls = Lazy.list({
       produce: () =>
         ['http://localhost:4200', 'http://localhost:4300'].concat(
-          this.findCloudFrontDistributions().map(
-            (d) => \`https://\${d.domainName}\`,
-          ),
+          this.findCloudFrontDomainNames().map((domain) => \`https://\${domain}\`),
         ),
     });
 
@@ -386,10 +384,17 @@ export class UserIdentity extends Construct {
     }).node.addDependency(userPoolClient, userPool, userPoolDomain);
   };
 
-  private findCloudFrontDistributions = (): Distribution[] =>
+  // Includes each distribution's default domain name plus any custom domain names (aliases) configured on it.
+  private findCloudFrontDomainNames = (): string[] =>
     Stack.of(this)
       .node.findAll()
-      .filter((child) => child instanceof Distribution);
+      .filter((child): child is Distribution => child instanceof Distribution)
+      .flatMap((d) => {
+        const cfnDistribution = d.node.defaultChild as CfnDistribution;
+        const distributionConfig =
+          cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+        return [d.domainName, ...(distributionConfig.aliases ?? [])];
+      });
 }
 "
 `;

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -241,11 +241,19 @@ resource "aws_cloudfront_distribution" "website" {
   }
 }
 
-# Add CloudFront domain to user pool client callback URLs
+# Add CloudFront domain and any custom domain names to user pool client callback URLs
+locals {
+  callback_urls = toset(concat(
+    ["https://\${aws_cloudfront_distribution.website.domain_name}"],
+    [for domain in var.custom_domain_names : "https://\${domain}"],
+  ))
+}
+
 module "add_callback_url" {
   source = "../user-identity/add-callback-url"
+  for_each = local.callback_urls
 
-  callback_url = "https://\${aws_cloudfront_distribution.website.domain_name}"
+  callback_url = each.value
 
   depends_on = [aws_cloudfront_distribution.website]
 }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.terraform.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.terraform.spec.ts
@@ -186,7 +186,14 @@ module "static_website" {
       'source = "../user-identity/add-callback-url"',
     );
     expect(coreStaticWebsiteContent).toContain(
-      'callback_url = "https://${aws_cloudfront_distribution.website.domain_name}"',
+      'for_each = local.callback_urls',
+    );
+    expect(coreStaticWebsiteContent).toContain('callback_url = each.value');
+    expect(coreStaticWebsiteContent).toContain(
+      '"https://${aws_cloudfront_distribution.website.domain_name}"',
+    );
+    expect(coreStaticWebsiteContent).toContain(
+      'for domain in var.custom_domain_names',
     );
 
     // Read the project-specific static website terraform file

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -30,7 +30,7 @@ import {
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config<% if (esm) { %>.js<% } %>';
-import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import { suppressRules } from './checkov<% if (esm) { %>.js<% } %>';
 
 const WEB_CLIENT_ID = 'WebClient';
@@ -242,9 +242,7 @@ export class UserIdentity extends Construct {
     const lazilyComputedCallbackUrls = Lazy.list({
       produce: () =>
         ['http://localhost:4200', 'http://localhost:4300'].concat(
-          this.findCloudFrontDistributions().map(
-            (d) => `https://${d.domainName}`
-          )
+          this.findCloudFrontDomainNames().map((domain) => `https://${domain}`)
         ),
     });
 
@@ -294,8 +292,15 @@ export class UserIdentity extends Construct {
     }).node.addDependency(userPoolClient, userPool, userPoolDomain);
   };
 
-  private findCloudFrontDistributions = (): Distribution[] =>
+  // Includes each distribution's default domain name plus any custom domain names (aliases) configured on it.
+  private findCloudFrontDomainNames = (): string[] =>
     Stack.of(this)
       .node.findAll()
-      .filter((child) => child instanceof Distribution);
+      .filter((child): child is Distribution => child instanceof Distribution)
+      .flatMap((d) => {
+        const cfnDistribution = d.node.defaultChild as CfnDistribution;
+        const distributionConfig =
+          cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+        return [d.domainName, ...(distributionConfig.aliases ?? [])];
+      });
 }

--- a/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
+++ b/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
@@ -102,14 +102,23 @@ const addIdentityTerraformModules = (
       'source = "../user-identity/add-callback-url"',
     )
   ) {
-    // Find the aws_cloudfront_distribution.website resource and add the callback URL module after it
+    // Find the aws_cloudfront_distribution.website resource and add the callback URL module after it.
+    // Includes the CloudFront domain plus any custom domain names (aliases) configured via var.custom_domain_names.
     const callbackUrlModule = `
 
-# Add CloudFront domain to user pool client callback URLs
+# Add CloudFront domain and any custom domain names to user pool client callback URLs
+locals {
+  callback_urls = toset(concat(
+    ["https://\${aws_cloudfront_distribution.website.domain_name}"],
+    [for domain in var.custom_domain_names : "https://\${domain}"],
+  ))
+}
+
 module "add_callback_url" {
   source = "../user-identity/add-callback-url"
+  for_each = local.callback_urls
 
-  callback_url = "https://\${aws_cloudfront_distribution.website.domain_name}"
+  callback_url = each.value
 
   depends_on = [aws_cloudfront_distribution.website]
 }`;


### PR DESCRIPTION
### Reason for this change

#948 added `domainNames`/`certificate` support to `StaticWebsite`, letting a CloudFront distribution serve a custom domain instead of only the default `*.cloudfront.net` domain. However, `UserIdentity` (the Cognito construct/module used by `ts#website#auth`) never learned about these custom domains: it only ever added the CloudFront default domain name as a valid OAuth callback/logout URL.

As a result, a user who configures a custom domain per the "Custom Domain & TLS" docs and then signs in via that domain hits Cognito's `redirect_mismatch` error, since the custom domain is never in the User Pool Client's allowed callback/logout URL list. Nothing in the code or docs calls this out as a manual step.

### Description of changes

- **CDK** (`user-identity.ts.template`): `findCloudFrontDistributions` is replaced with `findCloudFrontDomainNames`, which reads each CloudFront distribution's default domain name plus its configured `aliases` (custom domain names) straight off the underlying `CfnDistribution.distributionConfig` (CDK's `Distribution` L2 writes `aliases: props.domainNames` there directly), so no changes to `StaticWebsite` itself were needed.
- **Terraform** (`identity-constructs.ts`): the auto-inserted `add_callback_url` module block is now generated with a `locals.callback_urls` set (CloudFront domain + `for domain in var.custom_domain_names`) and a `for_each` over that set, instead of a single hardcoded `callback_url`.
- Updated the "Remove localhost callback URLs for production" doc note (and translated locales) to mention custom domain names are included automatically.

### Description of how you validated changes

- Updated/ran the existing `cognito-auth` generator unit tests (CDK + Terraform) and refreshed the snapshots that capture the generated `user-identity.ts` / `static-website.tf` content to reflect the new behavior.
- All tests in `packages/nx-plugin/src/ts/react-website/cognito-auth/generator*.spec.ts` pass.
- Deployed a real distribution with a custom domain and ACM certificate and confirmed the custom domain is added to the User Pool Client's callback and logout URLs.

### Issue # (if applicable)

N/A — found during review, no tracked issue.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*