### PR TITLE
fix(ts#website): exclude runtime-config.json from WebsiteDeployment prune

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1820,6 +1820,9 @@ export class StaticWebsite extends Construct {
       destinationBucket: this.websiteBucket,
       // Files in the distribution's edge caches will be invalidated after files are uploaded to the destination bucket.
       distribution: this.cloudFrontDistribution,
+      // Exclude the runtime config from this deployment's sync so its default pruning
+      // never deletes the file managed separately by RuntimeConfigDeployment below.
+      exclude: [DEFAULT_RUNTIME_CONFIG_FILENAME],
       memoryLimit: 1024,
     });
 
@@ -3538,6 +3541,9 @@ export class StaticWebsite extends Construct {
       destinationBucket: this.websiteBucket,
       // Files in the distribution's edge caches will be invalidated after files are uploaded to the destination bucket.
       distribution: this.cloudFrontDistribution,
+      // Exclude the runtime config from this deployment's sync so its default pruning
+      // never deletes the file managed separately by RuntimeConfigDeployment below.
+      exclude: [DEFAULT_RUNTIME_CONFIG_FILENAME],
       memoryLimit: 1024,
     });
 
@@ -5163,6 +5169,9 @@ export class StaticWebsite extends Construct {
       destinationBucket: this.websiteBucket,
       // Files in the distribution's edge caches will be invalidated after files are uploaded to the destination bucket.
       distribution: this.cloudFrontDistribution,
+      // Exclude the runtime config from this deployment's sync so its default pruning
+      // never deletes the file managed separately by RuntimeConfigDeployment below.
+      exclude: [DEFAULT_RUNTIME_CONFIG_FILENAME],
       memoryLimit: 1024,
     });
 

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -259,6 +259,9 @@ export class StaticWebsite extends Construct {
       destinationBucket: this.websiteBucket,
       // Files in the distribution's edge caches will be invalidated after files are uploaded to the destination bucket.
       distribution: this.cloudFrontDistribution,
+      // Exclude the runtime config from this deployment's sync so its default pruning
+      // never deletes the file managed separately by RuntimeConfigDeployment below.
+      exclude: [DEFAULT_RUNTIME_CONFIG_FILENAME],
       memoryLimit: 1024,
     });
 


### PR DESCRIPTION
### Reason for this change

The CDK `StaticWebsite` construct's `WebsiteDeployment` `BucketDeployment` defaults to `prune: true`, which deletes any object in the bucket not part of its own source manifest. `runtime-config.json` is uploaded separately by `RuntimeConfigDeployment`, so it's never in `WebsiteDeployment`'s manifest. This means every deploy where the website assets change can delete `runtime-config.json`, and it's only restored if `RuntimeConfigDeployment`'s own custom resource happens to re-run in that same deployment (which only happens when the config content itself changes). This can leave the deployed site without a runtime config until a later deploy. The Terraform template already guards against this: it explicitly excludes `runtime-config.json` from both its upload and delete steps.

### Description of changes

Added `exclude: [DEFAULT_RUNTIME_CONFIG_FILENAME]` to `WebsiteDeployment` in `static-website.ts.template`, so its sync/prune step never touches the runtime config file, matching the Terraform behavior.

### Description of how you validated changes

- Ran `pnpm nx run @aws/nx-plugin:test` and updated the 3 affected snapshots in `generator.spec.ts.snap`
- Deployed a generated website to AWS with the fix, redeployed with a website-content-only change, and confirmed `runtime-config.json` stayed in the bucket instead of being pruned

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the CONTRIBUTING GUIDE and DESIGN GUIDELINES

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*