### PR TITLE
fix(py#rdb): pin greenlet to keep the vended dependency graph deterministic

### DIFF
--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -1499,6 +1499,7 @@ readme = "README.md"
 dependencies = [
   "sqlmodel==0.0.39",
   "alembic==1.18.5",
+  "greenlet==3.5.4",
   "asyncpg==0.31.0",
   "boto3==1.43.51",
   "aws-lambda-powertools==3.31.1"

--- a/packages/nx-plugin/src/py/rdb/generator.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.ts
@@ -323,6 +323,11 @@ export const pyRdbGenerator = async (
   addDependenciesToPyProjectToml(tree, dir, [
     'sqlmodel',
     'alembic',
+    // SQLAlchemy's async engine (used by connection.py for both engines)
+    // requires greenlet at runtime. Vend it explicitly at a pinned version so
+    // the dependency graph is fully determined and doesn't float to an
+    // unpublished-wheel release at install time.
+    'greenlet',
     ...(engine === 'mysql'
       ? (['aiomysql', 'boto3', 'aws-lambda-powertools'] as const)
       : (['asyncpg', 'boto3', 'aws-lambda-powertools'] as const)),

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -175,6 +175,10 @@ export const PY_VERSIONS = {
   alembic: '==1.18.5',
   aiomysql: '==0.3.2',
   asyncpg: '==0.31.0',
+  // Pinned explicitly: SQLAlchemy's async engine pulls greenlet transitively,
+  // and leaving it unpinned lets uv resolve to a just-released version whose
+  // platform wheels may not all be published yet (breaking aarch64 installs).
+  greenlet: '==3.5.4',
 } as const;
 export type IPyDepVersion = keyof typeof PY_VERSIONS;
 


### PR DESCRIPTION
### Reason for this change

Every CI lane that scaffolds a Python relational-database project (`Smoke Tests - rdb`, `npm`, `bun`, `yarn-*`, `pnpm-*`, `standalone`, `local-dev`, …) started failing during `nx run-many --target build --all` with:

```
× No solution found when resolving dependencies:
╰─▶ Because greenlet{...aarch64...}==3.5.4 has no wheels with a matching platform tag
    (e.g., `manylinux_2_28_aarch64`) ... we can conclude that your requirements are unsatisfiable.
```

**Root cause — a transitive dependency we never pinned.** `greenlet` is a native transitive dependency of the SQLAlchemy async engine that the generated `connection.py` uses (via `sqlmodel`). We pin our *direct* Python dependencies in `PY_VERSIONS`, but transitive natives like `greenlet` were left to float to whatever the newest release was at install time.

`greenlet 3.5.4` was published to PyPI on 2026-07-22 with its platform wheels uploaded **incrementally** — I confirmed from the PyPI JSON API that the x86_64/macOS/Windows wheels landed at ~11:38–11:51 UTC but the Linux **aarch64** wheels did not land until **12:25 UTC**. Our CI runs on aarch64 runners, and the smoke tests ran inside that ~45-minute gap: `uv` resolved the unpinned `greenlet` to the just-released `3.5.4`, found no aarch64 wheel, and failed. (The aarch64 wheels are now published, so the transient trigger has cleared — but the fragility is real: any half-published upstream release of an unpinned transitive native breaks every generated Python RDB project.)

This is not caused by the docs work in flight — it reproduces identically on `main` (confirmed on the concurrent `main` CI run, same lanes, same error).

### Description of changes

- Pin `greenlet: '==3.5.4'` in `packages/nx-plugin/src/utils/versions.ts` (`PY_VERSIONS`). Because `scripts/update-versions.ts` iterates `PY_VERSIONS` through `pip-check-updates --target minor`, greenlet is now tracked and bumped within-minor like every other pin — deliberately, after wheels are published, rather than floating at install time.
- Vend `greenlet` in the `py#rdb` generator's dependency list (`generator.ts`). It's added to the common deps (not engine-specific) because `connection.py` uses SQLAlchemy's async engine for both the PostgreSQL and MySQL engines. The RDB connection sub-generators (fast-api / agent / mcp-server) pick it up transitively via the workspace-local dependency on the RDB project, so no separate change is needed there.
- Updated the `py#rdb` generator snapshot to include the vended `greenlet==3.5.4`.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:test src/py/rdb/generator.spec.ts -u` → 20/20 pass; snapshot now vends `greenlet==3.5.4`. `fast-api-connection` spec also green. Plugin compiles clean.
- Reproduced the resolution on an **aarch64** host (matching CI) with `uv`: wrote the exact vended dependency set to a `pyproject.toml` and ran `uv lock` — resolves cleanly (`Resolved 21 packages`, `greenlet 3.5.4`), whereas the unpinned graph is what allowed the bad float.
- Ran the `rdb` smoke test locally against the freshly-published local plugin to confirm a scaffolded RDB workspace builds end-to-end on aarch64.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
