### PR TITLE
chore: reassign duplicated generator metrics and guard with a test

### DIFF
--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -7,7 +7,7 @@
       "factory": "./src/init/generator",
       "schema": "./src/init/schema.json",
       "description": "Configure an existing Nx workspace to use the @aws/nx-plugin",
-      "metric": "g57",
+      "metric": "g66",
       "guidePages": ["existing-project"]
     },
     "agentcore-gateway": {
@@ -27,7 +27,7 @@
       "factory": "./src/agentcore-gateway/gateway-connection/generator",
       "schema": "./src/agentcore-gateway/gateway-connection/schema.json",
       "description": "Connect an AgentCore Gateway to another AgentCore Gateway",
-      "metric": "g52",
+      "metric": "g65",
       "hidden": true
     },
     "connection": {
@@ -215,7 +215,7 @@
       "factory": "./src/ts/dcr-proxy/generator",
       "schema": "./src/ts/dcr-proxy/schema.json",
       "description": "Generate an OAuth Dynamic Client Registration (DCR) proxy construct for Cognito-authenticated MCP servers",
-      "metric": "g56"
+      "metric": "g67"
     },
     "ts#mcp-server": {
       "factory": "./src/ts/mcp-server/generator",
@@ -248,7 +248,7 @@
       "factory": "./src/ts/website/app/generator",
       "schema": "./src/ts/website/app/schema.json",
       "description": "Generates a website application",
-      "metric": "g43",
+      "metric": "g60",
       "guidePages": ["website", "react-website"]
     },
     "ts#website#auth": {
@@ -405,27 +405,27 @@
       "factory": "./src/ts/dynamodb/generator",
       "schema": "./src/ts/dynamodb/schema.json",
       "description": "Create a TypeScript DynamoDB project",
-      "metric": "g43"
+      "metric": "g61"
     },
     "ts#dynamodb#trpc-connection": {
       "factory": "./src/ts/dynamodb/trpc-connection/generator",
       "schema": "./src/ts/dynamodb/trpc-connection/schema.json",
       "description": "Connect a ts#trpc-api project to a ts#dynamodb project",
-      "metric": "g44",
+      "metric": "g62",
       "hidden": true
     },
     "ts#dynamodb#smithy-connection": {
       "factory": "./src/ts/dynamodb/smithy-connection/generator",
       "schema": "./src/ts/dynamodb/smithy-connection/schema.json",
       "description": "Connect a Smithy backend to a ts#dynamodb project",
-      "metric": "g45",
+      "metric": "g63",
       "hidden": true
     },
     "ts#dynamodb#agent-connection": {
       "factory": "./src/ts/dynamodb/agent-connection/generator",
       "schema": "./src/ts/dynamodb/agent-connection/schema.json",
       "description": "Connect a ts#agent to a ts#dynamodb project",
-      "metric": "g46",
+      "metric": "g64",
       "hidden": true
     },
     "ts#dynamodb#mcp-server-connection": {

--- a/packages/nx-plugin/src/utils/generators.spec.ts
+++ b/packages/nx-plugin/src/utils/generators.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { buildGeneratorInfoList } from './generators';
+
+describe('generators', () => {
+  it('should not have duplicate metrics across generators', () => {
+    const generators = buildGeneratorInfoList(process.cwd());
+
+    const generatorsByMetric = new Map<string, string[]>();
+    for (const { id, metric } of generators) {
+      const ids = generatorsByMetric.get(metric) ?? [];
+      ids.push(id);
+      generatorsByMetric.set(metric, ids);
+    }
+
+    const duplicates = [...generatorsByMetric.entries()]
+      .filter(([, ids]) => ids.length > 1)
+      .map(([metric, ids]) => `${metric}: ${ids.join(', ')}`);
+
+    expect(
+      duplicates,
+      `Each generator must have a unique metric. Assign a new metric id to the most recently introduced generator.\nDuplicates found:\n${duplicates.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Reason for this change

Several generators in `packages/nx-plugin/generators.json` shared the same `metric` ID. Metrics are meant to uniquely identify each generator (they are emitted as tags in the CDK `MetricsAspect` and Terraform metrics locals), so collisions make usage attribution ambiguous — multiple distinct generators report under one ID. The duplicated metric IDs were:

| Metric | Generators sharing it |
|---|---|
| g43 | `ts#docs`, `ts#website`, `ts#dynamodb` |
| g44 | `ts#website#auth`, `ts#dynamodb#trpc-connection` |
| g45 | `py#api`, `ts#dynamodb#smithy-connection` |
| g46 | `ts#api`, `ts#dynamodb#agent-connection` |
| g52 | `py#dynamodb`, `agentcore-gateway#gateway-connection` |
| g56 | `py#rdb`, `ts#dcr-proxy` |
| g57 | `py#rdb#fast-api-connection`, `init` |

### Description of changes

In each collision, the metric ID stays with the **earlier-introduced** generator (based on the order of the PRs that added them), and the newer generator(s) are reassigned to fresh IDs continuing from the previous maximum, in PR-introduction order:

| Generator | Introduced by | New metric |
|---|---|---|
| `ts#website` | #734 | g60 |
| `ts#dynamodb` | #745 | g61 |
| `ts#dynamodb#trpc-connection` | #745 | g62 |
| `ts#dynamodb#smithy-connection` | #745 | g63 |
| `ts#dynamodb#agent-connection` | #745 | g64 |
| `agentcore-gateway#gateway-connection` | #802 | g65 |
| `init` | #929 | g66 |
| `ts#dcr-proxy` | #939 | g67 |

All generators now have distinct metrics (`g1`–`g67`).

A new unit test (`packages/nx-plugin/src/utils/generators.spec.ts`) reads the real generator list via `buildGeneratorInfoList` and asserts no two generators share a metric, so future duplicates are caught in CI.

### Description of how you validated changes

- Added `generators.spec.ts` asserting metric uniqueness; verified it **passes** on the fixed `generators.json` and **fails** (with a message listing the colliding metric/generators) when a duplicate is reintroduced.
- Confirmed programmatically that all metrics are now unique (`g1`–`g67`, 67 distinct).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*