### PR TITLE
chore(ts#react-website#auth): key callback_urls by static values for plan-time for_each

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -241,12 +241,14 @@ resource "aws_cloudfront_distribution" "website" {
   }
 }
 
-# Add CloudFront domain and any custom domain names to user pool client callback URLs
+# Add CloudFront domain and any custom domain names to user pool client callback URLs.
+# Keyed by statically-known values so for_each keys are resolvable at plan time; the
+# CloudFront domain is only known at apply time, so it appears in the value, not the key.
 locals {
-  callback_urls = toset(concat(
-    ["https://\${aws_cloudfront_distribution.website.domain_name}"],
-    [for domain in var.custom_domain_names : "https://\${domain}"],
-  ))
+  callback_urls = merge(
+    { cloudfront = "https://\${aws_cloudfront_distribution.website.domain_name}" },
+    { for domain in var.custom_domain_names : domain => "https://\${domain}" },
+  )
 }
 
 module "add_callback_url" {

--- a/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
+++ b/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
@@ -106,12 +106,14 @@ const addIdentityTerraformModules = (
     // Includes the CloudFront domain plus any custom domain names (aliases) configured via var.custom_domain_names.
     const callbackUrlModule = `
 
-# Add CloudFront domain and any custom domain names to user pool client callback URLs
+# Add CloudFront domain and any custom domain names to user pool client callback URLs.
+# Keyed by statically-known values so for_each keys are resolvable at plan time; the
+# CloudFront domain is only known at apply time, so it appears in the value, not the key.
 locals {
-  callback_urls = toset(concat(
-    ["https://\${aws_cloudfront_distribution.website.domain_name}"],
-    [for domain in var.custom_domain_names : "https://\${domain}"],
-  ))
+  callback_urls = merge(
+    { cloudfront = "https://\${aws_cloudfront_distribution.website.domain_name}" },
+    { for domain in var.custom_domain_names : domain => "https://\${domain}" },
+  )
 }
 
 module "add_callback_url" {


### PR DESCRIPTION
### Reason for this change

Terraform deploys of a website with Cognito auth (custom-domain support, added in #978) fail during `plan`/`apply` with:

```
Error: Invalid for_each argument
  on .../core/static-website/static-website.tf line 526, in module "add_callback_url":
   for_each = local.callback_urls
   local.callback_urls is set of string with 1 element
The "for_each" set includes values derived from resource attributes that cannot be
determined until apply, and so Terraform cannot determine the full set of keys...
```

The `add_callback_url` module iterated with `for_each` over a **set** built via `toset(concat(...))` that included `aws_cloudfront_distribution.website.domain_name` — an apply-time value. Terraform requires `for_each` **keys** to be known at plan time; when the set's elements are themselves unknown, it can't compute the keys, so the plan errors out. This broke the `@e2e-test/infra` CI lane.

### Description of changes

- `packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts`: switch the injected `local.callback_urls` from a `toset(concat(...))` set to a **map keyed by statically-known values** — a fixed `cloudfront` key for the distribution URL, plus `var.custom_domain_names` (static strings) as keys for the aliases. The apply-time CloudFront domain now lives only in the map *value*, which is exactly the shape Terraform's error message recommends.
- Updated the corresponding terraform snapshot.

### Description of how you validated changes

- Unit/snapshot tests: `nx run @aws/nx-plugin:test` for the cognito-auth suites (cdk + terraform) — all pass; snapshot regenerated. `compile` and `lint` pass.
- **End-to-end**: packed the locally-built plugin, generated a real workspace (`ts#react-website` + `ts#react-website#auth`, `--iac=terraform`), and ran `terraform test` with a mocked AWS provider (no credentials) against the real generated `static-website` module:
  - Fixed `merge(...)` form → **plan passes**.
  - Reverting the same generated file to the old `toset(concat(...))` form → **plan fails with the exact CI error**, confirming the fix addresses the root cause.

**Catching this earlier in PR CI without AWS credentials** (per the ask): `terraform validate` does *not* catch this — it's a plan-time graph error, and a validated config still fails at plan. A plain `terraform plan` of the generated stacks needs credentials because the modules call `data.aws_caller_identity`/`aws_region` (live STS). The credential-free option that reproduces it is Terraform's native test framework: a `*.tftest.hcl` with `mock_provider "aws" {}` (+ the `aws.us_east_1` alias) and a `run` block using `command = plan`. Mocked providers make zero network calls, so no creds are required, yet `for_each` expansion still runs and surfaces the error. I verified both directions of this against the real generated module. This could be wired into a PR-time job that runs `terraform test` over the vended terraform modules; happy to follow up with that in a separate PR if you'd like.

### Issue # (if applicable)

N/A (CI regression from #978).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
