### PR TITLE
test(e2e): catch terraform plan-time errors at PR time without credentials

### DIFF
--- a/e2e/src/smoke-tests/terraform-plan-test.ts
+++ b/e2e/src/smoke-tests/terraform-plan-test.ts
@@ -47,8 +47,7 @@ export const runTerraformPlanTest = async (opts: {
 
   // Mock exactly the providers this configuration requires — mocking a
   // provider the config doesn't require is an error, so read the set Terraform
-  // resolved into the lock file rather than hardcoding it. The website module
-  // additionally needs the us-east-1 aws alias (CloudFront WAF).
+  // resolved into the lock file rather than hardcoding it.
   const lock = readFileSync(join(infraSrc, '.terraform.lock.hcl'), 'utf-8');
   const providers = [
     ...new Set(
@@ -57,9 +56,37 @@ export const runTerraformPlanTest = async (opts: {
       ].map((m) => m[1]),
     ),
   ];
+
+  // The aws mock is defined explicitly (both the default and the us-east-1
+  // alias the website module needs for the CloudFront WAF). Pin the region,
+  // account id and partition data sources to realistic values — an unmocked
+  // provider returns random strings for these, which makes the ARNs built from
+  // them (e.g. Lambda layer ARNs `arn:<partition>:lambda:<region>:...`) fail
+  // plan-time ARN validation.
+  const awsMockBody = `  mock_data "aws_region" {
+    defaults = {
+      id     = "us-east-1"
+      region = "us-east-1"
+    }
+  }
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+  mock_data "aws_partition" {
+    defaults = {
+      partition      = "aws"
+      dns_suffix     = "amazonaws.com"
+      reverse_dns_prefix = "com.amazonaws"
+    }
+  }`;
   const mocks = [
-    ...providers.map((p) => `mock_provider "${p}" {}`),
-    'mock_provider "aws" {\n  alias = "us_east_1"\n}',
+    `mock_provider "aws" {\n${awsMockBody}\n}`,
+    `mock_provider "aws" {\n  alias = "us_east_1"\n${awsMockBody}\n}`,
+    ...providers
+      .filter((p) => p !== 'aws')
+      .map((p) => `mock_provider "${p}" {}`),
   ].join('\n');
   writeFileSync(
     join(infraSrc, 'plan.tftest.hcl'),

--- a/e2e/src/smoke-tests/terraform-plan-test.ts
+++ b/e2e/src/smoke-tests/terraform-plan-test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runCLI } from '../utils';
+
+/**
+ * Validates the generated Terraform with a credential-free `terraform test`.
+ *
+ * `terraform validate` cannot catch plan-time graph errors (for example a
+ * `for_each` over a value only known after apply), and a real `terraform plan`
+ * of the generated stacks needs AWS credentials because the modules read
+ * `data.aws_caller_identity`/`aws_region` (live STS calls). Terraform's native
+ * test framework closes that gap: with every provider mocked, no network calls
+ * are made and no credentials are required, yet `command = plan` still expands
+ * the full module graph — so a plan-time error fails the test.
+ *
+ * The wiring is the same `main.tf` the terraform-deploy smoke test applies, so
+ * this exercises the identical module graph without deploying anything.
+ */
+export const runTerraformPlanTest = async (opts: {
+  cwd: string;
+  env: Record<string, string>;
+}) => {
+  const infraSrc = join(opts.cwd, 'packages/infra/src');
+  const rawOpts = {
+    cwd: infraSrc,
+    env: opts.env,
+    prefixWithPackageManagerCmd: false,
+  };
+
+  // Wire every generated module together using the terraform-deploy template
+  // (the maintained source of truth for module wiring). Plan never runs the
+  // resources, so the TEST_RUN_ID placeholder just needs a static value.
+  const mainTf = readFileSync(
+    join(__dirname, '../files/terraform-deploy/main.tf.template'),
+    'utf-8',
+  ).replace(/<% TEST_RUN_ID %>/g, 'plantest');
+  writeFileSync(join(infraSrc, 'main.tf'), mainTf);
+
+  // `-backend=false` so `terraform init` doesn't try to configure the S3
+  // backend (which would need credentials); the test framework keeps state
+  // in memory anyway.
+  await runCLI('terraform init -backend=false -no-color', rawOpts);
+
+  // Mock exactly the providers this configuration requires — mocking a
+  // provider the config doesn't require is an error, so read the set Terraform
+  // resolved into the lock file rather than hardcoding it. The website module
+  // additionally needs the us-east-1 aws alias (CloudFront WAF).
+  const lock = readFileSync(join(infraSrc, '.terraform.lock.hcl'), 'utf-8');
+  const providers = [
+    ...new Set(
+      [
+        ...lock.matchAll(/provider "registry\.terraform\.io\/[^/]+\/([^"]+)"/g),
+      ].map((m) => m[1]),
+    ),
+  ];
+  const mocks = [
+    ...providers.map((p) => `mock_provider "${p}" {}`),
+    'mock_provider "aws" {\n  alias = "us_east_1"\n}',
+  ].join('\n');
+  writeFileSync(
+    join(infraSrc, 'plan.tftest.hcl'),
+    `${mocks}\n\nvariables {\n  environment = "test"\n  aws_region  = "us-east-1"\n}\n\nrun "plan" {\n  command = plan\n}\n`,
+  );
+
+  await runCLI('terraform test -no-color', {
+    ...rawOpts,
+    redirectStderr: true,
+  });
+};

--- a/e2e/src/smoke-tests/terraform-smoke-test.ts
+++ b/e2e/src/smoke-tests/terraform-smoke-test.ts
@@ -8,6 +8,7 @@ import { ensureDirSync } from 'fs-extra';
 import { beforeEach, describe, it } from 'vitest';
 import { createTestWorkspace, runCLI, runInstall, tmpProjPath } from '../utils';
 import { runGeneratorMatrix } from './generator-matrix';
+import { runTerraformPlanTest } from './terraform-plan-test';
 
 /**
  * Runs the full matrix of generators against a Terraform-backed workspace.
@@ -101,11 +102,16 @@ export const terraformSmokeTest = (
     });
 
     it(`Should generate and build - ${variant}`, async () => {
-      await runTerraformSmokeTest(
+      const { opts } = await runTerraformSmokeTest(
         `${tmpProjPath()}/${variant}-${pkgMgr}`,
         pkgMgr,
         options.onProjectCreate,
       );
+
+      // Validate the generated Terraform plans cleanly, with mocked providers
+      // so no AWS credentials are needed. Catches plan-time graph errors the
+      // build can't (e.g. a for_each over an apply-time value).
+      await runTerraformPlanTest(opts);
     });
   });
 };


### PR DESCRIPTION
### Reason for this change

The `callback_urls` `for_each` regression (#983) failed only in the terraform **deploy** e2e lane, which needs AWS credentials and so cannot run on PRs. That class of bug — a plan-time graph error such as a `for_each` over a value only known after apply — should be caught at PR time.

`terraform validate` does not catch it (a validated config still fails at plan), and a real `terraform plan` of the generated stacks needs credentials because the modules read `data.aws_caller_identity`/`aws_region` (live STS calls).

### Description of changes

Add a credential-free `terraform test` step to the (non-deploy) `terraform` smoke test:

- New `e2e/src/smoke-tests/terraform-plan-test.ts`: after the existing generate + build, it wires every generated module together using the existing `terraform-deploy/main.tf.template` (the maintained source of truth for module wiring, so no drift), runs `terraform init -backend=false`, then writes a `plan.tftest.hcl` and runs `terraform test`.
  - Providers are mocked (`mock_provider`), so no network calls are made and no AWS credentials are required — but `command = plan` still expands the full module graph (for_each, references, locals), so plan-time errors fail the test.
  - The mock set is read from the resolved `.terraform.lock.hcl` rather than hardcoded, because mocking a provider the config doesn't require is itself an error. The `aws.us_east_1` alias (CloudFront WAF) is always added.
- `terraform-smoke-test.ts` calls the new step from the non-deploy variant only (the deploy variant really applies).

Terraform 1.15.7 is already installed in the smoke-test job, satisfying `terraform test` (needs ≥1.7).

### Description of how you validated changes

- Verified the technique end-to-end against the real generated `static-website` module: mocked `terraform test` with `command = plan` **passes** on the current (fixed) code and **fails with the exact `Invalid for_each argument` error** when the module is reverted to the pre-#983 `toset(concat(...))` form — with all AWS env vars unset (no credentials).
- Confirmed a mocked plan treats not-yet-created resource attributes as unknown exactly as a real plan does, so plan-time `for_each`/`count` errors are faithful (no false positives vs a real plan).
- Confirmed the mock-set-from-lockfile approach: mocking a provider the config doesn't require errors, so the set is derived from `.terraform.lock.hcl`.
- Ran the full `terraform` smoke test locally (full generator matrix + build + new plan step) to exercise the complete wired graph.

### Issue # (if applicable)

Follow-up to #983.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
