### PR TITLE
chore: drop unit test run from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,6 @@ bash packages/nx-plugin/src/preset/git-secrets-files/git-secrets-dir/git-secrets
 PRE_SHA="$(git diff HEAD --ignore-space-at-eol | shasum -a 256  --tag)"
 
 FORCE_COLOR=1 pnpm lint-staged
-FORCE_COLOR=1 pnpm nx run @aws/nx-plugin:test
 cp packages/nx-plugin/README.md README.md
 pnpm tsx scripts/make-skills.ts
 


### PR DESCRIPTION
### Reason for this change

The local `.husky/pre-commit` hook runs the full unit test suite (`pnpm nx run @aws/nx-plugin:test`) on every commit. This is redundant: CI already runs the complete suite, sharded 10 ways, on every PR (`pr.yml`) and every push to `main` (`ci.yml`). Running it locally on each commit only slows contributors down.

### Description of changes

Removed the `pnpm nx run @aws/nx-plugin:test` line from `.husky/pre-commit`. The hook still:
- registers and runs `git-secrets` to scan staged files for AWS credential patterns,
- runs `lint-staged`,
- syncs the README and generated skills, and
- fails if the working directory was modified by the hook.

### Description of how you validated changes

Confirmed the unit test target runs in CI on both PRs and pushes:
- `.github/workflows/pr.yml:82` — `pnpm nx run @aws/nx-plugin:test ... --shard=${{ matrix.shard }}/10`
- `.github/workflows/ci.yml:87` — same, and gated as a required job in the release flow (`ci.yml:257`).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
