### PR TITLE
fix(ts#react-website): dedupe react to prevent duplicate-copy runtime crash

### DIFF
--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -52,7 +52,7 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
     },
   },
-  resolve: { tsconfigPaths: true },
+  resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] },
   define: { global: {} },
 }));
 "
@@ -108,7 +108,7 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
     },
   },
-  resolve: { tsconfigPaths: true },
+  resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] },
   define: { global: {} },
 }));
 "
@@ -1138,10 +1138,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > package.json 1`] = `
 "{
   "name": "@proj/source",
-  "dependencies": {
-    "react": "catalog:",
-    "react-dom": "catalog:"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@nx/js": "23.1.0",
     "@nx/react": "catalog:",
@@ -2688,7 +2685,7 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
     },
   },
-  resolve: { tsconfigPaths: true },
+  resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] },
   define: { global: {} },
 }));
 "
@@ -2926,10 +2923,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > package.json 1`] = `
 "{
   "name": "@proj/source",
-  "dependencies": {
-    "react": "catalog:",
-    "react-dom": "catalog:"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@nx/js": "23.1.0",
     "@nx/react": "catalog:",
@@ -4679,7 +4673,7 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
     },
   },
-  resolve: { tsconfigPaths: true },
+  resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] },
   define: { global: {} },
 }));
 "
@@ -4800,7 +4794,7 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
     },
   },
-  resolve: { tsconfigPaths: true },
+  resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] },
   define: { global: {} },
 }));
 "
@@ -5523,12 +5517,7 @@ root &&
 "
 `;
 
-exports[`react-website generator > should handle npm scope prefix correctly > scoped-dependencies 1`] = `
-{
-  "react": "catalog:",
-  "react-dom": "catalog:",
-}
-`;
+exports[`react-website generator > should handle npm scope prefix correctly > scoped-dependencies 1`] = `{}`;
 
 exports[`react-website generator ux tests > Cloudscape > should update package.json with required dependencies > test-app/src/components/AppLayout/index.tsx 1`] = `
 "import * as React from 'react';

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -74,6 +74,29 @@ describe('react-website generator', () => {
     expect(viteConfig).toMatchSnapshot('vite.config.mts');
   });
 
+  it('keeps a single react copy: declared only on the website and deduped', async () => {
+    await tsReactWebsiteGenerator(tree, options);
+
+    // The website declares its own react/react-dom.
+    const websitePackageJson = readJson(tree, 'test-app/package.json');
+    expect(websitePackageJson.dependencies?.react).toBeDefined();
+    expect(websitePackageJson.dependencies?.['react-dom']).toBeDefined();
+
+    // @nx/react seeds react/react-dom into the root manifest; without catalogs
+    // (npm) its floating range resolves to a different version than the
+    // website's pin and installs a second React. The generator removes them.
+    const rootPackageJson = readJson(tree, 'package.json');
+    expect(rootPackageJson.dependencies?.react).toBeUndefined();
+    expect(rootPackageJson.dependencies?.['react-dom']).toBeUndefined();
+    expect(rootPackageJson.devDependencies?.react).toBeUndefined();
+    expect(rootPackageJson.devDependencies?.['react-dom']).toBeUndefined();
+
+    // The bundle also dedupes react so a hoisted workspace-library copy can't
+    // become a second React instance at build time.
+    const viteConfig = tree.read('test-app/vite.config.mts')?.toString();
+    expect(viteConfig).toContain("dedupe: ['react', 'react-dom']");
+  });
+
   it('should generate shared constructs', async () => {
     await tsReactWebsiteGenerator(tree, options);
     // Check shared constructs files

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -8,6 +8,7 @@ import {
   names,
   OverwriteStrategy,
   readProjectConfiguration,
+  removeDependenciesFromPackageJson,
   type Tree,
   updateJson,
   updateProjectConfiguration,
@@ -416,11 +417,15 @@ export async function tsReactWebsiteGenerator(
       );
     }
 
-    // Use Vite's native tsconfig paths resolution (replaces vite-tsconfig-paths)
+    // Use Vite's native tsconfig paths resolution (replaces vite-tsconfig-paths).
+    // `dedupe` forces a single copy of react/react-dom into the bundle: each
+    // project declares its own react dependency, so without this a workspace
+    // library's hoisted copy can produce a second React instance and the
+    // "Invalid hook call" runtime crash.
     await applyGritQL(
       tree,
       viteConfigPath,
-      'or { `defineConfig(() => ({ $props }))` where { $props <: not some `resolve: $_`, $props += `resolve: { tsconfigPaths: true }` }, `defineConfig({ $props })` where { $props <: not some `resolve: $_`, $props += `resolve: { tsconfigPaths: true }` } }',
+      "or { `defineConfig(() => ({ $props }))` where { $props <: not some `resolve: $_`, $props += `resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] }` }, `defineConfig({ $props })` where { $props <: not some `resolve: $_`, $props += `resolve: { tsconfigPaths: true, dedupe: ['react', 'react-dom'] }` } }",
     );
 
     // Add define: { global: {} } to the config (handles both callback and direct forms)
@@ -518,6 +523,13 @@ export async function tsReactWebsiteGenerator(
     joinPathFragments(libraryRoot, 'package.json'),
   );
   addDependenciesToPackageJson(tree, {}, withVersions(rootDevDependencies));
+
+  // @nx/react's applicationGenerator seeds react/react-dom into the root
+  // manifest. The website now declares its own pinned versions, so drop the
+  // root copies: without catalogs (npm) the root's floating range resolves to
+  // a different version than the website's pin, installing a second React and
+  // producing the "Invalid hook call" runtime crash.
+  removeDependenciesFromPackageJson(tree, ['react', 'react-dom'], []);
 
   await addGeneratorMetricsIfApplicable(tree, [
     REACT_WEBSITE_APP_GENERATOR_INFO,


### PR DESCRIPTION
### Reason for this change

`main`'s `cdk-deploy` smoke test has been failing since #950 (idiomatic workspaces — per-project `package.json` + catalogs). The deployed React website white-screens on load with:

```
[browser:error] Invalid hook call. Hooks can only be called inside of the body of a function component.
[browser:pageerror] Cannot read properties of null (reading 'useContext')
```

Because the SPA never mounts, it never triggers the Cognito hosted-UI redirect, so the browser integration test times out at `page.waitForURL(/amazoncognito\.com/)`.

Root cause: since #950 each project declares its own `react`/`react-dom`. `@nx/react`'s `applicationGenerator` also seeds `react`/`react-dom` into the **root** manifest at a floating range. On **npm** (which has no catalog support, so the catalog-based dedup that keeps pnpm/yarn/bun green doesn't apply) the root range resolves to a different version than the website's pin, and a transitive dependency can still hoist a second `react` to the workspace root. Two React instances in the bundle produce the "Invalid hook call" crash. The standalone `react-website` smoke test stayed green because it doesn't add the connection/agent React deps that pull the second copy into the graph.

### Description of changes

- Add `resolve.dedupe: ['react', 'react-dom']` to the generated website's `vite.config.mts` so the bundle always resolves a single React copy regardless of what's hoisted into `node_modules` (the load-bearing fix).
- Remove the `react`/`react-dom` that `@nx/react` seeds into the **root** manifest so the website is the sole declarer (hygiene complement).
- Add a regression test asserting react is declared only on the website, absent from the root, and deduped in the vite config; update snapshots.

### Description of how you validated changes

- Unit tests: `react-website/app/generator.spec.ts` passes (61 tests), including the new regression test; snapshots updated.
- End-to-end, with locally-built plugin published to a local registry, generating `ts#website` + `ts#website#auth` + `ts#api` + `connection` under **npm**, then building the website bundle and loading it in a headless browser:
  - **Pre-fix bundle:** `#root` has 0 children — white screen (reproduces the CI failure).
  - **Post-fix bundle:** `#root` mounts and renders (1 child; shows the expected runtime-config error boundary since no backend was deployed). No "Invalid hook call".

### Issue # (if applicable)

N/A — regression from #950 caught by `main` CI.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
