### PR TITLE
docs: fix stale workspace dev description and add Finch to prerequisites

### DIFF
--- a/docs/src/content/docs/en/guides/workspace.mdx
+++ b/docs/src/content/docs/en/guides/workspace.mdx
@@ -113,9 +113,11 @@ Run tests across all projects:
 
 ### Dev
 
-If you have a <Link path="guides/react-website">website</Link>, start it and all connected components locally:
+Start all local development servers across your workspace:
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+See the <Link path="guides/local-development">Local Development</Link> guide for more details.
 
 ### Sync
 

--- a/docs/src/content/docs/en/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/prerequisites.mdx
@@ -10,7 +10,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommended
 
-- [Docker](https://www.docker.com/) is required for some generators. [Multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up.
+- [Docker](https://www.docker.com/) or [Finch](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
   - verify by running `terraform --version`
 - If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/en/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/prerequisites.mdx
@@ -10,7 +10,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommended
 
-- [Docker](https://www.docker.com/) or [Finch](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up.
+- [Docker](https://www.docker.com/) or [Finch](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up; Finch supports [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) out of the box.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
   - verify by running `terraform --version`
 - If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/es/guides/workspace.mdx
+++ b/docs/src/content/docs/es/guides/workspace.mdx
@@ -113,9 +113,11 @@ Ejecutar pruebas en todos los proyectos:
 
 ### Dev
 
-Si tienes un <Link path="guides/react-website">sitio web</Link>, inícialo junto con todos los componentes conectados localmente:
+Inicia todos los servidores de desarrollo locales en tu espacio de trabajo:
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+Consulta la guía de <Link path="guides/local-development">Desarrollo Local</Link> para más detalles.
 
 ### Sync
 

--- a/docs/src/content/docs/es/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/es/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recomendados
 
-- [Docker](https://www.docker.com/) es necesario para algunos generadores. Las [compilaciones multiplataforma](https://docs.docker.com/build/building/multi-platform/) deben estar configuradas.
+- [Docker](https://www.docker.com/) o [Finch](https://runfinch.com/) es necesario para algunos generadores. Para Docker, las [compilaciones multiplataforma](https://docs.docker.com/build/building/multi-platform/) deben estar configuradas; Finch admite [compilaciones multiplataforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) de forma predeterminada.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) es necesario si eliges usar esta herramienta para infraestructura como código en lugar de CDK
   - verifica ejecutando `terraform --version`
 - Si usas [VSCode](https://code.visualstudio.com/), recomendamos instalar el [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/fr/guides/workspace.mdx
+++ b/docs/src/content/docs/fr/guides/workspace.mdx
@@ -113,9 +113,11 @@ Exécuter les tests sur tous les projets :
 
 ### Dev
 
-Si vous avez un <Link path="guides/react-website">site web</Link>, démarrez-le ainsi que tous les composants connectés localement :
+Démarrez tous les serveurs de développement locaux dans votre espace de travail :
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+Consultez le guide <Link path="guides/local-development">Développement local</Link> pour plus de détails.
 
 ### Sync
 
@@ -190,4 +192,3 @@ export default {
 - **`containers.engine`** — le CLI de conteneur (`docker` ou `finch`) intégré dans les commandes de build/push/login générées. Les builds d'image-asset CDK récupèrent également cette valeur via la variable d'environnement `CDK_DOCKER`. Consultez le <Link path="guides/docker-bundling">guide de bundling Docker</Link> pour plus de détails.
 
 Vous pouvez modifier l'un ou l'autre paramètre à tout moment — les exécutions ultérieures du générateur récupéreront la nouvelle valeur.
-r l'un ou l'autre paramètre à tout moment — les exécutions ultérieures du générateur récupéreront la nouvelle valeur.

--- a/docs/src/content/docs/fr/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/fr/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommandé
 
-- [Docker](https://www.docker.com/) est requis pour certains générateurs. Les [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) doivent être configurés.
+- [Docker](https://www.docker.com/) ou [Finch](https://runfinch.com/) est requis pour certains générateurs. Pour Docker, les [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) doivent être configurés ; Finch prend en charge les [builds multi-plateformes](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) nativement.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) est requis si vous choisissez de l'utiliser pour l'infrastructure as code au lieu de CDK
   - vérifiez en exécutant `terraform --version`
 - Si vous utilisez [VSCode](https://code.visualstudio.com/), nous recommandons d'installer le [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/it/guides/workspace.mdx
+++ b/docs/src/content/docs/it/guides/workspace.mdx
@@ -111,9 +111,11 @@ Esegui i test su tutti i progetti:
 
 ### Dev
 
-Se hai un <Link path="guides/react-website">sito web</Link>, avvialo insieme a tutti i componenti connessi localmente:
+Avvia tutti i server di sviluppo locali nel tuo workspace:
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+Consulta la guida <Link path="guides/local-development">Sviluppo Locale</Link> per maggiori dettagli.
 
 ### Sync
 

--- a/docs/src/content/docs/it/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/it/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Consigliati
 
-- [Docker](https://www.docker.com/) è necessario per alcuni generatori. Le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) devono essere configurate.
+- [Docker](https://www.docker.com/) o [Finch](https://runfinch.com/) è necessario per alcuni generatori. Per Docker, le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) devono essere configurate; Finch supporta le [build multi-piattaforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) di default.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) è richiesto se scegli di utilizzarlo per l'infrastructure as code invece di CDK
   - verifica eseguendo `terraform --version`
 - Se utilizzi [VSCode](https://code.visualstudio.com/), consigliamo di installare il [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/jp/guides/workspace.mdx
+++ b/docs/src/content/docs/jp/guides/workspace.mdx
@@ -83,7 +83,9 @@ Nxは、以前に実行されたターゲットの出力をキャッシュし、
 
 これは、モノレポ内のすべてのプロジェクトがデフォルトで同じバージョンの依存関係を使用することを意味し、同じモノレポ内のパッケージがバージョンの不一致の問題に遭遇することを減らします。
 
-Nodeの観点からは、これはルートに単一のロックファイルがあり、依存関係が一度インストールされ、各プロジェクトにリンクされることを意味します。各Nodeプロジェクトは、そのソースがインポートするランタイム依存関係を独自の`package.json`で宣言し、共有のビルド/テストツールはルートの`package.json`の`devDependencies`に配置されます。プロジェクトのランタイム依存関係を追加するには、パッケージマネージャーのフィルター/ワークスペースフラグを使用し（例：`pnpm add <pkg> --filter <project>`）、共有の開発ツールはルートに追加してください。
+Nodeの観点からは、これはルートに単一のロックファイルがあり、依存関係が一度インストールされ、各プロジェクトにリンクされることを意味します。各Nodeプロジェクトは、そのソースがインポートするランタイム依存関係を独自の`package.json`で宣言し、共有のビルド/テストツールはルートの`package.json`の`devDependencies`に配置されます。プロジェクトのランタイム依存関係を追加するには、そのプロジェクトにインストールしてください：
+
+<InstallCommand pkg="some-npm-package" project="@my-scope/my-project" />
 
 カタログサポートを持つパッケージマネージャー（[pnpm](https://pnpm.io/catalogs)、[yarn](https://yarnpkg.com/features/catalogs)、[bun](https://bun.com/docs/install/catalogs)）の場合、依存関係のバージョンはカタログに記録され、`catalog:`プロトコルで参照されます。これにより、すべてのプロジェクトの`package.json`間でバージョンの単一の情報源が維持されます。npmワークスペースの場合、複数の`package.json`ファイル間で宣言されたバージョンを整合させるために[syncpack](https://github.com/JamieMason/syncpack)を推奨します。
 
@@ -111,9 +113,11 @@ Pythonの観点からは、これはモノレポのルートに単一の`.venv`�
 
 ### Dev
 
-<Link path="guides/react-website">ウェブサイト</Link>がある場合、それと接続されたすべてのコンポーネントをローカルで起動：
+ワークスペース全体のすべてのローカル開発サーバーを起動：
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+詳細については、<Link path="guides/local-development">ローカル開発</Link>ガイドを参照してください。
 
 ### 同期
 

--- a/docs/src/content/docs/jp/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/jp/snippets/prerequisites.mdx
@@ -10,7 +10,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 推奨
 
-- [Docker](https://www.docker.com/)は一部のジェネレーターで必要です。[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)をセットアップする必要があります。
+- [Docker](https://www.docker.com/)または[Finch](https://runfinch.com/)は一部のジェネレーターで必要です。Dockerの場合、[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)をセットアップする必要があります。Finchは[マルチプラットフォームビルド](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)を標準でサポートしています。
 - CDKの代わりにインフラストラクチャー・アズ・コードでTerraformを使用する場合、[Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)が必要です
   - `terraform --version` を実行して確認してください
 - [VSCode](https://code.visualstudio.com/)を使用する場合、[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)のインストールを推奨します

--- a/docs/src/content/docs/ko/guides/workspace.mdx
+++ b/docs/src/content/docs/ko/guides/workspace.mdx
@@ -6,6 +6,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
+import InstallCommand from '@components/install-command.astro';
 import NxCommands from '@components/nx-commands.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 
@@ -82,7 +83,9 @@ Nx는 이전에 실행된 타겟의 출력을 캐시하고 입력이 변경되�
 
 즉, 모노레포 내의 모든 프로젝트가 기본적으로 동일한 버전의 종속성을 사용하므로 동일한 모노레포의 패키지가 버전 불일치 문제에 직면하는 것과 관련된 문제를 줄입니다.
 
-Node 관점에서 이는 루트의 단일 lockfile을 의미하며, 종속성은 한 번 설치되고 각 프로젝트에 링크됩니다. 각 Node 프로젝트는 소스가 가져오는 런타임 종속성을 자체 `package.json`에 선언하고, 공유 빌드/테스트 도구는 루트 `package.json`의 `devDependencies`에 위치합니다. 프로젝트의 런타임 종속성은 패키지 매니저의 필터/워크스페이스 플래그(예: `pnpm add <pkg> --filter <project>`)로 추가하고, 공유 개발 도구는 루트에 추가하세요.
+Node 관점에서 이는 루트의 단일 lockfile을 의미하며, 종속성은 한 번 설치되고 각 프로젝트에 링크됩니다. 각 Node 프로젝트는 소스가 가져오는 런타임 종속성을 자체 `package.json`에 선언하고, 공유 빌드/테스트 도구는 루트 `package.json`의 `devDependencies`에 위치합니다. 프로젝트의 런타임 종속성을 추가하려면 해당 프로젝트에 설치하세요:
+
+<InstallCommand pkg="some-npm-package" project="@my-scope/my-project" />
 
 카탈로그를 지원하는 패키지 매니저([pnpm](https://pnpm.io/catalogs), [yarn](https://yarnpkg.com/features/catalogs) 및 [bun](https://bun.com/docs/install/catalogs))의 경우, 종속성 버전이 카탈로그에 기록되고 `catalog:` 프로토콜로 참조되므로, 모든 프로젝트의 `package.json`에서 버전에 대한 단일 소스를 유지합니다. npm 워크스페이스의 경우, 여러 `package.json` 파일에 선언된 버전을 정렬하기 위해 [syncpack](https://github.com/JamieMason/syncpack)을 권장합니다.
 
@@ -110,9 +113,11 @@ Python 관점에서 이는 모든 종속성이 설치된 모노레포 루트의 
 
 ### 개발
 
-<Link path="guides/react-website">웹사이트</Link>가 있는 경우, 웹사이트와 연결된 모든 구성 요소를 로컬에서 시작:
+워크스페이스 전체에서 모든 로컬 개발 서버 시작:
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+자세한 내용은 <Link path="guides/local-development">로컬 개발</Link> 가이드를 참조하세요.
 
 ### 동기화
 

--- a/docs/src/content/docs/ko/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/ko/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 권장 사항
 
-- 일부 생성기에는 [Docker](https://www.docker.com/)가 필요합니다. [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/)가 설정되어 있어야 합니다.
+- 일부 생성기에는 [Docker](https://www.docker.com/) 또는 [Finch](https://runfinch.com/)가 필요합니다. Docker의 경우 [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/)가 설정되어 있어야 하며, Finch는 [멀티 플랫폼 빌드](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)를 기본적으로 지원합니다.
 - CDK 대신 인프라스트럭처 코드로 Terraform을 사용할 경우 [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) 설치 필요
   - `terraform --version` 명령어로 버전 확인
 - [VSCode](https://code.visualstudio.com/) 사용 시 [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) 설치 권장

--- a/docs/src/content/docs/pt/guides/workspace.mdx
+++ b/docs/src/content/docs/pt/guides/workspace.mdx
@@ -113,9 +113,11 @@ Executar testes em todos os projetos:
 
 ### Dev
 
-Se você tem um <Link path="guides/react-website">website</Link>, inicie-o e todos os componentes conectados localmente:
+Inicie todos os servidores de desenvolvimento locais em seu workspace:
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+Consulte o guia <Link path="guides/local-development">Desenvolvimento Local</Link> para mais detalhes.
 
 ### Sync
 

--- a/docs/src/content/docs/pt/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/pt/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recomendados
 
-- [Docker](https://www.docker.com/) é necessário para alguns geradores. [Compilações multi-plataforma](https://docs.docker.com/build/building/multi-platform/) devem ser configuradas.
+- [Docker](https://www.docker.com/) ou [Finch](https://runfinch.com/) é necessário para alguns geradores. Para Docker, [compilações multi-plataforma](https://docs.docker.com/build/building/multi-platform/) devem ser configuradas; Finch suporta [compilações multi-plataforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) pronto para uso.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) é necessário se você optar por usar isso para infraestrutura como código em vez do CDK
   - verifique executando `terraform --version`
 - Se você usa [VSCode](https://code.visualstudio.com/), recomendamos instalar o [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/vi/guides/workspace.mdx
+++ b/docs/src/content/docs/vi/guides/workspace.mdx
@@ -110,9 +110,11 @@ Chạy test trên tất cả các dự án:
 
 ### Dev
 
-Nếu bạn có một <Link path="guides/react-website">website</Link>, khởi động nó và tất cả các component được kết nối cục bộ:
+Khởi động tất cả các máy chủ phát triển cục bộ trên workspace của bạn:
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+Xem hướng dẫn <Link path="guides/local-development">Local Development</Link> để biết thêm chi tiết.
 
 ### Sync
 

--- a/docs/src/content/docs/vi/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/vi/snippets/prerequisites.mdx
@@ -11,7 +11,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Khuyến nghị
 
-- [Docker](https://www.docker.com/) là bắt buộc đối với một số trình tạo. [Multi-platform builds](https://docs.docker.com/build/building/multi-platform/) phải được thiết lập.
+- [Docker](https://www.docker.com/) hoặc [Finch](https://runfinch.com/) là bắt buộc đối với một số trình tạo. Đối với Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) phải được thiết lập; Finch hỗ trợ [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) ngay từ đầu.
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) là bắt buộc nếu bạn chọn sử dụng công cụ này cho cơ sở hạ tầng dưới dạng mã thay vì CDK
   - xác minh bằng cách chạy `terraform --version`
 - Nếu bạn đang sử dụng [VSCode](https://code.visualstudio.com/), chúng tôi khuyến nghị cài đặt [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/zh/guides/workspace.mdx
+++ b/docs/src/content/docs/zh/guides/workspace.mdx
@@ -110,9 +110,11 @@ Nx 缓存先前执行的目标的输出，并在输入未更改时重放它们�
 
 ### 开发
 
-如果您有一个<Link path="guides/react-website">网站</Link>，在本地启动它和所有连接的组件：
+在工作空间中启动所有本地开发服务器：
 
 <PackageManagerShortCommand commands={["dev"]} />
+
+有关更多详细信息，请参阅<Link path="guides/local-development">本地开发</Link>指南。
 
 ### 同步
 

--- a/docs/src/content/docs/zh/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/zh/snippets/prerequisites.mdx
@@ -13,7 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 推荐
 
-- [Docker](https://www.docker.com/)：部分生成器需要。必须设置[多平台构建](https://docs.docker.com/build/building/multi-platform/)。
+- [Docker](https://www.docker.com/) 或 [Finch](https://runfinch.com/)：部分生成器需要。对于 Docker，必须设置[多平台构建](https://docs.docker.com/build/building/multi-platform/)；Finch 开箱即支持[多平台构建](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)。
 - [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)：如果选择使用 Terraform 替代 CDK 进行基础设施即代码时需要
   - 可通过运行 `terraform --version` 验证版本
 - 如果使用 [VSCode](https://code.visualstudio.com/)，推荐安装 [Nx Console VSCode 插件](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)


### PR DESCRIPTION
### Reason for this change

The workspace guide's `dev` command description was out of date — it suggested `pnpm dev` only applies when you have a website, but the root `dev` script runs `nx run-many --target dev`, starting all local development servers across the workspace. Additionally, the prerequisites snippet only mentioned Docker, but Finch is equally supported as a container engine.

### Description of changes

- `docs/src/content/docs/en/guides/workspace.mdx`: updated the Dev section to say the command starts all local development servers across your workspace, and added a link to the Local Development guide for more details.
- `docs/src/content/docs/en/snippets/prerequisites.mdx`: prerequisites now state Docker or [Finch](https://runfinch.com/) is required for some generators, with the multi-platform builds note scoped to Docker.

### Description of how you validated changes

Docs-only change; validated with a full `nx run docs:build` which passed.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*