### PR TITLE
test(nx-plugin): isolate git config in tests so they stop polluting the machine

### DIFF
--- a/e2e/src/smoke-tests/git-secrets.spec.ts
+++ b/e2e/src/smoke-tests/git-secrets.spec.ts
@@ -3,26 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from 'node:child_process';
-import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildCreateNxWorkspaceCommand, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - git-secrets', () => {
   const pkgMgr = 'pnpm';
   const targetDir = `${tmpProjPath()}/git-secrets-${pkgMgr}`;
+  let gitConfigDir: string;
+
+  /**
+   * `git` with an identity supplied through a throwaway config, rather than
+   * `git config --global`, which would overwrite the real `user.name`/
+   * `user.email` of whoever (or whatever CI runner) ran the suite and leave it
+   * overwritten afterwards. `GIT_CONFIG_SYSTEM` points at an empty file so
+   * system config cannot supply a conflicting identity.
+   */
+  const git = (args: string[], cwd: string) =>
+    execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: join(gitConfigDir, 'global'),
+        GIT_CONFIG_SYSTEM: join(gitConfigDir, 'system'),
+      },
+    });
 
   beforeEach(() => {
     if (existsSync(targetDir)) {
       rmSync(targetDir, { force: true, recursive: true });
     }
     ensureDirSync(targetDir);
-    execSync('git config --global user.email "test@example.com"', {
-      stdio: 'pipe',
-    });
-    execSync('git config --global user.name "Test"', { stdio: 'pipe' });
+
+    gitConfigDir = mkdtempSync(join(tmpdir(), 'nx-e2e-gitconfig-'));
+    writeFileSync(
+      join(gitConfigDir, 'global'),
+      '[user]\n\tname = E2E Test\n\temail = e2e-test@example.invalid\n',
+    );
+    writeFileSync(join(gitConfigDir, 'system'), '');
+  });
+
+  afterEach(() => {
+    if (gitConfigDir && existsSync(gitConfigDir)) {
+      rmSync(gitConfigDir, { force: true, recursive: true });
+    }
   });
 
   it('should block commits containing AWS access keys', async () => {
@@ -32,6 +62,10 @@ describe('smoke test - git-secrets', () => {
         cwd: targetDir,
         prefixWithPackageManagerCmd: false,
         redirectStderr: true,
+        env: {
+          GIT_CONFIG_GLOBAL: join(gitConfigDir, 'global'),
+          GIT_CONFIG_SYSTEM: join(gitConfigDir, 'system'),
+        },
       },
     );
     const projectRoot = `${targetDir}/gs-test`;
@@ -48,15 +82,11 @@ describe('smoke test - git-secrets', () => {
       join(projectRoot, 'secret.ts'),
       `export const KEY = "AKIAIOSFODNN7EXAMPLA";\n`,
     );
-    execSync('git add secret.ts', { cwd: projectRoot });
+    git(['add', 'secret.ts'], projectRoot);
 
     let blocked = false;
     try {
-      execSync('git commit -m "add secret"', {
-        cwd: projectRoot,
-        encoding: 'utf-8',
-        stdio: 'pipe',
-      });
+      git(['commit', '-m', 'add secret'], projectRoot);
     } catch (e) {
       blocked = true;
       expect(e.stderr).toContain('Matched one or more prohibited patterns');
@@ -64,19 +94,12 @@ describe('smoke test - git-secrets', () => {
     expect(blocked).toBe(true);
 
     // Safe files can be committed
-    execSync('git rm --cached secret.ts', {
-      cwd: projectRoot,
-      stdio: 'pipe',
-    });
+    git(['rm', '--cached', 'secret.ts'], projectRoot);
     writeFileSync(
       join(projectRoot, 'safe.ts'),
       `export const greeting = 'hello';\n`,
     );
-    execSync('git add safe.ts', { cwd: projectRoot });
-    execSync('git commit -m "add safe file"', {
-      cwd: projectRoot,
-      encoding: 'utf-8',
-      stdio: 'pipe',
-    });
+    git(['add', 'safe.ts'], projectRoot);
+    git(['commit', '-m', 'add safe file'], projectRoot);
   });
 });

--- a/packages/nx-plugin/src/license/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/license/sync/generator.spec.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { execSync } from 'child_process';
-import { mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { FsTree, flushChanges } from 'nx/src/generators/tree';
 import type { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
 import os from 'os';
@@ -14,11 +13,16 @@ import {
   updateAwsNxPluginConfig,
 } from '../../utils/config/utils';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { initTestGitRepo, useIsolatedGitEnv } from '../../utils/test-git';
 import type { LicenseSourceConfig } from '../config-types';
 import { licenseSyncGenerator } from './generator';
 
 describe('licenseSyncGenerator', () => {
   let tree: Tree;
+
+  // The git-backed cases below shell out to git in a temp directory; keep those
+  // calls off the developer's real repository and config.
+  useIsolatedGitEnv();
 
   beforeEach(() => {
     tree = createTreeUsingTsSolutionSetup();
@@ -110,7 +114,7 @@ describe('licenseSyncGenerator', () => {
 
       // Write file to the filesystem that's not tracked by the tree
       mkdirSync(path.join(tmpDir, 'nested'));
-      execSync("echo 'const foo = 3;' > nested/foo.ts", { cwd: tmpDir });
+      writeFileSync(path.join(tmpDir, 'nested/foo.ts'), 'const foo = 3;\n');
 
       await addLicenseConfig(undefined, fsTree);
 
@@ -939,9 +943,7 @@ describe('licenseSyncGenerator', () => {
 
     try {
       const fsTree = new FsTree(tmpDir, false);
-      execSync('git init', { cwd: tmpDir });
-      execSync('git config user.email test@example.com', { cwd: tmpDir });
-      execSync('git config user.name test', { cwd: tmpDir });
+      initTestGitRepo(tmpDir);
 
       // Add default config
       await addLicenseConfig(undefined, fsTree);
@@ -968,9 +970,7 @@ describe('licenseSyncGenerator', () => {
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'test-dir'));
 
     try {
-      execSync('git init', { cwd: tmpDir });
-      execSync('git config user.email test@example.com', { cwd: tmpDir });
-      execSync('git config user.name test', { cwd: tmpDir });
+      initTestGitRepo(tmpDir);
 
       const subDir = path.join(tmpDir, 'sub-dir');
       mkdirSync(subDir);

--- a/packages/nx-plugin/src/utils/git.spec.ts
+++ b/packages/nx-plugin/src/utils/git.spec.ts
@@ -3,40 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { FsTree, flushChanges, type Tree } from 'nx/src/generators/tree';
 import * as os from 'os';
 import * as path from 'path';
 import { getGitIncludedFiles, isWithinGitRepo, updateGitIgnore } from './git';
 import { createTreeUsingTsSolutionSetup } from './test';
-
-/**
- * Remove inherited GIT_* environment variables (eg GIT_DIR, GIT_INDEX_FILE)
- * before each test and restore them afterwards. When these tests run inside a
- * git hook (eg pre-commit), git exports these variables pointing at the
- * surrounding repository. Since they take precedence over `cwd`, the git
- * commands run here would otherwise operate on that repository - committing
- * test fixtures and deleting real files - instead of the isolated temp repo.
- */
-const useIsolatedGitEnv = () => {
-  const savedGitEnv: Record<string, string | undefined> = {};
-
-  beforeEach(() => {
-    for (const key of Object.keys(process.env)) {
-      if (key.startsWith('GIT_')) {
-        savedGitEnv[key] = process.env[key];
-        delete process.env[key];
-      }
-    }
-  });
-
-  afterEach(() => {
-    for (const [key, value] of Object.entries(savedGitEnv)) {
-      process.env[key] = value;
-    }
-  });
-};
+import { initTestGitRepo, runGit, useIsolatedGitEnv } from './test-git';
 
 describe('git utils', () => {
   describe('getGitIncludedFiles', () => {
@@ -48,9 +21,7 @@ describe('git utils', () => {
     beforeEach(() => {
       tmpDir = mkdtempSync(path.join(os.tmpdir(), 'test-dir'));
       tree = new FsTree(tmpDir, false);
-      execSync('git init', { cwd: tmpDir });
-      execSync('git config user.email test@example.com', { cwd: tmpDir });
-      execSync('git config user.name test', { cwd: tmpDir });
+      initTestGitRepo(tmpDir);
     });
 
     afterEach(() => {
@@ -64,8 +35,8 @@ describe('git utils', () => {
 
       flushChanges(tree.root, tree.listChanges());
 
-      execSync('git add .', { cwd: tmpDir });
-      execSync("git commit -m 'test' --no-verify", { cwd: tmpDir });
+      runGit(['add', '.'], tmpDir);
+      runGit(['commit', '-m', 'test', '--no-verify'], tmpDir);
 
       tree.write('new-and-not-committed.ts', "const bar = 'baz';");
       tree.write('ignored.txt', 'should not be included');
@@ -160,9 +131,7 @@ describe('git utils', () => {
 
     it('should return true when inside a git repository (without .git in root)', () => {
       // Initialize git repo
-      execSync('git init', { cwd: tmpDir });
-      execSync('git config user.email test@example.com', { cwd: tmpDir });
-      execSync('git config user.name test', { cwd: tmpDir });
+      initTestGitRepo(tmpDir);
 
       // Create a subdirectory tree that doesn't have .git but is within the repo
       const subDir = path.join(tmpDir, 'subdir');

--- a/packages/nx-plugin/src/utils/test-git.spec.ts
+++ b/packages/nx-plugin/src/utils/test-git.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initTestGitRepo, runGit, useIsolatedGitEnv } from './test-git';
+
+describe('test-git', () => {
+  describe('useIsolatedGitEnv', () => {
+    useIsolatedGitEnv();
+
+    it('should point git at a throwaway global config, not the real one', () => {
+      const globalConfig = process.env.GIT_CONFIG_GLOBAL;
+      expect(globalConfig).toBeDefined();
+      expect(globalConfig).toContain('nx-plugin-gitconfig-');
+
+      // A stray `--global` write lands in the throwaway file, so the
+      // developer's real ~/.gitconfig is never modified.
+      const dir = mkdtempSync(join(tmpdir(), 'test-git-'));
+      try {
+        initTestGitRepo(dir);
+        runGit(
+          ['config', '--global', 'user.email', 'stray@example.invalid'],
+          dir,
+        );
+        expect(readFileSync(globalConfig, 'utf-8')).toContain(
+          'stray@example.invalid',
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('should clear inherited GIT_DIR so git cannot escape to another repo', () => {
+      expect(process.env.GIT_DIR).toBeUndefined();
+      expect(process.env.GIT_INDEX_FILE).toBeUndefined();
+    });
+
+    it('should keep writes inside the temp repo when GIT_DIR points elsewhere', () => {
+      const outer = mkdtempSync(join(tmpdir(), 'test-git-outer-'));
+      const inner = mkdtempSync(join(tmpdir(), 'test-git-inner-'));
+      try {
+        initTestGitRepo(outer);
+        initTestGitRepo(inner);
+
+        // Simulate running under a git hook, which exports GIT_DIR pointing at
+        // the surrounding repository. `runGit` must ignore it.
+        process.env.GIT_DIR = join(outer, '.git');
+        process.env.GIT_INDEX_FILE = join(outer, '.git', 'index');
+
+        runGit(['config', 'user.email', 'inner@example.invalid'], inner);
+
+        expect(readFileSync(join(inner, '.git', 'config'), 'utf-8')).toContain(
+          'inner@example.invalid',
+        );
+        expect(
+          readFileSync(join(outer, '.git', 'config'), 'utf-8'),
+        ).not.toContain('inner@example.invalid');
+      } finally {
+        rmSync(outer, { recursive: true, force: true });
+        rmSync(inner, { recursive: true, force: true });
+      }
+    });
+
+    it('should give temp repos an identity without any per-repo git config', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'test-git-'));
+      try {
+        initTestGitRepo(dir);
+        writeFileSync(join(dir, 'file.txt'), 'contents\n');
+        runGit(['add', 'file.txt'], dir);
+        // Commits succeed purely from the isolated global config — no
+        // `git config user.*` call, so nothing can be written to a real repo.
+        runGit(['commit', '-m', 'test'], dir);
+
+        expect(runGit(['log', '--format=%ae'], dir).trim()).toBe(
+          'nx-plugin-for-aws-test@example.invalid',
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/test-git.ts
+++ b/packages/nx-plugin/src/utils/test-git.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach } from 'vitest';
+
+/**
+ * Identity used by the temp repositories these helpers create. Only ever
+ * written to a throwaway `GIT_CONFIG_GLOBAL` file, never to the developer's
+ * real config.
+ */
+const TEST_GIT_USER_NAME = 'nx-plugin-for-aws-test';
+const TEST_GIT_USER_EMAIL = 'nx-plugin-for-aws-test@example.invalid';
+
+/**
+ * Isolate every git invocation in the surrounding tests from the machine's real
+ * git configuration, and point the test identity at a throwaway config file.
+ *
+ * Two leaks are prevented:
+ *
+ * 1. Inherited `GIT_*` variables. When the test suite runs from a git hook (the
+ *    repo's `pre-commit` runs the unit tests), git exports `GIT_DIR` and
+ *    `GIT_INDEX_FILE` pointing at the surrounding repository. Those take
+ *    precedence over `cwd`, so `git init`/`git config`/`git commit` in a temp
+ *    directory operate on the real repository instead — writing `user.*` into
+ *    its `.git/config` and committing test fixtures.
+ * 2. Reads of, and writes to, the user's global and system config. Pointing
+ *    `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at files inside a temp directory
+ *    means a stray `git config --global` lands there and is deleted with it,
+ *    and the developer's real `user.email` can neither leak into assertions nor
+ *    be overwritten.
+ *
+ * Both env vars are restored after each test.
+ */
+export const useIsolatedGitEnv = () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  let configDir: string | undefined;
+
+  beforeEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('GIT_')) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    }
+
+    configDir = mkdtempSync(join(tmpdir(), 'nx-plugin-gitconfig-'));
+    // Seed the identity here rather than per-repo, so temp repos need no
+    // `git config` call at all and cannot write to a real repository.
+    writeFileSync(
+      join(configDir, 'global'),
+      `[user]\n\tname = ${TEST_GIT_USER_NAME}\n\temail = ${TEST_GIT_USER_EMAIL}\n`,
+    );
+    // Empty, so system config (which may set user.* or hook paths) cannot leak.
+    writeFileSync(join(configDir, 'system'), '');
+
+    for (const key of ['GIT_CONFIG_GLOBAL', 'GIT_CONFIG_SYSTEM'] as const) {
+      savedEnv[key] ??= process.env[key];
+    }
+    process.env.GIT_CONFIG_GLOBAL = join(configDir, 'global');
+    process.env.GIT_CONFIG_SYSTEM = join(configDir, 'system');
+  });
+
+  afterEach(() => {
+    // Clear every GIT_* variable first, so any set *during* the test (and
+    // therefore absent from savedEnv) cannot leak into the next one.
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('GIT_')) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value !== undefined) {
+        process.env[key] = value;
+      }
+    }
+    for (const key of Object.keys(savedEnv)) {
+      delete savedEnv[key];
+    }
+    if (configDir) {
+      rmSync(configDir, { force: true, recursive: true });
+      configDir = undefined;
+    }
+  });
+};
+
+/**
+ * Run a git command in `cwd`, with the ambient `GIT_DIR`/`GIT_INDEX_FILE`
+ * cleared so it cannot escape to a surrounding repository even if
+ * `useIsolatedGitEnv` is not in effect. `execFileSync` (no shell) keeps
+ * arguments from being re-split.
+ */
+export const runGit = (args: string[], cwd: string): string =>
+  execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      GIT_DIR: undefined,
+      GIT_WORK_TREE: undefined,
+      GIT_INDEX_FILE: undefined,
+      GIT_COMMON_DIR: undefined,
+    } as NodeJS.ProcessEnv,
+  });
+
+/**
+ * Create a git repository in `dir` for a test to work in. The identity comes
+ * from the isolated global config set up by `useIsolatedGitEnv`, so nothing is
+ * written outside `dir`. Hooks are disabled — the repo under test has a
+ * `pre-commit` hook that runs the whole test suite.
+ */
+export const initTestGitRepo = (dir: string): void => {
+  runGit(['init'], dir);
+  runGit(['config', 'core.hooksPath', '/dev/null'], dir);
+};


### PR DESCRIPTION
### Reason for this change

Several tests set `user.name`/`user.email` in a way that escaped the temp directory they were meant to be scoped to, leaving the placeholder identity (`test` / `test@example.com`) behind on developer machines and CI runners. Two independent leaks:

1. **`--global` write, never restored.** `e2e/src/smoke-tests/git-secrets.spec.ts` ran `git config --global user.email "test@example.com"` in `beforeEach` with no `afterEach`, permanently overwriting the real `~/.gitconfig` of whoever (or whatever runner) ran the e2e suite.

2. **`GIT_DIR` escape.** `packages/nx-plugin/src/utils/git.spec.ts` and `packages/nx-plugin/src/license/sync/generator.spec.ts` ran `git config user.email` with `cwd` set to a temp repo, which looks correctly scoped but is not. The repo's `pre-commit` hook runs the unit suite, and git exports `GIT_DIR`/`GIT_INDEX_FILE` to hooks; those take precedence over `cwd`, so the write landed in the **surrounding repository's** `.git/config`. In a linked worktree it is worse — `GIT_DIR` points at `.git/worktrees/<name>`, which has no config file of its own, so the write falls through to the shared main-repo config and pollutes every worktree at once.

The consequence is mis-authored commits: local commits and `Co-authored-by:` trailers attributed to `test <test@example.com>`.

`git.spec.ts` already had a partial guard (it stripped `GIT_*` variables), but it still called `git config user.*`, and the other two specs had no protection at all.

### Description of changes

Test-only change — no generator, template or vended code is touched, so there is no change to plugin behaviour.

New `packages/nx-plugin/src/utils/test-git.ts`:

- **`useIsolatedGitEnv()`** — clears all `GIT_*` variables and points `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at a temp directory seeded with the test identity, so even a stray `--global` write lands in a throwaway file that is deleted afterwards. `GIT_CONFIG_SYSTEM` is an empty file so system config cannot leak in either. `afterEach` clears every `GIT_*` variable before restoring the saved ones, so a variable set *during* a test cannot leak into the next.
- **`initTestGitRepo()`** — temp repos inherit their identity from that isolated global config, so there is no `git config user.*` call left to leak at all. Also sets `core.hooksPath` to `/dev/null`, since the repo under test has a `pre-commit` hook that runs the whole suite.
- **`runGit()`** — `execFileSync` (no shell, so arguments are not re-split) with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` cleared per call, so it cannot escape to a surrounding repository even where the fixture is not in effect.

The three offending specs now use these helpers. `git-secrets.spec.ts` threads a throwaway `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pair through to both the workspace creation and its `git` calls instead of writing to the global config, mirroring the isolation already used by the interactive case in `create-workspace.spec.ts`.

One incidental change: a non-git `execSync("echo ... > nested/foo.ts")` in `license/sync/generator.spec.ts` became a `writeFileSync`, as removing the git calls left `execSync` otherwise unused in that file.

### Description of how you validated changes

- Reproduced both leaks directly before fixing: a `GIT_DIR`-scoped `git config` write landing in an outer repo's config, and the same via a linked worktree's `GIT_DIR` falling through to the shared main-repo config.
- Added `test-git.spec.ts` covering the isolation contract: `--global` writes land in the throwaway file, inherited `GIT_DIR` is cleared, `runGit` keeps writes inside the temp repo when `GIT_DIR` points elsewhere, and temp repos commit with the isolated identity and no per-repo config.
- Ran the affected specs with `GIT_DIR`/`GIT_INDEX_FILE` pointed at a sacrificial repo to simulate the pre-commit hook: all pass, and the sacrificial repo received no `user.*` entries and no stray commits.
- Exercised the real failure mode end to end: the `pre-commit` hook ran the full suite while committing this change, and afterwards the commit was correctly authored and neither the global config nor any repo config had been touched.
- Full unit suite green locally: 2701 tests across 138 files. `lint` and `typecheck` pass for `@aws/nx-plugin` and `@aws/nx-plugin-e2e`; `@aws/nx-plugin:build` succeeds.
- CI green across all 56 checks, including the `git-secrets` smoke test on both Linux and Windows — the case that could not be run locally.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*