### PR TITLE
fix(nx-plugin): pin ruff rule selection and cwd when formatting at generation

### DIFF
--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -43,6 +43,7 @@ describe('format utils', () => {
     moduleName: string,
     lineLength?: number,
     requiresPython?: string,
+    select?: string[],
   ) => {
     const root = `packages/${name}`;
     addProjectConfiguration(tree, `proj.${name}`, { root });
@@ -54,6 +55,9 @@ describe('format utils', () => {
         '',
         ...(lineLength !== undefined
           ? ['[tool.ruff]', `line-length = ${lineLength}`, '']
+          : []),
+        ...(select !== undefined
+          ? ['[tool.ruff.lint]', `select = ${JSON.stringify(select)}`, '']
           : []),
         '[project]',
         `name = "proj-${name}"`,
@@ -144,9 +148,9 @@ describe('format utils', () => {
       expect(tree.read('lib/test.ts')?.toString()).toBe('const y = 2;\n');
     });
     it('should sort imports in Python files', async () => {
-      // isort (ruff rule I) is not in ruff's default rule set and the project
-      // config is not on disk during generation, so the formatter must opt into
-      // import sorting explicitly to match what the project's build enforces.
+      // The project's ruff config is not on disk during generation, so the
+      // formatter must pin the rule selection the project's build enforces
+      // (which includes isort, rule I) rather than defer to ruff's defaults.
       tree.write(
         'src/__init__.py',
         [
@@ -168,6 +172,45 @@ describe('format utils', () => {
           '__all__ = ["beta", "alpha"]',
           '',
         ].join('\n'),
+      );
+    });
+    it('should not apply rules outside the selection the project enforces', async () => {
+      // Ruff widens its default rule set between releases (0.16 went from `E`
+      // and `F` to 36 prefixes), so deferring to those defaults would rewrite
+      // generated files in ways the project's own `lint` target never asks for.
+      // RUF022 (`__all__` is not sorted) is one such default-on rule: it is
+      // outside the vended selection, so `__all__` must be left alone.
+      tree.write(
+        'src/__init__.py',
+        ['__all__ = ["beta", "alpha"]', ''].join('\n'),
+      );
+      // Execute
+      await formatFilesInSubtree(tree, 'src');
+      // Verify - `__all__` order preserved
+      expect(tree.read('src/__init__.py')?.toString()).toBe(
+        ['__all__ = ["beta", "alpha"]', ''].join('\n'),
+      );
+    });
+    it("should apply the owning project's own rule selection when set", async () => {
+      // A project that narrows its select must have that honoured: isort is not
+      // in the selection here, so imports are left unsorted.
+      addFirstPartyPythonProject('my_lib', 'my_lib', undefined, undefined, [
+        'E',
+        'F',
+      ]);
+      const unsorted = [
+        'from my_lib.b import beta',
+        'from my_lib.a import alpha',
+        '',
+        '__all__ = ["beta", "alpha"]',
+        '',
+      ].join('\n');
+      tree.write('packages/my_lib/my_lib/__init__.py', unsorted);
+      // Execute
+      await formatFilesInSubtree(tree, 'packages/my_lib');
+      // Verify - imports untouched
+      expect(tree.read('packages/my_lib/my_lib/__init__.py')?.toString()).toBe(
+        unsorted,
       );
     });
     it('should group a workspace package as first-party even when its module is not on disk', async () => {
@@ -376,6 +419,20 @@ describe('format utils', () => {
       await formatFilesInSubtree(tree, 'src');
       // Verify - imports left as-is (the on-disk config does not enable I)
       expect(tree.read('src/__init__.py')?.toString()).toBe(unsorted);
+    });
+    it('should apply formatter settings from an on-disk ruff config', async () => {
+      // Positive check that the on-disk config is genuinely read (ruff runs from
+      // tree.root so it discovers it): a formatter setting only this config sets
+      // must show up in the output.
+      writeFileSync(
+        path.join(workspaceDir, 'ruff.toml'),
+        ['[format]', 'quote-style = "single"', ''].join('\n'),
+      );
+      tree.write('src/quotes.py', 'x = "double"\n');
+      // Execute
+      await formatFilesInSubtree(tree, 'src');
+      // Verify - the config's quote-style was applied
+      expect(tree.read('src/quotes.py')?.toString()).toBe("x = 'double'\n");
     });
     it('should ignore a ruff config above the workspace root', async () => {
       // A ruff config in a parent of the workspace (e.g. a stray config on the

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -5,7 +5,11 @@
 
 import { Biome } from '@biomejs/js-api/nodejs';
 import { getProjects, type Tree } from '@nx/devkit';
-import { execFileSync, execSync } from 'child_process';
+import {
+  type ExecSyncOptionsWithStringEncoding,
+  execFileSync,
+  execSync,
+} from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
@@ -153,6 +157,12 @@ export async function formatFilesInSubtree(
     ? getPythonProjectRuffConfigs(tree)
     : [];
 
+  // Run ruff from the workspace root so it resolves the same on-disk config
+  // hasRuffConfigOnDisk probed for. An in-memory tree has no root on disk, in
+  // which case there is no config to find and the process cwd is left alone.
+  const ruffCwd =
+    pyFiles.length && existsSync(tree.root) ? tree.root : undefined;
+
   // Format Python files with ruff (lint fixes + formatting)
   for (const file of pyFiles) {
     try {
@@ -160,6 +170,7 @@ export async function formatFilesInSubtree(
         file.content.toString('utf-8'),
         file.path,
         hasRuffConfigOnDisk(tree, file.path),
+        ruffCwd,
         getOwningProjectRuffConfig(file.path, pythonProjectConfigs),
       );
       tree.write(file.path, content);
@@ -357,6 +368,14 @@ function hasRuffConfigOnDisk(tree: Tree, filePath: string): boolean {
   }
 }
 
+/**
+ * The `[tool.ruff.lint].select` generated Python projects vend. Generation
+ * formats before that config lands on disk, so it is pinned here to keep
+ * generated files clean under the project's own `lint` target rather than under
+ * whatever ruff's defaults happen to be for the pinned release.
+ */
+const DEFAULT_RUFF_SELECT = ['E', 'F', 'UP', 'B', 'SIM', 'I'];
+
 interface PythonProjectRuffConfig {
   /** Project root, normalised to use forward slashes. */
   readonly root: string;
@@ -370,6 +389,8 @@ interface PythonProjectRuffConfig {
    * explicitly — ruff's formatting differs by target.
    */
   readonly targetVersion?: string;
+  /** The project's `[tool.ruff.lint].select`, if set. */
+  readonly select?: string[];
 }
 
 /**
@@ -401,7 +422,8 @@ export const requiresPythonToRuffTarget = (
 /**
  * Map each Nx project with a `pyproject.toml` to the ruff settings the on-disk
  * build enforces for it: its top-level module names (from
- * `[tool.hatch.build.targets.wheel].packages`) and its `[tool.ruff].line-length`.
+ * `[tool.hatch.build.targets.wheel].packages`), its `[tool.ruff].line-length`
+ * and its `[tool.ruff.lint].select`.
  */
 function getPythonProjectRuffConfigs(tree: Tree): PythonProjectRuffConfig[] {
   const configs: PythonProjectRuffConfig[] = [];
@@ -424,12 +446,24 @@ function getPythonProjectRuffConfigs(tree: Tree): PythonProjectRuffConfig[] {
         const targetVersion = requiresPythonToRuffTarget(
           pyproject?.project?.['requires-python'],
         );
-        if (modules.length || typeof lineLength === 'number' || targetVersion) {
+        const selected: unknown = pyproject?.tool?.ruff?.lint?.select;
+        const select = Array.isArray(selected)
+          ? selected.filter(
+              (rule): rule is string => typeof rule === 'string' && !!rule,
+            )
+          : undefined;
+        if (
+          modules.length ||
+          typeof lineLength === 'number' ||
+          targetVersion ||
+          select?.length
+        ) {
           configs.push({
             root: project.root.split(path.sep).join('/'),
             modules,
             lineLength: typeof lineLength === 'number' ? lineLength : undefined,
             targetVersion,
+            select: select?.length ? select : undefined,
           });
         }
       } catch {
@@ -469,11 +503,16 @@ function getOwningProjectRuffConfig(
  * Run ruff check --fix and ruff format on Python file content via stdin.
  * Applies all configured lint fixes (including import sorting) and formatting.
  *
- * When no ruff config exists on disk (`hasConfig` false) ruff falls back to its
- * defaults, which omit isort — but generated projects enable rule `I` and their
- * build fails on unsorted imports (I001). In that case we add `--extend-select
- * I` so import sorting matches what the build enforces. When a config does
- * exist we defer to it entirely, honouring the user's rule selection.
+ * When no ruff config exists on disk (`hasConfig` false) ruff would fall back to
+ * its own defaults, which change between releases — 0.16 widened them from `E`
+ * and `F` to 36 rule prefixes — so generation would apply fixes the project's
+ * build never asks for (eg `RUF022` reordering `__all__`). Instead run
+ * `--isolated` with the project's own `lint.select` pinned, so generation
+ * enforces exactly what `lint` does and nothing more. `--isolated` also stops
+ * ruff walking above the workspace to a stray config on the host.
+ *
+ * When a config does exist we defer to it entirely, honouring the user's rule
+ * selection, and run from `tree.root` so ruff discovers it.
  *
  * `projectConfig` carries the owning project's ruff settings, which ruff cannot
  * detect from the filesystem during generation because the project lives only
@@ -487,13 +526,21 @@ function ruffFixAndFormat(
   content: string,
   filePath: string,
   hasConfig: boolean,
+  cwd: string | undefined,
   projectConfig?: PythonProjectRuffConfig,
 ): string {
   const ruff = getRuffCommand();
   if (!ruff) return content;
 
-  const extendSelect = hasConfig ? '' : ' --extend-select I';
   const configArgs: string[] = [];
+  // Pin the rule selection only when deferring to ruff's defaults would
+  // otherwise apply rules the project's build does not enforce.
+  const isolated = !hasConfig;
+  if (isolated) {
+    configArgs.push(
+      `lint.select = ${JSON.stringify(projectConfig?.select ?? DEFAULT_RUFF_SELECT)}`,
+    );
+  }
   if (projectConfig?.modules.length) {
     configArgs.push(
       `lint.isort.known-first-party = ${JSON.stringify(projectConfig.modules)}`,
@@ -508,12 +555,20 @@ function ruffFixAndFormat(
   const config = configArgs
     .map((arg) => ` --config ${JSON.stringify(arg)}`)
     .join('');
+  const flags = `${isolated ? ' --isolated' : ''}${config}`;
+  // Built per invocation: `input` carries the content the previous step emitted.
+  const options = (input: string): ExecSyncOptionsWithStringEncoding => ({
+    input,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...(cwd ? { cwd } : {}),
+  });
 
   // First apply lint fixes (import sorting, unused imports, etc.)
   try {
     const result = execSync(
-      `${ruff} check --fix${extendSelect}${config} --stdin-filename ${filePath} -`,
-      { input: content, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+      `${ruff} check --fix${flags} --stdin-filename ${filePath} -`,
+      options(content),
     );
     content = result;
   } catch (e: any) {
@@ -527,12 +582,8 @@ function ruffFixAndFormat(
   // Then apply formatting
   try {
     content = execSync(
-      `${ruff} format${config} --stdin-filename ${filePath} -`,
-      {
-        input: content,
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
+      `${ruff} format${flags} --stdin-filename ${filePath} -`,
+      options(content),
     );
   } catch {
     // Fall through with whatever content we have


### PR DESCRIPTION
### Reason for this change

Generation formats Python files via stdin *before* the project's ruff config lands on disk, so it relied on ruff's own defaults lining up with the vended `[tool.ruff.lint].select`. That coupling is fragile, and it broke: ruff widens its default rule set between releases — 0.16 goes from 2 prefixes (`E`, `F`) to 36, i.e. 59 enabled rules to 413. Generation then applies fixes the project's own `lint` target never selects, e.g. `RUF022` reordering `__all__` in vended `__init__.py` files.

This surfaced as 2 failures in `format.spec.ts` on the scheduled [Update Versions run](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/30220848593), which bumps `ruff 0.15.22 -> 0.16.0`. That bump is **not** included here — this PR only makes the formatter robust to it, so the version bump can land cleanly on its own.

While fixing that I found a second, latent bug: `ruffFixAndFormat` **never set a `cwd`**, so ruff resolved config relative to the process directory rather than the workspace — on-disk ruff config discovery never actually worked. The existing "should defer to an on-disk ruff config" test passed only by accident, because ruff's defaults happened to exclude isort; it would have kept passing with discovery fully broken.

### Description of changes

`packages/nx-plugin/src/utils/format.ts`:

1. **Pin the rule selection** rather than inheriting ruff's defaults. Runs `--isolated` with `lint.select` pinned — read from the owning project's `pyproject.toml` when present, else the vended `["E","F","UP","B","SIM","I"]`. Generation now enforces exactly what `lint` does and nothing more, independent of the pinned ruff release. This replaces the previous `--extend-select I` nudge.
2. **Run ruff from `tree.root`** when it exists on disk, so it discovers the on-disk config that `hasRuffConfigOnDisk` probed for — matching how the biome CLI path already works.

No version bumps and no snapshot changes.

### Description of how you validated changes

- **3 new tests**, each confirmed to genuinely guard a regression by reverting each fix independently and watching the matching test fail:
  - `should not apply rules outside the selection the project enforces` (`RUF022` must not reorder `__all__`)
  - `should apply the owning project's own rule selection when set`
  - `should apply formatter settings from an on-disk ruff config` — a *positive* check that the config is genuinely read, which the pre-existing test could not detect
- `format.spec.ts` passes 21/21 under **both** ruff 0.15.22 (currently pinned) and 0.16.0 — the fix is version-independent, which is the point
- Full suite: **2750 tests, 140 files** pass with **zero snapshot changes**, confirming the change is behaviour-neutral on the currently pinned ruff
- Full `pnpm nx run-many --target build --all` and CI-mode lint green
- **e2e against ruff 0.16.0** (run with the bump applied locally, to prove the fix actually unblocks it): `fast-api` smoke test passed, and `standalone projects` passed **59/59** — every generator including all Python ones generated and built cleanly

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
