### PR TITLE
fix(agentcore-gateway): wait for gateway role policy to propagate before CreateGateway

### DIFF
--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -433,6 +433,28 @@ describe('agentcore-gateway generator', () => {
       expect(module).toContain('render-cedar.cjs');
     });
 
+    it('waits for the gateway role policy to propagate before creating the gateway', () => {
+      const module = tree
+        .read(
+          'packages/common/terraform/src/app/gateways/my-gateway/my-gateway.tf',
+        )!
+        .toString();
+      // CreateGateway assumes the gateway role to call AuthorizeAction, so the
+      // policy must have propagated first or creation fails with AccessDenied.
+      expect(module).toContain('source  = "hashicorp/time"');
+      expect(module).toContain(
+        'resource "time_sleep" "gateway_role_policy_propagation"',
+      );
+      expect(module).toContain(
+        'depends_on = [time_sleep.gateway_role_policy_propagation]',
+      );
+      // Re-waits when the policy changes, e.g. a connection generator appends
+      // statements the check depends on.
+      expect(module).toContain(
+        'policy = aws_iam_role_policy.gateway_role_policy.policy',
+      );
+    });
+
     it('protects the gateway with a regional WAF web ACL by default', () => {
       const module = tree
         .read(

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -11,6 +11,10 @@ terraform {
       source  = "hashicorp/external"
       version = "<%- externalProviderVersion %>"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "<%- timeProviderVersion %>"
+    }
 <%_ } _%>
     random = {
       source  = "hashicorp/random"
@@ -135,6 +139,20 @@ resource "aws_iam_role_policy" "gateway_role_policy" {
     ], var.additional_iam_policy_statements)
   })
 }
+
+# IAM is eventually consistent, and CreateGateway assumes the gateway role to
+# call AuthorizeAction as part of its policy engine check. Without this wait
+# the check intermittently runs before the policy above has propagated and
+# CreateGateway fails with AccessDeniedException.
+resource "time_sleep" "gateway_role_policy_propagation" {
+  depends_on = [aws_iam_role_policy.gateway_role_policy]
+
+  create_duration = "30s"
+
+  triggers = {
+    policy = aws_iam_role_policy.gateway_role_policy.policy
+  }
+}
 <%_ } else { _%>
 # Inline policy for statements appended by connection generators
 # (e.g. InvokeAgentRuntime*)
@@ -190,7 +208,7 @@ resource "aws_bedrockagentcore_gateway" "this" {
     mode = "ENFORCE"
   }
 
-  depends_on = [aws_iam_role_policy.gateway_role_policy]
+  depends_on = [time_sleep.gateway_role_policy_propagation]
 <%_ } _%>
 }
 

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -234,6 +234,7 @@ export const TERRAFORM_VERSIONS = {
   archive: '2.8.0',
   external: '2.4.0',
   local: '2.9.0',
+  time: '0.14.0',
 } as const;
 export type ITerraformProviderVersion = keyof typeof TERRAFORM_VERSIONS;
 
@@ -248,4 +249,5 @@ export const terraformProviderVersions = () => ({
   archiveProviderVersion: TERRAFORM_VERSIONS.archive,
   externalProviderVersion: TERRAFORM_VERSIONS.external,
   localProviderVersion: TERRAFORM_VERSIONS.local,
+  timeProviderVersion: TERRAFORM_VERSIONS.time,
 });


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy` smoke test has been failing intermittently on `main` with:

```
Error: creating Bedrock AgentCore Gateway
  with module.my_gateway.aws_bedrockagentcore_gateway.this
AccessDeniedException: Policy Engine 'MyGateway_PolicyEngine_e0f8d813-zm9gm9rm0z'
does not have the required permissions. Access Denied due to following reasons:
User: arn:aws:sts::...:assumed-role/MyGateway-GatewayRole-e0f8d813/GenesisPolicyEngineCheck
is not authorized to perform: bedrock-agentcore:AuthorizeAction on resource:
arn:aws:bedrock-agentcore:...:policy-engine/MyGateway_PolicyEngine_e0f8d813-zm9gm9rm0z
because no identity-based policy allows the bedrock-agentcore:AuthorizeAction action
```

`CreateGateway` assumes the gateway role (as `GenesisPolicyEngineCheck`) and calls `AuthorizeAction` to validate the attached policy engine. The role's inline policy already grants that action and the gateway already `depends_on` it, but IAM is eventually consistent — so the check intermittently runs before the policy has propagated and gateway creation fails.

Because it is a propagation race rather than a missing grant, it fails on a different gateway each time and passes on retry. Recent `main` occurrences (all in the `terraform-deploy` lane):

- [30241537215](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/30241537215) — `my_gateway`
- [30227256750](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/30227256750) — `parent_gateway`
- [30050187382](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/30050187382)

The CDK path grants the same permissions, but CloudFormation's slower create path has not surfaced the race.

### Description of changes

- Add a `time_sleep` in the gateway Terraform module that depends on `aws_iam_role_policy.gateway_role_policy`, and gate `aws_bedrockagentcore_gateway.this` on it instead of on the policy directly. Dependency chain is now `iam_role_policy` → `time_sleep` → `gateway`.
- Key the wait's `triggers` on the policy document so it re-waits when the policy changes — e.g. when a connection generator appends `InvokeAgentRuntime*` statements the check depends on.
- Declare `hashicorp/time` in `required_providers` and pin it in `TERRAFORM_VERSIONS` alongside the other providers.

All of this is inside the `cedarPolicy` branch, so gateways generated with `cedarPolicy: false` (which have no policy engine and therefore no check) are unchanged and do not pull in the provider.

### Description of how you validated changes

- Added a generator test asserting the provider declaration, the `time_sleep` resource, the gateway's `depends_on`, and the policy-document trigger.
- `pnpm nx run @aws/nx-plugin:test` — 2751 tests pass across 140 files, no snapshot changes.
- `pnpm nx run @aws/nx-plugin:build` passes.
- Rendered the template for both `cedarPolicy: true` and `false` and confirmed the provider and wait only appear in the former.
- Ran `terraform init` + `terraform validate` on the rendered `cedarPolicy: true` module (`hashicorp/time` 0.14.0 resolves, config valid), and confirmed the ordering via `terraform graph`:
  ```
  "aws_bedrockagentcore_gateway.this" -> "time_sleep.gateway_role_policy_propagation"
  "time_sleep.gateway_role_policy_propagation" -> "aws_iam_role_policy.gateway_role_policy"
  ```

Not deployed to AWS from this branch — the failure only reproduces intermittently, so the `terraform-deploy` smoke test on this PR is the real signal.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*