### PR TITLE
feat(ts#agent): log tool execution errors alongside model errors

### DIFF
--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -1390,7 +1390,7 @@ output "security_group_id" {
 
 exports[`ts#agent generator > should match snapshot for generated files > agent-agent.ts 1`] = `
 "import { Agent, tool } from '@strands-agents/sdk';
-import { logModelErrors } from '@proj/agent-connection';
+import { logModelErrors, logToolErrors } from '@proj/agent-connection';
 import { z } from 'zod';
 
 const multiply = tool({
@@ -1411,6 +1411,7 @@ export const getAgent = async () => {
     tools: [multiply],
   });
   logModelErrors(agent);
+  logToolErrors(agent);
   return agent;
 };
 "

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ts#agent#a2a-connection generator > should match snapshot for agent-connection src files > agent-connection-index.ts 1`] = `
 "export * from './app/remote-client-strands.js';
+export * from './core/tool-errors-strands.js';
 export * from './core/model-errors-strands.js';
 export * from './core/with-session-id-strands.js';
 export * from './core/session-context.js';

--- a/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
@@ -1,5 +1,5 @@
 import { Agent, tool } from '@strands-agents/sdk';
-import { logModelErrors } from '<%- agentConnectionImport %>';
+import { logModelErrors, logToolErrors } from '<%- agentConnectionImport %>';
 import { z } from 'zod';
 
 const multiply = tool({
@@ -20,5 +20,6 @@ export const getAgent = async () => {
     tools: [multiply],
   });
   logModelErrors(agent);
+  logToolErrors(agent);
   return agent;
 };

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ts#agent#gateway-connection generator > should match snapshot for agent-connection src files > agent-connection-index.ts 1`] = `
 "export * from './app/my-gateway-client-strands.js';
+export * from './core/tool-errors-strands.js';
 export * from './core/model-errors-strands.js';
 export * from './core/with-session-id-strands.js';
 export * from './core/session-context.js';

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ts#agent#mcp-connection generator > should match snapshot for agent-connection src files > agent-connection-index.ts 1`] = `
 "export * from './app/inventory-mcp-client-strands.js';
+export * from './core/tool-errors-strands.js';
 export * from './core/model-errors-strands.js';
 export * from './core/with-session-id-strands.js';
 export * from './core/session-context.js';

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -175,6 +175,10 @@ const FRAMEWORKS: Record<AgentFramework, FrameworkTemplates> = {
           fromModule: './core/model-errors-strands.js',
           importName: '*',
         },
+        {
+          fromModule: './core/tool-errors-strands.js',
+          importName: '*',
+        },
       ],
       protocols: {
         mcp: 'core-strands/mcp',

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/tool-errors-strands.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/tool-errors-strands.ts.template
@@ -1,0 +1,22 @@
+import {
+  AfterToolCallEvent,
+  type LocalAgent,
+  TextBlock,
+} from '@strands-agents/sdk';
+
+/** Logs tool execution errors, including the tool name and underlying error or message when available. */
+export const logToolErrors = (agent: LocalAgent): void => {
+  agent.addHook(AfterToolCallEvent, (event) => {
+    if (event.result.status !== 'error') return;
+    const error = event.result.error ?? event.error;
+    const message =
+      error?.message ??
+      event.result.content
+        .filter((block): block is TextBlock => block instanceof TextBlock)
+        .map((block) => block.text)
+        .join(' ');
+    console.error(
+      `Tool '${event.toolUse.name}' failed${message ? `: ${message}` : ''}`,
+    );
+  });
+};


### PR DESCRIPTION
### Reason for this change

TypeScript Strands agents only logged model invocation errors (`logModelErrors`); tool execution errors surfaced from `AfterToolCallEvent` had no equivalent logging, making failed tool calls hard to diagnose.

### Description of changes

- Added `tool-errors-strands.ts.template` (`packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/`), exporting `logToolErrors`, which logs the tool name and underlying error/message on tool call failure — mirrors `model-errors-strands.ts.template`.
- Wired it into `agent-connection.ts` as a star re-export from the Strands TS base helpers, alongside the model-errors export, so it's re-exported from the shared `agent-connection` project's `index.ts`.
- Updated the `ts#agent` `agent.ts.template` to import and call `logToolErrors(agent)` next to `logModelErrors(agent)`.

### Description of how you validated changes

- Updated the affected snapshot tests (`ts#agent`, `ts#agent#a2a-connection`, `ts#agent#gateway-connection`, `ts#agent#mcp-connection`) to reflect the new re-export and generated `agent.ts` output; all pass.
- Validated against a deployed agent by forcing a tool call to fail and confirming `logToolErrors` logged the tool name and error message.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
