### PR TITLE
fix(ts#agent): register ag-ui session middleware before the /invocations route

### DIFF
--- a/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
@@ -1,7 +1,12 @@
 import { StrandsAgent } from '@ag-ui/aws-strands';
-import { createStrandsApp } from '@ag-ui/aws-strands/server';
+import {
+  addStrandsExpressEndpoint,
+  addPing,
+  addCapabilities,
+} from '@ag-ui/aws-strands/server';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import cors from 'cors';
 import { randomUUID } from 'node:crypto';
-import type { Request, Response, NextFunction } from 'express';
 import { runWithSessionId } from '<%- agentConnectionImport %>';
 import { getAgent } from './agent<% if (esm) { %>.js<% } %>';
 
@@ -9,6 +14,13 @@ const PORT = parseInt(process.env.PORT || '8080');
 const HOST = '0.0.0.0';
 
 const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
+
+// Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
+const sessionIdMiddleware = (req: Request, _res: Response, next: NextFunction) => {
+  const header = req.headers[SESSION_ID_HEADER];
+  const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
+  runWithSessionId(sessionId, () => next());
+};
 
 void (async () => {
   const agent = await getAgent();
@@ -22,14 +34,18 @@ void (async () => {
     description: 'A Strands Agent exposed via the AG-UI protocol.',
   });
 
-  const app = await createStrandsApp(aguiAgent, { path: '/invocations' });
+  // Built up manually (mirroring createStrandsApp's defaults) rather than via createStrandsApp
+  // https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/aws-strands/typescript/src/server.ts
+  const app = express();
+  app.use(cors({ origin: '*', credentials: true }));
+  app.use(express.json({ limit: '50mb' }));
 
-  // Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
-  app.use((req: Request, _res: Response, next: NextFunction) => {
-    const header = req.headers[SESSION_ID_HEADER];
-    const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
-    runWithSessionId(sessionId, () => next());
-  });
+  addPing(app, '/ping');
+  addCapabilities(app, '/capabilities', { agent: aguiAgent });
+
+  app.use(sessionIdMiddleware);
+
+  addStrandsExpressEndpoint(app, aguiAgent, { path: '/invocations' });
 
   app.listen(PORT, HOST, () => {
     console.log(`AG-UI server listening on ${HOST}:${PORT}`);


### PR DESCRIPTION
### Reason for this change

The `ts#agent` generator's `ag-ui` protocol template binds the inbound AgentCore session ID to `AsyncLocalStorage` via a session middleware, so downstream MCP / A2A calls made during an agent run can forward the caller's session ID. This middleware was registered with `app.use(...)` *after* `await createStrandsApp(...)`, but `createStrandsApp` (from `@ag-ui/aws-strands/server`) already registers the `/invocations`, `/ping`, and `/capabilities` routes synchronously before returning the app. Since Express dispatches middleware/routes in registration order and the `/invocations` handler responds without calling `next()`, the session middleware was never reached — it was dead code, and `getCurrentSessionId()` always returned `undefined` for AG-UI traffic, silently disabling session-affinity forwarding to downstream MCP/A2A calls.

### Description of changes

- Replaced `createStrandsApp(...)` with the lower-level `addStrandsExpressEndpoint` / `addPing` / `addCapabilities` (all public exports of the same module), building the Express app manually so the session middleware can be registered *before* the `/invocations` route.
- Manually replicated `createStrandsApp`'s defaults (`cors({ origin: '*', credentials: true })`, `express.json({ limit: '50mb' })`) to preserve identical behavior — verified against the [upstream source](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/aws-strands/typescript/src/server.ts).
- Registered `/ping` and `/capabilities` ahead of the session middleware, since neither triggers downstream MCP/A2A calls and so neither needs session context bound.
- Extracted the inline middleware into a named `sessionIdMiddleware` function.
- Confirmed the sibling `a2a` and `http` protocol templates don't have the same issue (different code paths, correctly ordered / not applicable).

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:build` — full build and test suite (2751 tests) passing.
- Deployed an agent generated with the `ag-ui` protocol and verified the session ID is correctly propagated to downstream MCP / A2A calls.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*