### PR TITLE
perf(nx-plugin): format with biome in-process instead of one process per file

### DIFF
--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -5,6 +5,7 @@
 
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { FsTree } from 'nx/src/generators/tree';
 import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -379,7 +380,12 @@ describe('format utils', () => {
       rmSync(workspaceDir, { recursive: true, force: true });
     });
     it("should format using the workspace's on-disk biome config", async () => {
-      // Setup - on-disk config with no semicolons and single quotes
+      // Setup - on-disk config with no semicolons and single quotes, read
+      // through a tree that holds no config of its own (as in a real run, where
+      // the tree carries one only when a generator has just written it). The
+      // test helper mirrors the preset by writing biome.json into the tree, so
+      // use a fresh tree here rather than one already carrying that copy.
+      const diskTree = new FsTree(workspaceDir, false);
       writeFileSync(
         path.join(workspaceDir, 'biome.json'),
         JSON.stringify({
@@ -391,13 +397,42 @@ describe('format utils', () => {
           },
         }),
       );
-      tree.write('src/test.ts', 'const x=1;const y="hello";');
+      diskTree.write('src/test.ts', 'const x=1;const y="hello";');
       // Execute
-      await formatFilesInSubtree(tree, 'src');
+      await formatFilesInSubtree(diskTree, 'src');
       // Verify - respects the on-disk config (no semicolons, single quotes)
-      expect(tree.read('src/test.ts')?.toString()).toBe(
+      expect(diskTree.read('src/test.ts')?.toString()).toBe(
         "const x = 1\nconst y = 'hello'\n",
       );
+    });
+
+    it('should prefer a biome config a generator has just written to the tree', async () => {
+      // The on-disk config would produce semicolon-free output, but a generator
+      // has written a newer config to the tree. Formatting must use the newer
+      // one — the state that motivates reading config through the tree.
+      writeFileSync(
+        path.join(workspaceDir, 'biome.json'),
+        JSON.stringify({
+          root: true,
+          javascript: {
+            formatter: { quoteStyle: 'single', semicolons: 'asNeeded' },
+          },
+        }),
+      );
+      tree.write(
+        'biome.json',
+        JSON.stringify({
+          root: true,
+          javascript: {
+            formatter: { quoteStyle: 'double', semicolons: 'always' },
+          },
+        }),
+      );
+      tree.write('src/test.ts', "const y='hello'");
+      // Execute
+      await formatFilesInSubtree(tree, 'src');
+      // Verify - the in-tree config wins (double quotes, semicolons)
+      expect(tree.read('src/test.ts')?.toString()).toBe('const y = "hello";\n');
     });
     it('should defer to an on-disk ruff config that omits import sorting', async () => {
       // On-disk ruff config selecting rules that exclude isort (I): the

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -181,12 +181,28 @@ export async function formatFilesInSubtree(
 }
 
 /**
- * Format files with Biome in-process, reusing one instance across the batch.
+ * The Biome configuration to format with: the workspace's own `biome.json`, else
+ * the config we vend.
  *
- * The workspace's own `biome.json` still applies: `tree.read` falls through to
- * disk, so a customised config — including path-based `overrides` — formats
- * exactly as the workspace's `format` target would, and unlike shelling out to
- * the CLI this also sees config a generator has just written to the tree.
+ * Read through the tree, which falls back to disk for a file it doesn't hold. So
+ * this resolves the most current config either way — the workspace's on-disk one,
+ * or the version a generator has just written to the tree and not yet flushed,
+ * which shelling out to the CLI could never see.
+ */
+function readBiomeConfig(tree: Tree): unknown {
+  const config = tree.read('biome.json', 'utf-8');
+  if (config) {
+    try {
+      return JSON.parse(config);
+    } catch {
+      // Malformed config — fall through to the config we vend
+    }
+  }
+  return getDefaultBiomeConfig(tree);
+}
+
+/**
+ * Format files with Biome in-process, reusing one instance across the batch.
  *
  * Replaces one `biome format --stdin-file-path` process per file, which
  * dominated generation at ~70ms each: `formatFilesInSubtree` formats every
@@ -203,14 +219,7 @@ function formatWithBiome(
   try {
     const biome = new Biome();
     const { projectKey } = biome.openProject();
-    // The workspace's own config when it has one, else the config we vend.
-    const workspaceConfig = tree.read('biome.json', 'utf-8');
-    biome.applyConfiguration(
-      projectKey,
-      workspaceConfig
-        ? JSON.parse(workspaceConfig)
-        : getDefaultBiomeConfig(tree),
-    );
+    biome.applyConfiguration(projectKey, readBiomeConfig(tree));
 
     for (const file of files) {
       try {

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -7,17 +7,13 @@ import { Biome } from '@biomejs/js-api/nodejs';
 import { getProjects, type Tree } from '@nx/devkit';
 import {
   type ExecSyncOptionsWithStringEncoding,
-  execFileSync,
   execSync,
 } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
-import { createRequire } from 'module';
 import path from 'path';
 import { uvxCommand } from './py';
 import { readToml } from './toml';
 import { TS_VERSIONS } from './versions';
-
-const require = createRequire(import.meta.url);
 
 /**
  * The biome.json vended into a new workspace. The pnpm catalog resolver is only
@@ -181,66 +177,39 @@ export async function formatFilesInSubtree(
 
   if (otherFiles.length === 0) return;
 
-  // Use the workspace's own Biome CLI (its version and config) when biome.json
-  // exists on disk; otherwise format via the bundled library API with the
-  // in-memory tree config. The CLI path does not see in-tree config changes.
-  if (existsSync(path.join(tree.root, 'biome.json'))) {
-    formatWithBiomeCli(tree, otherFiles);
-  } else {
-    formatWithBiomeApi(tree, otherFiles);
-  }
+  formatWithBiome(tree, otherFiles);
 }
 
 /**
- * Format files via the workspace's Biome CLI, run from the workspace root so it
- * discovers the on-disk biome.json.
+ * Format files with Biome in-process, reusing one instance across the batch.
+ *
+ * The workspace's own `biome.json` still applies: `tree.read` falls through to
+ * disk, so a customised config — including path-based `overrides` — formats
+ * exactly as the workspace's `format` target would, and unlike shelling out to
+ * the CLI this also sees config a generator has just written to the tree.
+ *
+ * Replaces one `biome format --stdin-file-path` process per file, which
+ * dominated generation at ~70ms each: `formatFilesInSubtree` formats every
+ * change accumulated in the tree, not only the ones its caller made, so
+ * generators sharing a tree reformat the same files once per call. In-process is
+ * ~0.5ms per file. Output was verified byte-identical across the plugin's whole
+ * source tree, except that the CLI corrupts control characters passed through
+ * stdin (a NUL in a template literal) where formatting in-process preserves them.
  */
-function formatWithBiomeCli(
-  tree: Tree,
-  files: { path: string; content: Buffer | null }[],
-): void {
-  const biome = getBiomeCommand(tree.root);
-  if (!biome) {
-    // Fall back to the library API if the CLI cannot be resolved
-    formatWithBiomeApi(tree, files);
-    return;
-  }
-
-  for (const file of files) {
-    try {
-      const content = execFileSync(
-        biome.command,
-        [...biome.args, 'format', `--stdin-file-path=${file.path}`],
-        {
-          input: file.content?.toString('utf-8') ?? '',
-          encoding: 'utf-8',
-          cwd: tree.root,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
-      );
-      tree.write(file.path, content);
-    } catch {
-      // Leave individual files that fail to format untouched
-    }
-  }
-}
-
-/**
- * Format files via the bundled Biome library API, applying the in-memory tree
- * config.
- */
-function formatWithBiomeApi(
+function formatWithBiome(
   tree: Tree,
   files: { path: string; content: Buffer | null }[],
 ): void {
   try {
     const biome = new Biome();
     const { projectKey } = biome.openProject();
-    // Apply the workspace biome.json if it exists in the tree, otherwise the defaults.
-    const treeConfig = tree.read('biome.json', 'utf-8');
+    // The workspace's own config when it has one, else the config we vend.
+    const workspaceConfig = tree.read('biome.json', 'utf-8');
     biome.applyConfiguration(
       projectKey,
-      treeConfig ? JSON.parse(treeConfig) : getDefaultBiomeConfig(tree),
+      workspaceConfig
+        ? JSON.parse(workspaceConfig)
+        : getDefaultBiomeConfig(tree),
     );
 
     for (const file of files) {
@@ -257,53 +226,6 @@ function formatWithBiomeApi(
     }
   } catch {
     // Silently skip formatting failures
-  }
-}
-
-interface BiomeCommand {
-  command: string;
-  args: string[];
-}
-
-/**
- * Resolve the `@biomejs/biome` CLI from the user's workspace, falling back to a
- * `biome` binary on the PATH.
- */
-const _biomeCommands = new Map<string, BiomeCommand | null>();
-function getBiomeCommand(root: string): BiomeCommand | undefined {
-  if (_biomeCommands.has(root)) {
-    return _biomeCommands.get(root) ?? undefined;
-  }
-
-  // Run via node for cross-platform execution of the bin shim.
-  try {
-    const pkgJsonPath = require.resolve('@biomejs/biome/package.json', {
-      paths: [root, import.meta.dirname],
-    });
-    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-    const binRelative =
-      typeof pkgJson.bin === 'string' ? pkgJson.bin : pkgJson.bin?.biome;
-    if (binRelative) {
-      const binPath = path.join(path.dirname(pkgJsonPath), binRelative);
-      const command = { command: process.execPath, args: [binPath] };
-      _biomeCommands.set(root, command);
-      return command;
-    }
-  } catch {
-    // Fall back to a biome binary on the PATH
-  }
-
-  try {
-    execSync('biome --version', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const command = { command: 'biome', args: [] };
-    _biomeCommands.set(root, command);
-    return command;
-  } catch {
-    _biomeCommands.set(root, null);
-    return undefined;
   }
 }
 


### PR DESCRIPTION
### Reason for this change

Generators format each changed file by spawning `biome format --stdin-file-path`, one process per file at ~70ms each.

That would be tolerable if each generator only formatted its own output, but `formatFilesInSubtree` formats **every change accumulated in the tree**, not only the ones its caller made. So when generators share a tree — a generator composing others (`connection` dispatches to ~30 sub-generators), or a sequence of them — the same files are reformatted once per call, each time paying a fresh process spawn.

This surfaced while prototyping a generator that composes the whole e2e matrix on one tree (for #705): it spent 11 minutes wall-clock without writing a single project, stuck spawning `biome format --stdin-file-path=...` per file. But it affects ordinary generation too — any generator that runs after others on the same tree pays for reformatting their output.

### Description of changes

Format in-process via the bundled Biome library API, reusing a single `Biome` instance across the batch. Measured ~0.5ms per file versus ~70ms per spawn — **140×**, and the per-file cost no longer includes process startup:

| files | one process per file | in-process |
| --- | --- | --- |
| 17 (one generator) | 1.2s | 0.01s |
| 500 | 35s | 0.25s |
| 1000 | 70s | 0.50s |

**The workspace's own config still applies** — this was the reason the CLI path existed. The config is read through the tree (`tree.read('biome.json')`), which falls back to disk for a file the tree doesn't hold, so one read resolves either the workspace's on-disk config or, when a generator has just written a newer one and not yet flushed it, that version. The latter is something shelling out to the CLI could never see.

Verified against a workspace with a deliberately unusual config (tabs, width 45, double quotes, no trailing commas, plus a `**/*.spec.ts` override switching to spaces at width 120): the API reproduced the CLI's output byte-for-byte for both the normal and the overridden file, so path-based `overrides` are honoured too.

Routing through the bundled API also costs no version fidelity: `npm-check-updates` bumps `@biomejs/wasm-nodejs` and the vended `@biomejs/biome` pin in the same weekly `update-versions` PR (checked across rc.10 → rc.48 — always identical).

Removes `getBiomeCommand` (CLI/PATH resolution) and the CLI-vs-API branch, since there is now a single path — `format.ts` goes +25/−94.

**Deliberately not included: any caching of what's already been formatted.** In-process formatting is cheap enough (~10s across a composition of every generator in the plugin) that tracking prior output isn't worth the bookkeeping, and always formatting means the result always reflects the current config.

This therefore does **not** fix Python: ruff still costs two `uvx` processes per file (`check --fix`, then `format`) at ~200ms each, and that repeated cost is real — measured on the composed matrix, `py#api` took 4.2s and the next one 7.0s, and a full run of that matrix still exceeds 20 minutes because of it. That's being addressed separately rather than with content bookkeeping here, so this PR stays scoped to the biome switch.

### Description of how you validated changes

- **Byte-for-byte output comparison over the plugin's entire source tree.** Ran all 473 formattable files (`.ts/.tsx/.js/.json/.css`, matching the real filter) through both the old CLI path and the new in-process path: **472 identical, 1 differing**. The single difference is the CLI *corrupting* input — `packages/nx-plugin/src/open-api/utils/parser.ts` contains a literal NUL (`U+0000`) in a template literal, which the CLI mangles when passed through stdin while the in-process path round-trips it exactly (`src === api` is true, `src === cli` is false). So the one behavioural change is a fidelity fix.
- **Custom-config fidelity**, including path-based `overrides`, as described above — byte-identical.
- `src/utils/format.spec.ts` passes (22 tests). This includes the pre-existing assertions that an on-disk `biome.json` and an on-disk `ruff.toml` are honoured, plus a new case that a config a generator has just written to the tree takes precedence over the on-disk one.
  - One existing test needed adjusting: it wrote a config to disk but ran against a tree that already carried its own `biome.json` (written by `createTreeUsingTsSolutionSetup` to mirror the preset), which shadowed it. That's a state a real run can't be in — there the tree holds a config only when a generator has just written one — so it now reads through a tree holding no config of its own.
- `pnpm nx run @aws/nx-plugin:lint` passes; `tsc --noEmit` clean over the lib project.

Note: `packages/nx-plugin` unit tests fail in my environment on unmodified `main` (`TypeError: Cannot read properties of null (reading 'version')` from `@nx/js`'s catalog manager — 27 failures in `infra/app/generator.spec.ts` alone). I confirmed this in a clean worktree at `origin/main` before and after this change — identical failures, so it's pre-existing and unrelated. `tsconfig.spec.json` likewise has 42 pre-existing `tsc` errors on the base, unchanged by this PR. CI runs the full suite.

### Issue # (if applicable)

Groundwork for #705.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

