### PR TITLE
fix(api-constructs): include CloudFront custom domain aliases in restrictCorsTo

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -302,19 +303,23 @@ export class GameApi<
    *
    * Configures the CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the AWS
-   * Lambda integrations.
+   * Lambda integrations. Any custom domain names (aliases) configured on a CloudFront
+   * distribution are included automatically alongside its default `*.cloudfront.net`
+   * domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Este archivo es la implementación del método `echo` y como puedes ver está fuertemente tipado declarando sus estructuras de datos de entrada y salida.
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -302,19 +303,22 @@ export class GameApi<
    *
    * Configura los dominios de distribución CloudFront o strings de origen
    * como los únicos orígenes CORS permitidos en las respuestas preflight de API Gateway y las
-   * integraciones AWS Lambda.
+   * integraciones AWS Lambda. Cualquier nombre de dominio personalizado (alias) configurado en una distribución
+   * CloudFront se incluye automáticamente junto con su dominio predeterminado `*.cloudfront.net`.
    *
    * @param origins - Los strings de origen, distribuciones CloudFront u objetos que contienen una distribución CloudFront desde los cuales otorgar CORS
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -852,7 +856,7 @@ import './styles.css';
 +  routeTree,
 +  context: { runtimeConfig: undefined, auth: undefined },
 +});
-// Registra la instancia del router para seguridad de tipos
+// Register the router instance for type safety
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Ce fichier est l'implémentation de la méthode `echo` et comme vous pouvez le voir, elle est fortement typée en déclarant ses structures de données d'entrée et de sortie.
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -302,19 +303,22 @@ export class GameApi<
    *
    * Configure les domaines de distribution CloudFront ou les chaînes d'origine
    * comme les seules origines CORS autorisées dans les réponses de pré-vérification d'API Gateway et les
-   * intégrations AWS Lambda.
+   * intégrations AWS Lambda. Tous les noms de domaine personnalisés (alias) configurés sur une distribution
+   * CloudFront sont inclus automatiquement aux côtés de son domaine par défaut `*.cloudfront.net`.
    *
    * @param origins - Les chaînes d'origine, distributions CloudFront, ou objets contenant une distribution CloudFront à partir desquels accorder CORS
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -628,7 +632,7 @@ L'état de notre jeu — les parties sauvegardées et l'inventaire de chaque jou
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[Développement local d'abord]
-Le générateur `ts#dynamodb` fournit une cible `serve-local` qui exécute [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) dans un conteneur. Combiné avec le générateur `connection` (que nous exécutons ci-dessous), cela signifie que **le jeu entier s'exécute sur votre machine sans déploiement** jusqu'à la fin du tutoriel.
+Le générateur `ts#dynamodb` fournit une cible `dev` qui exécute [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) dans un conteneur. Combiné avec le générateur `connection` (que nous exécutons ci-dessous), cela signifie que **le jeu entier s'exécute sur votre machine sans déploiement** jusqu'à la fin du tutoriel.
 :::
 
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
@@ -661,7 +665,7 @@ Le générateur `ts#dynamodb` génère ces fichiers.
           - dynamodb.ts construct générique de table DynamoDB
 </FileTree>
 
-Le `src/client.ts` généré exporte `getDynamoDBClient()` et `resolveTableName()`. Lorsque `SERVE_LOCAL=true` (défini automatiquement par les cibles `serve-local`), ceux-ci se connectent à DynamoDB Local ; sinon ils se connectent à AWS et résolvent le nom de table déployé depuis <Link path="guides/runtime-config">Runtime Configuration</Link>. Nous modéliserons nos entités `Game` et `Inventory` dans ce projet dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>.
+Le `src/client.ts` généré exporte `getDynamoDBClient()` et `resolveTableName()`. Lorsque `LOCAL_DEV=true` (défini automatiquement par les cibles `dev`), ceux-ci se connectent à DynamoDB Local ; sinon ils se connectent à AWS et résolvent le nom de table déployé depuis <Link path="guides/runtime-config">Runtime Configuration</Link>. Nous modéliserons nos entités `Game` et `Inventory` dans ce projet dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>.
 
 Pour plus de détails, consultez le <Link path="guides/ts-dynamodb">guide du générateur ts#dynamodb</Link>.
 
@@ -1004,7 +1008,7 @@ Le générateur :
 - Génère une classe `InventoryMcpServerClientStrands` qui gère la connexion au serveur MCP à la fois localement (HTTP direct) et lors du déploiement (via AgentCore avec authentification IAM)
 - Transforme `agent.py` pour importer le client, créer une instance et connecter les outils du serveur MCP à l'agent
 - Ajoute le projet `agent_connection` en tant que dépendance workspace du projet story
-- Met à jour la cible `serve-local` pour démarrer automatiquement le serveur MCP lors de l'exécution locale
+- Met à jour la cible `dev` pour démarrer automatiquement le serveur MCP lors de l'exécution locale
 
 Pour plus de détails, consultez le <Link path="guides/connection/py-agent-mcp">guide de connexion Python Agent vers MCP</Link>.
 </Drawer>
@@ -1050,7 +1054,7 @@ L'API de jeu et le serveur MCP d'inventaire lisent et écrivent tous deux dans n
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <Aside type="tip" title="Une commande démarre toute la pile localement">
-Comme la cible `agent-serve-local` de l'agent Story dépend déjà de la cible `mcp-server-serve-local` du serveur MCP d'inventaire (via la connexion `story → inventory` ci-dessus), et que l'API de jeu et le serveur MCP dépendent maintenant de `dungeon-db:serve-local`, l'exécution de la cible `serve-local` de n'importe quel projet démarre toutes les dépendances dont il a besoin dans le bon ordre.
+Comme la cible `agent-dev` de l'agent Story dépend déjà de la cible `mcp-server-dev` du serveur MCP d'inventaire (via la connexion `story → inventory` ci-dessus), et que l'API de jeu et le serveur MCP dépendent maintenant de `dungeon-db:dev`, l'exécution de la cible `dev` de n'importe quel projet démarre toutes les dépendances dont il a besoin dans le bon ordre.
 </Aside>
 
 ### Interface utilisateur du jeu : Infrastructure

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Questo file implementa il metodo `echo` ed è fortemente tipizzato dichiarando le strutture dati di input e output.
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -302,19 +303,22 @@ export class GameApi<
    *
    * Configura i domini della distribuzione CloudFront o le stringhe di origine
    * come uniche origini CORS permesse nelle risposte preflight di API Gateway e nelle
-   * integrazioni AWS Lambda.
+   * integrazioni AWS Lambda. Eventuali nomi di dominio personalizzati (alias) configurati su una
+   * distribuzione CloudFront sono inclusi automaticamente insieme al dominio predefinito `*.cloudfront.net`.
    *
    * @param origins - Le stringhe di origine, distribuzioni CloudFront, o oggetti contenenti una distribuzione CloudFront da cui concedere CORS
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -1033,7 +1037,7 @@ Il generatore `connection` genera/aggiorna questi file:
 </FileTree>
 
 Il generatore:
-- Rileva il `uxProvider` del sito web React (Shadcn qui) e fornisce componenti chat corrispondenti.
+- Rileva il `ux` del sito web React (Shadcn qui) e fornisce componenti chat corrispondenti.
 - Registra ogni agente connesso su un singolo `CopilotKitProvider` — rieseguire per un altro agente aggiunge semplicemente un altro hook.
 - Legge l'ARN del runtime dell'agente dalla Runtime Configuration, costruisce l'URL di invocazione AgentCore e allega il token bearer Cognito più l'header dell'id di sessione AgentCore.
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 このファイルは`echo`メソッドの実装であり、入力および出力データ構造を宣言することで厳密に型付けされています。
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -301,19 +302,23 @@ export class GameApi<
    *
    * CloudFrontディストリビューションドメインまたはオリジン文字列を、
    * API Gatewayプリフライトレスポンスおよび
-   * AWS Lambda統合で許可される唯一のCORSオリジンとして設定します。
+   * AWS Lambda統合で許可される唯一のCORSオリジンとして設定します。CloudFront
+   * ディストリビューションに設定されたカスタムドメイン名（エイリアス）は、
+   * デフォルトの`*.cloudfront.net`ドメインと共に自動的に含まれます。
    *
    * @param origins - CORSを許可するオリジン文字列、CloudFrontディストリビューション、またはCloudFrontディストリビューションを含むオブジェクト
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -476,7 +481,7 @@ _agent = _agent_ctx.__enter__()
 agui_agent = StrandsAgent(
     agent=_agent,
     name="StoryAgent",
-    description="A Agent exposed via the AG-UI protocol.",
+    description="An Agent exposed via the AG-UI protocol.",
 )
 
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -300,19 +301,23 @@ export class GameApi<
    * 제공된 출처로 CORS 제한
    *
    * CloudFront 배포 도메인 또는 출처 문자열을
-   * API Gateway 사전 요청 응답 및 AWS Lambda 통합에서 허용되는 유일한 CORS 출처로 구성
+   * API Gateway 사전 요청 응답 및 AWS Lambda 통합에서 허용되는 유일한 CORS 출처로 구성합니다.
+   * CloudFront 배포에 구성된 모든 사용자 정의 도메인 이름(별칭)은 기본 `*.cloudfront.net`
+   * 도메인과 함께 자동으로 포함됩니다.
    *
    * @param origins - CORS를 허용할 출처 문자열, CloudFront 배포 또는 CloudFront 배포를 포함하는 객체
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -657,7 +662,7 @@ export class StoryAgent extends Construct implements IGrantable {
           - dynamodb.ts 일반 DynamoDB 테이블 구성 요소
 </FileTree>
 
-생성된 `src/client.ts`는 `getDynamoDBClient()` 및 `resolveTableName()`을 익스포트합니다. `SERVE_LOCAL=true`일 때(`serve-local` 대상에 의해 자동으로 설정됨) 이들은 DynamoDB Local에 연결하고, 그렇지 않으면 AWS에 연결하여 <Link path="guides/runtime-config">런타임 구성</Link>에서 배포된 테이블 이름을 확인합니다. <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>에서 이 프로젝트의 `Game` 및 `Inventory` 엔티티를 모델링할 것입니다.
+생성된 `src/client.ts`는 `getDynamoDBClient()` 및 `resolveTableName()`을 익스포트합니다. `LOCAL_DEV=true`일 때(`dev` 대상에 의해 자동으로 설정됨) 이들은 DynamoDB Local에 연결하고, 그렇지 않으면 AWS에 연결하여 <Link path="guides/runtime-config">런타임 구성</Link>에서 배포된 테이블 이름을 확인합니다. <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>에서 이 프로젝트의 `Game` 및 `Inventory` 엔티티를 모델링할 것입니다.
 
 자세한 내용은 <Link path="guides/ts-dynamodb">ts#dynamodb 생성기 가이드</Link>를 참조하세요.
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 Este arquivo é a implementação do método `echo` e como você pode ver é fortemente tipado ao declarar suas estruturas de dados de entrada e saída.
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -302,19 +303,23 @@ export class GameApi<
    *
    * Configura os domínios de distribuição CloudFront ou strings de origem
    * como as únicas origens CORS permitidas nas respostas preflight do API Gateway e nas
-   * integrações AWS Lambda.
+   * integrações AWS Lambda. Quaisquer nomes de domínio personalizados (aliases) configurados
+   * em uma distribuição CloudFront são incluídos automaticamente junto com seu domínio
+   * padrão `*.cloudfront.net`.
    *
    * @param origins - As strings de origem, distribuições CloudFront, ou objetos contendo uma distribuição CloudFront para conceder CORS de
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -476,12 +481,12 @@ _agent = _agent_ctx.__enter__()
 agui_agent = StrandsAgent(
     agent=_agent,
     name="StoryAgent",
-    description="Um Agente exposto via protocolo AG-UI.",
+    description="An Agent exposed via the AG-UI protocol.",
 )
 
 
 class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Vincula o session ID para esta requisição para que clientes MCP / A2A downstream o encaminhem em chamadas de saída."""
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
 
     async def dispatch(self, request: Request, call_next):
         session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
@@ -627,7 +632,7 @@ O estado do nosso jogo — jogos salvos e o inventário de cada jogador — resi
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[Desenvolvimento local-first]
-O gerador `ts#dynamodb` fornece um target `serve-local` que executa [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um contêiner. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda em sua máquina sem uma implantação** até o final do tutorial.
+O gerador `ts#dynamodb` fornece um target `dev` que executa [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um contêiner. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda em sua máquina sem uma implantação** até o final do tutorial.
 :::
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
@@ -660,7 +665,7 @@ O gerador `ts#dynamodb` gera estes arquivos.
           - dynamodb.ts construct de tabela DynamoDB genérico
 </FileTree>
 
-O `src/client.ts` gerado exporta `getDynamoDBClient()` e `resolveTableName()`. Quando `SERVE_LOCAL=true` (definido automaticamente pelos targets `serve-local`) estes se conectam ao DynamoDB Local; caso contrário, eles se conectam à AWS e resolvem o nome da tabela implantada a partir da <Link path="guides/runtime-config">Configuração de Runtime</Link>. Vamos modelar nossas entidades `Game` e `Inventory` neste projeto no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
+O `src/client.ts` gerado exporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (definido automaticamente pelos targets `dev`) estes se conectam ao DynamoDB Local; caso contrário, eles se conectam à AWS e resolvem o nome da tabela implantada a partir da <Link path="guides/runtime-config">Configuração de Runtime</Link>. Vamos modelar nossas entidades `Game` e `Inventory` neste projeto no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
 
 Para mais detalhes, consulte o <Link path="guides/ts-dynamodb">guia do gerador ts#dynamodb</Link>.
 
@@ -852,7 +857,7 @@ import './styles.css';
 +  routeTree,
 +  context: { runtimeConfig: undefined, auth: undefined },
 +});
-// Registra a instância do router para segurança de tipo
+// Register the router instance for type safety
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
@@ -1042,7 +1047,7 @@ Para mais detalhes, consulte o <Link path="guides/connection/react-agui">guia de
 
 ### Conectar a Game API e o servidor MCP de inventário ao banco de dados
 
-Tanto a Game API quanto o servidor MCP de inventário leem e escrevem em nossa tabela DynamoDB, então vamos conectá-los ao projeto `DungeonDb`. O gerador `connection` detecta que o alvo é um projeto `ts#dynamodb` e configura o target `serve-local` de cada projeto de origem para iniciar o DynamoDB Local automaticamente.
+Tanto a Game API quanto o servidor MCP de inventário leem e escrevem em nossa tabela DynamoDB, então vamos conectá-los ao projeto `DungeonDb`. O gerador `connection` detecta que o alvo é um projeto `ts#dynamodb` e configura o target `dev` de cada projeto de origem para iniciar o DynamoDB Local automaticamente.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
@@ -1202,4 +1207,4 @@ Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir.
 
 Todos os artefatos construídos estão agora disponíveis dentro da pasta `dist/` localizada na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin`, pois não polui sua árvore de arquivos com arquivos gerados. Caso você queira limpar seus arquivos, delete a pasta `dist/` sem se preocupar com artefatos de build espalhados pela árvore de arquivos.
 
-Parabéns! Você criou todos os sub-projetos necessários para começar a implementar o núcleo do nosso jogo AI Dungeon Adventure.  🎉🎉🎉Adventure.  🎉🎉🎉🎉🎉
+Parabéns! Você criou todos os sub-projetos necessários para começar a implementar o núcleo do nosso jogo AI Dungeon Adventure.  🎉🎉🎉

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -302,19 +303,22 @@ export class GameApi<
    *
    * Cấu hình các domain CloudFront distribution hoặc chuỗi origin
    * là các CORS origin được phép duy nhất trong các phản hồi preflight của API Gateway và các
-   * tích hợp AWS Lambda.
+   * tích hợp AWS Lambda. Bất kỳ tên miền tùy chỉnh (bí danh) nào được cấu hình trên CloudFront
+   * distribution đều được bao gồm tự động cùng với domain `*.cloudfront.net` mặc định của nó.
    *
    * @param origins - Các chuỗi origin, CloudFront distribution, hoặc các đối tượng chứa CloudFront distribution để cấp CORS từ
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -146,7 +146,7 @@ import {
 export const echo = publicProcedure
   .input(EchoInputSchema)
   .output(EchoOutputSchema)
-  .query((opts) => ({ result: opts.input.message }));
+  .query((opts) => ({ message: opts.input.message }));
 ```
 
 该文件是 `echo` 方法的实现,通过声明输入输出数据结构实现强类型。
@@ -200,6 +200,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@dungeon-adventure/game-api';
@@ -300,19 +301,22 @@ export class GameApi<
    * 将 CORS 限制为提供的来源
    *
    * 将 CloudFront 分发域或来源字符串配置为 API Gateway 预检响应和 AWS
-   * Lambda 集成中唯一允许的 CORS 来源
+   * Lambda 集成中唯一允许的 CORS 来源。CloudFront 分发上配置的任何自定义域名(别名)
+   * 都会自动包含在其默认的 `*.cloudfront.net` 域旁边。
    *
    * @param origins - 授予 CORS 的来源字符串、CloudFront 分发或包含 CloudFront 分发的对象
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -5,6 +5,10 @@
     "latest-modernize-function-props-cast": {
       "description": "Replace the legacy angle-bracket FunctionProps type assertion with the modern as syntax in generated API constructs",
       "implementation": "./src/migrations/latest/modernize-function-props-cast/migration"
+    },
+    "latest-restrict-cors-to-custom-domains": {
+      "description": "Include CloudFront custom domain aliases in restrictCorsTo and UserIdentity callback URLs",
+      "implementation": "./src/migrations/latest/restrict-cors-to-custom-domains/migration"
     }
   }
 }

--- a/packages/nx-plugin/src/migrations/latest/restrict-cors-to-custom-domains/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/restrict-cors-to-custom-domains/migration.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const CORE_INDEX = 'packages/common/constructs/src/core/index.ts';
+const CLOUDFRONT_CORE_FILE =
+  'packages/common/constructs/src/core/cloudfront.ts';
+const API_APP_FILE = 'packages/common/constructs/src/app/apis/test-api.ts';
+const USER_IDENTITY_FILE =
+  'packages/common/constructs/src/core/user-identity.ts';
+
+const OLD_INDEX = `export * from './app.js';
+export * from './checkov.js';
+export * from './runtime-config.js';
+export * from './workspace.js';
+`;
+
+const OLD_API_APP_FILE = `import { Construct } from 'constructs';
+import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import {
+  ApiIntegrations,
+  IntegrationBuilder,
+  RestApiIntegration,
+} from '../../core/api/utils.js';
+import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
+
+export class TestApi extends RestApi {
+  private allowedOrigins: readonly string[] = ['*'];
+
+  public restrictCorsTo(
+    ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
+  ) {
+    const allowedOrigins = origins.map((origin) =>
+      typeof origin === 'string'
+        ? origin
+        : 'cloudFrontDistribution' in origin
+          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
+          : \`https://\${origin.distributionDomainName}\`,
+    );
+
+    this.allowedOrigins = allowedOrigins;
+  }
+}
+`;
+
+const OLD_USER_IDENTITY_FILE = `import { Construct } from 'constructs';
+import { Stack } from 'aws-cdk-lib';
+import { UserPool, UserPoolClient } from 'aws-cdk-lib/aws-cognito';
+import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { suppressRules } from './checkov.js';
+
+const WEB_CLIENT_ID = 'WebClient';
+
+export class UserIdentity extends Construct {
+  private createUserPoolClient = (userPool: UserPool) => {
+    const lazilyComputedCallbackUrls = Lazy.list({
+      produce: () =>
+        ['http://localhost:4200', 'http://localhost:4300'].concat(
+          this.findCloudFrontDomainNames().map((domain) => \`https://\${domain}\`),
+        ),
+    });
+
+    return userPool.addClient(WEB_CLIENT_ID, {
+      oAuth: {
+        callbackUrls: lazilyComputedCallbackUrls,
+        logoutUrls: lazilyComputedCallbackUrls,
+      },
+    });
+  };
+
+  // Includes each distribution's default domain name plus any custom domain names (aliases) configured on it.
+  private findCloudFrontDomainNames = (): string[] =>
+    Stack.of(this)
+      .node.findAll()
+      .filter((child): child is Distribution => child instanceof Distribution)
+      .flatMap((d) => {
+        const cfnDistribution = d.node.defaultChild as CfnDistribution;
+        const distributionConfig =
+          cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+        return [d.domainName, ...(distributionConfig.aliases ?? [])];
+      });
+}
+`;
+
+describe('restrict-cors-to-custom-domains migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should be a no-op when common/constructs does not exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(CLOUDFRONT_CORE_FILE)).toBeFalsy();
+  });
+
+  it('should apply to the shape your generators produce', async () => {
+    tree.write(CORE_INDEX, OLD_INDEX);
+    tree.write(API_APP_FILE, OLD_API_APP_FILE);
+    tree.write(USER_IDENTITY_FILE, OLD_USER_IDENTITY_FILE);
+
+    const result = await migration(tree);
+
+    // Adds the shared helper and exports it
+    expect(tree.exists(CLOUDFRONT_CORE_FILE)).toBeTruthy();
+    expect(tree.read(CLOUDFRONT_CORE_FILE, 'utf-8')).toContain(
+      'export const findCloudFrontDomainNames',
+    );
+    expect(tree.read(CORE_INDEX, 'utf-8')).toContain(
+      "export * from './cloudfront.js';",
+    );
+
+    // Updates restrictCorsTo and its import
+    const apiContent = tree.read(API_APP_FILE, 'utf-8');
+    expect(apiContent).toContain('origins.flatMap((origin) =>');
+    expect(apiContent).toContain('findCloudFrontDomainNames(');
+    expect(apiContent).toContain(
+      "import { findCloudFrontDomainNames } from '../../core/cloudfront.js';",
+    );
+    expect(apiContent).not.toContain('distributionDomainName');
+
+    // Updates UserIdentity to reuse the shared helper
+    const identityContent = tree.read(USER_IDENTITY_FILE, 'utf-8');
+    expect(identityContent).toContain(
+      "import { findCloudFrontDomainNames } from './cloudfront.js';",
+    );
+    expect(identityContent).toContain('.flatMap(findCloudFrontDomainNames)');
+    expect(identityContent).not.toContain('private findCloudFrontDomainNames');
+    expect(identityContent).not.toContain('CfnDistribution');
+
+    expect(result.nextSteps.length).toBeGreaterThan(0);
+  });
+
+  it('should skip and report a customised restrictCorsTo', async () => {
+    tree.write(CORE_INDEX, OLD_INDEX);
+    const customised = OLD_API_APP_FILE.replace(
+      "typeof origin === 'string'\n        ? origin",
+      "typeof origin === 'string'\n        ? origin.toUpperCase()",
+    );
+    tree.write(API_APP_FILE, customised);
+
+    const result = await migration(tree);
+
+    // Left alone (formatFilesInSubtree may still reformat whitespace, but the
+    // customisation and old shape must survive untouched).
+    const apiContent = tree.read(API_APP_FILE, 'utf-8');
+    expect(apiContent).toContain('origin.toUpperCase()');
+    expect(apiContent).toContain('distributionDomainName');
+    expect(apiContent).not.toContain('findCloudFrontDomainNames(');
+    expect(result.nextSteps.some((c) => c.includes(API_APP_FILE))).toBeTruthy();
+  });
+
+  it('should apply the UserIdentity fix while preserving an added allowed origin', async () => {
+    tree.write(CORE_INDEX, OLD_INDEX);
+    const customised = OLD_USER_IDENTITY_FILE.replace(
+      "'http://localhost:4200', 'http://localhost:4300'",
+      "'http://localhost:4200', 'http://localhost:4300', 'https://my-custom-preview.example.com'",
+    );
+    tree.write(USER_IDENTITY_FILE, customised);
+
+    const result = await migration(tree);
+
+    // The added origin is unrelated to the call site the fix targets, so it's
+    // preserved while the fix is still applied.
+    const identityContent = tree.read(USER_IDENTITY_FILE, 'utf-8');
+    expect(identityContent).toContain('https://my-custom-preview.example.com');
+    expect(identityContent).toContain('.flatMap(findCloudFrontDomainNames)');
+    expect(identityContent).not.toContain('private findCloudFrontDomainNames');
+    expect(
+      result.nextSteps.some((c) => c.includes(USER_IDENTITY_FILE)),
+    ).toBeTruthy();
+  });
+
+  it('should skip and report a UserIdentity with a renamed call site', async () => {
+    tree.write(CORE_INDEX, OLD_INDEX);
+    const customised = OLD_USER_IDENTITY_FILE.replace(
+      'this.findCloudFrontDomainNames()',
+      'this.getAllowedDomains()',
+    ).replace('private findCloudFrontDomainNames', 'private getAllowedDomains');
+    tree.write(USER_IDENTITY_FILE, customised);
+
+    const result = await migration(tree);
+
+    const identityContent = tree.read(USER_IDENTITY_FILE, 'utf-8');
+    expect(identityContent).toContain('private getAllowedDomains');
+    expect(identityContent).not.toContain(
+      '.flatMap(findCloudFrontDomainNames)',
+    );
+    expect(
+      result.nextSteps.some((c) => c.includes(USER_IDENTITY_FILE)),
+    ).toBeTruthy();
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(CORE_INDEX, OLD_INDEX);
+    tree.write(API_APP_FILE, OLD_API_APP_FILE);
+    tree.write(USER_IDENTITY_FILE, OLD_USER_IDENTITY_FILE);
+
+    await migration(tree);
+    const apiAfterFirst = tree.read(API_APP_FILE, 'utf-8');
+    const identityAfterFirst = tree.read(USER_IDENTITY_FILE, 'utf-8');
+    const indexAfterFirst = tree.read(CORE_INDEX, 'utf-8');
+
+    const secondResult = await migration(tree);
+
+    expect(tree.read(API_APP_FILE, 'utf-8')).toEqual(apiAfterFirst);
+    expect(tree.read(USER_IDENTITY_FILE, 'utf-8')).toEqual(identityAfterFirst);
+    expect(tree.read(CORE_INDEX, 'utf-8')).toEqual(indexAfterFirst);
+    expect(secondResult.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/restrict-cors-to-custom-domains/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/restrict-cors-to-custom-domains/migration.ts
@@ -1,0 +1,169 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import {
+  addDestructuredImport,
+  addStarExport,
+  applyGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import { isEsmWorkspace } from '../../../utils/module-format';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Include CloudFront custom domain aliases in restrictCorsTo and UserIdentity callback URLs
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Pattern-match before writing: skip files that have diverged from the shape
+ *   your generators produce and report them via `nextSteps`, rather than
+ *   clobbering the user's changes.
+ * - Idempotent: re-running must be a no-op.
+ * - Format what you write: finish with `formatFilesInSubtree` so the files your
+ *   migration wrote are formatted correctly.
+ */
+
+const CORE_DIR = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/core`;
+const APIS_APP_DIR = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/app/apis`;
+const CLOUDFRONT_CORE_FILE = `${CORE_DIR}/cloudfront.ts`;
+const CORE_INDEX_FILE = `${CORE_DIR}/index.ts`;
+const USER_IDENTITY_FILE = `${CORE_DIR}/user-identity.ts`;
+
+const CLOUDFRONT_HELPER_CONTENT = `import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+
+/**
+ * Finds the domain names associated with a CloudFront distribution.
+ *
+ * Includes the distribution's default \`*.cloudfront.net\` domain name plus any custom
+ * domain names (aliases) configured on it.
+ */
+export const findCloudFrontDomainNames = (
+  distribution: Distribution,
+): string[] => {
+  const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+  const distributionConfig =
+    cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+  return [distribution.domainName, ...(distributionConfig.aliases ?? [])];
+};
+`;
+
+// Rewrites the `restrictCorsTo` body as produced by generators prior to this fix.
+const RESTRICT_CORS_TO_GRITQL_PATTERN =
+  "`origins.map(($o) => typeof $o === 'string' ? $o : 'cloudFrontDistribution' in $o ? $branch1 : $branch2)` where { $branch1 <: contains `distributionDomainName`, $branch2 <: contains `distributionDomainName` } => raw`origins.flatMap(($o) => typeof $o === 'string' ? [$o] : findCloudFrontDomainNames('cloudFrontDistribution' in $o ? $o.cloudFrontDistribution : $o).map((domain) => \\`https://${domain}\\`))`";
+
+// Rewrites UserIdentity's callback/logout URL logic as produced by generators
+// prior to this fix.
+const USER_IDENTITY_CALLBACK_URLS_GRITQL_PATTERN =
+  '`this.findCloudFrontDomainNames()` => `Stack.of(this).node.findAll().filter((child): child is Distribution => child instanceof Distribution).flatMap(findCloudFrontDomainNames)`';
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(CORE_INDEX_FILE)) {
+    // No common/constructs shared library in this workspace - nothing to migrate.
+    return { nextSteps };
+  }
+
+  const esm = isEsmWorkspace(tree);
+  const apiCloudFrontImportSpecifier = esm
+    ? '../../core/cloudfront.js'
+    : '../../core/cloudfront';
+  const coreCloudFrontImportSpecifier = esm
+    ? './cloudfront.js'
+    : './cloudfront';
+
+  if (!tree.exists(CLOUDFRONT_CORE_FILE)) {
+    tree.write(CLOUDFRONT_CORE_FILE, CLOUDFRONT_HELPER_CONTENT);
+  }
+  await addStarExport(tree, CORE_INDEX_FILE, './cloudfront.js');
+
+  const apiAppFiles: string[] = [];
+  visitNotIgnoredFiles(tree, APIS_APP_DIR, (filePath) => {
+    apiAppFiles.push(filePath);
+  });
+
+  for (const filePath of apiAppFiles) {
+    if (!filePath.endsWith('.ts') || filePath.endsWith('/index.ts')) {
+      continue;
+    }
+    const rewrote = await applyGritQL(
+      tree,
+      filePath,
+      RESTRICT_CORS_TO_GRITQL_PATTERN,
+    );
+    if (rewrote) {
+      await addDestructuredImport(
+        tree,
+        filePath,
+        ['findCloudFrontDomainNames'],
+        apiCloudFrontImportSpecifier,
+      );
+      nextSteps.push(
+        `${filePath}: restrictCorsTo now includes CloudFront custom domain aliases automatically.`,
+      );
+      continue;
+    }
+    const contents = tree.read(filePath, 'utf-8') ?? '';
+    if (!contents.includes('findCloudFrontDomainNames(')) {
+      nextSteps.push(
+        `${filePath}: restrictCorsTo has diverged from the generated shape - left untouched. Manually apply the CloudFront custom domain fix (see findCloudFrontDomainNames in common/constructs/src/core/cloudfront.ts).`,
+      );
+    }
+    // Otherwise already migrated - silent skip.
+  }
+
+  if (tree.exists(USER_IDENTITY_FILE)) {
+    const rewrote = await applyGritQL(
+      tree,
+      USER_IDENTITY_FILE,
+      USER_IDENTITY_CALLBACK_URLS_GRITQL_PATTERN,
+    );
+    if (rewrote) {
+      await applyGritQL(
+        tree,
+        USER_IDENTITY_FILE,
+        "`import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront'` => `import { Distribution } from 'aws-cdk-lib/aws-cloudfront';`",
+      );
+      await applyGritQL(
+        tree,
+        USER_IDENTITY_FILE,
+        "or { `// Includes each distribution's default domain name plus any custom domain names (aliases) configured on it.` => ., `private findCloudFrontDomainNames = (): string[] => $body` => . }",
+      );
+      await addDestructuredImport(
+        tree,
+        USER_IDENTITY_FILE,
+        ['findCloudFrontDomainNames'],
+        coreCloudFrontImportSpecifier,
+      );
+      nextSteps.push(
+        `${USER_IDENTITY_FILE}: now reuses the shared findCloudFrontDomainNames helper.`,
+      );
+    } else {
+      const contents = tree.read(USER_IDENTITY_FILE, 'utf-8') ?? '';
+      if (!contents.includes('.flatMap(findCloudFrontDomainNames)')) {
+        nextSteps.push(
+          `${USER_IDENTITY_FILE}: the callback URL logic has diverged from the generated shape - left untouched. Manually apply the shared findCloudFrontDomainNames helper (see common/constructs/src/core/cloudfront.ts).`,
+        );
+      }
+      // Otherwise already migrated - silent skip.
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -171,6 +171,7 @@ exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime 
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > core-index.ts 1`] = `
 "export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -434,6 +434,7 @@ import {
   HttpApiIntegration,
   IntegrationBuilder,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { HttpApi } from '../../core/api/http-api.js';
 import {
   OPERATION_DETAILS,
@@ -549,6 +550,8 @@ export class TestApi<
    * as the only permitted CORS origins
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
+   * Any custom domain names (aliases) configured on a CloudFront distribution are
+   * included automatically alongside its default \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -559,12 +562,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -1406,6 +1411,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import {
   OPERATION_DETAILS,
@@ -1532,7 +1538,9 @@ export class TestApi<
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -1543,12 +1551,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`py#mcp-server generator > should match snapshot for BedrockAgentCoreRun
 exports[`py#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > core-index.ts 1`] = `
 "export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -32,6 +32,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import {
   OPERATION_DETAILS,
@@ -156,7 +157,9 @@ export class TestApi<
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -167,12 +170,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -221,6 +226,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import {
   OPERATION_DETAILS,
@@ -333,7 +339,9 @@ export class TestApi<
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -344,12 +352,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -380,6 +380,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@proj/test-api';
@@ -507,7 +508,9 @@ export class TestApi<
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -518,12 +521,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -592,6 +597,7 @@ import {
   HttpApiIntegration,
   IntegrationBuilder,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { HttpApi } from '../../core/api/http-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@proj/test-api';
@@ -709,6 +715,8 @@ export class TestApi<
    * as the only permitted CORS origins
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
+   * Any custom domain names (aliases) configured on a CloudFront distribution are
+   * included automatically alongside its default \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -719,12 +727,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -804,6 +814,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@proj/test-api';
@@ -941,7 +952,9 @@ export class TestApi<
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -952,12 +965,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     this.allowedOrigins = allowedOrigins;
@@ -1024,6 +1039,7 @@ import {
   HttpApiIntegration,
   IntegrationBuilder,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { HttpApi } from '../../core/api/http-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@proj/test-api';
@@ -1153,6 +1169,8 @@ export class TestApi<
    * as the only permitted CORS origins
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
+   * Any custom domain names (aliases) configured on a CloudFront distribution are
+   * included automatically alongside its default \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -1163,12 +1181,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -1391,6 +1411,7 @@ import {
   HttpApiIntegration,
   IntegrationBuilder,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { HttpApi } from '../../core/api/http-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@proj/test-api';
@@ -1495,6 +1516,8 @@ export class TestApi<
    * as the only permitted CORS origins
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
+   * Any custom domain names (aliases) configured on a CloudFront distribution are
+   * included automatically alongside its default \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -1505,12 +1528,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     const cfnApi = this.api.node.defaultChild;
@@ -2421,6 +2446,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils.js';
+import { findCloudFrontDomainNames } from '../../core/cloudfront.js';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api.js';
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils.js';
 import { AppRouter, appRouter } from '@proj/test-api';
@@ -2536,7 +2562,9 @@ export class TestApi<
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * \`*.cloudfront.net\` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
@@ -2547,12 +2575,14 @@ export class TestApi<
       | { cloudFrontDistribution: Distribution }
     )[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? \`https://\${origin.cloudFrontDistribution.distributionDomainName}\`
-          : \`https://\${origin.distributionDomainName}\`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => \`https://\${domain}\`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -747,6 +747,7 @@ exports[`ts#agent generator > should match snapshot for BedrockAgentCoreRuntime 
 exports[`ts#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > core-index.ts 1`] = `
 "export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`ts#mcp-server generator > should match snapshot for BedrockAgentCoreRun
 exports[`ts#mcp-server generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > core-index.ts 1`] = `
 "export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4736,6 +4736,7 @@ exports[`ts#rdb generator > should generate the aurora shared construct 6`] = `
 "export * from './rdb/aurora.js';
 export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1391,10 +1391,31 @@ export const suppressRules = (
 "
 `;
 
+exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/constructs/src/core/cloudfront.ts 1`] = `
+"import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+
+/**
+ * Finds the domain names associated with a CloudFront distribution.
+ *
+ * Includes the distribution's default \`*.cloudfront.net\` domain name plus any custom
+ * domain names (aliases) configured on it.
+ */
+export const findCloudFrontDomainNames = (
+  distribution: Distribution,
+): string[] => {
+  const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+  const distributionConfig =
+    cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+  return [distribution.domainName, ...(distributionConfig.aliases ?? [])];
+};
+"
+`;
+
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/constructs/src/core/index.ts 1`] = `
 "export * from './static-website.js';
 export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "
@@ -3180,10 +3201,31 @@ export const suppressRules = (
 "
 `;
 
+exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/constructs/src/core/cloudfront.ts 1`] = `
+"import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+
+/**
+ * Finds the domain names associated with a CloudFront distribution.
+ *
+ * Includes the distribution's default \`*.cloudfront.net\` domain name plus any custom
+ * domain names (aliases) configured on it.
+ */
+export const findCloudFrontDomainNames = (
+  distribution: Distribution,
+): string[] => {
+  const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+  const distributionConfig =
+    cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+  return [distribution.domainName, ...(distributionConfig.aliases ?? [])];
+};
+"
+`;
+
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/constructs/src/core/index.ts 1`] = `
 "export * from './static-website.js';
 export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "
@@ -5039,6 +5081,7 @@ exports[`react-website generator > should generate shared constructs > common/co
 "export * from './static-website.js';
 export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.spec.ts.snap
@@ -80,6 +80,7 @@ exports[`cognito-auth generator > should generate files > identity-index 1`] = `
 "export * from './user-identity.js';
 export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "
@@ -118,7 +119,8 @@ import {
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
-import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { findCloudFrontDomainNames } from './cloudfront.js';
 import { suppressRules } from './checkov.js';
 
 const WEB_CLIENT_ID = 'WebClient';
@@ -334,7 +336,13 @@ export class UserIdentity extends Construct {
     const lazilyComputedCallbackUrls = Lazy.list({
       produce: () =>
         ['http://localhost:4200', 'http://localhost:4300'].concat(
-          this.findCloudFrontDomainNames().map((domain) => \`https://\${domain}\`),
+          Stack.of(this)
+            .node.findAll()
+            .filter(
+              (child): child is Distribution => child instanceof Distribution,
+            )
+            .flatMap(findCloudFrontDomainNames)
+            .map((domain) => \`https://\${domain}\`),
         ),
     });
 
@@ -383,18 +391,6 @@ export class UserIdentity extends Construct {
       useCognitoProvidedValues: true,
     }).node.addDependency(userPoolClient, userPool, userPoolDomain);
   };
-
-  // Includes each distribution's default domain name plus any custom domain names (aliases) configured on it.
-  private findCloudFrontDomainNames = (): string[] =>
-    Stack.of(this)
-      .node.findAll()
-      .filter((child): child is Distribution => child instanceof Distribution)
-      .flatMap((d) => {
-        const cfnDistribution = d.node.defaultChild as CfnDistribution;
-        const distributionConfig =
-          cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
-        return [d.domainName, ...(distributionConfig.aliases ?? [])];
-      });
 }
 "
 `;
@@ -422,6 +418,7 @@ exports[`cognito-auth generator > should update shared constructs index.ts > com
 "export * from './user-identity.js';
 export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/utils/__snapshots__/shared-constructs.spec.ts.snap
@@ -79,9 +79,30 @@ export const suppressRules = (
 "
 `;
 
+exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/cloudfront.ts 1`] = `
+"import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+
+/**
+ * Finds the domain names associated with a CloudFront distribution.
+ *
+ * Includes the distribution's default \`*.cloudfront.net\` domain name plus any custom
+ * domain names (aliases) configured on it.
+ */
+export const findCloudFrontDomainNames = (
+  distribution: Distribution,
+): string[] => {
+  const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+  const distributionConfig =
+    cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+  return [distribution.domainName, ...(distributionConfig.aliases ?? [])];
+};
+"
+`;
+
 exports[`shared-constructs utils > sharedConstructsGenerator > should generate shared constructs when they do not exist > packages/common/constructs/src/core/index.ts 1`] = `
 "export * from './app.js';
 export * from './checkov.js';
+export * from './cloudfront.js';
 export * from './runtime-config.js';
 export * from './workspace.js';
 "

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -42,6 +42,7 @@ import {
   HttpApiIntegration,
   IntegrationBuilder,
 } from '../../core/api/utils<% if (esm) { %>.js<% } %>';
+import { findCloudFrontDomainNames } from '../../core/cloudfront<% if (esm) { %>.js<% } %>';
 import { HttpApi } from '../../core/api/http-api<% if (esm) { %>.js<% } %>';
 <%_ if (backend.type === 'trpc') { _%>
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils<% if (esm) { %>.js<% } %>';
@@ -245,18 +246,22 @@ export class <%= apiNameClassName %><
    * as the only permitted CORS origins
    * in the API gateway. The CORS origins are not configured within the AWS Lambda
    * integrations since the associated header is controlled by API Gateway v2.
+   * Any custom domain names (aliases) configured on a CloudFront distribution are
+   * included automatically alongside its default `*.cloudfront.net` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     const cfnApi = this.api.node.defaultChild;

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -45,6 +45,7 @@ import {
   IntegrationBuilder,
   RestApiIntegration,
 } from '../../core/api/utils<% if (esm) { %>.js<% } %>';
+import { findCloudFrontDomainNames } from '../../core/cloudfront<% if (esm) { %>.js<% } %>';
 import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api<% if (esm) { %>.js<% } %>';
 <%_ if (backend.type === 'trpc') { _%>
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils<% if (esm) { %>.js<% } %>';
@@ -284,19 +285,23 @@ export class <%= apiNameClassName %><
    *
    * Configures the provided CloudFront distribution domains or origin strings
    * as the only permitted CORS origins in API Gateway preflight responses and the
-   * AWS Lambda integrations.
+   * AWS Lambda integrations. Any custom domain names (aliases) configured on a
+   * CloudFront distribution are included automatically alongside its default
+   * `*.cloudfront.net` domain.
    *
    * @param origins - The origin strings, CloudFront distributions, or objects containing a CloudFront distribution to grant CORS from
    */
   public restrictCorsTo(
     ...origins: (string | Distribution | { cloudFrontDistribution: Distribution })[]
   ) {
-    const allowedOrigins = origins.map((origin) =>
+    const allowedOrigins = origins.flatMap((origin) =>
       typeof origin === 'string'
-        ? origin
-        : 'cloudFrontDistribution' in origin
-          ? `https://${origin.cloudFrontDistribution.distributionDomainName}`
-          : `https://${origin.distributionDomainName}`,
+        ? [origin]
+        : findCloudFrontDomainNames(
+            'cloudFrontDistribution' in origin
+              ? origin.cloudFrontDistribution
+              : origin,
+          ).map((domain) => `https://${domain}`),
     );
 
     this.allowedOrigins = allowedOrigins;

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/cloudfront.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/cloudfront.ts.template
@@ -1,0 +1,14 @@
+import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+
+/**
+ * Finds the domain names associated with a CloudFront distribution.
+ *
+ * Includes the distribution's default `*.cloudfront.net` domain name plus any custom
+ * domain names (aliases) configured on it.
+ */
+export const findCloudFrontDomainNames = (distribution: Distribution): string[] => {
+  const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+  const distributionConfig =
+    cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
+  return [distribution.domainName, ...(distributionConfig.aliases ?? [])];
+};

--- a/packages/nx-plugin/src/utils/files/common/constructs/src/core/index.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/constructs/src/core/index.ts.template
@@ -1,4 +1,5 @@
 export * from './app<% if (esm) { %>.js<% } %>';
 export * from './checkov<% if (esm) { %>.js<% } %>';
+export * from './cloudfront<% if (esm) { %>.js<% } %>';
 export * from './runtime-config<% if (esm) { %>.js<% } %>';
 export * from './workspace<% if (esm) { %>.js<% } %>';

--- a/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
+++ b/packages/nx-plugin/src/utils/identity-constructs/files/cdk/core/user-identity.ts.template
@@ -30,7 +30,8 @@ import {
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config<% if (esm) { %>.js<% } %>';
-import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import { findCloudFrontDomainNames } from './cloudfront<% if (esm) { %>.js<% } %>';
 import { suppressRules } from './checkov<% if (esm) { %>.js<% } %>';
 
 const WEB_CLIENT_ID = 'WebClient';
@@ -242,7 +243,11 @@ export class UserIdentity extends Construct {
     const lazilyComputedCallbackUrls = Lazy.list({
       produce: () =>
         ['http://localhost:4200', 'http://localhost:4300'].concat(
-          this.findCloudFrontDomainNames().map((domain) => `https://${domain}`)
+          Stack.of(this)
+            .node.findAll()
+            .filter((child): child is Distribution => child instanceof Distribution)
+            .flatMap(findCloudFrontDomainNames)
+            .map((domain) => `https://${domain}`)
         ),
     });
 
@@ -291,16 +296,4 @@ export class UserIdentity extends Construct {
       useCognitoProvidedValues: true,
     }).node.addDependency(userPoolClient, userPool, userPoolDomain);
   };
-
-  // Includes each distribution's default domain name plus any custom domain names (aliases) configured on it.
-  private findCloudFrontDomainNames = (): string[] =>
-    Stack.of(this)
-      .node.findAll()
-      .filter((child): child is Distribution => child instanceof Distribution)
-      .flatMap((d) => {
-        const cfnDistribution = d.node.defaultChild as CfnDistribution;
-        const distributionConfig =
-          cfnDistribution.distributionConfig as CfnDistribution.DistributionConfigProperty;
-        return [d.domainName, ...(distributionConfig.aliases ?? [])];
-      });
 }


### PR DESCRIPTION
### Reason for this change

When a website's CloudFront distribution has a custom domain configured (via `ts#website`'s `domainNames`/`certificate` props), `restrictCorsTo` only ever allow-listed the distribution's default `*.cloudfront.net` domain. A browser loading the site from the custom domain sends that domain as the `Origin` header, which never matches the allow-listed `*.cloudfront.net` origin — so the CORS preflight fails and the browser blocks all subsequent API requests.

### Description of changes

- Added a shared `findCloudFrontDomainNames` helper (`common/constructs/src/core/cloudfront.ts`) that reads a CloudFront distribution's aliases directly off its `CfnDistribution`, returning the default domain plus any custom domains.
- Updated `restrictCorsTo` in both the REST and HTTP API app constructs to use this helper, so custom domains are now included automatically alongside the default CloudFront domain.
- Refactored `UserIdentity`'s Cognito callback/logout URL logic to reuse the same shared helper instead of duplicating the alias-extraction logic.
- Updated the `dungeon-game` tutorial docs (all 9 locales) to keep the generated code excerpt in sync with the fix.

### Description of how you validated changes

- Rendered the updated templates through the `trpc`, `fastapi`, `smithy`, and `cognito-auth` generator test suites and confirmed the output matches expectations; updated snapshots accordingly.
- Deployed a workspace with a custom domain configured on the CloudFront distribution and confirmed the API's CORS preflight (`OPTIONS`) response returns the correct `Access-Control-Allow-Origin`, both when accessing via the custom domain and via the default CloudFront domain.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*