### PR TITLE
chore(dev): add @astral-sh/ruff-wasm-nodejs to root devDependencies for pnpm link workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@a2a-js/sdk": "0.3.14",
     "@apidevtools/swagger-parser": "12.1.0",
+    "@astral-sh/ruff-wasm-nodejs": "0.15.22",
     "@astrojs/react": "6.0.1",
     "@astrojs/starlight": "0.41.3",
     "@astrojs/starlight-tailwind": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@apidevtools/swagger-parser':
         specifier: 12.1.0
         version: 12.1.0(openapi-types@12.1.3)
+      '@astral-sh/ruff-wasm-nodejs':
+        specifier: 0.15.22
+        version: 0.15.22
       '@astrojs/react':
         specifier: 6.0.1
         version: 6.0.1(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@7.2.0)(terser@5.44.0)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
### Reason for this change

When developing locally using `pnpm link dist/packages/nx-plugin`, any generator that formats Python fails with:

```
Error: Cannot find package '@astral-sh/ruff-wasm-nodejs' imported from .../dist/packages/nx-plugin/src/utils/ruff.js
```

This happens because the linked dist package resolves its runtime dependencies from the workspace root `node_modules`, not from inside the dist directory. Since `@astral-sh/ruff-wasm-nodejs` (added in #1006 for in-process Python formatting) was only declared as a dependency in `packages/nx-plugin/package.json`, it is absent from the root workspace `node_modules` and therefore unavailable during the `pnpm link` dev workflow. Same root cause as #782's `jiti` fix.

### Description of changes

Add `@astral-sh/ruff-wasm-nodejs` (pinned to the same version already used in `packages/nx-plugin/package.json`) to the root `package.json` devDependencies, and update `pnpm-lock.yaml` accordingly.

### Description of how you validated changes

Confirmed the version matches the existing declaration in `packages/nx-plugin/package.json`, and that `pnpm install` resolves and installs the package into the root `node_modules`, mirroring the fix applied for the identical `jiti` issue in #782.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*