### PR TITLE
fix(api-constructs): replace legacy FunctionProps angle-bracket cast with as syntax

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -254,7 +254,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -254,7 +254,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -254,7 +254,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -254,7 +254,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -240,7 +240,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -253,7 +253,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -240,7 +240,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -253,7 +253,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -254,7 +254,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -241,7 +241,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -254,7 +254,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -240,7 +240,7 @@ export class GameApi<
   public static defaultIntegrations = (scope: Construct) => {
     return IntegrationBuilder.rest({
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -253,7 +253,7 @@ export class GameApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
         return {

--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -1,5 +1,10 @@
 {
   "$schema": "http://json-schema.org/schema",
   "name": "@aws/nx-plugin",
-  "generators": {}
+  "generators": {
+    "latest-modernize-function-props-cast": {
+      "description": "Replace the legacy angle-bracket FunctionProps type assertion with the modern as syntax in generated API constructs",
+      "implementation": "./src/migrations/latest/modernize-function-props-cast/migration"
+    }
+  }
 }

--- a/packages/nx-plugin/src/migrations/latest/modernize-function-props-cast/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/modernize-function-props-cast/migration.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const API_APP_FILE = 'packages/common/constructs/src/app/apis/test-api.ts';
+
+const OLD_API_APP_FILE = `import { Function, FunctionProps } from 'aws-cdk-lib/aws-lambda';
+
+export class TestApi {
+  public static defaultIntegrations = (scope) => {
+    const rc = RuntimeConfig.ensure(scope);
+    return IntegrationBuilder.rest({
+      pattern: 'isolated',
+      operations: routerToOperations(appRouter),
+      defaultIntegrationOptions: <FunctionProps>{
+        runtime: Runtime.NODEJS_LATEST,
+        handler: 'index.handler',
+        timeout: Duration.seconds(30),
+        tracing: Tracing.ACTIVE,
+      },
+      buildDefaultIntegration: (op, props: FunctionProps) => {
+        const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
+        return { handler };
+      },
+    });
+  };
+}
+`;
+
+describe('modernize-function-props-cast migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should be a no-op when no api app files exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should apply to the shape your generators produce', async () => {
+    tree.write(API_APP_FILE, OLD_API_APP_FILE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(API_APP_FILE, 'utf-8');
+    expect(content).not.toContain('<FunctionProps>');
+    expect(content).toContain('} as FunctionProps,');
+    expect(result.nextSteps.some((s) => s.includes(API_APP_FILE))).toBeTruthy();
+  });
+
+  it('should skip and report a customised file', async () => {
+    tree.write(
+      API_APP_FILE,
+      OLD_API_APP_FILE.replace(
+        '      },\n      buildDefaultIntegration:',
+        '      },\n      // a customisation between the cast and buildDefaultIntegration\n      buildDefaultIntegration:',
+      ),
+    );
+
+    const result = await migration(tree);
+
+    const content = tree.read(API_APP_FILE, 'utf-8');
+    expect(content).toContain('<FunctionProps>');
+    expect(result.nextSteps.some((s) => s.includes(API_APP_FILE))).toBeTruthy();
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(API_APP_FILE, OLD_API_APP_FILE);
+
+    await migration(tree);
+    const afterFirst = tree.read(API_APP_FILE, 'utf-8');
+
+    const secondResult = await migration(tree);
+
+    expect(tree.read(API_APP_FILE, 'utf-8')).toEqual(afterFirst);
+    expect(secondResult.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/modernize-function-props-cast/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/modernize-function-props-cast/migration.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { formatFilesInSubtree } from '../../../utils/format';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Replace the legacy angle-bracket FunctionProps type assertion with the modern as syntax in generated API constructs
+ *
+ * The legacy `<FunctionProps>{ ... }` cast form is not supported by GritQL's
+ * TypeScript parser, which silently breaks parsing (and therefore matching)
+ * for the entire containing file. Since several other migrations rely on
+ * GritQL to update these API construct files, this cast is replaced here with
+ * the equivalent, GritQL-compatible `{ ... } as FunctionProps` form. This is
+ * matched as an exact literal (rather than via GritQL) since GritQL cannot
+ * parse the file while the legacy cast is still present.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Pattern-match before writing: skip files that have diverged from the shape
+ *   your generators produce and report them via `nextSteps`, or consider a
+ *   hybrid migration, rather than clobbering the user's changes.
+ * - Idempotent: re-running must be a no-op.
+ * - Format what you write: finish with `formatFilesInSubtree` so the files your
+ *   migration wrote are formatted correctly.
+ */
+
+const APIS_APP_DIR = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/app/apis`;
+
+const OLD_CAST_OPEN = 'defaultIntegrationOptions: <FunctionProps>{';
+const NEW_CAST_OPEN = 'defaultIntegrationOptions: {';
+const OLD_CAST_CLOSE = '\n      },\n      buildDefaultIntegration:';
+const NEW_CAST_CLOSE =
+  '\n      } as FunctionProps,\n      buildDefaultIntegration:';
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(APIS_APP_DIR)) {
+    return { nextSteps };
+  }
+
+  const apiAppFiles: string[] = [];
+  visitNotIgnoredFiles(tree, APIS_APP_DIR, (filePath) => {
+    apiAppFiles.push(filePath);
+  });
+
+  for (const filePath of apiAppFiles) {
+    if (!filePath.endsWith('.ts') || filePath.endsWith('/index.ts')) {
+      continue;
+    }
+    const contents = tree.read(filePath, 'utf-8') ?? '';
+    if (!contents.includes(OLD_CAST_OPEN)) {
+      // Already migrated, or doesn't use this shape.
+      continue;
+    }
+    if (!contents.includes(OLD_CAST_CLOSE)) {
+      nextSteps.push(
+        `${filePath}: the defaultIntegrationOptions cast has diverged from the generated shape - left untouched. Manually replace \`<FunctionProps>{ ... }\` with \`{ ... } as FunctionProps\`.`,
+      );
+      continue;
+    }
+    tree.write(
+      filePath,
+      contents
+        .replace(OLD_CAST_OPEN, NEW_CAST_OPEN)
+        .replace(OLD_CAST_CLOSE, NEW_CAST_CLOSE),
+    );
+    nextSteps.push(
+      `${filePath}: replaced the legacy <FunctionProps> cast with the modern as FunctionProps syntax.`,
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -474,7 +474,7 @@ export class TestApi<
     return IntegrationBuilder.http({
       pattern: 'isolated',
       operations: OPERATION_DETAILS,
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.PYTHON_3_14,
         handler: 'run.sh',
         code: Code.fromAsset(
@@ -488,7 +488,7 @@ export class TestApi<
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -1454,7 +1454,7 @@ export class TestApi<
     return IntegrationBuilder.rest({
       pattern: 'isolated',
       operations: OPERATION_DETAILS,
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.PYTHON_3_14,
         handler: 'run.sh',
         code: Code.fromAsset(
@@ -1468,7 +1468,7 @@ export class TestApi<
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -86,7 +86,7 @@ export class TestApi<
     return IntegrationBuilder.rest({
       pattern: 'isolated',
       operations: OPERATION_DETAILS,
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -99,7 +99,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -269,7 +269,7 @@ export class TestApi<
     return IntegrationBuilder.rest({
       pattern: 'isolated',
       operations: OPERATION_DETAILS,
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -282,7 +282,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -435,7 +435,7 @@ export class TestApi<
     return IntegrationBuilder.rest({
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -448,7 +448,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -640,7 +640,7 @@ export class TestApi<
     return IntegrationBuilder.http({
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -653,7 +653,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -853,7 +853,7 @@ export class TestApi<
     return IntegrationBuilder.rest({
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -866,7 +866,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -1065,7 +1065,7 @@ export class TestApi<
     return IntegrationBuilder.http({
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -1078,7 +1078,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -1432,7 +1432,7 @@ export class TestApi<
     return IntegrationBuilder.http({
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -1445,7 +1445,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(
@@ -2470,7 +2470,7 @@ export class TestApi<
     return IntegrationBuilder.rest({
       pattern: 'isolated',
       operations: routerToOperations(appRouter),
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
         code: Code.fromAsset(
@@ -2483,7 +2483,7 @@ export class TestApi<
         ),
         timeout: Duration.seconds(30),
         tracing: Tracing.ACTIVE,
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, \`TestApi\${op}Handler\`, props);
         handler.addEnvironment(

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -108,7 +108,7 @@ export class <%= apiNameClassName %><
       <%_ } else { _%>
       operations: OPERATION_DETAILS,
       <%_ } _%>
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         <%_ if (['trpc', 'smithy'].includes(backend.type)) { _%>
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
@@ -137,7 +137,7 @@ export class <%= apiNameClassName %><
         <%_ if (backend.type === 'fastapi') { _%>
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
         <%_ } _%>
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         <%_ const lambdaTarget = backend.type === 'fastapi' ? 'handler.currentVersion' : 'handler'; _%>
         <%_ const integrationOptions = backend.integrationPattern === 'shared' ? ', { scopePermissionToRoute: false }' : ''; _%>

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -118,7 +118,7 @@ export class <%= apiNameClassName %><
       <%_ } else { _%>
       operations: OPERATION_DETAILS,
       <%_ } _%>
-      defaultIntegrationOptions: <FunctionProps>{
+      defaultIntegrationOptions: {
         <%_ if (['trpc', 'smithy'].includes(backend.type)) { _%>
         runtime: Runtime.NODEJS_LATEST,
         handler: 'index.handler',
@@ -147,7 +147,7 @@ export class <%= apiNameClassName %><
         <%_ if (backend.type === 'fastapi') { _%>
         snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
         <%_ } _%>
-      },
+      } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         <%_ const lambdaTarget = backend.type === 'fastapi' ? 'handler.currentVersion' : 'handler'; _%>
         <%_


### PR DESCRIPTION
### Reason for this change

While working on #1007, a GritQL-based rewrite surfaced a blocker: the generated API constructs' `defaultIntegrations` uses the legacy angle-bracket type assertion `<FunctionProps>{ ... }`. This is functionally identical to the modern `{ ... } as FunctionProps` form (verified both compile to identical JS output), but GritQL's TypeScript parser cannot handle the legacy angle-bracket form. It silently fails to parse the *entire containing file*, which blocks any GritQL-based pattern matching anywhere else in that file, including in unrelated methods like `restrictCorsTo`. Since #1007 and future GritQL-based migrations need to operate on these generated API construct files, this legacy syntax needs to go first.

### Description of changes

- Replaced `<FunctionProps>{ ... }` with `{ ... } as FunctionProps` in both the REST and HTTP API constructs templates (`api-constructs/files/cdk/app/apis/{rest,http}`).
- Added a `modernize-function-props-cast` migration so existing workspaces pick up the same change: it locates generated API app construct files, rewrites the cast if it still matches the generated shape, and reports (without touching) any file that has diverged.

### Description of how you validated changes

- Rendered the updated templates through the `trpc`, `fastapi`, and `smithy` generator test suites and confirmed the output matches expectations; updated snapshots accordingly.
- Unit tested the migration (apply / skip-customised / idempotent).
- Ran the migration against a real project generated on a previous version and confirmed it still builds and works correctly afterwards.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*