### PR TITLE
fix(terraform#project): adopt an existing state bucket when its bootstrap state is missing

### DIFF
--- a/packages/nx-plugin/src/terraform/project/files/application/scripts/bootstrap.ts.template
+++ b/packages/nx-plugin/src/terraform/project/files/application/scripts/bootstrap.ts.template
@@ -4,7 +4,8 @@
  * Equivalent to `cdk bootstrap` — resolves account + region from the AWS
  * SDK credential chain, pulls any existing bootstrap tfstate from S3,
  * runs `terraform apply` in the `bootstrap` dir, then pushes the new
- * state back to S3.
+ * state back to S3. Adopts an already-existing state bucket when its
+ * state object is missing.
  */
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -12,6 +13,7 @@ import { dirname, join, resolve } from 'node:path';
 import {
   S3Client,
   GetObjectCommand,
+  HeadBucketCommand,
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -34,6 +36,20 @@ const tfStatePath = join(
   'bootstrap.tfstate',
 );
 
+// S3 answers 404 only when the name is genuinely free; 403 means it exists
+// but is not readable with these credentials.
+const bucketExists = async (s3: S3Client, bucket: string) => {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    return true;
+  } catch (err: any) {
+    const status = err?.$metadata?.httpStatusCode;
+    if (status === 404) return false;
+    if (status === 403) return true;
+    throw err;
+  }
+};
+
 const main = async () => {
   const { accountId, region } = await resolveAwsConfig();
   const bucket = `${accountId}-tf-state-${region}`;
@@ -46,12 +62,14 @@ const main = async () => {
   // Pull any existing bootstrap tfstate. First-time bootstrap has no
   // remote state yet — fall through and let terraform apply create the
   // bucket.
+  let haveState = false;
   try {
     const out = await s3.send(
       new GetObjectCommand({ Bucket: bucket, Key: key }),
     );
     if (out.Body) {
       writeFileSync(tfStatePath, await out.Body.transformToByteArray());
+      haveState = true;
     }
   } catch (err: any) {
     const name = err?.name ?? '';
@@ -65,6 +83,27 @@ const main = async () => {
   }
 
   execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });
+
+  // The bucket holds its own state, so losing the state object while the
+  // bucket survives would otherwise wedge bootstrap on a permanent
+  // `BucketAlreadyOwnedByYou`. Adopt the existing bucket instead.
+  if (!haveState && (await bucketExists(s3, bucket))) {
+    console.log(
+      `State bucket ${bucket} already exists but its bootstrap state is missing — importing it.`,
+    );
+    execFileSync(
+      'terraform',
+      [
+        'import',
+        `-state=${tfStatePath}`,
+        `-var=aws_region=${region}`,
+        'aws_s3_bucket.terraform_state',
+        bucket,
+      ],
+      { cwd: bootstrapDir, stdio: 'inherit' },
+    );
+  }
+
   execFileSync(
     'terraform',
     [

--- a/packages/nx-plugin/src/terraform/project/generator.spec.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.spec.ts
@@ -137,6 +137,22 @@ describe('terraformProjectGenerator', () => {
       expect(bootstrapTarget.options.cwd).toBe('{workspaceRoot}');
     });
 
+    it('should import an existing state bucket when its state object is missing', async () => {
+      await terraformProjectGenerator(tree, applicationSchema);
+
+      const bootstrapScript = tree.read(
+        'packages/my-terraform-project/scripts/bootstrap.ts',
+        'utf-8',
+      );
+
+      // Without the import, a surviving bucket whose state object was lost
+      // wedges bootstrap on a permanent BucketAlreadyOwnedByYou.
+      expect(bootstrapScript).toContain('HeadBucketCommand');
+      expect(bootstrapScript).toContain("'import'");
+      expect(bootstrapScript).toContain("'aws_s3_bucket.terraform_state'");
+      expect(bootstrapScript).toMatch(/!haveState\s*&&/);
+    });
+
     it('should configure plan target correctly', async () => {
       await terraformProjectGenerator(tree, applicationSchema);
 


### PR DESCRIPTION
### Reason for this change

`terraform-deploy` and `terraform-deploy-rdb` have been failing on `main` since 2026-07-29, both on `nx bootstrap infra`:

```
Error: creating S3 Bucket (<account>-tf-state-us-west-2): ... StatusCode: 409,
BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.
```

The bootstrap state bucket stores its own tfstate at `s3://<account>-tf-state-<region>/bootstrap.tfstate`. `bootstrap.ts` pulls that object to seed local state, and treats a 404/403 as "first run" — falling through to `terraform apply`, which then tries to *create* the bucket.

That's correct only when the bucket genuinely doesn't exist. If the state object is lost while the bucket survives, bootstrap plans the bucket from scratch on every run and fails with `BucketAlreadyOwnedByYou` — a permanently wedged state that no retry clears. That is what happened to the e2e account: the object was deleted (delete marker at `2026-07-29T01:06:19Z`), the bucket remained, and every run since has failed.

### Description of changes

Before `apply`, when the state object is absent but the bucket is not, `terraform import` the bucket into local state so Terraform adopts it instead of recreating it. The remaining five resources (versioning, encryption, public-access-block, lifecycle, policy) are idempotent PUTs against an existing bucket, so `apply` converges from there.

`bucketExists` uses `HeadBucket`, treating 404 as "free" and 403 as "exists but not readable by these credentials" — 403 must not be read as absent, or the same wedge returns.

Unrelated to this change: the account's `bootstrap.tfstate` had to be restored to unblock CI, since the fix repairs future runs but cannot recover an object already deleted. I reconstructed state via the same import + apply path this change automates, verified a follow-up `plan` reports `No changes`, and re-uploaded it. Bucket versioning — which had been left `Suspended` — is `Enabled` again.

### Description of how you validated changes

- Added a generator test asserting the vended `bootstrap.ts` contains the import path. Confirmed it fails against the pre-fix template and passes after, so it is a real regression guard rather than a tautology.
- `vitest run src/terraform/project/generator.spec.ts` — 27 passed.
- Validated the import path against the real broken bucket with Terraform 1.15.8 (the version CI uses): `import` succeeded, the follow-up `plan` showed `5 to add, 0 to change, 0 to destroy` with the bucket adopted rather than recreated, `apply` completed, and a re-`plan` reported `No changes`.

Not validated: a full `terraform-deploy` smoke test run. The bootstrap path is now exercised in its recovered state by CI on this PR.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*