### PR TITLE
chore(terraform#project): migrate existing workspaces to adopt an existing state bucket

### DIFF
--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -9,6 +9,10 @@
     "latest-restrict-cors-to-custom-domains": {
       "description": "Include CloudFront custom domain aliases in restrictCorsTo and UserIdentity callback URLs",
       "implementation": "./src/migrations/latest/restrict-cors-to-custom-domains/migration"
+    },
+    "latest-terraform-bootstrap-adopt-existing-bucket": {
+      "description": "Adopt an existing Terraform state bucket in the vended bootstrap script when its state object is missing",
+      "implementation": "./src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration"
     }
   }
 }

--- a/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Tree } from '@nx/devkit';
+import { terraformProjectGenerator } from '../../../terraform/project/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const BOOTSTRAP_FILE = 'packages/infra/scripts/bootstrap.ts';
+
+// Today's vended script, read from the template the generator uses — so this
+// suite fails if the template moves on without the migration following it.
+const CURRENT_TEMPLATE = readFileSync(
+  join(
+    import.meta.dirname,
+    '../../../terraform/project/files/application/scripts/bootstrap.ts.template',
+  ),
+  'utf-8',
+);
+
+// The script as generated before the fix — verbatim, so the "before" state is
+// exactly what users are upgrading from rather than something derived.
+const PRE_FIX_BOOTSTRAP = `/**
+ * Bootstraps the remote Terraform state bucket.
+ *
+ * Equivalent to \`cdk bootstrap\` — resolves account + region from the AWS
+ * SDK credential chain, pulls any existing bootstrap tfstate from S3,
+ * runs \`terraform apply\` in the \`bootstrap\` dir, then pushes the new
+ * state back to S3.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { resolveAwsConfig } from './aws-config';
+
+const projectRootRel = process.argv[2];
+if (!projectRootRel) {
+  throw new Error(
+    'Expected the project root as argv[2] — this script is wired up by the generated \`bootstrap\` nx target and should be invoked through it.',
+  );
+}
+const workspaceRoot = process.cwd();
+const projectRoot = resolve(workspaceRoot, projectRootRel);
+const bootstrapDir = join(projectRoot, 'bootstrap');
+const tfStatePath = join(
+  workspaceRoot,
+  'dist',
+  projectRootRel,
+  'terraform',
+  'bootstrap.tfstate',
+);
+
+const main = async () => {
+  const { accountId, region } = await resolveAwsConfig();
+  const bucket = \`\${accountId}-tf-state-\${region}\`;
+  const key = 'bootstrap.tfstate';
+
+  const s3 = new S3Client({ region, credentials: fromNodeProviderChain() });
+
+  mkdirSync(dirname(tfStatePath), { recursive: true });
+
+  // Pull any existing bootstrap tfstate. First-time bootstrap has no
+  // remote state yet — fall through and let terraform apply create the
+  // bucket.
+  try {
+    const out = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    if (out.Body) {
+      writeFileSync(tfStatePath, await out.Body.transformToByteArray());
+    }
+  } catch (err: any) {
+    const name = err?.name ?? '';
+    const status = err?.\$metadata?.httpStatusCode;
+    const firstRun =
+      name === 'NoSuchBucket' ||
+      name === 'NoSuchKey' ||
+      status === 404 ||
+      status === 403;
+    if (!firstRun) throw err;
+  }
+
+  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });
+  execFileSync(
+    'terraform',
+    [
+      'apply',
+      '-auto-approve',
+      \`-state=\${tfStatePath}\`,
+      \`-var=aws_region=\${region}\`,
+    ],
+    { cwd: bootstrapDir, stdio: 'inherit' },
+  );
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: readFileSync(tfStatePath),
+    }),
+  );
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+`;
+
+/** Generates a terraform application project, then reverts its bootstrap.ts. */
+const generateWithPreFixBootstrap = async (tree: Tree) => {
+  await terraformProjectGenerator(tree, {
+    name: 'infra',
+    type: 'application',
+    directory: 'packages',
+  });
+  tree.write(BOOTSTRAP_FILE, PRE_FIX_BOOTSTRAP);
+};
+
+describe('terraform-bootstrap-adopt-existing-bucket migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should start from a fixture that lacks the fix', () => {
+    // Guards the fixture: if it already contained the fix, every assertion
+    // below would pass without the migration doing anything.
+    expect(PRE_FIX_BOOTSTRAP).not.toEqual(CURRENT_TEMPLATE);
+    expect(PRE_FIX_BOOTSTRAP).not.toContain('HeadBucketCommand');
+    expect(PRE_FIX_BOOTSTRAP).not.toContain('haveState');
+    expect(PRE_FIX_BOOTSTRAP).not.toContain("'aws_s3_bucket.terraform_state'");
+  });
+
+  it('should be a no-op when the workspace has no terraform project', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should produce exactly what the current generator vends', async () => {
+    await generateWithPreFixBootstrap(tree);
+
+    const result = await migration(tree);
+
+    // The point of a migration: the workspace ends up byte-identical to one
+    // generated from today's generators.
+    expect(tree.read(BOOTSTRAP_FILE, 'utf-8')).toEqual(CURRENT_TEMPLATE);
+    expect(
+      result.nextSteps.some((s) => s.includes(BOOTSTRAP_FILE)),
+    ).toBeTruthy();
+  });
+
+  it('should leave an already-migrated project untouched and unreported', async () => {
+    await terraformProjectGenerator(tree, {
+      name: 'infra',
+      type: 'application',
+      directory: 'packages',
+    });
+
+    const result = await migration(tree);
+
+    expect(tree.read(BOOTSTRAP_FILE, 'utf-8')).toEqual(CURRENT_TEMPLATE);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should skip and report a customised script', async () => {
+    await generateWithPreFixBootstrap(tree);
+    // A comment between `init` and the `apply` call breaks the anchor the
+    // migration keys off, standing in for any local edit to this region.
+    const customised = PRE_FIX_BOOTSTRAP.replace(
+      "  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });\n  execFileSync(",
+      "  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });\n\n  // a local customisation\n  execFileSync(",
+    );
+    tree.write(BOOTSTRAP_FILE, customised);
+
+    const result = await migration(tree);
+
+    // Reported rather than rewritten — a half-applied edit is worse than none.
+    expect(tree.read(BOOTSTRAP_FILE, 'utf-8')).toEqual(customised);
+    expect(
+      result.nextSteps.some(
+        (s) => s.includes(BOOTSTRAP_FILE) && s.includes('diverged'),
+      ),
+    ).toBeTruthy();
+  });
+
+  it('should not touch a terraform library project', async () => {
+    await terraformProjectGenerator(tree, {
+      name: 'tf-lib',
+      type: 'library',
+      directory: 'packages',
+    });
+
+    const result = await migration(tree);
+
+    // Libraries never vend bootstrap.ts.
+    expect(tree.exists('packages/tf-lib/scripts/bootstrap.ts')).toBeFalsy();
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    await generateWithPreFixBootstrap(tree);
+
+    await migration(tree);
+    const afterFirst = tree.read(BOOTSTRAP_FILE, 'utf-8');
+
+    const secondResult = await migration(tree);
+
+    expect(tree.read(BOOTSTRAP_FILE, 'utf-8')).toEqual(afterFirst);
+    expect(secondResult.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.spec.ts
@@ -173,24 +173,74 @@ describe('terraform-bootstrap-adopt-existing-bucket migration', () => {
     expect(result.nextSteps).toEqual([]);
   });
 
-  it('should skip and report a customised script', async () => {
+  it('should migrate a customised script without disturbing the customisation', async () => {
     await generateWithPreFixBootstrap(tree);
-    // A comment between `init` and the `apply` call breaks the anchor the
-    // migration keys off, standing in for any local edit to this region.
+    // Extra statements and reformatting around the edit sites — the kind of
+    // local change that defeats literal matching but not an AST rewrite.
     const customised = PRE_FIX_BOOTSTRAP.replace(
       "  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });\n  execFileSync(",
-      "  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });\n\n  // a local customisation\n  execFileSync(",
+      "  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });\n\n  // our team pins a workspace before applying\n  execFileSync('terraform', ['workspace', 'select', 'ops'], { cwd: bootstrapDir, stdio: 'inherit' });\n\n  execFileSync(",
     );
     tree.write(BOOTSTRAP_FILE, customised);
 
     const result = await migration(tree);
+    const migrated = tree.read(BOOTSTRAP_FILE, 'utf-8') ?? '';
 
-    // Reported rather than rewritten — a half-applied edit is worse than none.
-    expect(tree.read(BOOTSTRAP_FILE, 'utf-8')).toEqual(customised);
+    // The fix lands and the user's statement survives.
+    expect(migrated).toContain('await bucketExists(s3, bucket)');
+    expect(migrated).toContain("'workspace', 'select', 'ops'");
+    expect(migrated).toContain('// our team pins a workspace before applying');
+    expect(
+      result.nextSteps.some((s) => s.includes(BOOTSTRAP_FILE)),
+    ).toBeTruthy();
+  });
+
+  it('should skip and report a script missing an edit site', async () => {
+    await generateWithPreFixBootstrap(tree);
+    // Rewritten to fetch state without `GetObjectCommand`, so there is no
+    // try block to hang `haveState` on and the rewrite must not proceed.
+    const diverged = PRE_FIX_BOOTSTRAP.replace(
+      'new GetObjectCommand({ Bucket: bucket, Key: key }),',
+      'new CustomFetchCommand({ Bucket: bucket, Key: key }),',
+    );
+    tree.write(BOOTSTRAP_FILE, diverged);
+
+    const result = await migration(tree);
+
+    // Reported rather than part-rewritten — a half-applied edit is worse than none.
+    expect(tree.read(BOOTSTRAP_FILE, 'utf-8')).toEqual(diverged);
     expect(
       result.nextSteps.some(
         (s) => s.includes(BOOTSTRAP_FILE) && s.includes('diverged'),
       ),
+    ).toBeTruthy();
+  });
+
+  it('should still apply when the script has been reformatted', async () => {
+    await generateWithPreFixBootstrap(tree);
+    // Same AST, different formatting — the case literal matching cannot handle.
+    const reformatted = PRE_FIX_BOOTSTRAP.replace(
+      "  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });",
+      "  execFileSync('terraform', ['init'], {\n    cwd: bootstrapDir,\n    stdio: 'inherit',\n  });",
+    ).replace(
+      '  mkdirSync(dirname(tfStatePath), { recursive: true });',
+      '  mkdirSync(dirname(tfStatePath), {\n    recursive: true,\n  });',
+    );
+    tree.write(BOOTSTRAP_FILE, reformatted);
+
+    const result = await migration(tree);
+    const migrated = tree.read(BOOTSTRAP_FILE, 'utf-8') ?? '';
+
+    // Formatting differences must not cost the user the fix. The file won't be
+    // byte-identical to the template — the user's line breaks are preserved —
+    // but every part of the change has to land.
+    expect(migrated).toContain('HeadBucketCommand');
+    expect(migrated).toContain('let haveState = false;');
+    expect(migrated).toContain('haveState = true;');
+    expect(migrated).toContain('await bucketExists(s3, bucket)');
+    expect(migrated).toContain("'aws_s3_bucket.terraform_state'");
+    expect(
+      result.nextSteps.some((s) => s.includes(BOOTSTRAP_FILE)),
     ).toBeTruthy();
   });
 

--- a/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { TERRAFORM_PROJECT_GENERATOR_INFO } from '../../../terraform/project/generator';
+import { formatFilesInSubtree } from '../../../utils/format';
+
+/**
+ * Adopt an existing Terraform state bucket in the vended bootstrap script when its state object is missing
+ *
+ * The state bucket stores its own tfstate inside itself, so if that object is
+ * deleted while the bucket survives, `bootstrap` reads the 404 as a first run
+ * and asks terraform to create a bucket that already exists — failing with
+ * `BucketAlreadyOwnedByYou` on every subsequent run, with no retry that clears
+ * it. The vended script now imports the existing bucket instead.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Pattern-match before writing: skip files that have diverged from the shape
+ *   your generators produce and report them via `nextSteps`, or consider a
+ *   hybrid migration, rather than clobbering the user's changes.
+ * - Idempotent: re-running must be a no-op.
+ * - Format what you write: finish with `formatFilesInSubtree` so the files your
+ *   migration wrote are formatted correctly.
+ */
+
+// Marks the migrated shape — the guard that decides whether to import.
+const MIGRATED_MARKER = 'await bucketExists(s3, bucket)';
+
+// `haveState` records whether the remote state object was actually pulled, so
+// the import only runs when terraform has no prior knowledge of the bucket.
+const STATE_FLAG_ANCHOR = `  try {
+    const out = await s3.send(`;
+const STATE_FLAG_REPLACEMENT = `  let haveState = false;
+  try {
+    const out = await s3.send(`;
+
+const STATE_FLAG_SET_ANCHOR = `      writeFileSync(tfStatePath, await out.Body.transformToByteArray());
+    }`;
+const STATE_FLAG_SET_REPLACEMENT = `      writeFileSync(tfStatePath, await out.Body.transformToByteArray());
+      haveState = true;
+    }`;
+
+const HELPER_ANCHOR = `
+const main = async () => {`;
+const HELPER_REPLACEMENT = `
+// S3 answers 404 only when the name is genuinely free; 403 means it exists
+// but is not readable with these credentials.
+const bucketExists = async (s3: S3Client, bucket: string) => {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    return true;
+  } catch (err: any) {
+    const status = err?.$metadata?.httpStatusCode;
+    if (status === 404) return false;
+    if (status === 403) return true;
+    throw err;
+  }
+};
+
+const main = async () => {`;
+
+const IMPORT_ANCHOR = `  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });
+  execFileSync(`;
+const IMPORT_REPLACEMENT = `  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });
+
+  // The bucket holds its own state, so losing the state object while the
+  // bucket survives would otherwise wedge bootstrap on a permanent
+  // \`BucketAlreadyOwnedByYou\`. Adopt the existing bucket instead.
+  if (!haveState && (await bucketExists(s3, bucket))) {
+    console.log(
+      \`State bucket \${bucket} already exists but its bootstrap state is missing — importing it.\`,
+    );
+    execFileSync(
+      'terraform',
+      [
+        'import',
+        \`-state=\${tfStatePath}\`,
+        \`-var=aws_region=\${region}\`,
+        'aws_s3_bucket.terraform_state',
+        bucket,
+      ],
+      { cwd: bootstrapDir, stdio: 'inherit' },
+    );
+  }
+
+  execFileSync(`;
+
+const DOC_ANCHOR = ` * state back to S3.
+ */`;
+const DOC_REPLACEMENT = ` * state back to S3. Adopts an already-existing state bucket when its
+ * state object is missing.
+ */`;
+
+// Matches the generator's import order rather than appending, so a migrated
+// workspace is byte-identical to a freshly generated one.
+const IMPORT_ANCHOR_S3 = `  GetObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';`;
+const IMPORT_REPLACEMENT_S3 = `  GetObjectCommand,
+  HeadBucketCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  // Terraform application projects are the only ones that vend bootstrap.ts.
+  const bootstrapScripts = [...getProjects(tree).values()]
+    .filter(
+      (project) =>
+        (project.metadata as any)?.generator ===
+        TERRAFORM_PROJECT_GENERATOR_INFO.id,
+    )
+    .map((project) => joinPathFragments(project.root, 'scripts/bootstrap.ts'))
+    .filter((filePath) => tree.exists(filePath));
+
+  for (const filePath of bootstrapScripts) {
+    const contents = tree.read(filePath, 'utf-8') ?? '';
+
+    if (contents.includes(MIGRATED_MARKER)) {
+      // Already migrated - silent skip keeps re-runs a no-op.
+      continue;
+    }
+
+    // Every anchor must be present before writing any of them, so a partially
+    // matching (customised) script is left whole rather than half-edited.
+    const anchors = [
+      IMPORT_ANCHOR_S3,
+      STATE_FLAG_ANCHOR,
+      STATE_FLAG_SET_ANCHOR,
+      HELPER_ANCHOR,
+      IMPORT_ANCHOR,
+    ];
+    if (anchors.some((anchor) => !contents.includes(anchor))) {
+      nextSteps.push(
+        `${filePath}: the bootstrap script has diverged from the generated shape - left untouched. Manually \`terraform import aws_s3_bucket.terraform_state <bucket>\` before \`terraform apply\` when the state bucket exists but its \`bootstrap.tfstate\` object does not, otherwise bootstrap fails with BucketAlreadyOwnedByYou.`,
+      );
+      continue;
+    }
+
+    tree.write(
+      filePath,
+      contents
+        .replace(DOC_ANCHOR, DOC_REPLACEMENT)
+        .replace(IMPORT_ANCHOR_S3, IMPORT_REPLACEMENT_S3)
+        .replace(STATE_FLAG_ANCHOR, STATE_FLAG_REPLACEMENT)
+        .replace(STATE_FLAG_SET_ANCHOR, STATE_FLAG_SET_REPLACEMENT)
+        .replace(HELPER_ANCHOR, HELPER_REPLACEMENT)
+        .replace(IMPORT_ANCHOR, IMPORT_REPLACEMENT),
+    );
+
+    nextSteps.push(
+      `${filePath}: now adopts an existing Terraform state bucket when its bootstrap.tfstate object is missing.`,
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-bootstrap-adopt-existing-bucket/migration.ts
@@ -9,6 +9,12 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { TERRAFORM_PROJECT_GENERATOR_INFO } from '../../../terraform/project/generator';
+import {
+  applyGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
 
 /**
@@ -19,6 +25,9 @@ import { formatFilesInSubtree } from '../../../utils/format';
  * and asks terraform to create a bucket that already exists — failing with
  * `BucketAlreadyOwnedByYou` on every subsequent run, with no retry that clears
  * it. The vended script now imports the existing bucket instead.
+ *
+ * Every edit is expressed as a GritQL rewrite so the script is matched on its
+ * AST rather than its formatting.
  *
  * How to write a migration:
  * - https://nx.dev/docs/kb/migration-generators
@@ -33,27 +42,24 @@ import { formatFilesInSubtree } from '../../../utils/format';
  *   migration wrote are formatted correctly.
  */
 
-// Marks the migrated shape — the guard that decides whether to import.
-const MIGRATED_MARKER = 'await bucketExists(s3, bucket)';
+// Guards the whole migration: present only once the import step exists.
+const MIGRATED_PATTERN = '`bucketExists($_, $_)`';
 
-// `haveState` records whether the remote state object was actually pulled, so
-// the import only runs when terraform has no prior knowledge of the bucket.
-const STATE_FLAG_ANCHOR = `  try {
-    const out = await s3.send(`;
-const STATE_FLAG_REPLACEMENT = `  let haveState = false;
-  try {
-    const out = await s3.send(`;
+// Every edit site, matched structurally so formatting and argument layout
+// don't affect whether the script is recognised.
+const STATE_FETCH_TRY_PATTERN =
+  'try_statement() as $try where { $try <: contains `GetObjectCommand` }';
+const STATE_FLAG_SET_PATTERN = '`if (out.Body) { $body }`';
+const HELPER_PATTERN = '`const main = async () => { $body }`';
+const INIT_PATTERN = "`execFileSync('terraform', ['init'], $opts)`";
+const S3_IMPORT_PATTERN =
+  "`import { $before, GetObjectCommand, $after } from '@aws-sdk/client-s3'`";
+const HEADER_COMMENT_PATTERN =
+  'comment() as $c where { $c <: includes "state back to S3." }';
 
-const STATE_FLAG_SET_ANCHOR = `      writeFileSync(tfStatePath, await out.Body.transformToByteArray());
-    }`;
-const STATE_FLAG_SET_REPLACEMENT = `      writeFileSync(tfStatePath, await out.Body.transformToByteArray());
-      haveState = true;
-    }`;
-
-const HELPER_ANCHOR = `
-const main = async () => {`;
-const HELPER_REPLACEMENT = `
-// S3 answers 404 only when the name is genuinely free; 403 means it exists
+// GritQL snippets are parsed as backtick-quoted patterns, so any backtick in
+// the inserted source has to survive that layer escaped.
+const BUCKET_EXISTS_HELPER = `// S3 answers 404 only when the name is genuinely free; 403 means it exists
 // but is not readable with these credentials.
 const bucketExists = async (s3: S3Client, bucket: string) => {
   try {
@@ -65,15 +71,9 @@ const bucketExists = async (s3: S3Client, bucket: string) => {
     if (status === 403) return true;
     throw err;
   }
-};
+};`;
 
-const main = async () => {`;
-
-const IMPORT_ANCHOR = `  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });
-  execFileSync(`;
-const IMPORT_REPLACEMENT = `  execFileSync('terraform', ['init'], { cwd: bootstrapDir, stdio: 'inherit' });
-
-  // The bucket holds its own state, so losing the state object while the
+const IMPORT_STEP = `// The bucket holds its own state, so losing the state object while the
   // bucket survives would otherwise wedge bootstrap on a permanent
   // \`BucketAlreadyOwnedByYou\`. Adopt the existing bucket instead.
   if (!haveState && (await bucketExists(s3, bucket))) {
@@ -91,25 +91,22 @@ const IMPORT_REPLACEMENT = `  execFileSync('terraform', ['init'], { cwd: bootstr
       ],
       { cwd: bootstrapDir, stdio: 'inherit' },
     );
-  }
+  }`;
 
-  execFileSync(`;
-
-const DOC_ANCHOR = ` * state back to S3.
- */`;
-const DOC_REPLACEMENT = ` * state back to S3. Adopts an already-existing state bucket when its
+// Rewritten wholesale rather than appended to, since the summary sentence
+// changes rather than gaining a clause.
+const NEW_HEADER_COMMENT = `/**
+ * Bootstraps the remote Terraform state bucket.
+ *
+ * Equivalent to \\\`cdk bootstrap\\\` — resolves account + region from the AWS
+ * SDK credential chain, pulls any existing bootstrap tfstate from S3,
+ * runs \\\`terraform apply\\\` in the \\\`bootstrap\\\` dir, then pushes the new
+ * state back to S3. Adopts an already-existing state bucket when its
  * state object is missing.
  */`;
 
-// Matches the generator's import order rather than appending, so a migrated
-// workspace is byte-identical to a freshly generated one.
-const IMPORT_ANCHOR_S3 = `  GetObjectCommand,
-  PutObjectCommand,
-} from '@aws-sdk/client-s3';`;
-const IMPORT_REPLACEMENT_S3 = `  GetObjectCommand,
-  HeadBucketCommand,
-  PutObjectCommand,
-} from '@aws-sdk/client-s3';`;
+const DIVERGED_NEXT_STEP = (filePath: string) =>
+  `${filePath}: the bootstrap script has diverged from the generated shape - left untouched. Manually \`terraform import aws_s3_bucket.terraform_state <bucket>\` before \`terraform apply\` when the state bucket exists but its \`bootstrap.tfstate\` object does not, otherwise bootstrap fails with BucketAlreadyOwnedByYou.`;
 
 export default async function migration(
   tree: Tree,
@@ -127,38 +124,69 @@ export default async function migration(
     .filter((filePath) => tree.exists(filePath));
 
   for (const filePath of bootstrapScripts) {
-    const contents = tree.read(filePath, 'utf-8') ?? '';
-
-    if (contents.includes(MIGRATED_MARKER)) {
+    if (await matchGritQL(tree, filePath, MIGRATED_PATTERN)) {
       // Already migrated - silent skip keeps re-runs a no-op.
       continue;
     }
 
-    // Every anchor must be present before writing any of them, so a partially
-    // matching (customised) script is left whole rather than half-edited.
-    const anchors = [
-      IMPORT_ANCHOR_S3,
-      STATE_FLAG_ANCHOR,
-      STATE_FLAG_SET_ANCHOR,
-      HELPER_ANCHOR,
-      IMPORT_ANCHOR,
-    ];
-    if (anchors.some((anchor) => !contents.includes(anchor))) {
-      nextSteps.push(
-        `${filePath}: the bootstrap script has diverged from the generated shape - left untouched. Manually \`terraform import aws_s3_bucket.terraform_state <bucket>\` before \`terraform apply\` when the state bucket exists but its \`bootstrap.tfstate\` object does not, otherwise bootstrap fails with BucketAlreadyOwnedByYou.`,
-      );
+    // Confirm every edit site is present before writing any of them, so a
+    // script that only partly matches is left whole rather than half-edited.
+    const allSitesPresent = (
+      await Promise.all(
+        [
+          STATE_FETCH_TRY_PATTERN,
+          STATE_FLAG_SET_PATTERN,
+          HELPER_PATTERN,
+          INIT_PATTERN,
+          S3_IMPORT_PATTERN,
+          HEADER_COMMENT_PATTERN,
+        ].map((pattern) => matchGritQL(tree, filePath, pattern)),
+      )
+    ).every(Boolean);
+
+    if (!allSitesPresent) {
+      nextSteps.push(DIVERGED_NEXT_STEP(filePath));
       continue;
     }
 
-    tree.write(
+    // `haveState` distinguishes "no remote state" from "no bucket", so the
+    // import only runs when terraform has no prior knowledge of the bucket.
+    await insertViaGritQL(
+      tree,
       filePath,
-      contents
-        .replace(DOC_ANCHOR, DOC_REPLACEMENT)
-        .replace(IMPORT_ANCHOR_S3, IMPORT_REPLACEMENT_S3)
-        .replace(STATE_FLAG_ANCHOR, STATE_FLAG_REPLACEMENT)
-        .replace(STATE_FLAG_SET_ANCHOR, STATE_FLAG_SET_REPLACEMENT)
-        .replace(HELPER_ANCHOR, HELPER_REPLACEMENT)
-        .replace(IMPORT_ANCHOR, IMPORT_REPLACEMENT),
+      `${STATE_FETCH_TRY_PATTERN} => \`${GRIT_INSERT_PLACEHOLDER}\n  $try\``,
+      'let haveState = false;',
+    );
+    await applyGritQL(
+      tree,
+      filePath,
+      `${STATE_FLAG_SET_PATTERN} => \`if (out.Body) {\n      $body\n      haveState = true;\n    }\``,
+    );
+    await insertViaGritQL(
+      tree,
+      filePath,
+      `${HELPER_PATTERN} => \`${GRIT_INSERT_PLACEHOLDER}\n\nconst main = async () => { $body }\``,
+      BUCKET_EXISTS_HELPER,
+    );
+    await insertViaGritQL(
+      tree,
+      filePath,
+      `${INIT_PATTERN} => \`execFileSync('terraform', ['init'], $opts);\n\n  ${GRIT_INSERT_PLACEHOLDER}\n\``,
+      IMPORT_STEP,
+    );
+
+    // Placed in the generator's import position rather than appended, so a
+    // migrated workspace matches a freshly generated one.
+    await applyGritQL(
+      tree,
+      filePath,
+      `${S3_IMPORT_PATTERN} => \`import { $before, GetObjectCommand, HeadBucketCommand, $after } from '@aws-sdk/client-s3'\``,
+    );
+
+    await applyGritQL(
+      tree,
+      filePath,
+      `${HEADER_COMMENT_PATTERN} => \`${NEW_HEADER_COMMENT}\``,
     );
 
     nextSteps.push(


### PR DESCRIPTION
### Reason for this change

#1011 fixed the vended `bootstrap.ts` but shipped no migration. Per CONTRIBUTING, any change to a generator's output needs one — otherwise a workspace generated before the fix silently diverges from one generated today, and in this case keeps the defect: if `bootstrap.tfstate` is lost while the state bucket survives, `bootstrap` reads the 404 as a first run and asks terraform to create a bucket that already exists, failing with `BucketAlreadyOwnedByYou` on every run with no retry that clears it.

### Description of changes

Deterministic, not hybrid. CONTRIBUTING prefers hybrid by default, but here neither half would be shared: the edit has a single recognisable shape, and anything the codemod can't match needs no agent judgement — just the one-line `terraform import` recovery, which `nextSteps` states directly.

**Every edit is a GritQL rewrite, matched on the AST rather than on literal text.** Users own this file, so formatting drift and nearby edits are expected; literal anchors would skip a workspace that plainly still needs the fix. Matching structurally makes the migration strictly more capable — a customised script now *gets the fix with the customisation preserved*, where a string-based version could only report it and walk away.

- **Discovers projects via generator metadata** (`terraform#project`) through the Nx project graph, not a path glob — terraform *libraries* carry the same metadata but never vend `bootstrap.ts`, so the `tree.exists` filter drops them.
- **All-or-nothing site check**, now keyed on the GritQL patterns: every edit site must match before anything is written, so a script genuinely missing one (e.g. state fetched without `GetObjectCommand`) is reported via `nextSteps` rather than part-rewritten.
- **`haveState` is anchored on `try_statement()` containing `GetObjectCommand`**, which places the declaration exactly where the generator puts it. Note `catch ($p)` does *not* match the vended `catch (err: any)` — the typed parameter needs `try_statement()` or `catch ($p: any)`.
- **The `HeadBucketCommand` import is rewritten into the generator's position** rather than appended, so a migrated workspace matches a freshly generated one.
- **The header comment uses `comment() where { $c <: includes ... }`** — GritQL has no pattern that matches JSDoc text, so the comment node is matched and replaced wholesale.

### Description of how you validated changes

9 unit tests, all passing: applies to the vended shape, no-op with no terraform project, already-migrated is silent, **customised script migrated with the customisation intact**, **reformatted script still migrated**, script missing an edit site skipped + reported, terraform library untouched, idempotent. The central assertion reads today's template **from disk** and requires byte-identical output, so the suite fails if the template later moves on without the migration following.

I mutation-tested the assertions that matter, since a migration test that passes against a broken migration is worse than none:

- Removing the import rewrite → byte-identical test fails.
- Removing the all-sites guard → the missing-edit-site test fails.

I also ran the migration against the **real** pre-fix template extracted from `990ffb82^` (not just a derived fixture) and diffed the result: byte-identical to today's generator output.

Manually, against a real workspace with the local build (`pnpm package:all`, `nx migrate --run-migrations` via a hand-written `migrations.json`):

1. **Diff is exactly the fix** — doc comment, import, `bucketExists`, `haveState`, import step. Nothing else.
2. **Byte-identical to fresh generation** — migrated `bootstrap.ts` `diff`s clean against the current template.
3. **Builds** — `nx run-many --target build --all` passes.
4. **Idempotent** — second run reports "No changes were made".
5. **Customised workspace** — added a `terraform workspace select` call in the targeted region; the migration applied the fix, preserved the customisation, and the workspace still builds.

One gap worth stating: CONTRIBUTING asks for a baseline on the **published** version, which I could not build. `create-nx-workspace` with `--preset=@aws/nx-plugin@1.0.0-rc.49` fails resolving `@biomejs/wasm-nodejs@2.5.4`, which is not on npm (latest is 2.4.8) — an unrelated packaging issue in the published rc. I used the local build with `bootstrap.ts` reverted to the exact pre-fix content from git, which reproduces the same starting state. Worth a look separately, since it likely blocks real `create-nx-workspace` runs on rc.49.

### Issue # (if applicable)

Follow-up to #1011.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*