### PR TITLE
chore(dev): replace prettier vscode extension recommendation with biome

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
     "ms-python.vscode-pylance",
     "ms-python.debugpy",
     "ms-azuretools.vscode-containers",
-    "esbenp.prettier-vscode",
+    "biomejs.biome",
     "astro-build.astro-vscode"
   ]
 }


### PR DESCRIPTION
### Reason for this change

Repo uses Biome, not Prettier, for linting/formatting. The extension recommendation was stale.

### Description of changes

Swapped `esbenp.prettier-vscode` for `biomejs.biome` in `.vscode/extensions.json`.

### Checklist
- [x] My code adheres to the CONTRIBUTING GUIDE and DESIGN GUIDELINES

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*