### PR TITLE
fix(ts#rdb): dedupe @types/pg under @prisma/adapter-pg for yarn

### DIFF
--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -2,7 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import type { Tree } from '@nx/devkit';
+import * as devkit from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
 import { readProjectConfigurationUnqualified } from '../../utils/nx';
 import { sharedConstructsGenerator } from '../../utils/shared-constructs';
@@ -10,6 +12,7 @@ import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
 } from '../../utils/test';
+import { TS_VERSIONS } from '../../utils/versions';
 import { TS_RDB_GENERATOR_INFO, tsRdbGenerator } from './generator';
 
 describe('ts#rdb generator', () => {
@@ -250,6 +253,42 @@ describe('ts#rdb generator', () => {
     expect(projectPackageJson.dependencies.pg).toBeUndefined();
     expect(projectPackageJson.devDependencies?.['@types/pg']).toBeUndefined();
   });
+
+  it('should pin @prisma/adapter-pg @types/pg via yarn resolutions to match the workspace @types/pg', async () => {
+    vi.spyOn(devkit, 'detectPackageManager').mockReturnValue('yarn');
+
+    await tsRdbGenerator(tree, defaultOptions);
+
+    const rootPackageJson = JSON.parse(tree.read('package.json', 'utf-8'));
+    // Classic yarn honours the `**/` form, berry the bare one.
+    expect(
+      rootPackageJson.resolutions?.['**/@prisma/adapter-pg/@types/pg'],
+    ).toBe(TS_VERSIONS['@types/pg']);
+    expect(rootPackageJson.resolutions?.['@prisma/adapter-pg/@types/pg']).toBe(
+      TS_VERSIONS['@types/pg'],
+    );
+  });
+
+  it('should not add the @types/pg resolution for yarn when engine is MySQL', async () => {
+    vi.spyOn(devkit, 'detectPackageManager').mockReturnValue('yarn');
+
+    await tsRdbGenerator(tree, { ...defaultOptions, engine: 'mysql' });
+
+    const rootPackageJson = JSON.parse(tree.read('package.json', 'utf-8'));
+    expect(rootPackageJson.resolutions).toBeUndefined();
+  });
+
+  it.each(['pnpm', 'npm', 'bun'] as const)(
+    'should not add yarn resolutions for %s',
+    async (pkgMgr) => {
+      vi.spyOn(devkit, 'detectPackageManager').mockReturnValue(pkgMgr);
+
+      await tsRdbGenerator(tree, defaultOptions);
+
+      const rootPackageJson = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(rootPackageJson.resolutions).toBeUndefined();
+    },
+  );
 
   it('should generate terraform modules when iac is Terraform', async () => {
     await tsRdbGenerator(tree, {

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -4,6 +4,7 @@
  */
 import { relative } from 'node:path';
 import {
+  detectPackageManager,
   type GeneratorCallback,
   generateFiles,
   joinPathFragments,
@@ -309,6 +310,26 @@ export const tsRdbGenerator = async (
     ]),
     joinPathFragments(projectConfig.root, 'package.json'),
   );
+
+  // @prisma/adapter-pg depends on @types/pg ^8.16.0. Yarn does not dedupe it to
+  // the workspace's pinned @types/pg, so it installs a separate copy under the
+  // adapter's own node_modules whenever a newer @types/pg is published. The two
+  // copies declare structurally incompatible Pool types, so passing our `new
+  // Pool(...)` to `new PrismaPg(...)` fails to compile. Scope the resolution to
+  // the adapter so other @types/pg consumers are unaffected. Classic yarn only
+  // honours the `**/`-prefixed descriptor in a workspace and berry only the
+  // bare one, so declare both.
+  if (options.engine === 'postgres' && detectPackageManager() === 'yarn') {
+    updateJson(tree, 'package.json', (packageJson) => {
+      packageJson.resolutions = {
+        ...packageJson.resolutions,
+        '**/@prisma/adapter-pg/@types/pg': TS_VERSIONS['@types/pg'],
+        '@prisma/adapter-pg/@types/pg': TS_VERSIONS['@types/pg'],
+      };
+      return packageJson;
+    });
+  }
+
   // The prisma CLI and tsx run migration/seed scripts from the root.
   addDependenciesToPackageJson(tree, {}, withVersions(['prisma', 'tsx']));
 


### PR DESCRIPTION
### Reason for this change

The `yarn-classic` and `yarn-4` smoke tests started failing on `main` with `@e2e-test/postgres-db` not compiling:

```
src/prisma.ts:32:7 - error TS2345: Argument of type 'Pool' is not assignable to parameter of type 'string | Pool | PoolConfig'.
  Type 'import(".../node_modules/@types/pg/index").Pool' is not assignable to type
       'import(".../node_modules/@prisma/adapter-pg/node_modules/@types/pg/index").Pool'.
    Type 'PoolClient' is missing the following properties from type 'PoolClient': port, host, ssl, connection, end
```

This is upstream dependency drift, not a code change:

- `@prisma/adapter-pg@7.8.0` depends on `@types/pg: ^8.16.0`, while we pin `@types/pg` at `8.20.0`. Yarn does not dedupe the transitive dependency to the workspace pin, so it installs a second copy under the adapter's own `node_modules`.
- `@types/pg@8.20.1` and `8.20.2` were published on 2026-07-31 (18:31Z and 22:22Z). `8.20.2` changed `PoolClient extends ClientBase` to `PoolClient extends Client`, which makes the two copies structurally incompatible.
- The vended `prisma.ts` passes `new Pool(...)` (typed by the root copy) into `new PrismaPg(...)` (which expects the nested copy), so it no longer compiles.

`npm` and `pnpm` dedupe to the single pinned version and are unaffected, which is why only the two yarn jobs fail.

### Description of changes

Add a yarn `resolutions` entry scoped to `@prisma/adapter-pg`, so its `@types/pg` resolves to the same version the workspace pins. Follows the existing precedent for the `@modelcontextprotocol/sdk`/`zod` resolution in `ts#mcp-server`.

Two details worth calling out:

- **Only added for `engine: postgres` on yarn.** MySQL projects install neither `@prisma/adapter-pg` nor `@types/pg`, and npm/pnpm/bun dedupe correctly, so no resolution is written for them.
- **Both descriptor forms are declared.** I found empirically that in a workspace layout, classic yarn only honours the `**/`-prefixed descriptor and berry only honours the bare one — neither form alone fixes both. Verified by installing each form under both yarn versions and running `tsc`:

  | descriptor | yarn 1 (workspace) | yarn 4 (workspace) |
  |---|---|---|
  | `**/@prisma/adapter-pg/@types/pg` | 1 copy, tsc passes | 2 copies, **tsc fails** |
  | `@prisma/adapter-pg/@types/pg` | 2 copies, **tsc fails** | 1 copy, tsc passes |
  | both (this PR) | 1 copy, tsc passes | 1 copy, tsc passes |

Scoping to the adapter rather than pinning `@types/pg` globally keeps other `@types/pg` consumers unaffected. Bumping our pin to `8.20.2` would also turn the build green today, but it would break again on the next `@types/pg` publish since the adapter's range stays open.

### Description of how you validated changes

- Reproduced the exact CI error locally in a yarn workspace mirroring the e2e layout (root-pinned `@types/pg@8.20.0` + `@prisma/adapter-pg@7.8.0`), and confirmed the same `TS2345` with the same two-copy paths.
- Confirmed the root cause by diffing the `@types/pg` `8.20.0` and `8.20.2` tarballs — the only functional change is `PoolClient extends ClientBase` → `extends Client`.
- Verified the fix resolves to a single `@types/pg` copy and `tsc` exits 0 under both yarn 1 and yarn 4, and confirmed npm/pnpm dedupe without it.
- Added unit tests: the resolution is written for postgres on yarn (both descriptors, matching the pinned version), and not written for MySQL or for pnpm/npm/bun.
- `@aws/nx-plugin` build, lint, and full unit test suite pass (103 tests across the `ts/rdb` and `py/rdb` suites).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
